### PR TITLE
⏱️ add timeouts to CryptoClient network calls

### DIFF
--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -19,7 +19,7 @@ def mock_crypto_client():
             'server_public_key': base64.b64encode(b'mock_server_public_key').decode('utf-8')
         }
         mock_requests.get.return_value = mock_response
-        
+
         # Mock POST requests
         mock_post_response = MagicMock()
         mock_post_response.status_code = 200
@@ -30,7 +30,7 @@ def mock_crypto_client():
             'iv': base64.b64encode(b'mock_iv').decode('utf-8')
         }
         mock_requests.post.return_value = mock_post_response
-        
+
         # Create client and return with mocks
         client = CryptoClient('https://mock-server.com')
         yield client, mock_requests
@@ -47,17 +47,17 @@ def test_crypto_client_initialization():
 def test_fetch_server_public_key(mock_crypto_client):
     """Test fetching the server's public key"""
     client, mock_requests = mock_crypto_client
-    
+
     # Test the default endpoint
     result = client.fetch_server_public_key()
     assert result is True
-    mock_requests.get.assert_called_with('https://mock-server.com/next_server')
-    
+    mock_requests.get.assert_called_with('https://mock-server.com/next_server', timeout=10)
+
     # Test a custom endpoint
     result = client.fetch_server_public_key('/api/v1/public-key')
     assert result is True
-    mock_requests.get.assert_called_with('https://mock-server.com/api/v1/public-key')
-    
+    mock_requests.get.assert_called_with('https://mock-server.com/api/v1/public-key', timeout=10)
+
     # Test server key was set
     assert client.server_public_key is not None
     assert client.server_public_key_b64 is not None
@@ -65,18 +65,18 @@ def test_fetch_server_public_key(mock_crypto_client):
 def test_encrypt_message():
     """Test encrypting a message"""
     client = CryptoClient('https://test-server.com')
-    
+
     # Set a mock server public key
     _, public_key = generate_keys()
     client.server_public_key = public_key
-    
+
     # Test with dictionary
     test_dict = {'test': 'message', 'num': 123}
     encrypted = client.encrypt_message(test_dict)
     assert 'ciphertext' in encrypted
     assert 'cipherkey' in encrypted
     assert 'iv' in encrypted
-    
+
     # Test with string
     test_str = "Hello, world!"
     encrypted = client.encrypt_message(test_str)
@@ -87,29 +87,29 @@ def test_encrypt_message():
 def test_send_encrypted_message(mock_crypto_client):
     """Test sending an encrypted message"""
     client, mock_requests = mock_crypto_client
-    
+
     # Test sending a message
     payload = {'test': 'data'}
     response = client.send_encrypted_message('/test-endpoint', payload)
-    
-    mock_requests.post.assert_called_with('https://mock-server.com/test-endpoint', json=payload)
+
+      mock_requests.post.assert_called_with('https://mock-server.com/test-endpoint', json=payload, timeout=10)
     assert response is not None
     assert response['success'] is True
 
 def test_error_handling():
     """Test error handling in the CryptoClient"""
     client = CryptoClient('https://test-server.com')
-    
+
     # Test encrypt_message without server key
     with pytest.raises(ValueError):
         client.encrypt_message("This should fail")
-    
+
     # Mock a failed server key fetch
     with patch('utils.crypto_helpers.requests.get') as mock_get:
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_get.return_value = mock_response
-        
+
         result = client.fetch_server_public_key()
         assert result is False
 
@@ -121,7 +121,7 @@ def test_send_chat_message(mock_time, mock_requests):
     mock_faucet_response = MagicMock()
     mock_faucet_response.status_code = 200
     mock_faucet_response.json.return_value = {'success': True}
