### PR TITLE
🔧 : expose self global for Node JS crypto tests

### DIFF
--- a/tests/js_test_shim.js
+++ b/tests/js_test_shim.js
@@ -3,6 +3,8 @@ const crypto = require('crypto');
 
 // Mock window object
 global.window = global;
+// Some libraries (e.g., jsencrypt) expect a `self` global
+global.self = global;
 
 // Add navigator object
 global.navigator = {


### PR DESCRIPTION
what: define global self in js_test_shim so jsencrypt loads in Node
why: jsencrypt CJS bundle expects browser self, causing CI test failure
how to test: npm run lint && npm run test:ci && pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_68a6c383a030832f988418530362a3dd