### PR TITLE
Improve setup docs and test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@ Run tests with a specific marker using:
 python -m pytest -m marker_name
 ```
 
+For convenience, you can execute all available test suites with `./run_all_tests.sh` (or `./run_all_tests.ps1` on Windows).
+
 ## Configuration
 
 - [config.py](config.py): Configuration management for different environments

--- a/README.md
+++ b/README.md
@@ -108,13 +108,24 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 You may be missing some CMAKE dependencies
 
-on Debian, you can run the following
+on Debian/Ubuntu you can run the following
 
 ```sh
 sudo apt-get install build-essential cmake
 ```
 
-TODO: instructions for other common OSes
+on macOS, install the Xcode command line tools and CMake via Homebrew:
+
+```sh
+xcode-select --install  # if not already installed
+brew install cmake
+```
+
+On other Linux distributions, use your package manager to install the equivalents of `build-essential` and `cmake`. For example on Fedora:
+
+```sh
+sudo dnf install gcc-c++ make cmake
+```
 
 then, run:
 
@@ -191,12 +202,21 @@ llm = Llama(
 `n_gpu_layers` instructs llama to use as much of your GPU resources as possible.
 
 #### macos
+Install the [Homebrew](https://brew.sh) package manager if you haven't already,
+then reinstall `llama-cpp-python` with Metal support:
 
-TODO
+```sh
+brew install cmake
+CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --upgrade
+```
 
 #### unix/linux
+Most distributions can compile `llama-cpp-python` with OpenBLAS:
 
-TODO
+```sh
+sudo apt-get install build-essential cmake libopenblas-dev
+CMAKE_ARGS="-DLLAMA_OPENBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --upgrade
+```
 
 ## Running the servers
 
@@ -243,6 +263,17 @@ Run all tests:
 
 ```sh
 python -m pytest
+```
+
+To execute all available test suites (including JavaScript and end‑to‑end tests), use:
+
+```bash
+./run_all_tests.sh
+```
+or on Windows:
+
+```powershell
+./run_all_tests.ps1
 ```
 
 Run specific test files:
@@ -523,6 +554,8 @@ npm run test:js
 # Run crypto compatibility tests
 python tests/test_crypto_compatibility_simple.py
 ```
+
+To run every test category in one command (including Playwright and JS tests) execute `./run_all_tests.sh` (or `./run_all_tests.ps1` on Windows).
 
 ### Windows PowerShell Tips
 

--- a/client.py
+++ b/client.py
@@ -12,15 +12,14 @@ from cryptography.hazmat.backends import default_backend
 # Use an environment variable to determine the environment
 environment = os.getenv('ENVIRONMENT', 'dev')  # Default to 'dev' if not set
 
-# Choose the base URL based on the environment
-base_url = 'http://token.place' if environment == 'prod' else 'http://localhost'
-
-# TODO: handle prod case, where the port shouldn't be hardcoded (as we can't determine in advance if it's 80 or 443)
+# Choose the base domain based on the environment
+base_url = "http://token.place" if environment == "prod" else "http://localhost"
 
 # --- Configuration ---
 # Use the correct base URL for your running relay/API
+# You can override this with the API_BASE_URL environment variable.
 # If running locally with default port 5070:
-API_BASE_URL = "http://localhost:5070/api/v1" 
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:5070/api/v1")
 # Or use "http://localhost:5070" if targeting relay endpoints directly
 
 CLIENT_KEYS_DIR = "client_keys"


### PR DESCRIPTION
## Summary
- add note about full test script to `AGENTS.md`
- document cross-platform dependency installation
- add macOS/Linux GPU instructions
- mention `run_all_tests` scripts in README
- make client API base URL configurable with env var

## Testing
- `python -m pytest tests/unit -q`
- `npm run test:js`

------
https://chatgpt.com/codex/tasks/task_e_684931a06a24832fa119c6cdf5b53ea6