### PR TITLE
docs: add docs update prompt

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -40,6 +40,7 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [../llms.txt](../llms.txt): Machine-readable project summary for LLM assistants
 - [docs/prompts-codex-ci-fix.md](docs/prompts-codex-ci-fix.md): Codex prompt for fixing CI failures
 - [docs/prompts-codex-security.md](docs/prompts-codex-security.md): Codex prompt for security reviews
+- [docs/prompts-codex-docs.md](docs/prompts-codex-docs.md): Codex prompt for doc updates
 
 ## User Journeys
 

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex Docs Update Prompt'
+slug: 'prompts-codex-docs'
+---
+
+# Codex Docs Update Prompt
+
+Use this prompt to enhance or fix token.place documentation.
+
+```
+SYSTEM:
+You are an automated contributor for the token.place repository.
+
+GOAL:
+Improve documentation accuracy, links, or readability.
+
+CONTEXT:
+- Follow AGENTS.md and docs/AGENTS.md instructions.
+- Run `pre-commit run --all-files` before committing.
+
+REQUEST:
+1. Identify outdated, unclear, or missing docs.
+2. Apply minimal edits, ensuring token.place is styled properly.
+3. Update cross references or links as needed.
+4. Run `pre-commit run --all-files` to confirm tests and spell-check pass.
+5. Commit changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing documentation improvements.
+```
+
+Copy this block whenever token.place docs need updates.

--- a/docs/prompts-codex-security.md
+++ b/docs/prompts-codex-security.md
@@ -15,9 +15,9 @@ CONTEXT:
 - Do not log plaintext or ciphertext of user messages.
 CHECKS:
   - `pytest -q tests/test_security.py`
-  - `bandit -r tokenplace -lll`
-  - Verify README badges for Dependabot, CodeQL, secret-scanning.
-FAIL if any badge missing or Bandit score \u2265 MEDIUM.
+  - `bandit -r . -lll`
+  - Verify README includes badges for Dependabot, CodeQL, and secret scanning.
+Fail if any badge is missing or Bandit reports findings at MEDIUM severity or higher.
 REQUEST:
 1. Run all checks.
 2. Inspect code for potential leaks or missing encryption steps.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -29,6 +29,12 @@ OUTPUT:
 A pull request describing the change and summarizing test results.
 ```
 
+## Specialized prompts
+
+- [Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md)
+- [Codex Security Review Prompt](prompts-codex-security.md)
+- [Codex Docs Update Prompt](prompts-codex-docs.md)
+
 ## Implementation prompts
 
 ### 1 Document environment variables in README


### PR DESCRIPTION
## Summary
- add Codex Docs Update Prompt and link from docs index
- clarify bandit path and badge checks in security prompt
- list specialized prompts in Codex prompt

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(fails: Missing script "build")*
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689eb5b9ec90832f811959bc55db53e0