### PR TITLE
🔒 : harden network defaults

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /tests,/desktop,/node_modules

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -50,6 +50,7 @@ class ServerApp:
         self.server_port = server_port
         self.relay_port = relay_port
         self.relay_url = relay_url
+        self.server_host = config.get('server.host', '127.0.0.1')
 
         # Create Flask app
         self.app = Flask(__name__)
@@ -114,14 +115,14 @@ class ServerApp:
 
     def run(self):  # pragma: no cover
         """Run the server application."""
-        log_info(f"Starting server on port {self.server_port}")
+        log_info(f"Starting server on {self.server_host}:{self.server_port}")
 
         # Start relay polling in a background thread
         self.start_relay_polling()
 
         # Run the Flask app
         self.app.run(
-            host='0.0.0.0',
+            host=self.server_host,
             port=self.server_port,
             debug=not config.is_production,
             use_reloader=False  # Disable reloader to avoid duplicate threads

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -31,6 +31,8 @@ class ModelManager:
         self.file_name = config.get('model.filename', 'llama-3-8b-instruct.Q4_K_M.gguf')
         self.url = config.get('model.url', 'https://huggingface.co/TheBloke/Llama-3-8B-Instruct-GGUF/resolve/main/llama-3-8b-instruct.Q4_K_M.gguf')
         self.chunk_size_mb = config.get('model.download_chunk_size_mb', 10)
+        # Network timeout for model downloads (seconds)
+        self.download_timeout = config.get('model.download_timeout', 30)
         self.models_dir = config.get('paths.models_dir')
         self.model_path = os.path.join(self.models_dir, self.file_name)
         
@@ -75,7 +77,7 @@ class ModelManager:
             bool: True if download was successful, False otherwise
         """
         chunk_size_bytes = chunk_size_mb * 1024 * 1024  # Convert MB to bytes
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, timeout=self.download_timeout)
 
         if response.status_code != 200:
             self.log_error(f"Error: Unable to download file, status code {response.status_code}")


### PR DESCRIPTION
what: add request timeout for model downloads; default server host to localhost; config bandit exclusions.
why: reduce risk of hanging requests and unintended exposure on all interfaces.
how to test: pytest -q tests/test_security.py && bandit -r tokenplace -lll

pre-commit run --all-files (fails: Python Unit Tests, Crypto Compatibility Tests)


------
https://chatgpt.com/codex/tasks/task_e_6896eafa24f0832fa4d23dbcbb987075