### PR TITLE
📝: enforce token.place naming in tests and docs

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -33,6 +33,7 @@ Examples:
 - In variable names, use `tokenPlace` (camelCase) or `token_place` (snake_case) depending on the language conventions.
 - In class names, use `TokenPlace` (PascalCase).
 - For file names, use `token_place` (snake_case) for Python files and `tokenPlace` (camelCase) for JavaScript files.
+- In comments and docstrings, refer to the project as `token.place`.
 
 Examples:
 ```python
@@ -84,4 +85,4 @@ When referring to versions of `token.place`:
 - Use semantic versioning (MAJOR.MINOR.PATCH)
 - Reference versions as `token.place v1.0.0` not `Token.place Version 1.0.0`
 
-By following these guidelines, we ensure consistent presentation of the `token.place` brand across all platforms and materials. 
+By following these guidelines, we ensure consistent presentation of the `token.place` brand across all platforms and materials.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 """
-Token.place test package.
-""" 
+token.place test package.
+"""


### PR DESCRIPTION
## Summary
- align tests package docstring with lowercase token.place style
- note token.place naming in style guide comments and docstrings section

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test:ci` *(fails: Missing script)*
- `playwright install chromium`
- `playwright install-deps`
- `pre-commit run --all-files`
- `detect-secrets scan /tmp/diff.patch`


------
https://chatgpt.com/codex/tasks/task_e_689436e0955c832fa67c0e1952571bdd