### PR TITLE
🧹 chore: ignore coverage output and document CI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ wheels/
 # Coverage
 .coverage
 htmlcov/
+coverage/
 coverage.xml
 
 # Node.js

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ All pull requests must:
 
 - run `pre-commit run --all-files`
 - pass `npm run lint`
+- pass `npm run type-check`
+- pass `npm run build`
 - pass `npm run test:ci`
 - pass `pytest -q tests/test_security.py`
 - pass `bandit -r . -lll` with no medium or high findings


### PR DESCRIPTION
what: add coverage/ to .gitignore; note type-check/build in CI criteria
why: avoid committing coverage artifacts and clarify required checks
how: npm run lint && npm run type-check && npm run build &&
     npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a8066ee444832fa7b688ce1a822766