### PR TITLE
🐛 fix: validate existing paths in ensure_dir_exists

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -1,4 +1,5 @@
 import pathlib
+import pytest
 from utils import path_handling as ph
 
 
@@ -7,6 +8,13 @@ def test_ensure_dir_exists_existing(tmp_path):
     p.mkdir()
     result = ph.ensure_dir_exists(p)
     assert result == p
+
+
+def test_ensure_dir_exists_file(tmp_path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("data")
+    with pytest.raises(NotADirectoryError):
+        ph.ensure_dir_exists(file_path)
 
 
 def test_get_relative_path_not_relative(tmp_path):

--- a/utils/README.md
+++ b/utils/README.md
@@ -8,6 +8,8 @@ This directory contains utility modules for token.place that provide reusable fu
 
 Cross-platform path handling utilities that ensure consistent behavior across Windows, macOS, and Linux.
 
+- `ensure_dir_exists(path)`: Creates the directory if missing and raises `NotADirectoryError` when the path points to an existing file.
+
 ### Crypto Helpers (`crypto_helpers.py`)
 
 Simplifies encryption and decryption operations for end-to-end encrypted communication with the token.place server and relay.
@@ -34,7 +36,7 @@ client = CryptoClient('http://localhost:5010')
 if client.fetch_server_public_key():
     # Send a chat message
     response = client.send_chat_message("Hello, world!")
-    
+
     # Print the assistant's response
     for message in response:
         if message["role"] == "assistant":
@@ -56,9 +58,9 @@ if client.fetch_server_public_key('/api/v1/public-key'):
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Explain encryption in simple terms."}
     ]
-    
+
     response = client.send_api_request(messages)
-    
+
     if response:
         print(response['choices'][0]['message']['content'])
 ```
@@ -72,13 +74,13 @@ def test_with_crypto_client(setup_servers):
     """Test using the CryptoClient for cleaner test code"""
     # Create a client
     client = CryptoClient(base_url)
-    
+
     # Verify connection
     assert client.fetch_server_public_key() is True
-    
+
     # Test sending a message
     response = client.send_chat_message("Test message")
-    
+
     # Assertions on response
     assert response is not None
     assert len(response) >= 2
@@ -93,4 +95,4 @@ Using the `CryptoClient` has several advantages:
 2. **Improves readability**: Makes tests and application code more concise and focused
 3. **Centralizes logic**: Puts all encryption-related operations in one place
 4. **Simplifies maintenance**: Changes to encryption protocols only need to be updated in one place
-5. **Encapsulates complexity**: Hides the details of key management and encryption behind a clean API 
+5. **Encapsulates complexity**: Hides the details of key management and encryption behind a clean API

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -27,7 +27,7 @@ def get_app_data_dir() -> pathlib.Path:
         base_dir = get_user_home_dir() / 'Library' / 'Application Support'
     else:  # Linux and other Unix-like
         base_dir = get_user_home_dir() / '.local' / 'share'
-    
+
     return base_dir / 'token.place'
 
 def get_config_dir() -> pathlib.Path:
@@ -73,9 +73,12 @@ def get_logs_dir() -> pathlib.Path:
 def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     """
     Ensure a directory exists, creating it if necessary.
+    Raises NotADirectoryError if the path points to an existing file.
     Returns the path as a pathlib.Path object.
     """
     path = pathlib.Path(dir_path)
+    if path.exists() and not path.is_dir():
+        raise NotADirectoryError(f"{path} exists and is not a directory")
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -97,9 +100,9 @@ def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[
         base_path = pathlib.Path.cwd()
     else:
         base_path = normalize_path(base_path)
-    
+
     try:
         return path.relative_to(base_path)
     except ValueError:
         # If path is not relative to base_path, return the absolute path
-        return path 
+        return path


### PR DESCRIPTION
## Summary
- raise NotADirectoryError when ensure_dir_exists path points to file
- document ensure_dir_exists behaviour
- test file path handling

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:ci` *(fails: Missing script: "test:ci")*
- `pre-commit run --all-files` *(fails: Duplicate module named "server"; vulture path not found)*
- `python -m pytest tests/unit/test_path_handling_additional.py::test_ensure_dir_exists_file -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c087ca88832f86f86a3c3db7d826