### PR TITLE
Guard against unexpanded env vars in path helpers

### DIFF
--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import utils.path_handling as ph
 
 
@@ -78,3 +80,11 @@ def test_paths_macos(tmp_path):
         assert ph.get_config_dir() == home / 'Library' / 'Application Support' / 'token.place' / 'config'
         assert ph.get_cache_dir() == home / 'Library' / 'Caches' / 'token.place'
         assert ph.get_logs_dir() == home / 'Library' / 'Logs' / 'token.place'
+
+
+def test_unexpanded_env_var_raises():
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError):
+            ph.normalize_path("$UNSET_VAR/path")
+        with pytest.raises(ValueError):
+            ph.ensure_dir_exists("$UNSET_VAR/path")

--- a/utils/README.md
+++ b/utils/README.md
@@ -21,10 +21,10 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 
 - `normalize_path(path)`: Accepts strings or `os.PathLike` objects, strips surrounding whitespace, expands `~` and environment
   variables, then returns a normalized absolute path. Raises a `TypeError` when `path` is `None` and `ValueError` for empty
-  strings.
+  strings or when environment variables remain unexpanded.
 - `ensure_dir_exists(path)`: Accepts strings or `os.PathLike` objects, strips whitespace and creates the directory if missing,
   expanding `~` and environment variables, and raises `NotADirectoryError` when the path points to an existing file. Passing
-  `None` now raises `TypeError`, and empty paths raise `ValueError`.
+  `None` now raises `TypeError`, and empty paths or unexpanded environment variables raise `ValueError`.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
 - `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -1,7 +1,7 @@
 import os
-import sys
 import platform
 import pathlib
+import re
 from typing import Optional, Union
 
 # Define platform-specific constants
@@ -9,6 +9,14 @@ PLATFORM = platform.system().lower()
 IS_WINDOWS = PLATFORM == "windows"
 IS_MACOS = PLATFORM == "darwin"
 IS_LINUX = PLATFORM == "linux"
+
+_UNIX_ENV_PATTERN = re.compile(r"\$(?:\{[^}]+\}|[A-Za-z_][A-Za-z0-9_]*)")
+_WIN_ENV_PATTERN = re.compile(r"%(?:[^%]+)%")
+
+
+def _has_unexpanded_vars(path_str: str) -> bool:
+    """Return True if ``path_str`` still contains environment variable markers."""
+    return bool(_UNIX_ENV_PATTERN.search(path_str) or _WIN_ENV_PATTERN.search(path_str))
 
 def get_user_home_dir() -> pathlib.Path:
     """Get the user's home directory path in a cross-platform way."""
@@ -107,8 +115,9 @@ def ensure_dir_exists(dir_path: Union[str, os.PathLike[str]]) -> pathlib.Path:
     Accepts strings or ``os.PathLike`` objects, expands ``~`` and environment
     variables before creating the directory, and strips surrounding whitespace to
     avoid accidental directory names. Raises ``TypeError`` if ``dir_path`` is
-    ``None`` and ``NotADirectoryError`` if the path points to an existing file.
-    Returns the path as a ``pathlib.Path`` object.
+    ``None``, ``ValueError`` when environment variables remain unexpanded or the
+    path is empty, and ``NotADirectoryError`` if the path points to an existing
+    file. Returns the path as a ``pathlib.Path`` object.
     """
     if dir_path is None:
         raise TypeError("dir_path cannot be None")
@@ -118,6 +127,8 @@ def ensure_dir_exists(dir_path: Union[str, os.PathLike[str]]) -> pathlib.Path:
     # Expand environment variables and user home (~), then normalize
     # Also strip surrounding whitespace to avoid creating unintended paths
     path_str = os.path.expandvars(os.fspath(dir_path)).strip()
+    if _has_unexpanded_vars(path_str):
+        raise ValueError("dir_path contains unexpanded environment variables")
     if path_str == "":
         raise ValueError("dir_path cannot be empty")
     path = pathlib.Path(path_str).expanduser().resolve()
@@ -135,7 +146,8 @@ def normalize_path(path: Union[str, os.PathLike[str]]) -> pathlib.Path:
 
     Accepts strings or ``os.PathLike`` objects, strips surrounding whitespace,
     and expands environment variables and user home (``~``). Raises
-    ``TypeError`` when ``path`` is ``None``.
+    ``TypeError`` when ``path`` is ``None`` and ``ValueError`` when environment
+    variables remain unexpanded or the path is empty.
     """
     if path is None:
         raise TypeError("path cannot be None")
@@ -143,6 +155,8 @@ def normalize_path(path: Union[str, os.PathLike[str]]) -> pathlib.Path:
         raise TypeError("path must be path-like")
 
     expanded = os.path.expandvars(os.fspath(path)).strip()
+    if _has_unexpanded_vars(expanded):
+        raise ValueError("path contains unexpanded environment variables")
     if expanded == "":
         raise ValueError("path cannot be empty")
     return pathlib.Path(expanded).expanduser().resolve()


### PR DESCRIPTION
## Summary
- raise ValueError when normalize_path or ensure_dir_exists see unexpanded env vars
- document new behavior and add regression test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `playwright install chromium` *(fails: Write error - write (14: Bad address))*
- `pre-commit run --all-files`
- `python -m pytest tests/unit/test_path_handling.py::test_unexpanded_env_var_raises -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb6d7b34832fa4901acb47713afb