### PR TITLE
Add server provider directory endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [ ] Enhanced encryption options for model weights and inference data
   - [ ] Key rotation for relay and server certificates
 - [x] Signed relay binaries for client verification
-  - [ ] Optional content moderation hooks
-  - [ ] External security review of protocol and code
+- [ ] Optional content moderation hooks
+- [ ] External security review of protocol and code
 - [ ] Community features
-  - [ ] Server provider directory/registry
+  - [x] Server provider directory/registry
   - [ ] Model leaderboard based on community feedback
   - [ ] Contribution system for donating compute resources
 
@@ -568,6 +568,37 @@ Request body:
   "model": "llama-3-8b-instruct",
   "prompt": "Write a poem about AI",
   "max_tokens": 256
+}
+```
+
+#### Server Providers Directory
+```
+GET /api/v1/server-providers
+```
+Returns a curated directory of relay and server operators that have opted-in to
+list their infrastructure. Each entry includes status, region, and the exposed
+endpoint URLs so clients can preselect a compatible provider.
+
+Example response snippet:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "local-dev",
+      "name": "Local Development Node",
+      "region": "local",
+      "status": "active",
+      "endpoints": [
+        {"type": "relay", "url": "http://localhost:5010"},
+        {"type": "server", "url": "http://localhost:3000"}
+      ]
+    }
+  ],
+  "metadata": {
+    "updated_at": "2025-02-15T00:00:00Z"
+  }
 }
 ```
 

--- a/config/server_providers.yaml
+++ b/config/server_providers.yaml
@@ -1,0 +1,33 @@
+metadata:
+  updated_at: 2025-02-15T00:00:00Z
+  note: "Curated sample registry for local development and community providers."
+providers:
+  - id: local-dev
+    name: Local Development Node
+    region: local
+    status: active
+    description: "Reference node that ships with token.place for smoke testing."
+    capabilities:
+      - mock-llm
+      - llama-3-8b-instruct
+    contact:
+      email: ops@token.place
+    endpoints:
+      - type: relay
+        url: http://localhost:5010
+      - type: server
+        url: http://localhost:3000
+  - id: community-eu-west
+    name: Community Cluster (EU-West)
+    region: eu-west
+    status: onboarding
+    description: "Community maintained cluster accepting beta operators."
+    capabilities:
+      - llama-3-8b-instruct
+      - llama-3-70b-instruct
+    contact:
+      matrix: "#token.place:matrix.org"
+      email: community@token.place
+    endpoints:
+      - type: relay
+        url: https://relay.eu-west.community.token.place

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,6 +106,28 @@ def test_get_public_key(client):
     assert 'public_key' in data
     assert len(data['public_key']) > 0
 
+
+def test_server_provider_directory(client):
+    """The server provider registry should list known compute providers."""
+    response = client.get("/api/v1/server-providers")
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload["object"] == "list"
+    providers = payload["data"]
+    assert isinstance(providers, list)
+    assert providers, "expected at least one provider"
+
+    sample = providers[0]
+    required_fields = {"id", "name", "region", "status", "endpoints"}
+    assert required_fields.issubset(sample)
+    assert isinstance(sample["endpoints"], list)
+    assert sample["endpoints"], "providers should surface at least one endpoint"
+
+    for endpoint in sample["endpoints"]:
+        assert "type" in endpoint
+        assert "url" in endpoint
+
 def test_unencrypted_chat_completion(client, client_keys, mock_llama):
     """Test the chat completion API without encryption"""
     payload = {

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -1,0 +1,108 @@
+"""Unit tests for the provider registry loader utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+from utils.providers import ProviderRegistryError
+from utils.providers import registry
+
+
+@pytest.fixture(autouse=True)
+def clear_registry_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts with a clean cache and no env overrides."""
+
+    registry._reset_provider_directory_cache()
+    monkeypatch.delenv("TOKEN_PLACE_PROVIDER_REGISTRY", raising=False)
+    yield
+    registry._reset_provider_directory_cache()
+    monkeypatch.delenv("TOKEN_PLACE_PROVIDER_REGISTRY", raising=False)
+
+
+def _write_registry(path: Path, payload: Dict[str, Any] | Any) -> None:
+    """Helper to serialise payloads to YAML for the registry loader."""
+
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+
+def _valid_provider() -> Dict[str, Any]:
+    return {
+        "id": "test", "name": "Test", "region": "us-test", "status": "active",
+        "endpoints": [{"type": "relay", "url": "http://example"}]
+    }
+
+
+def test_get_provider_directory_uses_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The registry loader should honour TOKEN_PLACE_PROVIDER_REGISTRY overrides."""
+
+    registry_file = tmp_path / "registry.yaml"
+    _write_registry(
+        registry_file,
+        {
+            "metadata": {"version": 1},
+            "providers": [
+                {
+                    "id": "abc",
+                    "name": "ABC",  # minimal valid provider entry
+                    "region": "local",
+                    "status": "active",
+                    "description": "Custom registry entry",
+                    "endpoints": [{"type": "relay", "url": "http://localhost"}],
+                }
+            ],
+        },
+    )
+
+    monkeypatch.setenv("TOKEN_PLACE_PROVIDER_REGISTRY", str(registry_file))
+
+    result = registry.get_provider_directory()
+
+    assert result["metadata"] == {"version": 1}
+    assert result["providers"][0]["description"] == "Custom registry entry"
+
+
+def test_get_provider_directory_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing registry files should raise a ProviderRegistryError."""
+
+    missing_path = tmp_path / "missing.yaml"
+    monkeypatch.setenv("TOKEN_PLACE_PROVIDER_REGISTRY", str(missing_path))
+
+    with pytest.raises(ProviderRegistryError) as exc:
+        registry.get_provider_directory()
+
+    assert "not found" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message",
+    [
+        ([{"foo": "bar"}], "Provider registry root must be a mapping"),
+        ({"metadata": [1], "providers": []}, "Provider registry metadata must be a mapping"),
+        ({"metadata": {}, "providers": "nope"}, "Provider registry providers must be a list"),
+        ({"metadata": {}, "providers": ["bad"]}, "Each provider entry must be a mapping"),
+        ({"metadata": {}, "providers": [{"id": "x", "name": "X", "region": "R"}]}, "missing required fields"),
+        ({"metadata": {}, "providers": [{**_valid_provider(), "endpoints": "bad"}]}, "endpoints must be a list"),
+        ({"metadata": {}, "providers": [{**_valid_provider(), "endpoints": ["bad"]}]}, "invalid endpoint definition"),
+        ({"metadata": {}, "providers": [{**_valid_provider(), "endpoints": [{"type": "relay"}]}]}, "missing fields"),
+    ],
+)
+def test_get_provider_directory_validation_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Any,
+    expected_message: str,
+) -> None:
+    """Structured validation errors should surface as ProviderRegistryError."""
+
+    registry_file = tmp_path / "registry.yaml"
+    _write_registry(registry_file, payload)
+    monkeypatch.setenv("TOKEN_PLACE_PROVIDER_REGISTRY", str(registry_file))
+
+    with pytest.raises(ProviderRegistryError) as exc:
+        registry.get_provider_directory()
+
+    assert expected_message in str(exc.value)

