### PR TITLE
🔧 Add request timeouts to client requests

### DIFF
--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -92,7 +92,9 @@ def test_send_encrypted_message(mock_crypto_client):
     payload = {'test': 'data'}
     response = client.send_encrypted_message('/test-endpoint', payload)
 
-      mock_requests.post.assert_called_with('https://mock-server.com/test-endpoint', json=payload, timeout=10)
+    mock_requests.post.assert_called_with(
+        'https://mock-server.com/test-endpoint', json=payload, timeout=10
+    )
     assert response is not None
     assert response['success'] is True
 

--- a/tests/unit/test_chat_client.py
+++ b/tests/unit/test_chat_client.py
@@ -2,7 +2,7 @@ import base64
 import json
 from unittest.mock import patch, MagicMock
 
-from client import ChatClient
+from client import ChatClient, REQUEST_TIMEOUT
 
 
 def test_get_server_public_key():
@@ -13,7 +13,9 @@ def test_get_server_public_key():
         mock_get.return_value = resp
         key = client.get_server_public_key()
         assert key == b'k'
-        mock_get.assert_called_with('http://testserver:5000/next_server')
+        mock_get.assert_called_with(
+            'http://testserver:5000/next_server', timeout=REQUEST_TIMEOUT
+        )
 
 
 def test_send_message_flow():


### PR DESCRIPTION
## Summary
- add reusable timeout constant for client HTTP requests
- adjust tests to account for explicit timeouts

## Testing
- `pre-commit run --all-files` *(fails: Crypto Compatibility Tests require Playwright deps)*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*


------
https://chatgpt.com/codex/tasks/task_e_68946238fd64832fa368100d2423716d