### PR TITLE
🐛 fix: validate encrypted fields in CryptoClient.decrypt_message

### DIFF
--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -71,6 +71,19 @@ def test_decrypt_message_requires_private_key(monkeypatch):
         client.decrypt_message({'ciphertext': 'c', 'cipherkey': 'k', 'iv': 'i'})
 
 
+def test_decrypt_message_missing_fields():
+    client = _prep_client()
+    # missing cipherkey
+    enc = {'ciphertext': 'Yw==', 'iv': 'aQ=='}
+    assert client.decrypt_message(enc) is None
+
+
+def test_decrypt_message_invalid_base64():
+    client = _prep_client()
+    enc = {'ciphertext': '!!', 'cipherkey': '!!', 'iv': '!!'}
+    assert client.decrypt_message(enc) is None
+
+
 def test_decrypt_message_failure(monkeypatch):
     """Decrypt returns None when underlying decrypt fails"""
     client = _prep_client()

--- a/utils/README.md
+++ b/utils/README.md
@@ -31,6 +31,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 ### Crypto Helpers (`crypto_helpers.py`)
 
 Simplifies encryption and decryption operations for end-to-end encrypted communication with the token.place server and relay.
+`CryptoClient.decrypt_message` now validates required fields and returns `None` when data is incomplete or
+malformed to prevent unexpected exceptions.
 
 ### Crypto Manager (`crypto/crypto_manager.py`)
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -164,15 +164,22 @@ class CryptoClient:
         """
         if self.client_private_key is None:
             raise ValueError("Client private key not available")
+        logger.debug("Decrypting message...")
 
-        logger.debug(f"Decrypting message...")
+        required_fields = ("ciphertext", "cipherkey", "iv")
+        if not all(field in encrypted_data for field in required_fields):
+            logger.error("Missing required encrypted fields: %s", required_fields)
+            return None
 
-        # Extract and decode the encrypted components
-        encrypted_response = {
-            'ciphertext': base64.b64decode(encrypted_data['ciphertext']),
-            'iv': base64.b64decode(encrypted_data['iv'])
-        }
-        encrypted_key = base64.b64decode(encrypted_data['cipherkey'])
+        try:
+            encrypted_response = {
+                'ciphertext': base64.b64decode(encrypted_data['ciphertext']),
+                'iv': base64.b64decode(encrypted_data['iv'])
+            }
+            encrypted_key = base64.b64decode(encrypted_data['cipherkey'])
+        except Exception:
+            logger.error("Failed to decode encrypted fields")
+            return None
 
         # Decrypt the data
         decrypted_bytes = decrypt(encrypted_response, encrypted_key, self.client_private_key)


### PR DESCRIPTION
## What
- validate required fields and base64 decoding in CryptoClient.decrypt_message
- test missing fields and malformed base64
- document error handling for CryptoClient.decrypt_message

## Why
- prevent uncaught exceptions when server responses are incomplete or corrupt

## How to Test
- `npm run lint` *(fails: missing script)*
- `npm run test:ci` *(fails: missing script)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689c256fdaf4832f9c484ba8c5eafe66