### PR TITLE
Add AGENTS and CLAUDE docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# 🤖 AGENTS
+
+This repository uses lightweight LLM agents to automate routine tasks and keep the project healthy.
+
+- **Code Linter Agent** – runs lint and format checks on every pull request.
+- **Docs Agent** – checks documentation for spelling and link issues.
+- **Quest Generator Agent** – scaffolds new quests when requested.
+- **Synergy Bot** – proposes shared utilities across related repos.
+- **Release Drafter Bot** – updates release notes as commits land on `main`.
+- **Prompt Agent** – generates context-aware prompts.
+
+Before pushing changes:
+
+1. Run `./run_all_tests.sh`.
+2. Run `pre-commit run --all-files`.
+
+See [docs/AGENTS.md](docs/AGENTS.md) for full details and [CLAUDE.md](CLAUDE.md) for Claude-specific guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE
+
+Guidelines for Anthropic's Claude assistant when helping with **token.place**.
+
+- Prefer explicit IPv4 addresses like `127.0.0.1` in examples.
+- On Windows use semicolons (`;`) for command chaining instead of `&&`.
+- Keep replies concise and link to docs where possible.
+- Reference [docs/LLM_ASSISTANT_GUIDE.md](docs/LLM_ASSISTANT_GUIDE.md) for detailed tips.

--- a/llms.txt
+++ b/llms.txt
@@ -111,4 +111,6 @@ python -m pytest -m marker_name
 
 - [config.py](config.py): Configuration management for different environments
 - [utils/logging/logger.py](utils/logging/logger.py): Logging infrastructure for the application
-- [pytest.ini](pytest.ini): Configuration for Python test suite 
+- [pytest.ini](pytest.ini): Configuration for Python test suite
+
+For LLM usage guidelines, see AGENTS.md and CLAUDE.md.


### PR DESCRIPTION
## Summary
- document repo agents in a new `AGENTS.md`
- add guidance for Claude in `CLAUDE.md`
- mention these docs in `llms.txt`

## Testing
- `pre-commit run --files AGENTS.md CLAUDE.md llms.txt` *(fails: ModuleNotFoundError: No module named 'requests')*
- `./run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686775ebb13c832fac817b5af8ffd383