### PR TITLE
🐛: – reject zero-length PKCS7 padding

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -28,6 +28,9 @@ Unit tests verify individual components in isolation. Run with:
 python -m pytest tests/unit/
 ```
 
+These tests cover numerous edge cases, including rejection of invalid PKCS#7 padding
+such as zero-length padding, ensuring token.place's cryptography remains robust.
+
 ### Integration Tests
 
 Integration tests verify that components work together correctly:

--- a/encrypt.py
+++ b/encrypt.py
@@ -174,11 +174,11 @@ def pkcs7_unpad(padded_data: bytes, block_size: int) -> bytes:
     """
     Remove PKCS#7 padding
     """
-    padding_length = padded_data[-1]
-    if padding_length > block_size:
+    if not padded_data:
         raise ValueError("Invalid padding")
-    # Verify padding
-    for i in range(1, padding_length + 1):
-        if padded_data[-i] != padding_length:
-            raise ValueError("Invalid padding")
+    padding_length = padded_data[-1]
+    if padding_length == 0 or padding_length > block_size:
+        raise ValueError("Invalid padding")
+    if padded_data[-padding_length:] != bytes([padding_length]) * padding_length:
+        raise ValueError("Invalid padding")
     return padded_data[:-padding_length]

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -21,3 +21,10 @@ def test_unpad_padding_too_long():
     padded = b"abc" + b"\x11" * 17  # block size 16, padding byte 17 (>16)
     with pytest.raises(ValueError):
         pkcs7_unpad(padded, 16)
+
+
+def test_unpad_zero_padding():
+    """Zero-length padding should be rejected."""
+    padded = b"data" + b"\x00"
+    with pytest.raises(ValueError):
+        pkcs7_unpad(padded, 16)


### PR DESCRIPTION
## Summary
- harden PKCS#7 unpadding against zero-length padding
- test zero-length padding rejection
- document cryptography edge-case coverage

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --all-files` *(fails: codespell, mypy, vulture)
- `python -m pytest tests/unit/test_pkcs7_padding.py::test_unpad_zero_padding -v`


------
https://chatgpt.com/codex/tasks/task_e_6893c087ca88832f86f86a3c3db7d826