### PR TITLE
🧹 chore: ignore Windows Thumbs.db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/visual_verification/visual_report.json
 *.swp
 *.swo
 .DS_Store
+Thumbs.db
 
 # Integration tests
 integration_tests/

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -25,6 +25,8 @@ This ensures that plaintext prompts and responses never reach the relay or any i
 
 The project runs on Windows, macOS and Linux. Path handling, configuration locations and launcher scripts adapt automatically. For platform specifics and Docker instructions, see [CROSS_PLATFORM.md](CROSS_PLATFORM.md).
 
+The `.gitignore` file keeps OS artifacts like `.DS_Store` and `Thumbs.db` out of commits.
+
 ## Where to Go Next
 
 - **Architecture** – [docs/ARCHITECTURE.md](ARCHITECTURE.md)


### PR DESCRIPTION
## Summary
- ignore Windows Thumbs.db in .gitignore
- note OS-specific artifacts are ignored in docs/ONBOARDING.md

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a8066ee444832fa7b688ce1a822766