### PR TITLE
Add tests for CryptoClient edge cases

### DIFF
--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -26,6 +26,19 @@ def test_encrypt_message_none():
         client.encrypt_message(None)
 
 
+def test_encrypt_message_invalid_type():
+    """encrypt_message should reject unsupported message types."""
+    client = _prep_client()
+    with pytest.raises(TypeError):
+        client.encrypt_message(123)
+
+
+def test_send_chat_message_empty_list():
+    """send_chat_message should reject an empty chat history list."""
+    client = _prep_client()
+    assert client.send_chat_message([]) is None
+
+
 def test_send_encrypted_message_http_error(monkeypatch):
     client = _prep_client()
     resp = MagicMock(status_code=500, text='fail')

--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -242,7 +242,7 @@ def test_normalize_path_invalid_type():
     with pytest.raises(TypeError):
         ph.normalize_path(123)  # type: ignore[arg-type]
 
-        
+
 def test_is_subpath(tmp_path):
     """is_subpath should detect when a path lies within a base directory"""
     base = tmp_path / "base"
@@ -255,7 +255,7 @@ def test_is_subpath(tmp_path):
     assert ph.is_subpath(base, base) is True
     assert ph.is_subpath(other, base) is False
 
-    
+
 def test_get_env_strips_and_handles_missing(monkeypatch):
     """_get_env should strip whitespace and return None when unset."""
     monkeypatch.delenv("TP_TEST_ENV", raising=False)


### PR DESCRIPTION
## Summary
- test encrypt_message with unsupported types
- ensure empty chat history returns None
- trim stray whitespace in path handling tests

## Testing
- `pre-commit run --all-files`
- `pytest tests/unit tests/test_crypto_helpers_additional.py tests/test_crypto_helpers.py tests/test_crypto_mock.py -q --cov=utils.crypto_helpers --cov-report term-missing | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a942ed7d50832fb175d487d42295c1