### PR TITLE
Fix workflow artifact action

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Package application
         run: npm run ${{ matrix.build_script }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: |


### PR DESCRIPTION
## Summary
- fix failure due to deprecated upload-artifact v3

## Testing
- `pre-commit run --files .github/workflows/desktop-build.yml` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68815ec751d0832fad0b4d73ad02a985