### PR TITLE
Increase coverage with new unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = .
+[report]
+omit =
+    tests/*

--- a/tests/unit/test_chat_client.py
+++ b/tests/unit/test_chat_client.py
@@ -1,0 +1,35 @@
+import base64
+import json
+from unittest.mock import patch, MagicMock
+
+from client import ChatClient
+
+
+def test_get_server_public_key():
+    client = ChatClient('http://testserver', relay_port=5000)
+    with patch('client.requests.get') as mock_get:
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {'server_public_key': base64.b64encode(b'k').decode()}
+        mock_get.return_value = resp
+        key = client.get_server_public_key()
+        assert key == b'k'
+        mock_get.assert_called_with('http://testserver:5000/next_server')
+
+
+def test_send_message_flow():
+    client = ChatClient('http://test', relay_port=5000)
+    with patch.object(client, 'get_server_public_key', return_value=b'server_key') as m_get, \
+         patch('client.encrypt') as m_enc, \
+         patch('client.decrypt') as m_dec, \
+         patch.object(client, 'send_request_to_faucet') as m_faucet, \
+         patch.object(client, 'retrieve_response') as m_retrieve:
+        m_enc.return_value = ({'ciphertext': b'data', 'iv': b'iv'}, b'cipher', b'iv')
+        m_dec.return_value = b'[{"role":"user","content":"hi"},{"role":"assistant","content":"ok"}]'
+        m_faucet.return_value = MagicMock(status_code=200)
+        m_retrieve.return_value = [
+            {'role': 'user', 'content': 'hi'},
+            {'role': 'assistant', 'content': 'ok'}
+        ]
+        resp = client.send_message('hi')
+        assert resp[1]['content'] == 'ok'
+        assert client.chat_history == resp

--- a/tests/unit/test_crypto_helpers_simple.py
+++ b/tests/unit/test_crypto_helpers_simple.py
@@ -1,0 +1,60 @@
+import base64
+import json
+from unittest.mock import patch, MagicMock
+
+from utils.crypto_helpers import CryptoClient
+from encrypt import generate_keys, encrypt
+
+
+def test_fetch_server_public_key():
+    with patch('utils.crypto_helpers.requests') as mock_requests:
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {'server_public_key': base64.b64encode(b'k').decode()}
+        mock_requests.get.return_value = resp
+        client = CryptoClient('https://example.com')
+        assert client.fetch_server_public_key()
+        mock_requests.get.assert_called_with('https://example.com/next_server')
+        assert client.server_public_key is not None
+
+
+def test_encrypt_decrypt_message():
+    client = CryptoClient('https://example.com')
+    # Encrypt using the client's own public key so decrypt_message can succeed
+    data = {'msg': 'hi'}
+    cipher, key, iv = encrypt(json.dumps(data).encode(), client.client_public_key)
+    enc = {
+        'ciphertext': base64.b64encode(cipher['ciphertext']).decode(),
+        'cipherkey': base64.b64encode(key).decode(),
+        'iv': base64.b64encode(iv).decode()
+    }
+    dec = client.decrypt_message(enc)
+    assert dec == data
+
+
+def test_send_chat_message():
+    with patch('utils.crypto_helpers.encrypt') as mock_enc, \
+         patch('utils.crypto_helpers.decrypt') as mock_dec, \
+         patch('utils.crypto_helpers.requests') as mock_requests:
+        mock_enc.return_value = ({'ciphertext': b'd', 'iv': b'i'}, b'k', b'i')
+        mock_dec.return_value = json.dumps([
+            {'role': 'user', 'content': 'hi'},
+            {'role': 'assistant', 'content': 'hey'}
+        ]).encode()
+        get_resp = MagicMock(status_code=200)
+        get_resp.json.return_value = {'server_public_key': base64.b64encode(b'k').decode()}
+        post_resp = MagicMock(status_code=200)
+        post_resp.json.side_effect = [
+            {'success': True},
+            {
+                'chat_history': base64.b64encode(b'd').decode(),
+                'cipherkey': base64.b64encode(b'k').decode(),
+                'iv': base64.b64encode(b'i').decode()
+            }
+        ]
+        mock_requests.get.return_value = get_resp
+        mock_requests.post.return_value = post_resp
+
+        client = CryptoClient('https://example.com')
+        resp = client.send_chat_message('hi')
+        assert isinstance(resp, list) and resp[1]['role'] == 'assistant'
+        assert mock_requests.post.call_count == 2

--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+from pathlib import Path
+from unittest import mock
+
+
+def test_paths_linux(tmp_path):
+    with mock.patch('platform.system', return_value='Linux'):
+        import utils.path_handling as ph
+        importlib.reload(ph)
+        home = Path.home()
+        assert ph.get_app_data_dir() == home / '.local' / 'share' / 'token.place'
+        assert ph.get_config_dir() == home / '.config' / 'token.place'
+        assert ph.get_cache_dir() == home / '.cache' / 'token.place'
+        assert ph.get_models_dir() == home / '.local' / 'share' / 'token.place' / 'models'
+        assert ph.get_logs_dir() == home / '.local' / 'state' / 'token.place' / 'logs'
+
+        test_dir = tmp_path / 'newdir'
+        created = ph.ensure_dir_exists(test_dir)
+        assert created.is_dir()
+
+        assert ph.get_executable_extension() == ''
+        assert ph.normalize_path('~/test').is_absolute()
+        rel = ph.get_relative_path(created, tmp_path)
+        assert rel == Path('newdir')
+
+
+def test_paths_windows(tmp_path):
+    env = {
+        'APPDATA': str(tmp_path / 'AppData' / 'Roaming'),
+        'LOCALAPPDATA': str(tmp_path / 'AppData' / 'Local')
+    }
+    with mock.patch('platform.system', return_value='Windows'):
+        with mock.patch.dict(os.environ, env, clear=False):
+            import utils.path_handling as ph
+            importlib.reload(ph)
+            base = Path(env['APPDATA'])
+            assert ph.get_app_data_dir() == base / 'token.place'
+            assert ph.get_config_dir() == base / 'token.place' / 'config'
+            assert ph.get_cache_dir() == Path(env['LOCALAPPDATA']) / 'token.place' / 'cache'
+            assert ph.get_logs_dir() == base / 'token.place' / 'logs'
+            assert ph.get_executable_extension() == '.exe'
+
+
+def test_paths_macos(tmp_path):
+    with mock.patch('platform.system', return_value='Darwin'):
+        import utils.path_handling as ph
+        importlib.reload(ph)
+        home = Path.home()
+        assert ph.get_app_data_dir() == home / 'Library' / 'Application Support' / 'token.place'
+        assert ph.get_config_dir() == home / 'Library' / 'Application Support' / 'token.place' / 'config'
+        assert ph.get_cache_dir() == home / 'Library' / 'Caches' / 'token.place'
+        assert ph.get_logs_dir() == home / 'Library' / 'Logs' / 'token.place'

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+import server.server_app as sa
+
+
+def test_parse_args_defaults(monkeypatch):
+    import sys
+    monkeypatch.setattr(sys, 'argv', ['server.py'])
+    args = sa.parse_args()
+    assert args.server_port == 3000
+    assert args.relay_port == 5000
+    assert args.relay_url == "http://localhost"
+    assert args.use_mock_llm is False
+
+
+def test_initialize_llm_mock():
+    with patch('server.server_app.get_model_manager') as gm:
+        gm.return_value.use_mock_llm = True
+        app = sa.ServerApp()
+        # initialize_llm called in __init__; ensure method executed
+        gm.assert_called()
+
+
+def test_initialize_llm_download():
+    mm = MagicMock()
+    mm.use_mock_llm = False
+    mm.download_model_if_needed.return_value = True
+    with patch('server.server_app.get_model_manager', return_value=mm):
+        app = sa.ServerApp()
+        mm.download_model_if_needed.assert_called_once()
+
+
+def test_start_relay_polling():
+    with patch('server.server_app.RelayClient') as rc:
+        instance = rc.return_value
+        instance.poll_relay_continuously = MagicMock()
+        app = sa.ServerApp()
+        with patch('threading.Thread') as th:
+            thread = MagicMock()
+            th.return_value = thread
+            app.start_relay_polling()
+            thread.start.assert_called_once()


### PR DESCRIPTION
## Summary
- add `.coveragerc` to exclude tests from report
- create tests for path handling utilities, CryptoClient, ChatClient and server app
- achieve over 60% test coverage

## Testing
- `RUN_E2E=1 TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685318bd52ec832f84ed69576620ffe7