### PR TITLE
Fix README roadmap for relay cluster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,8 @@ For convenience, you can execute all available test suites with `./run_all_tests
 - [utils/logging/logger.py](utils/logging/logger.py): Logging infrastructure for the application
 - [pytest.ini](pytest.ini): Configuration for Python test suite
 - **Privacy**: Do not log plaintext or ciphertext of user messages. Remove debugging statements that could leak sensitive data.
+
+## Development Tips
+
+- Run `./run_all_tests.sh` to verify changes before committing.
+- Keep the roadmap in [README.md](README.md) updated as features progress.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
   - [x] automated browser testing of landing page, preventing regressions of the chat ui
   - [x] delete old /inference endpoint and everything upstream and downstream that's now unused
   - [x] simplified crypto utility (CryptoClient) for easy encrypted communication
-- [x] distribute relay.py across 2 or more machines
+- [ ] distribute relay.py across multiple machines
   - [x] personal gaming PC
-  - [x] basic DigitalOcean droplet
+  - [ ] raspi k3s pod
+  - [ ] once k3s pod is stable, run relay.py only on the cluster
+  - [ ] optional cloud fallback via Cloudflare
 - [x] OpenAI-compatible API with end-to-end encryption
   - [x] Models listing endpoint
   - [x] Chat completions endpoint
@@ -43,7 +45,9 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [x] landing page chat UI integrated with API v1
 - [ ] use best available llama family model that can run on an RTX 4090
 - [ ] [https://github.com/democratizedspace/dspace](DSPACE) (first 1st party integration) uses API v1 for dChat
-- [ ] set up production server (raspberry pi cluster lol)
+- [ ] set up production k3s raspberry pi pod running relay.py
+  - [ ] server.py stays on personal gaming PC
+  - [ ] potential cloud fallback node via Cloudflare
 - [ ] allow participation from other server.pys
   - [x] split relay/server python dependencies to reduce installation toil for relay-only nodes
 - [ ] API v2 with at least 10 models supported and available


### PR DESCRIPTION
## Summary
- update roadmap to clarify that only gaming PC is running the relay
- note future raspberry pi k3s pod and cloud fallback
- add development tips to `AGENTS.md`

## Testing
- `./run_all_tests.sh` *(fails: Node.js RSA decryption error)*

------
https://chatgpt.com/codex/tasks/task_e_684f8d2df274832f99d9f5ec83d648bd