### PR TITLE
Add community provider directory endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
   - [ ] Optional content moderation hooks
   - [ ] External security review of protocol and code
 - [ ] Community features
-  - [ ] Server provider directory/registry
+  - [x] Server provider directory/registry
   - [ ] Model leaderboard based on community feedback
   - [ ] Contribution system for donating compute resources
 
@@ -570,6 +570,15 @@ Request body:
   "max_tokens": 256
 }
 ```
+
+#### Community Provider Directory
+```
+GET /api/v1/community/providers
+```
+Lists community-operated relay nodes that have opted into the public registry.
+Each entry includes the provider identifier, advertised region, contact details,
+current status, and a representative latency measurement to help clients pick a
+nearby relay.
 
 ### End-to-End Encryption
 

--- a/api/v1/community.py
+++ b/api/v1/community.py
@@ -1,0 +1,77 @@
+"""Community helpers for the token.place directory endpoints."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+COMMUNITY_DIRECTORY_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "community" / "providers.json"
+)
+
+
+class CommunityDirectoryError(RuntimeError):
+    """Raised when the community directory payload cannot be parsed."""
+
+
+def _load_raw_directory() -> Dict[str, Any]:
+    """Load the raw community directory JSON file.
+
+    Returns a dictionary containing the parsed JSON contents. Missing files
+    resolve to an empty directory so the API can still respond gracefully.
+    """
+
+    if not COMMUNITY_DIRECTORY_PATH.exists():
+        return {"providers": [], "updated": None}
+
+    try:
+        return json.loads(COMMUNITY_DIRECTORY_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise CommunityDirectoryError("Invalid community provider directory JSON") from exc
+
+
+def _normalise_provider(provider: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a single provider entry and filter required fields."""
+
+    required_fields = ("id", "name", "region")
+    if not all(provider.get(field) for field in required_fields):
+        raise CommunityDirectoryError(
+            f"Provider entry missing required fields: {required_fields}"
+        )
+
+    return {
+        "id": provider["id"],
+        "name": provider["name"],
+        "region": provider["region"],
+        "latency_ms": provider.get("latency_ms"),
+        "status": provider.get("status", "unknown"),
+        "contact": provider.get("contact", {}),
+        "capabilities": provider.get("capabilities", []),
+        "notes": provider.get("notes"),
+    }
+
+
+@lru_cache(maxsize=1)
+def get_provider_directory() -> Dict[str, Any]:
+    """Return the cached community provider directory."""
+
+    raw_directory = _load_raw_directory()
+    providers: List[Dict[str, Any]] = []
+    for entry in raw_directory.get("providers", []):
+        providers.append(_normalise_provider(entry))
+
+    return {
+        "providers": providers,
+        "updated": raw_directory.get("updated"),
+    }
+
+
+def invalidate_provider_directory_cache() -> None:
+    """Clear the cached provider directory.
+
+    Useful for tests that update the directory contents.
+    """
+
+    get_provider_directory.cache_clear()

--- a/config/community/providers.json
+++ b/config/community/providers.json
@@ -1,0 +1,35 @@
+{
+  "updated": "2025-02-01T00:00:00Z",
+  "providers": [
+    {
+      "id": "token-place-lab",
+      "name": "token.place Lab",
+      "region": "us-west",
+      "latency_ms": 42,
+      "status": "online",
+      "contact": {
+        "email": "community@token.place"
+      },
+      "capabilities": [
+        "openai-compatible",
+        "mock-llm"
+      ],
+      "notes": "Reference node used for integration tests and community demos."
+    },
+    {
+      "id": "community-eu-testnet",
+      "name": "Community EU Testnet",
+      "region": "eu-central",
+      "latency_ms": 85,
+      "status": "maintenance",
+      "contact": {
+        "matrix": "#token-place:example.org"
+      },
+      "capabilities": [
+        "chat-completions",
+        "encryption"
+      ],
+      "notes": "Volunteer-operated relay currently upgrading GPUs."
+    }
+  ]
+}

--- a/tests/test_community_directory.py
+++ b/tests/test_community_directory.py
@@ -1,0 +1,32 @@
+import pytest
+
+from relay import app
+
+app.config['TESTING'] = True
+
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+
+def test_community_provider_directory_endpoint(client):
+    response = client.get("/api/v1/community/providers")
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload["object"] == "list"
+    assert isinstance(payload["data"], list)
+    assert payload["data"], "Expected at least one community provider"
+
+    provider = payload["data"][0]
+    expected_keys = {
+        "id",
+        "name",
+        "region",
+        "latency_ms",
+        "status",
+        "contact",
+    }
+    assert expected_keys.issubset(provider.keys())

--- a/tests/test_community_directory.py
+++ b/tests/test_community_directory.py
@@ -1,5 +1,9 @@
+import json
+from pathlib import Path
+
 import pytest
 
+from api.v1 import community
 from relay import app
 
 app.config['TESTING'] = True
@@ -11,7 +15,15 @@ def client():
         yield client
 
 
+def _reset_directory_cache():
+    """Clear the cached provider directory across tests."""
+
+    community.invalidate_provider_directory_cache()
+
+
 def test_community_provider_directory_endpoint(client):
+    _reset_directory_cache()
+
     response = client.get("/api/v1/community/providers")
     assert response.status_code == 200
 
@@ -30,3 +42,43 @@ def test_community_provider_directory_endpoint(client):
         "contact",
     }
     assert expected_keys.issubset(provider.keys())
+
+
+def test_get_provider_directory_missing_file(monkeypatch, tmp_path):
+    """The loader should gracefully handle a missing JSON file."""
+
+    monkeypatch.setattr(community, "COMMUNITY_DIRECTORY_PATH", tmp_path / "providers.json")
+    _reset_directory_cache()
+
+    directory = community.get_provider_directory()
+    assert directory == {"providers": [], "updated": None}
+
+
+def test_get_provider_directory_invalid_provider_entry(monkeypatch, tmp_path):
+    """Invalid provider entries should raise a directory error."""
+
+    payload_path = tmp_path / "providers.json"
+    payload = {"providers": [{"id": "missing-fields"}]}
+    payload_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(community, "COMMUNITY_DIRECTORY_PATH", payload_path)
+    _reset_directory_cache()
+
+    with pytest.raises(community.CommunityDirectoryError):
+        community.get_provider_directory()
+
+
+def test_list_community_providers_handles_directory_error(client, monkeypatch):
+    """The HTTP endpoint should convert directory errors into API responses."""
+
+    def _raise_error() -> Path:
+        raise community.CommunityDirectoryError("boom")
+
+    monkeypatch.setattr("api.v1.routes.get_provider_directory", _raise_error)
+
+    response = client.get("/api/v1/community/providers")
+    assert response.status_code == 500
+
+    payload = response.get_json()
+    assert payload["error"]["type"] == "internal_server_error"
+    assert payload["error"]["message"] == "Community directory temporarily unavailable"

--- a/tests/test_community_directory.py
+++ b/tests/test_community_directory.py
@@ -103,7 +103,7 @@ def test_list_community_providers_handles_directory_error(client, monkeypatch):
     def _raise_error() -> Path:
         raise community.CommunityDirectoryError("boom")
 
-    monkeypatch.setattr("api.v1.routes.get_provider_directory", _raise_error)
+    monkeypatch.setattr("api.v1.routes.get_community_provider_directory", _raise_error)
 
     response = client.get("/api/v1/community/providers")
     assert response.status_code == 500
@@ -133,7 +133,7 @@ def test_list_community_providers_omits_updated_when_missing(client, monkeypatch
             "updated": None,
         }
 
-    monkeypatch.setattr("api.v1.routes.get_provider_directory", _return_directory)
+    monkeypatch.setattr("api.v1.routes.get_community_provider_directory", _return_directory)
 
     response = client.get("/api/v1/community/providers")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- randomly selected the "Community features" roadmap item using a deterministic seed and focused on the server provider directory promise
- add a cached loader for config/community/providers.json and expose it via GET /api/v1/community/providers
- seed the registry with two sample providers, document the endpoint in README.md, and cover it with a regression test

## Testing
- npm run lint
- npm run test:ci
- ./run_all_tests.sh
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68db63bdb680832f9abb9f9848f7d300