### PR TITLE
fix: register real_llm pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,4 @@ markers =
     failure: mark a test for failure recovery scenarios
     e2e: mark a test as an end-to-end test
     parametrize: mark a test with multiple input parameters
+    real_llm: mark a test that exercises real LLM integration


### PR DESCRIPTION
what: add real_llm marker in pytest.ini to silence warnings
why: allows tests using real_llm mark to run without warnings
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a806722670832f866a8edb7167a4b6