### PR TITLE
Speed up CI with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: 'npm'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Install Node.js dependencies
-        run: npm install
+        run: npm ci
       - name: Run tests
         run: ./run_all_tests.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,4 @@ For convenience, you can execute all available test suites with `./run_all_tests
 
 - Run `./run_all_tests.sh` to verify changes before committing.
 - Keep the roadmap in [README.md](README.md) updated as features progress.
+- Use `npm ci` for faster, reproducible Node.js installs (mirrors the CI pipeline's behavior).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
   - [x] End-to-end tests with mock LLM
   - [x] Support for testing with real LLM models
   - [x] GitHub Actions CI for automated tests
+  - [x] CI caching for faster dependency installs
 - [x] API v1 with at least 1 model supported and available
 - [x] landing page chat UI integrated with API v1
 - [ ] use best available llama family model that can run on an RTX 4090


### PR DESCRIPTION
## Summary
- cache Python and Node dependencies in CI
- use `npm ci` for reproducible Node installs
- note CI caching on the roadmap
- mention `npm ci` tip for contributors

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fca8be6b0832fbef50c0c3fde58a2