### PR TITLE
fix Linux config directory path

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -55,7 +55,7 @@ We've implemented a comprehensive path handling system in `utils/path_handling.p
 
 | Path Type | Windows | macOS | Linux |
 |-----------|---------|-------|-------|
-| Config | %APPDATA%\token.place\config | ~/Library/Application Support/token.place/config | ~/.config/token.place |
+| Config | %APPDATA%\token.place\config | ~/Library/Application Support/token.place/config | ~/.config/token.place/config |
 | Data | %APPDATA%\token.place | ~/Library/Application Support/token.place | ~/.local/share/token.place |
 | Cache | %LOCALAPPDATA%\token.place\cache | ~/Library/Caches/token.place | ~/.cache/token.place |
 | Logs | %APPDATA%\token.place\logs | ~/Library/Logs/token.place | ~/.local/state/token.place/logs |

--- a/tests/platform_tests/test_path_handling.py
+++ b/tests/platform_tests/test_path_handling.py
@@ -74,7 +74,7 @@ class TestPathHandling:
         elif IS_MACOS:
             assert "Library/Application Support/token.place/config" in str(config_dir)
         elif IS_LINUX:
-            assert ".config/token.place" in str(config_dir)
+            assert ".config/token.place/config" in str(config_dir)
 
     def test_ensure_dir_exists(self, temp_dir):
         """Test that ensure_dir_exists creates directories correctly"""

--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -11,7 +11,7 @@ def test_paths_linux(tmp_path):
         importlib.reload(ph)
         home = Path.home()
         assert ph.get_app_data_dir() == home / '.local' / 'share' / 'token.place'
-        assert ph.get_config_dir() == home / '.config' / 'token.place'
+        assert ph.get_config_dir() == home / '.config' / 'token.place' / 'config'
         assert ph.get_cache_dir() == home / '.cache' / 'token.place'
         assert ph.get_models_dir() == home / '.local' / 'share' / 'token.place' / 'models'
         assert ph.get_logs_dir() == home / '.local' / 'state' / 'token.place' / 'logs'

--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -135,7 +135,7 @@ def test_linux_uses_xdg_dirs(tmp_path, monkeypatch):
     with mock.patch('platform.system', return_value='Linux'):
         importlib.reload(ph)
         assert ph.get_app_data_dir() == tmp_path / "xdg" / "data" / "token.place"
-        assert ph.get_config_dir() == tmp_path / "xdg" / "config" / "token.place"
+        assert ph.get_config_dir() == tmp_path / "xdg" / "config" / "token.place" / "config"
         assert ph.get_cache_dir() == tmp_path / "xdg" / "cache" / "token.place"
 
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -42,7 +42,7 @@ def get_config_dir() -> pathlib.Path:
     Get the appropriate configuration directory based on platform:
     - Windows: %APPDATA%/token.place/config
     - macOS: ~/Library/Application Support/token.place/config
-    - Linux: $XDG_CONFIG_HOME/token.place or ~/.config/token.place
+    - Linux: $XDG_CONFIG_HOME/token.place/config or ~/.config/token.place/config
     """
     if IS_WINDOWS or IS_MACOS:
         return ensure_dir_exists(get_app_data_dir() / 'config')
@@ -52,7 +52,7 @@ def get_config_dir() -> pathlib.Path:
             base_dir = pathlib.Path(xdg_config_home)
         else:
             base_dir = get_user_home_dir() / '.config'
-        return ensure_dir_exists(base_dir / 'token.place')
+        return ensure_dir_exists(base_dir / 'token.place' / 'config')
 
 def get_cache_dir() -> pathlib.Path:
     """


### PR DESCRIPTION
## Summary
- ensure get_config_dir appends `config` on Linux
- document updated Linux config path
- tests cover XDG and default config directories

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(fails: Missing script "build")*
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a00e20dc54832fb135b6a253675426