### PR TITLE
🔒 : redact client message logging

### DIFF
--- a/client_simplified.py
+++ b/client_simplified.py
@@ -99,7 +99,8 @@ def main():
 
     if args.message:
         # Single message mode
-        print(f"Sending message: {args.message}")
+        # Avoid logging plaintext user content
+        print("Sending message to server...")
         if client.fetch_server_public_key():
             response = client.send_chat_message(args.message)
             if response:


### PR DESCRIPTION
## Summary
- avoid logging plaintext user messages in simplified CLI client

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`


------
https://chatgpt.com/codex/tasks/task_e_689d5a2de55c832f871bef9f8ee4eae5