### PR TITLE
🛡️ Harden server defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v2.7
     hooks:
       - id: vulture
-        args: [".", "--min-confidence", "80"]
+        args: [".", "--min-confidence", "80", "--exclude", "tests,desktop,node_modules"]
   - repo: local
     hooks:
       - id: run-checks

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,4 @@
+exclude_dirs:
+  - tests
+  - desktop
+  - node_modules

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -121,7 +121,7 @@ class ServerApp:
 
         # Run the Flask app
         self.app.run(
-            host='0.0.0.0',
+            host='127.0.0.1',
             port=self.server_port,
             debug=not config.is_production,
             use_reloader=False  # Disable reloader to avoid duplicate threads

--- a/tests/unit/test_server_app_additional.py
+++ b/tests/unit/test_server_app_additional.py
@@ -48,7 +48,7 @@ def test_run_method(monkeypatch):
 
         poller.assert_called_once()
         flask_runner.assert_called_once_with(
-            host='0.0.0.0',
+            host='127.0.0.1',
             port=app.server_port,
             debug=not sa.config.is_production,
             use_reloader=False,

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -75,7 +75,8 @@ class ModelManager:
             bool: True if download was successful, False otherwise
         """
         chunk_size_bytes = chunk_size_mb * 1024 * 1024  # Convert MB to bytes
-        response = requests.get(url, stream=True)
+        # Use a timeout to avoid hanging during downloads
+        response = requests.get(url, stream=True, timeout=60)
 
         if response.status_code != 200:
             self.log_error(f"Error: Unable to download file, status code {response.status_code}")


### PR DESCRIPTION
## Summary
- restrict server to localhost and add download timeout
- ignore tests and vendor directories in static analysis

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r . -ll -c bandit.yaml`
- `bandit -r tokenplace -lll`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --all-files` *(fails: codespell and mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896cd83d070832f9630d007c2106fb1