### PR TITLE
🧪 : cover encrypt_message invalid inputs

### DIFF
--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -122,6 +122,17 @@ def test_error_handling():
         result = client.fetch_server_public_key()
         assert result is False
 
+    # Set a server key for additional validation
+    client.server_public_key = generate_keys()[1]
+
+    # Unsupported message types should raise TypeError
+    with pytest.raises(TypeError):
+        client.encrypt_message(123)
+
+    # None message should raise ValueError after server key is set
+    with pytest.raises(ValueError, match="message cannot be None"):
+        client.encrypt_message(None)
+
 @patch('utils.crypto_helpers.requests')
 @patch('utils.crypto_helpers.time')  # Mock time.sleep
 def test_send_chat_message(_mock_time, mock_requests):


### PR DESCRIPTION
what: add tests for unsupported and None message types in encrypt_message.
why: ensure bytes support patch is fully covered.
how to test: npm run lint && npm run test:ci && pre-commit run --all-files

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a942ed7d50832fb175d487d42295c1