### PR TITLE
Add JavaScript mock server test harness

### DIFF
--- a/docs/TESTING_IMPROVEMENTS.md
+++ b/docs/TESTING_IMPROVEMENTS.md
@@ -98,19 +98,18 @@ python -m pytest --cov=. --cov-report=term-missing
 - Regression coverage to ensure missing-field scenarios now surface explicit exceptions rather than
   returning `None` silently.
 
-## 10. Mock Server for JavaScript Tests
+## ✅ 10. Mock Server for JavaScript Tests (IMPLEMENTED)
 
-Create a simple mock server to test the JavaScript client without relying on the full Python server:
+**IMPLEMENTED in `tests/mock_js_server.js` with coverage in
+`tests/test_js_mock_server.js`, which:**
 
-```javascript
-// mock_server.js
-const express = require('express');
-const app = express();
-app.post('/api/chat', (req, res) => {
-  // Return mock encrypted responses
-});
-// Then use this in js tests
-```
+- Spins up a lightweight HTTP server that mimics the encrypted `/api/v1/chat/completions`
+  contract entirely in Node.js, avoiding the need to boot the Python stack for JavaScript
+  tests.
+- Handles RSA key exchange plus AES-CBC encryption/decryption using the same JSEncrypt and
+  CryptoJS libraries as the browser client, ensuring wire compatibility.
+- Responds with deterministic assistant messages so tests can assert on decrypted content.
+- Is exercised automatically via `npm run test:js`, alongside the existing crypto unit tests.
 
 ## 11. Real-World Integration Testing with DSPACE
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "pytest tests/",
-    "test:js": "node tests/test_js_crypto.js",
+    "test:js": "node tests/test_js_crypto.js && node tests/test_js_mock_server.js",
     "test:crypto-compat": "python tests/test_crypto_compatibility.py",
     "test:e2e": "pytest tests/test_e2e_chat.py",
     "test:all": "npm run test && npm run test:js && npm run test:crypto-compat && npm run test:e2e",

