### PR TITLE
Add patch coverage guidance to Codex prompts

### DIFF
--- a/docs/prompts/codex/prompts-codex-chore.md
+++ b/docs/prompts/codex/prompts-codex-chore.md
@@ -18,6 +18,7 @@ CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
 - Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`.
 - Run `pre-commit run --all-files` before committing.
+- Aim for 100% patch coverage to minimize regressions.
 
 REQUEST:
 1. Make a minimal maintenance change.

--- a/docs/prompts/codex/prompts-codex-ci-fix.md
+++ b/docs/prompts/codex/prompts-codex-ci-fix.md
@@ -25,6 +25,7 @@ CONTEXT:
   - `npm ci`
   - `pip install -r config/requirements_server.txt`
   - `pip install -r config/requirements_relay.txt`
+- Aim for 100% patch coverage to minimize regressions or new failures.
 
 REQUEST:
 1. Reproduce the failing check locally with `pre-commit run --all-files`.

--- a/docs/prompts/codex/prompts-codex-docs.md
+++ b/docs/prompts/codex/prompts-codex-docs.md
@@ -17,6 +17,7 @@ Improve documentation accuracy, links, or readability.
 CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
 - Run `pre-commit run --all-files` before committing.
+- Aim for 100% patch coverage to minimize regressions in documentation examples.
 
 REQUEST:
 1. Identify outdated, unclear, or missing docs.

--- a/docs/prompts/codex/prompts-codex-feature.md
+++ b/docs/prompts/codex/prompts-codex-feature.md
@@ -18,6 +18,7 @@ CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
 - Run `pre-commit run --all-files` before committing.
 - Ensure `npm run lint` and `npm run test:ci` succeed.
+- Aim for 100% patch coverage to reduce the risk of regressions.
 
 REQUEST:
 1. Write a failing test that captures the new behavior.

--- a/docs/prompts/codex/prompts-codex-refactor.md
+++ b/docs/prompts/codex/prompts-codex-refactor.md
@@ -18,6 +18,7 @@ CONTEXT:
 - Follow AGENTS.md and docs/AGENTS.md instructions.
 - Run `pre-commit run --all-files` before committing.
 - Ensure `npm run lint` and `npm run test:ci` succeed.
+- Aim for 100% patch coverage to guard against behavioral drift.
 
 REQUEST:
 1. Identify code that can be simplified or clarified.

--- a/docs/prompts/codex/prompts-codex-security.md
+++ b/docs/prompts/codex/prompts-codex-security.md
@@ -16,6 +16,7 @@ GOAL: Harden crypto & dependency hygiene.
 CONTEXT:
 - Follow [AGENTS.md](../AGENTS.md) and [docs/AGENTS.md](AGENTS.md).
 - Do not log plaintext or ciphertext of user messages.
+- Aim for 100% patch coverage to catch security regressions early.
 CHECKS:
   - `npm run lint`
   - `npm run type-check`

--- a/docs/prompts/codex/prompts-codex.md
+++ b/docs/prompts/codex/prompts-codex.md
@@ -25,6 +25,7 @@ CONTEXT:
 - Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 - Run `pre-commit run --all-files` before committing.
 - If Playwright browsers are missing, run `playwright install chromium`.
+- Aim for 100% patch coverage to minimize regressions or unexpected behavior.
 
 REQUEST:
 1. Identify a straightforward improvement or bug fix.
@@ -62,6 +63,7 @@ REQUIREMENTS
    with default values.
 2. Keep line width ≤ 120 characters.
 3. Run `pre-commit run --all-files` and update any affected docs.
+4. Aim for 100% patch coverage on the changes to avoid regressions.
 
 ACCEPTANCE CHECK
 `pre-commit run --all-files` passes with no changes other than the new table.
@@ -85,6 +87,7 @@ REQUIREMENTS
 1. Use pytest to send two rapid requests with a limit of `1/minute`.
 2. Assert that the second request responds with status code 429.
 3. Run `pre-commit run --all-files` to verify tests pass.
+4. Aim for 100% patch coverage on the modifications to prevent regressions.
 
 ACCEPTANCE CHECK
 `pre-commit run --all-files` succeeds and the new test fails if rate limiting is broken.


### PR DESCRIPTION
what: instruct Codex prompt docs to target 100% patch coverage
why: reduce risk of regressions from under-tested changes
how to test: documentation change only
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d8e82c5704832fb08f5d4e4c1f99b9