### PR TITLE
Bind server to 0.0.0.0 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ python relay.py
 The relay listens on port 5000. It automatically connects to the default server
 address baked into the project, so no environment variables are required.
 
-In a separate terminal, launch the server, which runs on http://localhost:3000:
+In a separate terminal, launch the server, which binds to `0.0.0.0` on port 3000 (accessible via http://localhost:3000):
 
 ```sh
 python server.py

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -121,7 +121,7 @@ class ServerApp:
 
         # Run the Flask app
         self.app.run(
-            host='127.0.0.1',
+            host='0.0.0.0',
             port=self.server_port,
             debug=not config.is_production,
             use_reloader=False  # Disable reloader to avoid duplicate threads


### PR DESCRIPTION
## Summary
- listen on all interfaces in server run method
- document server binding address

## Testing
- `pre-commit run --files server/server_app.py README.md` *(failed: Crypto Compatibility Tests (Playwright))*
- `./run_all_tests.sh` *(failed: Crypto Compatibility Tests (Playwright))*

------
https://chatgpt.com/codex/tasks/task_e_6895912e2274832f8fe2d4e60c85cfe8