### PR TITLE
📝: add refactor & chore codex prompts

### DIFF
--- a/docs/prompts-codex-chore.md
+++ b/docs/prompts-codex-chore.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Chore Prompt'
+slug: 'prompts-codex-chore'
+---
+
+# Codex Chore Prompt
+
+Use this prompt for dependency bumps, CI tweaks, or other routine upkeep in token.place.
+
+```
+SYSTEM:
+You are an automated contributor for the token.place repository.
+
+PURPOSE:
+Perform maintenance tasks such as dependency updates or configuration cleanup.
+
+CONTEXT:
+- Follow AGENTS.md and docs/AGENTS.md instructions.
+- Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`.
+- Run `pre-commit run --all-files` before committing.
+
+REQUEST:
+1. Make a minimal maintenance change.
+2. Update documentation if necessary.
+3. Run the commands above to confirm checks pass.
+
+OUTPUT:
+A pull request URL describing the chore and confirming passing checks.
+```
+
+Copy this block whenever performing routine maintenance in token.place.

--- a/docs/prompts-codex-refactor.md
+++ b/docs/prompts-codex-refactor.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex Refactor Prompt'
+slug: 'prompts-codex-refactor'
+---
+
+# Codex Refactor Prompt
+
+Use this prompt to restructure code in token.place without changing behavior.
+
+```
+SYSTEM:
+You are an automated contributor for the token.place repository.
+
+PURPOSE:
+Refactor existing code to improve clarity, reduce duplication, or align with conventions.
+
+CONTEXT:
+- Follow AGENTS.md and docs/AGENTS.md instructions.
+- Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`.
+- Run `pre-commit run --all-files` before committing.
+
+REQUEST:
+1. Identify a safe refactor in the codebase.
+2. Make the change without altering functionality.
+3. Update related tests or docs if needed.
+4. Run the commands above and ensure they pass.
+
+OUTPUT:
+A pull request URL summarizing the refactor and test results.
+```
+
+Copy this block whenever code needs refactoring in token.place.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -41,6 +41,8 @@ A pull request describing the change and summarizing test results.
 - [Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md)
 - [Codex Security Review Prompt](prompts-codex-security.md)
 - [Codex Docs Update Prompt](prompts-codex-docs.md)
+- [Codex Refactor Prompt](prompts-codex-refactor.md)
+- [Codex Chore Prompt](prompts-codex-chore.md)
 
 ## Implementation prompts
 
@@ -55,7 +57,8 @@ FILES OF INTEREST
 - README.md
 
 REQUIREMENTS
-1. Table must list at least `API_RATE_LIMIT`, `USE_MOCK_LLM`, and `TOKEN_PLACE_ENV` with default values.
+1. Table must list at least `API_RATE_LIMIT`, `USE_MOCK_LLM`, and `TOKEN_PLACE_ENV`
+   with default values.
 2. Keep line width ≤ 120 characters.
 3. Run `pre-commit run --all-files` and update any affected docs.
 


### PR DESCRIPTION
## Summary
- add refactor and chore codex prompt docs
- link new prompt types from main codex prompt index

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb8c9278832fbbaa5da1262e93b9