### PR TITLE
Add placeholder build and type-check npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "test:e2e": "pytest tests/test_e2e_chat.py",
     "test:all": "npm run test && npm run test:js && npm run test:crypto-compat && npm run test:e2e",
     "lint": "echo \"No lint configured\"",
-    "test:ci": "./run_all_tests.sh"
+    "test:ci": "./run_all_tests.sh",
+    "type-check": "echo \"No type-check configured\"",
+    "build": "echo \"No build configured\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add placeholder npm scripts for build and type-check to prevent missing-script failures

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a00ddcb11c832f98b666ce6e5bf567