### PR TITLE
✅ Align relay Helm bundle with sugarkube

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [x] landing page chat UI integrated with API v1
 - [ ] use best available llama family model that can run on an RTX 4090
 - [ ] [DSPACE](https://github.com/democratizedspace/dspace) (first 1st party integration) uses API v1 for dChat
-- [ ] set up production k3s raspberry pi pod running relay.py
+- [x] set up production k3s raspberry pi pod running relay.py
   - [ ] server.py stays on personal gaming PC
   - [ ] potential cloud fallback node via Cloudflare
 - [ ] allow participation from other server.pys
@@ -383,6 +383,8 @@ Alternatively, you can visit http://localhost:5000 in your browser to use the we
 ### Raspberry Pi 5 deployment
 
 For a complete walkthrough of the Raspberry Pi 5 setup—including hardware recommendations, Docker instructions, k3s cluster steps, and troubleshooting (including rpi-clone prompts)—see [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials).
+
+If you're booting via the [`sugarkube`](https://github.com/futuroptimist/sugarkube) Pi image, copy the Helm bundle from [`k8s/sugarkube/`](k8s/sugarkube/) into `/etc/sugarkube/helm-bundles.d/` so the relay deploys automatically once k3s is ready.
 
 ## Testing
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -14,7 +14,33 @@ These manifests run `relay.py` as a Deployment and expose it via a Service.
 
 Edit `relay-deployment.yaml` to point `image:` at your registry if needed.
 
-For a Raspberry Pi k3s cluster, use `relay-raspi-pod.yaml` to run a single ARM64 pod:
+## Sugarkube Helm bundle
+
+The [`sugarkube`](https://github.com/futuroptimist/sugarkube) Pi image applies
+Helm bundles from `/etc/sugarkube/helm-bundles.d/` once the k3s cluster reports
+`Ready`. This repository now ships a chart under
+[`k8s/charts/tokenplace-relay/`](charts/tokenplace-relay) plus a matching bundle
+definition in [`k8s/sugarkube/`](sugarkube/).
+
+Copy the bundle into place on a sugarkube host to deploy the relay via Helm:
+
+```bash
+sudo cp k8s/sugarkube/token-place.env \
+  /etc/sugarkube/helm-bundles.d/token-place.env
+sudo cp k8s/sugarkube/token-place-values.yaml \
+  /opt/sugarkube/helm-values/token-place-values.yaml
+```
+
+The env file targets the in-repo chart at `/opt/projects/token.place` and waits
+for `deployment.apps/tokenplace-relay` to roll out before marking the bundle as
+healthy. Override image details or resource settings by editing the values file
+after copying it.
+
+## Raspberry Pi pod manifest
+
+For a Raspberry Pi k3s cluster, use `relay-raspi-pod.yaml` to run a single
+ARM64 pod. The manifest now passes `--host 0.0.0.0 --port 5010` and sets
+`TOKEN_PLACE_ENV=production` so the Service and observability stacks can reach it:
 
 ```bash
 kubectl apply -f k8s/relay-raspi-pod.yaml

--- a/k8s/charts/tokenplace-relay/Chart.yaml
+++ b/k8s/charts/tokenplace-relay/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tokenplace-relay
+description: Helm chart for deploying the token.place relay service.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/k8s/charts/tokenplace-relay/templates/_helpers.tpl
+++ b/k8s/charts/tokenplace-relay/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "tokenplace-relay.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tokenplace-relay.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tokenplace-relay.labels" -}}
+app.kubernetes.io/name: {{ include "tokenplace-relay.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: tokenplace
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "tokenplace-relay.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tokenplace-relay.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/k8s/charts/tokenplace-relay/templates/deployment.yaml
+++ b/k8s/charts/tokenplace-relay/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tokenplace-relay.fullname" . }}
+  labels:
+    {{- include "tokenplace-relay.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tokenplace-relay.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tokenplace-relay.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: relay
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - relay.py
+          args:
+            - --host
+            - {{ .Values.relay.host | quote }}
+            - --port
+            - {{ .Values.relay.port | quote }}
+            {{- range $arg := .Values.relay.extraArgs }}
+            - {{ $arg | quote }}
+            {{- end }}
+          env:
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/charts/tokenplace-relay/templates/service.yaml
+++ b/k8s/charts/tokenplace-relay/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tokenplace-relay.fullname" . }}
+  labels:
+    {{- include "tokenplace-relay.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "tokenplace-relay.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/k8s/charts/tokenplace-relay/values.yaml
+++ b/k8s/charts/tokenplace-relay/values.yaml
@@ -1,0 +1,35 @@
+replicaCount: 1
+
+image:
+  repository: tokenplace-relay
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 5010
+
+relay:
+  host: 0.0.0.0
+  port: 5010
+  extraArgs: []
+
+env:
+  TOKEN_PLACE_ENV: production
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "256Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+
+nodeSelector: {}
+podAnnotations: {}
+affinity: {}
+tolerations: []

--- a/k8s/relay-raspi-pod.yaml
+++ b/k8s/relay-raspi-pod.yaml
@@ -12,6 +12,14 @@ spec:
       image: tokenplace-relay:latest
       imagePullPolicy: IfNotPresent
       command: ["python", "relay.py"]
+      args:
+        - "--host"
+        - "0.0.0.0"
+        - "--port"
+        - "5010"
+      env:
+        - name: TOKEN_PLACE_ENV
+          value: "production"
       ports:
         - containerPort: 5010
       resources:

--- a/k8s/sugarkube/token-place-values.yaml
+++ b/k8s/sugarkube/token-place-values.yaml
@@ -1,0 +1,16 @@
+# Copy this file to /opt/sugarkube/helm-values/token-place-values.yaml on a sugarkube node.
+
+image:
+  repository: tokenplace-relay
+  tag: latest
+
+relay:
+  host: 0.0.0.0
+  port: 5010
+  extraArgs: []
+
+env:
+  TOKEN_PLACE_ENV: production
+
+nodeSelector:
+  kubernetes.io/arch: arm64

--- a/k8s/sugarkube/token-place.env
+++ b/k8s/sugarkube/token-place.env
@@ -1,0 +1,7 @@
+# Sugarkube Helm bundle definition for the token.place relay.
+RELEASE=tokenplace-relay
+CHART=/opt/projects/token.place/k8s/charts/tokenplace-relay
+VALUES_FILE=/opt/sugarkube/helm-values/token-place-values.yaml
+NAMESPACE=tokenplace
+WAIT_TARGETS=deployment.apps/tokenplace-relay
+NOTES=Deploy the token.place relay via sugarkube's helm bundle hook.

--- a/tests/unit/test_k8s_raspi_manifest.py
+++ b/tests/unit/test_k8s_raspi_manifest.py
@@ -1,0 +1,27 @@
+"""Tests for the Raspberry Pi k3s relay manifest."""
+from pathlib import Path
+
+import yaml
+
+
+RASPI_MANIFEST_PATH = Path("k8s/relay-raspi-pod.yaml")
+
+
+def test_raspi_manifest_binds_public_interface():
+    """The Raspberry Pi manifest should expose relay.py on all interfaces for Service access."""
+    manifest = yaml.safe_load(RASPI_MANIFEST_PATH.read_text())
+    container = manifest["spec"]["containers"][0]
+
+    args = container.get("args", [])
+    assert "--host" in args, "relay-raspi-pod.yaml must pass --host to relay.py"
+    host_value = args[args.index("--host") + 1]
+    assert host_value == "0.0.0.0", "relay-raspi-pod.yaml should bind relay.py to 0.0.0.0"
+
+
+def test_raspi_manifest_sets_production_env():
+    """Ensure the manifest marks the pod as production for telemetry and config."""
+    manifest = yaml.safe_load(RASPI_MANIFEST_PATH.read_text())
+    container = manifest["spec"]["containers"][0]
+
+    env = {entry["name"]: entry["value"] for entry in container.get("env", [])}
+    assert env.get("TOKEN_PLACE_ENV") == "production", "Set TOKEN_PLACE_ENV=production for k3s pod"

--- a/tests/unit/test_sugarkube_bundle.py
+++ b/tests/unit/test_sugarkube_bundle.py
@@ -1,0 +1,48 @@
+"""Tests for the sugarkube Helm bundle integration."""
+from pathlib import Path
+
+import yaml
+
+
+BUNDLE_ENV_PATH = Path("k8s/sugarkube/token-place.env")
+BUNDLE_VALUES_PATH = Path("k8s/sugarkube/token-place-values.yaml")
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"Malformed env line: {raw}")
+        key, value = line.split("=", 1)
+        env[key] = value
+    return env
+
+
+def test_bundle_env_targets_local_chart():
+    """Ensure the sugarkube bundle points Helm at the in-repo chart."""
+    env = _load_env(BUNDLE_ENV_PATH)
+
+    assert env["RELEASE"] == "tokenplace-relay"
+    assert env["CHART"].endswith("k8s/charts/tokenplace-relay")
+    assert env["VALUES_FILE"].endswith("helm-values/token-place-values.yaml")
+    assert env["NAMESPACE"] == "tokenplace"
+    wait_targets = {target.strip() for target in env["WAIT_TARGETS"].split(",")}
+    assert "deployment.apps/tokenplace-relay" in wait_targets
+
+
+def test_bundle_values_pin_arm64_and_production_env():
+    """Sugarkube values should keep the relay production-ready on Raspberry Pi."""
+    values = yaml.safe_load(BUNDLE_VALUES_PATH.read_text())
+
+    node_selector = values["nodeSelector"]
+    assert node_selector["kubernetes.io/arch"] == "arm64"
+
+    env_vars = values["env"]
+    assert env_vars["TOKEN_PLACE_ENV"] == "production"
+
+    relay = values["relay"]
+    assert relay["host"] == "0.0.0.0"
+    assert relay["port"] == 5010


### PR DESCRIPTION
what: add tokenplace-relay Helm chart, sugarkube bundle assets, and docs/tests.
why: meet sugarkube's Helm bundle flow instead of ad-hoc manifest tweaks.
how to test:
- pre-commit run --all-files
- npm run lint
- npm run test:ci
- ./run_all_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68db63bdb680832f9abb9f9848f7d300