### PR TITLE
Add Raspberry Pi k3s pod manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
   - [x] simplified crypto utility (CryptoClient) for easy encrypted communication
 - [ ] distribute relay.py across multiple machines
   - [x] personal gaming PC
-  - [ ] raspi k3s pod
+  - [x] raspi k3s pod 💯
   - [ ] once k3s pod is stable, run relay.py only on the cluster
   - [ ] optional cloud fallback via Cloudflare
 - [x] OpenAI-compatible API with end-to-end encryption

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -14,5 +14,11 @@ These manifests run `relay.py` as a Deployment and expose it via a Service.
 
 Edit `relay-deployment.yaml` to point `image:` at your registry if needed.
 
+For a Raspberry Pi k3s cluster, use `relay-raspi-pod.yaml` to run a single ARM64 pod:
+
+```bash
+kubectl apply -f k8s/relay-raspi-pod.yaml
+```
+
 The deployment manifest includes resource requests/limits and basic health
 probes. Adjust these values according to your cluster capacity.

--- a/k8s/relay-raspi-pod.yaml
+++ b/k8s/relay-raspi-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tokenplace-relay-raspi
+  labels:
+    app: tokenplace-relay
+spec:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+  containers:
+    - name: relay
+      image: tokenplace-relay:latest
+      imagePullPolicy: IfNotPresent
+      command: ["python", "relay.py"]
+      ports:
+        - containerPort: 5010
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+        limits:
+          cpu: "500m"
+          memory: "512Mi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ playwright>=1.40.0        # Required by pytest-playwright 0.7.0+
 pytest-cov                # Code coverage
 pytest-mock               # Mocking utilities
 pytest-benchmark==5.1.0   # Performance benchmarking, requires pytest>=8.1
+PyYAML>=6.0
 
 # JavaScript test dependencies
 # Note: Install these with npm ci

--- a/tests/unit/test_k8s_raspi_pod.py
+++ b/tests/unit/test_k8s_raspi_pod.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_raspi_pod_manifest_valid():
+    manifest = Path(__file__).resolve().parents[2] / 'k8s' / 'relay-raspi-pod.yaml'
+    with manifest.open() as f:
+        data = yaml.safe_load(f)
+
+    assert data['kind'] == 'Pod'
+    assert data['metadata']['name'] == 'tokenplace-relay-raspi'
+
+    spec = data['spec']
+    assert spec['nodeSelector']['kubernetes.io/arch'] == 'arm64'
+
+    container = spec['containers'][0]
+    assert 'relay.py' in container['command'][-1]
+    assert container['ports'][0]['containerPort'] == 5010


### PR DESCRIPTION
## Summary
- add ARM64 pod manifest for k3s Raspberry Pi relay
- document new manifest and mark roadmap item complete
- test manifest loading via PyYAML

## Testing
- `pre-commit run --files README.md k8s/README.md k8s/relay-raspi-pod.yaml tests/unit/test_k8s_raspi_pod.py requirements.txt`
- `pytest -q` *(fails: path handling and crypto failure tests, PIL missing)*
- `pytest -q tests/unit/test_k8s_raspi_pod.py`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:ci` *(fails: Missing script: "test:ci")*


------
https://chatgpt.com/codex/tasks/task_e_689d5a5e5d68832f9aef11412c299667