### PR TITLE
📝 docs: use npm ci for reproducible installs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Thank you for your interest in contributing to token.place! This document provid
 
 4. Install Node.js dependencies:
    ```bash
-   npm install
+    npm ci
    ```
 
 5. Set up pre-commit hooks:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/futuroptimist/token.place.git
 cd token.place
 pip install -r config/requirements_server.txt
 pip install -r config/requirements_relay.txt
-npm install
+ npm ci
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files
@@ -199,7 +199,7 @@ pip install -r config/requirements_relay.txt   # relay-only dependencies
 For JavaScript dependencies, run:
 
 ```
-npm install
+ npm ci
 ```
 
 #### troubleshooting `llama_cpp_python` builds

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,7 +10,7 @@ Before running the tests, install the required Python and Node.js dependencies a
 pip install -r config/requirements_server.txt
 pip install -r config/requirements_relay.txt
 pip install -r requirements.txt
-npm install
+ npm ci
 playwright install
 ```
 
@@ -158,7 +158,7 @@ The Visual Verification framework captures and compares screenshots of the UI to
 ### How Visual Verification Works
 
 1. The framework captures screenshots of key UI states
-2. These screenshots are compared with baseline images 
+2. These screenshots are compared with baseline images
 3. Differences are highlighted and quantified
 4. A visual report is generated
 
@@ -265,4 +265,4 @@ python -m pytest tests/test_security.py
 ## Additional Resources
 
 - [TESTING_IMPROVEMENTS.md](TESTING_IMPROVEMENTS.md) - Detailed ideas for test improvements
-- [tests/visual_verification/README.md](../tests/visual_verification/README.md) - Visual verification framework documentation 
+- [tests/visual_verification/README.md](../tests/visual_verification/README.md) - Visual verification framework documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ pytest-mock               # Mocking utilities
 pytest-benchmark==5.1.0   # Performance benchmarking, requires pytest>=8.1
 
 # JavaScript test dependencies
-# Note: Install these with npm install
+# Note: Install these with npm ci

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,7 +90,7 @@ Some tests (particularly Playwright tests) require additional setup or running s
    ```
 5. All Node.js dependencies installed:
    ```bash
-   npm install
+    npm ci
    ```
 
 ## Test Configuration
@@ -166,4 +166,4 @@ To generate a test coverage report:
 python -m pytest --cov=. --cov-report=html
 ```
 
-The HTML report will be available in the `htmlcov` directory. 
+The HTML report will be available in the `htmlcov` directory.


### PR DESCRIPTION
## Summary
- replace npm install with npm ci in setup and testing docs

## Testing
- npm run lint (missing script)
- npm run test:ci (missing script)
- pre-commit run --files README.md CONTRIBUTING.md docs/TESTING.md docs/TESTING_IMPROVEMENTS.md tests/README.md requirements.txt
- ./run_all_tests.sh (Crypto Compatibility Tests - Playwright deps missing)
- git diff --cached | ./scripts/scan-secrets.py (missing script)


------
https://chatgpt.com/codex/tasks/task_e_689436e0955c832fa67c0e1952571bdd