### PR TITLE
Guard path utilities against empty strings

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -138,3 +138,15 @@ def test_ensure_dir_exists_none():
     """ensure_dir_exists should reject None values"""
     with pytest.raises(TypeError):
         ph.ensure_dir_exists(None)
+
+
+def test_ensure_dir_exists_empty_string():
+    """ensure_dir_exists should reject empty or whitespace-only paths"""
+    with pytest.raises(ValueError):
+        ph.ensure_dir_exists("   ")
+
+
+def test_normalize_path_empty_string():
+    """normalize_path should reject empty or whitespace-only paths"""
+    with pytest.raises(ValueError):
+        ph.normalize_path("")

--- a/utils/README.md
+++ b/utils/README.md
@@ -20,9 +20,10 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
 - `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized
-  absolute path. Raises a `TypeError` when `path` is `None`.
+  absolute path. Raises a `TypeError` when `path` is `None` and `ValueError` for empty strings.
 - `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment
-  variables, and raises `NotADirectoryError` when the path points to an existing file. Passing `None` now raises `TypeError`.
+  variables, and raises `NotADirectoryError` when the path points to an existing file. Passing `None` now raises `TypeError`,
+  and empty paths raise `ValueError`.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -116,6 +116,8 @@ def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
     # Expand environment variables and user home (~), then normalize
     # Also strip surrounding whitespace to avoid creating unintended paths
     path_str = os.path.expandvars(str(dir_path)).strip()
+    if path_str == "":
+        raise ValueError("dir_path cannot be empty")
     path = pathlib.Path(path_str).expanduser().resolve()
     if path.exists() and not path.is_dir():
         raise NotADirectoryError(f"{path} exists and is not a directory")
@@ -136,6 +138,8 @@ def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
         raise TypeError("path cannot be None")
 
     expanded = os.path.expandvars(str(path)).strip()
+    if expanded == "":
+        raise ValueError("path cannot be empty")
     return pathlib.Path(expanded).expanduser().resolve()
 
 def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:


### PR DESCRIPTION
## Summary
- reject empty or whitespace-only paths in path utilities
- document empty path handling
- test normalization and directory creation reject empty strings

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: Crypto Compatibility Tests (Playwright))*
- `pre-commit run --all-files` *(fails: Python Integration Tests)*
- `python -m pytest tests/unit/test_path_handling_additional.py::test_ensure_dir_exists_empty_string tests/unit/test_path_handling_additional.py::test_normalize_path_empty_string -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb5b1b03c832faeb37ccb650fd48f