### PR TITLE
Improve performance monitor test coverage and env parsing

### DIFF
--- a/docs/TESTING_IMPROVEMENTS.md
+++ b/docs/TESTING_IMPROVEMENTS.md
@@ -86,6 +86,12 @@ python -m pytest --cov=. --cov-report=term-missing
 # Then add tests for the modules with lower coverage percentages
 ```
 
+**Progress:** Added targeted unit tests in
+`tests/unit/test_performance_monitor_unit.py` covering throughput calculations
+and resilient environment parsing for `utils/performance/monitor.py`. Remaining
+modules with low coverage (`utils/crypto_helpers.py`, `utils/crypto/crypto_manager.py`,
+`utils/llm/model_manager.py`) still need focused suites.
+
 ## ✅ 8. Snapshot Testing (IMPLEMENTED)
 
 **IMPLEMENTED in tests/unit/test_encrypt_snapshot.py, which includes:**

--- a/utils/performance/monitor.py
+++ b/utils/performance/monitor.py
@@ -56,9 +56,11 @@ class PerformanceMonitor:
         max_samples: Optional[int] = None
         if max_samples_raw:
             try:
-                max_samples = int(max_samples_raw)
+                parsed_max_samples = int(max_samples_raw)
             except ValueError:
                 max_samples = None
+            else:
+                max_samples = parsed_max_samples if parsed_max_samples > 0 else None
         self.configure(enabled=monitor_enabled, max_samples=max_samples)
 
     def record(self, operation: str, payload_bytes: int, duration_seconds: float) -> None:


### PR DESCRIPTION
## Summary
- add unit tests for `PerformanceMonitor` covering throughput stats and env parsing edge cases
- ignore non-positive `TOKEN_PLACE_PERF_SAMPLES` values when refreshing config from the environment
- document the new coverage in `docs/TESTING_IMPROVEMENTS.md` and note remaining modules

## Testing
- npm run lint
- npm run test:ci
- ./run_all_tests.sh
- pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_68d9b2a63870832f8b3bf55c201a544d