### PR TITLE
Add Electron desktop build workflow

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,41 @@
+name: Build Desktop Apps
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    defaults:
+      run:
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: desktop/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build application
+        run: npm run build
+      - name: Package app
+        run: |
+          if [ "${{ matrix.os }}" = 'windows-latest' ]; then
+            npm run package:win
+          else
+            npm run package:mac
+          fi
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.os }}
+          path: desktop/dist/**

--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ token.place now has full cross-platform support for Windows, macOS, and Linux. T
 - Native launcher scripts for each platform
 - Docker containerization for consistent deployment
 - Cross-platform testing framework
+- Automated desktop installers for Windows (.exe) and macOS (.dmg) built via GitHub Actions
 
 For detailed information on cross-platform features and containerization, see [CROSS_PLATFORM.md](CROSS_PLATFORM.md).
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -252,6 +252,7 @@ To further enhance cross-platform support, future work includes:
    - Windows installer (.msi)
    - macOS package (.pkg)
    - Linux package (.deb, .rpm)
+   - Windows `.exe` and macOS `.dmg` builds are generated automatically via GitHub Actions
 
 2. **Platform-Specific UI Optimizations**:
    - Native UI integrations 


### PR DESCRIPTION
## Summary
- build Windows `.exe` and macOS `.dmg` using GitHub Actions
- document new installers in README and CROSS_PLATFORM.md

## Testing
- `pre-commit run --all-files` *(fails: Python Unit Tests, Python Integration Tests, API Tests, Crypto Compatibility Tests (Simple), Crypto Compatibility Tests (Local), Crypto Compatibility Tests (Playwright), JavaScript Tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ed80d8dcc832f8d49d7f59d72a817