### PR TITLE
🐛 : handle missing Windows AppData paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v2.4.0
     hooks:
       - id: codespell
-        args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,*.svg,webapp/static/js/*"]
+        args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,package-lock.json,*.svg,webapp/static/js/*"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:
@@ -19,7 +19,7 @@ repos:
     rev: v2.7
     hooks:
       - id: vulture
-        args: ["token.place", "--min-confidence", "80"]
+        args: [".", "--min-confidence", "80"]
   - repo: local
     hooks:
       - id: run-checks

--- a/docs/CHANGELOG_STEP.md
+++ b/docs/CHANGELOG_STEP.md
@@ -14,3 +14,7 @@ This document captures incremental improvements to `token.place` over time. Add 
 - `api/__init__.py` now initializes rate limiting and metrics.
 - README expanded with quickstart instructions, architecture link, and environment variable notes.
 - Kubernetes documentation mentions production-ready probes and resources.
+
+## [2025-08-06]
+### Changed
+- Windows path helpers now default to `AppData` directories when environment variables are missing.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = ^server/__init__\.py$

--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -42,6 +42,17 @@ def test_paths_windows(tmp_path):
             assert ph.get_executable_extension() == '.exe'
 
 
+def test_paths_windows_missing_env():
+    with mock.patch('platform.system', return_value='Windows'):
+        with mock.patch.dict(os.environ, {'APPDATA': '', 'LOCALAPPDATA': ''}, clear=False):
+            import utils.path_handling as ph
+            importlib.reload(ph)
+            home = Path.home()
+            assert ph.get_app_data_dir() == home / 'AppData' / 'Roaming' / 'token.place'
+            assert ph.get_config_dir() == home / 'AppData' / 'Roaming' / 'token.place' / 'config'
+            assert ph.get_cache_dir() == home / 'AppData' / 'Local' / 'token.place' / 'cache'
+
+
 def test_paths_macos(tmp_path):
     with mock.patch('platform.system', return_value='Darwin'):
         import utils.path_handling as ph

--- a/utils/README.md
+++ b/utils/README.md
@@ -7,6 +7,7 @@ This directory contains utility modules for token.place that provide reusable fu
 ### Path Handling (`path_handling.py`)
 
 Cross-platform path handling utilities that ensure consistent behavior across Windows, macOS, and Linux.
+These helpers now fall back to standard `AppData` locations when Windows environment variables are missing.
 
 ### Crypto Helpers (`crypto_helpers.py`)
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -22,7 +22,11 @@ def get_app_data_dir() -> pathlib.Path:
     - Linux: ~/.local/share/token.place
     """
     if IS_WINDOWS:
-        base_dir = pathlib.Path(os.environ.get('APPDATA', ''))
+        appdata = os.environ.get('APPDATA')
+        if appdata:
+            base_dir = pathlib.Path(appdata)
+        else:
+            base_dir = get_user_home_dir() / 'AppData' / 'Roaming'
     elif IS_MACOS:
         base_dir = get_user_home_dir() / 'Library' / 'Application Support'
     else:  # Linux and other Unix-like
@@ -50,7 +54,11 @@ def get_cache_dir() -> pathlib.Path:
     - Linux: ~/.cache/token.place
     """
     if IS_WINDOWS:
-        base_dir = pathlib.Path(os.environ.get('LOCALAPPDATA', ''))
+        local_appdata = os.environ.get('LOCALAPPDATA')
+        if local_appdata:
+            base_dir = pathlib.Path(local_appdata)
+        else:
+            base_dir = get_user_home_dir() / 'AppData' / 'Local'
         return base_dir / 'token.place' / 'cache'
     elif IS_MACOS:
         return get_user_home_dir() / 'Library' / 'Caches' / 'token.place'


### PR DESCRIPTION
what: ensure Windows path helpers fall back to AppData when env vars absent
why: avoid relative paths when APPDATA or LOCALAPPDATA unset
how to test: npm ci && npx playwright install chromium && pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_6893c087ca88832f86f86a3c3db7d826