### PR TITLE
Expand ~ in ensure_dir_exists

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -17,6 +17,15 @@ def test_ensure_dir_exists_file(tmp_path):
         ph.ensure_dir_exists(file_path)
 
 
+def test_ensure_dir_exists_expands_user(tmp_path, monkeypatch):
+    """ensure_dir_exists should expand '~' to the user's home directory"""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path_with_tilde = "~/nested"
+    result = ph.ensure_dir_exists(path_with_tilde)
+    assert result == tmp_path / "nested"
+    assert result.exists()
+
+
 def test_get_relative_path_not_relative(tmp_path):
     a = tmp_path / "a"
     b = tmp_path / "b"

--- a/utils/README.md
+++ b/utils/README.md
@@ -9,7 +9,8 @@ This directory contains utility modules for token.place that provide reusable fu
 Cross-platform path handling utilities that ensure consistent behavior across Windows, macOS, and Linux.
 These helpers now fall back to standard `AppData` locations when Windows environment variables are missing.
 
-- `ensure_dir_exists(path)`: Creates the directory if missing and raises `NotADirectoryError` when the path points to an existing file.
+- `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
+  `NotADirectoryError` when the path points to an existing file.
 
 ### Crypto Helpers (`crypto_helpers.py`)
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -84,7 +84,8 @@ def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     Raises NotADirectoryError if the path points to an existing file.
     Returns the path as a pathlib.Path object.
     """
-    path = pathlib.Path(dir_path)
+    # Expand user home (~) and normalize to an absolute path
+    path = pathlib.Path(dir_path).expanduser().resolve()
     if path.exists() and not path.is_dir():
         raise NotADirectoryError(f"{path} exists and is not a directory")
     path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- expand `ensure_dir_exists` to resolve `~` to home path
- add regression test covering tilde expansion
- document directory expansion in utils README

## Testing
- `npm run lint` (fails: Missing script "lint")
- `npm run test:ci` (fails: Missing script "test:ci")
- `pre-commit run --files utils/path_handling.py tests/unit/test_path_handling_additional.py utils/README.md` (fails: mypy, vulture errors in unrelated files)
- `pytest tests/unit/test_path_handling_additional.py::test_ensure_dir_exists_expands_user -q`
- `detect-secrets scan utils/path_handling.py tests/unit/test_path_handling_additional.py utils/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6893e20a5ea8832fab092f85360454f5