### PR TITLE
♻️ streamline env path helpers

### DIFF
--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -227,3 +227,11 @@ def test_normalize_path_invalid_type():
     """normalize_path should reject non-path-like values"""
     with pytest.raises(TypeError):
         ph.normalize_path(123)  # type: ignore[arg-type]
+
+
+def test_get_env_strips_and_handles_missing(monkeypatch):
+    """_get_env should strip whitespace and return None when unset."""
+    monkeypatch.delenv("TP_TEST_ENV", raising=False)
+    assert ph._get_env("TP_TEST_ENV") is None
+    monkeypatch.setenv("TP_TEST_ENV", "  value  ")
+    assert ph._get_env("TP_TEST_ENV") == "value"


### PR DESCRIPTION
what: centralize environment-based path fallbacks.
why: reduce duplication and clarify directory resolution.
how to test:
- npm run lint
- npm run test:ci
- pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_68a92c37026c832fa01b1656fe7a51b3