### PR TITLE
Fix README security doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ We welcome contributions! See our [Contributing Guide](docs/CONTRIBUTING.md) for
 
 ## Security
 
-Security is our top priority. Please report any vulnerabilities responsibly. See [SECURITY.md](docs/SECURITY.md) for details.
+Security is our top priority. Please report any vulnerabilities responsibly. See [Security and Privacy Audit](SECURITY_PRIVACY_AUDIT.md) for details.
 
 ## License
 


### PR DESCRIPTION
## Summary
- correct broken `SECURITY.md` link in README

## Testing
- `python -m pytest` *(fails: 12 failed, 144 passed)*

------
https://chatgpt.com/codex/tasks/task_e_683ff88488fc832f87f15d14e52c5891