### PR TITLE
Add tests for crypto_helpers and routes

### DIFF
--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock
+import pytest
+
+from relay import app
+from api.v1 import routes
+from api.v1.models import ModelError
+from api.v1.validation import ValidationError
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_get_public_key_exception(client, monkeypatch):
+    monkeypatch.setattr(routes, 'encryption_manager', MagicMock(public_key_b64=property(lambda self: (_ for _ in ()).throw(RuntimeError('fail')))))
+    resp = client.get('/api/v1/public-key')
+    assert resp.status_code == 400
+    assert 'Failed to retrieve public key' in resp.get_json()['error']['message']
+
+
+def test_chat_completion_encrypted_validation_error(client, monkeypatch):
+    monkeypatch.setattr(routes, 'validate_encrypted_request', MagicMock(side_effect=ValidationError('bad', 'field', 'code')))
+    payload = {'model': 'llama-3-8b-instruct', 'encrypted': True, 'client_public_key': 'x', 'messages': {}}
+    resp = client.post('/api/v1/chat/completions', json=payload)
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data['error']['message'] == 'bad'
+    assert data['error']['code'] == 'code'
+
+
+def test_create_completion_missing_body(client):
+    resp = client.post('/api/v1/completions', data='', content_type='application/json')
+    assert resp.status_code == 400
+
+
+def test_create_completion_missing_model(client):
+    resp = client.post('/api/v1/completions', json={})
+    assert resp.status_code == 400
+    assert 'Invalid request body' in resp.get_json()['error']['message']
+
+
+def test_create_completion_model_error(client, monkeypatch):
+    monkeypatch.setattr(routes, 'get_model_instance', MagicMock(side_effect=ModelError('oops', status_code=400)))
+    payload = {'model': 'bad', 'prompt': 'hi'}
+    resp = client.post('/api/v1/completions', json=payload)
+    assert resp.status_code == 400
+
+
+def test_health_check_exception(client, monkeypatch):
+    orig_jsonify = routes.jsonify
+    def fake_jsonify(*args, **kwargs):
+        if not hasattr(fake_jsonify, 'called'):
+            fake_jsonify.called = True
+            raise RuntimeError('boom')
+        return orig_jsonify(*args, **kwargs)
+    monkeypatch.setattr(routes, 'jsonify', fake_jsonify)
+    resp = client.get('/api/v1/health')
+    assert resp.status_code == 400
+    assert 'Health check failed' in resp.get_json()['error']['message']
+
+
+def test_openai_alias_get_model(client):
+    models = client.get('/api/v1/models').get_json()['data']
+    model_id = models[0]['id']
+    api_resp = client.get(f'/api/v1/models/{model_id}').get_json()
+    alias_resp = client.get(f'/v1/models/{model_id}').get_json()
+    assert api_resp == alias_resp
+

--- a/tests/unit/test_crypto_helpers_branch.py
+++ b/tests/unit/test_crypto_helpers_branch.py
@@ -1,0 +1,104 @@
+import base64
+from unittest.mock import MagicMock
+from utils.crypto_helpers import CryptoClient
+
+
+def _fresh_client():
+    return CryptoClient('https://example.com')
+
+
+def test_send_chat_message_no_public_key(monkeypatch):
+    client = _fresh_client()
+    monkeypatch.setattr(client, 'fetch_server_public_key', lambda: False)
+    assert client.send_chat_message('hi') is None
+
+
+def test_retrieve_chat_error_object(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    seq = [
+        {'error': {'message': 'No response available'}},
+        {
+            'chat_history': base64.b64encode(b'[{}]').decode(),
+            'cipherkey': base64.b64encode(b'k').decode(),
+            'iv': base64.b64encode(b'i').decode()
+        }
+    ]
+    monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(side_effect=seq))
+    monkeypatch.setattr(client, 'decrypt_message', lambda data: [{}])
+    monkeypatch.setattr('utils.crypto_helpers.time.sleep', lambda x: None)
+    assert client.retrieve_chat_response(max_retries=2, retry_delay=0) is None
+
+
+def test_retrieve_chat_invalid_entry(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    enc = {
+        'chat_history': base64.b64encode(b'[{"role":"assistant"}]').decode(),
+        'cipherkey': base64.b64encode(b'k').decode(),
+        'iv': base64.b64encode(b'i').decode()
+    }
+    monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(return_value=enc))
+    monkeypatch.setattr(client, 'decrypt_message', lambda data: [{"role": "assistant"}])
+    assert client.retrieve_chat_response(max_retries=1, retry_delay=0) is None
+
+
+def test_retrieve_chat_decrypt_exception(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    enc = {
+        'chat_history': base64.b64encode(b'd').decode(),
+        'cipherkey': base64.b64encode(b'k').decode(),
+        'iv': base64.b64encode(b'i').decode()
+    }
+    monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(return_value=enc))
+    def boom(*a, **k):
+        raise RuntimeError('bad decrypt')
+    monkeypatch.setattr(client, 'decrypt_message', boom)
+    assert client.retrieve_chat_response(max_retries=1, retry_delay=0) is None
+
+
+def test_retrieve_chat_unexpected_fields(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    monkeypatch.setattr(client, 'send_encrypted_message', MagicMock(return_value={'foo': 'bar'}))
+    monkeypatch.setattr('utils.crypto_helpers.time.sleep', lambda x: None)
+    assert client.retrieve_chat_response(max_retries=1, retry_delay=0) is None
+
+
+def test_send_api_request_no_server_key(monkeypatch):
+    client = _fresh_client()
+    monkeypatch.setattr(client, 'fetch_server_public_key', lambda endpoint='/api/v1/public-key': False)
+    assert client.send_api_request([{'role': 'user', 'content': 'hi'}]) is None
+
+
+def test_send_api_request_encrypt_error(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    monkeypatch.setattr(client, 'encrypt_message', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('fail')))
+    assert client.send_api_request([{'role': 'user', 'content': 'hi'}]) is None
+
+
+def test_send_api_request_no_response(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    monkeypatch.setattr(client, 'encrypt_message', lambda msgs: {'ciphertext': 'c', 'cipherkey': 'k', 'iv': 'i'})
+    monkeypatch.setattr(client, 'send_encrypted_message', lambda *a, **k: None)
+    assert client.send_api_request([{'role': 'user', 'content': 'hi'}]) is None
+
+
+def test_send_api_request_decrypt_error(monkeypatch):
+    client = _fresh_client()
+    client.server_public_key = client.client_public_key
+    client.server_public_key_b64 = client.client_public_key_b64
+    monkeypatch.setattr(client, 'encrypt_message', lambda msgs: {'ciphertext': 'c', 'cipherkey': 'k', 'iv': 'i'})
+    monkeypatch.setattr(client, 'send_encrypted_message', lambda *a, **k: {'data': {'encrypted': True, 'ciphertext': 'c', 'cipherkey': 'k', 'iv': 'i'}})
+    monkeypatch.setattr(client, 'decrypt_message', lambda *a, **k: (_ for _ in ()).throw(RuntimeError('bad')))
+    assert client.send_api_request([{'role': 'user', 'content': 'hi'}]) is None
+


### PR DESCRIPTION
## Summary
- add branch coverage tests for CryptoClient
- add additional API v1 route error tests

## Testing
- `pre-commit run --all-files`
- `TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870cf756428832f9531b16495f88cb5