### PR TITLE
Enforce bytes-only inputs for encryption helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ GET /v1/public-key
 
 2. Encrypt your request with the server's public key
 
+   The helper functions `encrypt` and `decrypt` operate on bytes and raise `TypeError` for strings.
+
 3. Send your encrypted request:
 ```json
 {

--- a/encrypt.py
+++ b/encrypt.py
@@ -68,7 +68,14 @@ def encrypt(plaintext: bytes, public_key_pem: bytes, use_pkcs1v15: bool = False)
         - ciphertext_dict: Dictionary with 'ciphertext' and 'iv' keys
         - encrypted_key: The AES key encrypted with RSA
         - iv: Initialization vector used for AES-CBC
+
+    Raises:
+        TypeError: If ``plaintext`` or ``public_key_pem`` are not bytes-like objects.
     """
+    if not isinstance(plaintext, (bytes, bytearray)):
+        raise TypeError("plaintext must be bytes-like")
+    if not isinstance(public_key_pem, (bytes, bytearray)):
+        raise TypeError("public_key_pem must be bytes-like")
     # Generate a random AES key
     aes_key = secrets.token_bytes(AES_KEY_SIZE)  # 256-bit key
 
@@ -121,7 +128,23 @@ def decrypt(ciphertext_dict: Dict[str, bytes], encrypted_key: bytes, private_key
 
     Returns:
         Decrypted plaintext or None if decryption fails
+
+    Raises:
+        TypeError: If inputs are not bytes-like or ``ciphertext_dict`` is malformed.
     """
+    if not isinstance(ciphertext_dict, dict):
+        raise TypeError("ciphertext_dict must be a dict")
+    if 'ciphertext' not in ciphertext_dict or 'iv' not in ciphertext_dict:
+        raise TypeError("ciphertext_dict must contain 'ciphertext' and 'iv'")
+    if not isinstance(ciphertext_dict['ciphertext'], (bytes, bytearray)):
+        raise TypeError("ciphertext must be bytes-like")
+    if not isinstance(ciphertext_dict['iv'], (bytes, bytearray)):
+        raise TypeError("iv must be bytes-like")
+    if not isinstance(encrypted_key, (bytes, bytearray)):
+        raise TypeError("encrypted_key must be bytes-like")
+    if not isinstance(private_key_pem, (bytes, bytearray)):
+        raise TypeError("private_key_pem must be bytes-like")
+
     try:
         # First decrypt the AES key using RSA
         private_key = serialization.load_pem_private_key(

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,6 +1,5 @@
-import os
-import base64
 import json
+import pytest
 from encrypt import generate_keys, encrypt, decrypt
 
 def test_encrypt_decrypt():
@@ -83,3 +82,24 @@ def test_encrypt_decrypt_empty_plaintext():
     # Assert that the decrypted plaintext matches the original plaintext
     assert decrypted_bytes is not None
     assert decrypted_bytes == plaintext_bytes
+
+
+def test_encrypt_rejects_non_bytes_inputs():
+    """encrypt should raise TypeError when given non-bytes arguments."""
+    _, public_key = generate_keys()
+    with pytest.raises(TypeError, match="plaintext must be bytes-like"):
+        encrypt("not-bytes", public_key)
+    with pytest.raises(TypeError, match="public_key_pem must be bytes-like"):
+        encrypt(b"data", "not-bytes")
+
+
+def test_decrypt_rejects_non_bytes_inputs():
+    """decrypt should raise TypeError on malformed inputs."""
+    private_key, public_key = generate_keys()
+    ciphertext_dict, cipherkey, _ = encrypt(b"hello", public_key)
+    with pytest.raises(TypeError, match="ciphertext_dict must be a dict"):
+        decrypt("not-dict", cipherkey, private_key)
+    with pytest.raises(TypeError, match="encrypted_key must be bytes-like"):
+        decrypt(ciphertext_dict, "not-bytes", private_key)
+    with pytest.raises(TypeError, match="private_key_pem must be bytes-like"):
+        decrypt(ciphertext_dict, cipherkey, "not-bytes")


### PR DESCRIPTION
what: validate bytes-only input for encrypt/decrypt helpers; docs updated
why: avoid unexpected type errors and clarify API
how to test:
  npm run lint
  npm run type-check
  npm run build
  npm run test:ci
  pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68a80680ad68832f9d1ffe76c5bd0046