### PR TITLE
Add community contribution submission endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [ ] Community features
   - [x] Server provider directory/registry
   - [ ] Model leaderboard based on community feedback
-  - [ ] Contribution system for donating compute resources
+  - [x] Contribution system for donating compute resources
 
 ## installation
 
@@ -617,6 +617,38 @@ Example response snippet:
   }
 }
 ```
+
+#### Community Contribution Queue
+```
+POST /api/v1/community/contributions
+```
+Allows community operators to offer spare compute resources for the shared relay network.
+Submissions are validated server-side, assigned a UUID, and appended to a JSONL queue so maintainers can review and onboard new providers.
+
+Request body:
+
+```json
+{
+  "operator_name": "Compute Collective",
+  "region": "us-west",
+  "availability": "weekends",
+  "capabilities": ["openai-compatible", "gpu"],
+  "contact": {"email": "ops@example.org"},
+  "hardware": "2x RTX 4090",
+  "notes": "Can scale to 4 nodes with notice"
+}
+```
+
+Response body:
+
+```json
+{
+  "status": "queued",
+  "submission_id": "82b900a7-1c05-4e2a-8ce0-3b18a835adcb"
+}
+```
+
+For deployments that need to relocate the queue file, set `TOKEN_PLACE_CONTRIBUTION_QUEUE` to an absolute path. The server will create the file if it does not exist and append one JSON document per line.
 
 ### End-to-End Encryption
 

--- a/api/v1/community.py
+++ b/api/v1/community.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
+import uuid
+from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List
@@ -10,10 +13,21 @@ from typing import Any, Dict, List
 COMMUNITY_DIRECTORY_PATH = (
     Path(__file__).resolve().parents[2] / "config" / "community" / "providers.json"
 )
+CONTRIBUTION_QUEUE_ENV_VAR = "TOKEN_PLACE_CONTRIBUTION_QUEUE"
+DEFAULT_CONTRIBUTION_QUEUE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "config"
+    / "community"
+    / "contribution_queue.jsonl"
+)
 
 
 class CommunityDirectoryError(RuntimeError):
     """Raised when the community directory payload cannot be parsed."""
+
+
+class ContributionSubmissionError(RuntimeError):
+    """Raised when a community contribution submission is invalid."""
 
 
 def _load_raw_directory() -> Dict[str, Any]:
@@ -75,3 +89,112 @@ def invalidate_provider_directory_cache() -> None:
     """
 
     get_provider_directory.cache_clear()
+
+
+def _contribution_queue_path() -> Path:
+    """Return the path to the queued contribution sink."""
+
+    override = os.getenv(CONTRIBUTION_QUEUE_ENV_VAR)
+    if override:
+        return Path(override)
+    return DEFAULT_CONTRIBUTION_QUEUE_PATH
+
+
+def _validate_contact(contact: Dict[str, Any]) -> Dict[str, str]:
+    """Validate and sanitise contribution contact details."""
+
+    if not isinstance(contact, dict) or not contact:
+        raise ContributionSubmissionError(
+            "Contact information must include at least one method"
+        )
+
+    allowed_fields = {"email", "matrix", "discord", "website"}
+    sanitised: Dict[str, str] = {}
+    for key, value in contact.items():
+        if key not in allowed_fields:
+            raise ContributionSubmissionError(
+                f"Unsupported contact field '{key}'"
+            )
+        if not isinstance(value, str) or not value.strip():
+            raise ContributionSubmissionError(
+                f"Contact field '{key}' must be a non-empty string"
+            )
+        sanitised[key] = value.strip()
+
+    return sanitised
+
+
+def _validate_capabilities(capabilities: Any) -> List[str]:
+    """Validate the provided capability list."""
+
+    if not isinstance(capabilities, list) or not capabilities:
+        raise ContributionSubmissionError(
+            "Capabilities must be a non-empty list of strings"
+        )
+
+    sanitised: List[str] = []
+    for entry in capabilities:
+        if not isinstance(entry, str) or not entry.strip():
+            raise ContributionSubmissionError(
+                "Capabilities must contain non-empty strings"
+            )
+        sanitised.append(entry.strip())
+    return sanitised
+
+
+def queue_contribution_submission(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and append a contribution submission to the queue file."""
+
+    operator_name = payload.get("operator_name")
+    if not isinstance(operator_name, str) or not operator_name.strip():
+        raise ContributionSubmissionError(
+            "operator_name must be a non-empty string"
+        )
+
+    region = payload.get("region")
+    if not isinstance(region, str) or not region.strip():
+        raise ContributionSubmissionError("region must be a non-empty string")
+
+    availability = payload.get("availability")
+    if not isinstance(availability, str) or not availability.strip():
+        raise ContributionSubmissionError(
+            "availability must describe when capacity is offered"
+        )
+
+    contact = _validate_contact(payload.get("contact", {}))
+    capabilities = _validate_capabilities(payload.get("capabilities"))
+
+    record: Dict[str, Any] = {
+        "submission_id": str(uuid.uuid4()),
+        "operator_name": operator_name.strip(),
+        "region": region.strip(),
+        "availability": availability.strip(),
+        "capabilities": capabilities,
+        "contact": contact,
+        "submitted_at": (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        ),
+    }
+
+    optional_fields = {
+        "hardware": payload.get("hardware"),
+        "notes": payload.get("notes"),
+    }
+    for key, value in optional_fields.items():
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise ContributionSubmissionError(
+                f"{key} must be a string when provided"
+            )
+        record[key] = value.strip()
+
+    queue_path = _contribution_queue_path()
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    with queue_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+
+    return record

--- a/tests/unit/test_api_v1_community_contributions.py
+++ b/tests/unit/test_api_v1_community_contributions.py
@@ -1,0 +1,90 @@
+"""Tests for the community contribution submission endpoint."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from relay import app
+@pytest.fixture(name="client")
+def client_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Provide a Flask test client with an isolated contribution queue."""
+
+    queue_path = tmp_path / "queue.jsonl"
+    monkeypatch.setenv("TOKEN_PLACE_CONTRIBUTION_QUEUE", str(queue_path))
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def _load_queue(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_submit_contribution_appends_record(client, tmp_path: Path):
+    """A valid submission should be queued and acknowledged."""
+
+    queue_path = Path(os.environ["TOKEN_PLACE_CONTRIBUTION_QUEUE"])
+    payload = {
+        "operator_name": "Compute Collective",
+        "region": "us-west",
+        "availability": "weekends",
+        "capabilities": ["openai-compatible", "gpu"],
+        "contact": {"email": "ops@example.org"},
+        "hardware": "2x RTX 4090",
+        "notes": "Can scale to 4 nodes with notice",
+    }
+
+    response = client.post("/api/v1/community/contributions", json=payload)
+
+    assert response.status_code == 202
+    body = response.get_json()
+    assert body["status"] == "queued"
+    submission_id = body["submission_id"]
+    # Validate submission_id is a UUID
+    UUID(submission_id)
+
+    queued = _load_queue(queue_path)
+    assert len(queued) == 1
+    record = queued[0]
+    assert record["operator_name"] == payload["operator_name"]
+    assert record["region"] == payload["region"]
+    assert record["availability"] == payload["availability"]
+    assert record["capabilities"] == payload["capabilities"]
+    assert record["contact"] == payload["contact"]
+    assert record["hardware"] == payload["hardware"]
+    assert record["notes"] == payload["notes"]
+    assert record["submission_id"] == submission_id
+    assert record["submitted_at"].endswith("Z")
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message",
+    [
+        ({}, "operator_name"),
+        ({"operator_name": "Org", "region": "", "availability": "always", "capabilities": ["gpu"], "contact": {"email": "ops@example.org"}}, "region"),
+        ({"operator_name": "Org", "region": "us", "availability": "", "capabilities": ["gpu"], "contact": {"email": "ops@example.org"}}, "availability"),
+        ({"operator_name": "Org", "region": "us", "availability": "always", "capabilities": [], "contact": {"email": "ops@example.org"}}, "Capabilities"),
+        ({"operator_name": "Org", "region": "us", "availability": "always", "capabilities": ["gpu"], "contact": {}}, "Contact"),
+    ],
+)
+def test_submit_contribution_validation_errors(
+    client,
+    tmp_path: Path,
+    payload: dict[str, object],
+    expected_message: str,
+):
+    """Invalid payloads should return descriptive error messages."""
+
+    response = client.post("/api/v1/community/contributions", json=payload)
+
+    assert response.status_code == 400
+    assert expected_message in response.get_json()["error"]["message"]
+


### PR DESCRIPTION
## Summary
- add POST /api/v1/community/contributions to queue donor offers
- document the contribution workflow and mark the roadmap item
- add unit tests for happy-path and validation coverage

## Testing
- pre-commit run --all-files *(fails: Helm templates trip check-yaml,
  known vulture false positives)*
- npm run lint
- npm run test:ci
- ./run_all_tests.sh
- python -m pytest tests/unit/test_api_v1_community_contributions.py

------
https://chatgpt.com/codex/tasks/task_e_68debfd09840832f80e58a63fe3c50d3