### PR TITLE
fix: ensure save_user_config creates parent dirs

### DIFF
--- a/config.py
+++ b/config.py
@@ -253,12 +253,20 @@ class Config:
         config[keys[-1]] = value
 
     def save_user_config(self, config_path: Optional[str] = None):
-        """
-        Save the current configuration to a user config file.
+        """Save the current configuration to a user config file.
+
+        When ``config_path`` points to a file inside a non-existent directory, the
+        missing parent directories are created automatically before writing the
+        file.
         """
         path = config_path or self.config_path
         if not path:
             path = os.path.join(self.config['paths']['config_dir'], 'user_config.json')
+
+        # Import locally to avoid circular import at module load time
+        from utils.path_handling import ensure_dir_exists
+
+        ensure_dir_exists(os.path.dirname(path))
 
         try:
             with open(path, 'w') as f:

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -88,6 +88,9 @@ config.set('server.workers', 8)
 # Save user configuration
 config.save_user_config()
 
+# Save to a custom path; parent directories are created automatically
+config.save_user_config('/tmp/token.place/settings.json')
+
 # Check environment and platform
 if config.is_development and config.is_windows:
     # Windows-specific development logic

--- a/tests/unit/test_config_module_additional.py
+++ b/tests/unit/test_config_module_additional.py
@@ -66,3 +66,12 @@ def test_env_properties_and_global_get(tmp_path, monkeypatch):
     assert cfg_dev.is_development and not cfg_dev.is_production
     assert cfg_prod.is_production and not cfg_prod.is_development
     assert isinstance(config.get_config(), config.Config)
+
+
+def test_save_user_config_creates_parent_dirs(tmp_path, monkeypatch):
+    """save_user_config should create missing parent directories"""
+    base = patched_paths_no_config(tmp_path, monkeypatch)
+    cfg = config.Config()
+    custom = base / 'nested' / 'configs' / 'settings.json'
+    cfg.save_user_config(str(custom))
+    assert custom.exists()


### PR DESCRIPTION
## Summary
- create parent directories before saving user config
- test save_user_config with nested custom path
- document custom path usage

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(fails: Missing script "build")*
- `npm run test:ci`
- `playwright install chromium`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a00debb2b0832fbb01902a70a051a8