### PR TITLE
Add API v1 model error logging tests

### DIFF
--- a/tests/unit/test_api_v1_models_errors.py
+++ b/tests/unit/test_api_v1_models_errors.py
@@ -1,0 +1,32 @@
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+@patch.dict(os.environ, {"USE_MOCK_LLM": "0"})
+def test_invalid_response_structure(monkeypatch):
+    import api.v1.models as models
+    importlib.reload(models)
+    class Dummy:
+        def create_chat_completion(self, messages):
+            return {"bad": "data"}
+    monkeypatch.setattr(models, "get_model_instance", lambda mid: Dummy())
+    messages = [{"role": "user", "content": "hi"}]
+    with pytest.raises(models.ModelError) as exc:
+        models.generate_response("llama-3-8b-instruct", messages)
+    assert exc.value.error_type == "model_response_error"
+
+@patch.dict(os.environ, {"USE_MOCK_LLM": "0"})
+def test_model_exception(monkeypatch):
+    import api.v1.models as models
+    importlib.reload(models)
+    class Dummy:
+        def create_chat_completion(self, messages):
+            raise RuntimeError("fail")
+    monkeypatch.setattr(models, "get_model_instance", lambda mid: Dummy())
+    messages = [{"role": "user", "content": "hi"}]
+    with pytest.raises(models.ModelError) as exc:
+        models.generate_response("llama-3-8b-instruct", messages)
+    assert exc.value.error_type == "model_inference_error"
+

--- a/tests/unit/test_api_v1_models_logging.py
+++ b/tests/unit/test_api_v1_models_logging.py
@@ -1,0 +1,18 @@
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+@patch.dict(os.environ, {"ENVIRONMENT": "dev"})
+def test_log_functions_call(monkeypatch):
+    import api.v1.models as models
+    importlib.reload(models)
+    fake_logger = MagicMock()
+    monkeypatch.setattr(models, "logger", fake_logger)
+    models.log_info("info")
+    models.log_warning("warn")
+    models.log_error("err", exc_info=True)
+    fake_logger.info.assert_called_with("info")
+    fake_logger.warning.assert_called_with("warn")
+    fake_logger.error.assert_called_with("err", exc_info=True)


### PR DESCRIPTION
## Summary
- add tests covering api.v1.models log helpers
- test generate_response error branches

## Testing
- `pytest tests/unit/test_api_v1_models_logging.py tests/unit/test_api_v1_models_errors.py -q`
- `pre-commit run --all-files` *(fails: JavaScript tests missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6870c752237c832fa67b678802e1ea21