### PR TITLE
Desktop: real Python inference bridge with shared ModelManager (preserve NDJSON contract)

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -14,18 +14,26 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
   - Windows x64 => `CUDA / NVIDIA`
   - other targets => `CPU fallback`
 - Sidecar-driven streaming output with explicit cancellation.
+  - Defaults to `src-tauri/python/inference_bridge.py`, which reuses the shared
+    Python model runtime for real local inference.
+  - Keeps `sidecar/fake_llama_sidecar.py` available via
+    `TOKEN_PLACE_USE_FAKE_SIDECAR=1` (or `TOKEN_PLACE_SIDECAR_KIND=mock`) for
+    CI and fast local tests.
 - Optional `Encrypt + forward output` action that sends the final output through
   the existing relay-compatible encrypted `/next_server` + `/faucet` flow.
 
-## Why a fake sidecar for this slice?
+## Sidecar contract
 
-To keep this PR vertical and small, the app uses a tiny NDJSON sidecar
-(`sidecar/fake_llama_sidecar.py`) that models the interface we need for
-llama.cpp integration (start/token/done/error/canceled) without requiring model
-runtime packaging in CI.
+Desktop inference consumes NDJSON events with this contract:
 
-The seam is intentionally replaceable: swap the sidecar executable and preserve
-the JSON event contract.
+- `started`
+- `token`
+- `done`
+- `canceled`
+- `error`
+
+`inference_bridge.py` emits this same contract while using the shared Python
+runtime and model manager. The fake sidecar remains opt-in for CI/dev speed.
 
 ## Run locally
 

