### PR TITLE
Enforce strict base64 validation for API inputs

### DIFF
--- a/api/v1/validation.py
+++ b/api/v1/validation.py
@@ -96,8 +96,9 @@ def validate_string_length(data: Dict[str, Any], field: str,
 
 
 def validate_base64(data: Dict[str, Any], field: str) -> None:
-    """
-    Validate that a field contains valid base64 data.
+    """Validate that a field contains valid base64 data.
+
+    Uses strict decoding to reject any characters outside the base64 alphabet.
 
     Args:
         data: The data containing the field
@@ -113,7 +114,7 @@ def validate_base64(data: Dict[str, Any], field: str) -> None:
 
     try:
         # Check if it can be decoded
-        base64.b64decode(value)
+        base64.b64decode(value, validate=True)
     except Exception:
         raise ValidationError(
             f"Invalid base64 encoding for {field}",

--- a/tests/unit/test_api_v1_validation.py
+++ b/tests/unit/test_api_v1_validation.py
@@ -28,6 +28,11 @@ def test_validate_base64_invalid():
         val.validate_base64({'b64': 'abc!'}, 'b64')
 
 
+def test_validate_base64_invalid_chars():
+    with pytest.raises(val.ValidationError):
+        val.validate_base64({'b64': 'ab$cd'}, 'b64')
+
+
 def test_validate_json_string_invalid():
     with pytest.raises(val.ValidationError):
         val.validate_json_string({'js': 'not-json'}, 'js')


### PR DESCRIPTION
## Summary
- ensure base64 validator rejects non‑alphabet characters using strict decode
- cover invalid character scenario in validation tests

## Testing
- `npm run lint` (No lint configured)
- `npm run type-check` (missing script)
- `npm run build` (missing script)
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689f89e92224832f92c095259c49effb