### PR TITLE
🐛 fix: flush clear_screen output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ python server.py
 ```
 
 Open `http://localhost:5000` or run `python client.py`. For a minimal client use
-`python client_simplified.py`; it only clears the screen when running interactively. Metrics are
-exposed at `/metrics`.
+`python client_simplified.py`; it clears the screen when running interactively using ANSI codes
+with flushed output. Metrics are exposed at `/metrics`.
 
 ### Key environment variables
 

--- a/client_simplified.py
+++ b/client_simplified.py
@@ -18,7 +18,7 @@ def clear_screen():
     """
     if sys.stdout.isatty():
         # Use ANSI escape codes to avoid shell injection via os.system
-        print("\033[2J\033[H", end="")
+        print("\033[2J\033[H", end="", flush=True)
 
 def format_message(message: Dict) -> str:
     """Format a message for display"""


### PR DESCRIPTION
what: flush clear_screen ANSI codes and document screen clearing
why: prevents buffered output delaying terminal refresh
how to test:
- npm run lint # missing script
- npm run test:ci # missing script
- playwright install chromium
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_689d5a2f5b38832fab178f1f446b8fc9