### PR TITLE
fix: preserve symlink paths in ensure_dir_exists

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -44,6 +44,18 @@ def test_ensure_dir_exists_expands_env_vars(tmp_path, monkeypatch):
     assert result.exists()
 
 
+@pytest.mark.skipif(ph.IS_WINDOWS, reason="Symlink creation needs privileges on Windows")
+def test_ensure_dir_exists_preserves_symlink(tmp_path):
+    target = tmp_path / "real"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    subdir = link / "newdir"
+    result = ph.ensure_dir_exists(subdir)
+    assert result == subdir
+    assert subdir.exists()
+
+
 def test_normalize_path_expands_env_vars(tmp_path, monkeypatch):
     """normalize_path should expand environment variables"""
     monkeypatch.setenv("TEST_BASE", str(tmp_path))

--- a/utils/README.md
+++ b/utils/README.md
@@ -20,8 +20,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
 - `normalize_path(path)`: Expands `~` and environment variables then returns a normalized absolute path.
-- `ensure_dir_exists(path)`: Creates the directory if missing, expanding `~` and environment variables, and
-  raises `NotADirectoryError` when the path points to an existing file.
+- `ensure_dir_exists(path)`: Creates the directory if missing, expanding `~` and environment variables,
+  preserves symlink paths, and raises `NotADirectoryError` when the path points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -102,15 +102,15 @@ def get_logs_dir() -> pathlib.Path:
         return ensure_dir_exists(base_dir / 'token.place' / 'logs')
 
 def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
-    """
-    Ensure a directory exists, creating it if necessary.
+    """Ensure a directory exists, creating it if necessary.
+
     Expands ``~`` and environment variables before creating the directory.
-    Raises NotADirectoryError if the path points to an existing file.
-    Returns the path as a pathlib.Path object.
+    Raises ``NotADirectoryError`` if the path points to an existing file.
+    The returned path is absolute with symlinks preserved.
     """
     # Expand environment variables and user home (~), then normalize
     path_str = os.path.expandvars(str(dir_path))
-    path = pathlib.Path(path_str).expanduser().resolve()
+    path = pathlib.Path(path_str).expanduser().absolute()
     if path.exists() and not path.is_dir():
         raise NotADirectoryError(f"{path} exists and is not a directory")
     path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
what: preserve symlink paths in ensure_dir_exists
why: avoid resolving links unexpectedly
how: pre-commit run --files utils/path_handling.py utils/README.md
how: pre-commit run --files tests/unit/test_path_handling_additional.py
how: ./run_all_tests.sh
how: npm run lint (missing script)
how: npm run test:ci (missing script)
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c256fdaf4832f9c484ba8c5eafe66