### PR TITLE
🐛 enforce PKCS#7 unpad block size bounds

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,7 +29,8 @@ python -m pytest tests/unit/
 ```
 
 These tests cover numerous edge cases, including rejection of invalid PKCS#7 padding
-such as zero-length padding, ensuring token.place's cryptography remains robust.
+such as zero-length padding or invalid block sizes, ensuring token.place's
+cryptography remains robust.
 
 ### Integration Tests
 

--- a/encrypt.py
+++ b/encrypt.py
@@ -186,9 +186,20 @@ def pkcs7_pad(data: bytes, block_size: int) -> bytes:
     return data + padding
 
 def pkcs7_unpad(padded_data: bytes, block_size: int) -> bytes:
+    """Remove PKCS#7 padding from *padded_data*.
+
+    Args:
+        padded_data: Input bytes to unpad.
+        block_size: Size of each block in bytes (1-255).
+
+    Returns:
+        Unpadded byte string.
+
+    Raises:
+        ValueError: If *block_size* is not between 1 and 255 (inclusive) or padding is invalid.
     """
-    Remove PKCS#7 padding
-    """
+    if block_size <= 0 or block_size > 255:
+        raise ValueError("Block size must be between 1 and 255")
     if not padded_data:
         raise ValueError("Invalid padding")
     if len(padded_data) % block_size != 0:

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -1,7 +1,8 @@
 import pytest
 from encrypt import pkcs7_pad, pkcs7_unpad
 
-@pytest.mark.parametrize("data", [b"test", b"" , b"1234567890abcdef"*2])
+
+@pytest.mark.parametrize("data", [b"test", b"", b"1234567890abcdef" * 2])
 def test_pad_unpad_roundtrip(data):
     padded = pkcs7_pad(data, 16)
     assert len(padded) % 16 == 0
@@ -43,3 +44,12 @@ def test_pad_invalid_block_size():
         pkcs7_pad(b"data", 0)
     with pytest.raises(ValueError):
         pkcs7_pad(b"data", 256)
+
+
+def test_unpad_invalid_block_size():
+    """Block sizes outside 1-255 should raise during unpadding."""
+    padded = pkcs7_pad(b"data", 16)
+    with pytest.raises(ValueError):
+        pkcs7_unpad(padded, 0)
+    with pytest.raises(ValueError):
+        pkcs7_unpad(padded, 256)


### PR DESCRIPTION
## Summary
- validate block_size in pkcs7_unpad to avoid ZeroDivisionError
- test invalid block sizes for pkcs7 padding/unpadding
- note block size coverage in testing guide

## Testing
- `npm run lint` (fails: Missing script "lint")
- `npm run test:ci` (fails: Missing script "test:ci")
- `pre-commit run --files encrypt.py tests/unit/test_pkcs7_padding.py docs/TESTING.md`
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c256fdaf4832f9c484ba8c5eafe66