### PR TITLE
fix: expand env vars in ensure_dir_exists

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -31,6 +31,19 @@ def test_ensure_dir_exists_expands_user(tmp_path, monkeypatch):
     assert result.exists()
 
 
+def test_ensure_dir_exists_expands_env_vars(tmp_path, monkeypatch):
+    """ensure_dir_exists should expand environment variables"""
+    monkeypatch.setenv("TEST_BASE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    if ph.IS_WINDOWS:
+        path_with_var = "%TEST_BASE%\\envdir"
+    else:
+        path_with_var = "$TEST_BASE/envdir"
+    result = ph.ensure_dir_exists(path_with_var)
+    assert result == tmp_path / "envdir"
+    assert result.exists()
+
+
 def test_normalize_path_expands_env_vars(tmp_path, monkeypatch):
     """normalize_path should expand environment variables"""
     monkeypatch.setenv("TEST_BASE", str(tmp_path))

--- a/utils/README.md
+++ b/utils/README.md
@@ -20,8 +20,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and
 `XDG_CACHE_HOME` environment variables when they are set.
 
 - `normalize_path(path)`: Expands `~` and environment variables then returns a normalized absolute path.
-- `ensure_dir_exists(path)`: Creates the directory if missing (expands `~` to the user's home) and raises
-  `NotADirectoryError` when the path points to an existing file.
+- `ensure_dir_exists(path)`: Creates the directory if missing, expanding `~` and environment variables, and
+  raises `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the
   two locations do not share a common ancestor. If the paths are on different drives

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -94,11 +94,13 @@ def get_logs_dir() -> pathlib.Path:
 def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     """
     Ensure a directory exists, creating it if necessary.
+    Expands ``~`` and environment variables before creating the directory.
     Raises NotADirectoryError if the path points to an existing file.
     Returns the path as a pathlib.Path object.
     """
-    # Expand user home (~) and normalize to an absolute path
-    path = pathlib.Path(dir_path).expanduser().resolve()
+    # Expand environment variables and user home (~), then normalize
+    path_str = os.path.expandvars(str(dir_path))
+    path = pathlib.Path(path_str).expanduser().resolve()
     if path.exists() and not path.is_dir():
         raise NotADirectoryError(f"{path} exists and is not a directory")
     path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- expand environment variables in ensure_dir_exists
- document env var expansion and add unit test

## Testing
- `npm run lint` (fails: Missing script "lint")
- `npm run test:ci` (fails: Missing script "test:ci")
- `pre-commit run --files utils/path_handling.py utils/README.md tests/unit/test_path_handling_additional.py`
- `pytest tests/unit/test_path_handling_additional.py::test_ensure_dir_exists_expands_env_vars -q`


------
https://chatgpt.com/codex/tasks/task_e_689abb1972dc832fad7deca62496997e