### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
## Summary
- update pre-commit-hooks to v6 to remove deprecated stage names

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb5a97f94832fbe53dd066abc2e3e