### PR TITLE
Add XDG_CONFIG_HOME path handling test

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -125,6 +125,7 @@ during tests or `https://token.place/v1` in production.
 - Correct path resolution across Windows, macOS, and Linux
 - Configuration loading from platform-specific locations
 - Platform-specific behavior adaptations
+- Support for XDG environment variables like `XDG_CONFIG_HOME` and `XDG_STATE_HOME`
 
 ### 5. Security and Failure Recovery
 

--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -35,6 +35,15 @@ def test_paths_linux_with_xdg_state_home(tmp_path):
             assert ph.get_logs_dir() == base / 'token.place' / 'logs'
 
 
+def test_paths_linux_with_xdg_config_home(tmp_path):
+    env = {'XDG_CONFIG_HOME': str(tmp_path / 'xdg' / 'config')}
+    with mock.patch('platform.system', return_value='Linux'):
+        with mock.patch.dict(os.environ, env, clear=False):
+            importlib.reload(ph)
+            base = tmp_path / 'xdg' / 'config'
+            assert ph.get_config_dir() == base / 'token.place' / 'config'
+
+
 def test_paths_windows(tmp_path):
     env = {
         'APPDATA': str(tmp_path / 'AppData' / 'Roaming'),


### PR DESCRIPTION
## Summary
- test get_config_dir with XDG_CONFIG_HOME on Linux
- document XDG environment variable coverage in testing guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a57aa687cc832fa2fa10e88f24ee86