### PR TITLE
🛡️ : enforce valid PKCS7 block sizes

### DIFF
--- a/encrypt.py
+++ b/encrypt.py
@@ -166,9 +166,20 @@ def decrypt(ciphertext_dict: Dict[str, bytes], encrypted_key: bytes, private_key
         return None
 
 def pkcs7_pad(data: bytes, block_size: int) -> bytes:
+    """Pad *data* to a multiple of *block_size* using PKCS#7 padding.
+
+    Args:
+        data: Input bytes to pad.
+        block_size: Size of each block in bytes (1-255).
+
+    Returns:
+        Padded byte string whose length is a multiple of *block_size*.
+
+    Raises:
+        ValueError: If *block_size* is not between 1 and 255 (inclusive).
     """
-    Pad data using PKCS#7 padding scheme
-    """
+    if block_size <= 0 or block_size > 255:
+        raise ValueError("Block size must be between 1 and 255")
     padding_length = block_size - (len(data) % block_size)
     padding = bytes([padding_length] * padding_length)
     return data + padding

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -35,3 +35,11 @@ def test_unpad_non_block_multiple():
     padded = b"abcde\x01"  # len=6, not divisible by block size
     with pytest.raises(ValueError):
         pkcs7_unpad(padded, 16)
+
+
+def test_pad_invalid_block_size():
+    """Block sizes outside 1-255 should raise."""
+    with pytest.raises(ValueError):
+        pkcs7_pad(b"data", 0)
+    with pytest.raises(ValueError):
+        pkcs7_pad(b"data", 256)


### PR DESCRIPTION
what: validate PKCS7 padding block size and test invalid values
why: prevent misuse of padding with unsupported block sizes
how to test:
- npm run lint (fails: Missing script "lint")
- npm run test:ci (fails: Missing script "test:ci")
- pytest -q tests/test_security.py
- bandit -r tokenplace -lll (no files)
- bandit -r . -lll
- pre-commit run --all-files (auto-fixed unrelated files, reverted)
- ./run_all_tests.sh

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6899179f68e8832f947d1bb8e6bc3b38