### PR TITLE
🔒: avoid global logging config

### DIFF
--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -36,9 +36,9 @@ import time
 # Import encryption functions
 from encrypt import generate_keys, encrypt, decrypt
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger('crypto_client')
+# Set up module-level logger without configuring global logging
+logger = logging.getLogger("crypto_client")
+logger.addHandler(logging.NullHandler())
 
 class CryptoClient:
     """


### PR DESCRIPTION
## Summary
- avoid global logging configuration in crypto helpers to prevent unintended info-level logs

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`


------
https://chatgpt.com/codex/tasks/task_e_689d5a2de55c832f871bef9f8ee4eae5