### PR TITLE
🧹 : chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,package-lock.json,desktop/package-lock.json,*.svg,webapp/static/js/*"]
   - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.7
+    rev: v2.14
     hooks:
       - id: vulture
         args: [".", "--min-confidence", "80", "--exclude", "node_modules,desktop/node_modules"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Maintenance
 - Bump Playwright dev dependency to v1.55.0
+- Update pre-commit hooks: codespell to v2.4.1 and vulture to v2.14
 
 ## Version 1.0.0 (March 2025)
 


### PR DESCRIPTION
what: bump codespell to v2.4.1 and vulture to v2.14
why: keep lint tooling current
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68aa978db1e4832f94e3e10770f8ef6e