### PR TITLE
Wire desktop to Python NDJSON inference sidecar (real bridge)

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -24,9 +24,13 @@ Desktop now defaults to a Python NDJSON bridge
 `utils.llm.model_manager` runtime and emits the existing
 `started/token/done/canceled/error` event contract.
 
-For CI and fast local testing, the fake sidecar remains available at
-`sidecar/fake_llama_sidecar.py` and can be selected by setting
-`TOKEN_PLACE_SIDECAR`.
+The fake sidecar remains available at `sidecar/fake_llama_sidecar.py` for CI
+and fast local testing:
+
+- Set `TOKEN_PLACE_USE_FAKE_SIDECAR=1` to explicitly opt into the fake sidecar.
+- Set `TOKEN_PLACE_SIDECAR=/full/path/to/script.py` to explicitly override the
+  sidecar command path (this takes precedence over
+  `TOKEN_PLACE_USE_FAKE_SIDECAR`).
 
 ## Run locally
 

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -17,15 +17,16 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
 - Optional `Encrypt + forward output` action that sends the final output through
   the existing relay-compatible encrypted `/next_server` + `/faucet` flow.
 
-## Why a fake sidecar for this slice?
+## Inference sidecar behavior
 
-To keep this PR vertical and small, the app uses a tiny NDJSON sidecar
-(`sidecar/fake_llama_sidecar.py`) that models the interface we need for
-llama.cpp integration (start/token/done/error/canceled) without requiring model
-runtime packaging in CI.
+Desktop now defaults to a Python NDJSON bridge
+(`src-tauri/python/inference_sidecar.py`) that reuses the shared
+`utils.llm.model_manager` runtime and emits the existing
+`started/token/done/canceled/error` event contract.
 
-The seam is intentionally replaceable: swap the sidecar executable and preserve
-the JSON event contract.
+For CI and fast local testing, the fake sidecar remains available at
+`sidecar/fake_llama_sidecar.py` and can be selected by setting
+`TOKEN_PLACE_SIDECAR`.
 
 ## Run locally
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -10,7 +10,7 @@ import queue
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Callable, Dict, Iterable, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
@@ -65,7 +65,7 @@ def canceled_requested() -> bool:
             return True
 
 
-def _normalize_chunk(chunk: Any) -> Dict[str, Any]:
+def _fallback_normalize_chunk(chunk: Any) -> Dict[str, Any]:
     if isinstance(chunk, dict):
         return chunk
 
@@ -84,7 +84,10 @@ def _normalize_chunk(chunk: Any) -> Dict[str, Any]:
     return {}
 
 
-def _stream_content(completion: Iterable[Any]) -> Tuple[str, bool]:
+def _stream_content(
+    completion: Iterable[Any],
+    normalize_chunk: Callable[[Any], Dict[str, Any]],
+) -> Tuple[str, bool]:
     full_text = []
     emitted = False
     for raw_chunk in completion:
@@ -92,7 +95,7 @@ def _stream_content(completion: Iterable[Any]) -> Tuple[str, bool]:
             emit({"type": "canceled"})
             return "", True
 
-        chunk = _normalize_chunk(raw_chunk)
+        chunk = normalize_chunk(raw_chunk)
         choices = chunk.get("choices") or []
         if not choices:
             continue
@@ -112,12 +115,27 @@ def _stream_content(completion: Iterable[Any]) -> Tuple[str, bool]:
     return "".join(full_text) if emitted else "", False
 
 
+def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
+    choices = completion.get("choices") or [{}]
+    choice = choices[0] if choices else {}
+    message = choice.get("message") or {}
+    return message.get("content", "") if isinstance(message, dict) else ""
+
+
+def _apply_compute_mode(manager: Any, mode: str) -> None:
+    selected = (mode or "auto").lower()
+    if selected == "cpu":
+        manager.default_n_gpu_layers = 0
+    elif selected in {"metal", "cuda"}:
+        manager.default_n_gpu_layers = -1
+
+
 def run(args: argparse.Namespace) -> int:
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
 
     try:
