### PR TITLE
🔒 : allow CryptoClient.encrypt_message to handle bytes

### DIFF
--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -84,6 +84,13 @@ def test_encrypt_message():
     assert 'cipherkey' in encrypted
     assert 'iv' in encrypted
 
+    # Test with bytes
+    test_bytes = b"binary data\x00"
+    encrypted = client.encrypt_message(test_bytes)
+    assert 'ciphertext' in encrypted
+    assert 'cipherkey' in encrypted
+    assert 'iv' in encrypted
+
 def test_send_encrypted_message(mock_crypto_client):
     """Test sending an encrypted message"""
     client, mock_requests = mock_crypto_client

--- a/utils/README.md
+++ b/utils/README.md
@@ -55,7 +55,8 @@ hanging connections. You can override this by passing a `timeout` argument to
 `encrypt_message` validates inputs, raising a `ValueError` for `None` and a
 `TypeError` for unsupported message types to avoid confusing cryptography
 errors. Passing `None` previously encrypted the string "None"; now it raises
-`ValueError` to surface invalid inputs early.
+`ValueError` to surface invalid inputs early. `encrypt_message` also accepts
+raw ``bytes`` messages in addition to strings and JSON-serializable objects.
 
 ## Crypto Helpers
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -133,30 +133,32 @@ class CryptoClient:
             )
             return False
 
-    def encrypt_message(self, message: Union[Dict, List, str]) -> Dict[str, str]:
+    def encrypt_message(self, message: Union[Dict, List, str, bytes]) -> Dict[str, str]:
         """
         Encrypt a message for the server.
 
         Args:
-            message: Message to encrypt (string, list, or dict). Must not be ``None``.
+            message: Message to encrypt (string, bytes, list, or dict). Must not be ``None``.
 
         Returns:
             Dictionary with base64-encoded ciphertext, cipherkey, and iv.
 
         Raises:
             ValueError: If ``message`` is ``None`` or the server key is missing.
-            TypeError: If ``message`` is not a ``dict``, ``list``, or ``str``.
+            TypeError: If ``message`` is not a ``dict``, ``list``, ``str``, or ``bytes``.
         """
         if self.server_public_key is None:
             raise ValueError("Server public key not available. Call fetch_server_public_key() first.")
         if message is None:
             raise ValueError("message cannot be None")
-        if not isinstance(message, (dict, list, str)):
+        if not isinstance(message, (dict, list, str, bytes)):
             raise TypeError(f"Unsupported message type: {type(message).__name__}")
 
         # Convert to JSON if it's a dict or list
         if isinstance(message, (dict, list)):
             plaintext = json.dumps(message).encode('utf-8')
+        elif isinstance(message, bytes):
+            plaintext = message
         else:
             plaintext = message.encode('utf-8')
 


### PR DESCRIPTION
what: let encrypt_message accept raw bytes.
why: enables encrypting binary payloads without TypeError.
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92c411058832fb3e392b34d90eea4