### PR TITLE
Validate CryptoClient.encrypt_message inputs

### DIFF
--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -20,6 +20,12 @@ def test_encrypt_message_requires_key():
         client.encrypt_message({'msg': 'hi'})
 
 
+def test_encrypt_message_none():
+    client = _prep_client()
+    with pytest.raises(ValueError):
+        client.encrypt_message(None)
+
+
 def test_send_encrypted_message_http_error(monkeypatch):
     client = _prep_client()
     resp = MagicMock(status_code=500, text='fail')

--- a/utils/README.md
+++ b/utils/README.md
@@ -49,7 +49,8 @@ hanging connections. You can override this by passing a `timeout` argument to
 `CryptoClient.fetch_server_public_key` or `CryptoClient.send_encrypted_message`.
 `encrypt_message` validates inputs, raising a `ValueError` for `None` and a
 `TypeError` for unsupported message types to avoid confusing cryptography
-errors.
+errors. Passing `None` previously encrypted the string "None"; now it raises
+`ValueError` to surface invalid inputs early.
 
 ## Crypto Helpers
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -127,22 +127,30 @@ class CryptoClient:
 
     def encrypt_message(self, message: Union[Dict, List, str]) -> Dict[str, str]:
         """
-        Encrypt a message for the server
+        Encrypt a message for the server.
 
         Args:
-            message: Message to encrypt (will be converted to JSON)
+            message: Message to encrypt (string, list, or dict). Must not be ``None``.
 
         Returns:
-            Dictionary with base64-encoded ciphertext, cipherkey, and iv
+            Dictionary with base64-encoded ciphertext, cipherkey, and iv.
+
+        Raises:
+            ValueError: If ``message`` is ``None`` or the server key is missing.
+            TypeError: If ``message`` is not a ``dict``, ``list``, or ``str``.
         """
         if self.server_public_key is None:
             raise ValueError("Server public key not available. Call fetch_server_public_key() first.")
+        if message is None:
+            raise ValueError("message cannot be None")
+        if not isinstance(message, (dict, list, str)):
+            raise TypeError(f"Unsupported message type: {type(message).__name__}")
 
         # Convert to JSON if it's a dict or list
         if isinstance(message, (dict, list)):
             plaintext = json.dumps(message).encode('utf-8')
         else:
-            plaintext = str(message).encode('utf-8')
+            plaintext = message.encode('utf-8')
 
         logger.debug("Encrypting message of length %d bytes", len(plaintext))
 


### PR DESCRIPTION
## Summary
- enforce non-null, typed messages in `CryptoClient.encrypt_message`
- document and test rejection of `None` messages

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a57aa687cc832fa2fa10e88f24ee86