### PR TITLE
Allow CryptoManager decrypt_message to accept JSON strings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Provide `get_temp_dir()` utility for temporary token.place files
 - Include `service` field in `/api/v1/health` responses
+- Allow `CryptoManager.decrypt_message` to accept JSON string input
 
 ### Fixes
 - Validate PKCS#7 unpadding length to reject improperly padded input

--- a/tests/unit/test_crypto_manager.py
+++ b/tests/unit/test_crypto_manager.py
@@ -241,6 +241,24 @@ class TestCryptoManager:
         mock_decrypt.assert_called_once_with(expected_encrypted_dict, b'encrypted_key', b'test_private_key')
 
     @patch('utils.crypto.crypto_manager.decrypt')
+    def test_decrypt_message_json_string(self, mock_decrypt, crypto_manager):
+        """Decrypt_message should handle JSON strings as input."""
+        encrypted_data = {
+            'chat_history': base64.b64encode(b'encrypted_content').decode('utf-8'),
+            'cipherkey': base64.b64encode(b'encrypted_key').decode('utf-8'),
+            'iv': base64.b64encode(b'iv_value').decode('utf-8')
+        }
+
+        mock_decrypt.return_value = b'hello'
+
+        result = crypto_manager.decrypt_message(json.dumps(encrypted_data))
+
+        assert result == 'hello'
+
+        expected_encrypted_dict = {'ciphertext': b'encrypted_content', 'iv': b'iv_value'}
+        mock_decrypt.assert_called_once_with(expected_encrypted_dict, b'encrypted_key', b'test_private_key')
+
+    @patch('utils.crypto.crypto_manager.decrypt')
     def test_decrypt_message_missing_fields(self, mock_decrypt, crypto_manager):
         """Test decrypting a message with missing fields."""
         # Setup - missing 'iv'

--- a/utils/README.md
+++ b/utils/README.md
@@ -47,9 +47,9 @@ unhandled `ValueError` exceptions.
 ### Crypto Manager (`crypto/crypto_manager.py`)
 
 Manages server-side encryption keys and message processing. The
-`decrypt_message` helper now returns raw bytes when decrypted content is not
-valid UTF-8 or JSON and returns `None` when given non-dict input to avoid
-attribute errors.
+`decrypt_message` helper accepts dicts or JSON strings, returns raw bytes when
+decrypted content is not valid UTF-8 or JSON, and yields `None` for invalid
+inputs or when required fields are missing.
 
 Network requests in this module now use a default 10 second timeout to prevent
 hanging connections. You can override this by passing a `timeout` argument to

--- a/utils/crypto/crypto_manager.py
+++ b/utils/crypto/crypto_manager.py
@@ -145,20 +145,26 @@ class CryptoManager:
             log_error(f"Error encrypting message: {e}", exc_info=True)
             raise
 
-    def decrypt_message(self, encrypted_data: Dict[str, str]) -> Optional[Union[Dict, str, bytes]]:
-        """
-        Decrypt a message using the server's private key.
+    def decrypt_message(self, encrypted_data: Dict[str, str] | str) -> Optional[Union[Dict, str, bytes]]:
+        """Decrypt a message using the server's private key.
 
         Args:
-            encrypted_data: Dict containing 'chat_history', 'cipherkey', and 'iv' in base64
+            encrypted_data: Dict or JSON string containing 'chat_history', 'cipherkey', and 'iv' in
+                base64
 
         Returns:
             Decrypted message as a dict, string, or raw bytes when the content is not UTF-8.
             Returns None if decryption fails.
         """
         try:
-            if not isinstance(encrypted_data, dict):
-                log_error("Encrypted data must be a dict")
+            if isinstance(encrypted_data, str):
+                try:
+                    encrypted_data = json.loads(encrypted_data)
+                except json.JSONDecodeError:
+                    log_error("Encrypted data string is not valid JSON")
+                    return None
+            elif not isinstance(encrypted_data, dict):
+                log_error("Encrypted data must be a dict or JSON string")
                 return None
 
             # Extract and decode the encrypted data


### PR DESCRIPTION
## Summary
- support JSON string input in `CryptoManager.decrypt_message`
- test JSON string decryption path
- document JSON string support

## Testing
- `npm run lint`
- `npm run test:ci`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68aa968e71d4832fadccf0e6ec222bfa