### PR TITLE
docs: note codecov app

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Run tests with coverage report:
 TEST_COVERAGE=1 ./run_all_tests.sh
 # Coverage results are uploaded to Codecov on CI
 ```
+If you don't see coverage comments on your pull requests, install the [Codecov GitHub App](https://github.com/marketplace/codecov) on your fork.
 Every pull request automatically runs this test suite in GitHub Actions, so you can rely on the status checks for pass/fail information.
 
 ### Test Categories

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -128,4 +128,5 @@ For convenience, you can execute all available test suites with `./run_all_tests
 - Install Python dependencies with `pip install -r config/requirements_server.txt` and `pip install -r config/requirements_relay.txt` before running tests. If Playwright tests complain about missing browsers, run `playwright install chromium`.
 - For development and unit testing, also run `pip install -r requirements.txt` to install extra tooling like pytest-playwright, then run `playwright install`.
 - Every pull request triggers the GitHub Actions workflow in `.github/workflows/ci.yml` which runs `./run_all_tests.sh` with coverage enabled and uploads results to Codecov.
+- Ensure the [Codecov GitHub App](https://github.com/marketplace/codecov) is installed on your fork so coverage badges and PR comments work reliably.
 - Real-world integration tests live in the [DSPACE project](https://github.com/democratizedspace/dspace); token.place acts as its OpenAI-compatible backend.


### PR DESCRIPTION
## Summary
- note the Codecov GitHub app in AGENTS and README

## Testing
- `pre-commit run --files docs/AGENTS.md README.md`
- `TEST_COVERAGE=1 ./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6869b9497020832f99281c4c37eb5c7d