### PR TITLE
Draft: 🐛 avoid default config mutation

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ import sys
 import platform
 import json
 import logging
+import copy
 from typing import Dict, Any, Optional
 from pathlib import Path
 
@@ -150,8 +151,8 @@ class Config:
         # Detect platform if not already set
         self.platform = os.environ.get('PLATFORM', platform.system().lower())
 
-        # Load base configuration
-        self.config = DEFAULT_CONFIG.copy()
+        # Load base configuration using a deep copy to avoid mutating DEFAULT_CONFIG
+        self.config = copy.deepcopy(DEFAULT_CONFIG)
 
         # Apply environment-specific overrides
         if self.env in ENV_OVERRIDES:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Validate PKCS#7 unpadding length to reject improperly padded input
 - Remove unused imports from simplified CLI client to avoid unnecessary dependencies
 - Handle EOF in simplified CLI client to end sessions cleanly
+- Deep copy default configuration to prevent cross-test mutations
 
 ## Version 1.0.0 (March 2025)
 

--- a/tests/unit/test_config_default_immutable.py
+++ b/tests/unit/test_config_default_immutable.py
@@ -1,0 +1,10 @@
+import copy
+
+from config import Config, DEFAULT_CONFIG
+
+
+def test_config_initialization_does_not_mutate_default_config():
+    """Config initialization should not modify DEFAULT_CONFIG."""
+    snapshot = copy.deepcopy(DEFAULT_CONFIG)
+    Config(env="testing")
+    assert DEFAULT_CONFIG == snapshot


### PR DESCRIPTION
## Summary
- deep copy `DEFAULT_CONFIG` to prevent mutation across Config instances
- add regression test guarding `DEFAULT_CONFIG` immutability
- document fix in changelog

## Testing
- `npm run lint` *(no lint configured)*
- `npm run type-check` *(script missing)*
- `npm run build` *(script missing)*
- `npm run test:ci` *(pytest missing; tests failed)*
- `playwright install chromium` *(command not found)*
- `pre-commit run --all-files` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689f89f1ab60832fac27128c01c1bc33