### PR TITLE
docs: clarify public key endpoint usage

### DIFF
--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -78,8 +78,12 @@ class CryptoClient:
         logger.debug("Client keys generated successfully")
 
     def fetch_server_public_key(self, endpoint: str = "/next_server", timeout: float = 10) -> bool:
-        """
-        Fetch the server's public key
+        """Fetch the server's public key.
+
+        By default this queries the relay's ``/next_server`` endpoint to
+        discover a server and retrieve its public key. When connecting
+        directly to a token.place server, pass ``"/api/v1/public-key"`` as the
+        ``endpoint`` parameter instead.
 
         Args:
             endpoint: API endpoint to fetch the public key


### PR DESCRIPTION
## Summary
- document that CryptoClient.fetch_server_public_key defaults to the relay's `/next_server` endpoint and mention how to request `/api/v1/public-key` directly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a57a977cdc832fbb699b6145e87c83