### PR TITLE
🐛 fix get_relative_path for non-descendant paths

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -49,7 +49,7 @@ def test_get_relative_path_not_relative(tmp_path):
     a.mkdir()
     b.mkdir()
     result = ph.get_relative_path(a, b)
-    assert result == a.resolve()
+    assert result == pathlib.Path("..") / "a"
 
 
 def test_get_relative_path_default_base(tmp_path, monkeypatch):

--- a/utils/README.md
+++ b/utils/README.md
@@ -17,6 +17,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and
 - `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
   `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
+- `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the
+  two locations do not share a common ancestor.
 
 ### Crypto Helpers (`crypto_helpers.py`)
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -114,9 +114,11 @@ def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
     return pathlib.Path(expanded).expanduser().resolve()
 
 def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:
-    """
-    Get a path relative to the base path.
-    If base_path is None, uses the current working directory.
+    """Return ``path`` relative to ``base_path``.
+
+    If ``base_path`` is ``None`` the current working directory is used. When the
+    two paths do not share a common ancestor, the returned path contains ``..``
+    segments instead of an absolute path.
     """
     path = normalize_path(path)
     if base_path is None:
@@ -127,5 +129,5 @@ def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[
     try:
         return path.relative_to(base_path)
     except ValueError:
-        # If path is not relative to base_path, return the absolute path
-        return path
+        # If path is not relative to base_path, compute a relative path
+        return pathlib.Path(os.path.relpath(path, base_path))


### PR DESCRIPTION
## Summary
- ensure utils.get_relative_path returns relative paths for unrelated locations
- document relative path behavior
- cover get_relative_path edge case with a unit test

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:ci` *(fails: Missing script: "test:ci")*
- `SKIP=codespell,mypy,vulture pre-commit run --files utils/path_handling.py tests/unit/test_path_handling_additional.py utils/README.md`
- `python -m pytest tests/unit/test_path_handling_additional.py::test_get_relative_path_not_relative -v`


------
https://chatgpt.com/codex/tasks/task_e_6896eb027e84832fa413b7f17c9120f0