### PR TITLE
Improve validation and model unit tests

### DIFF
--- a/tests/unit/test_api_v1_models_additional.py
+++ b/tests/unit/test_api_v1_models_additional.py
@@ -1,0 +1,44 @@
+import importlib
+import os
+import random
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
+def test_get_model_instance_mock():
+    import api.v1.models as models
+    importlib.reload(models)
+    inst = models.get_model_instance('llama-3-8b-instruct')
+    assert inst == "MOCK_MODEL"
+
+
+@patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
+def test_get_model_instance_invalid():
+    import api.v1.models as models
+    importlib.reload(models)
+    with pytest.raises(models.ModelError):
+        models.get_model_instance('bad-id')
+
+
+@patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
+def test_generate_response_mock(monkeypatch):
+    import api.v1.models as models
+    importlib.reload(models)
+    # Force deterministic choice
+    monkeypatch.setattr(random, 'choice', lambda seq: seq[0])
+    messages = [{'role': 'user', 'content': 'hi'}]
+    resp = models.generate_response('llama-3-8b-instruct', messages)
+    assert resp[-1]['role'] == 'assistant'
+    assert 'Mock response:' in resp[-1]['content']
+
+
+@patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
+def test_generate_response_validation_errors():
+    import api.v1.models as models
+    importlib.reload(models)
+    with pytest.raises(models.ModelError):
+        models.generate_response('llama-3-8b-instruct', [])
+    bad_messages = [{'role': 'user'}]
+    with pytest.raises(models.ModelError):
+        models.generate_response('llama-3-8b-instruct', bad_messages)

--- a/tests/unit/test_api_v1_validation.py
+++ b/tests/unit/test_api_v1_validation.py
@@ -1,0 +1,49 @@
+import pytest
+import base64
+from api.v1 import validation as val
+
+
+def test_validate_required_fields_missing():
+    with pytest.raises(val.ValidationError) as exc:
+        val.validate_required_fields({'a': 1}, ['a', 'b'])
+    assert 'Missing required parameter: b' in str(exc.value)
+
+
+def test_validate_field_type_invalid():
+    data = {'num': 'not-int'}
+    with pytest.raises(val.ValidationError):
+        val.validate_field_type(data, 'num', int)
+
+
+def test_validate_string_length_bounds():
+    data = {'s': 'abc'}
+    with pytest.raises(val.ValidationError):
+        val.validate_string_length(data, 's', min_length=5)
+    with pytest.raises(val.ValidationError):
+        val.validate_string_length(data, 's', max_length=2)
+
+
+def test_validate_base64_invalid():
+    with pytest.raises(val.ValidationError):
+        val.validate_base64({'b64': 'abc!'}, 'b64')
+
+
+def test_validate_json_string_invalid():
+    with pytest.raises(val.ValidationError):
+        val.validate_json_string({'js': 'not-json'}, 'js')
+
+
+def test_validate_chat_messages_invalid_role():
+    messages = [{'role': 'bad', 'content': 'hi'}]
+    with pytest.raises(val.ValidationError):
+        val.validate_chat_messages(messages)
+
+
+def test_validate_encrypted_request_missing_fields():
+    with pytest.raises(val.ValidationError):
+        val.validate_encrypted_request({'client_public_key': 'x'})
+
+
+def test_validate_model_name_not_found():
+    with pytest.raises(val.ValidationError):
+        val.validate_model_name('nope', ['model'])

--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -74,3 +74,23 @@ def test_send_chat_message_unexpected_faucet(monkeypatch):
     client = _prep_client()
     monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(return_value={'success': False}))
     assert client.send_chat_message('hi') is None
+
+def test_send_chat_message_fetch_key_fail(monkeypatch):
+    client = _prep_client()
+    monkeypatch.setattr(client, 'fetch_server_public_key', lambda: False)
+    assert client.send_chat_message('hi') is None
+
+
+def test_retrieve_chat_response_server_error(monkeypatch):
+    client = _prep_client()
+    # First call to send_encrypted_message returns {'error': 'fail'} so it exits
+    monkeypatch.setattr(client, 'send_encrypted_message', lambda *a, **k: {'error': 'fail'})
+    result = client.retrieve_chat_response(max_retries=1, retry_delay=0)
+    assert result is None
+
+
+def test_send_api_request_invalid_format(monkeypatch):
+    client = _prep_client()
+    monkeypatch.setattr(client, 'send_encrypted_message', lambda *a, **k: {'unexpected': True})
+    res = client.send_api_request([{'role': 'user', 'content': 'hi'}])
+    assert res is None


### PR DESCRIPTION
## Summary
- add unit tests for API validation helpers
- add additional unit tests for API model helpers
- extend tests for crypto helpers error handling
- expand API tests with edge cases

## Testing
- `TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685336335748832fada704e6cc0f7da8