### PR TITLE
Add community contribution summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,11 @@ For a quick orientation to the repository layout and key docs, see [docs/ONBOARD
 - [x] Signed relay binaries for client verification
 - [x] Optional content moderation hooks
 - [ ] External security review of protocol and code
-- [ ] Community features
+- [x] Community features
   - [x] Server provider directory/registry
   - [x] Model leaderboard based on community feedback
   - [x] Contribution system for donating compute resources
+  - [x] Contribution summary endpoint for maintainers
 
 ## installation
 
@@ -749,6 +750,25 @@ Response body:
 ```
 
 For deployments that need to relocate the queue file, set `TOKEN_PLACE_CONTRIBUTION_QUEUE` to an absolute path. The server will create the file if it does not exist and append one JSON document per line.
+
+#### Community Contribution Summary
+```
+GET /api/v1/community/contributions/summary
+```
+Summarises queued community contributions so maintainers can understand incoming capacity at a glance.
+Returns the total number of submissions, a sorted list of participating regions, the occurrence count for each advertised capability, and the timestamp of the most recent submission.
+
+Example response:
+
+```json
+{
+  "object": "community.contribution_summary",
+  "total_submissions": 2,
+  "regions": ["eu-central", "us-west"],
+  "capability_counts": {"gpu": 2, "openai-compatible": 1},
+  "last_submission_at": "2025-01-15T09:30:00Z"
+}
+```
 
 ### End-to-End Encryption
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -18,8 +18,10 @@ from api.v1.community import (
     get_provider_directory as _get_community_provider_directory,
     CommunityDirectoryError,
     ContributionSubmissionError,
+    ContributionQueueError,
     ModelFeedbackError,
     get_model_leaderboard,
+    get_contribution_summary,
     queue_contribution_submission,
 )
 from api.v1.models import get_models_info, generate_response, get_model_instance, ModelError
@@ -414,6 +416,24 @@ def submit_community_contribution():
     )
     response.status_code = 202
     return response
+
+
+@v1_bp.route('/community/contributions/summary', methods=['GET'])
+def community_contribution_summary():
+    """Summarise queued contribution offers for maintainers."""
+
+    try:
+        log_info("API request: GET /community/contributions/summary")
+        summary = get_contribution_summary()
+    except ContributionQueueError:
+        log_error("Failed to load contribution summary", exc_info=True)
+        return format_error_response(
+            "Unable to summarise contribution queue",
+            error_type="internal_server_error",
+            status_code=500,
+        )
+
+    return jsonify(summary)
 
 
 @v1_bp.route('/server-providers', methods=['GET'])


### PR DESCRIPTION
what:
- add cached contribution summary helper and expose /community/contributions/summary
- mark the README roadmap entry complete using seeded random pick (20240920)
- extend unit coverage and docs so community maintainers can review queued offers

why:
- community features roadmap item now delivers actionable queue visibility

how to test:
- pre-commit run --all-files
- npm run lint
- npm run test:ci
- ./run_all_tests.sh

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e55d28f5e4832f920cc85982863212