### PR TITLE
Add uppercase data URL coverage for vision analyzer

### DIFF
--- a/docs/TESTING_IMPROVEMENTS.md
+++ b/docs/TESTING_IMPROVEMENTS.md
@@ -79,6 +79,8 @@ python -m pytest --cov=. --cov-report=term-missing
 
 - ✅ Added regression coverage for `utils.system.resource_monitor.collect_resource_usage`
   to ensure CPU/memory metrics degrade gracefully when `psutil` raises errors.
+- ✅ Added data-URL normalisation tests for `utils.vision.image_analysis` so uppercase
+  `DATA:` prefixes stay decodable across platforms.
 
 ## ✅ 8. Snapshot Testing (IMPLEMENTED)
 

--- a/tests/unit/test_utils_vision_image_analysis.py
+++ b/tests/unit/test_utils_vision_image_analysis.py
@@ -82,6 +82,19 @@ def test_analyze_base64_image_orientation_variants(monkeypatch):
     assert analysis["height"] is None
 
 
+def test_analyze_base64_image_accepts_uppercase_data_scheme():
+    """Data URLs should be handled case-insensitively."""
+
+    payload = base64.b64encode(_make_png(2, 1)).decode()
+    uppercase_url = f"DATA:image/png;base64,{payload}"
+
+    analysis = ia.analyze_base64_image(uppercase_url)
+
+    assert analysis["format"] == "png"
+    assert analysis["width"] == 2
+    assert analysis["height"] == 1
+
+
 def test_summarize_analysis_variants():
     single = {"format": "png", "width": 1, "height": 2, "size_bytes": 42, "orientation": "portrait"}
     assert ia.summarize_analysis(single) == "Vision analysis: PNG image, 1x2 px, 42 bytes, portrait orientation."
@@ -92,4 +105,3 @@ def test_summarize_analysis_variants():
     assert "2. UNKNOWN image" in summary
 
     assert ia.summarize_analysis([]) == "Vision analysis unavailable."
-

--- a/utils/vision/image_analysis.py
+++ b/utils/vision/image_analysis.py
@@ -13,10 +13,11 @@ AnalysisRecord = Dict[str, Optional[Union[str, int]]]
 
 def _strip_data_url(encoded: str) -> str:
     """Remove any data URL prefix from a base64 string."""
-    if encoded.startswith("data:"):
-        _, _, payload = encoded.partition(",")
+    trimmed = encoded.lstrip()
+    if trimmed[:5].lower() == "data:":
+        _, _, payload = trimmed.partition(",")
         return payload.strip()
-    return encoded.strip()
+    return trimmed.strip()
 
 
 def _decode_base64_image(encoded: str) -> bytes:
@@ -161,4 +162,3 @@ def summarize_analysis(
 
     enumerated = [f"{idx}. {line}" for idx, line in enumerate(lines, start=1)]
     return "Vision analysis:\n" + "\n".join(enumerated)
-


### PR DESCRIPTION
## Summary
- normalize the `_strip_data_url` helper so uppercase `DATA:` schemes and leading whitespace are handled
- add a regression test covering uppercase data URLs and document the new coverage in testing improvements

## Testing
- npm run lint
- npm run test:ci
- ./run_all_tests.sh
- SKIP=end-of-file-fixer,check-yaml,vulture pre-commit run --all-files (skipped templated Helm YAML and external newline fixes)


------
https://chatgpt.com/codex/tasks/task_e_68debfd09840832f80e58a63fe3c50d3