-        from utils.llm.model_manager import get_model_manager
+        from utils.llm.model_manager import ModelManager, get_model_manager
     except ModuleNotFoundError as exc:
         return emit_error(
             "runtime_unavailable",
@@ -126,9 +144,7 @@ def run(args: argparse.Namespace) -> int:
 
     manager = get_model_manager()
     manager.model_path = args.model
-
-    if os.getenv("TOKEN_PLACE_USE_FAKE_SIDECAR") == "1":
-        manager.use_mock_llm = True
+    _apply_compute_mode(manager, args.mode)
 
     llm = manager.get_llm_instance()
     if llm is None:
@@ -140,26 +156,44 @@ def run(args: argparse.Namespace) -> int:
         return 0
 
     messages = [{"role": "user", "content": args.prompt}]
+    request_kwargs = {
+        "messages": messages,
+        "max_tokens": manager.config.get("model.max_tokens", 512),
+        "temperature": manager.config.get("model.temperature", 0.7),
+        "top_p": manager.config.get("model.top_p", 0.9),
+        "stop": manager.config.get("model.stop_tokens", []),
+    }
     try:
         completion = llm.create_chat_completion(
-            messages=messages,
-            max_tokens=manager.config.get("model.max_tokens", 512),
-            temperature=manager.config.get("model.temperature", 0.7),
-            top_p=manager.config.get("model.top_p", 0.9),
-            stop=manager.config.get("model.stop_tokens", []),
+            **request_kwargs,
             stream=True,
         )
     except Exception as exc:  # pragma: no cover - defensive runtime handling
         return emit_error("inference_failed", f"streaming completion failed: {exc}")
 
+    normalize_chunk = getattr(ModelManager, "_normalize_stream_chunk", _fallback_normalize_chunk)
+
     if isinstance(completion, dict):
-        text = ((completion.get("choices") or [{}])[0].get("message") or {}).get("content", "")
+        text = _extract_text_from_completion(completion)
         if text:
             emit({"type": "token", "text": text})
     else:
-        _, canceled = _stream_content(completion)
+        text, canceled = _stream_content(completion, normalize_chunk)
         if canceled:
             return 0
+
+        if not text:
+            try:
+                fallback = llm.create_chat_completion(
+                    **request_kwargs,
+                    stream=False,
+                )
+            except Exception as exc:  # pragma: no cover - defensive runtime handling
+                return emit_error("inference_failed", f"non-streaming completion failed: {exc}")
+
+            fallback_text = _extract_text_from_completion(fallback)
+            if fallback_text:
+                emit({"type": "token", "text": fallback_text})
 
     emit({"type": "done"})
     return 0
@@ -168,7 +202,7 @@ def run(args: argparse.Namespace) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop inference sidecar")
     parser.add_argument("--model", required=True)
-    parser.add_argument("--mode", default="auto")
+    parser.add_argument("--mode", default="auto", choices=["auto", "metal", "cuda", "cpu"])
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
     try:

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""NDJSON inference sidecar that reuses the shared Python model runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Dict, Iterable, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_stdin_lines: queue.Queue[str] = queue.Queue()
+_stdin_reader_started = False
+_stdin_reader_lock = threading.Lock()
+
+
+def _start_stdin_reader() -> None:
+    global _stdin_reader_started
+    with _stdin_reader_lock:
+        if _stdin_reader_started:
+            return
+
+        def _reader() -> None:
+            while True:
+                line = sys.stdin.readline()
+                if line == "":
+                    break
+                _stdin_lines.put(line)
+
+        threading.Thread(target=_reader, daemon=True).start()
+        _stdin_reader_started = True
+
+
+def emit(payload: Dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def emit_error(code: str, message: str) -> int:
+    emit({"type": "error", "code": code, "message": message})
+    return 1
+
+
+def canceled_requested() -> bool:
+    _start_stdin_reader()
+    while True:
+        try:
+            line = _stdin_lines.get_nowait().strip()
+        except queue.Empty:
+            return False
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("type") == "cancel":
+            return True
+
+
+def _normalize_chunk(chunk: Any) -> Dict[str, Any]:
+    if isinstance(chunk, dict):
+        return chunk
+
+    for attr in ("to_dict", "model_dump", "dict"):
+        handler = getattr(chunk, attr, None)
+        if callable(handler):
+            try:
+                parsed = handler()
+            except TypeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+
+    if hasattr(chunk, "__dict__") and isinstance(chunk.__dict__, dict):
+        return chunk.__dict__
+    return {}
+
+
+def _stream_content(completion: Iterable[Any]) -> Tuple[str, bool]:
+    full_text = []
+    emitted = False
+    for raw_chunk in completion:
+        if canceled_requested():
+            emit({"type": "canceled"})
+            return "", True
+
+        chunk = _normalize_chunk(raw_chunk)
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        delta = (choices[0] or {}).get("delta") or {}
+        if not isinstance(delta, dict):
+            continue
+
+        text = delta.get("content")
+        if text:
+            full_text.append(text)
+            emitted = True
+            emit({"type": "token", "text": text})
+
+        if (choices[0] or {}).get("finish_reason"):
+            break
+
+    return "".join(full_text) if emitted else "", False
+
+
+def run(args: argparse.Namespace) -> int:
+    if not os.path.exists(args.model):
+        return emit_error("bad_model", "model path not found")
+
+    try:
+        from utils.llm.model_manager import get_model_manager
+    except ModuleNotFoundError as exc:
+        return emit_error(
+            "runtime_unavailable",
+            f"Missing Python dependency for local inference ({exc}).",
+        )
+
+    manager = get_model_manager()
+    manager.model_path = args.model
+
+    if os.getenv("TOKEN_PLACE_USE_FAKE_SIDECAR") == "1":
+        manager.use_mock_llm = True
+
+    llm = manager.get_llm_instance()
+    if llm is None:
+        return emit_error("bad_model", "unable to initialize model runtime")
+
+    emit({"type": "started"})
+    if canceled_requested():
+        emit({"type": "canceled"})
+        return 0
+
+    messages = [{"role": "user", "content": args.prompt}]
+    try:
+        completion = llm.create_chat_completion(
+            messages=messages,
+            max_tokens=manager.config.get("model.max_tokens", 512),
+            temperature=manager.config.get("model.temperature", 0.7),
+            top_p=manager.config.get("model.top_p", 0.9),
+            stop=manager.config.get("model.stop_tokens", []),
+            stream=True,
+        )
+    except Exception as exc:  # pragma: no cover - defensive runtime handling
+        return emit_error("inference_failed", f"streaming completion failed: {exc}")
+
+    if isinstance(completion, dict):
+        text = ((completion.get("choices") or [{}])[0].get("message") or {}).get("content", "")
+        if text:
+            emit({"type": "token", "text": text})
+    else:
+        _, canceled = _stream_content(completion)
+        if canceled:
+            return 0
+
+    emit({"type": "done"})
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="token.place desktop inference sidecar")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mode", default="auto")
+    parser.add_argument("--prompt", required=True)
+    args = parser.parse_args()
+    try:
+        return run(args)
+    except Exception as exc:  # pragma: no cover - last resort error handling
+        return emit_error("inference_failed", f"bridge failure: {exc}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -71,7 +71,7 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
 
     if is_python {
         let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python".into());
+            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
         let mut cmd = Command::new(python_bin);
         cmd.arg(sidecar_path);
         return cmd;
@@ -81,15 +81,66 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
 }
 
 fn resolve_default_sidecar_script() -> String {
-    let candidates = [
+    let mut candidates = Vec::new();
+
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            candidates.push(exe_dir.join("python").join("inference_sidecar.py"));
+            candidates.push(
+                exe_dir
+                    .join("resources")
+                    .join("python")
+                    .join("inference_sidecar.py"),
+            );
+            candidates.push(
+                exe_dir
+                    .join("resources")
+                    .join("python")
+                    .join("fake_llama_sidecar.py"),
+            );
+            candidates.push(exe_dir.join("inference_sidecar.py"));
+            candidates.push(exe_dir.join("fake_llama_sidecar.py"));
+
+            if let Some(parent_dir) = exe_dir.parent() {
+                candidates.push(
+                    parent_dir
+                        .join("Resources")
+                        .join("python")
+                        .join("inference_sidecar.py"),
+                );
+                candidates.push(
+                    parent_dir
+                        .join("Resources")
+                        .join("python")
+                        .join("fake_llama_sidecar.py"),
+                );
+                candidates.push(
+                    parent_dir
+                        .join("resources")
+                        .join("python")
+                        .join("inference_sidecar.py"),
+                );
+                candidates.push(
+                    parent_dir
+                        .join("resources")
+                        .join("python")
+                        .join("fake_llama_sidecar.py"),
+                );
+            }
+        }
+    }
+
+    candidates.push(
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("python")
             .join("inference_sidecar.py"),
+    );
+    candidates.push(
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("sidecar")
             .join("fake_llama_sidecar.py"),
-    ];
+    );
 
     for candidate in candidates {
         if candidate.is_file() {
@@ -227,6 +278,7 @@ mod tests {
             .arg("cpu")
             .arg("--prompt")
             .arg("hello world")
+            .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .spawn()
             .expect("spawn fake sidecar");
@@ -255,6 +307,7 @@ mod tests {
             .arg("--prompt")
             .arg("hello world")
             .env("USE_MOCK_LLM", "1")
+            .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .spawn()
             .expect("spawn bridge sidecar");

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -151,6 +151,13 @@ fn resolve_default_sidecar_script() -> String {
     "../sidecar/fake_llama_sidecar.py".into()
 }
 
+fn should_force_fake_sidecar() -> bool {
+    matches!(
+        std::env::var("TOKEN_PLACE_USE_FAKE_SIDECAR").as_deref(),
+        Ok("1")
+    )
+}
+
 pub async fn start_sidecar(
     app: AppHandle,
     state: SidecarState,
@@ -168,8 +175,13 @@ pub async fn start_sidecar(
         *state.stdin.lock().await = None;
     }
 
-    let sidecar_script =
-        std::env::var("TOKEN_PLACE_SIDECAR").unwrap_or_else(|_| resolve_default_sidecar_script());
+    let sidecar_script = std::env::var("TOKEN_PLACE_SIDECAR").unwrap_or_else(|_| {
+        if should_force_fake_sidecar() {
+            "../sidecar/fake_llama_sidecar.py".into()
+        } else {
+            resolve_default_sidecar_script()
+        }
+    });
 
     let mut child = build_sidecar_command(&sidecar_script)
         .arg("--model")

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -80,6 +80,26 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
     Command::new(sidecar_path)
 }
 
+fn resolve_default_sidecar_script() -> String {
+    let candidates = [
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("python")
+            .join("inference_sidecar.py"),
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("sidecar")
+            .join("fake_llama_sidecar.py"),
+    ];
+
+    for candidate in candidates {
+        if candidate.is_file() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+
+    "../sidecar/fake_llama_sidecar.py".into()
+}
+
 pub async fn start_sidecar(
     app: AppHandle,
     state: SidecarState,
@@ -97,8 +117,8 @@ pub async fn start_sidecar(
         *state.stdin.lock().await = None;
     }
 
-    let sidecar_script = std::env::var("TOKEN_PLACE_SIDECAR")
-        .unwrap_or_else(|_| "../sidecar/fake_llama_sidecar.py".into());
+    let sidecar_script =
+        std::env::var("TOKEN_PLACE_SIDECAR").unwrap_or_else(|_| resolve_default_sidecar_script());
 
     let mut child = build_sidecar_command(&sidecar_script)
         .arg("--model")
@@ -216,6 +236,37 @@ mod tests {
             .await
             .expect("collect events");
         assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
+        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+    }
+
+    #[tokio::test]
+    async fn real_bridge_happy_path_with_mock_runtime() {
+        let model = NamedTempFile::new().expect("tempfile");
+        let sidecar_script = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("python")
+            .join("inference_sidecar.py");
+
+        let mut child = Command::new("python3")
+            .arg(sidecar_script)
+            .arg("--model")
+            .arg(model.path())
+            .arg("--mode")
+            .arg("cpu")
+            .arg("--prompt")
+            .arg("hello world")
+            .env("USE_MOCK_LLM", "1")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn bridge sidecar");
+
+        let stdout = child.stdout.take().expect("stdout");
+        let events = collect_events_from_stdout(stdout)
+            .await
+            .expect("collect events");
+        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Token { .. })));
         assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
     }
 }

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -1,0 +1,103 @@
+"""Unit tests for the desktop NDJSON inference sidecar."""
+
+import importlib.util
+import json
+import queue
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'src-tauri'
+    / 'python'
+    / 'inference_sidecar.py'
+)
+SPEC = importlib.util.spec_from_file_location('desktop_inference_sidecar', MODULE_PATH)
+inference_sidecar = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(inference_sidecar)
+
+
+class FakeConfig:
+    def get(self, _key, default=None):
+        return default
+
+
+class FakeLlm:
+    def create_chat_completion(self, **_kwargs):
+        return iter(
+            [
+                {'choices': [{'delta': {'content': 'Hello'}, 'finish_reason': None}]},
+                {'choices': [{'delta': {'content': ' world'}, 'finish_reason': None}]},
+                {'choices': [{'delta': {}, 'finish_reason': 'stop'}]},
+            ]
+        )
+
+
+class FakeManager:
+    def __init__(self):
+        self.config = FakeConfig()
+        self.model_path = ''
+        self.use_mock_llm = False
+
+    def get_llm_instance(self):
+        return FakeLlm()
+
+
+def _install_fake_manager_module(manager):
+    module = ModuleType('utils.llm.model_manager')
+    module.get_model_manager = lambda: manager
+    sys.modules['utils.llm.model_manager'] = module
+
+
+def _reset_cancel_queue():
+    inference_sidecar._stdin_lines = queue.Queue()
+    inference_sidecar._stdin_reader_started = True
+
+
+def test_run_emits_bad_model_error_for_missing_path(capsys):
+    _reset_cancel_queue()
+    args = SimpleNamespace(model='/does/not/exist.gguf', mode='cpu', prompt='hello')
+
+    status = inference_sidecar.run(args)
+
+    assert status == 1
+    event = json.loads(capsys.readouterr().out.strip())
+    assert event['type'] == 'error'
+    assert event['code'] == 'bad_model'
+
+
+def test_run_streams_started_token_done_with_shared_runtime(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode='cpu', prompt='Say hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['type'] for event in events] == ['started', 'token', 'token', 'done']
+
+
+def test_run_emits_canceled_when_cancel_signal_arrives(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+    inference_sidecar._stdin_lines.put('{"type":"cancel"}')
+
+    args = SimpleNamespace(model=str(model_path), mode='cpu', prompt='Cancel me')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['type'] for event in events] == ['started', 'canceled']

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -304,3 +304,61 @@ def test_run_cancels_during_streaming_after_started(tmp_path, capsys):
 
 def test_extract_text_from_completion_handles_non_dict_message():
     assert inference_sidecar._extract_text_from_completion({'choices': [{'message': 'x'}]}) == ''
+
+
+def test_extract_text_from_completion_handles_empty_choices():
+    assert inference_sidecar._extract_text_from_completion({}) == ''
+
+
+def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
+    class WithBadDict:
+        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+            return {'choices': []}
+
+    class UnknownShape:
+        pass
+
+    assert inference_sidecar._fallback_normalize_chunk(WithBadDict()) == {}
+    assert inference_sidecar._fallback_normalize_chunk(UnknownShape()) == {}
+
+
+def test_stream_content_ignores_invalid_chunks_and_stops_on_finish_reason(capsys):
+    inference_sidecar._stdin_lines = queue.Queue()
+    inference_sidecar._stdin_reader_started = True
+
+    chunks = iter(
+        [
+            {'choices': []},
+            {'choices': [{'delta': 'not-a-dict', 'finish_reason': None}]},
+            {'choices': [{'delta': {'content': 'ok'}, 'finish_reason': 'stop'}]},
+            {'choices': [{'delta': {'content': 'skipped-after-stop'}, 'finish_reason': None}]},
+        ]
+    )
+    text, canceled = inference_sidecar._stream_content(chunks, lambda chunk: chunk)
+
+    assert canceled is False
+    assert text == 'ok'
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events == [{'type': 'token', 'text': 'ok'}]
+
+
+def test_run_done_without_token_when_stream_and_fallback_are_empty(tmp_path, capsys):
+    class EmptyLlm:
+        def create_chat_completion(self, **kwargs):
+            if kwargs.get('stream') is False:
+                return {'choices': [{'message': {'content': ''}}]}
+            return iter([{'choices': [{'delta': {}, 'finish_reason': 'stop'}]}])
+
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager(llm=EmptyLlm())
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['type'] for event in events] == ['started', 'done']

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -71,6 +71,21 @@ class FakeDictCompletionLlm:
         return {'choices': [{'message': {'content': 'dict response'}}]}
 
 
+class FakeNoLlmManager(FakeManager):
+    def get_llm_instance(self):
+        return None
+
+
+class FakeLongStreamLlm:
+    def create_chat_completion(self, **_kwargs):
+        return iter(
+            [
+                {'choices': [{'delta': {'content': 'first'}, 'finish_reason': None}]},
+                {'choices': [{'delta': {'content': ' second'}, 'finish_reason': None}]},
+            ]
+        )
+
+
 @pytest.fixture(autouse=True)
 def restore_model_manager_module():
     original = sys.modules.get('utils.llm.model_manager')
@@ -227,3 +242,65 @@ def test_normalize_chunk_fallback_handles_object_shapes():
     assert inference_sidecar._fallback_normalize_chunk(WithDunderDict()) == {
         'choices': [{'delta': {'content': 'z'}}]
     }
+
+
+def test_run_emits_runtime_unavailable_when_model_manager_missing(tmp_path, capsys, monkeypatch):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'utils.llm.model_manager':
+            raise ModuleNotFoundError("No module named 'utils'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    sys.modules.pop('utils.llm.model_manager', None)
+
+    args = SimpleNamespace(model=str(model_path), mode='cpu', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 1
+    event = json.loads(capsys.readouterr().out.strip())
+    assert event['code'] == 'runtime_unavailable'
+
+
+def test_run_emits_bad_model_when_runtime_returns_no_llm(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeNoLlmManager()
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode='cpu', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 1
+    event = json.loads(capsys.readouterr().out.strip())
+    assert event['code'] == 'bad_model'
+
+
+def test_run_cancels_during_streaming_after_started(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager(llm=FakeLongStreamLlm())
+    _install_fake_manager_module(manager)
+    inference_sidecar._stdin_lines.put('not-json')
+    inference_sidecar._stdin_lines.put('{"type":"noop"}')
+    inference_sidecar._stdin_lines.put('{"type":"cancel"}')
+
+    args = SimpleNamespace(model=str(model_path), mode='cpu', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['type'] for event in events] == ['started', 'canceled']
+
+
+def test_extract_text_from_completion_handles_non_dict_message():
+    assert inference_sidecar._extract_text_from_completion({'choices': [{'message': 'x'}]}) == ''

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[2]
@@ -27,7 +28,10 @@ class FakeConfig:
 
 
 class FakeLlm:
-    def create_chat_completion(self, **_kwargs):
+    def create_chat_completion(self, **kwargs):
+        if kwargs.get('stream') is False:
+            return {'choices': [{'message': {'content': 'fallback response'}}]}
+
         return iter(
             [
                 {'choices': [{'delta': {'content': 'Hello'}, 'finish_reason': None}]},
@@ -37,19 +41,51 @@ class FakeLlm:
         )
 
 
+class FakeStreamNoContentLlm:
+    def create_chat_completion(self, **kwargs):
+        if kwargs.get('stream') is False:
+            return {'choices': [{'message': {'content': 'fallback response'}}]}
+
+        return iter(
+            [
+                {'choices': [{'delta': {}, 'finish_reason': None}]},
+                {'choices': [{'delta': {}, 'finish_reason': 'stop'}]},
+            ]
+        )
+
+
 class FakeManager:
-    def __init__(self):
+    def __init__(self, llm=None):
         self.config = FakeConfig()
         self.model_path = ''
         self.use_mock_llm = False
+        self.default_n_gpu_layers = -1
+        self._llm = llm or FakeLlm()
 
     def get_llm_instance(self):
-        return FakeLlm()
+        return self._llm
+
+
+@pytest.fixture(autouse=True)
+def restore_model_manager_module():
+    original = sys.modules.get('utils.llm.model_manager')
+    yield
+    if original is None:
+        sys.modules.pop('utils.llm.model_manager', None)
+    else:
+        sys.modules['utils.llm.model_manager'] = original
 
 
 def _install_fake_manager_module(manager):
     module = ModuleType('utils.llm.model_manager')
     module.get_model_manager = lambda: manager
+
+    class _ModelManager:
+        @staticmethod
+        def _normalize_stream_chunk(chunk):
+            return chunk
+
+    module.ModelManager = _ModelManager
     sys.modules['utils.llm.model_manager'] = module
 
 
@@ -84,6 +120,7 @@ def test_run_streams_started_token_done_with_shared_runtime(tmp_path, capsys):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert [event['type'] for event in events] == ['started', 'token', 'token', 'done']
+    assert manager.default_n_gpu_layers == 0
 
 
 def test_run_emits_canceled_when_cancel_signal_arrives(tmp_path, capsys):
@@ -101,3 +138,20 @@ def test_run_emits_canceled_when_cancel_signal_arrives(tmp_path, capsys):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert [event['type'] for event in events] == ['started', 'canceled']
+
+
+def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager(llm=FakeStreamNoContentLlm())
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='Say hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['type'] for event in events] == ['started', 'token', 'done']
+    assert events[1]['text'] == 'fallback response'

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -66,6 +66,11 @@ class FakeManager:
         return self._llm
 
 
+class FakeDictCompletionLlm:
+    def create_chat_completion(self, **_kwargs):
+        return {'choices': [{'message': {'content': 'dict response'}}]}
+
+
 @pytest.fixture(autouse=True)
 def restore_model_manager_module():
     original = sys.modules.get('utils.llm.model_manager')
@@ -155,3 +160,70 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert [event['type'] for event in events] == ['started', 'token', 'done']
     assert events[1]['text'] == 'fallback response'
+
+
+@pytest.mark.parametrize(
+    ('mode', 'expected'),
+    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+)
+def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode=mode, prompt='Mode test')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    _ = capsys.readouterr()
+    assert manager.default_n_gpu_layers == expected
+
+
+def test_run_handles_dict_completion_payload(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager(llm=FakeDictCompletionLlm())
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['type'] for event in events] == ['started', 'token', 'done']
+    assert events[1]['text'] == 'dict response'
+
+
+def test_normalize_chunk_fallback_handles_object_shapes():
+    class WithToDict:
+        def to_dict(self):
+            return {'choices': []}
+
+    class WithModelDump:
+        def model_dump(self):
+            return {'choices': [{'delta': {'content': 'x'}}]}
+
+    class WithDictMethod:
+        def dict(self):
+            return {'choices': [{'delta': {'content': 'y'}}]}
+
+    class WithDunderDict:
+        def __init__(self):
+            self.choices = [{'delta': {'content': 'z'}}]
+
+    assert inference_sidecar._fallback_normalize_chunk({'choices': []}) == {'choices': []}
+    assert inference_sidecar._fallback_normalize_chunk(WithToDict()) == {'choices': []}
+    assert inference_sidecar._fallback_normalize_chunk(WithModelDump()) == {
+        'choices': [{'delta': {'content': 'x'}}]
+    }
+    assert inference_sidecar._fallback_normalize_chunk(WithDictMethod()) == {
+        'choices': [{'delta': {'content': 'y'}}]
+    }
+    assert inference_sidecar._fallback_normalize_chunk(WithDunderDict()) == {
+        'choices': [{'delta': {'content': 'z'}}]
+    }


### PR DESCRIPTION
### Motivation
- Replace the prompt-echo fake sidecar with a real NDJSON inference bridge that reuses the shared Python model runtime so desktop test inference can produce actual completions while keeping the existing event contract.
- Preserve the minimal protocol surface (`started`, `token`, `done`, `canceled`, `error`) and stdin cancellation so the UI/event parser requires no breaking changes.
- Keep a fast/mock option for CI and developer testing to avoid heavy runtime packaging in CI.

### Description
- Add `desktop-tauri/src-tauri/python/inference_sidecar.py`, a Python NDJSON bridge that imports `utils.llm.model_manager`, initializes the LLM, streams tokens with `started/token/done`, supports cancel via stdin, and maps runtime errors to `error` events.
- Update Rust sidecar resolution in `desktop-tauri/src-tauri/src/sidecar.rs` to prefer the new `src-tauri/python/inference_sidecar.py` while preserving `TOKEN_PLACE_SIDECAR` override and falling back to the existing fake sidecar.
- Add focused tests: `tests/unit/test_desktop_inference_sidecar.py` for the Python bridge (missing model, stream, cancel) and a Rust unit test in `sidecar.rs` that exercises the real bridge happy path using the mock runtime (`USE_MOCK_LLM=1`).
- Update `desktop-tauri/README.md` to document the new default bridge and the fake-sidecar opt-in for CI/fast local tests.

### Testing
- Ran focused Python unit tests: `python -m pytest -q tests/unit/test_desktop_inference_sidecar.py --confcutdir=tests/unit` which passed (3/3 tests passed).
- Built frontend: `cd desktop-tauri && npm run build` succeeded.
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which is blocked/failed in this environment due to missing native system libraries for Tauri/GTK (`glib`/`libsoup` etc.).
- Full Python test run `python -m pytest -q` and `npm run test:ci` are failing in this environment due to missing Python dependencies (`requests`, `cryptography`) required by repo-wide tests and CI harness; these are environmental and not specific to the sidecar changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73dfa5b1c832fa8ff86aedac026c0)