### PR TITLE
🔧 : strip whitespace from env vars in path helpers

### DIFF
--- a/tests/unit/test_path_handling.py
+++ b/tests/unit/test_path_handling.py
@@ -46,6 +46,23 @@ def test_paths_linux_with_xdg_config_home(tmp_path):
             assert ph.get_config_dir() == base / 'token.place' / 'config'
 
 
+def test_env_vars_with_whitespace(tmp_path):
+    env = {
+        'XDG_DATA_HOME': str(tmp_path / 'xdg' / 'data') + '  ',
+        'XDG_CONFIG_HOME': str(tmp_path / 'xdg' / 'config') + '\n',
+        'XDG_CACHE_HOME': str(tmp_path / 'xdg' / 'cache') + '\t',
+        'XDG_STATE_HOME': str(tmp_path / 'xdg' / 'state') + ' ',
+    }
+    with mock.patch('platform.system', return_value='Linux'):
+        with mock.patch.dict(os.environ, env, clear=True):
+            importlib.reload(ph)
+            base = tmp_path / 'xdg'
+            assert ph.get_app_data_dir() == base / 'data' / 'token.place'
+            assert ph.get_config_dir() == base / 'config' / 'token.place' / 'config'
+            assert ph.get_cache_dir() == base / 'cache' / 'token.place'
+            assert ph.get_logs_dir() == base / 'state' / 'token.place' / 'logs'
+
+
 def test_paths_windows(tmp_path):
     env = {
         'APPDATA': str(tmp_path / 'AppData' / 'Roaming'),

--- a/utils/README.md
+++ b/utils/README.md
@@ -18,6 +18,7 @@ and automatically create directories when accessed.
 
 On Linux, these functions honor the `XDG_DATA_HOME`, `XDG_CONFIG_HOME`,
 `XDG_CACHE_HOME`, and `XDG_STATE_HOME` environment variables when they are set.
+Environment variable values are stripped of surrounding whitespace before use.
 
 - `normalize_path(path)`: Accepts strings or `os.PathLike` objects, strips surrounding whitespace, expands `~` and environment
   variables, then returns a normalized absolute path. Raises a `TypeError` when `path` is `None` and `ValueError` for empty

--- a/utils/path_handling.py
+++ b/utils/path_handling.py
@@ -14,6 +14,16 @@ _UNIX_ENV_PATTERN = re.compile(r"\$(?:\{[^}]+\}|[A-Za-z_][A-Za-z0-9_]*)")
 _WIN_ENV_PATTERN = re.compile(r"%(?:[^%]+)%")
 
 
+def _get_env(name: str) -> Optional[str]:
+    """Return the value of ``name`` stripped of whitespace or ``None`` when unset."""
+    value = os.environ.get(name)
+    if value:
+        value = value.strip()
+        if value:
+            return value
+    return None
+
+
 def _has_unexpanded_vars(path_str: str) -> bool:
     """Return True if ``path_str`` still contains environment variable markers."""
     return bool(_UNIX_ENV_PATTERN.search(path_str) or _WIN_ENV_PATTERN.search(path_str))
@@ -30,7 +40,7 @@ def get_app_data_dir() -> pathlib.Path:
     - Linux: $XDG_DATA_HOME/token.place or ~/.local/share/token.place
     """
     if IS_WINDOWS:
-        appdata = os.environ.get('APPDATA')
+        appdata = _get_env('APPDATA')
         if appdata:
             base_dir = pathlib.Path(appdata)
         else:
@@ -38,7 +48,7 @@ def get_app_data_dir() -> pathlib.Path:
     elif IS_MACOS:
         base_dir = get_user_home_dir() / 'Library' / 'Application Support'
     else:  # Linux and other Unix-like
-        xdg_data_home = os.environ.get('XDG_DATA_HOME')
+        xdg_data_home = _get_env('XDG_DATA_HOME')
         if xdg_data_home:
             base_dir = pathlib.Path(xdg_data_home)
         else:
@@ -55,7 +65,7 @@ def get_config_dir() -> pathlib.Path:
     if IS_WINDOWS or IS_MACOS:
         return ensure_dir_exists(get_app_data_dir() / 'config')
     else:  # Linux and other Unix-like
-        xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
+        xdg_config_home = _get_env('XDG_CONFIG_HOME')
         if xdg_config_home:
             base_dir = pathlib.Path(xdg_config_home)
         else:
@@ -70,7 +80,7 @@ def get_cache_dir() -> pathlib.Path:
     - Linux: $XDG_CACHE_HOME/token.place or ~/.cache/token.place
     """
     if IS_WINDOWS:
-        local_appdata = os.environ.get('LOCALAPPDATA')
+        local_appdata = _get_env('LOCALAPPDATA')
         if local_appdata:
             base_dir = pathlib.Path(local_appdata)
         else:
@@ -79,7 +89,7 @@ def get_cache_dir() -> pathlib.Path:
     elif IS_MACOS:
         return ensure_dir_exists(get_user_home_dir() / 'Library' / 'Caches' / 'token.place')
     else:  # Linux and other Unix-like
-        xdg_cache_home = os.environ.get('XDG_CACHE_HOME')
+        xdg_cache_home = _get_env('XDG_CACHE_HOME')
         if xdg_cache_home:
             base_dir = pathlib.Path(xdg_cache_home)
         else:
@@ -102,7 +112,7 @@ def get_logs_dir() -> pathlib.Path:
             get_user_home_dir() / 'Library' / 'Logs' / 'token.place'
         )
     else:  # Linux and other Unix-like
-        xdg_state_home = os.environ.get('XDG_STATE_HOME')
+        xdg_state_home = _get_env('XDG_STATE_HOME')
         if xdg_state_home:
             base_dir = pathlib.Path(xdg_state_home)
         else:


### PR DESCRIPTION
what: trim env var whitespace in path utilities
why: avoid paths with stray spaces
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci && pre-commit run --all-files
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_68a80680ad68832f9d1ffe76c5bd0046