### PR TITLE
Add cross-platform installers to electron builder config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
     hooks:
       - id: bandit
         args: ["-lll", "-x", "tests"]
+        additional_dependencies:
+          - pbr
   - repo: local
     hooks:
       - id: run-checks

--- a/desktop/electron-builder.json
+++ b/desktop/electron-builder.json
@@ -6,11 +6,37 @@
     "buildResources": "assets"
   },
   "mac": {
-    "target": "dmg",
+    "target": ["dmg", "pkg"],
     "icon": "assets/icon.icns"
   },
   "win": {
-    "target": "nsis",
+    "target": [
+      {
+        "target": "nsis",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "msi",
+        "arch": ["x64", "arm64"]
+      }
+    ],
     "icon": "assets/icon.ico"
+  },
+  "linux": {
+    "target": [
+      {
+        "target": "AppImage",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "deb",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "rpm",
+        "arch": ["x64", "arm64"]
+      }
+    ],
+    "category": "Utility"
   }
 }

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -217,27 +217,31 @@ The `CryptoClient` utility significantly reduces the amount of boilerplate code 
 
 See the detailed documentation in `utils/README.md` for more information on using the CryptoClient.
 
+## Desktop distribution improvements
+
+token.place now ships electron-builder targets for truly cross-platform installers:
+
+- Windows `.msi` and `.exe` packages (via NSIS and MSI targets)
+- macOS `.dmg` and `.pkg` artifacts
+- Linux `.AppImage`, `.deb`, and `.rpm` bundles for x64 and arm64
+
+See `desktop/electron-builder.json` for the authoritative configuration that powers these builds.
+
 ## Next Steps
 
 To further enhance cross-platform support, future work includes:
 
-1. **Cross-Platform Installers**:
-   - Windows installer (.msi)
-   - macOS package (.pkg)
-   - Linux package (.deb, .rpm)
-   - Windows `.exe` and macOS `.dmg` builds are generated automatically via GitHub Actions
-
-2. **Platform-Specific UI Optimizations**:
+1. **Platform-Specific UI Optimizations**:
    - Native UI integrations
    - Platform-specific UX enhancements
    - Touch support for mobile devices
 
-3. **Performance Tuning**:
+2. **Performance Tuning**:
    - Platform-specific performance optimizations
    - Hardware acceleration on supported platforms
    - Resource usage monitoring and tuning
 
-4. **CI/CD Pipeline**:
+3. **CI/CD Pipeline**:
    - Matrix testing across all supported platforms
    - Automated builds for all platforms
    - Containerized testing environments

--- a/tests/unit/test_electron_builder_config.py
+++ b/tests/unit/test_electron_builder_config.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_electron_builder_targets_cover_cross_platform_installers():
+    config_path = Path(__file__).resolve().parents[2] / "desktop" / "electron-builder.json"
+    config = json.loads(config_path.read_text())
+
+    def extract_targets(target_spec):
+        if isinstance(target_spec, str):
+            return {target_spec}
+        if isinstance(target_spec, list):
+            targets = set()
+            for item in target_spec:
+                targets.update(extract_targets(item))
+            return targets
+        if isinstance(target_spec, dict):
+            targets = set()
+            if "target" in target_spec:
+                targets.update(extract_targets(target_spec["target"]))
+            return targets
+        return set()
+
+    mac_targets = extract_targets(config.get("mac", {}).get("target", []))
+    win_targets = extract_targets(config.get("win", {}).get("target", []))
+    linux_targets = extract_targets(config.get("linux", {}).get("target", []))
+
+    assert {"dmg", "pkg"}.issubset(mac_targets)
+    assert {"nsis", "msi"}.issubset(win_targets)
+    assert {"deb", "rpm"}.issubset(linux_targets)


### PR DESCRIPTION
## Summary
- selected the "Cross-Platform Installers" roadmap item via deterministic shuffle and updated electron-builder to emit MSI, PKG, DEB, RPM, and AppImage artifacts alongside existing builds
- added a unit test that enforces the required targets so future config edits keep cross-platform installer coverage intact
- refreshed docs to announce the shipped installers and adjusted pre-commit so Bandit runs with its pbr dependency

## Testing
- pre-commit run --all-files
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d8edb83148832fbe9ab421f4bac01f