### PR TITLE
🐛: ensure log_error works in production

### DIFF
--- a/docs/SECURITY_PRIVACY_AUDIT.md
+++ b/docs/SECURITY_PRIVACY_AUDIT.md
@@ -84,6 +84,7 @@ Refined logging helpers to avoid swallowing system interrupt exceptions.
 **Completed Improvements**
 - Updated `log_info` and `log_error` to catch only standard exceptions, allowing
   `KeyboardInterrupt` and `SystemExit` to propagate.
+- Ensured `log_error` always logs messages even in production.
 
 **Recommendations**
 - Continue monitoring logging utilities for unintended side effects.

--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -309,6 +309,23 @@ class TestCryptoManager:
             cm.log_error('bye')
 
 
+def test_log_error_logs_in_production(monkeypatch, caplog):
+    """log_error should emit messages in production without tracebacks."""
+    from utils.crypto import crypto_manager as cm
+    monkeypatch.setattr(
+        cm,
+        'get_config_lazy',
+        MagicMock(return_value=MagicMock(is_production=True)),
+    )
+    with caplog.at_level('ERROR', logger='crypto_manager'):
+        try:
+            raise ValueError('boom')
+        except ValueError:
+            cm.log_error('boom', exc_info=True)
+    assert 'boom' in caplog.text
+    assert 'ValueError' not in caplog.text
+
+
 def test_decrypt_message_returns_bytes_for_non_utf8():
     """CryptoManager.decrypt_message returns raw bytes for non UTF-8 content."""
     manager = CryptoManager()

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -29,10 +29,16 @@ def log_info(message):
         logger.info(message)
 
 def log_error(message, exc_info=False):
-    """Log errors only in non-production environments"""
+    """Log errors in all environments.
+
+    In production environments, stack traces are suppressed even if
+    ``exc_info`` is set to avoid leaking sensitive information.
+    """
     try:
         config = get_config_lazy()
-        if not config.is_production:
+        if config.is_production:
+            logger.error(message)
+        else:
             logger.error(message, exc_info=exc_info)
     except Exception:
         # Fallback to always log if config is not available


### PR DESCRIPTION
what: log_error now emits errors in production while suppressing tracebacks.
why: previous behavior swallowed production errors, hindering debugging.
how to test:
- npm run lint
- npm run type-check (Missing script)
- npm run build (Missing script)
- npm run test:ci
- pre-commit run --all-files
- python -m pytest tests/unit/test_crypto_manager.py::test_log_error_logs_in_production -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689f89e92224832f92c095259c49effb