### PR TITLE
Add community model leaderboard endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [ ] External security review of protocol and code
 - [ ] Community features
   - [x] Server provider directory/registry
-  - [ ] Model leaderboard based on community feedback
+  - [x] Model leaderboard based on community feedback
   - [x] Contribution system for donating compute resources
 
 ## installation
@@ -624,6 +624,29 @@ Example response snippet:
   "metadata": {
     "updated_at": "2025-02-15T00:00:00Z"
   }
+}
+```
+
+#### Community Model Leaderboard
+```
+GET /api/v1/community/leaderboard
+```
+Aggregates community ratings for deployed models, returning the highest-rated experiences first.
+Each entry reports the average rating, number of submitted votes, and the most recent feedback timestamp so client applications can highlight trending models.
+
+Example response snippet:
+
+```json
+{
+  "entries": [
+    {
+      "model_id": "anthropic/claude-3.5-sonnet",
+      "average_rating": 4.8,
+      "ratings_count": 27,
+      "last_feedback_at": "2024-12-19T09:10:00Z"
+    }
+  ],
+  "updated": "2024-12-19T09:10:00Z"
 }
 ```
 

--- a/api/v1/community.py
+++ b/api/v1/community.py
@@ -136,7 +136,12 @@ def _parse_timestamp(timestamp: Any, line_no: int) -> datetime | None:
     try:
         if value.endswith("Z"):
             value = value[:-1] + "+00:00"
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            raise ModelFeedbackError(
+                f"submitted_at must include timezone information (line {line_no})"
+            )
+        return parsed.astimezone(timezone.utc)
     except ValueError as exc:
         raise ModelFeedbackError(
             f"submitted_at must be an ISO-8601 string (line {line_no})"

--- a/api/v1/community.py
+++ b/api/v1/community.py
@@ -8,7 +8,16 @@ import uuid
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
+
+
+MODEL_FEEDBACK_ENV_VAR = "TOKEN_PLACE_MODEL_FEEDBACK_PATH"
+DEFAULT_MODEL_FEEDBACK_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "config"
+    / "community"
+    / "model_feedback.jsonl"
+)
 
 COMMUNITY_DIRECTORY_PATH = (
     Path(__file__).resolve().parents[2] / "config" / "community" / "providers.json"
@@ -28,6 +37,10 @@ class CommunityDirectoryError(RuntimeError):
 
 class ContributionSubmissionError(RuntimeError):
     """Raised when a community contribution submission is invalid."""
+
+
+class ModelFeedbackError(RuntimeError):
+    """Raised when community feedback data cannot be processed."""
 
 
 def _load_raw_directory() -> Dict[str, Any]:
@@ -98,6 +111,176 @@ def _contribution_queue_path() -> Path:
     if override:
         return Path(override)
     return DEFAULT_CONTRIBUTION_QUEUE_PATH
+
+
+def _model_feedback_path() -> Path:
+    """Return the path containing community feedback entries."""
+
+    override = os.getenv(MODEL_FEEDBACK_ENV_VAR)
+    if override:
+        return Path(override)
+    return DEFAULT_MODEL_FEEDBACK_PATH
+
+
+def _parse_timestamp(timestamp: Any, line_no: int) -> datetime | None:
+    """Parse optional ISO-8601 timestamps from feedback entries."""
+
+    if timestamp is None:
+        return None
+    if not isinstance(timestamp, str) or not timestamp.strip():
+        raise ModelFeedbackError(
+            f"submitted_at must be an ISO-8601 string (line {line_no})"
+        )
+
+    value = timestamp.strip()
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ModelFeedbackError(
+            f"submitted_at must be an ISO-8601 string (line {line_no})"
+        ) from exc
+
+
+def _format_timestamp(value: datetime | None) -> str | None:
+    """Serialise timestamps back to a standardised ISO-8601 string."""
+
+    if value is None:
+        return None
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _normalise_feedback_entry(entry: Dict[str, Any], line_no: int) -> Dict[str, Any]:
+    """Validate and normalise a single feedback entry."""
+
+    model_id = entry.get("model_id")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise ModelFeedbackError(f"model_id is required (line {line_no})")
+
+    raw_rating = entry.get("rating")
+    if not isinstance(raw_rating, (int, float)):
+        raise ModelFeedbackError(f"rating must be numeric (line {line_no})")
+
+    rating = float(raw_rating)
+    if not (1.0 <= rating <= 5.0):
+        raise ModelFeedbackError(
+            f"rating must be between 1 and 5 inclusive (line {line_no})"
+        )
+
+    weight = entry.get("votes") or entry.get("count") or entry.get("weight") or 1
+    if not isinstance(weight, int) or weight < 1:
+        raise ModelFeedbackError(f"votes/count must be a positive integer (line {line_no})")
+
+    submitted_at = _parse_timestamp(entry.get("submitted_at"), line_no)
+
+    return {
+        "model_id": model_id.strip(),
+        "rating": rating,
+        "weight": weight,
+        "submitted_at": submitted_at,
+    }
+
+
+@lru_cache(maxsize=1)
+def _load_feedback_entries() -> Tuple[Dict[str, Any], ...]:
+    """Load raw community feedback entries from disk."""
+
+    path = _model_feedback_path()
+    if not path.exists():
+        return ()
+
+    entries: List[Dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, raw_line in enumerate(handle, 1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+                    raise ModelFeedbackError(
+                        f"Invalid JSON in feedback file (line {line_no})"
+                    ) from exc
+                entries.append(_normalise_feedback_entry(payload, line_no))
+    except OSError as exc:  # pragma: no cover - IO errors should surface clearly
+        raise ModelFeedbackError("Unable to read community feedback file") from exc
+
+    return tuple(entries)
+
+
+def invalidate_model_feedback_cache() -> None:
+    """Clear cached feedback entries."""
+
+    _load_feedback_entries.cache_clear()
+
+
+def get_model_leaderboard(limit: int | None = None) -> Dict[str, Any]:
+    """Aggregate community ratings into a leaderboard payload."""
+
+    if limit is not None:
+        if not isinstance(limit, int) or limit <= 0:
+            raise ModelFeedbackError("limit must be a positive integer")
+
+    entries = list(_load_feedback_entries())
+    if not entries:
+        return {"entries": [], "updated": None}
+
+    aggregates: Dict[str, Dict[str, Any]] = {}
+    latest_timestamp: datetime | None = None
+
+    for entry in entries:
+        model_id = entry["model_id"]
+        weight = entry["weight"]
+        rating = entry["rating"]
+        submitted_at = entry["submitted_at"]
+
+        bucket = aggregates.setdefault(
+            model_id,
+            {
+                "model_id": model_id,
+                "total_rating": 0.0,
+                "ratings_count": 0,
+                "last_feedback_at": None,
+            },
+        )
+
+        bucket["total_rating"] += rating * weight
+        bucket["ratings_count"] += weight
+
+        if submitted_at is not None:
+            if bucket["last_feedback_at"] is None or submitted_at > bucket["last_feedback_at"]:
+                bucket["last_feedback_at"] = submitted_at
+            if latest_timestamp is None or submitted_at > latest_timestamp:
+                latest_timestamp = submitted_at
+
+    leaderboard_entries: List[Dict[str, Any]] = []
+    for bucket in aggregates.values():
+        average = bucket["total_rating"] / bucket["ratings_count"]
+        leaderboard_entries.append(
+            {
+                "model_id": bucket["model_id"],
+                "average_rating": round(average, 2),
+                "ratings_count": bucket["ratings_count"],
+                "last_feedback_at": _format_timestamp(bucket["last_feedback_at"]),
+            }
+        )
+
+    leaderboard_entries.sort(
+        key=lambda item: (
+            -item["average_rating"],
+            -item["ratings_count"],
+            item["model_id"],
+        )
+    )
+
+    if limit is not None:
+        leaderboard_entries = leaderboard_entries[:limit]
+
+    updated = _format_timestamp(latest_timestamp)
+
+    return {"entries": leaderboard_entries, "updated": updated}
 
 
 def _validate_contact(contact: Dict[str, Any]) -> Dict[str, str]:

--- a/config/community/model_feedback.jsonl
+++ b/config/community/model_feedback.jsonl
@@ -1,0 +1,3 @@
+{"model_id": "openai/gpt-4o-mini", "rating": 4.7, "votes": 18, "submitted_at": "2024-12-18T22:45:00Z"}
+{"model_id": "meta/llama-3.1-8b-instruct", "rating": 4.4, "votes": 11, "submitted_at": "2024-12-15T18:30:00Z"}
+{"model_id": "anthropic/claude-3.5-sonnet", "rating": 4.8, "votes": 27, "submitted_at": "2024-12-19T09:10:00Z"}

--- a/tests/unit/test_api_v1_community_leaderboard.py
+++ b/tests/unit/test_api_v1_community_leaderboard.py
@@ -1,0 +1,80 @@
+"""Tests for the community feedback leaderboard endpoints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from api.v1 import community
+from relay import app
+
+
+FEEDBACK_ENV_VAR = "TOKEN_PLACE_MODEL_FEEDBACK_PATH"
+
+
+def _write_feedback_file(path: Path, entries: list[dict[str, object]]) -> None:
+    lines = [json.dumps(entry) for entry in entries]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture(name="feedback_file")
+def feedback_file_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Provide an isolated feedback store for leaderboard tests."""
+
+    path = tmp_path / "feedback.jsonl"
+    monkeypatch.setenv(FEEDBACK_ENV_VAR, str(path))
+    yield path
+
+
+def _prepare_feedback(entries: list[dict[str, object]], feedback_file: Path) -> None:
+    _write_feedback_file(feedback_file, entries)
+    community.invalidate_model_feedback_cache()
+
+
+def test_model_leaderboard_orders_by_rating(feedback_file: Path) -> None:
+    """Models with higher community ratings should lead the leaderboard."""
+
+    _prepare_feedback(
+        [
+            {"model_id": "gpt-4o", "rating": 5, "submitted_at": "2024-08-01T12:00:00Z"},
+            {"model_id": "gpt-4o", "rating": 4, "submitted_at": "2024-08-02T12:00:00Z"},
+            {"model_id": "mixtral", "rating": 5, "submitted_at": "2024-08-03T12:00:00Z"},
+            {"model_id": "mixtral", "rating": 3, "submitted_at": "2024-08-04T12:00:00Z"},
+            {"model_id": "llama-3", "rating": 4, "submitted_at": "2024-08-05T12:00:00Z"},
+            {"model_id": "llama-3", "rating": 4, "submitted_at": "2024-08-06T12:00:00Z"},
+        ],
+        feedback_file,
+    )
+
+    leaderboard = community.get_model_leaderboard()
+    entries = leaderboard["entries"]
+
+    assert [entry["model_id"] for entry in entries] == ["gpt-4o", "llama-3", "mixtral"]
+    assert entries[0]["average_rating"] == pytest.approx(4.5)
+    assert entries[0]["ratings_count"] == 2
+    assert leaderboard["updated"] == "2024-08-06T12:00:00Z"
+
+
+def test_leaderboard_endpoint_applies_limit(feedback_file: Path) -> None:
+    """The HTTP endpoint should honour the limit query parameter."""
+
+    _prepare_feedback(
+        [
+            {"model_id": "gpt-4o", "rating": 5, "submitted_at": "2024-08-01T12:00:00Z"},
+            {"model_id": "sonnet", "rating": 5, "submitted_at": "2024-08-02T12:00:00Z"},
+            {"model_id": "mixtral", "rating": 4, "submitted_at": "2024-08-03T12:00:00Z"},
+        ],
+        feedback_file,
+    )
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        response = client.get("/api/v1/community/leaderboard?limit=1")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert len(payload["entries"]) == 1
+    assert payload["entries"][0]["model_id"] == "gpt-4o"
+


### PR DESCRIPTION
## Summary
- convert the roadmap item for a community model leaderboard into a shipped feature by aggregating ratings data and exposing it via `/api/v1/community/leaderboard`
- load community feedback from a cached JSONL source with validation, surfaced through the Flask route and documented in the README
- add unit coverage for the leaderboard aggregation and HTTP endpoint, plus seed config data so the endpoint returns meaningful defaults

## Testing
- `npm run lint`
- `npm run test:ci`
- `./run_all_tests.sh`
- `SKIP=check-yaml,vulture,end-of-file-fixer,trim-trailing-whitespace pre-commit run --all-files`
- `detect-secrets scan $(git diff --cached --name-only)`


------
https://chatgpt.com/codex/tasks/task_e_68e1b775a370832f9db729f9e4e11e99