### PR TITLE
🔧 : remove unused imports from simplified client

### DIFF
--- a/client_simplified.py
+++ b/client_simplified.py
@@ -4,11 +4,8 @@ Uses the CryptoClient helper to handle encryption and API communication
 """
 
 import argparse
-import os
-import subprocess
 import sys
-import time
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 # Import our CryptoClient
 from utils.crypto_helpers import CryptoClient

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Validate PKCS#7 unpadding length to reject improperly padded input
+- Remove unused imports from simplified CLI client to avoid unnecessary dependencies
 
 ## Version 1.0.0 (March 2025)
 

--- a/tests/unit/test_client_simplified.py
+++ b/tests/unit/test_client_simplified.py
@@ -12,6 +12,12 @@ def test_format_message_user_and_assistant():
     assert "System:" in cs.format_message(other_msg)
 
 
+def test_no_unused_imports():
+    """Ensure no leftover modules remain imported unintentionally."""
+    for name in ["os", "subprocess", "time"]:
+        assert name not in cs.__dict__, f"{name} should not be imported"
+
+
 def test_main_single_message(monkeypatch, capsys):
     mock_client = MagicMock()
     mock_client.fetch_server_public_key.return_value = True


### PR DESCRIPTION
## Summary
- drop unused imports from client_simplified
- guard against stray imports with unit test
- document cleanup in changelog

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --all-files` *(fails: codespell, mypy, vulture warnings)*
- `python -m pytest tests/unit/test_client_simplified.py::test_no_unused_imports -q`


------
https://chatgpt.com/codex/tasks/task_e_6896eb027e84832fa413b7f17c9120f0