### PR TITLE
🧪 test: cover ensure_dir_exists file case

### DIFF
--- a/tests/platform_tests/test_path_handling.py
+++ b/tests/platform_tests/test_path_handling.py
@@ -5,26 +5,26 @@ import tempfile
 from pathlib import Path
 import sys
 
-# Add the project root to the path 
+# Add the project root to the path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from utils.path_handling import (
-    get_user_home_dir, get_app_data_dir, get_config_dir, get_cache_dir, 
+    get_user_home_dir, get_app_data_dir, get_config_dir, get_cache_dir,
     get_models_dir, get_logs_dir, ensure_dir_exists, normalize_path,
     get_relative_path, IS_WINDOWS, IS_MACOS, IS_LINUX
 )
 
 class TestPathHandling:
     """Test suite for the path_handling module"""
-    
+
     def test_platform_detection(self, platform_info):
         """Test that the platform is correctly detected"""
         system = platform.system().lower()
-        
+
         # Check that exactly one platform flag is True
         platform_flags = [IS_WINDOWS, IS_MACOS, IS_LINUX]
         assert sum(platform_flags) == 1, "Exactly one platform flag should be True"
-        
+
         # Check that the correct flag is True
         if system == "windows":
             assert IS_WINDOWS is True
@@ -35,27 +35,27 @@ class TestPathHandling:
         elif system == "linux":
             assert IS_LINUX is True
             assert platform_info["is_linux"] is True
-    
+
     def test_get_user_home_dir(self):
         """Test that the user home directory is correctly detected"""
         home_dir = get_user_home_dir()
         assert home_dir.exists(), "Home directory should exist"
         assert home_dir.is_dir(), "Home directory should be a directory"
-        
+
         # Check against environment variables
         if IS_WINDOWS:
             expected = os.environ.get("USERPROFILE")
         else:
             expected = os.environ.get("HOME")
-        
+
         assert str(home_dir) == expected, f"Home directory should be {expected}, got {home_dir}"
-    
+
     def test_get_app_data_dir(self):
         """Test that the application data directory is correctly constructed"""
         app_data_dir = get_app_data_dir()
-        
+
         # The directory may not exist yet, so we don't check that
-        
+
         # Check the platform-specific structure
         if IS_WINDOWS:
             assert "AppData\\Roaming\\token.place" in str(app_data_dir)
@@ -63,11 +63,11 @@ class TestPathHandling:
             assert "Library/Application Support/token.place" in str(app_data_dir)
         elif IS_LINUX:
             assert ".local/share/token.place" in str(app_data_dir)
-    
+
     def test_get_config_dir(self):
         """Test that the configuration directory is correctly constructed"""
         config_dir = get_config_dir()
-        
+
         # Check the platform-specific structure
         if IS_WINDOWS:
             assert "AppData\\Roaming\\token.place\\config" in str(config_dir)
@@ -75,58 +75,63 @@ class TestPathHandling:
             assert "Library/Application Support/token.place/config" in str(config_dir)
         elif IS_LINUX:
             assert ".config/token.place" in str(config_dir)
-    
+
     def test_ensure_dir_exists(self, temp_dir):
         """Test that ensure_dir_exists creates directories correctly"""
         # Create a nested directory structure
         test_dir = temp_dir / "test" / "nested" / "dirs"
-        
+
         # Directory should not exist yet
         assert not test_dir.exists()
-        
+
         # Ensure it exists
         result = ensure_dir_exists(test_dir)
-        
+
         # Check that it now exists
         assert test_dir.exists()
         assert test_dir.is_dir()
-        
+
         # Check that the function returns the path
         assert result == test_dir
-    
+
+    def test_ensure_dir_exists_with_file(self, temp_file):
+        """ensure_dir_exists raises when path points to a file"""
+        with pytest.raises(NotADirectoryError):
+            ensure_dir_exists(temp_file)
+
     def test_normalize_path(self):
         """Test that normalize_path correctly normalizes paths"""
         # Test with a tilde expansion
         home_path = normalize_path("~/test")
         assert "~" not in str(home_path)
         assert get_user_home_dir().name in str(home_path)
-        
+
         # Test with relative paths
         rel_path = normalize_path("./test")
         assert rel_path.is_absolute()
-        
+
         # Test with an absolute path
         abs_path = Path("/tmp" if not IS_WINDOWS else "C:\\Windows").absolute()
         norm_abs_path = normalize_path(abs_path)
         assert norm_abs_path == abs_path
-    
+
     def test_get_relative_path(self, temp_dir):
         """Test that get_relative_path correctly computes relative paths"""
         # Create a nested directory structure
         base_dir = temp_dir
         nested_dir = base_dir / "nested" / "dirs"
         ensure_dir_exists(nested_dir)
-        
+
         # Get a relative path
         rel_path = get_relative_path(nested_dir, base_dir)
         assert not rel_path.is_absolute()
         assert str(rel_path) == os.path.join("nested", "dirs")
-        
+
         # Get a relative path when the path is not relative to the base
         other_dir = ensure_dir_exists(temp_dir.parent / "other")
         rel_path_2 = get_relative_path(other_dir, base_dir)
-        assert rel_path_2.is_absolute()
-        assert rel_path_2 == other_dir
+        assert not rel_path_2.is_absolute()
+        assert rel_path_2 == Path("..") / "other"
 
     def test_get_relative_path_default_base(self, tmp_path, monkeypatch):
         """Path is made relative to CWD when base_path is None"""

--- a/utils/README.md
+++ b/utils/README.md
@@ -22,6 +22,10 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 - `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized absolute path.
 - `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment variables, and
   raises `NotADirectoryError` when the path points to an existing file.
+  ```python
+  # raises NotADirectoryError if "config.json" is a file
+  ensure_dir_exists("config.json")
+  ```
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the


### PR DESCRIPTION
## Summary
- add regression test for ensure_dir_exists when path points to file
- document usage of ensure_dir_exists in utils README
- adjust relative path test to expect '..' for sibling directories

## Testing
- `npm ci`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:ci` *(fails: Missing script: "test:ci")*
- `pre-commit run --files tests/platform_tests/test_path_handling.py utils/README.md`
- `pytest -q` *(fails: 4 failed, 423 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689d5a538f9c832fa1cc049b00829804