### PR TITLE
🧪 : – allow timestamp drift in alias route test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -422,7 +422,17 @@ def test_openai_alias_routes_extended(client):
             data_alias['id'] = data_api.get('id')
             if 'created' in data_alias:
                 data_alias['created'] = data_api.get('created')
-        assert data_alias == data_api
+        # If both responses contain a timestamp, allow slight drift
+        if (
+            isinstance(data_alias, dict)
+            and 'timestamp' in data_alias
+            and 'timestamp' in data_api
+        ):
+            assert data_alias['status'] == data_api['status']
+            assert data_alias['version'] == data_api['version']
+            assert abs(data_alias['timestamp'] - data_api['timestamp']) <= 2
+        else:
+            assert data_alias == data_api
 
 
 def test_logging_prod_environment(monkeypatch):


### PR DESCRIPTION
what: relax timestamp equality check in alias routes test
why: timestamps differ between calls and caused assertion failures
how to test: pre-commit run --files tests/test_api.py && ./run_all_tests.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689a83e9041c832f9800677ea105b962