### PR TITLE
Clarify rpi-clone prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Alternatively, you can visit http://localhost:5000 in your browser to use the we
 
 ### Raspberry Pi 5 deployment
 
-For a complete walkthrough of the Raspberry Pi 5 setup—including hardware recommendations, Docker instructions, k3s cluster steps, and troubleshooting—see [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials).
+For a complete walkthrough of the Raspberry Pi 5 setup—including hardware recommendations, Docker instructions, k3s cluster steps, and troubleshooting (including rpi-clone prompts)—see [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials).
 
 ## Testing
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -36,7 +36,7 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [docs/TESTING_IMPROVEMENTS.md](docs/TESTING_IMPROVEMENTS.md): Ideas for further testing improvements
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): Detailed architectural overview of the system
 - [docs/LLM_ASSISTANT_GUIDE.md](docs/LLM_ASSISTANT_GUIDE.md): Guide for AI assistants working with this codebase
-- [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials): Hardware list, setup instructions, and troubleshooting tips for Raspberry Pi deployments
+- [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials): Hardware list, setup instructions, and troubleshooting tips for Raspberry Pi deployments (including rpi-clone prompt walkthrough)
 - [../llms.txt](../llms.txt): Machine-readable project summary for LLM assistants
 
 ## User Journeys

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -42,6 +42,13 @@ This list reflects our setup. Other hardware choices will also work. Contributio
    sudo raspi-config  # Advanced Options -> Boot Order -> USB Boot
    sudo poweroff                                             # shut down to switch boot devices
    ```
+The `rpi-clone` command will ask four questions:
+1. When asked to *Initialize and clone to the destination disk*, type `yes`.
+2. At the optional rootfs label prompt, press Enter (or provide a custom label).
+3. When prompted to *Run setup script (no)*, just press Enter.
+4. For *Verbose mode (no)*, press Enter.
+You can skip these questions on later runs with `sudo rpi-clone -u /dev/sda`.
+
 6. Remove the SD card and power on. The Pi should boot from the SSD. Repeat for the remaining nodes using the same SD card.
 
 ### Moving the SSD to the M.2 slot


### PR DESCRIPTION
## Summary
- document rpi-clone interactive options in the Raspberry Pi deployment guide
- highlight the new instructions in docs/AGENTS
- mention rpi-clone prompts in README

## Testing
- `npm ci`
- `playwright install chromium`
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860e60305bc832fb64adf0ebc2a639a