### PR TITLE
🧪 Align created timestamp in alias routes test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -420,6 +420,8 @@ def test_openai_alias_routes_extended(client):
         data_api = res_api.get_json()
         if isinstance(data_alias, dict) and 'id' in data_alias:
             data_alias['id'] = data_api.get('id')
+            if 'created' in data_alias:
+                data_alias['created'] = data_api.get('created')
         assert data_alias == data_api
 
 


### PR DESCRIPTION
## Summary
- ensure alias and API responses use same `created` timestamp before comparison

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --all-files`
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68991735d77c832fa5a493de1abd444c