### PR TITLE
🐛: guard against file base path in get_relative_path

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -117,6 +117,15 @@ def test_get_relative_path_default_base(tmp_path, monkeypatch):
     assert result == pathlib.Path("sub")
 
 
+def test_get_relative_path_base_is_file(tmp_path):
+    base_file = tmp_path / "base.txt"
+    base_file.write_text("data")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    with pytest.raises(NotADirectoryError):
+        ph.get_relative_path(sub, base_file)
+
+
 def test_get_app_data_dir_creates_directory(tmp_path, monkeypatch):
     """get_app_data_dir should ensure the directory exists"""
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/utils/README.md
+++ b/utils/README.md
@@ -29,7 +29,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the
   two locations do not share a common ancestor. If the paths are on different drives
-  (Windows), the absolute `path` is returned instead of raising an error.
+  (Windows), the absolute `path` is returned instead of raising an error. Passing a
+  base path that points to a file now raises `NotADirectoryError`.
 
 ### Crypto Helpers (`crypto_helpers.py`)
 

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -157,13 +157,16 @@ def get_relative_path(
     two paths do not share a common ancestor, the returned path contains ``..``
     segments instead of an absolute path. On Windows, paths on different drives
     return the absolute ``path`` because ``os.path.relpath`` raises ``ValueError``
-    in this scenario.
+    in this scenario. Raises ``NotADirectoryError`` when ``base_path`` points to
+    an existing file.
     """
     path = normalize_path(path)
     if base_path is None:
         base_path = pathlib.Path.cwd()
     else:
         base_path = normalize_path(base_path)
+        if base_path.exists() and not base_path.is_dir():
+            raise NotADirectoryError(f"{base_path} is not a directory")
 
     try:
         return path.relative_to(base_path)


### PR DESCRIPTION
what: raise NotADirectoryError when get_relative_path base is a file
why: prevent treating files as directories and clarify API
how to test: npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a00debb2b0832fbb01902a70a051a8