### PR TITLE
🔒 reduce decryption error logging

### DIFF
--- a/encrypt.py
+++ b/encrypt.py
@@ -162,7 +162,7 @@ def decrypt(ciphertext_dict: Dict[str, bytes], encrypted_key: bytes, private_key
         plaintext = pkcs7_unpad(padded_plaintext, 16)
         return plaintext
     except Exception:
-        logger.error("Decryption error", exc_info=True)
+        logger.warning("Decryption failed")
         return None
 
 def pkcs7_pad(data: bytes, block_size: int) -> bytes:


### PR DESCRIPTION
## Summary
- avoid stack traces when decryption fails to reduce log exposure

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r tokenplace -lll`


------
https://chatgpt.com/codex/tasks/task_e_689917467210832f89c03feae57dbacc