### PR TITLE
fix: correct utils exports for star import

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/futuroptimist/token.place.git
 cd token.place
 pip install -r config/requirements_server.txt
 pip install -r config/requirements_relay.txt
- npm ci
+npm ci
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files
@@ -205,7 +205,7 @@ pip install -r config/requirements_relay.txt   # relay-only dependencies
 For JavaScript dependencies, run:
 
 ```
- npm ci
+npm ci
 ```
 
 #### troubleshooting `llama_cpp_python` builds

--- a/tests/unit/test_utils_exports.py
+++ b/tests/unit/test_utils_exports.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+
+
+def test_utils_star_import_exports_expected():
+    """Star import should expose high-level helpers from utils."""
+    if 'utils' in sys.modules:
+        importlib.reload(sys.modules['utils'])
+    namespace = {}
+    exec('from utils import *', namespace)
+    assert 'get_model_manager' in namespace
+    assert 'get_crypto_manager' in namespace
+    assert 'RelayClient' in namespace

--- a/utils/README.md
+++ b/utils/README.md
@@ -2,6 +2,12 @@
 
 This directory contains utility modules for token.place that provide reusable functionality across the project.
 
+The package's top level re-exports a few commonly used helpers, so you can import them directly:
+
+```python
+from utils import get_model_manager, get_crypto_manager, RelayClient
+```
+
 ## Available Utilities
 
 ### Path Handling (`path_handling.py`)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,4 +7,5 @@ from utils.llm.model_manager import get_model_manager
 from utils.crypto.crypto_manager import get_crypto_manager
 from utils.networking.relay_client import RelayClient
 
-__all__ = ['model_manager', 'crypto_manager', 'RelayClient'] 
+# Re-export the high-level helpers and Relay client
+__all__ = ['get_model_manager', 'get_crypto_manager', 'RelayClient']


### PR DESCRIPTION
## Summary
- expose get_model_manager, get_crypto_manager, and RelayClient through utils package
- add regression test for utils star import
- document utility exports and fix npm ci formatting in README

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test:ci` *(fails: Missing script)*
- `pytest tests/unit/test_utils_exports.py`
- `pre-commit run --files README.md utils/README.md utils/__init__.py tests/unit/test_utils_exports.py` *(Crypto Compatibility Tests (Playwright) failed)*

------
https://chatgpt.com/codex/tasks/task_e_6899179f68e8832f947d1bb8e6bc3b38