### PR TITLE
Increase test coverage to 91%

### DIFF
--- a/tests/unit/test_api_v1_routes_errors.py
+++ b/tests/unit/test_api_v1_routes_errors.py
@@ -1,0 +1,36 @@
+import base64
+import pytest
+from relay import app
+from api.v1 import routes
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_list_models_exception(client, monkeypatch):
+    monkeypatch.setattr(routes, "get_models_info", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    resp = client.get("/api/v1/models")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert "Internal server error" in data["error"]["message"]
+
+
+def test_get_model_exception(client, monkeypatch):
+    monkeypatch.setattr(routes, "get_models_info", lambda: (_ for _ in ()).throw(RuntimeError("fail")))
+    resp = client.get("/api/v1/models/test-model")
+    assert resp.status_code == 400
+    assert "Internal server error" in resp.get_json()["error"]["message"]
+
+
+def test_chat_completion_unexpected_error(client, monkeypatch):
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "test-model"}])
+    monkeypatch.setattr(routes, "get_model_instance", lambda m: object())
+    monkeypatch.setattr(routes, "generate_response", lambda m, msgs: (_ for _ in ()).throw(RuntimeError("oops")))
+    payload = {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]}
+    resp = client.post("/api/v1/chat/completions", json=payload)
+    assert resp.status_code == 500
+    assert "Internal server error" in resp.get_json()["error"]["message"]

--- a/tests/unit/test_api_v1_validation_additional.py
+++ b/tests/unit/test_api_v1_validation_additional.py
@@ -1,0 +1,22 @@
+import base64
+from api.v1 import validation as val
+
+
+def test_validate_field_type_allows_missing_and_none():
+    data = {}
+    assert val.validate_field_type(data, 'x', int) is None
+    data['x'] = None
+    assert val.validate_field_type(data, 'x', int, allow_none=True) is None
+
+
+def test_validate_string_length_and_base64_json():
+    data = {}
+    # field missing should simply return
+    assert val.validate_string_length(data, 's') is None
+    assert val.validate_base64(data, 'b') is None
+    assert val.validate_json_string(data, 'j') is None
+    # valid cases
+    data = {'s': 'abc', 'b': base64.b64encode(b'ok').decode(), 'j': '{"a":1}'}
+    assert val.validate_string_length(data, 's') is None
+    assert val.validate_base64(data, 'b') is None
+    assert val.validate_json_string(data, 'j') is None

--- a/tests/unit/test_crypto_helpers_additional.py
+++ b/tests/unit/test_crypto_helpers_additional.py
@@ -30,3 +30,16 @@ def test_retrieve_chat_invalid_decrypted(monkeypatch):
     monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value='oops'))
     result = client.retrieve_chat_response(max_retries=1, retry_delay=0)
     assert result is None
+
+def test_retrieve_chat_success(monkeypatch):
+    client = _prep_client()
+    enc = {
+        'chat_history': base64.b64encode(b'c').decode(),
+        'cipherkey': base64.b64encode(b'k').decode(),
+        'iv': base64.b64encode(b'i').decode()
+    }
+    monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(return_value=enc))
+    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value=[{'role':'assistant','content':'ok'}]))
+    monkeypatch.setattr('utils.crypto_helpers.time.sleep', lambda x: None)
+    result = client.retrieve_chat_response(max_retries=1, retry_delay=0)
+    assert result[0]['content'] == 'ok'


### PR DESCRIPTION
## Summary
- add missing error-handling tests for API v1 routes
- add extra validation tests for success paths
- enhance crypto helper tests with success and failure scenarios

## Testing
- `pre-commit run --files tests/unit/test_crypto_helpers_failures.py tests/unit/test_crypto_helpers_additional.py tests/unit/test_api_v1_routes_errors.py tests/unit/test_api_v1_validation_additional.py`
- `TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869ad5952d4832f9508b52603e08809