### PR TITLE
✨: honor XDG base dirs on Linux

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -1,6 +1,8 @@
 import importlib
 import pathlib
 import platform
+from unittest import mock
+
 import pytest
 from utils import path_handling as ph
 
@@ -54,3 +56,14 @@ def test_get_app_data_dir_creates_directory(tmp_path, monkeypatch):
     expected = tmp_path / ".local" / "share" / "token.place"
     assert app_dir == expected
     assert app_dir.exists()
+
+
+def test_linux_uses_xdg_dirs(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg" / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg" / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg" / "cache"))
+    with mock.patch('platform.system', return_value='Linux'):
+        importlib.reload(ph)
+        assert ph.get_app_data_dir() == tmp_path / "xdg" / "data" / "token.place"
+        assert ph.get_config_dir() == tmp_path / "xdg" / "config" / "token.place"
+        assert ph.get_cache_dir() == tmp_path / "xdg" / "cache" / "token.place"

--- a/utils/README.md
+++ b/utils/README.md
@@ -10,6 +10,9 @@ Cross-platform path handling utilities that ensure consistent behavior across Wi
 These helpers now fall back to standard `AppData` locations when Windows environment variables are missing
 and automatically create directories when accessed.
 
+On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and
+`XDG_CACHE_HOME` environment variables when they are set.
+
 - `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
   `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -19,7 +19,7 @@ def get_app_data_dir() -> pathlib.Path:
     Get the appropriate application data directory based on platform:
     - Windows: %APPDATA%/token.place
     - macOS: ~/Library/Application Support/token.place
-    - Linux: ~/.local/share/token.place
+    - Linux: $XDG_DATA_HOME/token.place or ~/.local/share/token.place
     """
     if IS_WINDOWS:
         appdata = os.environ.get('APPDATA')
@@ -30,7 +30,11 @@ def get_app_data_dir() -> pathlib.Path:
     elif IS_MACOS:
         base_dir = get_user_home_dir() / 'Library' / 'Application Support'
     else:  # Linux and other Unix-like
-        base_dir = get_user_home_dir() / '.local' / 'share'
+        xdg_data_home = os.environ.get('XDG_DATA_HOME')
+        if xdg_data_home:
+            base_dir = pathlib.Path(xdg_data_home)
+        else:
+            base_dir = get_user_home_dir() / '.local' / 'share'
     return ensure_dir_exists(base_dir / 'token.place')
 
 def get_config_dir() -> pathlib.Path:
@@ -38,19 +42,24 @@ def get_config_dir() -> pathlib.Path:
     Get the appropriate configuration directory based on platform:
     - Windows: %APPDATA%/token.place/config
     - macOS: ~/Library/Application Support/token.place/config
-    - Linux: ~/.config/token.place
+    - Linux: $XDG_CONFIG_HOME/token.place or ~/.config/token.place
     """
     if IS_WINDOWS or IS_MACOS:
         return ensure_dir_exists(get_app_data_dir() / 'config')
     else:  # Linux and other Unix-like
-        return ensure_dir_exists(get_user_home_dir() / '.config' / 'token.place')
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
+        if xdg_config_home:
+            base_dir = pathlib.Path(xdg_config_home)
+        else:
+            base_dir = get_user_home_dir() / '.config'
+        return ensure_dir_exists(base_dir / 'token.place')
 
 def get_cache_dir() -> pathlib.Path:
     """
     Get the appropriate cache directory based on platform:
     - Windows: %LOCALAPPDATA%/token.place/cache
     - macOS: ~/Library/Caches/token.place
-    - Linux: ~/.cache/token.place
+    - Linux: $XDG_CACHE_HOME/token.place or ~/.cache/token.place
     """
     if IS_WINDOWS:
         local_appdata = os.environ.get('LOCALAPPDATA')
@@ -62,7 +71,12 @@ def get_cache_dir() -> pathlib.Path:
     elif IS_MACOS:
         return ensure_dir_exists(get_user_home_dir() / 'Library' / 'Caches' / 'token.place')
     else:  # Linux and other Unix-like
-        return ensure_dir_exists(get_user_home_dir() / '.cache' / 'token.place')
+        xdg_cache_home = os.environ.get('XDG_CACHE_HOME')
+        if xdg_cache_home:
+            base_dir = pathlib.Path(xdg_cache_home)
+        else:
+            base_dir = get_user_home_dir() / '.cache'
+        return ensure_dir_exists(base_dir / 'token.place')
 
 def get_models_dir() -> pathlib.Path:
     """Get the directory for storing downloaded models."""


### PR DESCRIPTION
## Summary
- use XDG_DATA_HOME, XDG_CONFIG_HOME, and XDG_CACHE_HOME in path helpers
- document XDG support for path utilities
- test Linux paths when XDG variables are set

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `playwright install chromium`
- `playwright install-deps`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68946238fd64832fa368100d2423716d