### PR TITLE
docs: use docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ docker compose up -d
 
 **Docker:**
 ```bash
-docker-compose up -d  # starts the relay service
+docker compose up -d  # starts the relay service
 ```
 
 ## Features
@@ -638,7 +638,7 @@ docker-compose up -d  # starts the relay service
 ## Quick Start
 
 1. Clone the repository
-2. Run `docker-compose up` to build and start the relay container
+2. Run `docker compose up` to build and start the relay container
 3. Open `http://localhost:5000` in your browser to begin chatting
 
 ## Development

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,7 +18,7 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [docs/ONBOARDING.md](docs/ONBOARDING.md): Quick orientation to the repository structure
 - [requirements.txt](requirements.txt): Python dependencies for the project
 - [package.json](package.json): Node.js dependencies for JavaScript components
-- `docker-compose up` starts the relay container for quick local testing
+- `docker compose up` starts the relay container for quick local testing
 
 ## Core Components
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -24,13 +24,13 @@ We've implemented Docker support for easy deployment:
 
 ```bash
 # Build and start the relay service
-docker-compose up -d
+docker compose up -d
 
 # View logs
-docker-compose logs -f
+docker compose logs -f
 
 # Stop the service
-docker-compose down
+docker compose down
 ```
 
 ### Container Architecture

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -49,7 +49,7 @@ Contributions describing different configurations are welcome so the project can
    ```bash
    git clone https://github.com/futuroptimist/token.place.git  # download the project
    cd token.place                                             # enter the project folder
-   sudo apt install -y docker.io docker-compose               # install Docker runtime
+    sudo apt install -y docker.io docker-compose-plugin        # install Docker runtime and Compose plugin
    sudo usermod -aG docker $USER                              # allow the current user to run Docker
    newgrp docker                                              # apply the new group membership
    ```

--- a/tests/e2e/test_installation_docs.py
+++ b/tests/e2e/test_installation_docs.py
@@ -8,5 +8,4 @@ def test_server_setup_instructions_exist(page: Page):
     page.goto(f'file://{readme_path}')
     content = page.content()
     assert 'python server.py' in content or 'python -m server' in content
-    assert 'docker-compose up' in content
-
+    assert 'docker compose up' in content


### PR DESCRIPTION
## Summary
- use `docker compose` instead of deprecated `docker-compose` in docs
- update installation test accordingly

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `playwright install chromium`
- `pre-commit run --files README.md docs/AGENTS.md docs/CROSS_PLATFORM.md docs/RPI_DEPLOYMENT_GUIDE.md tests/e2e/test_installation_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_689c25962614832fa75d183160a3a76d