### PR TITLE
Add governance files and pre-commit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+- **What happened:**
+- **Expected behavior:**
+- **Steps to reproduce:**
+
+## Additional Context
+Add screenshots or logs if helpful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+- **Type of change:** _feature_, _fix_, or _docs_
+- **Related issues:** closes #
+
+## Checklist
+- [ ] Linted
+- [ ] Tests added/updated
+- [ ] Docs updated
+- [ ] AGENTS.md updated if applicable
+
+## Notes
+Describe any notable changes or additional context.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: local
+    hooks:
+      - id: run-checks
+        name: run project checks
+        entry: bash scripts/checks.sh
+        language: script
+        pass_filenames: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Be kind, inclusive, and constructive. Report unacceptable behavior to the maintainers.

--- a/README.md
+++ b/README.md
@@ -608,6 +608,12 @@ curl http://localhost:5000/test
 ## Contributing
 
 We welcome contributions! See our [Contributing Guide](docs/CONTRIBUTING.md) for details.
+Before submitting commits, install the pre-commit hooks and run them locally:
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
 
 ## Security
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -122,6 +122,7 @@ For convenience, you can execute all available test suites with `./run_all_tests
 ## Development Tips
 
 - Run `./run_all_tests.sh` to verify changes before committing. Set `TEST_COVERAGE=1` to collect coverage data when running this script. Coverage is uploaded to Codecov automatically via the GitHub Actions workflow.
+- Install `pre-commit` and run `pre-commit run --all-files` before pushing changes.
 - Keep the roadmap in [README.md](README.md) updated as features progress.
 - Use `npm ci` for faster, reproducible Node.js installs (mirrors the CI pipeline's behavior).
 - Install Python dependencies with `pip install -r config/requirements_server.txt` and `pip install -r config/requirements_relay.txt` before running tests. If Playwright tests complain about missing browsers, run `playwright install chromium`.

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+# Run all tests and code quality checks
+./run_all_tests.sh


### PR DESCRIPTION
## Summary
- add Code of Conduct and PR/issue templates
- add pre‑commit config with checks script
- document pre‑commit usage in README and AGENTS guide

## Testing
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6861cef9a058832f9796af46c80f5277