### PR TITLE
🐛 : handle None in decrypt_message

### DIFF
--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -242,6 +242,13 @@ class TestCryptoManager:
         mock_decrypt.assert_not_called()
 
     @patch('utils.crypto.crypto_manager.decrypt')
+    def test_decrypt_message_invalid_input(self, mock_decrypt, crypto_manager):
+        """Decrypting None should return None without calling decrypt."""
+        result = crypto_manager.decrypt_message(None)
+        assert result is None
+        mock_decrypt.assert_not_called()
+
+    @patch('utils.crypto.crypto_manager.decrypt')
     def test_decrypt_message_decrypt_returns_none(self, mock_decrypt, crypto_manager):
         """Test when the decrypt function returns None."""
         # Setup

--- a/utils/README.md
+++ b/utils/README.md
@@ -42,7 +42,8 @@ malformed to prevent unexpected exceptions.
 
 Manages server-side encryption keys and message processing. The
 `decrypt_message` helper now returns raw bytes when decrypted content is not
-valid UTF-8 or JSON.
+valid UTF-8 or JSON and returns `None` when given non-dict input to avoid
+attribute errors.
 
 Network requests in this module now use a default 10 second timeout to prevent
 hanging connections. You can override this by passing a `timeout` argument to

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -148,6 +148,10 @@ class CryptoManager:
             Returns None if decryption fails.
         """
         try:
+            if not isinstance(encrypted_data, dict):
+                log_error("Encrypted data must be a dict")
+                return None
+
             # Extract and decode the encrypted data
             encrypted_chat_history_b64 = encrypted_data.get('chat_history')
             cipherkey_b64 = encrypted_data.get('cipherkey')


### PR DESCRIPTION
what: gracefully handle non-dict input in CryptoManager.decrypt_message
why: prevent AttributeError when decrypting invalid data
how to test: npm run test:ci && pre-commit run --all-files
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a57aa687cc832fa2fa10e88f24ee86