### PR TITLE
docs: mention Playwright setup in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cd token.place
 pip install -r config/requirements_server.txt
 pip install -r config/requirements_relay.txt
 npm ci
+playwright install chromium
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files


### PR DESCRIPTION
## Summary
- document `playwright install chromium` in Quickstart setup

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_689abb1972dc832fad7deca62496997e