### PR TITLE
🧹 : bump codespell hook to v2.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,package-lock.json,desktop/package-lock.json,*.svg,webapp/static/js/*"]

--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ pip install pre-commit
 pre-commit install
 pre-commit run --all-files
 ```
+These hooks run linting, tests, and spelling checks via codespell.
 
 ## Security
 


### PR DESCRIPTION
what: bump codespell pre-commit hook to v2.4.1 and note codespell in README
why: stay current with spell-check tooling
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci # fails: Playwright browsers missing
- pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa978db1e4832f94e3e10770f8ef6e