### PR TITLE
✨ add daily request quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ exposed at `/metrics`.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | API_RATE_LIMIT | 60/hour | Per-IP rate limit for API requests |
+| API_DAILY_QUOTA | 1000/day | Per-IP daily request quota |
 | USE_MOCK_LLM | 0 | Run with mock LLM instead of downloading a real model |
 | TOKEN_PLACE_ENV | development | Deployment environment (`development`, `testing`, `production`) |
 
@@ -126,7 +127,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
   - [ ] Batched inference for relay servers with multiple connected clients
 - [ ] Advanced security features
   - [ ] Client authentication for relay servers
-  - [ ] Rate limiting and quota enforcement
+  - [x] Rate limiting and quota enforcement 💯
 - [ ] Enhanced encryption options for model weights and inference data
   - [ ] Key rotation for relay and server certificates
   - [ ] Signed relay binaries for client verification

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -15,7 +15,10 @@ def init_app(app):
     Limiter(
         get_remote_address,
         app=app,
-        default_limits=[os.environ.get("API_RATE_LIMIT", "60/hour")],
+        default_limits=[
+            os.environ.get("API_RATE_LIMIT", "60/hour"),
+            os.environ.get("API_DAILY_QUOTA", "1000/day"),
+        ],
     )
     PrometheusMetrics(app)
     app.register_blueprint(v1_routes.v1_bp)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -17,3 +17,18 @@ def test_exceeding_rate_limit_returns_429():
 
         second = client.get("/api/v1/models")
         assert second.status_code == 429
+
+
+@patch.dict(
+    os.environ,
+    {"API_RATE_LIMIT": "1000/minute", "API_DAILY_QUOTA": "2/day"},
+)
+def test_exceeding_daily_quota_returns_429():
+    app = Flask(__name__)
+    init_app(app)
+
+    with app.test_client() as client:
+        assert client.get("/api/v1/models").status_code == 200
+        assert client.get("/api/v1/models").status_code == 200
+        third = client.get("/api/v1/models")
+        assert third.status_code == 429


### PR DESCRIPTION
## Summary
- enforce per-IP daily request quota via `API_DAILY_QUOTA`
- test quota limits and document new env var

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `pytest -q tests/unit/test_rate_limit.py`
- `pre-commit run --files api/__init__.py tests/unit/test_rate_limit.py README.md`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d5a5e5d68832f9aef11412c299667