### PR TITLE
Add GitHub workflow to build desktop binaries

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,45 @@
+name: Build Desktop App
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            build_script: package:win
+            artifact_name: token-place-desktop-win
+          - os: macos-latest
+            build_script: package:mac
+            artifact_name: token-place-desktop-mac
+    defaults:
+      run:
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: desktop/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build sources
+        run: npm run build
+      - name: Package application
+        run: npm run ${{ matrix.build_script }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            desktop/dist/**/*.exe
+            desktop/dist/**/*.dmg
+            desktop/dist/**/*.zip
+            desktop/dist/**/*.pkg

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,12 +15,12 @@
     "package:win": "electron-builder --config electron-builder.json --win"
   },
   "dependencies": {
-    "electron": "^30.0.0",
     "electron-store": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "electron": "^30.0.0",
     "@types/node": "^20.9.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/desktop/src/main/Main.ts
+++ b/desktop/src/main/Main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, Event } from 'electron';
 import Store from 'electron-store';
 import path from 'path';
 import { AppTray } from './Tray';
@@ -29,7 +29,7 @@ function createWindow(): void {
 
   mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
 
-  mainWindow.on('close', (e) => {
+  mainWindow.on('close', (e: Event) => {
     e.preventDefault();
     mainWindow?.hide();
   });
@@ -59,6 +59,6 @@ ipcMain.handle('set-settings', (_, data: UserSettings) => {
   scheduler.removeAllListeners();
 });
 
-app.on('window-all-closed', (e) => {
+app.on('window-all-closed', (e: Event) => {
   e.preventDefault();
 });

--- a/desktop/src/main/Tray.ts
+++ b/desktop/src/main/Tray.ts
@@ -2,12 +2,13 @@ import { Menu, Tray, nativeImage } from 'electron';
 import Store from 'electron-store';
 import path from 'path';
 import { IdleScheduler } from './IdleScheduler';
+import { UserSettings } from '../common/types';
 
 export class AppTray {
   private tray: Tray | null = null;
   constructor(
     private scheduler: IdleScheduler,
-    private store: Store,
+    private store: Store<UserSettings>,
   ) {}
 
   init(): void {

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react"
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to package the Electron desktop app for Windows and macOS
- move `electron` to devDependencies and enable JSX in the TypeScript config
- update Electron main and tray sources with stricter typing

## Testing
- `pre-commit run --files desktop/package.json desktop/src/main/Main.ts desktop/src/main/Tray.ts desktop/tsconfig.json .github/workflows/desktop-build.yml`

------
https://chatgpt.com/codex/tasks/task_e_687ed80d8dcc832f8d49d7f59d72a817