### PR TITLE
Add CI coverage badge and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,10 @@ jobs:
         run: npm ci
       - name: Run tests
         run: ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ wheels/
 # Coverage
 .coverage
 htmlcov/
+coverage.xml
 
 # Node.js
 node_modules/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # token.place
+
+[![CI](https://github.com/futuroptimist/token.place/actions/workflows/ci.yml/badge.svg)](https://github.com/futuroptimist/token.place/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/futuroptimist/token.place/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/token.place)
+
 p2p generative AI platform
 
 # vision
@@ -307,7 +311,8 @@ python -m pytest tests/test_e2e_network.py
 Run tests with coverage report:
 
 ```sh
-python -m pytest --cov=.
+TEST_COVERAGE=1 ./run_all_tests.sh
+# Coverage results are uploaded to Codecov on CI
 ```
 
 ### Test Categories
@@ -576,7 +581,7 @@ npm run test:js
 python tests/test_crypto_compatibility_simple.py
 ```
 
-To run every test category in one command (including Playwright and JS tests) execute `./run_all_tests.sh` (or `./run_all_tests.ps1` on Windows).
+To run every test category in one command (including Playwright and JS tests) execute `TEST_COVERAGE=1 ./run_all_tests.sh` (or `./run_all_tests.ps1` on Windows).
 
 ### Windows PowerShell Tips
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -120,6 +120,6 @@ For convenience, you can execute all available test suites with `./run_all_tests
 
 ## Development Tips
 
-- Run `./run_all_tests.sh` to verify changes before committing.
+- Run `./run_all_tests.sh` to verify changes before committing. Set `TEST_COVERAGE=1` to collect coverage data when running this script. Coverage is uploaded to Codecov automatically via the GitHub Actions workflow.
 - Keep the roadmap in [README.md](README.md) updated as features progress.
 - Use `npm ci` for faster, reproducible Node.js installs (mirrors the CI pipeline's behavior).

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -3,6 +3,16 @@
 
 set -e
 
+# Enable coverage collection if TEST_COVERAGE=1
+if [ "$TEST_COVERAGE" = "1" ]; then
+    echo "Coverage mode enabled"
+    COVERAGE_ARGS="--cov=. --cov-append"
+    COVERAGE_MODE=true
+else
+    COVERAGE_ARGS=""
+    COVERAGE_MODE=false
+fi
+
 echo "======================================================"
 echo " token.place Test Runner"
 echo "======================================================"
@@ -41,38 +51,38 @@ run_test() {
 }
 
 # 1. Run main Python tests
-run_test "Python Unit Tests" "python -m pytest tests/unit/ -v" "Testing individual components in isolation"
+run_test "Python Unit Tests" "python -m pytest tests/unit/ -v $COVERAGE_ARGS" "Testing individual components in isolation"
 
 # 2. Run integration tests if they exist
 if [ -d "tests/integration/" ]; then
-    run_test "Python Integration Tests" "python -m pytest tests/integration/ -v" "Testing interactions between components"
+    run_test "Python Integration Tests" "python -m pytest tests/integration/ -v $COVERAGE_ARGS" "Testing interactions between components"
 fi
 
 # 3. Run API tests
-run_test "API Tests" "python -m pytest tests/test_api.py -v" "Testing API functionality and compatibility"
+run_test "API Tests" "python -m pytest tests/test_api.py -v $COVERAGE_ARGS" "Testing API functionality and compatibility"
 
 # 4. Run crypto compatibility tests - simple
-run_test "Crypto Compatibility Tests (Simple)" "python tests/test_crypto_compatibility_simple.py" "Testing cross-language compatibility for encryption (simple tests)"
+run_test "Crypto Compatibility Tests (Simple)" "python tests/test_crypto_compatibility_simple.py $COVERAGE_ARGS" "Testing cross-language compatibility for encryption (simple tests)"
 
 # 5. Run crypto compatibility tests - local
-run_test "Crypto Compatibility Tests (Local)" "python tests/test_crypto_compatibility_local.py" "Testing cross-language compatibility for encryption (local tests)"
+run_test "Crypto Compatibility Tests (Local)" "python tests/test_crypto_compatibility_local.py $COVERAGE_ARGS" "Testing cross-language compatibility for encryption (local tests)"
 
 # 6. Run crypto compatibility tests - Playwright
-run_test "Crypto Compatibility Tests (Playwright)" "python -m pytest tests/test_crypto_compatibility_playwright.py -v" "Testing cross-language compatibility in browsers with Playwright"
+run_test "Crypto Compatibility Tests (Playwright)" "python -m pytest tests/test_crypto_compatibility_playwright.py -v $COVERAGE_ARGS" "Testing cross-language compatibility in browsers with Playwright"
 
 # 7. Run JavaScript tests
 run_test "JavaScript Tests" "npm run test:js" "Testing JavaScript functionality"
 
 # 8. Run E2E tests
 if [ "$RUN_E2E" = "1" ]; then
-    run_test "End-to-End Tests" "python -m pytest tests/test_e2e_*.py -v" "Testing complete workflows"
+    run_test "End-to-End Tests" "python -m pytest tests/test_e2e_*.py -v $COVERAGE_ARGS" "Testing complete workflows"
 else
     echo "Skipping End-to-End Tests (set RUN_E2E=1 to enable)"
 fi
 
 # 9. Run failure recovery tests
 if [ "$RUN_E2E" = "1" ]; then
-    run_test "Failure Recovery Tests" "python -m pytest tests/test_failure_recovery.py -v" "Testing system resilience against errors"
+    run_test "Failure Recovery Tests" "python -m pytest tests/test_failure_recovery.py -v $COVERAGE_ARGS" "Testing system resilience against errors"
 else
     echo "Skipping Failure Recovery Tests (set RUN_E2E=1 to enable)"
 fi
@@ -97,6 +107,11 @@ if [ -d "integration_tests/" ]; then
     else
         echo -e "\e[32m✅ DSPACE Integration Tests passed\e[0m"
     fi
+fi
+
+# Generate coverage report if enabled
+if [ "$COVERAGE_MODE" = true ]; then
+    coverage xml
 fi
 
 # Summary


### PR DESCRIPTION
## Summary
- display CI and Codecov badges in the README
- ignore coverage.xml output
- allow coverage collection via TEST_COVERAGE in run_all_tests.sh
- upload coverage in the CI workflow
- mention TEST_COVERAGE in AGENTS instructions
- document that coverage uploads to Codecov

## Testing
- `npm install`
- `playwright install`
- `TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851d41960dc832f8148dc6e46320756