### PR TITLE
🐛: propagate system interrupts in logging

### DIFF
--- a/docs/SECURITY_PRIVACY_AUDIT.md
+++ b/docs/SECURITY_PRIVACY_AUDIT.md
@@ -76,4 +76,14 @@ Project structure reorganization and documentation updates.
 **Recommendations**
 - Continue to monitor for broken links or outdated paths after large refactors.
 
+### [2025-08-09] - commit TBD
 
+**Summary**
+Refined logging helpers to avoid swallowing system interrupt exceptions.
+
+**Completed Improvements**
+- Updated `log_info` and `log_error` to catch only standard exceptions, allowing
+  `KeyboardInterrupt` and `SystemExit` to propagate.
+
+**Recommendations**
+- Continue monitoring logging utilities for unintended side effects.

--- a/tests/unit/test_relay_client_logging.py
+++ b/tests/unit/test_relay_client_logging.py
@@ -1,4 +1,6 @@
 from unittest.mock import MagicMock, patch
+
+import pytest
 import utils.networking.relay_client as rc
 
 
@@ -46,3 +48,15 @@ def test_log_error_fallback():
     with patch.object(rc, 'logger', logger), patch.object(rc, 'get_config_lazy', side_effect=RuntimeError()):
         rc.log_error("oops {}", "fail")
     logger.error.assert_called_with("oops fail", exc_info=False)
+
+
+def test_log_info_propagates_keyboardinterrupt():
+    with patch.object(rc, 'get_config_lazy', side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            rc.log_info("ignored")
+
+
+def test_log_error_propagates_keyboardinterrupt():
+    with patch.object(rc, 'get_config_lazy', side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            rc.log_error("ignored")

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -52,7 +52,7 @@ def log_info(message, *args):
                 logger.info(message.format(*args))
             else:
                 logger.info(message)
-    except:
+    except Exception:
         # Fallback to always log if config is not available
         if args:
             logger.info(message.format(*args))
@@ -68,7 +68,7 @@ def log_error(message, *args, exc_info=False):
                 logger.error(message.format(*args), exc_info=exc_info)
             else:
                 logger.error(message, exc_info=exc_info)
-    except:
+    except Exception:
         # Fallback to always log if config is not available
         if args:
             logger.error(message.format(*args), exc_info=exc_info)


### PR DESCRIPTION
## Summary
- prevent `log_info` and `log_error` from catching system interrupts
- add tests ensuring logging helpers don't swallow `KeyboardInterrupt`
- document logging change in security audit log

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --all-files` *(fails: codespell, mypy, vulture issues in repository)*

Status: Draft
Labels: needs-triage

------
https://chatgpt.com/codex/tasks/task_e_6896cd8847a8832fb84570bcb13d376e