### PR TITLE
Add root Docker Compose for relay and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ python relay.py
 python server.py
 ```
 
+Or start both services with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
 Open `http://localhost:5000` or run `python client.py`. For a minimal client use
 `python client_simplified.py`; it clears the screen when running interactively using ANSI codes
 with flushed output. Metrics are exposed at `/metrics`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.server
+    ports:
+      - "3000:3000"
+    environment:
+      - PLATFORM=${PLATFORM:-linux}
+      - ENV=${ENV:-development}
+    restart: unless-stopped
+
+  relay:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.relay
+    ports:
+      - "5000:5000"
+    environment:
+      - PLATFORM=${PLATFORM:-linux}
+      - ENV=${ENV:-development}
+    depends_on:
+      - server
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add root-level docker-compose with relay and server services
- document Docker Compose startup in README

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a64dc1ca14832f85cf3b08fd1894ea