### PR TITLE
📝 docs: clarify path handling helpers

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -19,9 +19,11 @@ and automatically create directories when accessed.
 On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
-- `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized absolute path.
-- `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment variables, and
-  raises `NotADirectoryError` when the path points to an existing file.
+- `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment
+  variables, then returns a normalized absolute path.
+- `ensure_dir_exists(path)`: Expands `~` and environment variables, strips whitespace,
+  creates the directory if missing, and raises `NotADirectoryError` when the path
+  points to an existing file.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the


### PR DESCRIPTION
## Summary
- clarify `normalize_path` and `ensure_dir_exists` docs

## Testing
- `SKIP=run-checks pre-commit run --files utils/README.md`
- `pytest -q` *(fails: BrowserType.launch missing executable)*

------
https://chatgpt.com/codex/tasks/task_e_689d5a538f9c832fa1cc049b00829804