### PR TITLE
Improve test coverage with additional edge cases

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -305,11 +305,14 @@ def test_create_completion_exception(client, monkeypatch, mock_llama):
 
 def test_format_error_response_function():
     with app.app_context():
-        resp = format_error_response("bad request", code="oops", status_code=418)
+        resp = format_error_response(
+            "bad request", code="oops", param="field", status_code=418
+        )
         data = resp.get_json()
         assert resp.status_code == 418
         assert data["error"]["message"] == "bad request"
         assert data["error"]["code"] == "oops"
+        assert data["error"]["param"] == "field"
 
 
 def test_openai_alias_routes(client):

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -1,0 +1,59 @@
+import base64
+import pytest
+from relay import app
+from api.v1 import routes
+from api.v1.validation import ValidationError
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+def test_get_public_key_exception(client, monkeypatch):
+    class Bad:
+        @property
+        def public_key_b64(self):
+            raise RuntimeError("boom")
+    monkeypatch.setattr(routes, "encryption_manager", Bad())
+    res = client.get("/api/v1/public-key")
+    assert res.status_code == 400
+    assert "Failed to retrieve public key" in res.get_json()["error"]["message"]
+
+def test_chat_completion_encrypted_validation_error(client, monkeypatch):
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "model"}])
+    monkeypatch.setattr(routes, "get_model_instance", lambda m: object())
+    monkeypatch.setattr(routes, "generate_response", lambda m, msgs: msgs)
+    def bad(data):
+        raise ValidationError("bad", field="f", code="c")
+    monkeypatch.setattr(routes, "validate_encrypted_request", bad)
+    payload = {
+        "model": "model",
+        "encrypted": True,
+        "client_public_key": base64.b64encode(b"x").decode(),
+        "messages": {"ciphertext": "c", "cipherkey": "k", "iv": "i"}
+    }
+    res = client.post("/api/v1/chat/completions", json=payload)
+    data = res.get_json()
+    assert res.status_code == 400
+    assert data["error"]["param"] == "f"
+    assert data["error"]["code"] == "c"
+
+def test_health_check_exception(client, monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("x")
+
+    original = routes.jsonify
+
+    def fake_format(msg, **kw):
+        resp = original({"error": {"message": msg}})
+        resp.status_code = 400
+        return resp
+
+    monkeypatch.setattr(routes, "jsonify", boom)
+    monkeypatch.setattr(routes, "format_error_response", fake_format)
+
+    res = client.get("/api/v1/health")
+    assert res.status_code == 400
+    data = res.get_json()
+    assert data["error"]["message"].startswith("Health check failed")

--- a/tests/unit/test_config_module_additional.py
+++ b/tests/unit/test_config_module_additional.py
@@ -11,3 +11,18 @@ def test_save_user_config_error(tmp_path, monkeypatch, caplog):
     with caplog.at_level('ERROR'):
         cfg.save_user_config(str(bad_path))
     assert any('Error saving configuration' in r.message for r in caplog.records)
+
+
+def test_load_user_config_missing_file(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+    config_path = tmp_path / 'nope.json'
+    monkeypatch.setattr('utils.path_handling.get_config_dir', lambda: tmp_path / 'config')
+    monkeypatch.setattr('utils.path_handling.get_app_data_dir', lambda: tmp_path / 'data')
+    monkeypatch.setattr('utils.path_handling.get_models_dir', lambda: tmp_path / 'models')
+    monkeypatch.setattr('utils.path_handling.get_logs_dir', lambda: tmp_path / 'logs')
+    monkeypatch.setattr('utils.path_handling.get_cache_dir', lambda: tmp_path / 'cache')
+    monkeypatch.setattr('utils.path_handling.ensure_dir_exists', lambda p: Path(p).mkdir(parents=True, exist_ok=True))
+    with caplog.at_level('WARNING'):
+        cfg = config.Config(config_path=str(config_path))
+    assert any('User configuration file not found' in r.message for r in caplog.records)
+    assert cfg.get('server.port') == 8001

--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -1,3 +1,4 @@
+import pathlib
 from utils import path_handling as ph
 
 
@@ -6,3 +7,20 @@ def test_ensure_dir_exists_existing(tmp_path):
     p.mkdir()
     result = ph.ensure_dir_exists(p)
     assert result == p
+
+
+def test_get_relative_path_not_relative(tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    result = ph.get_relative_path(a, b)
+    assert result == a.resolve()
+
+
+def test_get_relative_path_default_base(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    result = ph.get_relative_path(sub)
+    assert result == pathlib.Path("sub")


### PR DESCRIPTION
## Summary
- add tests for new API v1 route edge cases
- expand coverage of format_error_response
- extend config module tests for missing user configs
- test crypto helpers for additional failure scenarios
- cover more path handling utilities

## Testing
- `pre-commit run --files tests/test_api.py tests/unit/test_config_module_additional.py tests/unit/test_crypto_helpers_additional.py tests/unit/test_path_handling_additional.py tests/unit/test_api_v1_routes_additional.py`
- `TEST_COVERAGE=1 ./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870ce06f770832fb22a2da7ed0a0721