### PR TITLE
🐛 : make TOKEN_PLACE_ENV case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Open `http://localhost:5000` or run `python client.py`. Metrics are exposed at `
 |----------|---------|-------------|
 | API_RATE_LIMIT | 60/hour | Per-IP rate limit for API requests |
 | USE_MOCK_LLM | 0 | Run with mock LLM instead of downloading a real model |
-| TOKEN_PLACE_ENV | development | Deployment environment (`development`, `testing`, `production`) |
+| TOKEN_PLACE_ENV | development | Deployment environment (`development`, `testing`, `production`; case-insensitive) |
 
 ## CI pass criteria
 

--- a/config.py
+++ b/config.py
@@ -34,7 +34,7 @@ DEFAULT_CONFIG = {
         'timeout': 30,
         'base_url': 'http://localhost',
     },
-    
+
     # Relay settings
     'relay': {
         'host': '127.0.0.1',
@@ -42,7 +42,7 @@ DEFAULT_CONFIG = {
         'server_url': 'http://localhost:5000',
         'workers': 2,
     },
-    
+
     # API settings
     'api': {
         'host': '127.0.0.1',
@@ -50,14 +50,14 @@ DEFAULT_CONFIG = {
         'relay_url': 'http://localhost:5000',
         'cors_origins': ['*'],
     },
-    
+
     # Security settings
     'security': {
         'encryption_enabled': True,
         'key_size': 2048,
         'key_expiry_days': 30,
     },
-    
+
     # Data paths (these will be overridden based on platform)
     'paths': {
         'data_dir': '',  # Will be set based on platform
@@ -66,7 +66,7 @@ DEFAULT_CONFIG = {
         'cache_dir': '',  # Will be set based on platform
         'keys_dir': '',  # Will be set based on platform
     },
-    
+
     # Model settings
     'model': {
         'default_model': 'gpt-3.5-turbo',
@@ -80,7 +80,7 @@ DEFAULT_CONFIG = {
         'chat_format': 'llama-3',
         'download_chunk_size_mb': 10,
     },
-    
+
     # Helper constants
     'constants': {
         'KB': 1024,
@@ -137,55 +137,57 @@ ENV_OVERRIDES = {
 
 class Config:
     """Configuration manager for token.place"""
-    
+
     def __init__(self, env: Optional[str] = None, config_path: Optional[str] = None):
         """
         Initialize configuration with the specified environment.
         If env is None, it tries to read from TOKEN_PLACE_ENV environment variable,
-        defaulting to 'development' if not set.
+        defaulting to 'development' if not set. The environment value is
+        normalized to lowercase so that values like 'TESTING' are accepted.
         """
-        # Determine the environment
-        self.env = env or os.environ.get('TOKEN_PLACE_ENV', 'development')
-        
+        # Determine the environment (case-insensitive)
+        env_value = env or os.environ.get('TOKEN_PLACE_ENV', 'development')
+        self.env = env_value.lower()
+
         # Detect platform if not already set
         self.platform = os.environ.get('PLATFORM', platform.system().lower())
-        
+
         # Load base configuration
         self.config = DEFAULT_CONFIG.copy()
-        
+
         # Apply environment-specific overrides
         if self.env in ENV_OVERRIDES:
             self._merge_configs(self.config, ENV_OVERRIDES[self.env])
-        
+
         # Set platform-specific paths
         self._configure_platform_paths()
-        
+
         # Load user configuration if it exists
         self.config_path = config_path or os.environ.get('TOKEN_PLACE_CONFIG')
         if self.config_path:
             self._load_user_config()
-        
+
         logger.info(f"Configuration initialized for environment: {self.env}, platform: {self.platform}")
-    
+
     def _configure_platform_paths(self):
         """Configure paths based on the detected platform"""
         # Import path handling here to avoid circular imports
         from utils.path_handling import (
-            get_config_dir, ensure_dir_exists, get_app_data_dir, 
+            get_config_dir, ensure_dir_exists, get_app_data_dir,
             get_models_dir, get_logs_dir, get_cache_dir
         )
-        
+
         config_dir = get_config_dir()
-        
+
         # Ensure the config directory exists
         ensure_dir_exists(config_dir)
-        
+
         app_data_dir = get_app_data_dir()
         models_dir = get_models_dir()
         logs_dir = get_logs_dir()
         cache_dir = get_cache_dir()
         keys_dir = config_dir / 'keys'
-        
+
         # Update the paths in the config
         self.config['paths'].update({
             'data_dir': str(app_data_dir),
@@ -195,11 +197,11 @@ class Config:
             'keys_dir': str(keys_dir),
             'config_dir': str(config_dir),
         })
-        
+
         # Ensure all directories exist
         for dir_path in [app_data_dir, models_dir, logs_dir, cache_dir, keys_dir]:
             ensure_dir_exists(dir_path)
-    
+
     def _load_user_config(self):
         """Load user configuration file and merge with current config"""
         try:
@@ -213,7 +215,7 @@ class Config:
             logger.error(f"Error decoding JSON in user configuration file: {self.config_path}")
         except Exception as e:
             logger.error(f"Error loading user configuration: {str(e)}")
-    
+
     def _merge_configs(self, base_config: Dict[str, Any], override_config: Dict[str, Any]):
         """
         Recursively merge the override_config into the base_config.
@@ -223,7 +225,7 @@ class Config:
                 self._merge_configs(base_config[key], value)
             else:
                 base_config[key] = value
-    
+
     def get(self, key: str, default: Any = None) -> Any:
         """
         Get a configuration value by dot-separated key path.
@@ -237,7 +239,7 @@ class Config:
             return value
         except (KeyError, TypeError):
             return default
-    
+
     def set(self, key: str, value: Any):
         """
         Set a configuration value by dot-separated key path.
@@ -250,7 +252,7 @@ class Config:
                 config[k] = {}
             config = config[k]
         config[keys[-1]] = value
-    
+
     def save_user_config(self, config_path: Optional[str] = None):
         """
         Save the current configuration to a user config file.
@@ -258,39 +260,39 @@ class Config:
         path = config_path or self.config_path
         if not path:
             path = os.path.join(self.config['paths']['config_dir'], 'user_config.json')
-        
+
         try:
             with open(path, 'w') as f:
                 json.dump(self.config, f, indent=2)
             logger.info(f"Configuration saved to {path}")
         except Exception as e:
             logger.error(f"Error saving configuration: {str(e)}")
-    
+
     @property
     def is_windows(self) -> bool:
         """Check if the current platform is Windows"""
         return self.platform == 'windows'
-    
+
     @property
     def is_macos(self) -> bool:
         """Check if the current platform is macOS"""
         return self.platform == 'darwin'
-    
+
     @property
     def is_linux(self) -> bool:
         """Check if the current platform is Linux"""
         return self.platform == 'linux'
-    
+
     @property
     def is_development(self) -> bool:
         """Check if the current environment is development"""
         return self.env == 'development'
-    
+
     @property
     def is_testing(self) -> bool:
         """Check if the current environment is testing"""
         return self.env == 'testing'
-    
+
     @property
     def is_production(self) -> bool:
         """Check if the current environment is production"""
@@ -301,4 +303,4 @@ config = Config()
 
 def get_config() -> Config:
     """Get the global configuration instance"""
-    return config 
+    return config

--- a/tests/unit/test_config_module_additional.py
+++ b/tests/unit/test_config_module_additional.py
@@ -66,3 +66,16 @@ def test_env_properties_and_global_get(tmp_path, monkeypatch):
     assert cfg_dev.is_development and not cfg_dev.is_production
     assert cfg_prod.is_production and not cfg_prod.is_development
     assert isinstance(config.get_config(), config.Config)
+
+
+def test_env_variable_case_insensitive(tmp_path, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'TESTING')
+    monkeypatch.setattr('utils.path_handling.get_config_dir', lambda: tmp_path / 'config')
+    monkeypatch.setattr('utils.path_handling.get_app_data_dir', lambda: tmp_path / 'data')
+    monkeypatch.setattr('utils.path_handling.get_models_dir', lambda: tmp_path / 'models')
+    monkeypatch.setattr('utils.path_handling.get_logs_dir', lambda: tmp_path / 'logs')
+    monkeypatch.setattr('utils.path_handling.get_cache_dir', lambda: tmp_path / 'cache')
+    monkeypatch.setattr('utils.path_handling.ensure_dir_exists', lambda p: Path(p).mkdir(parents=True, exist_ok=True))
+    cfg = config.Config()
+    assert cfg.is_testing
+    assert cfg.get('server.port') == 8001


### PR DESCRIPTION
## Summary
- lower-case TOKEN_PLACE_ENV in Config for consistent environment overrides
- document TOKEN_PLACE_ENV as case-insensitive
- test uppercase TOKEN_PLACE_ENV

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test:ci` *(fails: Missing script)*
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`
- `pre-commit run --files config.py README.md tests/unit/test_config_module_additional.py`


------
https://chatgpt.com/codex/tasks/task_e_6899179f68e8832f947d1bb8e6bc3b38