--- a/desktop-tauri/src-tauri/python/inference_bridge.py
+++ b/desktop-tauri/src-tauri/python/inference_bridge.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""NDJSON inference bridge for the desktop app backed by shared Python runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from utils.llm.model_manager import ModelManager
+
+
+_STDIN_LINES: queue.Queue[str] = queue.Queue()
+_STDIN_STARTED = False
+_STDIN_LOCK = threading.Lock()
+
+
+class BridgeConfig:
+    """Minimal config adapter for ModelManager without full server imports."""
+
+    def __init__(self, *, model_path: str):
+        model_file = os.path.basename(model_path)
+        models_dir = str(Path(model_path).resolve().parent)
+        self.is_production = False
+        self._values: Dict[str, Any] = {
+            "model.filename": model_file,
+            "paths.models_dir": models_dir,
+            "model.max_tokens": int(os.environ.get("TOKEN_PLACE_MAX_TOKENS", "512")),
+            "model.temperature": float(os.environ.get("TOKEN_PLACE_TEMPERATURE", "0.7")),
+            "model.top_p": float(os.environ.get("TOKEN_PLACE_TOP_P", "0.9")),
+            "model.stop_tokens": [],
+            "model.use_mock": os.environ.get("USE_MOCK_LLM") == "1",
+            "model.n_gpu_layers": int(os.environ.get("TOKEN_PLACE_N_GPU_LAYERS", "-1")),
+            "model.gpu_memory_headroom_percent": float(
+                os.environ.get("TOKEN_PLACE_GPU_HEADROOM_PERCENT", "0.1")
+            ),
+            "model.enforce_gpu_memory_headroom": True,
+        }
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self._values[key] = value
+
+
+def _emit(payload: Dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _start_stdin_reader() -> None:
+    global _STDIN_STARTED
+    with _STDIN_LOCK:
+        if _STDIN_STARTED:
+            return
+
+        def _reader() -> None:
+            while True:
+                line = sys.stdin.readline()
+                if line == "":
+                    break
+                _STDIN_LINES.put(line)
+
+        threading.Thread(target=_reader, daemon=True).start()
+        _STDIN_STARTED = True
+
+
+def _cancel_requested() -> bool:
+    _start_stdin_reader()
+    while True:
+        try:
+            line = _STDIN_LINES.get_nowait().strip()
+        except queue.Empty:
+            return False
+
+        if not line:
+            continue
+
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if payload.get("type") == "cancel":
+            return True
+
+
+def _normalise_chunk(chunk: Any) -> Dict[str, Any]:
+    if isinstance(chunk, dict):
+        return chunk
+
+    for attr in ("to_dict", "model_dump", "dict"):
+        handler = getattr(chunk, attr, None)
+        if callable(handler):
+            try:
+                normalised = handler()
+            except TypeError:
+                continue
+            if isinstance(normalised, dict):
+                return normalised
+
+    if hasattr(chunk, "__dict__") and isinstance(chunk.__dict__, dict):
+        return chunk.__dict__
+
+    return {}
+
+
+def _stream_completion_tokens(completion: Any) -> Iterable[str]:
+    if isinstance(completion, dict):
+        message = ((completion.get("choices") or [{}])[0] or {}).get("message") or {}
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            yield content
+        return
+
+    for raw_chunk in completion:
+        chunk = _normalise_chunk(raw_chunk)
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+
+        delta = (choices[0] or {}).get("delta") or {}
+        if not isinstance(delta, dict):
+            continue
+
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            yield content
+
+
+def run_inference(*, model_path: str, mode: str, prompt: str) -> int:
+    _ = mode
+    if not os.path.exists(model_path):
+        _emit({"type": "error", "code": "bad_model", "message": "model path not found"})
+        return 2
+
+    runtime_config = BridgeConfig(model_path=model_path)
+    manager = ModelManager(config=runtime_config)
+    manager.model_path = model_path
+    manager.llm = None
+
+    llm = manager.get_llm_instance()
+    if llm is None:
+        _emit(
+            {
+                "type": "error",
+                "code": "runtime_unavailable",
+                "message": "unable to initialize local model runtime",
+            }
+        )
+        return 2
+
+    token_delay = max(0.0, float(os.environ.get("TOKEN_PLACE_SIDECAR_TOKEN_DELAY_SECONDS", "0")))
+
+    try:
+        completion = llm.create_chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=runtime_config.get("model.max_tokens", 512),
+            temperature=runtime_config.get("model.temperature", 0.7),
+            top_p=runtime_config.get("model.top_p", 0.9),
+            stop=runtime_config.get("model.stop_tokens", []),
+            stream=True,
+        )
+
+        _emit({"type": "started"})
+        for token_text in _stream_completion_tokens(completion):
+            if _cancel_requested():
+                _emit({"type": "canceled"})
+                return 0
+            _emit({"type": "token", "text": token_text})
+            if token_delay:
+                time.sleep(token_delay)
+
+        if _cancel_requested():
+            _emit({"type": "canceled"})
+            return 0
+
+        _emit({"type": "done"})
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive runtime failures
+        _emit(
+            {
+                "type": "error",
+                "code": "inference_failed",
+                "message": f"inference bridge failed: {exc}",
+            }
+        )
+        return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="token.place desktop inference bridge")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mode", default="auto")
+    parser.add_argument("--prompt", required=True)
+    args = parser.parse_args()
+
+    return run_inference(model_path=args.model, mode=args.mode, prompt=args.prompt)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -80,6 +80,48 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
     Command::new(sidecar_path)
 }
 
