### PR TITLE
Add Playwright browser matrix crypto test

### DIFF
--- a/docs/TESTING_IMPROVEMENTS.md
+++ b/docs/TESTING_IMPROVEMENTS.md
@@ -54,17 +54,17 @@ This document serves as a scratch pad for potential testing improvements to impl
 - Testing with binary data
 - Testing encryption compatibility between different key sizes
 
-## 6. Cross-Platform Browser Tests
+## ✅ 6. Cross-Platform Browser Tests (IMPLEMENTED)
 
-Expand browser testing to include different environments:
+**IMPLEMENTED in `tests/test_crypto_browser_matrix.py`, which:**
 
-```python
-@pytest.mark.parametrize("browser_type", ["chromium", "firefox", "webkit"])
-def test_js_encryption_in_different_browsers(browser_type, playwright):
-    browser = getattr(playwright, browser_type).launch()
-    page = browser.new_page()
-    # Run your encryption tests in this browser
-```
+- Parameterizes Playwright across Chromium, Firefox, and WebKit using the
+  shared `browser_matrix` fixture in `tests/conftest.py`.
+- Exercises the documented encryption runner (`tests/crypto_runner.html`) in
+  each browser engine to prove Python-encrypted payloads decrypt correctly in
+  JavaScript.
+- Skips gracefully if a browser runtime is unavailable locally while still
+  providing coverage wherever Playwright installs are present.
 
 ## 7. Test Coverage Improvements
 

--- a/tests/test_crypto_browser_matrix.py
+++ b/tests/test_crypto_browser_matrix.py
@@ -1,0 +1,74 @@
+"""Cross-browser crypto compatibility tests for token.place."""
+
+import base64
+import json
+import pathlib
+
+import pytest
+
+from encrypt import generate_keys, encrypt
+
+
+@pytest.mark.crypto
+@pytest.mark.browser
+@pytest.mark.parametrize("payload_text", [
+    "Cross-browser crypto works!",
+])
+def test_python_encrypt_js_decrypt_across_browsers(browser_matrix, payload_text):
+    """Ensure the JS crypto runner decrypts Python ciphertext in all supported browsers."""
+    browser_name, page = browser_matrix
+
+    private_key, public_key = generate_keys()
+
+    message = {
+        "message": payload_text,
+        "browser": browser_name,
+        "numbers": [1, 2, 3],
+    }
+
+    ciphertext, encrypted_key, iv = encrypt(
+        json.dumps(message).encode("utf-8"),
+        public_key,
+        use_pkcs1v15=True,
+    )
+
+    args = {
+        "ciphertext_b64": base64.b64encode(ciphertext["ciphertext"]).decode("utf-8"),
+        "encryptedKey_b64": base64.b64encode(encrypted_key).decode("utf-8"),
+        "iv_b64": base64.b64encode(iv).decode("utf-8"),
+        "privateKeyPem": private_key.decode("utf-8"),
+    }
+
+    runner_url = pathlib.Path("tests/crypto_runner.html").resolve().as_uri()
+    page.goto(runner_url)
+    page.wait_for_load_state("networkidle")
+    page.wait_for_function("typeof window.JSEncrypt === 'function'")
+    page.wait_for_function(
+        "typeof window.CryptoJS === 'object' && typeof window.CryptoJS.AES === 'object'",
+    )
+
+    decrypted = page.evaluate(
+        """
+        (args) => {
+            const { ciphertext_b64, encryptedKey_b64, iv_b64, privateKeyPem } = args;
+            const jsEncrypt = new window.JSEncrypt();
+            jsEncrypt.setPrivateKey(privateKeyPem);
+            const decryptedKey_b64 = jsEncrypt.decrypt(encryptedKey_b64);
+            if (!decryptedKey_b64) {
+                throw new Error('RSA key unwrap failed');
+            }
+            const aesKey = CryptoJS.enc.Base64.parse(decryptedKey_b64);
+            const iv = CryptoJS.enc.Base64.parse(iv_b64);
+            const ciphertext = CryptoJS.enc.Base64.parse(ciphertext_b64);
+            const decrypted = CryptoJS.AES.decrypt(
+                { ciphertext },
+                aesKey,
+                { iv, mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 },
+            );
+            return CryptoJS.enc.Utf8.stringify(decrypted);
+        }
+        """,
+        args,
+    )
+
+    assert json.loads(decrypted) == message


### PR DESCRIPTION
## Summary
- use a seeded Python picker (seed=2025) to select the cross-platform browser test idea from docs/TESTING_IMPROVEMENTS.md
- add a Playwright-driven browser matrix fixture plus regression for Python -> JS crypto roundtrip in Chromium, Firefox, and WebKit
- document the implemented coverage and harden the shared Playwright fixtures to avoid premature shutdowns

## Testing
- pre-commit run --all-files
- npm run lint
- npm run test:ci
- ./run_all_tests.sh
- detect-secrets scan $(git diff --cached --name-only)


------
https://chatgpt.com/codex/tasks/task_e_68da35a73798832fa9557723aa63ede0