### PR TITLE
Add key rotation to CryptoManager

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ token.place is an end-to-end encrypted proxy service that sits between clients a
   - Provides encryption/decryption services
   - Manages secure session handling
   - Validates presence of client public keys before encryption
+  - Supports key rotation via `rotate_keys()` to regenerate RSA keys
 
 - **Model Manager** (`utils/models/model_manager.py`):
   - Connects to various AI providers

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -77,6 +77,10 @@ class CryptoManager:
         """Get the base64-encoded public key."""
         return self._public_key_b64
 
+    def rotate_keys(self):
+        """Regenerate the RSA key pair for key rotation."""
+        self.initialize_keys()
+
     def encrypt_message(self, message: Union[str, bytes, Dict, List],
                         client_public_key: Union[str, bytes]) -> Dict[str, str]:
         """


### PR DESCRIPTION
## Summary
- expose rotate_keys on CryptoManager
- document key rotation support

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: Crypto Compatibility Tests (Playwright))*
- `pre-commit run --all-files`

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a806799408832fb66fa2e6c736f31b