### PR TITLE
Add logo usage guidelines and regression test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^k8s/charts/tokenplace-relay/templates/
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -58,7 +58,28 @@ For URLs and domains, always use the full form:
 
 ## Logo and Visual Elements
 
-[TBD: Add logo usage guidelines when a logo is created]
+### Logo usage guidelines
+
+`token.place` ships a minimalist logomark derived from the production favicon. The canonical
+vector source lives at `static/favicon.svg`, and a multi-resolution raster bundle is available as
+`static/icon.ico` for legacy platforms. Always source artwork directly from these files instead of
+re-exporting screenshots or compressed assets.
+
+- Maintain a clear space equal to the height of the "t" glyph on all sides. This spacing prevents
+  neighboring interface elements from crowding the logomark and keeps the glyph legible at small
+  sizes.
+- Preserve the original cyan-on-dark color pairing. If you must place the mark on a light surface,
+  invert it by rendering the glyph in `#00FFFF` atop a solid `#111111` circular backdrop sized to the
+  logomark's viewbox.
+- Do not apply drop shadows, gradients, or color shifts. The favicon's flat styling ensures the
+  brand remains crisp across Retina, OLED, and e-ink displays.
+- When a square avatar is required (for example, Slack workspaces or GitHub org icons), use the ICO
+  file directly so operating systems can pick the resolution that best matches the display density.
+
+### Animated usage
+
+Avoid animating the logo. Motion is reserved for contextual loading indicators inside the
+application UI to keep the brand calm and trustworthy.
 
 ## Color Scheme
 

--- a/tests/unit/test_docs_style_guide.py
+++ b/tests/unit/test_docs_style_guide.py
@@ -1,0 +1,17 @@
+"""Regression tests for documentation promises in docs/STYLE_GUIDE.md."""
+from pathlib import Path
+
+import pytest
+
+
+def test_style_guide_includes_logo_usage_guidelines():
+    """The style guide should document how to use the official logo assets."""
+    guide_path = Path('docs/STYLE_GUIDE.md')
+    guide_text = guide_path.read_text(encoding='utf-8')
+
+    assert '[TBD: Add logo usage guidelines when a logo is created]' not in guide_text
+    assert 'Logo usage guidelines' in guide_text
+    assert 'static/favicon.svg' in guide_text
+    assert 'static/icon.ico' in guide_text
+    # Encourage contributors to maintain consistent safe-area guidance.
+    assert 'clear space' in guide_text.lower()


### PR DESCRIPTION
## Summary
- replace the placeholder logo note in `docs/STYLE_GUIDE.md` with concrete usage guidance tied to the shipped favicon assets
- add a pytest regression that asserts the style guide documents the logo assets and spacing guidance
- exclude Helm templates from the `check-yaml` hook so pre-commit can run cleanly on untouched charts

## Testing
- ✅ `pre-commit run --all-files`
- ✅ `npm run lint`
- ✅ `npm run test:ci`
- ✅ `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68e4c273f140832f81134052c8167c93