--- a/tests/mock_js_server.js
+++ b/tests/mock_js_server.js
@@ -1,0 +1,161 @@
+require('./js_test_shim.js');
+
+const http = require('http');
+const { once } = require('events');
+const JSEncrypt = require('jsencrypt');
+const CryptoJS = require('crypto-js');
+
+function encryptForClient(plaintext, clientPublicKey) {
+    const aesKey = CryptoJS.lib.WordArray.random(32);
+    const iv = CryptoJS.lib.WordArray.random(16);
+
+    const encrypted = CryptoJS.AES.encrypt(
+        CryptoJS.enc.Utf8.parse(plaintext),
+        aesKey,
+        {
+            iv,
+            mode: CryptoJS.mode.CBC,
+            padding: CryptoJS.pad.Pkcs7
+        }
+    );
+
+    const jsEncrypt = new JSEncrypt();
+    jsEncrypt.setPublicKey(clientPublicKey);
+    const aesKeyBase64 = CryptoJS.enc.Base64.stringify(aesKey);
+    const encryptedKey = jsEncrypt.encrypt(aesKeyBase64);
+
+    if (!encryptedKey) {
+        throw new Error('Failed to encrypt AES key for client');
+    }
+
+    return {
+        ciphertext: CryptoJS.enc.Base64.stringify(encrypted.ciphertext),
+        cipherkey: encryptedKey,
+        iv: CryptoJS.enc.Base64.stringify(iv)
+    };
+}
+
+function decryptRequestBody(body, serverPrivateKey) {
+    const jsEncrypt = new JSEncrypt();
+    jsEncrypt.setPrivateKey(serverPrivateKey);
+
+    const decryptedKeyBase64 = jsEncrypt.decrypt(body.cipherkey);
+    if (!decryptedKeyBase64) {
+        throw new Error('Unable to decrypt AES key with mock server private key');
+    }
+
+    const aesKey = CryptoJS.enc.Base64.parse(decryptedKeyBase64);
+    const iv = CryptoJS.enc.Base64.parse(body.iv);
+    const ciphertext = CryptoJS.enc.Base64.parse(body.ciphertext);
+
+    const decrypted = CryptoJS.AES.decrypt(
+        { ciphertext },
+        aesKey,
+        {
+            iv,
+            mode: CryptoJS.mode.CBC,
+            padding: CryptoJS.pad.Pkcs7
+        }
+    );
+
+    const plaintext = CryptoJS.enc.Utf8.stringify(decrypted);
+    if (!plaintext) {
+        throw new Error('Mock server failed to recover plaintext payload');
+    }
+
+    return plaintext;
+}
+
+async function startMockServer() {
+    const serverCrypt = new JSEncrypt({ default_key_size: 2048 });
+    serverCrypt.getKey();
+    const serverPrivateKey = serverCrypt.getPrivateKey();
+    const serverPublicKey = serverCrypt.getPublicKey();
+
+    const server = http.createServer(async (req, res) => {
+        try {
+            if (req.method === 'GET' && req.url === '/api/v1/public-key') {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ public_key: serverPublicKey }));
+                return;
+            }
+
+            if (req.method === 'POST' && req.url === '/api/v1/chat/completions') {
+                let bodyRaw = '';
+                req.on('data', chunk => {
+                    bodyRaw += chunk;
+                });
+
+                req.on('end', () => {
+                    try {
+                        const parsed = JSON.parse(bodyRaw || '{}');
+                        const requiredFields = ['ciphertext', 'cipherkey', 'iv', 'client_public_key'];
+                        for (const field of requiredFields) {
+                            if (!parsed[field]) {
+                                res.writeHead(400, { 'Content-Type': 'application/json' });
+                                res.end(JSON.stringify({ error: `Missing field: ${field}` }));
+                                return;
+                            }
+                        }
+
+                        const requestPlaintext = decryptRequestBody(parsed, serverPrivateKey);
+                        let userMessage;
+                        try {
+                            const jsonPayload = JSON.parse(requestPlaintext);
+                            userMessage = jsonPayload.content || '';
+                        } catch (error) {
+                            userMessage = requestPlaintext;
+                        }
+
+                        const responsePayload = {
+                            role: 'assistant',
+                            content: `Mock response: ${userMessage}`
+                        };
+                        const encryptedResponse = encryptForClient(
+                            JSON.stringify(responsePayload),
+                            parsed.client_public_key
+                        );
+
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify(encryptedResponse));
+                    } catch (error) {
+                        res.writeHead(500, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ error: error.message }));
+                    }
+                });
+                return;
+            }
+
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Not Found' }));
+        } catch (error) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: error.message }));
+        }
+    });
+
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    return {
+        baseUrl,
+        publicKey: serverPublicKey,
+        async stop() {
+            await new Promise((resolve, reject) => {
+                server.close(err => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
+            });
+        }
+    };
+}
+
+module.exports = {
+    startMockServer
+};

