### PR TITLE
🔒: restrict default hosts and remove shell calls

### DIFF
--- a/client_simplified.py
+++ b/client_simplified.py
@@ -13,8 +13,9 @@ from typing import List, Dict, Optional
 from utils.crypto_helpers import CryptoClient
 
 def clear_screen():
-    """Clear the terminal screen"""
-    os.system('cls' if os.name == 'nt' else 'clear')
+    """Clear the terminal screen without invoking a shell."""
+    # ANSI escape sequence clears the screen and positions cursor at top-left
+    print("\033[2J\033[H", end="")
 
 def format_message(message: Dict) -> str:
     """Format a message for display"""

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('config')
 DEFAULT_CONFIG = {
     # Server settings
     'server': {
-        'host': '0.0.0.0',
+        'host': '127.0.0.1',
         'port': 5000,
         'debug': False,
         'workers': 4,
@@ -37,7 +37,7 @@ DEFAULT_CONFIG = {
     
     # Relay settings
     'relay': {
-        'host': '0.0.0.0',
+        'host': '127.0.0.1',
         'port': 5000,
         'server_url': 'http://localhost:5000',
         'workers': 2,
@@ -45,7 +45,7 @@ DEFAULT_CONFIG = {
     
     # API settings
     'api': {
-        'host': '0.0.0.0',
+        'host': '127.0.0.1',
         'port': 3000,
         'relay_url': 'http://localhost:5000',
         'cors_origins': ['*'],
@@ -121,6 +121,13 @@ ENV_OVERRIDES = {
         'server': {
             'debug': False,
             'workers': 8,
+            'host': os.environ.get('PROD_SERVER_HOST', '127.0.0.1'),
+        },
+        'relay': {
+            'host': os.environ.get('PROD_RELAY_HOST', '127.0.0.1'),
+        },
+        'api': {
+            'host': os.environ.get('PROD_API_HOST', '127.0.0.1'),
         },
         'security': {
             'encryption_enabled': True,

--- a/relay.py
+++ b/relay.py
@@ -11,6 +11,7 @@ import time
 # Parse command line arguments early to set environment variables before imports
 parser = argparse.ArgumentParser(description="token.place relay server")
 parser.add_argument("--port", type=int, default=5010, help="Port to run the relay server on")
+parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind the relay server")
 parser.add_argument("--use_mock_llm", action="store_true", help="Use mock LLM for testing")
 
 if __name__ == "__main__":  # pragma: no cover
@@ -84,7 +85,7 @@ def inference():
     url = 'http://localhost:3000/'
 
     # Forward the POST request to the other service and get the response
-    response = requests.post(url, json=data)
+    response = requests.post(url, json=data, timeout=10)
 
     # Return the response received from the other service to the client
     return jsonify(response.json()), response.status_code
@@ -250,4 +251,4 @@ def retrieve():
         return jsonify({'error': 'No response available for the given public key'}), 200
 
 if __name__ == '__main__':  # pragma: no cover
-    app.run(host='0.0.0.0', port=args.port)
+    app.run(host=args.host, port=args.port)

--- a/scripts/validate_dependencies.py
+++ b/scripts/validate_dependencies.py
@@ -10,18 +10,20 @@ import subprocess
 import sys
 import tempfile
 import os
+import shlex
 from pathlib import Path
 
 def run_command(cmd, cwd=None):
     """Run a command and return success status and output."""
+    if isinstance(cmd, str):
+        cmd = shlex.split(cmd)
     try:
         result = subprocess.run(
-            cmd, 
-            shell=True, 
-            capture_output=True, 
-            text=True, 
+            cmd,
+            capture_output=True,
+            text=True,
             cwd=cwd,
-            check=False
+            check=False,
         )
         return result.returncode == 0, result.stdout, result.stderr
     except Exception as e:

--- a/server.py
+++ b/server.py
@@ -45,7 +45,13 @@ class ServerApp:
     """
     Main server application that integrates all components.
     """
-    def __init__(self, server_port: int = 3000, relay_port: int = 5000, relay_url: str = "http://localhost"):
+    def __init__(
+        self,
+        server_port: int = 3000,
+        relay_port: int = 5000,
+        relay_url: str = "http://localhost",
+        server_host: str = "127.0.0.1",
+    ):
         """
         Initialize the server application.
 
@@ -55,6 +61,7 @@ class ServerApp:
             relay_url: URL of the relay server
         """
         self.server_port = server_port
+        self.server_host = server_host
         self.relay_port = relay_port
         self.relay_url = relay_url
 
@@ -128,7 +135,7 @@ class ServerApp:
 
         # Run the Flask app
         self.app.run(
-            host='0.0.0.0',
+            host=self.server_host,
             port=self.server_port,
             debug=not config.is_production,
             use_reloader=False  # Disable reloader to avoid duplicate threads
@@ -138,6 +145,7 @@ def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="token.place server")
     parser.add_argument("--server_port", type=int, default=3000, help="Port to run the server on")
+    parser.add_argument("--server_host", default="127.0.0.1", help="Host interface to bind the server")
     parser.add_argument("--relay_port", type=int, default=5000, help="Port the relay server is running on")
     parser.add_argument("--relay_url", type=str, default="http://localhost", help="URL of the relay server")
     parser.add_argument("--use_mock_llm", action="store_true", help="Use mock LLM for testing")
@@ -155,6 +163,7 @@ def main():
     # Create and run the server
     server = ServerApp(
         server_port=args.server_port,
+        server_host=args.server_host,
         relay_port=args.relay_port,
         relay_url=args.relay_url
     )

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -121,7 +121,7 @@ class ServerApp:
 
         # Run the Flask app
         self.app.run(
-            host='0.0.0.0',
+            host='127.0.0.1',
             port=self.server_port,
             debug=not config.is_production,
             use_reloader=False  # Disable reloader to avoid duplicate threads

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def setup_servers() -> Generator[Tuple[subprocess.Popen, subprocess.Popen], None
     relay_ready = False
     for _ in range(15):  # Try for 15 seconds
         try:
-            response = requests.get(f"{E2E_BASE_URL}/")
+            response = requests.get(f"{E2E_BASE_URL}/", timeout=10)
             if response.status_code == 200:
                 relay_ready = True
                 print("✓ Relay server is running")
@@ -211,7 +211,7 @@ def setup_servers() -> Generator[Tuple[subprocess.Popen, subprocess.Popen], None
     server_registered = False
     for _ in range(30):  # 30 seconds timeout
         try:
-            response = requests.get(f"{E2E_BASE_URL}/next_server")
+            response = requests.get(f"{E2E_BASE_URL}/next_server", timeout=10)
             if response.status_code == 200 and response.json().get('server_public_key'):
                 server_registered = True
                 print("✓ Server registered with relay")


### PR DESCRIPTION
## Summary
- avoid shell invocation for screen clearing
- add request timeouts and limit default bind hosts

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`
- `pre-commit run --all-files` *(fails: Python Unit Tests, Crypto Compatibility Tests)*
- `npm run lint` *(missing script)*
- `npm run test:ci` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6894623298b0832f8f9a27581b658f19