### PR TITLE
Use sys.executable in tests for portable server startups

### DIFF
--- a/tests/test_e2e_conversation_flow.py
+++ b/tests/test_e2e_conversation_flow.py
@@ -7,6 +7,7 @@ import signal
 from contextlib import contextmanager
 import requests
 from typing import Generator, List
+import sys
 
 from tests.utils.client_simulator import ClientSimulator
 
@@ -30,7 +31,7 @@ def start_server(use_mock_llm: bool = True) -> Generator[None, None, None]:
         env['USE_MOCK_LLM'] = '1'
 
     # Start the server process
-    server_cmd = ["python", "server.py", "--server_port", "3000", "--relay_port", "5000"]
+    server_cmd = [sys.executable, "server.py", "--server_port", "3000", "--relay_port", "5000"]
     if use_mock_llm:
         server_cmd.append("--use_mock_llm")
 
@@ -82,7 +83,7 @@ def start_relay() -> Generator[None, None, None]:
         None
     """
     # Start the relay process
-    relay_cmd = ["python", "relay.py", "--port", "5000"]
+    relay_cmd = [sys.executable, "relay.py", "--port", "5000"]
     env = os.environ.copy()
     env["USE_MOCK_LLM"] = "1"
     process = subprocess.Popen(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,8 @@ from client import ChatClient
 import base64
 import json
 from encrypt import encrypt, decrypt, generate_keys
-import os # Import os
+import os  # Import os
+import sys
 
 @pytest.fixture(scope="session")
 def setup_servers():
@@ -18,7 +19,7 @@ def setup_servers():
     client = ChatClient('http://localhost', relay_port)
 
     # Start the relay server
-    relay_process = subprocess.Popen(["python", "relay.py", "--port", str(relay_port)])
+    relay_process = subprocess.Popen([sys.executable, "relay.py", "--port", str(relay_port)])
     print("Launched relay server. Waiting for 5 seconds...")
     time.sleep(5)  # Give the relay server some time to start
 
@@ -26,7 +27,7 @@ def setup_servers():
     server_env = os.environ.copy() # Get a copy of the current environment
     server_env["USE_MOCK_LLM"] = "1" # Set the variable
     server_process = subprocess.Popen(
-        ["python", "server.py", "--server_port", str(server_port), "--relay_port", str(relay_port)],
+        [sys.executable, "server.py", "--server_port", str(server_port), "--relay_port", str(relay_port)],
         env=server_env # Pass the modified environment
     )
     print("Launched server with USE_MOCK_LLM=1. Waiting for 5 seconds...") # Reduced wait time as no model download needed


### PR DESCRIPTION
## Summary
- use sys.executable instead of hardcoded `python` in integration and e2e tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a92c276ac0832faf3e3fc9afd361e6