### PR TITLE
🐛 fix: handle unmatched quotes in run_command

### DIFF
--- a/scripts/validate_dependencies.py
+++ b/scripts/validate_dependencies.py
@@ -13,10 +13,13 @@ import os
 import shlex
 from pathlib import Path
 
+
 def run_command(cmd, cwd=None):
-    """Run a command and return success status and output."""
-    if isinstance(cmd, str):
-        cmd = shlex.split(cmd)
+    """Run a command and return success status and output.
+
+    Any ``shlex.split`` failures are caught and surfaced as errors instead of
+    raising exceptions.
+    """
     try:
         cmd_list = shlex.split(cmd) if isinstance(cmd, str) else cmd
         result = subprocess.run(

--- a/tests/unit/test_validate_dependencies.py
+++ b/tests/unit/test_validate_dependencies.py
@@ -36,6 +36,11 @@ def test_run_command_exception(monkeypatch):
     assert not success and err
 
 
+def test_run_command_split_error():
+    success, _, err = vd.run_command("echo '")
+    assert not success and err
+
+
 def test_validate_dependencies_success(tmp_path, monkeypatch):
     project_root, fake_script = _setup(tmp_path)
     monkeypatch.setattr(vd, "__file__", str(fake_script))


### PR DESCRIPTION
## Summary
- catch shlex.split errors in run_command
- add regression test for malformed commands

## Testing
- `pre-commit run --all-files`
- `python -m pytest tests/unit/test_validate_dependencies.py::test_run_command_split_error -q`


------
https://chatgpt.com/codex/tasks/task_e_689c256fdaf4832f9c484ba8c5eafe66