### PR TITLE
Validate CryptoManager message input

### DIFF
--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -122,6 +122,11 @@ class TestCryptoManager:
         # Verify mock calls
         mock_encrypt.assert_called_once_with(b'test bytes', client_public_key)
 
+    def test_encrypt_message_none_raises(self, crypto_manager):
+        """encrypt_message should reject None input."""
+        with pytest.raises(ValueError, match="Message cannot be None"):
+            crypto_manager.encrypt_message(None, b'client_public_key')
+
     @patch('utils.crypto.crypto_manager.encrypt')
     def test_encrypt_message_exception(self, mock_encrypt, crypto_manager):
         """Test handling of exceptions during encryption."""

--- a/utils/README.md
+++ b/utils/README.md
@@ -41,6 +41,8 @@ valid UTF-8 or JSON.
 Network requests in this module now use a default 10 second timeout to prevent
 hanging connections. You can override this by passing a `timeout` argument to
 `CryptoClient.fetch_server_public_key` or `CryptoClient.send_encrypted_message`.
+`encrypt_message` validates inputs and raises a `ValueError` when provided
+`None`, avoiding confusing cryptography errors.
 
 ## Crypto Helpers
 

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -81,8 +81,14 @@ class CryptoManager:
         Returns:
             Dict with 'chat_history' (base64 encoded ciphertext), 'cipherkey' (encrypted key),
             and 'iv' (initialization vector)
+
+        Raises:
+            ValueError: If ``message`` is ``None``.
         """
         try:
+            if message is None:
+                raise ValueError("Message cannot be None")
+
             # Convert message to bytes if it's not already
             if isinstance(message, (dict, list)):
                 message_bytes = json.dumps(message).encode('utf-8')


### PR DESCRIPTION
## Summary
- ensure CryptoManager.encrypt_message rejects None messages
- cover new validation with unit test and docs

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `playwright install chromium`
- `pre-commit run --files utils/crypto/crypto_manager.py tests/unit/test_crypto_manager.py utils/README.md`
- `python -m pytest tests/unit/test_crypto_manager.py::TestCryptoManager::test_encrypt_message_none_raises -q`

------
https://chatgpt.com/codex/tasks/task_e_689c25962614832fa75d183160a3a76d