### PR TITLE
🐛 : guard path helpers against None

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -126,3 +126,15 @@ def test_get_relative_path_relpath_error(monkeypatch, tmp_path):
     target.mkdir()
     result = ph.get_relative_path(target, base)
     assert result == target
+
+
+def test_normalize_path_none():
+    """normalize_path should reject None values"""
+    with pytest.raises(TypeError):
+        ph.normalize_path(None)
+
+
+def test_ensure_dir_exists_none():
+    """ensure_dir_exists should reject None values"""
+    with pytest.raises(TypeError):
+        ph.ensure_dir_exists(None)

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,9 +19,10 @@ and automatically create directories when accessed.
 On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
-- `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized absolute path.
-- `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment variables, and
-  raises `NotADirectoryError` when the path points to an existing file.
+- `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized
+  absolute path. Raises a `TypeError` when `path` is `None`.
+- `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment
+  variables, and raises `NotADirectoryError` when the path points to an existing file. Passing `None` now raises `TypeError`.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -106,9 +106,13 @@ def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     Ensure a directory exists, creating it if necessary.
     Expands ``~`` and environment variables before creating the directory, and
     strips surrounding whitespace to avoid accidental directory names.
-    Raises NotADirectoryError if the path points to an existing file.
-    Returns the path as a pathlib.Path object.
+    Raises ``TypeError`` if ``dir_path`` is ``None`` and ``NotADirectoryError``
+    if the path points to an existing file. Returns the path as a
+    ``pathlib.Path`` object.
     """
+    if dir_path is None:
+        raise TypeError("dir_path cannot be None")
+
     # Expand environment variables and user home (~), then normalize
     # Also strip surrounding whitespace to avoid creating unintended paths
     path_str = os.path.expandvars(str(dir_path)).strip()
@@ -123,10 +127,14 @@ def get_executable_extension() -> str:
     return '.exe' if IS_WINDOWS else ''
 
 def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
-    """Convert a path string to a normalized pathlib.Path object.
+    """Convert a path string to a normalized ``pathlib.Path`` object.
 
-    Strips surrounding whitespace and expands environment variables and user home (~).
+    Strips surrounding whitespace and expands environment variables and user
+    home (``~``). Raises ``TypeError`` when ``path`` is ``None``.
     """
+    if path is None:
+        raise TypeError("path cannot be None")
+
     expanded = os.path.expandvars(str(path)).strip()
     return pathlib.Path(expanded).expanduser().resolve()
 


### PR DESCRIPTION
## Summary
- raise TypeError when path helpers receive None
- document rejection of None in utils README
## Testing
- `pre-commit run --files tests/unit/test_path_handling_additional.py utils/path_handling.py utils/README.md -v`
- `npm run lint` (missing script)
- `npm run test:ci` (missing script)

------
https://chatgpt.com/codex/tasks/task_e_689d5a2f5b38832fab178f1f446b8fc9