### PR TITLE
Enforce integer block size for PKCS7 helpers

### DIFF
--- a/docs/TESTING_IMPROVEMENTS.md
+++ b/docs/TESTING_IMPROVEMENTS.md
@@ -115,6 +115,10 @@ def test_decrypt_with_missing_fields():
 ```python
 with pytest.raises(TypeError):
     pkcs7_unpad("not-bytes", 16)
+
+# New: block size must be an integer
+with pytest.raises(TypeError):
+    pkcs7_pad(b"data", 16.0)
 ```
 
 ## 10. Mock Server for JavaScript Tests

--- a/encrypt.py
+++ b/encrypt.py
@@ -178,10 +178,12 @@ def pkcs7_pad(data: bytes, block_size: int) -> bytes:
 
     Raises:
         ValueError: If *block_size* is not between 1 and 255 (inclusive).
-        TypeError: If *data* is not bytes-like.
+        TypeError: If *data* is not bytes-like or *block_size* is not an ``int``.
     """
     if not isinstance(data, (bytes, bytearray)):
         raise TypeError("data must be bytes-like")
+    if not isinstance(block_size, int):
+        raise TypeError("block_size must be an integer")
     if block_size <= 0 or block_size > 255:
         raise ValueError("Block size must be between 1 and 255")
     padding_length = block_size - (len(data) % block_size)
@@ -200,10 +202,12 @@ def pkcs7_unpad(padded_data: bytes, block_size: int) -> bytes:
 
     Raises:
         ValueError: If *block_size* is not between 1 and 255 (inclusive) or padding is invalid.
-        TypeError: If *padded_data* is not bytes-like.
+        TypeError: If *padded_data* is not bytes-like or *block_size* is not an ``int``.
     """
     if not isinstance(padded_data, (bytes, bytearray)):
         raise TypeError("padded_data must be bytes-like")
+    if not isinstance(block_size, int):
+        raise TypeError("block_size must be an integer")
     if block_size <= 0 or block_size > 255:
         raise ValueError("Block size must be between 1 and 255")
     if not padded_data:

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -65,3 +65,12 @@ def test_unpad_non_bytes_input():
     """Non-byte inputs to pkcs7_unpad should raise TypeError."""
     with pytest.raises(TypeError):
         pkcs7_unpad("not-bytes", 16)
+
+
+def test_non_int_block_size():
+    """Non-integer block sizes should raise TypeError with a helpful message."""
+    padded = pkcs7_pad(b"data", 16)
+    with pytest.raises(TypeError, match="block_size must be an integer"):
+        pkcs7_pad(b"data", 16.0)
+    with pytest.raises(TypeError, match="block_size must be an integer"):
+        pkcs7_unpad(padded, 16.0)


### PR DESCRIPTION
## What
- require integer block_size in pkcs7_pad and pkcs7_unpad
- document and test block_size validation

## Why
- avoid unexpected behavior when block_size is non-integer

## How to Test
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- pre-commit run --all-files

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a6cb6d7b34832fa4901acb47713afb