### PR TITLE
Update k3s deployment guide to note apex domain usage

### DIFF
--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -270,13 +270,26 @@ Cloudflare Tunnel.
      - service: http_status:404
    ```
 
+   > **Tip:** The `hostname` value can also be the zone's apex domain. Replace
+   > `relay.your-domain.com` with your root domain to expose the relay at the
+   > base URL:
+   >
+   > ```yaml
+   > ingress:
+   >   - hostname: your-domain.com
+   >     service: http://localhost:30500
+   >   - service: http_status:404
+   > ```
+   >
+   > Cloudflare handles the DNS record via CNAME flattening.
+
    Start the tunnel and keep it running:
 
    ```bash
    cloudflared tunnel run tokenplace-prod
    ```
 
-After the tunnel is active, your relay is reachable at `https://relay.your-domain.com` and traffic is
+After the tunnel is active, your relay is reachable at `https://relay.your-domain.com` (or `https://your-domain.com` if you used the apex domain) and traffic is
 forwarded into the k3s cluster.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- clarify that the Cloudflare Tunnel hostname can be the zone's apex domain
- mention the root domain in the reachability note

## Testing
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6870c4f76560832f9c20b4e0fef88537