### PR TITLE
Fix docs and tests, decode server public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI =
 
 This indicates that `server.py` can correctly access your GPU resources.
 
-llama_cpp_python is initialized like this:
+llama-cpp-python is initialized like this:
 
 ```py
 llm = Llama(
@@ -244,7 +244,7 @@ You can test things out using the simple command-line client, `client.py`:
 python client.py
 ```
 
-Type your message when prompted and press Enter. All of this is now happening on your local hardware, thanks to `llama_cpp_python`, a binding for llama.cpp.
+Type your message when prompted and press Enter. All of this is now happening on your local hardware, thanks to `llama-cpp-python`, a binding for llama.cpp.
 
 To exit, press Ctrl+C/Cmd+C.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,7 +30,6 @@ Thank you for your interest in contributing to token.place! This document provid
 3. Install Python dependencies:
    ```bash
    pip install -r requirements.txt
-   pip install -r requirements-dev.txt  # Development dependencies
    ```
 
 4. Install Node.js dependencies:

--- a/tests/test_e2e_chat.py
+++ b/tests/test_e2e_chat.py
@@ -44,6 +44,7 @@ def test_chat_encryption_e2e(page, base_url, setup_servers):
     screenshot_path = os.path.join(os.path.dirname(__file__), "encryption_test_screenshot.png")
     page.screenshot(path=screenshot_path)
     print(f"Screenshot saved to {screenshot_path}")
+    assert os.path.exists(screenshot_path)
     
     # Test direct API connection with CryptoClient
     crypto_client = CryptoClient(base_url, debug=True)

--- a/tests/utils/client_simulator.py
+++ b/tests/utils/client_simulator.py
@@ -34,8 +34,13 @@ class ClientSimulator:
         """
         response = self.session.get(f"{self.base_url}/api/v1/public-key")
         response.raise_for_status()
-        
-        self.server_public_key = response.content
+
+        data = response.json()
+        key_b64 = data.get("server_public_key") or data.get("public_key")
+        if key_b64 is None:
+            raise ValueError("Public key not found in response")
+
+        self.server_public_key = base64.b64decode(key_b64)
         return self.server_public_key
         
     def encrypt_message(self, message: Union[str, Dict], server_key: Optional[bytes] = None) -> Dict:


### PR DESCRIPTION
## Summary
- fix package name in README
- remove reference to non-existent `requirements-dev.txt`
- properly decode server public key in `ClientSimulator`
- ensure screenshot file is created in end-to-end chat test

## Testing
- `pytest tests/test_crypto_helpers.py::test_fetch_server_public_key -q`
- `pytest tests/test_crypto_helpers.py::test_crypto_client_initialization -q`


------
https://chatgpt.com/codex/tasks/task_e_683f66893f14832f9d53896991e72feb