### PR TITLE
docs: deduplicate env var table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,11 @@ Open `http://localhost:5000` or run `python client.py`. Metrics are exposed at `
 
 ### Key environment variables
 
-| Variable        | Default     | Description                        |
-|-----------------|-------------|------------------------------------|
-| API_RATE_LIMIT  | 60/hour     | Per-IP request limit               |
-| USE_MOCK_LLM    | 0           | Use mock LLM instead of real model |
-| TOKEN_PLACE_ENV | development | Runtime environment name           |
-
-| Variable        | Default     | Description                                                   |
-|-----------------|-------------|---------------------------------------------------------------|
-| `API_RATE_LIMIT`  | `60/hour`   | Per-IP rate limit for API requests                            |
-| `USE_MOCK_LLM`    | `0`         | Run with mock LLM instead of downloading a real model         |
-| `TOKEN_PLACE_ENV` | `development` | Deployment environment (`development`, `testing`, `production`) |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| API_RATE_LIMIT | 60/hour | Per-IP rate limit for API requests |
+| USE_MOCK_LLM | 0 | Run with mock LLM instead of downloading a real model |
+| TOKEN_PLACE_ENV | development | Deployment environment (`development`, `testing`, `production`) |
 
 ## CI pass criteria
 


### PR DESCRIPTION
## Summary
- remove duplicate Key environment variables table from README

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_6896eb027e84832fa413b7f17c9120f0