### PR TITLE
🐛: normalize endpoint path in fetch_server_public_key

### DIFF
--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -58,6 +58,13 @@ def test_fetch_server_public_key(mock_crypto_client):
     assert result is True
     mock_requests.get.assert_called_with('https://mock-server.com/api/v1/public-key', timeout=10)
 
+    # Test endpoint without leading slash
+    result = client.fetch_server_public_key('api/v1/public-key')
+    assert result is True
+    mock_requests.get.assert_called_with(
+        'https://mock-server.com/api/v1/public-key', timeout=10
+    )
+
     # Test server key was set
     assert client.server_public_key is not None
     assert client.server_public_key_b64 is not None

--- a/utils/README.md
+++ b/utils/README.md
@@ -46,6 +46,8 @@ valid UTF-8 or JSON.
 Network requests in this module now use a default 10 second timeout to prevent
 hanging connections. You can override this by passing a `timeout` argument to
 `CryptoClient.fetch_server_public_key` or `CryptoClient.send_encrypted_message`.
+The `endpoint` argument of `fetch_server_public_key` accepts paths with or without a
+leading slash for convenience.
 `encrypt_message` validates inputs, raising a `ValueError` for `None` and a
 `TypeError` for unsupported message types to avoid confusing cryptography
 errors.

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -82,12 +82,15 @@ class CryptoClient:
         Fetch the server's public key
 
         Args:
-            endpoint: API endpoint to fetch the public key
+            endpoint: API endpoint to fetch the public key. May be provided with or without a
+                leading slash.
             timeout: Maximum time in seconds to wait for a response
 
         Returns:
             True if successful, False otherwise
         """
+        if not endpoint.startswith('/'):
+            endpoint = f"/{endpoint}"
         full_url = f"{self.base_url}{endpoint}"
         logger.debug(f"Fetching server public key from: {full_url}")
 


### PR DESCRIPTION
## Summary
- ensure CryptoClient.fetch_server_public_key adds a leading slash when needed
- document the flexible endpoint argument
- test endpoint normalization

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(fails: Missing script "build")*
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a00debb2b0832fbb01902a70a051a8