### PR TITLE
📝 docs: link style guide and quickstart tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ playwright install --with-deps chromium
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files
+npm run lint
+npm run test:ci
 ```
+
+Verify code style and tests with `npm run lint` and `npm run test:ci`.
 
 The development requirements live in [requirements.txt](requirements.txt).
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -10,7 +10,9 @@ Key components:
 - Hybrid RSA/AES encryption system ensuring secure message exchange
 - Cross-language compatibility between Python and JavaScript implementations
 
-Important: Always stylize the project name as lowercase `token.place` (not Title case "Token.place") to emphasize that it's a URL.
+Important: Always stylize the project name as lowercase `token.place` (not Title case
+"Token.place") to emphasize that it's a URL. See
+[STYLE_GUIDE.md](STYLE_GUIDE.md) for full branding guidelines.
 
 ## Setup and Installation
 


### PR DESCRIPTION
what: cross-link style guide and mention lint/test commands in quickstart.
why: improve branding guidance and setup completeness.
how to test: npm run lint; npm run test:ci; pre-commit run --all-files (fails: apt write error).

------
https://chatgpt.com/codex/tasks/task_e_68a92c2db404832f9dd40f59867842fa