### PR TITLE
⬆️ : bump playwright to 1.55.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Handle EOF in simplified CLI client to end sessions cleanly
 - Deep copy default configuration to prevent cross-test mutations
 
+### Maintenance
+- Bump Playwright dev dependency to v1.55.0
+
 ## Version 1.0.0 (March 2025)
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "selenium-webdriver": "^4.35.0"
       },
       "devDependencies": {
-        "playwright": "^1.54.1"
+        "playwright": "^1.55.0"
       }
     },
     "node_modules/@bazel/runfiles": {
@@ -678,13 +678,13 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/playwright": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
-      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.54.1"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
-      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "selenium-webdriver": "^4.35.0"
   },
   "devDependencies": {
-    "playwright": "^1.54.1"
+    "playwright": "^1.55.0"
   }
 }


### PR DESCRIPTION
what: update Playwright dev dependency and changelog
why: keep browser test tooling current
how to test: npm run lint && npm run type-check &&
  npm run build && npm run test:ci &&
  pre-commit run --all-files
Refs: #0
needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68a92c260cb4832f89918f15e5e29e4c