### PR TITLE
📝: clarify API base URL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,9 +503,9 @@ The token.place API is designed to be compatible with the OpenAI API format, mak
 
 ### API Endpoints
 
-All routes are available under `/api/v1` as well as `/v1` so that the standard
-OpenAI Python client can interact with `token.place` by simply changing the
-base URL to `https://token.place/v1`.
+All routes are served under `/api/v1` (preferred) and are also available at
+`/v1` for compatibility with standard OpenAI clients. Set the base URL to
+`https://token.place/api/v1`.
 
 #### List Models
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -101,7 +101,7 @@ token.place tests are organized around key user journeys that represent how user
 
 The API routes are mirrored at `/v1` specifically so that the OpenAI Python
 client can be used by simply setting `base_url` to `http://localhost:5055/v1`
-during tests or `https://token.place/v1` in production.
+during tests or `https://token.place/api/v1` in production.
 
 **Test Files**:
 - `tests/test_api.py` - Tests all API endpoints for functionality and compatibility


### PR DESCRIPTION
## Summary
- document /api/v1 as the preferred base URL
- sync testing docs with updated API endpoint

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb63fcac832f83960e8e84fe97e8