### PR TITLE
✨ : allow CryptoClient server key reset

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Provide `get_temp_dir()` utility for temporary token.place files
+- Add `clear_server_public_key()` to `CryptoClient` for resetting cached server keys
 
 ### Fixes
 - Validate PKCS#7 unpadding length to reject improperly padded input

--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -62,6 +62,17 @@ def test_fetch_server_public_key(mock_crypto_client):
     assert client.server_public_key is not None
     assert client.server_public_key_b64 is not None
 
+
+def test_clear_server_public_key(mock_crypto_client):
+    """Clearing the server key resets client state"""
+    client, _ = mock_crypto_client
+    assert client.fetch_server_public_key() is True
+    assert client.has_server_public_key() is True
+    client.clear_server_public_key()
+    assert client.server_public_key is None
+    assert client.server_public_key_b64 is None
+    assert client.has_server_public_key() is False
+
 def test_encrypt_message():
     """Test encrypting a message"""
     client = CryptoClient('https://test-server.com')

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -81,6 +81,11 @@ class CryptoClient:
         """Return True if a server public key has been loaded."""
         return self.server_public_key is not None
 
+    def clear_server_public_key(self) -> None:
+        """Clear any cached server public key to force a refetch."""
+        self.server_public_key = None
+        self.server_public_key_b64 = None
+
     def fetch_server_public_key(self, endpoint: str = "/next_server", timeout: float = 10) -> bool:
         """Fetch the server's public key.
 


### PR DESCRIPTION
what: add clear_server_public_key to reset cached server key
why: lets clients discard stale keys before fetching new ones
how to test: npm run lint && npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92c32ae00832fb531585b7c34e269