### PR TITLE
🐛: trim whitespace in path helpers

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -44,6 +44,14 @@ def test_ensure_dir_exists_expands_env_vars(tmp_path, monkeypatch):
     assert result.exists()
 
 
+def test_ensure_dir_exists_strips_whitespace(tmp_path):
+    """ensure_dir_exists should strip surrounding whitespace from the path"""
+    path_with_spaces = f"  {tmp_path / 'spaced'}  "
+    result = ph.ensure_dir_exists(path_with_spaces)
+    assert result == tmp_path / "spaced"
+    assert result.exists()
+
+
 def test_normalize_path_expands_env_vars(tmp_path, monkeypatch):
     """normalize_path should expand environment variables"""
     monkeypatch.setenv("TEST_BASE", str(tmp_path))
@@ -54,6 +62,15 @@ def test_normalize_path_expands_env_vars(tmp_path, monkeypatch):
     else:
         path_with_var = "$TEST_BASE/nested"
     result = ph.normalize_path(path_with_var)
+    assert result == target
+
+
+def test_normalize_path_strips_whitespace(tmp_path):
+    """normalize_path should strip leading/trailing whitespace"""
+    target = tmp_path / "clean"
+    target.mkdir()
+    path_with_spaces = f"  {target}  "
+    result = ph.normalize_path(path_with_spaces)
     assert result == target
 
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,8 +19,8 @@ and automatically create directories when accessed.
 On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
-- `normalize_path(path)`: Expands `~` and environment variables then returns a normalized absolute path.
-- `ensure_dir_exists(path)`: Creates the directory if missing, expanding `~` and environment variables, and
+- `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized absolute path.
+- `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment variables, and
   raises `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -104,12 +104,14 @@ def get_logs_dir() -> pathlib.Path:
 def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     """
     Ensure a directory exists, creating it if necessary.
-    Expands ``~`` and environment variables before creating the directory.
+    Expands ``~`` and environment variables before creating the directory, and
+    strips surrounding whitespace to avoid accidental directory names.
     Raises NotADirectoryError if the path points to an existing file.
     Returns the path as a pathlib.Path object.
     """
     # Expand environment variables and user home (~), then normalize
-    path_str = os.path.expandvars(str(dir_path))
+    # Also strip surrounding whitespace to avoid creating unintended paths
+    path_str = os.path.expandvars(str(dir_path)).strip()
     path = pathlib.Path(path_str).expanduser().resolve()
     if path.exists() and not path.is_dir():
         raise NotADirectoryError(f"{path} exists and is not a directory")
@@ -121,8 +123,11 @@ def get_executable_extension() -> str:
     return '.exe' if IS_WINDOWS else ''
 
 def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
-    """Convert a path string to a normalized pathlib.Path object."""
-    expanded = os.path.expandvars(str(path))
+    """Convert a path string to a normalized pathlib.Path object.
+
+    Strips surrounding whitespace and expands environment variables and user home (~).
+    """
+    expanded = os.path.expandvars(str(path)).strip()
     return pathlib.Path(expanded).expanduser().resolve()
 
 def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:


### PR DESCRIPTION
## Summary
- handle paths with surrounding spaces in `ensure_dir_exists` and `normalize_path`
- document whitespace trimming in path utilities
- test trimming behavior in path handling helpers

## Testing
- `pytest tests/unit/test_path_handling_additional.py`
- `npm ci`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:ci` *(fails: Missing script: "test:ci")*
- `pre-commit run --files utils/path_handling.py tests/unit/test_path_handling_additional.py utils/README.md`


------
https://chatgpt.com/codex/tasks/task_e_689c25962614832fa75d183160a3a76d