### PR TITLE
🧪 fix: importlib for path tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -116,6 +116,7 @@ during tests or `https://token.place/v1` in production.
 **User Journey**: Users run token.place on different operating systems.
 
 **Test Files**:
+- `tests/unit/test_path_handling.py` - Quick checks for path utilities on each OS
 - `tests/platform_tests/test_path_handling.py` - Tests path handling across platforms
 - `tests/platform_tests/test_config.py` - Tests configuration loading on different platforms
 
@@ -158,7 +159,7 @@ The Visual Verification framework captures and compares screenshots of the UI to
 ### How Visual Verification Works
 
 1. The framework captures screenshots of key UI states
-2. These screenshots are compared with baseline images 
+2. These screenshots are compared with baseline images
 3. Differences are highlighted and quantified
 4. A visual report is generated
 
@@ -265,4 +266,4 @@ python -m pytest tests/test_security.py
 ## Additional Resources
 
 - [TESTING_IMPROVEMENTS.md](TESTING_IMPROVEMENTS.md) - Detailed ideas for test improvements
-- [tests/visual_verification/README.md](../tests/visual_verification/README.md) - Visual verification framework documentation 
+- [tests/visual_verification/README.md](../tests/visual_verification/README.md) - Visual verification framework documentation

--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -3,10 +3,11 @@ import os
 from pathlib import Path
 from unittest import mock
 
+import utils.path_handling as ph
+
 
 def test_paths_linux(tmp_path):
     with mock.patch('platform.system', return_value='Linux'):
-        import utils.path_handling as ph
         importlib.reload(ph)
         home = Path.home()
         assert ph.get_app_data_dir() == home / '.local' / 'share' / 'token.place'
@@ -32,7 +33,6 @@ def test_paths_windows(tmp_path):
     }
     with mock.patch('platform.system', return_value='Windows'):
         with mock.patch.dict(os.environ, env, clear=False):
-            import utils.path_handling as ph
             importlib.reload(ph)
             base = Path(env['APPDATA'])
             assert ph.get_app_data_dir() == base / 'token.place'
@@ -45,7 +45,6 @@ def test_paths_windows(tmp_path):
 def test_paths_windows_missing_env():
     with mock.patch('platform.system', return_value='Windows'):
         with mock.patch.dict(os.environ, {'APPDATA': '', 'LOCALAPPDATA': ''}, clear=False):
-            import utils.path_handling as ph
             importlib.reload(ph)
             home = Path.home()
             assert ph.get_app_data_dir() == home / 'AppData' / 'Roaming' / 'token.place'
@@ -55,7 +54,6 @@ def test_paths_windows_missing_env():
 
 def test_paths_macos(tmp_path):
     with mock.patch('platform.system', return_value='Darwin'):
-        import utils.path_handling as ph
         importlib.reload(ph)
         home = Path.home()
         assert ph.get_app_data_dir() == home / 'Library' / 'Application Support' / 'token.place'


### PR DESCRIPTION
## Summary
- add missing import and reload to path handling tests
- document path test coverage

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test:ci` *(fails: Missing script)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689436e0955c832fa67c0e1952571bdd