### PR TITLE
✨ : – add containerized test runner tooling

### DIFF
--- a/docker/test-runner.Dockerfile
+++ b/docker/test-runner.Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        nodejs \
+        npm \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY requirements.txt ./
+COPY config/requirements_server.txt config/requirements_server.txt
+COPY config/requirements_relay.txt config/requirements_relay.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir -r config/requirements_server.txt \
+    && pip install --no-cache-dir -r config/requirements_relay.txt
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=optional
+
+COPY . .
+
+CMD ["./run_all_tests.sh"]

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -254,4 +254,6 @@ To further enhance cross-platform support, future work includes:
    - ✅ Matrix testing across all supported platforms via `utils/testing/platform_matrix.py`
      and the accompanying regression in `tests/unit/test_platform_matrix.py`
    - ✅ Automated builds for all platforms through the `desktop/package:all` script
-   - Containerized testing environments
+   - ✅ Containerized testing environments with `scripts/run_tests_in_container.py`
+     orchestrating the Docker-based test runner defined in
+     `docker/test-runner.Dockerfile`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -71,6 +71,10 @@ python scripts/validate_dependencies.py
 
 # 4. Run tests
 ./run_all_tests.sh
+
+# 5. (Optional) Validate the suite inside a container
+python scripts/run_tests_in_container.py --dry-run  # inspect command
+# python scripts/run_tests_in_container.py          # execute via docker/podman
 ```
 
 ### Troubleshooting

--- a/scripts/run_tests_in_container.py
+++ b/scripts/run_tests_in_container.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Helpers for running the token.place test suite inside a container."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RUNTIME = os.environ.get("CONTAINER_RUNTIME", "docker")
+ALLOWED_RUNTIMES = {"docker", "podman"}
+DEFAULT_IMAGE = os.environ.get("CONTAINER_TEST_IMAGE", "token.place-test-runner:latest")
+DOCKERFILE_RELATIVE = Path("docker/test-runner.Dockerfile")
+WORKDIR = "/workspace"
+
+
+def _normalise_runtime(runtime: str) -> str:
+    runtime = runtime.lower()
+    if runtime not in ALLOWED_RUNTIMES:
+        raise SystemExit(
+            f"Unsupported container runtime '{runtime}'. Choose one of: {', '.join(sorted(ALLOWED_RUNTIMES))}."
+        )
+    return runtime
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runtime",
+        default=DEFAULT_RUNTIME,
+        help="Container runtime to invoke (docker or podman). Defaults to CONTAINER_RUNTIME or docker.",
+    )
+    parser.add_argument(
+        "--image",
+        default=DEFAULT_IMAGE,
+        help=(
+            "Tag to use for the built container image. Defaults to CONTAINER_TEST_IMAGE or "
+            "token.place-test-runner:latest."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the container command as JSON without executing docker/podman.",
+    )
+    parser.add_argument(
+        "extra",
+        nargs=argparse.REMAINDER,
+        help="Optional arguments forwarded to ./run_all_tests.sh. Use '-- <args>' to pass them.",
+    )
+    return parser.parse_args(argv)
+
+
+def _build_run_command(runtime: str, image: str, forwarded: list[str]) -> list[str]:
+    mount = f"{PROJECT_ROOT}:/workspace"
+    command = [
+        runtime,
+        "run",
+        "--rm",
+        "-t",
+        "-v",
+        mount,
+        "-w",
+        WORKDIR,
+        image,
+        "./run_all_tests.sh",
+    ]
+    if forwarded and forwarded[0] == "--":
+        forwarded = forwarded[1:]
+    if forwarded:
+        command.extend(forwarded)
+    return command
+
+
+def _build_spec(runtime: str, image: str, forwarded: list[str]) -> dict[str, object]:
+    dockerfile = PROJECT_ROOT / DOCKERFILE_RELATIVE
+    return {
+        "runtime": runtime,
+        "image": image,
+        "dockerfile": str(DOCKERFILE_RELATIVE),
+        "context": str(PROJECT_ROOT),
+        "workdir": WORKDIR,
+        "command": _build_run_command(runtime, image, forwarded),
+        "dockerfile_exists": dockerfile.exists(),
+    }
+
+
+def _ensure_runtime_available(runtime: str) -> None:
+    if shutil.which(runtime) is None:
+        raise SystemExit(
+            f"Container runtime '{runtime}' not found on PATH. Install it or run with --dry-run."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    runtime = _normalise_runtime(args.runtime)
+    image = args.image
+    forwarded = list(args.extra or [])
+
+    spec = _build_spec(runtime, image, forwarded)
+
+    if args.dry_run:
+        json.dump(spec, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    dockerfile_path = PROJECT_ROOT / DOCKERFILE_RELATIVE
+    if not dockerfile_path.exists():
+        raise SystemExit(f"Dockerfile not found at {dockerfile_path}")
+
+    _ensure_runtime_available(runtime)
+
+    build_cmd = [
+        runtime,
+        "build",
+        "-f",
+        str(dockerfile_path),
+        "-t",
+        image,
+        str(PROJECT_ROOT),
+    ]
+
+    run_cmd = spec["command"]
+
+    subprocess.run(build_cmd, check=True)
+    subprocess.run(run_cmd, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_containerized_environment.py
+++ b/tests/test_containerized_environment.py
@@ -1,0 +1,40 @@
+"""Tests for the containerized testing helper tooling."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_containerized_test_runner_dry_run_outputs_spec(tmp_path):
+    """The dry-run flag should describe the containerized test execution plan."""
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "run_tests_in_container.py"
+
+    assert script_path.exists(), "Expected container test runner script to be present"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--dry-run"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert lines, "Dry-run output should include a JSON payload"
+
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:  # pragma: no cover - ensures helpful error message
+        raise AssertionError(f"Dry-run output was not valid JSON: {result.stdout}") from exc
+
+    assert payload["dockerfile"].endswith("docker/test-runner.Dockerfile")
+    assert payload["image"].startswith("token.place-test-runner")
+    assert payload["workdir"].endswith("/workspace")
+    assert payload["runtime"] in {"docker", "podman"}
+    assert any("run_all_tests.sh" in token for token in payload["command"])


### PR DESCRIPTION
what: add dockerized test runner and unit test for its dry-run output.
why: finish the roadmap promise for containerized testing environments.
how to test: python scripts/run_tests_in_container.py --dry-run; npm run test:ci.


------
https://chatgpt.com/codex/tasks/task_e_68da35a73798832fa9557723aa63ede0