### PR TITLE
Add Contributor Covenant code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,33 @@
 # Code of Conduct
 
-Be kind, inclusive, and constructive. Report unacceptable behavior to the maintainers.
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment‑free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+
+Examples of unacceptable behavior include:
+- Trolling, insulting/derogatory comments, and personal attacks
+- Public or private harassment
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards and enforcing this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project.
+
+## Enforcement
+
+Instances of abusive behavior may be reported by contacting the project maintainer at [futuroptimist@gmail.com](mailto:futuroptimist@gmail.com).
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.


### PR DESCRIPTION
## Summary
- flesh out CODE_OF_CONDUCT.md using the Contributor Covenant template

## Testing
- `pre-commit run --files CODE_OF_CONDUCT.md` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686c52c42cf8832f87621ba97e84e396