### PR TITLE
🔒 : remove plaintext logging from crypto helper example

### DIFF
--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -15,7 +15,7 @@ client.fetch_server_public_key()
 
 # Send a chat message and get the response
 response = client.send_chat_message("Hello, how are you?")
-print(response)
+# handle the response without logging plaintext
 
 # For API usage
 client.fetch_server_public_key('/api/v1/public-key')
@@ -23,7 +23,7 @@ api_response = client.send_api_request([
     {"role": "system", "content": "You are a helpful assistant."},
     {"role": "user", "content": "Tell me a joke."}
 ])
-print(api_response['choices'][0]['message']['content'])
+# process api_response without logging plaintext
 """
 
 import json


### PR DESCRIPTION
## What
- stop printing decrypted responses in crypto helper example

## Why
- avoid suggesting plaintext logging in docs

## How to Test
- `npm run lint`
- `npm run test:ci`
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`


------
https://chatgpt.com/codex/tasks/task_e_68a00e3da648832f8f8a5f834a20b4c9