### PR TITLE
Allow CryptoManager to accept base64 public keys

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -31,3 +31,8 @@ A pull request URL summarizing the fix and showing passing checks.
 ```
 
 Copy this block whenever CI needs attention in token.place.
+
+## Lessons learned
+
+- CryptoManager assumed client public keys were always bytes. CI failed when tests
+  passed a base64 string. We now decode strings before encryption to support both formats.

--- a/outages/2025-08-13-crypto-key-str.json
+++ b/outages/2025-08-13-crypto-key-str.json
@@ -1,0 +1,8 @@
+{
+  "date": "2025-08-13",
+  "slug": "crypto-key-str",
+  "summary": "CryptoManager accepted only byte public keys causing encryption to fail when a base64 string was provided.",
+  "impact": "CI tests using string public keys failed, preventing merges.",
+  "fix": "crypto_manager.encrypt_message now decodes base64 strings before encryption.",
+  "lessons": "Validate input types and support common representations."
+}

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["date", "slug", "summary", "impact", "fix", "lessons"],
+  "properties": {
+    "date": {"type": "string", "format": "date"},
+    "slug": {"type": "string"},
+    "summary": {"type": "string"},
+    "impact": {"type": "string"},
+    "fix": {"type": "string"},
+    "lessons": {"type": "string"}
+  }
+}

--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -123,6 +123,21 @@ class TestCryptoManager:
         mock_encrypt.assert_called_once_with(b'test bytes', client_public_key)
 
     @patch('utils.crypto.crypto_manager.encrypt')
+    def test_encrypt_message_accepts_base64_key(self, mock_encrypt, crypto_manager):
+        """Public key may be provided as a base64 string."""
+        message = "hi"
+        b64_key = base64.b64encode(b'client_public_key').decode('utf-8')
+
+        mock_encrypted_data = {'ciphertext': b'encrypted_content', 'iv': b'iv_value'}
+        mock_encrypted_key = b'encrypted_key'
+        mock_iv = b'iv_value'
+        mock_encrypt.return_value = (mock_encrypted_data, mock_encrypted_key, mock_iv)
+
+        crypto_manager.encrypt_message(message, b64_key)
+
+        mock_encrypt.assert_called_once_with(b'hi', b'client_public_key')
+
+    @patch('utils.crypto.crypto_manager.encrypt')
     def test_encrypt_message_exception(self, mock_encrypt, crypto_manager):
         """Test handling of exceptions during encryption."""
         # Setup

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -70,13 +70,14 @@ class CryptoManager:
         """Get the base64-encoded public key."""
         return self._public_key_b64
 
-    def encrypt_message(self, message: Union[str, bytes, Dict, List], client_public_key: bytes) -> Dict[str, str]:
+    def encrypt_message(self, message: Union[str, bytes, Dict, List],
+                        client_public_key: Union[str, bytes]) -> Dict[str, str]:
         """
         Encrypt a message for a client using their public key.
 
         Args:
             message: The message to encrypt (string, bytes, dict, or list)
-            client_public_key: The client's public key in bytes
+            client_public_key: The client's public key in bytes or base64 string
 
         Returns:
             Dict with 'chat_history' (base64 encoded ciphertext), 'cipherkey' (encrypted key),
@@ -90,6 +91,10 @@ class CryptoManager:
                 message_bytes = message.encode('utf-8')
             else:
                 message_bytes = message
+
+            # Ensure client_public_key is bytes
+            if isinstance(client_public_key, str):
+                client_public_key = base64.b64decode(client_public_key)
 
             # Encrypt the message
             encrypted_data, encrypted_key, iv = encrypt(message_bytes, client_public_key)


### PR DESCRIPTION
## Summary
- handle base64 string public keys in CryptoManager
- document CI lesson
- track outage

## Testing
- `pre-commit run --files utils/crypto/crypto_manager.py tests/unit/test_crypto_manager.py docs/prompts-codex-ci-fix.md outages/schema.json outages/2025-08-13-crypto-key-str.json`
- `pytest tests/unit/test_crypto_manager.py::TestCryptoManager::test_encrypt_message_accepts_base64_key -q`
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c259a1508832faada33198cee28f6