### PR TITLE
Ensure path helpers create application directories

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -1,4 +1,6 @@
+import importlib
 import pathlib
+import platform
 import pytest
 from utils import path_handling as ph
 
@@ -41,3 +43,14 @@ def test_get_relative_path_default_base(tmp_path, monkeypatch):
     sub.mkdir()
     result = ph.get_relative_path(sub)
     assert result == pathlib.Path("sub")
+
+
+def test_get_app_data_dir_creates_directory(tmp_path, monkeypatch):
+    """get_app_data_dir should ensure the directory exists"""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    importlib.reload(ph)
+    app_dir = ph.get_app_data_dir()
+    expected = tmp_path / ".local" / "share" / "token.place"
+    assert app_dir == expected
+    assert app_dir.exists()

--- a/utils/README.md
+++ b/utils/README.md
@@ -7,10 +7,12 @@ This directory contains utility modules for token.place that provide reusable fu
 ### Path Handling (`path_handling.py`)
 
 Cross-platform path handling utilities that ensure consistent behavior across Windows, macOS, and Linux.
-These helpers now fall back to standard `AppData` locations when Windows environment variables are missing.
+These helpers now fall back to standard `AppData` locations when Windows environment variables are missing
+and automatically create directories when accessed.
 
 - `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
   `NotADirectoryError` when the path points to an existing file.
+- `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 
 ### Crypto Helpers (`crypto_helpers.py`)
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -31,8 +31,7 @@ def get_app_data_dir() -> pathlib.Path:
         base_dir = get_user_home_dir() / 'Library' / 'Application Support'
     else:  # Linux and other Unix-like
         base_dir = get_user_home_dir() / '.local' / 'share'
-
-    return base_dir / 'token.place'
+    return ensure_dir_exists(base_dir / 'token.place')
 
 def get_config_dir() -> pathlib.Path:
     """
@@ -42,9 +41,9 @@ def get_config_dir() -> pathlib.Path:
     - Linux: ~/.config/token.place
     """
     if IS_WINDOWS or IS_MACOS:
-        return get_app_data_dir() / 'config'
+        return ensure_dir_exists(get_app_data_dir() / 'config')
     else:  # Linux and other Unix-like
-        return get_user_home_dir() / '.config' / 'token.place'
+        return ensure_dir_exists(get_user_home_dir() / '.config' / 'token.place')
 
 def get_cache_dir() -> pathlib.Path:
     """
@@ -59,24 +58,24 @@ def get_cache_dir() -> pathlib.Path:
             base_dir = pathlib.Path(local_appdata)
         else:
             base_dir = get_user_home_dir() / 'AppData' / 'Local'
-        return base_dir / 'token.place' / 'cache'
+        return ensure_dir_exists(base_dir / 'token.place' / 'cache')
     elif IS_MACOS:
-        return get_user_home_dir() / 'Library' / 'Caches' / 'token.place'
+        return ensure_dir_exists(get_user_home_dir() / 'Library' / 'Caches' / 'token.place')
     else:  # Linux and other Unix-like
-        return get_user_home_dir() / '.cache' / 'token.place'
+        return ensure_dir_exists(get_user_home_dir() / '.cache' / 'token.place')
 
 def get_models_dir() -> pathlib.Path:
     """Get the directory for storing downloaded models."""
-    return get_app_data_dir() / 'models'
+    return ensure_dir_exists(get_app_data_dir() / 'models')
 
 def get_logs_dir() -> pathlib.Path:
     """Get the directory for storing log files."""
     if IS_WINDOWS:
-        return get_app_data_dir() / 'logs'
+        return ensure_dir_exists(get_app_data_dir() / 'logs')
     elif IS_MACOS:
-        return get_user_home_dir() / 'Library' / 'Logs' / 'token.place'
+        return ensure_dir_exists(get_user_home_dir() / 'Library' / 'Logs' / 'token.place')
     else:  # Linux and other Unix-like
-        return get_user_home_dir() / '.local' / 'state' / 'token.place' / 'logs'
+        return ensure_dir_exists(get_user_home_dir() / '.local' / 'state' / 'token.place' / 'logs')
 
 def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     """


### PR DESCRIPTION
## What
- create app/config/cache/model/log directories on access
- document automatic path creation
- test app data dir creation

## Why
- prevent failures when expected directories are missing

## How to Test
- `npm run lint` (missing script)
- `npm run test:ci` (missing script)
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689436e0955c832fa67c0e1952571bdd