### PR TITLE
🐛: handle empty decrypted messages

### DIFF
--- a/tests/unit/test_crypto_helpers_edge.py
+++ b/tests/unit/test_crypto_helpers_edge.py
@@ -2,6 +2,7 @@ import base64
 import logging
 from unittest.mock import patch
 
+from encrypt import encrypt
 from utils.crypto_helpers import CryptoClient, logger
 
 
@@ -42,3 +43,14 @@ def test_send_api_request_old_format_decrypt_exception():
          patch('utils.crypto_helpers.encrypt', return_value=({'ciphertext': b'c', 'iv': b'i'}, b'k', b'i')), \
          patch.object(client, 'decrypt_message', side_effect=Exception('fail')):
         assert client.send_api_request([{'role': 'user', 'content': 'hi'}]) is None
+
+
+def test_decrypt_message_empty_plaintext():
+    client = CryptoClient('https://empty.test')
+    cipher_dict, enc_key, _ = encrypt(b'', client.client_public_key)
+    encrypted = {
+        'ciphertext': base64.b64encode(cipher_dict['ciphertext']).decode(),
+        'cipherkey': base64.b64encode(enc_key).decode(),
+        'iv': base64.b64encode(cipher_dict['iv']).decode(),
+    }
+    assert client.decrypt_message(encrypted) == ''

--- a/utils/README.md
+++ b/utils/README.md
@@ -38,9 +38,10 @@ Environment variable values are stripped of surrounding whitespace before use.
 ### Crypto Helpers (`crypto_helpers.py`)
 
 Simplifies encryption and decryption operations for end-to-end encrypted communication with the token.place server and relay.
-`CryptoClient.decrypt_message` now validates required fields and returns `None` when data is incomplete or
-malformed to prevent unexpected exceptions. `CryptoClient.send_encrypted_message` returns `None` when a 200 OK
-response cannot be decoded as JSON, avoiding unhandled `ValueError` exceptions.
+`CryptoClient.decrypt_message` now validates required fields, returns `None` when data is incomplete or
+malformed to prevent unexpected exceptions, and correctly yields an empty string when the decrypted content is empty.
+`CryptoClient.send_encrypted_message` returns `None` when a 200 OK response cannot be decoded as JSON, avoiding
+unhandled `ValueError` exceptions.
 
 ### Crypto Manager (`crypto/crypto_manager.py`)
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -181,6 +181,7 @@ class CryptoClient:
 
         Returns:
             Decrypted data (parsed from JSON if possible)
+            or an empty string when the decrypted content is empty
         """
         if self.client_private_key is None:
             raise ValueError("Client private key not available")
@@ -204,7 +205,7 @@ class CryptoClient:
         # Decrypt the data
         decrypted_bytes = decrypt(encrypted_response, encrypted_key, self.client_private_key)
 
-        if not decrypted_bytes:
+        if decrypted_bytes is None:
             logger.error("Decryption failed, got None")
             return None
 


### PR DESCRIPTION
what: allow CryptoClient.decrypt_message to return empty string
why: empty server replies are valid but previously returned None
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92c411058832fb3e392b34d90eea4