### PR TITLE
📝 docs: clarify Playwright install with dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd token.place
 pip install -r config/requirements_server.txt
 pip install -r config/requirements_relay.txt
 npm ci
-playwright install chromium
+playwright install --with-deps chromium
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files


### PR DESCRIPTION
## Summary
- ensure Quickstart installs Playwright browser dependencies via `playwright install --with-deps`

## Testing
- `pre-commit run --files README.md`
- `pytest -q` *(fails: BrowserType.launch: Host system is missing dependencies)*
- `pytest -q tests/test_security.py`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:ci` *(fails: Missing script: "test:ci")*
- `bandit -r tokenplace -lll` *(fails: command not found: bandit)*

------
https://chatgpt.com/codex/tasks/task_e_689d5a538f9c832fa1cc049b00829804