### PR TITLE
Add filesystem case-sensitivity helper

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -126,3 +126,11 @@ def test_get_relative_path_relpath_error(monkeypatch, tmp_path):
     target.mkdir()
     result = ph.get_relative_path(target, base)
     assert result == target
+
+
+def test_is_case_sensitive_filesystem(tmp_path):
+    """is_case_sensitive_filesystem returns expected boolean and cleans up."""
+    result = ph.is_case_sensitive_filesystem(tmp_path)
+    assert isinstance(result, bool)
+    if ph.IS_LINUX:
+        assert result is True

--- a/utils/README.md
+++ b/utils/README.md
@@ -27,6 +27,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the
   two locations do not share a common ancestor. If the paths are on different drives
   (Windows), the absolute `path` is returned instead of raising an error.
+- `is_case_sensitive_filesystem(path)`: Detects whether the filesystem treats names with different
+  casing as distinct.
 
 ### Crypto Helpers (`crypto_helpers.py`)
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -156,3 +156,27 @@ def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[
             return pathlib.Path(os.path.relpath(path, base_path))
         except ValueError:
             return path
+
+
+def is_case_sensitive_filesystem(path: Union[str, pathlib.Path] = ".") -> bool:
+    """Return True if the filesystem at ``path`` treats names as case-sensitive.
+
+    The check creates two temporary files whose names differ only by case and
+    verifies whether both can exist simultaneously.
+    """
+    base = normalize_path(path)
+    base.mkdir(parents=True, exist_ok=True)
+    test_lower = base / "tmp_case_test"
+    test_upper = base / "TMP_CASE_TEST"
+    try:
+        test_lower.write_text("a")
+        if test_upper.exists():
+            return False
+        test_upper.write_text("b")
+        return True
+    finally:
+        for p in (test_lower, test_upper):
+            try:
+                p.unlink()
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary
- add `is_case_sensitive_filesystem` helper for path utilities
- document filesystem case sensitivity helper in utils README
- test filesystem case sensitivity detection

## Testing
- `pre-commit run --files utils/path_handling.py utils/README.md tests/unit/test_path_handling_additional.py`
- `pytest tests/unit/test_path_handling_additional.py::test_is_case_sensitive_filesystem -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5a538f9c832fa1cc049b00829804