### PR TITLE
🐛: – validate message type in encrypt_message

### DIFF
--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -132,6 +132,11 @@ class TestCryptoManager:
         with pytest.raises(ValueError, match="Client public key cannot be None"):
             crypto_manager.encrypt_message("hi", None)
 
+    def test_encrypt_message_invalid_type(self, crypto_manager):
+        """encrypt_message should reject unsupported message types."""
+        with pytest.raises(TypeError, match="Unsupported message type: int"):
+            crypto_manager.encrypt_message(123, crypto_manager.public_key)
+
     @patch('utils.crypto.crypto_manager.encrypt')
     def test_encrypt_message_accepts_base64_key(self, mock_encrypt, crypto_manager):
         """Public key may be provided as a base64 string."""

--- a/utils/README.md
+++ b/utils/README.md
@@ -45,8 +45,9 @@ valid UTF-8 or JSON.
 Network requests in this module now use a default 10 second timeout to prevent
 hanging connections. You can override this by passing a `timeout` argument to
 `CryptoClient.fetch_server_public_key` or `CryptoClient.send_encrypted_message`.
-`encrypt_message` validates inputs and raises a `ValueError` when provided
-`None`, avoiding confusing cryptography errors.
+`encrypt_message` validates inputs, raising a `ValueError` for `None` and a
+`TypeError` for unsupported message types to avoid confusing cryptography
+errors.
 
 ## Crypto Helpers
 

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -85,7 +85,8 @@ class CryptoManager:
             and 'iv' (initialization vector)
 
         Raises:
-            ValueError: If ``message`` is ``None``.
+            ValueError: If ``message`` or ``client_public_key`` is ``None``.
+            TypeError: If ``message`` is of an unsupported type.
         """
         try:
             if message is None:
@@ -98,8 +99,12 @@ class CryptoManager:
                 message_bytes = json.dumps(message).encode('utf-8')
             elif isinstance(message, str):
                 message_bytes = message.encode('utf-8')
-            else:
+            elif isinstance(message, bytes):
                 message_bytes = message
+            else:
+                raise TypeError(
+                    f"Unsupported message type: {type(message).__name__}"
+                )
 
             # Ensure client_public_key is bytes
             if isinstance(client_public_key, str):


### PR DESCRIPTION
what: reject unsupported message types early in encrypt_message
why: clarify errors before hitting cryptography layer
how to test: npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689f89e92224832f92c095259c49effb