### PR TITLE
Accept memoryview inputs in PKCS#7 padding helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove unused imports from simplified CLI client to avoid unnecessary dependencies
 - Handle EOF in simplified CLI client to end sessions cleanly
 - Deep copy default configuration to prevent cross-test mutations
+- Accept memoryview inputs in PKCS#7 padding helpers to support more bytes-like objects
 
 ## Version 1.0.0 (March 2025)
 

--- a/encrypt.py
+++ b/encrypt.py
@@ -170,7 +170,7 @@ def pkcs7_pad(data: bytes, block_size: int) -> bytes:
     """Pad *data* to a multiple of *block_size* using PKCS#7 padding.
 
     Args:
-        data: Input bytes to pad.
+        data: Input bytes-like object to pad.
         block_size: Size of each block in bytes (1-255).
 
     Returns:
@@ -180,6 +180,8 @@ def pkcs7_pad(data: bytes, block_size: int) -> bytes:
         ValueError: If *block_size* is not between 1 and 255 (inclusive).
         TypeError: If *data* is not bytes-like or *block_size* is not an ``int``.
     """
+    if isinstance(data, memoryview):
+        data = data.tobytes()
     if not isinstance(data, (bytes, bytearray)):
         raise TypeError("data must be bytes-like")
     if not isinstance(block_size, int):
@@ -194,7 +196,7 @@ def pkcs7_unpad(padded_data: bytes, block_size: int) -> bytes:
     """Remove PKCS#7 padding from *padded_data*.
 
     Args:
-        padded_data: Input bytes to unpad.
+        padded_data: Input bytes-like object to unpad.
         block_size: Size of each block in bytes (1-255).
 
     Returns:
@@ -204,6 +206,8 @@ def pkcs7_unpad(padded_data: bytes, block_size: int) -> bytes:
         ValueError: If *block_size* is not between 1 and 255 (inclusive) or padding is invalid.
         TypeError: If *padded_data* is not bytes-like or *block_size* is not an ``int``.
     """
+    if isinstance(padded_data, memoryview):
+        padded_data = padded_data.tobytes()
     if not isinstance(padded_data, (bytes, bytearray)):
         raise TypeError("padded_data must be bytes-like")
     if not isinstance(block_size, int):

--- a/tests/unit/test_pkcs7_padding.py
+++ b/tests/unit/test_pkcs7_padding.py
@@ -10,6 +10,13 @@ def test_pad_unpad_roundtrip(data):
     assert result == data
 
 
+def test_pad_unpad_memoryview():
+    """Ensure pkcs7 helpers accept memoryview inputs."""
+    data = memoryview(b"example")
+    padded = pkcs7_pad(data, 16)
+    assert pkcs7_unpad(padded, 16) == data.tobytes()
+
+
 def test_unpad_invalid_padding():
     # invalid sequence: last byte value 3 but previous bytes not all 3
     padded = b"invalidpadding" + b"\x01\x02\x03"


### PR DESCRIPTION
what: allow pkcs7_pad/unpad to accept memoryview objects.
why: support more bytes-like inputs in encryption utilities.
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci && pre-commit run --all-files.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a80680ad68832f9d1ffe76c5bd0046