### PR TITLE
docs: fix cross-platform link in onboarding guide

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -23,7 +23,7 @@ This ensures that plaintext prompts and responses never reach the relay or any i
 
 ## Cross-Platform Notes
 
-The project runs on Windows, macOS and Linux. Path handling, configuration locations and launcher scripts adapt automatically. For platform specifics and Docker instructions, see [CROSS_PLATFORM.md](../CROSS_PLATFORM.md).
+The project runs on Windows, macOS and Linux. Path handling, configuration locations and launcher scripts adapt automatically. For platform specifics and Docker instructions, see [CROSS_PLATFORM.md](CROSS_PLATFORM.md).
 
 ## Where to Go Next
 


### PR DESCRIPTION
## Summary
- fix broken relative link in onboarding guide to the cross-platform doc

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a00de2ac6c832fbc31486ace4dbcb9