--- a/tests/test_js_mock_server.js
+++ b/tests/test_js_mock_server.js
@@ -1,0 +1,136 @@
+/**
+ * Integration test verifying the JavaScript mock server round-trip.
+ */
+
+require('./js_test_shim.js');
+
+const assert = require('assert');
+const JSEncrypt = require('jsencrypt');
+const CryptoJS = require('crypto-js');
+const { startMockServer } = require('./mock_js_server');
+
+function encryptForServer(plaintext, serverPublicKey) {
+    const aesKey = CryptoJS.lib.WordArray.random(32); // 256-bit AES key
+    const iv = CryptoJS.lib.WordArray.random(16);
+
+    const encrypted = CryptoJS.AES.encrypt(
+        CryptoJS.enc.Utf8.parse(plaintext),
+        aesKey,
+        {
+            iv,
+            mode: CryptoJS.mode.CBC,
+            padding: CryptoJS.pad.Pkcs7
+        }
+    );
+
+    const jsEncrypt = new JSEncrypt();
+    jsEncrypt.setPublicKey(serverPublicKey);
+    const aesKeyBase64 = CryptoJS.enc.Base64.stringify(aesKey);
+    const encryptedKey = jsEncrypt.encrypt(aesKeyBase64);
+
+    if (!encryptedKey) {
+        throw new Error('Failed to RSA encrypt AES key for server');
+    }
+
+    return {
+        ciphertext: CryptoJS.enc.Base64.stringify(encrypted.ciphertext),
+        cipherkey: encryptedKey,
+        iv: CryptoJS.enc.Base64.stringify(iv)
+    };
+}
+
+function decryptFromServer(payload, clientPrivateKey) {
+    const jsEncrypt = new JSEncrypt();
+    jsEncrypt.setPrivateKey(clientPrivateKey);
+
+    const decryptedKeyBase64 = jsEncrypt.decrypt(payload.cipherkey);
+    if (!decryptedKeyBase64) {
+        throw new Error('Failed to RSA decrypt AES key from server');
+    }
+
+    const aesKey = CryptoJS.enc.Base64.parse(decryptedKeyBase64);
+    const iv = CryptoJS.enc.Base64.parse(payload.iv);
+    const ciphertext = CryptoJS.enc.Base64.parse(payload.ciphertext);
+
+    const decrypted = CryptoJS.AES.decrypt(
+        { ciphertext },
+        aesKey,
+        {
+            iv,
+            mode: CryptoJS.mode.CBC,
+            padding: CryptoJS.pad.Pkcs7
+        }
+    );
+
+    return CryptoJS.enc.Utf8.stringify(decrypted);
+}
+
+async function runMockServerTest() {
+    const clientCrypt = new JSEncrypt({ default_key_size: 2048 });
+    clientCrypt.getKey();
+    const clientPrivateKey = clientCrypt.getPrivateKey();
+    const clientPublicKey = clientCrypt.getPublicKey();
+
+    const server = await startMockServer();
+
+    try {
+        assert.ok(server.baseUrl, 'Mock server should expose baseUrl');
+
+        const keyResponse = await fetch(`${server.baseUrl}/api/v1/public-key`);
+        assert.strictEqual(keyResponse.status, 200, 'Public key endpoint should return 200');
+        const keyPayload = await keyResponse.json();
+        assert.strictEqual(
+            keyPayload.public_key,
+            server.publicKey,
+            'Server should return its public key'
+        );
+
+        const plaintext = JSON.stringify({
+            role: 'user',
+            content: 'Hello mock server!'
+        });
+
+        const encryptedPayload = encryptForServer(plaintext, server.publicKey);
+
+        const response = await fetch(`${server.baseUrl}/api/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                ciphertext: encryptedPayload.ciphertext,
+                cipherkey: encryptedPayload.cipherkey,
+                iv: encryptedPayload.iv,
+                client_public_key: clientPublicKey,
+                model: 'mock-llm'
+            })
+        });
+
+        assert.strictEqual(response.status, 200, 'Chat endpoint should return 200');
+        const encryptedReply = await response.json();
+        assert.ok(encryptedReply.ciphertext, 'Response should include ciphertext');
+        assert.ok(encryptedReply.cipherkey, 'Response should include cipherkey');
+        assert.ok(encryptedReply.iv, 'Response should include iv');
+
+        const decryptedReply = decryptFromServer(encryptedReply, clientPrivateKey);
+        const parsedReply = JSON.parse(decryptedReply);
+
+        assert.strictEqual(parsedReply.role, 'assistant', 'Reply should be from assistant');
+        assert.strictEqual(
+            parsedReply.content,
+            'Mock response: Hello mock server!',
+            'Reply content should match mock server output'
+        );
+
+        console.log('✅ Mock server round-trip test passed');
+    } finally {
+        await server.stop();
+    }
+}
+
+if (require.main === module) {
+    runMockServerTest().catch(error => {
+        console.error('❌ Mock server test failed:', error);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = { runMockServerTest };


### PR DESCRIPTION
## Summary
- implement a Node.js mock server (`tests/mock_js_server.js`) that mirrors the encrypted `/api/v1/chat/completions` contract so browserless JS tests can exercise key exchange and AES payloads
- add a new integration test (`tests/test_js_mock_server.js`) that performs a full encrypt -> relay -> decrypt round-trip using the mock server and expose it via `npm run test:js`
- mark the "Mock Server for JavaScript Tests" roadmap item in `docs/TESTING_IMPROVEMENTS.md` as implemented with notes about the new coverage

## Testing
- pre-commit run --all-files
- npm run lint
- npm run test:ci
- ./run_all_tests.sh


------
https://chatgpt.com/codex/tasks/task_e_68da35a73798832fa9557723aa63ede0