### PR TITLE
🔧 expand env var handling in path normalization

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -49,6 +49,7 @@ We've implemented a comprehensive path handling system in `utils/path_handling.p
 - Detects the operating system and uses appropriate paths
 - Handles user directories, config paths, and cache locations correctly per platform
 - Ensures directories exist before attempting to use them
+- Expands `~` and environment variables when normalizing paths
 
 ### Platform-Specific Paths
 

--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -30,6 +30,19 @@ def test_ensure_dir_exists_expands_user(tmp_path, monkeypatch):
     assert result.exists()
 
 
+def test_normalize_path_expands_env_vars(tmp_path, monkeypatch):
+    """normalize_path should expand environment variables"""
+    monkeypatch.setenv("TEST_BASE", str(tmp_path))
+    target = tmp_path / "nested"
+    target.mkdir()
+    if ph.IS_WINDOWS:
+        path_with_var = "%TEST_BASE%\\nested"
+    else:
+        path_with_var = "$TEST_BASE/nested"
+    result = ph.normalize_path(path_with_var)
+    assert result == target
+
+
 def test_get_relative_path_not_relative(tmp_path):
     a = tmp_path / "a"
     b = tmp_path / "b"

--- a/utils/README.md
+++ b/utils/README.md
@@ -13,6 +13,7 @@ and automatically create directories when accessed.
 On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and
 `XDG_CACHE_HOME` environment variables when they are set.
 
+- `normalize_path(path)`: Expands `~` and environment variables then returns a normalized absolute path.
 - `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
   `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -110,7 +110,8 @@ def get_executable_extension() -> str:
 
 def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
     """Convert a path string to a normalized pathlib.Path object."""
-    return pathlib.Path(path).expanduser().resolve()
+    expanded = os.path.expandvars(str(path))
+    return pathlib.Path(expanded).expanduser().resolve()
 
 def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:
     """


### PR DESCRIPTION
## Summary
- expand normalize_path to resolve environment variables
- document path normalization behavior across docs
- cover env var expansion with unit test

## Testing
- pre-commit run --all-files
- pytest tests/unit/test_path_handling_additional.py::test_normalize_path_expands_env_vars
- npm run lint (missing script)
- npm run test:ci (missing script)


------
https://chatgpt.com/codex/tasks/task_e_6896cd8847a8832fb84570bcb13d376e