### PR TITLE
test: cover log dir creation in path utils

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -137,6 +137,17 @@ def test_get_app_data_dir_creates_directory(tmp_path, monkeypatch):
     assert app_dir.exists()
 
 
+def test_get_logs_dir_creates_directory(tmp_path, monkeypatch):
+    """get_logs_dir should ensure the directory exists"""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    importlib.reload(ph)
+    logs_dir = ph.get_logs_dir()
+    expected = tmp_path / ".local" / "state" / "token.place" / "logs"
+    assert logs_dir == expected
+    assert logs_dir.exists()
+
+
 def test_linux_uses_xdg_dirs(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg" / "data"))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg" / "config"))

--- a/utils/README.md
+++ b/utils/README.md
@@ -26,7 +26,7 @@ On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
   expanding `~` and environment variables, and raises `NotADirectoryError` when the path points to an existing file. Passing
   `None` now raises `TypeError`, and empty paths raise `ValueError`.
 - `get_app_data_dir()`: Returns the platform-specific application data directory and ensures it exists.
-- `get_logs_dir()`: Returns the platform-specific logs directory and ensures it exists.
+- `get_logs_dir()`: Returns the platform-specific logs directory, creating it if missing.
 - `get_relative_path(path, base_path)`: Returns `path` relative to `base_path`, using `..` segments when the
   two locations do not share a common ancestor. If the paths are on different drives
   (Windows), the absolute `path` is returned instead of raising an error. Passing a

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -83,7 +83,7 @@ def get_models_dir() -> pathlib.Path:
     return ensure_dir_exists(get_app_data_dir() / 'models')
 
 def get_logs_dir() -> pathlib.Path:
-    """Get the directory for storing log files.
+    """Get the directory for storing log files, creating it if missing.
 
     On Linux, honors the ``XDG_STATE_HOME`` environment variable when set.
     """


### PR DESCRIPTION
## Summary
- test that `get_logs_dir` creates missing log directories
- document that `get_logs_dir` creates its directory

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb6d7b34832fa4901acb47713afb