-    
+
     mock_retrieve_response = MagicMock()
     mock_retrieve_response.status_code = 200
     chat_history = json.dumps([
@@ -133,35 +133,35 @@ def test_send_chat_message(mock_time, mock_requests):
         'cipherkey': base64.b64encode(b'mock_key').decode(),
         'iv': base64.b64encode(b'mock_iv').decode()
     }
-    
+
     # Set up the request.post side effects to return different responses
     mock_requests.post.side_effect = [mock_faucet_response, mock_retrieve_response]
-    
+
     # Create client with mocked encryption/decryption
     with patch('utils.crypto_helpers.encrypt') as mock_encrypt, \
          patch('utils.crypto_helpers.decrypt') as mock_decrypt:
-        
+
         # Mock encrypt to return predictable values
         mock_encrypt.return_value = (
             {'ciphertext': b'mock_ciphertext', 'iv': b'mock_iv'},
             b'mock_cipherkey',
             b'mock_iv'
         )
-        
+
         # Mock decrypt to return the chat history
         mock_decrypt.return_value = chat_history.encode()
-        
+
         # Create client and set server key
         client = CryptoClient('https://test-server.com')
         client.server_public_key = b'mock_public_key'
-        
+
         # Test sending a message
         response = client.send_chat_message("Test message")
-        
+
         # Verify the proper calls were made
         assert mock_encrypt.called
         assert mock_decrypt.called
         assert mock_requests.post.call_count == 2
         assert len(response) == 2
         assert response[0]['role'] == 'user'
-        assert response[1]['role'] == 'assistant' 
+        assert response[1]['role'] == 'assistant'

--- a/tests/unit/test_crypto_helpers_simple.py
+++ b/tests/unit/test_crypto_helpers_simple.py
@@ -13,7 +13,7 @@ def test_fetch_server_public_key():
         mock_requests.get.return_value = resp
         client = CryptoClient('https://example.com')
         assert client.fetch_server_public_key()
-        mock_requests.get.assert_called_with('https://example.com/next_server')
+        mock_requests.get.assert_called_with('https://example.com/next_server', timeout=10)
         assert client.server_public_key is not None
 
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -15,6 +15,10 @@ These helpers now fall back to standard `AppData` locations when Windows environ
 
 Simplifies encryption and decryption operations for end-to-end encrypted communication with the token.place server and relay.
 
+Network requests in this module now use a default 10 second timeout to prevent
+hanging connections. You can override this by passing a `timeout` argument to
+`CryptoClient.fetch_server_public_key` or `CryptoClient.send_encrypted_message`.
+
 ## Crypto Helpers
 
 The `CryptoClient` class provides a high-level abstraction over the encryption/decryption process, making it easy to:

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -45,11 +45,11 @@ class CryptoClient:
     Helper class for end-to-end encryption operations.
     Simplifies the process of encryption, decryption, and API communication.
     """
-    
+
     def __init__(self, base_url: str, debug: bool = False):
         """
         Initialize the crypto client
-        
+
         Args:
             base_url: Base URL for the relay server
             debug: Whether to enable debug logging
@@ -61,57 +61,58 @@ class CryptoClient:
         self.client_public_key = None
         self.client_public_key_b64 = None
         self.debug = debug
-        
+
         if debug:
             logger.setLevel(logging.DEBUG)
-            
+
         logger.info(f"CryptoClient initialized with base URL: {self.base_url}")
-        
+
         # Generate client keys on initialization
         self._generate_client_keys()
-    
+
     def _generate_client_keys(self):
         """Generate RSA key pair for the client"""
         logger.debug("Generating client keys...")
         self.client_private_key, self.client_public_key = generate_keys()
         self.client_public_key_b64 = base64.b64encode(self.client_public_key).decode('utf-8')
         logger.debug("Client keys generated successfully")
-    
-    def fetch_server_public_key(self, endpoint: str = "/next_server") -> bool:
+
+    def fetch_server_public_key(self, endpoint: str = "/next_server", timeout: float = 10) -> bool:
         """
         Fetch the server's public key
-        
+
         Args:
             endpoint: API endpoint to fetch the public key
-            
+            timeout: Maximum time in seconds to wait for a response
+
         Returns:
             True if successful, False otherwise
         """
         full_url = f"{self.base_url}{endpoint}"
         logger.debug(f"Fetching server public key from: {full_url}")
-        
+
         try:
-            response = requests.get(full_url)
+            response = requests.get(full_url, timeout=timeout)
             logger.debug(f"Server response status: {response.status_code}")
-            
+
             if response.status_code != 200:
                 logger.error(f"Failed to get server public key: {response.status_code}")
                 return False
-                
+
             data = response.json()
-            
+
             # Check if there's an error in the response
             if 'error' in data:
                 error_msg = data['error'].get('message', 'Unknown error')
                 logger.error(f"Server returned error: {error_msg}")
                 return False
-                
+
             key_field = "server_public_key" if "server_public_key" in data else "public_key"
-            
+
             if key_field not in data:
                 logger.error(f"No public key found in response, available fields: {list(data.keys())}")
                 return False
-                
+
             self.server_public_key_b64 = data[key_field]
             self.server_public_key = base64.b64decode(self.server_public_key_b64)
             logger.info(f"Successfully fetched server public key")
@@ -119,69 +120,69 @@ class CryptoClient:
         except Exception as e:
             logger.error(f"Exception while fetching server public key: {str(e)}", exc_info=self.debug)
             return False
-    
+
     def encrypt_message(self, message: Union[Dict, List, str]) -> Dict[str, str]:
         """
         Encrypt a message for the server
-        
+
         Args:
             message: Message to encrypt (will be converted to JSON)
-            
+
         Returns:
             Dictionary with base64-encoded ciphertext, cipherkey, and iv
         """
         if self.server_public_key is None:
             raise ValueError("Server public key not available. Call fetch_server_public_key() first.")
-            
+
         # Convert to JSON if it's a dict or list
         if isinstance(message, (dict, list)):
             plaintext = json.dumps(message).encode('utf-8')
         else:
             plaintext = str(message).encode('utf-8')
-            
+
         logger.debug("Encrypting message of length %d bytes", len(plaintext))
-            
+
         # Encrypt the message
         encrypted_dict, cipherkey, iv = encrypt(plaintext, self.server_public_key)
-        
+
         # Convert to Base64 for transmission
         return {
             'ciphertext': base64.b64encode(encrypted_dict['ciphertext']).decode('utf-8'),
             'cipherkey': base64.b64encode(cipherkey).decode('utf-8'),
             'iv': base64.b64encode(iv).decode('utf-8')
         }
-    
+
     def decrypt_message(self, encrypted_data: Dict[str, str]) -> Any:
         """
         Decrypt a message from the server
-        
+
         Args:
             encrypted_data: Dictionary with base64-encoded encrypted fields
-            
+
         Returns:
             Decrypted data (parsed from JSON if possible)
         """
         if self.client_private_key is None:
             raise ValueError("Client private key not available")
-            
+
         logger.debug(f"Decrypting message...")
-            
+
         # Extract and decode the encrypted components
         encrypted_response = {
             'ciphertext': base64.b64decode(encrypted_data['ciphertext']),
             'iv': base64.b64decode(encrypted_data['iv'])
         }
         encrypted_key = base64.b64decode(encrypted_data['cipherkey'])
-        
+
         # Decrypt the data
         decrypted_bytes = decrypt(encrypted_response, encrypted_key, self.client_private_key)
-        
+
         if not decrypted_bytes:
             logger.error("Decryption failed, got None")
             return None
-            
+
         logger.debug(f"Successfully decrypted {len(decrypted_bytes)} bytes")
-        
+
         # Try to parse as JSON
         try:
             return json.loads(decrypted_bytes.decode('utf-8'))
@@ -189,44 +190,45 @@ class CryptoClient:
             # Return as string if not valid JSON
             logger.debug("Could not parse as JSON, returning as string")
             return decrypted_bytes.decode('utf-8')
-    
-    def send_encrypted_message(self, endpoint: str, payload: Dict) -> Optional[Dict]:
+
+    def send_encrypted_message(self, endpoint: str, payload: Dict, timeout: float = 10) -> Optional[Dict]:
         """
         Send an encrypted message to an endpoint
-        
+
         Args:
             endpoint: API endpoint to send to
             payload: Data to include in the request
-            
+            timeout: Maximum time in seconds to wait for a response
+
         Returns:
             Server response as dictionary or None if failed
         """
         full_url = f"{self.base_url}{endpoint}"
         logger.debug(f"Sending encrypted message to: {full_url}")
         logger.debug(f"Payload keys: {list(payload.keys())}")
-        
+
         try:
-            response = requests.post(full_url, json=payload)
+            response = requests.post(full_url, json=payload, timeout=timeout)
             logger.debug(f"Server response status: {response.status_code}")
-            
+
             if response.status_code != 200:
                 logger.error(f"Server returned error status: {response.status_code}")
                 logger.debug(f"Response content: {response.text[:200]}")
                 return None
-                
-            return response.json() 
+
+            return response.json()
         except Exception as e:
             logger.error(f"Exception while sending encrypted message: {str(e)}", exc_info=self.debug)
             return None
-    
+
     def send_chat_message(self, message: Union[str, List[Dict]], max_retries: int = 5) -> Optional[List[Dict]]:
         """
         Send a chat message through the relay server
-        
+
         Args:
             message: Message content or chat history to send
             max_retries: Maximum number of retry attempts for retrieving the response
-            
+
         Returns:
             Decrypted server response or None if failed
         """
@@ -234,22 +236,22 @@ class CryptoClient:
         if not self.server_public_key and not self.fetch_server_public_key():
             logger.error("Failed to get server public key")
             return None
-            
+
         # Prepare the chat history
         if isinstance(message, str):
             chat_history = [{"role": "user", "content": message}]
         else:
             chat_history = message
-            
+
         logger.debug("Sending chat message with %d entries", len(chat_history))
-            
+
         # Encrypt the chat history
         try:
             encrypted_data = self.encrypt_message(chat_history)
         except Exception as e:
             logger.error(f"Failed to encrypt message: {str(e)}", exc_info=self.debug)
             return None
-        
+
         # Prepare the payload
         payload = {
             'client_public_key': self.client_public_key_b64,
@@ -258,53 +260,53 @@ class CryptoClient:
             'cipherkey': encrypted_data['cipherkey'],
             'iv': encrypted_data['iv']
         }
-        
+
         # Send to the faucet endpoint
         response = self.send_encrypted_message('/faucet', payload)
         if not response:
             logger.error("Failed to send message to faucet")
             return None
-            
+
         if not response.get('success', False) and 'message' not in response:
             logger.error(f"Unexpected response from faucet: {response}")
             return None
-            
+
         logger.debug("Message sent successfully, waiting for processing")
-            
+
         # Wait for processing
         time.sleep(3)
-        
+
         # Retrieve the response
         return self.retrieve_chat_response(max_retries)
-    
+
     def retrieve_chat_response(self, max_retries: int = 5, retry_delay: int = 2) -> Optional[List[Dict]]:
         """
         Retrieve and decrypt a chat response from the server
-        
+
         Args:
             max_retries: Maximum number of retry attempts
             retry_delay: Delay between retries in seconds
-            
+
         Returns:
             Decrypted chat history or None if failed
         """
         payload = {
             'client_public_key': self.client_public_key_b64
         }
-        
+
         logger.debug(f"Attempting to retrieve response, max retries: {max_retries}")
-        
+
         for i in range(max_retries):
             logger.debug(f"Retrieve attempt {i+1}/{max_retries}")
             response = self.send_encrypted_message('/retrieve', payload)
-            
+
             if not response:
                 logger.error("Failed to retrieve response")
                 time.sleep(retry_delay)
                 continue
-                
+
             logger.debug(f"Received response keys: {list(response.keys())}")
-                
+
             # Check for error messages
             if 'error' in response:
                 # Handle case where error is a string
@@ -315,9 +317,9 @@ class CryptoClient:
                     error_msg = response['error']['message']
                 else:
                     error_msg = str(response['error'])
-                
+
                 logger.debug(f"Server returned error: {error_msg}")
-                
+
                 # If the error indicates no response available yet, wait and retry
                 if "No response available" in error_msg:
                     logger.debug("No response available yet, retrying...")
@@ -326,7 +328,7 @@ class CryptoClient:
                 else:
                     logger.error(f"Server error: {error_msg}")
                     return None
-                
+
             if "chat_history" in response and "cipherkey" in response and "iv" in response:
                 logger.debug("Got encrypted response, attempting to decrypt")
                 # Decrypt the response
@@ -336,7 +338,7 @@ class CryptoClient:
                         'cipherkey': response['cipherkey'],
                         'iv': response['iv']
                     })
