### PR TITLE
Add padding & RSA fallback tests

### DIFF
--- a/tests/unit/test_client_simplified.py
+++ b/tests/unit/test_client_simplified.py
@@ -1,0 +1,47 @@
+import builtins
+from unittest.mock import patch, MagicMock
+import client_simplified as cs
+
+
+def test_format_message_user_and_assistant():
+    user_msg = {"role": "user", "content": "hi"}
+    assistant_msg = {"role": "assistant", "content": "hello"}
+    other_msg = {"role": "system", "content": "info"}
+    assert "User:" in cs.format_message(user_msg)
+    assert "Assistant:" in cs.format_message(assistant_msg)
+    assert "System:" in cs.format_message(other_msg)
+
+
+def test_main_single_message(monkeypatch, capsys):
+    mock_client = MagicMock()
+    mock_client.fetch_server_public_key.return_value = True
+    mock_client.send_chat_message.return_value = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    with patch.object(cs, "CryptoClient", return_value=mock_client):
+        monkeypatch.setattr(cs.sys, "argv", ["client_simplified.py", "--message", "hi"])
+        cs.main()
+    out = capsys.readouterr().out
+    assert "Assistant: ok" in out
+    mock_client.fetch_server_public_key.assert_called_once()
+    mock_client.send_chat_message.assert_called_once()
+
+
+def test_chat_loop_single_iteration(monkeypatch, capsys):
+    mock_client = MagicMock()
+    mock_client.fetch_server_public_key.return_value = True
+    mock_client.send_chat_message.return_value = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    inputs = iter(["hi", "exit"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+    monkeypatch.setattr(cs, "clear_screen", lambda: None)
+
+    cs.chat_loop(mock_client)
+    out = capsys.readouterr().out
+    assert "Assistant is thinking" in out
+    assert "ok" in out

--- a/tests/unit/test_decrypt_fallback.py
+++ b/tests/unit/test_decrypt_fallback.py
@@ -1,0 +1,9 @@
+from encrypt import generate_keys, encrypt, decrypt
+
+
+def test_decrypt_pkcs1v15_fallback():
+    priv, pub = generate_keys()
+    message = b"fallback test"
+    ciphertext_dict, cipherkey, _ = encrypt(message, pub, use_pkcs1v15=True)
+    decrypted = decrypt(ciphertext_dict, cipherkey, priv)
+    assert decrypted == message

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -1,0 +1,16 @@
+import pytest
+from encrypt import pkcs7_pad, pkcs7_unpad
+
+@pytest.mark.parametrize("data", [b"test", b"" , b"1234567890abcdef"*2])
+def test_pad_unpad_roundtrip(data):
+    padded = pkcs7_pad(data, 16)
+    assert len(padded) % 16 == 0
+    result = pkcs7_unpad(padded, 16)
+    assert result == data
+
+
+def test_unpad_invalid_padding():
+    # invalid sequence: last byte value 3 but previous bytes not all 3
+    padded = b"invalidpadding" + b"\x01\x02\x03"
+    with pytest.raises(ValueError):
+        pkcs7_unpad(padded, 16)


### PR DESCRIPTION
## Summary
- increase coverage of encrypt.py by testing PKCS7 padding helpers
- verify RSA PKCS1v15 fallback path in decrypt
- exercise client_simplified CLI via new unit tests

## Testing
- `pre-commit run --files tests/unit/test_client_simplified.py tests/unit/test_pkcs7_padding.py tests/unit/test_decrypt_fallback.py`
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6867712846a8832fb7e0126d5f338e92