### PR TITLE
🐛 fix: update ModelManager download tests for timeout

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -112,7 +112,9 @@ class TestModelManager:
         assert os.path.getsize(file_path) == 1048576  # 1MB
 
         # Verify mock calls
-        mock_get.assert_called_once_with('https://example.com/model.gguf', stream=True)
+        mock_get.assert_called_once_with(
+            'https://example.com/model.gguf', stream=True, timeout=30
+        )
         mock_response.iter_content.assert_called_once_with(chunk_size=1048576)
 
     @patch('utils.llm.model_manager.requests.get')
@@ -134,7 +136,9 @@ class TestModelManager:
         assert not os.path.exists(file_path)
 
         # Verify mock calls
-        mock_get.assert_called_once_with('https://example.com/model.gguf', stream=True)
+        mock_get.assert_called_once_with(
+            'https://example.com/model.gguf', stream=True, timeout=30
+        )
 
     @patch('os.path.exists')
     @patch('utils.llm.model_manager.ModelManager.download_file_in_chunks')


### PR DESCRIPTION
## What
- expect timeout argument in download_file_in_chunks tests

## Why
- ModelManager adds timeout=30 to requests.get; tests must match

## How to Test
- playwright install-deps
- playwright install
- ./run_all_tests.sh

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68970daab4b4832fb2c7cbe418753118