### PR TITLE
Update RPI deploy docs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -15,6 +15,7 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 ## Setup and Installation
 
 - [README.md](README.md): Project overview and getting started instructions
+- [docs/ONBOARDING.md](docs/ONBOARDING.md): Quick orientation to the repository structure
 - [requirements.txt](requirements.txt): Python dependencies for the project
 - [package.json](package.json): Node.js dependencies for JavaScript components
 - `docker-compose up` starts the relay container for quick local testing


### PR DESCRIPTION
## Summary
- document how to back out of the token.place directory before cloning **rpi-clone**
- explain the terminal commands in the Raspberry Pi deployment guide
- mention the ONBOARDING guide in AGENTS

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860e363b56c832f905dea4dfe5e182f