### PR TITLE
Add optional content moderation hooks to chat endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,20 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 | API_DAILY_QUOTA | 1000/day     | Per-IP daily request quota                                        |
 | USE_MOCK_LLM    | 0            | Use mock LLM instead of downloading a model (`1` to enable)        |
 | TOKEN_PLACE_ENV | development  | Deployment environment (`development`, `testing`, `production`)    |
+| CONTENT_MODERATION_MODE | disabled     | Set to `block` to enable request filtering before inference           |
+| CONTENT_MODERATION_BLOCKLIST | (defaults)  | Comma-separated phrases added to the default safety blocklist         |
+| CONTENT_MODERATION_INCLUDE_DEFAULTS | 1            | Set to `0` to skip the built-in phrases when filtering requests        |
 | PROD_API_HOST   | 127.0.0.1    | IP address for production API host                                |
 
 The development requirements live in [requirements.txt](requirements.txt).
+
+### Content moderation hooks
+
+Set `CONTENT_MODERATION_MODE=block` to enable pre-inference moderation for both
+`/api/v1/chat/completions` and `/api/v1/completions`.
+Requests containing phrases from the built-in safety blocklist (or any terms supplied via
+`CONTENT_MODERATION_BLOCKLIST`) are rejected with a standardized `content_policy_violation` error before they reach the model.
+Set `CONTENT_MODERATION_INCLUDE_DEFAULTS=0` if you only want to enforce your custom blocklist.
 
 Run the relay and server in separate terminals:
 
@@ -165,7 +176,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [ ] Enhanced encryption options for model weights and inference data
   - [ ] Key rotation for relay and server certificates
 - [x] Signed relay binaries for client verification
-- [ ] Optional content moderation hooks
+- [x] Optional content moderation hooks
 - [ ] External security review of protocol and code
 - [ ] Community features
   - [x] Server provider directory/registry
@@ -577,8 +588,8 @@ Request body:
 ```
 GET /api/v1/community/providers
 ```
-Lists community-operated relay nodes and server operators that have opted into the public registry.  
-Each entry includes the provider identifier, advertised region, contact details, current status, and the exposed endpoint URLs so clients can preselect a compatible provider.  
+Lists community-operated relay nodes and server operators that have opted into the public registry.
+Each entry includes the provider identifier, advertised region, contact details, current status, and the exposed endpoint URLs so clients can preselect a compatible provider.
 A representative latency measurement may also be included to help clients pick a nearby relay.
 
 Example response snippet:

