### PR TITLE
Handle EOF in simplified client

### DIFF
--- a/client_simplified.py
+++ b/client_simplified.py
@@ -78,7 +78,7 @@ def chat_loop(client: CryptoClient):
             # Display updated conversation
             display_conversation(conversation)
 
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, EOFError):
         print("\nChat session ended by user.")
 
     print("Thank you for using token.place!")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 - Validate PKCS#7 unpadding length to reject improperly padded input
 - Remove unused imports from simplified CLI client to avoid unnecessary dependencies
+- Handle EOF in simplified CLI client to end sessions cleanly
 
 ## Version 1.0.0 (March 2025)
 

--- a/tests/unit/test_client_simplified.py
+++ b/tests/unit/test_client_simplified.py
@@ -63,3 +63,21 @@ def test_chat_loop_single_iteration(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Assistant is thinking" in out
     assert "ok" in out
+
+
+def test_chat_loop_eof(monkeypatch, capsys):
+    """Gracefully exit when stdin closes."""
+    mock_client = MagicMock()
+    mock_client.fetch_server_public_key.return_value = True
+
+    def raise_eof(_):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", raise_eof)
+    monkeypatch.setattr(cs, "clear_screen", lambda: None)
+
+    cs.chat_loop(mock_client)
+
+    out = capsys.readouterr().out
+    assert "Chat session ended" in out
+    mock_client.send_chat_message.assert_not_called()


### PR DESCRIPTION
## Summary
- gracefully exit token.place simplified CLI when stdin closes
- cover EOF scenario with unit test
- note change in changelog

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689eb5b1b03c832faeb37ccb650fd48f