### PR TITLE
🧪 : cover encrypt_message None input

### DIFF
--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -113,6 +113,12 @@ def test_error_handling():
     with pytest.raises(ValueError):
         client.encrypt_message("This should fail")
 
+    # Test encrypt_message with None message
+    _, public_key = generate_keys()
+    client.server_public_key = public_key
+    with pytest.raises(ValueError):
+        client.encrypt_message(None)
+
     # Mock a failed server key fetch
     with patch('utils.crypto_helpers.requests.get') as mock_get:
         mock_response = MagicMock()

--- a/tests/unit/test_path_handling_additional.py
+++ b/tests/unit/test_path_handling_additional.py
@@ -242,7 +242,7 @@ def test_normalize_path_invalid_type():
     with pytest.raises(TypeError):
         ph.normalize_path(123)  # type: ignore[arg-type]
 
-        
+
 def test_is_subpath(tmp_path):
     """is_subpath should detect when a path lies within a base directory"""
     base = tmp_path / "base"
@@ -255,7 +255,7 @@ def test_is_subpath(tmp_path):
     assert ph.is_subpath(base, base) is True
     assert ph.is_subpath(other, base) is False
 
-    
+
 def test_get_env_strips_and_handles_missing(monkeypatch):
     """_get_env should strip whitespace and return None when unset."""
     monkeypatch.delenv("TP_TEST_ENV", raising=False)


### PR DESCRIPTION
## Summary
- add test ensuring CryptoClient.encrypt_message rejects None input
- fix trailing whitespace flagged by pre-commit

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a942ed7d50832fb175d487d42295c1