### PR TITLE
🔒 : redact browser console logs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,10 +130,10 @@ def configure_test_environment():
 
 # Helper function to print console messages
 def print_console_message(msg):
-    """Callback function to print console messages."""
-    # Avoid printing the noisy [Server Poll] messages coming from server.py
-    if "[Server Poll]" not in msg.text:
-        print(f"Browser Console [{msg.type}]: {msg.text}")
+    """Callback for console messages with redacted content."""
+    if "[Server Poll]" in msg.text:
+        return
+    print(f"Browser Console [{msg.type}]: <redacted>")
 
 # CONSTANTS USED BY THE TEST FIXTURES
 E2E_SERVER_PORT = 8010


### PR DESCRIPTION
what: redact browser console logs to avoid leaking message text
why: reduces exposure of sensitive prompt data in test output
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- pre-commit run --all-files
- pytest -q tests/test_security.py
- bandit -r . -lll


------
https://chatgpt.com/codex/tasks/task_e_68aa9652fdc4832f8cb57b5f2d3ad8b7