### PR TITLE
Update k3s deployment doc for apex domain

### DIFF
--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -184,6 +184,10 @@ ingress:
   - service: http_status:404
 ```
 
+> **Tip**: Cloudflare can route the zone's apex domain. Replace
+> `relay.your-domain.com` with your root domain, e.g. `token.place`, to serve
+> the relay at the apex.
+
 Run the tunnel:
 
 ```bash
@@ -264,20 +268,24 @@ Cloudflare Tunnel.
    tunnel: TUNNEL_ID
    credentials-file: /home/pi/.cloudflared/TUNNEL_ID.json
 
-   ingress:
-     - hostname: relay.your-domain.com
-       service: http://localhost:30500
-     - service: http_status:404
-   ```
+  ingress:
+    - hostname: relay.your-domain.com
+      service: http://localhost:30500
+    - service: http_status:404
+  ```
 
-   Start the tunnel and keep it running:
+    Replace `relay.your-domain.com` with your zone's root (e.g. `token.place`)
+    if you prefer the relay on the apex domain.
+
+  Start the tunnel and keep it running:
 
    ```bash
    cloudflared tunnel run tokenplace-prod
    ```
 
-After the tunnel is active, your relay is reachable at `https://relay.your-domain.com` and traffic is
-forwarded into the k3s cluster.
+After the tunnel is active, your relay is reachable at the hostname you
+specified (`https://relay.your-domain.com` or `https://token.place`), and
+traffic is forwarded into the k3s cluster.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- clarify Cloudflare Tunnel hostname example in Raspberry Pi guide
- show apex domain usage in k3s instructions

## Testing
- `pre-commit run --files docs/RPI_DEPLOYMENT_GUIDE.md` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6870c4f76560832f9c20b4e0fef88537