-                    
+
                     # Validate the response structure
                     if isinstance(decrypted_data, list) and len(decrypted_data) > 0:
                         for msg in decrypted_data:
@@ -352,21 +354,21 @@ class CryptoClient:
                     return None
             else:
                 logger.debug(f"Response doesn't contain expected fields: {response}")
-                
+
             # Wait before retrying
             time.sleep(retry_delay)
-            
+
         logger.error(f"Failed to retrieve chat response after {max_retries} attempts")
         return None
-    
+
     def send_api_request(self, messages: List[Dict], model: str = 'llama-3-8b-instruct') -> Optional[Dict]:
         """
         Send an encrypted API request to the chat completions endpoint
-        
+
         Args:
             messages: List of message dictionaries
             model: Model name to use
-            
+
         Returns:
             Decrypted API response or None if failed
         """
@@ -375,14 +377,14 @@ class CryptoClient:
             if not self.fetch_server_public_key('/api/v1/public-key'):
                 logger.error("Failed to get API public key")
                 return None
-            
+
         # Encrypt the messages
         try:
             encrypted_data = self.encrypt_message(messages)
         except Exception as e:
             logger.error(f"Failed to encrypt API request: {str(e)}", exc_info=self.debug)
             return None
-        
+
         # Prepare the payload
         payload = {
             'model': model,
@@ -394,18 +396,18 @@ class CryptoClient:
                 'iv': encrypted_data['iv']
             }
         }
