### PR TITLE
docs: link codex prompt docs

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -17,7 +17,10 @@ Diagnose and fix CI failures so tests and checks pass.
 CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
 - Run `pre-commit run --all-files` (which executes `./run_all_tests.sh`).
-- Install dependencies with `npm ci` for Node.js and `pip install -r config/requirements_server.txt` plus `pip install -r config/requirements_relay.txt` as needed.
+- Install dependencies:
+  - `npm ci`
+  - `pip install -r config/requirements_server.txt`
+  - `pip install -r config/requirements_relay.txt`
 
 REQUEST:
 1. Reproduce the failing check locally with `pre-commit run --all-files`.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -29,6 +29,11 @@ OUTPUT:
 A pull request describing the change and summarizing test results.
 ```
 
+For specialized tasks, see:
+
+- [Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md)
+- [Codex Security Review Prompt](prompts-codex-security.md)
+
 ## Implementation prompts
 
 ### 1 Document environment variables in README


### PR DESCRIPTION
## Summary
- cross-link CI and security prompts from codex index
- clarify dependency installation steps in CI failure prompt

## Testing
- `npm run lint`
- `npm run type-check` (missing script)
- `npm run build` (missing script)
- `npm run test:ci`
- `pre-commit run --all-files` (timed out)


------
https://chatgpt.com/codex/tasks/task_e_689eb5b9ec90832f811959bc55db53e0