### PR TITLE
🐛 : – handle os.PathLike paths in utils

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -8,6 +8,16 @@ import pytest
 from utils import path_handling as ph
 
 
+class DummyPath:
+    """Simple ``os.PathLike`` implementation without ``__str__``."""
+
+    def __init__(self, path: pathlib.Path):
+        self._path = path
+
+    def __fspath__(self) -> str:  # pragma: no cover - trivial
+        return str(self._path)
+
+
 def test_ensure_dir_exists_existing(tmp_path):
     p = tmp_path / 'sub'
     p.mkdir()
@@ -52,6 +62,14 @@ def test_ensure_dir_exists_strips_whitespace(tmp_path):
     assert result.exists()
 
 
+def test_ensure_dir_exists_pathlike(tmp_path):
+    """ensure_dir_exists should accept ``os.PathLike`` objects"""
+    target = tmp_path / "pathlike"
+    result = ph.ensure_dir_exists(DummyPath(target))
+    assert result == target
+    assert result.exists()
+
+
 def test_normalize_path_expands_env_vars(tmp_path, monkeypatch):
     """normalize_path should expand environment variables"""
     monkeypatch.setenv("TEST_BASE", str(tmp_path))
@@ -71,6 +89,14 @@ def test_normalize_path_strips_whitespace(tmp_path):
     target.mkdir()
     path_with_spaces = f"  {target}  "
     result = ph.normalize_path(path_with_spaces)
+    assert result == target
+
+
+def test_normalize_path_pathlike(tmp_path):
+    """normalize_path should accept ``os.PathLike`` objects"""
+    target = tmp_path / "pl"
+    target.mkdir()
+    result = ph.normalize_path(DummyPath(target))
     assert result == target
 
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,11 +19,12 @@ and automatically create directories when accessed.
 On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
-- `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized
-  absolute path. Raises a `TypeError` when `path` is `None` and `ValueError` for empty strings.
-- `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment
-  variables, and raises `NotADirectoryError` when the path points to an existing file. Passing `None` now raises `TypeError`,
-  and empty paths raise `ValueError`.
+- `normalize_path(path)`: Accepts strings or `os.PathLike` objects, strips surrounding whitespace, expands `~` and environment
+  variables, then returns a normalized absolute path. Raises a `TypeError` when `path` is `None` and `ValueError` for empty
+  strings.
+- `ensure_dir_exists(path)`: Accepts strings or `os.PathLike` objects, strips whitespace and creates the directory if missing,
+  expanding `~` and environment variables, and raises `NotADirectoryError` when the path points to an existing file. Passing
+  `None` now raises `TypeError`, and empty paths raise `ValueError`.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -2,7 +2,7 @@ import os
 import sys
 import platform
 import pathlib
-from typing import Optional, Union, List
+from typing import Optional, Union
 
 # Define platform-specific constants
 PLATFORM = platform.system().lower()
@@ -101,21 +101,21 @@ def get_logs_dir() -> pathlib.Path:
             base_dir = get_user_home_dir() / '.local' / 'state'
         return ensure_dir_exists(base_dir / 'token.place' / 'logs')
 
-def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
+def ensure_dir_exists(dir_path: Union[str, os.PathLike[str]]) -> pathlib.Path:
     """
     Ensure a directory exists, creating it if necessary.
-    Expands ``~`` and environment variables before creating the directory, and
-    strips surrounding whitespace to avoid accidental directory names.
-    Raises ``TypeError`` if ``dir_path`` is ``None`` and ``NotADirectoryError``
-    if the path points to an existing file. Returns the path as a
-    ``pathlib.Path`` object.
+    Accepts strings or ``os.PathLike`` objects, expands ``~`` and environment
+    variables before creating the directory, and strips surrounding whitespace to
+    avoid accidental directory names. Raises ``TypeError`` if ``dir_path`` is
+    ``None`` and ``NotADirectoryError`` if the path points to an existing file.
+    Returns the path as a ``pathlib.Path`` object.
     """
     if dir_path is None:
         raise TypeError("dir_path cannot be None")
 
     # Expand environment variables and user home (~), then normalize
     # Also strip surrounding whitespace to avoid creating unintended paths
-    path_str = os.path.expandvars(str(dir_path)).strip()
+    path_str = os.path.expandvars(os.fspath(dir_path)).strip()
     if path_str == "":
         raise ValueError("dir_path cannot be empty")
     path = pathlib.Path(path_str).expanduser().resolve()
@@ -128,21 +128,25 @@ def get_executable_extension() -> str:
     """Get the appropriate executable extension for the current platform."""
     return '.exe' if IS_WINDOWS else ''
 
-def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
-    """Convert a path string to a normalized ``pathlib.Path`` object.
+def normalize_path(path: Union[str, os.PathLike[str]]) -> pathlib.Path:
+    """Convert a path to a normalized ``pathlib.Path`` object.
 
-    Strips surrounding whitespace and expands environment variables and user
-    home (``~``). Raises ``TypeError`` when ``path`` is ``None``.
+    Accepts strings or ``os.PathLike`` objects, strips surrounding whitespace,
+    and expands environment variables and user home (``~``). Raises
+    ``TypeError`` when ``path`` is ``None``.
     """
     if path is None:
         raise TypeError("path cannot be None")
 
-    expanded = os.path.expandvars(str(path)).strip()
+    expanded = os.path.expandvars(os.fspath(path)).strip()
     if expanded == "":
         raise ValueError("path cannot be empty")
     return pathlib.Path(expanded).expanduser().resolve()
 
-def get_relative_path(path: Union[str, pathlib.Path], base_path: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:
+def get_relative_path(
+    path: Union[str, os.PathLike[str]],
+    base_path: Optional[Union[str, os.PathLike[str]]] = None,
+) -> pathlib.Path:
     """Return ``path`` relative to ``base_path``.
 
     If ``base_path`` is ``None`` the current working directory is used. When the


### PR DESCRIPTION
## Summary
- allow normalize_path/ensure_dir_exists to accept os.PathLike objects
- test and document PathLike support for path utilities

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(fails: Missing script "build")*
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689f89e92224832f92c095259c49effb