--- a/utils/providers/__init__.py
+++ b/utils/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider registry utilities for token.place."""
+
+from .registry import get_provider_directory, ProviderRegistryError
+
+__all__ = ["get_provider_directory", "ProviderRegistryError"]

--- a/utils/providers/registry.py
+++ b/utils/providers/registry.py
@@ -1,0 +1,114 @@
+"""Utilities for loading the token.place server provider registry."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+
+class ProviderRegistryError(RuntimeError):
+    """Raised when the provider registry cannot be loaded."""
+
+
+def _registry_path() -> Path:
+    """Return the configured path to the provider registry file."""
+
+    override = os.getenv("TOKEN_PLACE_PROVIDER_REGISTRY")
+    if override:
+        return Path(override)
+
+    return Path(__file__).resolve().parents[2] / "config" / "server_providers.yaml"
+
+
+@lru_cache(maxsize=1)
+def get_provider_directory() -> Dict[str, Any]:
+    """Load and normalise the provider directory from disk."""
+
+    path = _registry_path()
+    if not path.exists():
+        raise ProviderRegistryError(
+            f"Provider registry file not found at {path}."
+        )
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            raw_data = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        raise ProviderRegistryError("Failed to parse provider registry YAML") from exc
+
+    if not isinstance(raw_data, dict):
+        raise ProviderRegistryError("Provider registry root must be a mapping")
+
+    metadata = raw_data.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise ProviderRegistryError("Provider registry metadata must be a mapping")
+
+    providers = raw_data.get("providers") or []
+    if not isinstance(providers, list):
+        raise ProviderRegistryError("Provider registry providers must be a list")
+
+    normalised: List[Dict[str, Any]] = []
+    for entry in providers:
+        if not isinstance(entry, dict):
+            raise ProviderRegistryError("Each provider entry must be a mapping")
+
+        missing_fields = [
+            field for field in ("id", "name", "region", "status") if field not in entry
+        ]
+        if missing_fields:
+            raise ProviderRegistryError(
+                "Provider entry missing required fields: " + ", ".join(missing_fields)
+            )
+
+        endpoints = entry.get("endpoints") or []
+        if not isinstance(endpoints, list):
+            raise ProviderRegistryError(
+                f"Provider '{entry['id']}' endpoints must be a list"
+            )
+
+        normalised_endpoints: List[Dict[str, Any]] = []
+        for endpoint in endpoints:
+            if not isinstance(endpoint, dict):
+                raise ProviderRegistryError(
+                    f"Provider '{entry['id']}' has an invalid endpoint definition"
+                )
+
+            missing_endpoint_fields = [
+                field for field in ("type", "url") if field not in endpoint
+            ]
+            if missing_endpoint_fields:
+                raise ProviderRegistryError(
+                    "Endpoint for provider '{id}' missing fields: {fields}".format(
+                        id=entry["id"], fields=", ".join(missing_endpoint_fields)
+                    )
+                )
+
+            normalised_endpoints.append({
+                key: endpoint[key] for key in endpoint
+            })
+
+        normalised_entry: Dict[str, Any] = {
+            "id": entry["id"],
+            "name": entry["name"],
+            "region": entry["region"],
+            "status": entry["status"],
+            "endpoints": normalised_endpoints,
+        }
+
+        for optional_key in ("description", "capabilities", "contact", "notes"):
+            if optional_key in entry:
+                normalised_entry[optional_key] = entry[optional_key]
+
+        normalised.append(normalised_entry)
+
+    return {"metadata": metadata, "providers": normalised}
+
+
+def _reset_provider_directory_cache() -> None:
+    """Reset the directory cache - exposed for tests."""
+
+    get_provider_directory.cache_clear()


### PR DESCRIPTION
what: surface a curated server provider registry via /api/v1/server-providers
why: fulfill the roadmap promise for a provider directory so clients can discover relay nodes
how to test:
- pre-commit run --all-files
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68db63bdb680832f9abb9f9848f7d300