### PR TITLE
🐛: enforce scheme on CryptoClient base URL – add validation

### DIFF
--- a/tests/unit/test_crypto_helpers_edge.py
+++ b/tests/unit/test_crypto_helpers_edge.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 from unittest.mock import patch
+import pytest
 
 from encrypt import encrypt
 from utils.crypto_helpers import CryptoClient, logger
@@ -16,6 +17,12 @@ def _prep_client():
 def test_debug_logging_level():
     CryptoClient('https://debug.com', debug=True)
     assert logger.level == logging.DEBUG
+
+
+@pytest.mark.parametrize("url", ["", "example.com", "ftp://example.com"])
+def test_base_url_requires_scheme(url: str) -> None:
+    with pytest.raises(ValueError):
+        CryptoClient(url)
 
 
 def test_send_chat_message_list_branch():

--- a/utils/README.md
+++ b/utils/README.md
@@ -73,6 +73,8 @@ The `CryptoClient` class provides a high-level abstraction over the encryption/d
 
 ### Basic Usage
 
+The `CryptoClient` requires a base URL with an explicit `http://` or `https://` scheme.
+
 ```python
 from utils.crypto_helpers import CryptoClient
 

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -51,9 +51,12 @@ class CryptoClient:
         Initialize the crypto client
 
         Args:
-            base_url: Base URL for the relay server
+            base_url: Base URL for the relay server. Must include http:// or https://.
             debug: Whether to enable debug logging
         """
+        base_url = base_url.strip()
+        if not base_url or not base_url.startswith(("http://", "https://")):
+            raise ValueError("base_url must start with http:// or https://")
         self.base_url = base_url.rstrip('/')  # Remove trailing slash if present
         self.server_public_key = None
         self.server_public_key_b64 = None


### PR DESCRIPTION
what: validate CryptoClient base_url and document requirement
why: prevent misconfigurations
how to test: npm run test:ci && pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa9638e820832fb69629f70b3601d2