### PR TITLE
Update claude workflow with API key secret

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     permissions:
       contents: read
       pull-requests: read
@@ -32,7 +34,6 @@ jobs:
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"
           # mode: tag  # Default: responds to @claude mentions
           # Optional: Restrict network access to specific domains only


### PR DESCRIPTION
## Summary
- wire ANTHROPIC_API_KEY secret into `claude.yml`

## Testing
- `pre-commit run --all-files` *(fails: Python and JS tests fail)*
- `gh workflow run claude.yml -R . --ref work` *(fails: `gh` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688839beb8b8832fa42bc8b406f0be6f