### PR TITLE
✨: add server key check helper

### DIFF
--- a/tests/unit/test_crypto_helpers_simple.py
+++ b/tests/unit/test_crypto_helpers_simple.py
@@ -58,3 +58,13 @@ def test_send_chat_message():
         resp = client.send_chat_message('hi')
         assert isinstance(resp, list) and resp[1]['role'] == 'assistant'
         assert mock_requests.post.call_count == 2
+
+def test_has_server_public_key():
+    client = CryptoClient('https://example.com')
+    assert not client.has_server_public_key()
+    with patch('utils.crypto_helpers.requests') as mock_requests:
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {'server_public_key': base64.b64encode(b'k').decode()}
+        mock_requests.get.return_value = resp
+        assert client.fetch_server_public_key()
+    assert client.has_server_public_key()

--- a/utils/README.md
+++ b/utils/README.md
@@ -59,6 +59,7 @@ errors. Passing `None` previously encrypted the string "None"; now it raises
 The `CryptoClient` class provides a high-level abstraction over the encryption/decryption process, making it easy to:
 
 - Fetch public keys from the server
+- Check if the server public key has been loaded
 - Encrypt messages for the server
 - Decrypt messages from the server
 - Send encrypted chat messages

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -77,6 +77,10 @@ class CryptoClient:
         self.client_public_key_b64 = base64.b64encode(self.client_public_key).decode('utf-8')
         logger.debug("Client keys generated successfully")
 
+    def has_server_public_key(self) -> bool:
+        """Return True if a server public key has been loaded."""
+        return self.server_public_key is not None
+
     def fetch_server_public_key(self, endpoint: str = "/next_server", timeout: float = 10) -> bool:
         """Fetch the server's public key.
 


### PR DESCRIPTION
## Summary
- add `has_server_public_key` helper to `CryptoClient`
- document new helper in utilities guide
- cover helper with unit test

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a806799408832fb66fa2e6c736f31b