### PR TITLE
Add service name to health check response

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -20,6 +20,7 @@ from api.v1.validation import (
 
 # Check environment
 ENVIRONMENT = os.getenv('ENVIRONMENT', 'dev')  # Default to 'dev' if not set
+SERVICE_NAME = os.getenv('SERVICE_NAME', 'token.place')
 
 # Configure logging based on environment
 if ENVIRONMENT != 'prod':
@@ -499,6 +500,7 @@ def health_check():
         return jsonify({
             'status': 'ok',
             'version': 'v1',
+            'service': SERVICE_NAME,
             'timestamp': int(time.time())
         })
     except Exception as e:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Provide `get_temp_dir()` utility for temporary token.place files
+- Include `service` field in `/api/v1/health` responses
 
 ### Fixes
 - Validate PKCS#7 unpadding length to reject improperly padded input

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,7 @@ def test_api_health(client):
     data = response.get_json()
     assert data['status'] == 'ok'
     assert data['version'] == 'v1'
+    assert data['service'] == 'token.place'
     assert 'timestamp' in data
 
 def test_list_models(client):


### PR DESCRIPTION
## Summary
- include `service` field in `/api/v1/health` response
- document health response field in changelog
- verify health endpoint returns service name

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92c32ae00832fb531585b7c34e269