### PR TITLE
🐛: handle string error responses in fetch_server_public_key

### DIFF
--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -53,6 +54,15 @@ def test_fetch_server_public_key_error_field(monkeypatch):
     resp = MagicMock(status_code=200, json=lambda: {'error': {'message': 'no'}})
     monkeypatch.setattr('utils.crypto_helpers.requests.get', lambda *a, **_kw: resp)
     assert not client.fetch_server_public_key()
+
+
+def test_fetch_server_public_key_error_string(monkeypatch, caplog):
+    client = CryptoClient('https://example.com')
+    resp = MagicMock(status_code=200, json=lambda: {'error': 'no'})
+    monkeypatch.setattr('utils.crypto_helpers.requests.get', lambda *a, **_kw: resp)
+    with caplog.at_level(logging.ERROR):
+        assert not client.fetch_server_public_key()
+    assert "Server returned error: no" in caplog.text
 
 
 def test_fetch_server_public_key_exception(monkeypatch):

--- a/utils/README.md
+++ b/utils/README.md
@@ -30,9 +30,12 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 
 ### Crypto Helpers (`crypto_helpers.py`)
 
-Simplifies encryption and decryption operations for end-to-end encrypted communication with the token.place server and relay.
-`CryptoClient.decrypt_message` now validates required fields and returns `None` when data is incomplete or
-malformed to prevent unexpected exceptions.
+Simplifies encryption and decryption operations for end-to-end encrypted communication
+with the token.place server and relay.
+`CryptoClient.decrypt_message` now validates required fields and returns `None`
+when data is incomplete or malformed to prevent unexpected exceptions.
+`CryptoClient.fetch_server_public_key` now tolerates string `error` fields,
+logging the message and returning `False` instead of raising an exception.
 
 ### Crypto Manager (`crypto/crypto_manager.py`)
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -103,7 +103,11 @@ class CryptoClient:
 
             # Check if there's an error in the response
             if 'error' in data:
-                error_msg = data['error'].get('message', 'Unknown error')
+                error_val = data['error']
+                if isinstance(error_val, dict):
+                    error_msg = error_val.get('message', 'Unknown error')
+                else:
+                    error_msg = str(error_val)
                 logger.error(f"Server returned error: {error_msg}")
                 return False
 


### PR DESCRIPTION
what: handle string error responses in CryptoClient.fetch_server_public_key
why: avoid exception on string error payloads and improve logging
how: npm run lint (fails: Missing script), npm run test:ci (fails: Missing script), pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689d5a2f5b38832fab178f1f446b8fc9