### PR TITLE
Make compose run relay only

### DIFF
--- a/CROSS_PLATFORM.md
+++ b/CROSS_PLATFORM.md
@@ -15,26 +15,21 @@ This document explains the improvements made to make token.place work seamlessly
 
 ## Docker Containerization
 
-We've implemented Docker support for easy deployment of all components:
+We've implemented Docker support for easy deployment:
 
-- `docker/Dockerfile.server` - Server component container
 - `docker/Dockerfile.relay` - Relay component container
-- `docker/Dockerfile.api` - API component container
-- `docker-compose.yml` - Orchestrates all services together
+- `docker-compose.yml` - Launches the relay service
 
 ### Building and Running with Docker
 
 ```bash
-# Build and start all services
+# Build and start the relay service
 docker-compose up -d
-
-# Build and start a specific service
-docker-compose up -d server
 
 # View logs
 docker-compose logs -f
 
-# Stop all services
+# Stop the service
 docker-compose down
 ```
 

--- a/README.md
+++ b/README.md
@@ -210,30 +210,8 @@ Launch the relay, which runs on http://localhost:5000:
 python relay.py
 ```
 
-Then, in a separate terminal tab, launch the server, which runs on http://localhost:3000:
-
-```sh
-python server.py
-```
-
-NOTE: When first launched, or if the model file isn't present (currently only [Llama 3 8B Instruct GGUF](https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF)), the script will download the model (approximately 4GB) and will save it in the `models/` directory in your project directory under the same filename. This will be gated by user interaction in the future to prevent large file downloads without the user's consent. Eventually you'll basically browse models and choose one from a list.
-
-#### Mock LLM Mode for Testing
-
-For faster testing without downloading the full model, you can use mock mode:
-
-```sh
-python server.py --use_mock_llm
-```
-
-Or set the environment variable:
-
-```sh
-export USE_MOCK_LLM=1
-python server.py
-```
-
-This mode provides mock responses for all queries, making it ideal for development and testing.
+The relay listens on port 5000. It expects a running server specified by the
+`SERVER_URL` environment variable.
 
 ### Using the Application
 
@@ -512,7 +490,7 @@ scripts\start.bat
 
 **Docker:**
 ```bash
-docker-compose up -d
+docker-compose up -d  # starts the relay service
 ```
 
 ## Features
@@ -526,10 +504,9 @@ docker-compose up -d
 ## Quick Start
 
 1. Clone the repository
-2. Install server dependencies with `pip install -r requirements_server.txt`
-   (for relay-only nodes, use `pip install -r requirements_relay.txt`)
-3. Run the server with `python server.py`
-4. Connect to the server at `http://localhost:5000`
+2. Install relay dependencies with `pip install -r requirements_relay.txt`
+3. Run the relay with `python relay.py`
+4. Ensure the `SERVER_URL` environment variable points at your server
 
 ## Development
 

--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ DEFAULT_CONFIG = {
     # Server settings
     'server': {
         'host': '0.0.0.0',
-        'port': 8000,
+        'port': 5000,
         'debug': False,
         'workers': 4,
         'timeout': 30,
@@ -39,7 +39,7 @@ DEFAULT_CONFIG = {
     'relay': {
         'host': '0.0.0.0',
         'port': 5000,
-        'server_url': 'http://localhost:8000',
+        'server_url': 'http://localhost:5000',
         'workers': 2,
     },
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,57 +1,14 @@
 version: '3.8'
 
 services:
-  server:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.server
-    ports:
-      - "8000:8000"
-    volumes:
-      - ./data:/app/data
-    environment:
-      - PLATFORM=${PLATFORM:-linux}
-      - ENV=${ENV:-development}
-    restart: unless-stopped
-    networks:
-      - token-network
-
   relay:
     build:
       context: .
       dockerfile: docker/Dockerfile.relay
     ports:
       - "5000:5000"
-    depends_on:
-      - server
     environment:
       - PLATFORM=${PLATFORM:-linux}
       - ENV=${ENV:-development}
-      - SERVER_URL=http://server:8000
+      - SERVER_URL=${SERVER_URL:-http://localhost:5000}
     restart: unless-stopped
-    networks:
-      - token-network
-
-  api:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.api
-    ports:
-      - "3000:3000"
-    depends_on:
-      - relay
-    environment:
-      - PLATFORM=${PLATFORM:-linux}
-      - ENV=${ENV:-development}
-      - RELAY_URL=http://relay:5000
-    restart: unless-stopped
-    networks:
-      - token-network
-
-networks:
-  token-network:
-    driver: bridge
-
-volumes:
-  data:
-    driver: local

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -32,7 +32,7 @@ USER appuser
 ENV PYTHONUNBUFFERED=1
 
 # Expose the port the server runs on
-EXPOSE 8000
+EXPOSE 5000
 
 # Command to run the server
 CMD ["python", "-m", "server.main"] 

--- a/docs/RPI_RELAY_RUNBOOK.md
+++ b/docs/RPI_RELAY_RUNBOOK.md
@@ -27,6 +27,9 @@ git clone https://github.com/futuroptimist/token.place.git
 cd token.place
 ```
 
+ 
+The relay listens on port 5000. Set the `SERVER_URL` environment variable to point at your server.
+
 ## 3. Configure relay
 
 The relay container needs to know where your server instance is running.
@@ -41,14 +44,14 @@ The relay container needs to know where your server instance is running.
    - **Temporary for the current shell:**
 
      ```bash
-     export SERVER_URL="http://192.168.1.100:8000"
+    export SERVER_URL="http://192.168.1.100:5000"
      ```
 
    - **Persistent with a `.env` file** (create this file next to
      `docker-compose.yml`):
 
      ```
-     SERVER_URL=http://192.168.1.100:8000
+    SERVER_URL=http://192.168.1.100:5000
      ```
 
 Docker Compose automatically loads variables from `.env` when you run the
@@ -56,10 +59,10 @@ Docker Compose automatically loads variables from `.env` when you run the
 
 ## 4. Start relay with Docker Compose
 
-Launch only the relay service (skip the bundled server and API containers):
+The compose file now only defines the relay service, so simply run:
 
 ```bash
-docker compose up -d --no-deps relay
+docker compose up -d
 ```
 
 The relay listens on port 5000 by default.


### PR DESCRIPTION
## Summary
- keep Docker compose focused on running the relay service
- default all docs and configs to port 5000

## Testing
- `python -m pytest test_encrypt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68468fe77d8c832fb9e52f80916556bd