### PR TITLE
🔧 fix: silence HTTP server output in Playwright tests

### DIFF
--- a/tests/test_crypto_compatibility_playwright.py
+++ b/tests/test_crypto_compatibility_playwright.py
@@ -52,10 +52,9 @@ def web_server():
     server_process = subprocess.Popen(
         server_cmd,
         cwd=str(cwd),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         env=os.environ.copy(),
-        text=True
     )
 
     # Wait for the server to start


### PR DESCRIPTION
## Summary
- discard stdout/stderr from test web server to prevent blocking

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68aa96383170832fb25ceb01812e510d