### PR TITLE
docs: clarify RSA padding options

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,8 @@ token.place is an end-to-end encrypted proxy service that sits between clients a
 - **Encryption Implementation** (`encrypt.py`):
   - Provides the core encryption and decryption functions
   - Implements hybrid RSA-AES encryption
+  - Uses RSA-OAEP by default with an optional PKCS#1 v1.5 mode for legacy JavaScript
+    compatibility
   - Ensures compatibility between Python and JavaScript implementations
 
 ## Data Flow

--- a/encrypt.py
+++ b/encrypt.py
@@ -62,6 +62,8 @@ def encrypt(plaintext: bytes, public_key_pem: bytes, use_pkcs1v15: bool = False)
     Args:
         plaintext: The data to encrypt
         public_key_pem: RSA public key in PEM format
+        use_pkcs1v15: Use PKCS#1 v1.5 padding instead of OAEP for RSA key encryption
+            (for compatibility with legacy JavaScript clients)
 
     Returns:
         Tuple (ciphertext_dict, encrypted_key, iv)


### PR DESCRIPTION
## Summary
- document optional PKCS#1 v1.5 mode in encrypt.py
- explain RSA padding choices in architecture guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a92c411058832fb3e392b34d90eea4