+fn should_use_mock_sidecar() -> bool {
+    std::env::var("TOKEN_PLACE_USE_FAKE_SIDECAR")
+        .ok()
+        .is_some_and(|value| value == "1")
+        || std::env::var("TOKEN_PLACE_SIDECAR_KIND")
+            .ok()
+            .is_some_and(|value| value.eq_ignore_ascii_case("mock"))
+}
+
+fn resolve_default_sidecar_path() -> String {
+    if should_use_mock_sidecar() {
+        return "../sidecar/fake_llama_sidecar.py".into();
+    }
+
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            let packaged = exe_dir
+                .join("resources")
+                .join("python")
+                .join("inference_bridge.py");
+            if packaged.is_file() {
+                return packaged.to_string_lossy().to_string();
+            }
+
+            let macos_bundle = exe_dir
+                .join("..")
+                .join("Resources")
+                .join("python")
+                .join("inference_bridge.py");
+            if macos_bundle.is_file() {
+                return macos_bundle.to_string_lossy().to_string();
+            }
+        }
+    }
+
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("python")
+        .join("inference_bridge.py")
+        .to_string_lossy()
+        .to_string()
+}
+
 pub async fn start_sidecar(
     app: AppHandle,
     state: SidecarState,
@@ -97,8 +139,8 @@ pub async fn start_sidecar(
         *state.stdin.lock().await = None;
     }
 
-    let sidecar_script = std::env::var("TOKEN_PLACE_SIDECAR")
-        .unwrap_or_else(|_| "../sidecar/fake_llama_sidecar.py".into());
+    let sidecar_script =
+        std::env::var("TOKEN_PLACE_SIDECAR").unwrap_or_else(|_| resolve_default_sidecar_path());
 
     let mut child = build_sidecar_command(&sidecar_script)
         .arg("--model")
@@ -217,5 +259,52 @@ mod tests {
             .expect("collect events");
         assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
         assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+    }
+
+    #[tokio::test]
+    async fn inference_bridge_happy_path_uses_shared_runtime() {
+        let model = NamedTempFile::new().expect("tempfile");
+        let bridge_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("python")
+            .join("inference_bridge.py");
+        let mut child = Command::new("python3")
+            .arg(bridge_path)
+            .arg("--model")
+            .arg(model.path())
+            .arg("--mode")
+            .arg("cpu")
+            .arg("--prompt")
+            .arg("hello world")
+            .env("USE_MOCK_LLM", "1")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn inference bridge");
+
+        let stdout = child.stdout.take().expect("stdout");
+        let events = collect_events_from_stdout(stdout)
+            .await
+            .expect("collect events");
+
+        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
+        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Token { text } if !text.trim().is_empty())));
+    }
+
+    #[test]
+    fn defaults_to_real_inference_bridge() {
+        std::env::remove_var("TOKEN_PLACE_USE_FAKE_SIDECAR");
+        std::env::remove_var("TOKEN_PLACE_SIDECAR_KIND");
+        let path = resolve_default_sidecar_path();
+        assert!(path.ends_with("python/inference_bridge.py"));
+    }
+
+    #[test]
+    fn supports_mock_sidecar_opt_in() {
+        std::env::set_var("TOKEN_PLACE_USE_FAKE_SIDECAR", "1");
+        let path = resolve_default_sidecar_path();
+        std::env::remove_var("TOKEN_PLACE_USE_FAKE_SIDECAR");
+        assert!(path.ends_with("sidecar/fake_llama_sidecar.py"));
     }
 }

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -63,7 +63,7 @@ Desktop parity includes model-management behaviors, not just prompt UI.
   - <https://www.llama.com/models/>
 - Show the actual GGUF artifact the runtime is using (path/name/version where available).
 - Support model browse + download UX (with explicit status/progress/error handling).
-- Default relay URL should be `https://token.place`, but must remain overrideable for local/staging.
+- Default relay URL should be `https://token.place`, but must remain overridable for local/staging.
 
 ## Operational alignment
 

