### PR TITLE
🔒 avoid logging sensitive response data

### DIFF
--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -436,5 +436,9 @@ class CryptoClient:
                 logger.error(f"Failed to decrypt API response (encrypted_content format): {str(e)}", exc_info=self.debug)
                 return None
 
-        logger.error(f"Invalid API response format: {response}")
+        # Avoid logging full response to prevent leaking ciphertext or other data
+        logger.error(
+            "Invalid API response format: keys=%s",
+            list(response.keys()) if isinstance(response, dict) else type(response).__name__,
+        )
         return None


### PR DESCRIPTION
## Summary
- stop logging full API responses to avoid leaking ciphertext

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`


------
https://chatgpt.com/codex/tasks/task_e_689c256ee6dc832f98556570a56ce2b8