### PR TITLE
Ensure path utilities reject non-path-like inputs

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -150,3 +150,15 @@ def test_normalize_path_empty_string():
     """normalize_path should reject empty or whitespace-only paths"""
     with pytest.raises(ValueError):
         ph.normalize_path("")
+
+
+def test_ensure_dir_exists_invalid_type():
+    """ensure_dir_exists should reject non-path-like values"""
+    with pytest.raises(TypeError):
+        ph.ensure_dir_exists(123)  # type: ignore[arg-type]
+
+
+def test_normalize_path_invalid_type():
+    """normalize_path should reject non-path-like values"""
+    with pytest.raises(TypeError):
+        ph.normalize_path(123)  # type: ignore[arg-type]

--- a/utils/README.md
+++ b/utils/README.md
@@ -20,10 +20,10 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
 
 - `normalize_path(path)`: Strips surrounding whitespace, expands `~` and environment variables, then returns a normalized
-  absolute path. Raises a `TypeError` when `path` is `None` and `ValueError` for empty strings.
+  absolute path. Raises a `TypeError` when `path` is `None` or not path-like and `ValueError` for empty strings.
 - `ensure_dir_exists(path)`: Strips whitespace and creates the directory if missing, expanding `~` and environment
-  variables, and raises `NotADirectoryError` when the path points to an existing file. Passing `None` now raises `TypeError`,
-  and empty paths raise `ValueError`.
+  variables, and raises `NotADirectoryError` when the path points to an existing file. Passing `None` or non-path-like values
+  now raises `TypeError`, and empty paths raise `ValueError`.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -101,17 +101,19 @@ def get_logs_dir() -> pathlib.Path:
             base_dir = get_user_home_dir() / '.local' / 'state'
         return ensure_dir_exists(base_dir / 'token.place' / 'logs')
 
-def ensure_dir_exists(dir_path: Union[str, pathlib.Path]) -> pathlib.Path:
+def ensure_dir_exists(dir_path: Union[str, os.PathLike]) -> pathlib.Path:
     """
     Ensure a directory exists, creating it if necessary.
     Expands ``~`` and environment variables before creating the directory, and
     strips surrounding whitespace to avoid accidental directory names.
-    Raises ``TypeError`` if ``dir_path`` is ``None`` and ``NotADirectoryError``
-    if the path points to an existing file. Returns the path as a
-    ``pathlib.Path`` object.
+    Raises ``TypeError`` if ``dir_path`` is ``None`` or not path-like and
+    ``NotADirectoryError`` if the path points to an existing file. Returns the
+    path as a ``pathlib.Path`` object.
     """
     if dir_path is None:
         raise TypeError("dir_path cannot be None")
+    if not isinstance(dir_path, (str, os.PathLike)):
+        raise TypeError("dir_path must be path-like")
 
     # Expand environment variables and user home (~), then normalize
     # Also strip surrounding whitespace to avoid creating unintended paths
@@ -128,14 +130,17 @@ def get_executable_extension() -> str:
     """Get the appropriate executable extension for the current platform."""
     return '.exe' if IS_WINDOWS else ''
 
-def normalize_path(path: Union[str, pathlib.Path]) -> pathlib.Path:
+def normalize_path(path: Union[str, os.PathLike]) -> pathlib.Path:
     """Convert a path string to a normalized ``pathlib.Path`` object.
 
     Strips surrounding whitespace and expands environment variables and user
-    home (``~``). Raises ``TypeError`` when ``path`` is ``None``.
+    home (``~``). Raises ``TypeError`` when ``path`` is ``None`` or not
+    path-like.
     """
     if path is None:
         raise TypeError("path cannot be None")
+    if not isinstance(path, (str, os.PathLike)):
+        raise TypeError("path must be path-like")
 
     expanded = os.path.expandvars(str(path)).strip()
     if expanded == "":


### PR DESCRIPTION
## Summary
- validate path-like arguments in ensure_dir_exists and normalize_path
- test invalid path types
- clarify path utility docs

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*
- `npm run test:ci` *(terminated early: run_all_tests.sh)*
- `pre-commit run --all-files` *(run project checks; tests interrupted during Playwright phase)*
- `python -m pytest tests/unit/test_path_handling_additional.py::test_ensure_dir_exists_invalid_type -q`
- `python -m pytest tests/unit/test_path_handling_additional.py::test_normalize_path_invalid_type -q`


------
https://chatgpt.com/codex/tasks/task_e_689f89f1ab60832fac27128c01c1bc33