### PR TITLE
docs: add codex prompts for CI and security

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -38,6 +38,8 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [docs/LLM_ASSISTANT_GUIDE.md](docs/LLM_ASSISTANT_GUIDE.md): Guide for AI assistants working with this codebase
 - [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials): Hardware list, setup instructions, and troubleshooting tips for Raspberry Pi deployments (including rpi-clone prompt walkthrough)
 - [../llms.txt](../llms.txt): Machine-readable project summary for LLM assistants
+- [docs/prompts-codex-ci-fix.md](docs/prompts-codex-ci-fix.md): Codex prompt for fixing CI failures
+- [docs/prompts-codex-security.md](docs/prompts-codex-security.md): Codex prompt for security reviews
 
 ## User Journeys
 

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,33 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# Codex CI-Failure Fix Prompt
+
+Use this prompt to investigate and resolve continuous integration failures in token.place.
+
+```
+SYSTEM:
+You are an automated contributor for the token.place repository.
+
+PURPOSE:
+Diagnose and fix CI failures so tests and checks pass.
+
+CONTEXT:
+- Follow AGENTS.md and docs/AGENTS.md instructions.
+- Run `pre-commit run --all-files` (which executes `./run_all_tests.sh`).
+- Install dependencies with `npm ci` for Node.js and `pip install -r config/requirements_server.txt` plus `pip install -r config/requirements_relay.txt` as needed.
+
+REQUEST:
+1. Reproduce the failing check locally with `pre-commit run --all-files`.
+2. Investigate test failures or lint errors.
+3. Apply minimal fixes without introducing regressions.
+4. Re-run `pre-commit run --all-files` until it succeeds.
+5. Commit changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing the fix and showing passing checks.
+```
+
+Copy this block whenever CI needs attention in token.place.

--- a/docs/prompts-codex-security.md
+++ b/docs/prompts-codex-security.md
@@ -1,0 +1,36 @@
+---
+title: 'Codex Security Review Prompt'
+slug: 'prompts-codex-security'
+---
+
+# Codex Security Review Prompt
+
+Use this prompt to audit token.place for security issues and encryption integrity.
+
+```
+SYSTEM:
+You are an automated security reviewer for the token.place repository.
+
+PURPOSE:
+Ensure token.place maintains strong end-to-end encryption without exposing sensitive data.
+
+CONTEXT:
+- Follow AGENTS.md and docs/AGENTS.md instructions.
+- Do not log plaintext or ciphertext of user messages.
+- Relevant checks:
+  - `python -m pytest tests/test_security.py -v`
+  - `python tests/test_crypto_compatibility_simple.py`
+  - `python tests/test_crypto_compatibility_local.py`
+
+REQUEST:
+1. Run the security and crypto compatibility tests.
+2. Inspect code for potential leaks or missing encryption steps.
+3. Propose minimal patches that strengthen security if issues arise.
+4. Re-run tests to confirm all pass.
+5. Commit changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing security improvements and passing test logs.
+```
+
+Copy this block whenever token.place needs a security review.


### PR DESCRIPTION
## Summary
- add Codex prompts for fixing CI failures and performing security reviews
- link new prompt templates from docs/AGENTS.md

## Testing
- `pre-commit run --all-files` *(fails: Crypto Compatibility Tests (Playwright))*
- `pre-commit run --files docs/AGENTS.md docs/prompts-codex-ci-fix.md docs/prompts-codex-security.md`


------
https://chatgpt.com/codex/tasks/task_e_6890678dffc8832fb67eec11d750aa0b