### PR TITLE
docs: add local test instructions to onboarding guide

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -33,4 +33,16 @@ The project runs on Windows, macOS and Linux. Path handling, configuration locat
 - **Style guide** – [docs/STYLE_GUIDE.md](STYLE_GUIDE.md)
 - **LLM assistant tips** – [docs/LLM_ASSISTANT_GUIDE.md](LLM_ASSISTANT_GUIDE.md)
 
+## Local checks
+
+Set up development dependencies and run the full test suite before pushing changes:
+
+```bash
+pip install pre-commit
+npm ci
+pip install -r config/requirements_server.txt
+pip install -r config/requirements_relay.txt
+pre-commit run --all-files
+```
+
 Happy hacking!


### PR DESCRIPTION
## Summary
- document installing dependencies and running `pre-commit run --all-files`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a57a977cdc832fbb699b6145e87c83