### PR TITLE
🐛 : respect XDG_STATE_HOME for logs dir

### DIFF
--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -26,6 +26,15 @@ def test_paths_linux(tmp_path):
         assert rel == Path('newdir')
 
 
+def test_paths_linux_with_xdg_state_home(tmp_path):
+    env = {'XDG_STATE_HOME': str(tmp_path / 'xdg' / 'state')}
+    with mock.patch('platform.system', return_value='Linux'):
+        with mock.patch.dict(os.environ, env, clear=False):
+            importlib.reload(ph)
+            base = tmp_path / 'xdg' / 'state'
+            assert ph.get_logs_dir() == base / 'token.place' / 'logs'
+
+
 def test_paths_windows(tmp_path):
     env = {
         'APPDATA': str(tmp_path / 'AppData' / 'Roaming'),

--- a/utils/README.md
+++ b/utils/README.md
@@ -16,13 +16,14 @@ Cross-platform path handling utilities that ensure consistent behavior across Wi
 These helpers now fall back to standard `AppData` locations when Windows environment variables are missing
 and automatically create directories when accessed.
 
-On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and
-`XDG_CACHE_HOME` environment variables when they are set.
+On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
+`XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
 - `normalize_path(path)`: Expands `~` and environment variables then returns a normalized absolute path.
 - `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
   `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
+- `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the
   two locations do not share a common ancestor. If the paths are on different drives
   (Windows), the absolute `path` is returned instead of raising an error.

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -83,13 +83,23 @@ def get_models_dir() -> pathlib.Path:
     return ensure_dir_exists(get_app_data_dir() / 'models')
 
 def get_logs_dir() -> pathlib.Path:
-    """Get the directory for storing log files."""
+    """Get the directory for storing log files.
+
+    On Linux, honors the ``XDG_STATE_HOME`` environment variable when set.
+    """
     if IS_WINDOWS:
         return ensure_dir_exists(get_app_data_dir() / 'logs')
     elif IS_MACOS:
-        return ensure_dir_exists(get_user_home_dir() / 'Library' / 'Logs' / 'token.place')
+        return ensure_dir_exists(
+            get_user_home_dir() / 'Library' / 'Logs' / 'token.place'
+        )
     else:  # Linux and other Unix-like
-        return ensure_dir_exists(get_user_home_dir() / '.local' / 'state' / 'token.place' / 'logs')
+        xdg_state_home = os.environ.get('XDG_STATE_HOME')
+        if xdg_state_home:
+            base_dir = pathlib.Path(xdg_state_home)
+        else:
+            base_dir = get_user_home_dir() / '.local' / 'state'
+        return ensure_dir_exists(base_dir / 'token.place' / 'logs')
 
 def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     """


### PR DESCRIPTION
what: honor XDG_STATE_HOME in get_logs_dir; document and test.
why: match XDG base directory spec for log storage.
how to test: npm ci; npm run lint (missing script); npm run test:ci (missing
script); pre-commit run --files utils/path_handling.py utils/README.md
tests/unit/test_path_handling.py; ./run_all_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_689abb1972dc832fad7deca62496997e