### PR TITLE
🐛: tolerate whitespace in base64 client keys

### DIFF
--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -381,3 +381,11 @@ def test_encrypt_message_accepts_pem_string():
     iv = base64.b64decode(encrypted['iv'])
     decrypted = decrypt({'ciphertext': ciphertext, 'iv': iv}, cipherkey, client_private)
     assert decrypted.decode('utf-8') == "hello"
+
+
+def test_encrypt_message_accepts_base64_with_whitespace():
+    """encrypt_message handles base64 keys containing whitespace."""
+    manager = CryptoManager()
+    public_key_b64_with_ws = manager.public_key_b64 + "\n"
+    result = manager.encrypt_message("hello", public_key_b64_with_ws)
+    assert {"chat_history", "cipherkey", "iv"}.issubset(result)

--- a/utils/README.md
+++ b/utils/README.md
@@ -59,6 +59,8 @@ hanging connections. You can override this by passing a `timeout` argument to
 errors. Passing `None` previously encrypted the string "None"; now it raises
 `ValueError` to surface invalid inputs early. `encrypt_message` also accepts
 raw ``bytes`` messages in addition to strings and JSON-serializable objects.
+It now trims whitespace from base64-encoded public keys before decoding so
+keys copied with line breaks do not raise errors.
 
 ## Crypto Helpers
 

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -5,6 +5,7 @@ import base64
 import binascii
 import json
 import logging
+import re
 from typing import Dict, Tuple, Any, Optional, Union, List
 
 # Import from the existing encrypt.py
@@ -120,8 +121,9 @@ class CryptoManager:
                     client_public_key = client_public_key.encode('utf-8')
                 else:
                     try:
+                        cleaned_key = re.sub(r"\s+", "", client_public_key)
                         client_public_key = base64.b64decode(
-                            client_public_key, validate=True
+                            cleaned_key, validate=True
                         )
                     except (binascii.Error, ValueError) as e:
                         raise ValueError(


### PR DESCRIPTION
## Summary
- allow CryptoManager to strip whitespace from base64 client keys
- document whitespace-tolerant key handling
- add regression test for base64 keys with trailing newline

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: Crypto Compatibility Tests (Playwright))*
- `pre-commit run --all-files`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa9638e820832fb69629f70b3601d2