### PR TITLE
docs: fix bandit command and clarify testing reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All pull requests must:
 
 - run `pre-commit run --all-files`
 - pass `pytest -q tests/test_security.py`
-- pass `bandit -r tokenplace -lll` with no medium or high findings
+- pass `bandit -r . -lll` with no medium or high findings
 - keep Dependabot, CodeQL, and secret-scanning badges in this README
 
 # vision
@@ -662,7 +662,7 @@ docker compose up -d  # starts the relay service
 
 ### Testing
 
-We have comprehensive testing to ensure quality:
+We have comprehensive testing to ensure quality. See [docs/TESTING.md](docs/TESTING.md) for a complete overview:
 
 ```bash
 # Run all Python tests

--- a/docs/prompts-codex-security.md
+++ b/docs/prompts-codex-security.md
@@ -23,7 +23,7 @@ CHECKS:
   - `npm run test:ci`
   - `pre-commit run --all-files`
   - `pytest -q tests/test_security.py`
-  - `bandit -r tokenplace -lll`
+  - `bandit -r . -lll`
   - Ensure [README.md](../README.md) includes badges for Dependabot, CodeQL, and secret scanning.
 FAIL if any badge is missing or Bandit reports MEDIUM or higher findings.
 REQUEST:


### PR DESCRIPTION
## Summary
- fix bandit command paths in README and security review prompt
- link to docs/TESTING.md for fuller test guidance

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a57aa190c0832f869efa43c8923176