### PR TITLE
Add Claude PR Assistant workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"
+          # mode: tag  # Default: responds to @claude mentions
+          # Optional: Restrict network access to specific domains only
+          # experimental_allowed_domains: |
+          #   .anthropic.com
+          #   .github.com
+          #   api.github.com
+          #   .githubusercontent.com
+          #   bun.sh
+          #   registry.npmjs.org
+          #   .blob.core.windows.net

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - **When:** pushes or PRs
 - **Does:** run tests via GitHub Actions
 
+### Claude PR Assistant
+- **When:** you mention `@claude` in a PR or issue
+- **Does:** analyzes your code changes and proposes patches
+
 ### Security Bot
 - **When:** dependency or vulnerability alerts appear
 - **Does:** open PRs to patch them
@@ -51,4 +55,3 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 ### Prompt Agent
 - **When:** you run `flywheel prompt`
 - **Does:** generate context-aware prompts for Codex or other LLM assistants
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Claude Integration
+
+This file summarizes best practices from [Anthropic's "Claude Code Best Practices"](https://www.anthropic.com/engineering/claude-code-best-practices).
+It complements [AGENTS.md](AGENTS.md) and [llms.txt](llms.txt) by focusing on guidance specific to the Claude model family.
+
+## Key Points
+- Keep prompts concise and provide explicit context.
+- Prefer deterministic functions with clear input and output formats.
+- Use code comments to explain non-obvious logic.
+- Validate model output before acting on it.
+
+For broader assistant behavior, see [docs/AGENTS.md](docs/AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - Comprehensive tests and CI via GitHub Actions
 - [AGENTS.md](AGENTS.md) lists repo helpers for LLMs
 - [llms.txt](llms.txt) provides machine-readable context
+- [CLAUDE.md](CLAUDE.md) summarizes Claude integration tips
 
 ## roadmap
 
@@ -365,6 +366,8 @@ TEST_COVERAGE=1 ./run_all_tests.sh
 ```
 If you don't see coverage comments on your pull requests, install the [Codecov GitHub App](https://github.com/marketplace/codecov) on your fork.
 Every pull request automatically runs this test suite in GitHub Actions, so you can rely on the status checks for pass/fail information.
+
+Tag **@claude** in any pull request or issue to invoke the automated Claude PR Assistant for implementation help.
 
 ### Test Categories
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -128,5 +128,6 @@ For convenience, you can execute all available test suites with `./run_all_tests
 - Install Python dependencies with `pip install -r config/requirements_server.txt` and `pip install -r config/requirements_relay.txt` before running tests. If Playwright tests complain about missing browsers, run `playwright install chromium`.
 - For development and unit testing, also run `pip install -r requirements.txt` to install extra tooling like pytest-playwright, then run `playwright install`.
 - Every pull request triggers the GitHub Actions workflow in `.github/workflows/ci.yml` which runs `./run_all_tests.sh` with coverage enabled and uploads results to Codecov.
+- Tag **@claude** in a pull request or issue to invoke the Claude PR Assistant defined in `.github/workflows/claude.yml`.
 - Ensure the [Codecov GitHub App](https://github.com/marketplace/codecov) is installed on your fork so coverage badges and PR comments work reliably.
 - Real-world integration tests live in the [DSPACE project](https://github.com/democratizedspace/dspace); token.place acts as its OpenAI-compatible backend.

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@ Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python
 - Synergy Bot: spot shared utilities across repos
 - Release Drafter Bot: draft notes on pushes to main
 - CI Bot: run tests on GitHub Actions
+- Claude PR Assistant: tag @claude in PRs or issues for automated help
 - Security Bot: patch dependency alerts
 - Prompt Agent: generate flywheel prompts
 
@@ -26,4 +27,3 @@ Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python
 - Tests live in `tests/` and cover Python, JS, and Playwright
 - Docs in `docs/` with onboarding and style guides
 - See AGENTS.md for the Markdown version of this file
-


### PR DESCRIPTION
## Summary
- add GitHub action that runs anthropics/claude-code-action
- document Claude integration tips and update AGENTS
- mention Claude assistant in README and llms.txt

## Testing
- `pre-commit run --files README.md AGENTS.md docs/AGENTS.md llms.txt CLAUDE.md .github/workflows/claude.yml` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688830f21640832fa543f5503c787fac