### PR TITLE
Handle non-JSON responses in CryptoClient

### DIFF
--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -34,6 +34,14 @@ def test_send_encrypted_message_http_error(monkeypatch):
     assert result is None
 
 
+def test_send_encrypted_message_invalid_json(monkeypatch):
+    client = _prep_client()
+    resp = MagicMock(status_code=200, text='not json')
+    resp.json.side_effect = ValueError('boom')
+    monkeypatch.setattr('utils.crypto_helpers.requests.post', lambda *a, **_kw: resp)
+    assert client.send_encrypted_message('/ok', {}) is None
+
+
 def test_retrieve_chat_response_retry(monkeypatch):
     client = _prep_client()
     enc = {'ciphertext': 'c', 'cipherkey': 'k', 'iv': 'i'}

--- a/utils/README.md
+++ b/utils/README.md
@@ -36,7 +36,8 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 
 Simplifies encryption and decryption operations for end-to-end encrypted communication with the token.place server and relay.
 `CryptoClient.decrypt_message` now validates required fields and returns `None` when data is incomplete or
-malformed to prevent unexpected exceptions.
+malformed to prevent unexpected exceptions. `CryptoClient.send_encrypted_message` returns `None` when a 200 OK
+response cannot be decoded as JSON, avoiding unhandled `ValueError` exceptions.
 
 ### Crypto Manager (`crypto/crypto_manager.py`)
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -225,6 +225,7 @@ class CryptoClient:
 
         Returns:
             Server response as dictionary or None if failed
+            or if the response body is not valid JSON
         """
         full_url = f"{self.base_url}{endpoint}"
         logger.debug(f"Sending encrypted message to: {full_url}")
@@ -235,11 +236,19 @@ class CryptoClient:
             logger.debug(f"Server response status: {response.status_code}")
 
             if response.status_code != 200:
-                logger.error(f"Server returned error status: {response.status_code}")
-                logger.debug("Response content length: %d", len(response.text))
+                logger.error(
+                    f"Server returned error status: {response.status_code}"
+                )
+                logger.debug(
+                    "Response content length: %d", len(response.text)
+                )
                 return None
 
-            return response.json()
+            try:
+                return response.json()
+            except ValueError:
+                logger.error("Server returned non-JSON response")
+                return None
         except Exception as e:
             logger.error(
                 "Exception while sending encrypted message: %s",


### PR DESCRIPTION
## Summary
- avoid crashes when relay returns non-JSON by checking `response.json`
- cover invalid JSON scenario with unit test
- document new behavior in utils README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb6d7b34832fa4901acb47713afb