### PR TITLE
Add real desktop inference sidecar bridge with NDJSON contract

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -17,15 +17,22 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
 - Optional `Encrypt + forward output` action that sends the final output through
   the existing relay-compatible encrypted `/next_server` + `/faucet` flow.
 
-## Why a fake sidecar for this slice?
+## Sidecar runtime modes
 
-To keep this PR vertical and small, the app uses a tiny NDJSON sidecar
-(`sidecar/fake_llama_sidecar.py`) that models the interface we need for
-llama.cpp integration (start/token/done/error/canceled) without requiring model
-runtime packaging in CI.
+By default, desktop now runs a real Python inference sidecar
+(`src-tauri/python/inference_sidecar.py`) that reuses the shared
+`utils.llm.model_manager` runtime and streams NDJSON events
+(`started`/`token`/`done`/`canceled`/`error`).
 
-The seam is intentionally replaceable: swap the sidecar executable and preserve
-the JSON event contract.
+For CI and fast local testing, a fake sidecar is still available at
+`sidecar/fake_llama_sidecar.py`. Choose sidecar mode with
+`TOKEN_PLACE_SIDECAR_MODE`:
+
+- `auto` (default): real sidecar when available, otherwise fake sidecar
+- `real`: require the Python inference bridge
+- `mock`: force the fake sidecar
+
+You can also set `TOKEN_PLACE_SIDECAR` to an explicit executable/script path.
 
 ## Run locally
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""NDJSON inference sidecar backed by the shared Python model runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_stdin_lines: queue.Queue[str] = queue.Queue()
+_stdin_reader_started = False
+_stdin_reader_lock = threading.Lock()
+
+
+def _start_stdin_reader() -> None:
+    global _stdin_reader_started
+    with _stdin_reader_lock:
+        if _stdin_reader_started:
+            return
+
+        def _reader() -> None:
+            while True:
+                line = sys.stdin.readline()
+                if line == "":
+                    break
+                _stdin_lines.put(line)
+
+        threading.Thread(target=_reader, daemon=True).start()
+        _stdin_reader_started = True
+
+
+def emit(payload: Dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def canceled_requested() -> bool:
+    _start_stdin_reader()
+    while True:
+        try:
+            line = _stdin_lines.get_nowait().strip()
+        except queue.Empty:
+            return False
+
+        if not line:
+            continue
+
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if msg.get("type") == "cancel":
+            return True
+
+
+def _normalise_stream_chunk(chunk: Any) -> Dict[str, Any]:
+    if isinstance(chunk, dict):
+        return chunk
+
+    for attr in ("to_dict", "model_dump", "dict"):
+        handler = getattr(chunk, attr, None)
+        if callable(handler):
+            try:
+                normalised = handler()
+            except TypeError:
+                continue
+            if isinstance(normalised, dict):
+                return normalised
+
+    if hasattr(chunk, "__dict__") and isinstance(chunk.__dict__, dict):
+        return chunk.__dict__
+
+    return {}
+
+
+def _iter_text_deltas(completion: Any) -> Iterable[str]:
+    if isinstance(completion, dict):
+        content = ((completion.get("choices") or [{}])[0].get("message") or {}).get("content")
+        if isinstance(content, str) and content:
+            yield content
+        return
+
+    for raw_chunk in completion:
+        chunk = _normalise_stream_chunk(raw_chunk)
+        if not chunk:
+            continue
+
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+
+        choice = choices[0] or {}
+        delta = choice.get("delta") or {}
+        if isinstance(delta, dict):
+            content = delta.get("content")
+            if isinstance(content, str) and content:
+                yield content
+
+        if choice.get("finish_reason"):
+            break
+
+
+def _apply_mode_overrides(manager: Any, mode: str) -> None:
+    if mode == "cpu":
+        manager.default_n_gpu_layers = 0
+
+
+def run_inference(
+    model_path: str,
+    prompt: str,
+    mode: str,
+    *,
+    emit_fn: Callable[[Dict[str, Any]], None],
+    canceled_fn: Callable[[], bool],
+) -> int:
+    if not os.path.exists(model_path):
+        emit_fn({"type": "error", "code": "bad_model", "message": "model path not found"})
+        return 2
+
+    try:
+        from utils.llm.model_manager import get_model_manager
+    except ModuleNotFoundError as exc:
+        emit_fn(
+            {
+                "type": "error",
+                "code": "missing_dependency",
+                "message": f"Missing Python dependency ({exc})",
+            }
+        )
+        return 2
+
+    manager = get_model_manager()
+    manager.model_path = model_path
+    _apply_mode_overrides(manager, mode)
+
+    llm = manager.get_llm_instance()
+    if llm is None:
+        emit_fn(
+            {
+                "type": "error",
+                "code": "init_failed",
+                "message": "unable to initialize model runtime",
+            }
+        )
+        return 2
+
+    emit_fn({"type": "started"})
+
+    messages = [{"role": "user", "content": prompt}]
+    try:
+        completion = llm.create_chat_completion(
+            messages=messages,
+            max_tokens=manager.config.get("model.max_tokens", 512),
+            temperature=manager.config.get("model.temperature", 0.7),
+            top_p=manager.config.get("model.top_p", 0.9),
+            stop=manager.config.get("model.stop_tokens", []),
+            stream=True,
+        )
+
+        for text in _iter_text_deltas(completion):
+            if canceled_fn():
+                emit_fn({"type": "canceled"})
+                return 0
+            emit_fn({"type": "token", "text": text})
+
+        if canceled_fn():
+            emit_fn({"type": "canceled"})
+            return 0
+
+        emit_fn({"type": "done"})
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive sidecar bridge handling
+        emit_fn({"type": "error", "code": "inference_failed", "message": str(exc)})
+        return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="token.place desktop inference sidecar")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mode", default="auto")
+    parser.add_argument("--prompt", required=True)
+    args = parser.parse_args()
+
+    return run_inference(
+        args.model,
+        args.prompt,
+        args.mode.lower(),
+        emit_fn=emit,
+        canceled_fn=canceled_requested,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,6 +1,6 @@
 use crate::backend::ComputeMode;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -62,6 +62,68 @@ pub async fn collect_events_from_stdout<R: tokio::io::AsyncRead + Unpin>(
     Ok(events)
 }
 
+fn find_existing_sidecar_path(relative_candidates: &[&str]) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            for candidate in relative_candidates {
+                candidates.push(exe_dir.join(candidate));
+            }
+        }
+    }
+
+    for candidate in relative_candidates {
+        candidates.push(Path::new(env!("CARGO_MANIFEST_DIR")).join(candidate));
+    }
+
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+fn resolve_real_sidecar_path() -> Option<String> {
+    find_existing_sidecar_path(&[
+        "python/inference_sidecar.py",
+        "resources/python/inference_sidecar.py",
+        "../Resources/python/inference_sidecar.py",
+    ])
+    .map(|path| path.to_string_lossy().to_string())
+}
+
+fn resolve_mock_sidecar_path() -> Option<String> {
+    find_existing_sidecar_path(&[
+        "../sidecar/fake_llama_sidecar.py",
+        "sidecar/fake_llama_sidecar.py",
+        "resources/sidecar/fake_llama_sidecar.py",
+    ])
+    .map(|path| path.to_string_lossy().to_string())
+}
+
+fn resolve_sidecar_path() -> anyhow::Result<String> {
+    if let Ok(explicit) = std::env::var("TOKEN_PLACE_SIDECAR") {
+        return Ok(explicit);
+    }
+
+    let mode = std::env::var("TOKEN_PLACE_SIDECAR_MODE").unwrap_or_else(|_| "auto".into());
+
+    match mode.to_ascii_lowercase().as_str() {
+        "mock" | "fake" => resolve_mock_sidecar_path()
+            .ok_or_else(|| anyhow::anyhow!("unable to locate mock sidecar script")),
+        "real" => resolve_real_sidecar_path()
+            .ok_or_else(|| anyhow::anyhow!("unable to locate real inference sidecar script")),
+        "auto" => {
+            if let Some(real) = resolve_real_sidecar_path() {
+                return Ok(real);
+            }
+            resolve_mock_sidecar_path().ok_or_else(|| {
+                anyhow::anyhow!("unable to locate either real or mock sidecar script")
+            })
+        }
+        other => {
+            anyhow::bail!("invalid TOKEN_PLACE_SIDECAR_MODE `{other}`; expected auto|real|mock")
+        }
+    }
+}
+
 fn build_sidecar_command(sidecar_path: &str) -> Command {
     let path = Path::new(sidecar_path);
     let is_python = path
@@ -97,8 +159,7 @@ pub async fn start_sidecar(
         *state.stdin.lock().await = None;
     }
 
-    let sidecar_script = std::env::var("TOKEN_PLACE_SIDECAR")
-        .unwrap_or_else(|_| "../sidecar/fake_llama_sidecar.py".into());
+    let sidecar_script = resolve_sidecar_path()?;
 
     let mut child = build_sidecar_command(&sidecar_script)
         .arg("--model")
@@ -179,14 +240,16 @@ mod tests {
 
     #[test]
     fn parses_token_event() {
-        let event = parse_event_line(r#"{"type":"token","text":"hi"}"#).expect("parse");
+        let event = parse_event_line(r#"{\"type\":\"token\",\"text\":\"hi\"}"#).expect("parse");
         assert_eq!(event, SidecarEvent::Token { text: "hi".into() });
     }
 
     #[test]
     fn maps_error_event() {
-        let event = parse_event_line(r#"{"type":"error","code":"bad_model","message":"no file"}"#)
-            .expect("parse");
+        let event = parse_event_line(
+            r#"{\"type\":\"error\",\"code\":\"bad_model\",\"message\":\"no file\"}"#,
+        )
+        .expect("parse");
         assert_eq!(
             event,
             SidecarEvent::Error {
@@ -194,6 +257,13 @@ mod tests {
                 message: "no file".into()
             }
         );
+    }
+
+    #[test]
+    fn resolves_sidecar_mode() {
+        let _guard = ScopedEnvVar::set("TOKEN_PLACE_SIDECAR_MODE", Some("mock"));
+        let path = resolve_sidecar_path().expect("resolve mock sidecar");
+        assert!(path.contains("fake_llama_sidecar.py"));
     }
 
     #[tokio::test]
@@ -217,5 +287,63 @@ mod tests {
             .expect("collect events");
         assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
         assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+    }
+
+    #[tokio::test]
+    async fn real_bridge_happy_path_with_mock_llm() {
+        let model = NamedTempFile::new().expect("tempfile");
+        let mut child = Command::new("python3")
+            .arg("python/inference_sidecar.py")
+            .arg("--model")
+            .arg(model.path())
+            .arg("--mode")
+            .arg("cpu")
+            .arg("--prompt")
+            .arg("say hi")
+            .env("USE_MOCK_LLM", "1")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn real bridge sidecar");
+
+        let stdout = child.stdout.take().expect("stdout");
+        let events = collect_events_from_stdout(stdout)
+            .await
+            .expect("collect events");
+
+        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
+        assert!(
+            events.iter().any(
+                |e| matches!(e, SidecarEvent::Token { text } if text.contains("Mock Response"))
+            ),
+            "expected real bridge to emit model-derived token text"
+        );
+        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+    }
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let previous = std::env::var(key).ok();
+            if let Some(next) = value {
+                std::env::set_var(key, next);
+            } else {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
     }
 }

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable, List
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / 'desktop-tauri' / 'src-tauri' / 'python' / 'inference_sidecar.py'
+SPEC = importlib.util.spec_from_file_location('desktop_inference_sidecar', MODULE_PATH)
+inference_sidecar = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(inference_sidecar)
+
+
+class _FakeLlm:
+    def __init__(self, chunks: Iterable[Dict[str, Any]]):
+        self._chunks = list(chunks)
+
+    def create_chat_completion(self, **kwargs: Any) -> Iterable[Dict[str, Any]]:
+        return iter(self._chunks)
+
+
+class _FakeManager:
+    def __init__(self, chunks: Iterable[Dict[str, Any]]):
+        self.config = {
+            'model.max_tokens': 16,
+            'model.temperature': 0.7,
+            'model.top_p': 0.9,
+            'model.stop_tokens': [],
+        }
+        self.default_n_gpu_layers = -1
+        self._llm = _FakeLlm(chunks)
+        self.model_path = ''
+
+    def get_llm_instance(self) -> _FakeLlm:
+        return self._llm
+
+
+def _collect_events() -> tuple[List[Dict[str, Any]], Any]:
+    events: List[Dict[str, Any]] = []
+
+    def emit_fn(payload: Dict[str, Any]) -> None:
+        events.append(payload)
+
+    return events, emit_fn
+
+
+def test_run_inference_emits_started_tokens_and_done(tmp_path: Path):
+    model_path = tmp_path / 'fake.gguf'
+    model_path.write_bytes(b'gguf')
+
+    manager = _FakeManager(
+        [
+            {'choices': [{'delta': {'content': 'Hello'}}]},
+            {'choices': [{'delta': {'content': ' world'}, 'finish_reason': 'stop'}]},
+        ]
+    )
+
+    events, emit_fn = _collect_events()
+    with patch.dict('sys.modules', {'utils.llm.model_manager': SimpleNamespace(get_model_manager=lambda: manager)}):
+        status = inference_sidecar.run_inference(
+            str(model_path),
+            'say hi',
+            'cpu',
+            emit_fn=emit_fn,
+            canceled_fn=lambda: False,
+        )
+
+    assert status == 0
+    assert events[0] == {'type': 'started'}
+    assert events[1] == {'type': 'token', 'text': 'Hello'}
+    assert events[2] == {'type': 'token', 'text': ' world'}
+    assert events[3] == {'type': 'done'}
+    assert manager.default_n_gpu_layers == 0
+
+
+def test_run_inference_emits_canceled_when_requested(tmp_path: Path):
+    model_path = tmp_path / 'fake.gguf'
+    model_path.write_bytes(b'gguf')
+
+    manager = _FakeManager([{'choices': [{'delta': {'content': 'Hello'}}]}])
+    events, emit_fn = _collect_events()
+
+    calls = {'count': 0}
+
+    def canceled_fn() -> bool:
+        calls['count'] += 1
+        return calls['count'] >= 2
+
+    with patch.dict('sys.modules', {'utils.llm.model_manager': SimpleNamespace(get_model_manager=lambda: manager)}):
+        status = inference_sidecar.run_inference(
+            str(model_path),
+            'cancel me',
+            'auto',
+            emit_fn=emit_fn,
+            canceled_fn=canceled_fn,
+        )
+
+    assert status == 0
+    assert events[0] == {'type': 'started'}
+    assert events[1] == {'type': 'token', 'text': 'Hello'}
+    assert events[2] == {'type': 'canceled'}
+
+
+def test_run_inference_emits_bad_model_error_when_path_missing():
+    events, emit_fn = _collect_events()
+    status = inference_sidecar.run_inference(
+        '/path/does/not/exist.gguf',
+        'hello',
+        'auto',
+        emit_fn=emit_fn,
+        canceled_fn=lambda: False,
+    )
+
+    assert status == 2
+    assert events == [{'type': 'error', 'code': 'bad_model', 'message': 'model path not found'}]


### PR DESCRIPTION
### Motivation
- Replace the prompt-echo fake sidecar with a real inference bridge that reuses the shared Python model runtime so desktop returns real completions. 
- Preserve the existing NDJSON event contract (`started`, `token`, `done`, `canceled`, `error`) so the UI and event parser remain unchanged. 
- Keep a fast mock/fake sidecar option for CI and local quick tests and make the runtime selection configurable. 

### Description
- Add a Python inference bridge at `desktop-tauri/src-tauri/python/inference_sidecar.py` that calls `utils.llm.model_manager`, streams model deltas as NDJSON `token` events, supports cancel-over-stdin, and emits `started`/`token`/`done`/`canceled`/`error` events. 
- Update the Tauri sidecar launcher in `desktop-tauri/src-tauri/src/sidecar.rs` to resolve the sidecar path via `TOKEN_PLACE_SIDECAR_MODE` (`auto|real|mock`) and keep `TOKEN_PLACE_SIDECAR` as an explicit override. 
- Add focused tests: Rust tests in `sidecar.rs` that parse events and exercise a real-bridge happy path (spawning `python/inference_sidecar.py` with `USE_MOCK_LLM=1`), and Python unit tests in `tests/unit/test_desktop_inference_sidecar.py` for streaming, cancellation, and bad-model handling. 
- Update `desktop-tauri/README.md` to document the new sidecar runtime modes and selection environment variables. 

### Testing
- Ran focused Python unit tests with `python -m pytest -q --confcutdir=tests/unit tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_model_bridge.py` and they passed (`10 passed`). 
- Built the frontend with `cd desktop-tauri && npm run build` and the build succeeded. 
- Linted JS with `npm run lint` which passed; `pre-commit run --all-files` was not runnable in this environment because `pre-commit` is not installed. 
- Attempted full Rust test suite with `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` but the environment lacked native GTK/libsoup system packages initially; installing system dev packages was required and some platform-native crates still require system libs so the full Rust test run could not be completed end-to-end in this container. 
- The repo-wide `python -m pytest -q` and CI `npm run test:ci` runs failed in this environment due to missing system Python test dependencies (initially `requests`, `cryptography`, `playwright`, `psutil`, `jsonschema` were installed as needed) and environment setup differences; focused unit tests for the new sidecar were exercised and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73dfa5b1c832fa8ff86aedac026c0)