-        
+
         # Send the request
         response = self.send_encrypted_message('/api/v1/chat/completions', payload)
-        
+
         if not response:
             logger.error("Failed to get API response")
             return None
-            
+
         logger.debug(f"API response keys: {list(response.keys())}")
-            
+
         # Handle different response formats
-        
+
         # New format: response has 'data' key with encrypted content
         if 'data' in response and isinstance(response['data'], dict) and 'encrypted' in response['data']:
             try:
@@ -419,7 +421,7 @@ class CryptoClient:
             except Exception as e:
                 logger.error(f"Failed to decrypt API response (data format): {str(e)}", exc_info=self.debug)
                 return None
-            
+
         # Original format: response has 'encrypted_content' key
         elif 'encrypted' in response and response['encrypted'] and 'encrypted_content' in response:
             try:
@@ -433,6 +435,6 @@ class CryptoClient:
             except Exception as e:
                 logger.error(f"Failed to decrypt API response (encrypted_content format): {str(e)}", exc_info=self.debug)
                 return None
-                
+
         logger.error(f"Invalid API response format: {response}")
-        return None 
+        return None


### PR DESCRIPTION
## Summary
- add default 10s request timeout to CryptoClient key fetch and encrypted sends
- document and test the new timeout behaviour

## Testing
- `pre-commit run --files utils/crypto_helpers.py tests/test_crypto_helpers.py tests/unit/test_crypto_helpers_simple.py utils/README.md`
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893e20a5ea8832fab092f85360454f5