### PR TITLE
Improve coverage with new unit tests

### DIFF
--- a/tests/unit/test_crypto_helpers_additional.py
+++ b/tests/unit/test_crypto_helpers_additional.py
@@ -1,0 +1,32 @@
+import base64
+from unittest.mock import MagicMock
+import pytest
+from utils.crypto_helpers import CryptoClient
+
+
+def _prep_client():
+    client = CryptoClient('https://example.com')
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    return client
+
+
+def test_retrieve_chat_no_response(monkeypatch):
+    client = _prep_client()
+    monkeypatch.setattr(client, 'send_encrypted_message', lambda *a, **k: None)
+    monkeypatch.setattr('utils.crypto_helpers.time.sleep', lambda x: None)
+    result = client.retrieve_chat_response(max_retries=1, retry_delay=0)
+    assert result is None
+
+
+def test_retrieve_chat_invalid_decrypted(monkeypatch):
+    client = _prep_client()
+    enc = {
+        'chat_history': base64.b64encode(b'd').decode(),
+        'cipherkey': base64.b64encode(b'k').decode(),
+        'iv': base64.b64encode(b'i').decode()
+    }
+    monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(return_value=enc))
+    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value='oops'))
+    result = client.retrieve_chat_response(max_retries=1, retry_delay=0)
+    assert result is None

--- a/tests/unit/test_relay_client_logging.py
+++ b/tests/unit/test_relay_client_logging.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+import utils.networking.relay_client as rc
+
+
+def test_log_info_respects_config(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(rc, 'logger', logger)
+    config = MagicMock(is_production=False)
+    monkeypatch.setattr(rc, 'get_config_lazy', lambda: config)
+    rc.log_info('Hi {}', 'there')
+    logger.info.assert_called_with('Hi there')
+    logger.info.reset_mock()
+    config.is_production = True
+    rc.log_info('No log')
+    logger.info.assert_not_called()
+
+
+def test_log_info_fallback(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(rc, 'logger', logger)
+    def boom():
+        raise Exception('fail')
+    monkeypatch.setattr(rc, 'get_config_lazy', boom)
+    rc.log_info('Hello {}', 'world')
+    logger.info.assert_called_with('Hello world')
+
+
+def test_log_error_respects_config(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(rc, 'logger', logger)
+    config = MagicMock(is_production=False)
+    monkeypatch.setattr(rc, 'get_config_lazy', lambda: config)
+    rc.log_error('Err {}', 'oops')
+    logger.error.assert_called_with('Err oops', exc_info=False)
+    logger.error.reset_mock()
+    config.is_production = True
+    rc.log_error('Silence')
+    logger.error.assert_not_called()
+
+
+def test_log_error_fallback(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(rc, 'logger', logger)
+    def boom():
+        raise Exception('fail')
+    monkeypatch.setattr(rc, 'get_config_lazy', boom)
+    rc.log_error('Bad {}', 'news', exc_info=True)
+    logger.error.assert_called_with('Bad news', exc_info=True)


### PR DESCRIPTION
## Summary
- add CryptoClient retrieval edge case tests
- add tests for relay logger helpers

## Testing
- `python -m pytest tests/unit/test_crypto_helpers_additional.py tests/unit/test_relay_client_logging.py -v`
- `TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868c801d8c8832f95f341c0b4f7f06f