### PR TITLE
docs: clarify Playwright install command in testing guide

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,17 +4,17 @@ This guide provides an overview of the token.place testing approach, including t
 
 ## Prerequisites
 
-Before running the tests, install the required Python and Node.js dependencies and download the Playwright browsers. The [docs/AGENTS.md](AGENTS.md) file lists the exact commands, summarized here:
+Before running the tests, install the required Python and Node.js dependencies and download the Playwright browsers. The [AGENTS.md](AGENTS.md) file lists the exact commands, summarized here:
 
 ```bash
 pip install -r config/requirements_server.txt
 pip install -r config/requirements_relay.txt
 pip install -r requirements.txt
 npm ci
-playwright install
+playwright install --with-deps chromium
 ```
 
-The final step fetches browser binaries so that the Playwright-based tests can run successfully.
+The final step installs browser binaries and system dependencies so the Playwright-based tests can run successfully.
 
 ## Test Types
 


### PR DESCRIPTION
what: clarify Playwright install instructions in testing guide
why: ensure browsers and deps install for reliable Playwright tests
how to test:
- npm run lint
- npm run test:ci
- pre-commit run --all-files

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a8067750b4832f883b80dfdf61c9b5