### PR TITLE
🐛 Validate ciphertext fields before decryption

### DIFF
--- a/encrypt.py
+++ b/encrypt.py
@@ -121,7 +121,13 @@ def decrypt(ciphertext_dict: Dict[str, bytes], encrypted_key: bytes, private_key
 
     Returns:
         Decrypted plaintext or None if decryption fails
+
+    Raises:
+        ValueError: If ``ciphertext_dict`` lacks required fields.
     """
+    if "ciphertext" not in ciphertext_dict or "iv" not in ciphertext_dict:
+        raise ValueError("ciphertext_dict must contain 'ciphertext' and 'iv' keys")
+
     try:
         # First decrypt the AES key using RSA
         private_key = serialization.load_pem_private_key(
@@ -150,8 +156,8 @@ def decrypt(ciphertext_dict: Dict[str, bytes], encrypted_key: bytes, private_key
         aes_key = base64.b64decode(aes_key_b64)
 
         # Get the ciphertext and IV
-        ciphertext = ciphertext_dict['ciphertext']
-        iv = ciphertext_dict['iv']
+        ciphertext = ciphertext_dict["ciphertext"]
+        iv = ciphertext_dict["iv"]
 
         # Decrypt the ciphertext using AES-CBC
         cipher = Cipher(AES(aes_key), CBC(iv), backend=default_backend())

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,6 +1,5 @@
-import os
-import base64
 import json
+import pytest
 from encrypt import generate_keys, encrypt, decrypt
 
 def test_encrypt_decrypt():
@@ -83,3 +82,11 @@ def test_encrypt_decrypt_empty_plaintext():
     # Assert that the decrypted plaintext matches the original plaintext
     assert decrypted_bytes is not None
     assert decrypted_bytes == plaintext_bytes
+
+
+def test_decrypt_missing_fields_raises_value_error():
+    private_key, public_key = generate_keys()
+    ciphertext_dict, cipherkey, _ = encrypt(b"data", public_key)
+    del ciphertext_dict["iv"]
+    with pytest.raises(ValueError):
+        decrypt(ciphertext_dict, cipherkey, private_key)


### PR DESCRIPTION
## Summary
- raise ValueError when decrypt is missing ciphertext or iv
- cover this behavior with unit test

## Testing
- `npm run lint` (fails: Missing script "lint")
- `npm run test:ci` (fails: Missing script "test:ci")
- `pre-commit run --all-files`
- `pytest tests/test_encrypt.py -q`
- `git diff --cached | detect-secrets scan --all-files --string @stdin`


------
https://chatgpt.com/codex/tasks/task_e_689abb1972dc832fad7deca62496997e