### PR TITLE
Avoid clearing screen on non-TTY in simplified client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ python relay.py
 python server.py
 ```
 
-Open `http://localhost:5000` or run `python client.py`. Metrics are exposed at `/metrics`.
+Open `http://localhost:5000` or run `python client.py`. For a minimal client use
+`python client_simplified.py`; it only clears the screen when running interactively. Metrics are
+exposed at `/metrics`.
 
 ### Key environment variables
 

--- a/client_simplified.py
+++ b/client_simplified.py
@@ -10,10 +10,15 @@ from typing import List, Dict
 # Import our CryptoClient
 from utils.crypto_helpers import CryptoClient
 
+
 def clear_screen():
-    """Clear the terminal screen without spawning a shell"""
-    # Use ANSI escape codes to avoid shell injection via os.system
-    print("\033[2J\033[H", end="")
+    """Clear the terminal screen without spawning a shell.
+
+    Skips output when stdout is not a TTY.
+    """
+    if sys.stdout.isatty():
+        # Use ANSI escape codes to avoid shell injection via os.system
+        print("\033[2J\033[H", end="")
 
 def format_message(message: Dict) -> str:
     """Format a message for display"""

--- a/tests/unit/test_client_simplified.py
+++ b/tests/unit/test_client_simplified.py
@@ -1,4 +1,5 @@
 import builtins
+import io
 from unittest.mock import patch, MagicMock
 import client_simplified as cs
 
@@ -33,6 +34,17 @@ def test_main_single_message(monkeypatch, capsys):
     assert "Assistant: ok" in out
     mock_client.fetch_server_public_key.assert_called_once()
     mock_client.send_chat_message.assert_called_once()
+
+
+def test_clear_screen_skips_when_not_tty(monkeypatch):
+    class FakeStdout(io.StringIO):
+        def isatty(self):
+            return False
+
+    fake = FakeStdout()
+    monkeypatch.setattr(cs.sys, "stdout", fake)
+    cs.clear_screen()
+    assert fake.getvalue() == ""
 
 
 def test_chat_loop_single_iteration(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- skip terminal clearing in `client_simplified.py` when stdout isn't a TTY
- add regression test for `clear_screen`
- document simplified client usage in README

## Testing
- `pre-commit run --files client_simplified.py tests/unit/test_client_simplified.py README.md`
- `python -m pytest tests/unit/test_client_simplified.py::test_clear_screen_skips_when_not_tty -q`


------
https://chatgpt.com/codex/tasks/task_e_689c25962614832fa75d183160a3a76d