### PR TITLE
🧪 : ensure Playwright deps for tests

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -26,6 +26,11 @@ fi
 # Get Node.js version
 node -v
 
+# Ensure Playwright browsers and system dependencies are installed
+if command -v playwright >/dev/null 2>&1; then
+    playwright install --with-deps chromium >/dev/null
+fi
+
 # Array to track test failures
 FAILED_TESTS=()
 
@@ -135,4 +140,3 @@ else
     echo -e "\e[31m${#FAILED_TESTS[@]} test(s) failed\e[0m"
     exit 1
 fi
-


### PR DESCRIPTION
## Summary
- install Playwright browsers and system dependencies before running tests

## Testing
- `pre-commit run --all-files`
- `./run_all_tests.sh`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*


------
https://chatgpt.com/codex/tasks/task_e_68991735d77c832fa5a493de1abd444c