### PR TITLE
📝 docs: fix security audit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,8 @@ pre-commit run --all-files
 
 ## Security
 
-Security is our top priority. Please report any vulnerabilities responsibly. See [Security and Privacy Audit](SECURITY_PRIVACY_AUDIT.md) for details.
+Security is our top priority. Please report any vulnerabilities responsibly.
+See [Security and Privacy Audit](docs/SECURITY_PRIVACY_AUDIT.md) for details.
 token.place intentionally avoids storing user prompts or LLM responses in logs to protect user privacy.
 
 ## License


### PR DESCRIPTION
what: correct README link to security audit doc
why: broken path caused 404
how to test:
- npm run lint
- npm run test:ci
- pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a8067750b4832f883b80dfdf61c9b5