### PR TITLE
📝 : clarify security review prompt

### DIFF
--- a/docs/prompts-codex-security.md
+++ b/docs/prompts-codex-security.md
@@ -5,19 +5,19 @@ slug: 'prompts-codex-security'
 
 # Codex Security Review Prompt
 
-Use this prompt to audit token.place for security issues and encryption integrity.
+Use this prompt to audit token.place for security flaws and verify encryption integrity.
 
 ```
 SYSTEM: Automated security reviewer for token.place.
 GOAL: Harden crypto & dependency hygiene.
 CONTEXT:
-- Follow AGENTS.md and docs/AGENTS.md instructions.
+- Follow [AGENTS.md](../AGENTS.md) and [docs/AGENTS.md](AGENTS.md).
 - Do not log plaintext or ciphertext of user messages.
 CHECKS:
   - `pytest -q tests/test_security.py`
   - `bandit -r tokenplace -lll`
-  - Verify README badges for Dependabot, CodeQL, secret-scanning.
-FAIL if any badge missing or Bandit score \u2265 MEDIUM.
+  - Ensure [README.md](../README.md) includes badges for Dependabot, CodeQL, and secret scanning.
+FAIL if any badge is missing or Bandit reports MEDIUM or higher findings.
 REQUEST:
 1. Run all checks.
 2. Inspect code for potential leaks or missing encryption steps.
@@ -25,8 +25,8 @@ REQUEST:
 4. Re-run checks to confirm all pass.
 5. Commit changes with a concise message and open a pull request.
 OUTPUT_FORMAT: JSON
-{"issues":[\u2026], "recommendations":[\u2026], "tests_pass":true}
-If tests_pass is true, append the required patch in ```diff fences.
+{"issues": […], "recommendations": […], "tests_pass": true}
+If `tests_pass` is true, append the required patch inside ```diff fenced block.
 ```
 
 Copy this block whenever token.place needs a security review.


### PR DESCRIPTION
What: refine wording and link README in security review prompt
Why: clearer instructions for security audits
How to test:
- npm run lint
- npm run type-check (missing script)
- npm run build (missing script)
- npm run test:ci
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_689eb5b9ec90832f811959bc55db53e0