--- a/tests/unit/test_desktop_inference_bridge.py
+++ b/tests/unit/test_desktop_inference_bridge.py
@@ -1,0 +1,116 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BRIDGE = REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / "inference_bridge.py"
+
+
+class DesktopInferenceBridgeTests(unittest.TestCase):
+    def _bridge_cmd(self, *, model_path: Path, prompt: str):
+        return [
+            sys.executable,
+            str(BRIDGE),
+            "--model",
+            str(model_path),
+            "--mode",
+            "cpu",
+            "--prompt",
+            prompt,
+        ]
+
+    def test_happy_path_streams_ndjson_events(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.gguf"
+            model_path.write_bytes(b"stub")
+
+            env = os.environ.copy()
+            env["USE_MOCK_LLM"] = "1"
+
+            proc = subprocess.Popen(
+                self._bridge_cmd(model_path=model_path, prompt="What is token.place?"),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                cwd=str(REPO_ROOT),
+            )
+
+            events = []
+            self.assertIsNotNone(proc.stdout)
+            for line in proc.stdout:
+                text = line.strip()
+                if text:
+                    events.append(json.loads(text))
+
+            return_code = proc.wait(timeout=30)
+            if proc.stdout:
+                proc.stdout.close()
+            if proc.stderr:
+                proc.stderr.close()
+            self.assertEqual(return_code, 0)
+            self.assertGreaterEqual(len(events), 3)
+
+            event_types = [event["type"] for event in events]
+            self.assertEqual(event_types[0], "started")
+            self.assertEqual(event_types[-1], "done")
+
+            token_payload = "".join(
+                event.get("text", "") for event in events if event["type"] == "token"
+            )
+            self.assertIn("Mock Response", token_payload)
+            self.assertNotEqual(token_payload.strip(), "What is token.place?")
+
+    def test_cancel_emits_canceled_event(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.gguf"
+            model_path.write_bytes(b"stub")
+
+            env = os.environ.copy()
+            env["USE_MOCK_LLM"] = "1"
+            env["TOKEN_PLACE_SIDECAR_TOKEN_DELAY_SECONDS"] = "0.05"
+
+            proc = subprocess.Popen(
+                self._bridge_cmd(model_path=model_path, prompt="Cancel this response please"),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                cwd=str(REPO_ROOT),
+            )
+
+            self.assertIsNotNone(proc.stdout)
+            self.assertIsNotNone(proc.stdin)
+
+            first_event = json.loads(proc.stdout.readline().strip())
+            self.assertEqual(first_event["type"], "started")
+
+            proc.stdin.write('{"type":"cancel"}\n')
+            proc.stdin.flush()
+
+            remaining_events = []
+            for line in proc.stdout:
+                text = line.strip()
+                if text:
+                    remaining_events.append(json.loads(text))
+
+            return_code = proc.wait(timeout=30)
+            proc.stdin.close()
+            proc.stdout.close()
+            if proc.stderr:
+                proc.stderr.close()
+            self.assertEqual(return_code, 0)
+
+            event_types = [event["type"] for event in remaining_events]
+            self.assertIn("canceled", event_types)
+            self.assertNotIn("done", event_types)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Replace the transitional fake NDJSON sidecar with a real desktop inference bridge that reuses the shared Python `ModelManager` runtime so the desktop prompt UI can produce actual completions when runtime deps and model artifacts are present. 
- Preserve the existing NDJSON event contract (`started`, `token`, `done`, `canceled`, `error`) and keep a fast/mock option available for CI and local dev.

### Description
- Added a new Python inference bridge `desktop-tauri/src-tauri/python/inference_bridge.py` that adapts a minimal `BridgeConfig`, instantiates `ModelManager`, and emits NDJSON sidecar events while supporting cancellation via stdin. 
- Updated Rust sidecar resolution in `desktop-tauri/src-tauri/src/sidecar.rs` to prefer a packaged `inference_bridge.py` (with macOS bundle fallbacks) while honoring `TOKEN_PLACE_SIDECAR` overrides and opt-in mock via `TOKEN_PLACE_USE_FAKE_SIDECAR` or `TOKEN_PLACE_SIDECAR_KIND=mock`. 
- Added focused tests: a Python unit test `tests/unit/test_desktop_inference_bridge.py` that validates streaming NDJSON events and cancel behavior, and Rust tests in `sidecar.rs` that assert event parsing, default bridge resolution, and a mocked bridge happy path. 
- Updated `desktop-tauri/README.md` and design docs to document the new default bridge and the mock opt-in path, and fixed a `codespell` spelling issue.

### Testing
- Ran `cd desktop-tauri && npm run build` which succeeded (frontend build OK). 
- Ran `python -m unittest -q tests.unit.test_desktop_inference_bridge` and the new bridge unit tests passed. 
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` but the crate build fails in this container due to missing system `glib-2.0.pc` / pkg-config resolution (environment/system dependency issue). 
- Ran `python -m pytest -q` and full pytest suite failed in this environment due to missing Python `playwright` dependency required by `tests/conftest.py`. 
- Ran `pre-commit run --all-files` which started hooks and surfaced a `codespell` issue that was fixed, but full run-checks still fail in this container because required test/CI deps are not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73dfa5b1c832fa8ff86aedac026c0)