### PR TITLE
🐛 : reject missing public key in CryptoManager

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ token.place is an end-to-end encrypted proxy service that sits between clients a
 
 ### 1. Client-Side Components
 
-- **JavaScript Client Library** (`static/chat.js`): 
+- **JavaScript Client Library** (`static/chat.js`):
   - Generates client-side RSA key pairs
   - Encrypts messages using a hybrid RSA-AES approach
   - Decrypts responses from the server
@@ -30,6 +30,7 @@ token.place is an end-to-end encrypted proxy service that sits between clients a
   - Generates and manages RSA key pairs
   - Provides encryption/decryption services
   - Manages secure session handling
+  - Validates presence of client public keys before encryption
 
 - **Model Manager** (`utils/models/model_manager.py`):
   - Connects to various AI providers
@@ -112,4 +113,4 @@ token.place is designed to be deployed in various configurations:
 
 1. **Self-Hosted**: Run on your own infrastructure
 2. **Cloud Services**: Deploy to standard cloud providers
-3. **Development Mode**: Local setup for testing and development 
+3. **Development Mode**: Local setup for testing and development

--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -127,6 +127,11 @@ class TestCryptoManager:
         with pytest.raises(ValueError, match="Message cannot be None"):
             crypto_manager.encrypt_message(None, b'client_public_key')
 
+    def test_encrypt_message_missing_public_key(self, crypto_manager):
+        """encrypt_message should reject None public key."""
+        with pytest.raises(ValueError, match="Client public key cannot be None"):
+            crypto_manager.encrypt_message("hi", None)
+
     @patch('utils.crypto.crypto_manager.encrypt')
     def test_encrypt_message_accepts_base64_key(self, mock_encrypt, crypto_manager):
         """Public key may be provided as a base64 string."""

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -90,6 +90,8 @@ class CryptoManager:
         try:
             if message is None:
                 raise ValueError("Message cannot be None")
+            if client_public_key is None:
+                raise ValueError("Client public key cannot be None")
 
             # Convert message to bytes if it's not already
             if isinstance(message, (dict, list)):


### PR DESCRIPTION
## Summary
- require non-null client public key in `CryptoManager.encrypt_message`
- cover missing-key scenario with unit test
- document key validation in CryptoManager docs

## Testing
- `pre-commit run --files tests/unit/test_crypto_manager.py utils/crypto/crypto_manager.py docs/ARCHITECTURE.md`
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*

------
https://chatgpt.com/codex/tasks/task_e_689d5a2f5b38832fab178f1f446b8fc9