### PR TITLE
🛡️: – validate bytes input in PKCS#7 helpers

### DIFF
--- a/docs/TESTING_IMPROVEMENTS.md
+++ b/docs/TESTING_IMPROVEMENTS.md
@@ -110,6 +110,13 @@ def test_decrypt_with_missing_fields():
         decrypt_message(bad_data, private_key)
 ```
 
+- Ensure encryption helpers reject invalid types:
+
+```python
+with pytest.raises(TypeError):
+    pkcs7_unpad("not-bytes", 16)
+```
+
 ## 10. Mock Server for JavaScript Tests
 
 Create a simple mock server to test the JavaScript client without relying on the full Python server:

--- a/encrypt.py
+++ b/encrypt.py
@@ -178,7 +178,10 @@ def pkcs7_pad(data: bytes, block_size: int) -> bytes:
 
     Raises:
         ValueError: If *block_size* is not between 1 and 255 (inclusive).
+        TypeError: If *data* is not bytes-like.
     """
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError("data must be bytes-like")
     if block_size <= 0 or block_size > 255:
         raise ValueError("Block size must be between 1 and 255")
     padding_length = block_size - (len(data) % block_size)
@@ -197,7 +200,10 @@ def pkcs7_unpad(padded_data: bytes, block_size: int) -> bytes:
 
     Raises:
         ValueError: If *block_size* is not between 1 and 255 (inclusive) or padding is invalid.
+        TypeError: If *padded_data* is not bytes-like.
     """
+    if not isinstance(padded_data, (bytes, bytearray)):
+        raise TypeError("padded_data must be bytes-like")
     if block_size <= 0 or block_size > 255:
         raise ValueError("Block size must be between 1 and 255")
     if not padded_data:

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -53,3 +53,15 @@ def test_unpad_invalid_block_size():
         pkcs7_unpad(padded, 0)
     with pytest.raises(ValueError):
         pkcs7_unpad(padded, 256)
+
+
+def test_pad_non_bytes_input():
+    """Non-byte inputs to pkcs7_pad should raise TypeError."""
+    with pytest.raises(TypeError):
+        pkcs7_pad("not-bytes", 16)
+
+
+def test_unpad_non_bytes_input():
+    """Non-byte inputs to pkcs7_unpad should raise TypeError."""
+    with pytest.raises(TypeError):
+        pkcs7_unpad("not-bytes", 16)


### PR DESCRIPTION
what: enforce bytes-like inputs for pkcs7_pad/unpad and document negative tests
why: prevent confusing ValueErrors when strings are supplied
how to test: npm run lint && npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689eb5b1b03c832faeb37ccb650fd48f