### PR TITLE
Increase test coverage

### DIFF
--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -14,3 +14,10 @@ def test_unpad_invalid_padding():
     padded = b"invalidpadding" + b"\x01\x02\x03"
     with pytest.raises(ValueError):
         pkcs7_unpad(padded, 16)
+
+
+def test_unpad_padding_too_long():
+    """Raise error when padding length byte exceeds block size."""
+    padded = b"abc" + b"\x11" * 17  # block size 16, padding byte 17 (>16)
+    with pytest.raises(ValueError):
+        pkcs7_unpad(padded, 16)


### PR DESCRIPTION
## Summary
- test `pkcs7_unpad` for padding length greater than block size

## Testing
- `pytest tests/unit/test_pkcs7_padding.py -q`
- `pre-commit run --files tests/unit/test_pkcs7_padding.py`


------
https://chatgpt.com/codex/tasks/task_e_68720d5f221c832fa56927a648109dbe