### PR TITLE
Improve Pi cgroup setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,21 +23,37 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+      - name: Prepare Raspberry Pi cgroups
+        id: prep
+        run: |
+          set +e
+          sudo bash scripts/prepare-pi-cgroups.sh
+          echo "rc=$?" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Stop for reboot
+        if: steps.prep.outputs.rc == '2'
+        run: echo "Cgroup configuration updated. Reboot runner and re-run job."
       - name: Validate dependency compatibility
         run: python scripts/validate_dependencies.py
+        if: steps.prep.outputs.rc != '2'
       - name: Install Python dependencies
+        if: steps.prep.outputs.rc != '2'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Install Playwright browsers
+        if: steps.prep.outputs.rc != '2'
         run: playwright install
       - name: Install Node.js dependencies
+        if: steps.prep.outputs.rc != '2'
         run: npm ci
       - name: Run tests
+        if: steps.prep.outputs.rc != '2'
         run: ./run_all_tests.sh
         env:
           TEST_COVERAGE: '1'
       - name: Upload coverage reports to Codecov
+        if: steps.prep.outputs.rc != '2'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -215,6 +215,17 @@ cloudflared tunnel run tokenplace-relay  # run the tunnel using the above config
 The steps below create a tiny Kubernetes cluster across several Pi boards and expose the relay via a
 Cloudflare Tunnel.
 
+### Prerequisites
+
+k3s will not start without memory cgroups enabled. Raspberry Pi OS disables them by default, so update
+`/boot/cmdline.txt` to enable the necessary controllers before installing k3s:
+
+```bash
+sudo sed -i 's/$/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory/' /boot/cmdline.txt
+```
+
+Reboot after editing the file. See the [k3s requirements](https://docs.k3s.io/installation/requirements#control-plane-nodes), [GitHub issue #2067](https://github.com/k3s-io/k3s/issues/2067) and [StackOverflow question 74294548](https://stackoverflow.com/questions/74294548) for background.
+
 1. **Install k3s on the control-plane node**
 
    ```bash

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -73,6 +73,9 @@ run_test "Crypto Compatibility Tests (Playwright)" "python -m pytest tests/test_
 # 7. Run JavaScript tests
 run_test "JavaScript Tests" "npm run test:js" "Testing JavaScript functionality"
 
+# 7b. Test Raspberry Pi cgroup setup script
+run_test "Cgroup Setup Script Tests" "bash tests/test_cgroup.sh" "Validating prepare-pi-cgroups.sh logic"
+
 # 8. Run E2E tests
 if [ "$RUN_E2E" = "1" ]; then
     run_test "End-to-End Tests" "python -m pytest tests/test_e2e_*.py -v $COVERAGE_ARGS" "Testing complete workflows"

--- a/scripts/prepare-pi-cgroups.sh
+++ b/scripts/prepare-pi-cgroups.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Configure memory cgroups on Raspberry Pi for k3s
+set -e
+
+CPUINFO_PATH="${CPUINFO_PATH:-/proc/cpuinfo}"
+CGROUPS_PATH="${CGROUPS_PATH:-/proc/cgroups}"
+CMDLINE_FILE="${CMDLINE_FILE:-}"
+
+# Detect Raspberry Pi
+if ! grep -qi raspberry "$CPUINFO_PATH"; then
+    exit 0
+fi
+
+# Memory cgroup already enabled?
+if grep -qE '^memory\s+.*\s1$' "$CGROUPS_PATH"; then
+    exit 0
+fi
+
+# Determine cmdline file
+if [ -z "$CMDLINE_FILE" ]; then
+    if [ -f /boot/cmdline.txt ]; then
+        CMDLINE_FILE=/boot/cmdline.txt
+    elif [ -f /boot/firmware/cmdline.txt ]; then
+        CMDLINE_FILE=/boot/firmware/cmdline.txt
+    else
+        echo "cmdline.txt not found" >&2
+        exit 1
+    fi
+fi
+
+PARAMS="cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory"
+
+if ! grep -q "cgroup_memory=1" "$CMDLINE_FILE"; then
+    sed -i "s/\$/ $PARAMS/" "$CMDLINE_FILE"
+fi
+
+echo "Reboot required"
+exit 2

--- a/tests/test_cgroup.sh
+++ b/tests/test_cgroup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+
+tmpdir=$(mktemp -d)
+CPUINFO=$tmpdir/cpuinfo
+CGROUPS=$tmpdir/cgroups
+CMDLINE=$tmpdir/cmdline.txt
+
+echo "Intel" > "$CPUINFO"
+: > "$CGROUPS"
+: > "$CMDLINE"
+
+CPUINFO_PATH="$CPUINFO" CGROUPS_PATH="$CGROUPS" CMDLINE_FILE="$CMDLINE" bash scripts/prepare-pi-cgroups.sh
+[ $? -eq 0 ]
+
+# Scenario: Pi without memory cgroup
+echo "Raspberry Pi" > "$CPUINFO"
+echo -e "memory\t0\t1\t0" > "$CGROUPS"
+echo "console=ttyAMA0" > "$CMDLINE"
+
+set +e
+CPUINFO_PATH="$CPUINFO" CGROUPS_PATH="$CGROUPS" CMDLINE_FILE="$CMDLINE" bash scripts/prepare-pi-cgroups.sh
+rc=$?
+set -e
+[ $rc -eq 2 ]
+grep -q "cgroup_memory=1" "$CMDLINE"
+count=$(grep -o "cgroup_memory=1" "$CMDLINE" | wc -l)
+[ "$count" -eq 1 ]
+
+# Running again without reboot should not duplicate
+set +e
+CPUINFO_PATH="$CPUINFO" CGROUPS_PATH="$CGROUPS" CMDLINE_FILE="$CMDLINE" bash scripts/prepare-pi-cgroups.sh
+rc=$?
+set -e
+[ $rc -eq 2 ]
+count=$(grep -o "cgroup_memory=1" "$CMDLINE" | wc -l)
+[ "$count" -eq 1 ]
+
+# After reboot (memory cgroup enabled)
+echo -e "memory\t0\t1\t1" > "$CGROUPS"
+CPUINFO_PATH="$CPUINFO" CGROUPS_PATH="$CGROUPS" CMDLINE_FILE="$CMDLINE" bash scripts/prepare-pi-cgroups.sh
+[ $? -eq 0 ]
+
+rm -r "$tmpdir"


### PR DESCRIPTION
## Summary
- add helper script `prepare-pi-cgroups.sh` to enable memory cgroups
- document the need for cgroups when running k3s
- run the helper from CI before installing k3s
- test the helper logic and integrate the test into the runner

## Testing
- `pre-commit run --all-files`
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879876a72e8832f9be5fc5307665480