### PR TITLE
🔒 avoid plaintext echo in CLI

### DIFF
--- a/client_simplified.py
+++ b/client_simplified.py
@@ -99,7 +99,7 @@ def main():
 
     if args.message:
         # Single message mode
-        print(f"Sending message: {args.message}")
+        print("Sending message")
         if client.fetch_server_public_key():
             response = client.send_chat_message(args.message)
             if response:


### PR DESCRIPTION
## Summary
- stop echoing user-provided plaintext when using single-message CLI mode

## Testing
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`
- `npm run lint` *(fails: Missing script)*
- `npm run test:ci` *(fails: Missing script)*
- `pre-commit run --files client_simplified.py`


------
https://chatgpt.com/codex/tasks/task_e_689d5a3e82e8832f975ce42a99d046e0