### PR TITLE
chore: ignore local env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ models.bak
 __pycache__
 .pytest_cache
 .env
+.env.local
 f2clipboard.py
 
 # Python

--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ pre-commit run --all-files
 
 ### Key environment variables
 
+Environment variables can be stored in a `.env` file and overridden in a `.env.local` file, which is ignored by git.
+
 | Variable        | Default     | Description                                                      |
 |-----------------|-------------|------------------------------------------------------------------|
 | API_RATE_LIMIT  | 60/hour     | Per-IP rate limit for API requests                               |
 | API_DAILY_QUOTA | 1000/day    | Per-IP daily request quota                                       |
 | USE_MOCK_LLM    | 0           | Use mock LLM instead of downloading a model (`1` to enable)      |
 | TOKEN_PLACE_ENV | development | Deployment environment (development, testing, production)        |
+| PROD_API_HOST   | 127.0.0.1   | IP address for production API host                               |
 
 The development requirements live in [requirements.txt](requirements.txt).
 
@@ -69,16 +72,6 @@ docker compose up --build
 Open `http://localhost:5000` or run `python client.py`. For a minimal client use
 `python client_simplified.py`; it clears the screen when running interactively using ANSI codes
 with flushed output. Metrics are exposed at `/metrics`.
-
-### Key environment variables
-
-| Variable        | Default      | Description                                                        |
-|-----------------|--------------|--------------------------------------------------------------------|
-| API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for API requests                                |
-| API_DAILY_QUOTA | 1000/day     | Per-IP daily request quota                                        |
-| USE_MOCK_LLM    | 0            | Use mock LLM instead of downloading a model (`1` to enable)        |
-| TOKEN_PLACE_ENV | development  | Deployment environment (`development`, `testing`, `production`)    |
-| PROD_API_HOST   | 127.0.0.1    | IP address for production API host                                |
 
 ## CI pass criteria
 


### PR DESCRIPTION
## Summary
- ignore `.env.local` for git safety
- document environment file usage in README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68aa978db1e4832f94e3e10770f8ef6e