--- a/api/v1/moderation.py
+++ b/api/v1/moderation.py
@@ -1,0 +1,129 @@
+"""Content moderation utilities for token.place API endpoints."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Optional, Sequence, Union, Any
+
+DEFAULT_BLOCKLIST = (
+    "build a bomb",
+    "harm humans",
+    "kill",
+    "make a weapon",
+    "weaponize",
+)
+
+
+@dataclass
+class ModerationDecision:
+    """Represents the outcome of evaluating a message payload."""
+
+    allowed: bool
+    reason: Optional[str] = None
+    matched_term: Optional[str] = None
+    flagged_text: Optional[str] = None
+
+    @property
+    def status(self) -> str:
+        return "allowed" if self.allowed else "blocked"
+
+
+Message = Mapping[str, Any]
+MessageSequence = Sequence[Message]
+ContentType = Union[str, Sequence[Mapping[str, Any]], Mapping[str, Any]]
+
+
+def _get_mode() -> str:
+    mode = os.getenv("CONTENT_MODERATION_MODE", "disabled").strip().lower()
+    if mode in {"1", "true", "on"}:
+        return "block"
+    return mode
+
+
+def _get_blocklist() -> List[str]:
+    extra_terms = [
+        term.strip().lower()
+        for term in os.getenv("CONTENT_MODERATION_BLOCKLIST", "").split(",")
+        if term.strip()
+    ]
+
+    include_defaults = os.getenv("CONTENT_MODERATION_INCLUDE_DEFAULTS", "1").strip().lower()
+    use_defaults = include_defaults not in {"0", "false", "no", "off"}
+
+    blocklist: List[str] = []
+    if use_defaults:
+        blocklist.extend(term.lower() for term in DEFAULT_BLOCKLIST)
+    blocklist.extend(extra_terms)
+
+    # Deduplicate while preserving order
+    seen = set()
+    unique_terms = []
+    for term in blocklist:
+        if term not in seen:
+            unique_terms.append(term)
+            seen.add(term)
+    return unique_terms
+
+
+def _iter_text_fragments(content: ContentType) -> Iterable[str]:
+    if isinstance(content, str):
+        yield content
+        return
+
+    if isinstance(content, Mapping):
+        text = content.get("text")
+        if isinstance(text, str):
+            yield text
+        elif isinstance(text, (list, tuple)):
+            for fragment in text:
+                yield from _iter_text_fragments(fragment)
+        return
+
+    if isinstance(content, Sequence):
+        for item in content:
+            if isinstance(item, Mapping):
+                if item.get("type") == "text" and isinstance(item.get("text"), str):
+                    yield item["text"]
+                else:
+                    yield from _iter_text_fragments(item)
+            elif isinstance(item, str):
+                yield item
+        return
+
+
+def evaluate_messages_for_policy(messages: MessageSequence) -> ModerationDecision:
+    """Evaluate chat messages against the configured moderation policy."""
+
+    mode = _get_mode()
+    if mode in {"disabled", "off", "none", ""}:
+        return ModerationDecision(allowed=True)
+
+    blocklist = _get_blocklist()
+    if not blocklist:
+        return ModerationDecision(allowed=True)
+
+    for message in messages:
+        content = message.get("content") if isinstance(message, Mapping) else None
+        if content is None:
+            continue
+
+        for fragment in _iter_text_fragments(content):
+            normalized = fragment.lower()
+            for term in blocklist:
+                if term and term in normalized:
+                    reason = (
+                        "Request blocked by content moderation policy: "
+                        f"matched banned term '{term}'."
+                    )
+                    return ModerationDecision(
+                        allowed=False,
+                        reason=reason,
+                        matched_term=term,
+                        flagged_text=fragment,
+                    )
+
+    return ModerationDecision(allowed=True)
+
+
+__all__ = ["ModerationDecision", "evaluate_messages_for_policy"]

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -12,6 +12,7 @@ import logging
 import os
 
 from api.v1.encryption import encryption_manager
+from api.v1.moderation import evaluate_messages_for_policy
 from api.v1.community import (
     get_provider_directory as _get_community_provider_directory,
     CommunityDirectoryError,
@@ -257,7 +258,7 @@ def list_server_providers():
         response_payload["metadata"] = metadata
 
     return jsonify(response_payload)
-  
+
 
 @v1_bp.route('/chat/completions', methods=['POST'])
 def create_chat_completion():
@@ -370,6 +371,19 @@ def create_chat_completion():
                     param=e.field,
                     code=e.code,
                     status_code=400
+                )
+
+            decision = evaluate_messages_for_policy(messages)
+            if not decision.allowed:
+                log_warning(
+                    "Blocking chat completion request due to content policy violation: %s"
+                    % (decision.matched_term or "unknown term")
+                )
+                return format_error_response(
+                    decision.reason or "Request blocked by content moderation policy.",
+                    error_type="content_policy_violation",
+                    code="content_blocked",
+                    status_code=400,
                 )
 
             # Generate response using the specified model
@@ -544,6 +558,19 @@ def create_completion():
                 "content": prompt,
             }
         ]
+
+        decision = evaluate_messages_for_policy(messages)
+        if not decision.allowed:
+            log_warning(
+                "Blocking legacy completion request due to content policy violation: %s"
+                % (decision.matched_term or "unknown term")
+            )
+            return format_error_response(
+                decision.reason or "Request blocked by content moderation policy.",
+                error_type="content_policy_violation",
+                code="content_blocked",
+                status_code=400,
+            )
 
         # Generate response
         try:

--- a/docs/SECURITY_PRIVACY_AUDIT.md
+++ b/docs/SECURITY_PRIVACY_AUDIT.md
@@ -41,7 +41,6 @@ Initial audit establishing baseline security and privacy posture.
 - Improved test reliability by explicitly passing mock LLM flags and fixing encoding issues.
 
 **Recommendations**
-- Implement content safety measures to prevent misuse of the system.
 - Add rate limiting to protect against DoS attacks.
 - Move sensitive configuration values to environment variables.
 - Enhance input validation for all API endpoints.
@@ -85,6 +84,7 @@ Refined logging helpers to avoid swallowing system interrupt exceptions.
 - Updated `log_info` and `log_error` to catch only standard exceptions, allowing
   `KeyboardInterrupt` and `SystemExit` to propagate.
 - Ensured `log_error` always logs messages even in production.
+- Added configurable content moderation hooks that reject disallowed prompts before inference.
 
 **Recommendations**
 - Continue monitoring logging utilities for unintended side effects.

--- a/tests/unit/test_api_v1_moderation_utils.py
+++ b/tests/unit/test_api_v1_moderation_utils.py
@@ -1,0 +1,99 @@
+import pytest
+
+from api.v1 import moderation
+
+
+def test_get_mode_interprets_truthy_values(monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "  TrUe ")
+    assert moderation._get_mode() == "block"
+
+
+def test_get_mode_returns_normalized_mode(monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", " Audit ")
+    assert moderation._get_mode() == "audit"
+
+
+def test_get_blocklist_includes_defaults_and_extra_terms(monkeypatch):
+    monkeypatch.delenv("CONTENT_MODERATION_INCLUDE_DEFAULTS", raising=False)
+    monkeypatch.setenv("CONTENT_MODERATION_BLOCKLIST", " Alpha ,  Beta  ")
+
+    blocklist = moderation._get_blocklist()
+
+    assert blocklist[: len(moderation.DEFAULT_BLOCKLIST)] == [
+        term.lower() for term in moderation.DEFAULT_BLOCKLIST
+    ]
+    assert blocklist[-2:] == ["alpha", "beta"]
+
+
+def test_get_blocklist_deduplicates_and_respects_defaults_flag(monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_INCLUDE_DEFAULTS", "0")
+    monkeypatch.setenv("CONTENT_MODERATION_BLOCKLIST", " Foo , foo, Bar ")
+
+    blocklist = moderation._get_blocklist()
+
+    assert blocklist == ["foo", "bar"]
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ("plain text", ["plain text"]),
+        ({"text": ["part", {"text": "nested"}]}, ["part", "nested"]),
+        (
+            [
+                "alpha",
+                {"type": "text", "text": "beta"},
+                {"type": "other", "text": ["gamma", {"text": "delta"}]},
+            ],
+            ["alpha", "beta", "gamma", "delta"],
+        ),
+    ],
+)
+def test_iter_text_fragments_handles_various_structures(content, expected):
+    assert list(moderation._iter_text_fragments(content)) == expected
+
+
+def test_evaluate_messages_allows_when_disabled(monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "disabled")
+
+    decision = moderation.evaluate_messages_for_policy([
+        {"role": "user", "content": "anything"}
+    ])
+
+    assert decision.allowed is True
+    assert decision.reason is None
+
+
+def test_evaluate_messages_allows_when_blocklist_empty(monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "block")
+    monkeypatch.setenv("CONTENT_MODERATION_INCLUDE_DEFAULTS", "false")
+    monkeypatch.delenv("CONTENT_MODERATION_BLOCKLIST", raising=False)
+
+    decision = moderation.evaluate_messages_for_policy([
+        {"role": "user", "content": "still allowed"}
+    ])
+
+    assert decision.allowed is True
+
+
+def test_evaluate_messages_blocks_on_nested_fragment(monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "block")
+    monkeypatch.setenv("CONTENT_MODERATION_INCLUDE_DEFAULTS", "0")
+    monkeypatch.setenv("CONTENT_MODERATION_BLOCKLIST", "danger")
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "safe"},
+                {"type": "other", "text": ["The danger is here"]},
+            ],
+        }
+    ]
+
+    decision = moderation.evaluate_messages_for_policy(messages)
+
+    assert decision.allowed is False
+    assert decision.matched_term == "danger"
+    assert decision.flagged_text == "The danger is here"
+    assert "danger" in (decision.reason or "").lower()

--- a/tests/unit/test_api_v1_routes_moderation.py
+++ b/tests/unit/test_api_v1_routes_moderation.py
@@ -1,0 +1,62 @@
+import pytest
+
+from api.v1 import routes
+from relay import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_chat_completion_blocked_by_content_policy(client, monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "block")
+    monkeypatch.setenv("CONTENT_MODERATION_BLOCKLIST", "forbidden")
+
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "test-model"}])
+    monkeypatch.setattr(routes, "get_model_instance", lambda model_id: object())
+    monkeypatch.setattr(
+        routes,
+        "generate_response",
+        lambda model_id, messages: messages + [{"role": "assistant", "content": "ack"}],
+    )
+
+    payload = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "This text is clearly forbidden."}],
+    }
+
+    response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"]["type"] == "content_policy_violation"
+    assert body["error"]["code"] == "content_blocked"
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+def test_text_completion_blocked_by_content_policy(client, monkeypatch):
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "block")
+    monkeypatch.setenv("CONTENT_MODERATION_BLOCKLIST", "forbidden")
+
+    monkeypatch.setattr(routes, "get_model_instance", lambda model_id: object())
+
+    def _generate(model_id, messages):
+        return messages + [{"role": "assistant", "content": "ack"}]
+
+    monkeypatch.setattr(routes, "generate_response", _generate)
+
+    payload = {
+        "model": "test-model",
+        "prompt": "Make something forbidden",
+    }
+
+    response = client.post("/api/v1/completions", json=payload)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"]["type"] == "content_policy_violation"
+    assert body["error"]["code"] == "content_blocked"
+    assert "forbidden" in body["error"]["message"].lower()


### PR DESCRIPTION
## Summary
- add a reusable moderation helper that enforces configurable blocklists before inference
- gate the chat and legacy completions endpoints to surface `content_policy_violation` errors when text is blocked
- cover the new behaviour with unit tests and document the moderation configuration and audit log update

## Testing
- pre-commit run --all-files *(fails on Helm templates; reran with SKIP=check-yaml)*
- SKIP=check-yaml pre-commit run --all-files
- npm run lint
- npm run test:ci
- detect-secrets scan $(git diff --cached --name-only)

------
https://chatgpt.com/codex/tasks/task_e_68dc4c8b6fc8832f9c123c2db63be173