### PR TITLE
📚 docs: refresh codex prompt templates

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -38,8 +38,10 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [docs/LLM_ASSISTANT_GUIDE.md](docs/LLM_ASSISTANT_GUIDE.md): Guide for AI assistants working with this codebase
 - [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials): Hardware list, setup instructions, and troubleshooting tips for Raspberry Pi deployments (including rpi-clone prompt walkthrough)
 - [../llms.txt](../llms.txt): Machine-readable project summary for LLM assistants
+- [docs/prompts-codex.md](docs/prompts-codex.md): Baseline Codex prompt for routine contributions
 - [docs/prompts-codex-ci-fix.md](docs/prompts-codex-ci-fix.md): Codex prompt for fixing CI failures
-- [docs/prompts-codex-security.md](docs/prompts-codex-security.md): Codex prompt for security reviews
+- [docs/prompts-codex-security.md](docs/prompts-codex-security.md):
+  Codex prompt for security reviews
 
 ## User Journeys
 

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -7,6 +7,9 @@ slug: 'prompts-codex-ci-fix'
 
 Use this prompt to investigate and resolve continuous integration failures in token.place.
 
+See also [Baseline Codex Prompt](prompts-codex.md) and
+[Codex Security Review Prompt](prompts-codex-security.md) for related workflows.
+
 ```
 SYSTEM:
 You are an automated contributor for the token.place repository.
@@ -16,14 +19,18 @@ Diagnose and fix CI failures so tests and checks pass.
 
 CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
+- Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 - Run `pre-commit run --all-files` (which executes `./run_all_tests.sh`).
-- Install dependencies with `npm ci` for Node.js and `pip install -r config/requirements_server.txt` plus `pip install -r config/requirements_relay.txt` as needed.
+- Install dependencies with `npm ci` for Node.js and
+  `pip install -r config/requirements_server.txt` plus
+  `pip install -r config/requirements_relay.txt` as needed.
 
 REQUEST:
 1. Reproduce the failing check locally with `pre-commit run --all-files`.
 2. Investigate test failures or lint errors.
 3. Apply minimal fixes without introducing regressions.
-4. Re-run `pre-commit run --all-files` until it succeeds.
+4. Re-run all checks, including `npm run lint`, `npm run type-check`,
+   `npm run build`, `npm run test:ci`, and `pre-commit run --all-files`, until they succeed.
 5. Commit changes with a concise message and open a pull request.
 
 OUTPUT:

--- a/docs/prompts-codex-security.md
+++ b/docs/prompts-codex-security.md
@@ -7,6 +7,9 @@ slug: 'prompts-codex-security'
 
 Use this prompt to audit token.place for security issues and encryption integrity.
 
+See also [Baseline Codex Prompt](prompts-codex.md) and
+[Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md) for complementary guidance.
+
 ```
 SYSTEM: Automated security reviewer for token.place.
 GOAL: Harden crypto & dependency hygiene.
@@ -14,6 +17,11 @@ CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
 - Do not log plaintext or ciphertext of user messages.
 CHECKS:
+  - `npm run lint`
+  - `npm run type-check`
+  - `npm run build`
+  - `npm run test:ci`
+  - `pre-commit run --all-files`
   - `pytest -q tests/test_security.py`
   - `bandit -r tokenplace -lll`
   - Verify README badges for Dependabot, CodeQL, secret-scanning.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -5,7 +5,13 @@ slug: 'prompts-codex'
 
 # token.place Codex Prompt
 
-This document stores the baseline prompt for instructing automated agents to contribute to token.place. Keeping prompts versioned lets us refine them over time.
+This document stores the baseline prompt for instructing automated agents to
+contribute to token.place. Keeping prompts versioned lets us refine them over
+time.
+
+See also [Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md) and
+[Codex Security Review Prompt](prompts-codex-security.md) for specialized
+tasks.
 
 ```
 SYSTEM:
@@ -16,6 +22,7 @@ Make small, well-tested improvements that keep token.place secure and usable.
 
 CONTEXT:
 - Follow the conventions in AGENTS.md and README.md.
+- Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 - Run `pre-commit run --all-files` before committing.
 - If Playwright browsers are missing, run `playwright install chromium`.
 


### PR DESCRIPTION
what: refresh Codex prompt templates and cross-links
why: ensure prompt docs reflect current check workflow
how to test:
- npm run lint
- npm run type-check # Missing script
- npm run build # Missing script
- npm run test:ci
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_689eb5d78b5c832f8934f6c21e99d40c