### PR TITLE
🔒: avoid verbose API error logs

### DIFF
--- a/client.py
+++ b/client.py
@@ -125,7 +125,8 @@ def call_chat_completions_encrypted(server_pub_key_b64, client_priv_key, client_
         response.raise_for_status()
         encrypted_response_data = response.json()
     except requests.exceptions.RequestException as e:
-        print(f"API request failed: {e}")
+        # Avoid logging potentially sensitive error details
+        print(f"API request failed: {e.__class__.__name__}")
         if hasattr(e, 'response') and e.response is not None:
              try:
                  err_status = e.response.status_code


### PR DESCRIPTION
## Summary
- avoid printing full API error details in client

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: Crypto Compatibility Tests (Playwright))*
- `pre-commit run --all-files` *(skipped run-checks)*
- `pytest -q tests/test_security.py`
- `bandit -r . -lll`


------
https://chatgpt.com/codex/tasks/task_e_68aa9652fdc4832f8cb57b5f2d3ad8b7