### PR TITLE
♻️ : consolidate role color mapping

### DIFF
--- a/client_simplified.py
+++ b/client_simplified.py
@@ -20,16 +20,17 @@ def clear_screen():
         # Use ANSI escape codes to avoid shell injection via os.system
         print("\033[2J\033[H", end="", flush=True)
 
+ROLE_COLORS = {
+    "User": "1;34",
+    "Assistant": "1;32",
+}
+
+
 def format_message(message: Dict) -> str:
-    """Format a message for display"""
+    """Format a message for display."""
     role = message["role"].capitalize()
-    content = message["content"]
-    if role == "User":
-        return f"\033[1;34m{role}: \033[0m{content}"
-    elif role == "Assistant":
-        return f"\033[1;32m{role}: \033[0m{content}"
-    else:
-        return f"\033[1;33m{role}: \033[0m{content}"
+    color = ROLE_COLORS.get(role, "1;33")
+    return f"\033[{color}m{role}: \033[0m{message['content']}"
 
 def display_conversation(messages: List[Dict]):
     """Display the conversation history"""

--- a/tests/unit/test_client_simplified.py
+++ b/tests/unit/test_client_simplified.py
@@ -13,6 +13,15 @@ def test_format_message_user_and_assistant():
     assert "System:" in cs.format_message(other_msg)
 
 
+def test_format_message_colors():
+    msg = {"role": "user", "content": "hi"}
+    assert "\033[1;34m" in cs.format_message(msg)
+    msg["role"] = "assistant"
+    assert "\033[1;32m" in cs.format_message(msg)
+    msg["role"] = "system"
+    assert "\033[1;33m" in cs.format_message(msg)
+
+
 def test_no_unused_imports():
     """Ensure no leftover modules remain imported unintentionally."""
     for name in ["os", "subprocess", "time"]:


### PR DESCRIPTION
what: simplify CLI message formatting with role→color map
why: removes duplication and clarifies output
how to test: pre-commit run --all-files; npm run lint; npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68a8067effd4832fa4ce86a4145aaa83