### PR TITLE
Desktop Tauri compute-node mode reaches legacy relay parity

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -4,7 +4,7 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
 
 ## Scope of this MVP
 
-- Single-screen UI for BYO GGUF model path + prompt entry.
+- Single-screen UI with a background compute-node operator mode plus a local prompt smoke-test panel.
 - Shows the canonical model family page and runtime GGUF artifact metadata from
   shared Python config/runtime logic.
 - Lets users either browse to an existing GGUF or download the configured GGUF
@@ -13,16 +13,16 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
   - macOS arm64 => `Metal / Apple Silicon`
   - Windows x64 => `CUDA / NVIDIA`
   - other targets => `CPU fallback`
-- Sidecar-driven streaming output with explicit cancellation.
-- Optional `Encrypt + forward output` action that sends the final output through
-  the existing relay-compatible encrypted `/next_server` + `/faucet` flow.
+- Background compute-node mode that registers and polls via `/sink`, decrypts requests, runs local inference, and posts responses to `/source` (or `/stream/source` when streaming is requested by the relay contract).
+- Sidecar-driven local prompt smoke-test output with explicit cancellation.
+- Optional debug-only relay forward action for manual `/next_server` + `/faucet` checks.
 
-## Inference sidecar behavior
+## Compute-node bridge behavior
 
-Desktop now defaults to a Python NDJSON bridge
-(`src-tauri/python/inference_sidecar.py`) that reuses the shared
-`utils.llm.model_manager` runtime and emits the existing
-`started/token/done/canceled/error` event contract.
+Desktop includes a Python compute-node bridge
+(`src-tauri/python/compute_node_bridge.py`) that reuses
+`utils.compute_node_runtime` for the legacy relay `/sink` + `/source` flow used by `server.py`.
+The bridge runs as the primary operator path and emits status events (running/registered, active relay URL, backend mode, model path, and last error).
 
 The fake sidecar remains available at `sidecar/fake_llama_sidecar.py` for CI
 and fast local testing:
@@ -69,3 +69,6 @@ Desktop binaries are published by the GitHub Actions workflow
 
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.
+
+
+The local prompt panel still uses `src-tauri/python/inference_sidecar.py` as a smoke test for local model setup.

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import queue
 import sys
 import threading
@@ -142,6 +141,8 @@ def run(args: argparse.Namespace) -> int:
                         last_error = "failed to process relay request"
                     else:
                         last_error = None
+                else:
+                    last_error = None
 
             emit(
                 {
@@ -169,7 +170,7 @@ def run(args: argparse.Namespace) -> int:
             "active_relay_url": runtime.relay_client.relay_url,
             "backend_mode": args.mode,
             "model_path": args.model,
-            "last_error": last_error,
+            "last_error": None,
         }
     )
     return 0

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Desktop compute-node bridge that reuses the shared compute runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_stdin_lines: queue.Queue[str] = queue.Queue()
+_stdin_reader_started = False
+_stdin_reader_lock = threading.Lock()
+
+
+def _start_stdin_reader() -> None:
+    global _stdin_reader_started
+    with _stdin_reader_lock:
+        if _stdin_reader_started:
+            return
+
+        def _reader() -> None:
+            while True:
+                line = sys.stdin.readline()
+                if line == "":
+                    break
+                _stdin_lines.put(line)
+
+        threading.Thread(target=_reader, daemon=True).start()
+        _stdin_reader_started = True
+
+
+def stop_requested() -> bool:
+    _start_stdin_reader()
+    while True:
+        try:
+            line = _stdin_lines.get_nowait().strip()
+        except queue.Empty:
+            return False
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if payload.get("type") == "cancel":
+            return True
+
+
+def emit(payload: Dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _apply_compute_mode(manager: Any, mode: str) -> None:
+    selected = (mode or "auto").lower()
+    if selected == "cpu":
+        manager.default_n_gpu_layers = 0
+    elif selected in {"metal", "cuda"}:
+        manager.default_n_gpu_layers = -1
+
+
+def _sleep_with_cancel(seconds: float) -> bool:
+    deadline = time.time() + max(seconds, 0)
+    while time.time() < deadline:
+        if stop_requested():
+            return True
+        time.sleep(0.1)
+    return stop_requested()
+
+
+def run(args: argparse.Namespace) -> int:
+    try:
+        from utils.compute_node_runtime import (
+            ComputeNodeRuntime,
+            ComputeNodeRuntimeConfig,
+            resolve_relay_port,
+            resolve_relay_url,
+        )
+    except ModuleNotFoundError as exc:
+        emit({"type": "error", "message": f"runtime unavailable: {exc}"})
+        return 1
+
+    relay_url = resolve_relay_url(args.relay_url)
+    relay_port = resolve_relay_port(args.relay_port, relay_url)
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(
+            relay_url=relay_url,
+            relay_port=relay_port,
+        )
+    )
+
+    runtime.model_manager.model_path = args.model
+    _apply_compute_mode(runtime.model_manager, args.mode)
+
+    if not runtime.ensure_model_ready():
+        emit(
+            {
+                "type": "error",
+                "message": "failed to initialize model runtime",
+                "active_relay_url": runtime.relay_client.relay_url,
+            }
+        )
+        return 1
+
+    last_error: Optional[str] = None
+    emit(
+        {
+            "type": "started",
+            "running": True,
+            "registered": False,
+            "active_relay_url": runtime.relay_client.relay_url,
+            "backend_mode": args.mode,
+            "model_path": args.model,
+            "last_error": None,
+        }
+    )
+
+    try:
+        while not stop_requested():
+            relay_response = runtime.register_and_poll_once()
+            active_relay_url = runtime.relay_client.relay_url
+            registered = "error" not in relay_response
+
+            if not registered:
+                last_error = str(relay_response.get("error", "relay registration failed"))
+            else:
+                required_fields = {"client_public_key", "chat_history", "cipherkey", "iv"}
+                if required_fields.issubset(relay_response.keys()):
+                    processed = runtime.process_relay_request(relay_response)
+                    if not processed:
+                        last_error = "failed to process relay request"
+                    else:
+                        last_error = None
+
+            emit(
+                {
+                    "type": "status",
+                    "running": True,
+                    "registered": registered,
+                    "active_relay_url": active_relay_url,
+                    "backend_mode": args.mode,
+                    "model_path": args.model,
+                    "last_error": last_error,
+                }
+            )
+
+            wait_seconds = float(relay_response.get("next_ping_in_x_seconds", 1))
+            if _sleep_with_cancel(wait_seconds):
+                break
+    finally:
+        runtime.stop()
+
+    emit(
+        {
+            "type": "stopped",
+            "running": False,
+            "registered": False,
+            "active_relay_url": runtime.relay_client.relay_url,
+            "backend_mode": args.mode,
+            "model_path": args.model,
+            "last_error": last_error,
+        }
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mode", default="auto", choices=["auto", "metal", "cuda", "cpu"])
+    parser.add_argument("--relay-url", default="https://token.place")
+    parser.add_argument("--relay-port", type=int, default=None)
+    args = parser.parse_args()
+
+    try:
+        return run(args)
+    except Exception as exc:  # pragma: no cover - last resort failure handling
+        emit({"type": "error", "message": f"bridge failure: {exc}"})
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,0 +1,233 @@
+use crate::backend::ComputeMode;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputeNodeRequest {
+    pub model_path: String,
+    pub relay_base_url: String,
+    pub mode: ComputeMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ComputeNodeStatus {
+    pub running: bool,
+    pub registered: bool,
+    pub active_relay_url: String,
+    pub backend_mode: String,
+    pub model_path: String,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone, Default)]
+pub struct ComputeNodeState {
+    pub child: Arc<Mutex<Option<Child>>>,
+    pub stdin: Arc<Mutex<Option<ChildStdin>>>,
+    pub status: Arc<Mutex<ComputeNodeStatus>>,
+}
+
+fn build_bridge_command(bridge_path: &str) -> Command {
+    let path = Path::new(bridge_path);
+    let is_python = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
+
+    if is_python {
+        let python_bin =
+            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
+        let mut cmd = Command::new(python_bin);
+        cmd.arg(bridge_path);
+        return cmd;
+    }
+
+    Command::new(bridge_path)
+}
+
+fn resolve_bridge_script() -> String {
+    let mut candidates = Vec::new();
+
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
+            candidates.push(
+                exe_dir
+                    .join("resources")
+                    .join("python")
+                    .join("compute_node_bridge.py"),
+            );
+            if let Some(parent_dir) = exe_dir.parent() {
+                candidates.push(
+                    parent_dir
+                        .join("Resources")
+                        .join("python")
+                        .join("compute_node_bridge.py"),
+                );
+                candidates.push(
+                    parent_dir
+                        .join("resources")
+                        .join("python")
+                        .join("compute_node_bridge.py"),
+                );
+            }
+        }
+    }
+
+    candidates.push(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("python")
+            .join("compute_node_bridge.py"),
+    );
+
+    for candidate in candidates {
+        if candidate.is_file() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+
+    "python/compute_node_bridge.py".into()
+}
+
+fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
+    if let Some(running) = payload.get("running").and_then(Value::as_bool) {
+        status.running = running;
+    }
+    if let Some(registered) = payload.get("registered").and_then(Value::as_bool) {
+        status.registered = registered;
+    }
+    if let Some(active_relay_url) = payload.get("active_relay_url").and_then(Value::as_str) {
+        status.active_relay_url = active_relay_url.into();
+    }
+    if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
+        status.backend_mode = backend_mode.into();
+    }
+    if let Some(model_path) = payload.get("model_path").and_then(Value::as_str) {
+        status.model_path = model_path.into();
+    }
+    if payload.get("last_error").is_some() {
+        status.last_error = payload
+            .get("last_error")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("type").and_then(Value::as_str) == Some("error") {
+        status.last_error = payload
+            .get("message")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| Some("compute-node bridge error".into()));
+    }
+}
+
+pub async fn start_compute_node(
+    app: AppHandle,
+    state: ComputeNodeState,
+    request: ComputeNodeRequest,
+) -> anyhow::Result<()> {
+    {
+        let mut child_slot = state.child.lock().await;
+        if child_slot
+            .as_mut()
+            .is_some_and(|child| child.try_wait().ok().flatten().is_none())
+        {
+            anyhow::bail!("compute node already running; stop it before starting a new session");
+        }
+        *child_slot = None;
+        *state.stdin.lock().await = None;
+    }
+
+    {
+        let mut status = state.status.lock().await;
+        *status = ComputeNodeStatus {
+            running: true,
+            registered: false,
+            active_relay_url: request.relay_base_url.clone(),
+            backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            model_path: request.model_path.clone(),
+            last_error: None,
+        };
+    }
+
+    let bridge_script = resolve_bridge_script();
+    let mut child = build_bridge_command(&bridge_script)
+        .arg("--model")
+        .arg(&request.model_path)
+        .arg("--mode")
+        .arg(format!("{:?}", request.mode).to_lowercase())
+        .arg("--relay-url")
+        .arg(&request.relay_base_url)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing compute-node bridge stdout"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing compute-node bridge stdin"))?;
+
+    {
+        let mut child_slot = state.child.lock().await;
+        *child_slot = Some(child);
+        let mut stdin_slot = state.stdin.lock().await;
+        *stdin_slot = Some(stdin);
+    }
+
+    let mut lines = BufReader::new(stdout).lines();
+    while let Some(line) = lines.next_line().await? {
+        if let Ok(payload) = serde_json::from_str::<Value>(&line) {
+            {
+                let mut status = state.status.lock().await;
+                update_status_from_event(&mut status, &payload);
+            }
+            app.emit("compute_node_event", payload)?;
+        }
+    }
+
+    {
+        let mut status = state.status.lock().await;
+        status.running = false;
+    }
+    *state.child.lock().await = None;
+    *state.stdin.lock().await = None;
+
+    Ok(())
+}
+
+pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
+    if let Some(stdin) = state.stdin.lock().await.as_mut() {
+        stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
+        stdin.flush().await?;
+    }
+
+    let mut child_lock = state.child.lock().await;
+    if let Some(child) = child_lock.as_mut() {
+        for _ in 0..20 {
+            if child.try_wait()?.is_some() {
+                *child_lock = None;
+                *state.stdin.lock().await = None;
+                state.status.lock().await.running = false;
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let _ = child.kill().await;
+    }
+
+    *child_lock = None;
+    *state.stdin.lock().await = None;
+    state.status.lock().await.running = false;
+    Ok(())
+}

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -32,6 +32,7 @@ pub struct ComputeNodeState {
     pub child: Arc<Mutex<Option<Child>>>,
     pub stdin: Arc<Mutex<Option<ChildStdin>>>,
     pub status: Arc<Mutex<ComputeNodeStatus>>,
+    pub lifecycle_lock: Arc<Mutex<()>>,
 }
 
 fn build_bridge_command(bridge_path: &str) -> Command {
@@ -132,6 +133,8 @@ pub async fn start_compute_node(
     state: ComputeNodeState,
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
+    let _lifecycle_lock = state.lifecycle_lock.lock().await;
+
     {
         let mut child_slot = state.child.lock().await;
         if child_slot
@@ -144,20 +147,8 @@ pub async fn start_compute_node(
         *state.stdin.lock().await = None;
     }
 
-    {
-        let mut status = state.status.lock().await;
-        *status = ComputeNodeStatus {
-            running: true,
-            registered: false,
-            active_relay_url: request.relay_base_url.clone(),
-            backend_mode: format!("{:?}", request.mode).to_lowercase(),
-            model_path: request.model_path.clone(),
-            last_error: None,
-        };
-    }
-
     let bridge_script = resolve_bridge_script();
-    let mut child = build_bridge_command(&bridge_script)
+    let spawn_result = build_bridge_command(&bridge_script)
         .arg("--model")
         .arg(&request.model_path)
         .arg("--mode")
@@ -167,7 +158,27 @@ pub async fn start_compute_node(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()?;
+        .spawn();
+
+    let mut child = match spawn_result {
+        Ok(child) => child,
+        Err(err) => {
+            {
+                let mut status = state.status.lock().await;
+                *status = ComputeNodeStatus {
+                    running: false,
+                    registered: false,
+                    active_relay_url: request.relay_base_url.clone(),
+                    backend_mode: format!("{:?}", request.mode).to_lowercase(),
+                    model_path: request.model_path.clone(),
+                    last_error: Some(format!("failed to start compute-node bridge: {err}")),
+                };
+            }
+            *state.child.lock().await = None;
+            *state.stdin.lock().await = None;
+            anyhow::bail!("failed to spawn compute-node bridge: {err}");
+        }
+    };
 
     let stdout = child
         .stdout
@@ -183,6 +194,15 @@ pub async fn start_compute_node(
         *child_slot = Some(child);
         let mut stdin_slot = state.stdin.lock().await;
         *stdin_slot = Some(stdin);
+        let mut status = state.status.lock().await;
+        *status = ComputeNodeStatus {
+            running: true,
+            registered: false,
+            active_relay_url: request.relay_base_url.clone(),
+            backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            model_path: request.model_path.clone(),
+            last_error: None,
+        };
     }
 
     let mut lines = BufReader::new(stdout).lines();
@@ -199,6 +219,7 @@ pub async fn start_compute_node(
     {
         let mut status = state.status.lock().await;
         status.running = false;
+        status.registered = false;
     }
     *state.child.lock().await = None;
     *state.stdin.lock().await = None;
@@ -207,27 +228,47 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
+    let _lifecycle_lock = state.lifecycle_lock.lock().await;
+
     if let Some(stdin) = state.stdin.lock().await.as_mut() {
         stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
         stdin.flush().await?;
     }
 
-    let mut child_lock = state.child.lock().await;
-    if let Some(child) = child_lock.as_mut() {
-        for _ in 0..20 {
-            if child.try_wait()?.is_some() {
-                *child_lock = None;
-                *state.stdin.lock().await = None;
-                state.status.lock().await.running = false;
-                return Ok(());
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+    let mut should_kill = false;
+    for _ in 0..20 {
+        let mut child_lock = state.child.lock().await;
+        let Some(child) = child_lock.as_mut() else {
+            break;
+        };
+
+        if child.try_wait()?.is_some() {
+            *child_lock = None;
+            *state.stdin.lock().await = None;
+            let mut status = state.status.lock().await;
+            status.running = false;
+            status.registered = false;
+            return Ok(());
         }
-        let _ = child.kill().await;
+
+        should_kill = true;
+        drop(child_lock);
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
-    *child_lock = None;
+    if should_kill {
+        let mut child_lock = state.child.lock().await;
+        if let Some(child) = child_lock.as_mut() {
+            let _ = child.kill().await;
+        }
+    }
+
+    *state.child.lock().await = None;
     *state.stdin.lock().await = None;
-    state.status.lock().await.running = false;
+    {
+        let mut status = state.status.lock().await;
+        status.running = false;
+        status.registered = false;
+    }
     Ok(())
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod compute_node;
 mod config;
 mod forward;
 mod keygen;
@@ -6,6 +7,7 @@ mod logging;
 mod sidecar;
 
 use backend::{detect_backend_for, BackendInfo};
+use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
 use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
@@ -18,6 +20,7 @@ use tokio::sync::Mutex;
 #[derive(Default)]
 struct AppState {
     sidecar: SidecarState,
+    compute_node: ComputeNodeState,
     config_dir: Mutex<Option<PathBuf>>,
 }
 
@@ -208,6 +211,31 @@ async fn encrypt_and_forward(relay_base_url: String, final_output: String) -> Re
 }
 
 #[tauri::command]
+async fn start_compute_node(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    request: ComputeNodeRequest,
+) -> Result<(), String> {
+    compute_node::start_compute_node(app, state.compute_node.clone(), request)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn stop_compute_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    compute_node::stop_compute_node(state.compute_node.clone())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_compute_node_status(
+    state: tauri::State<'_, AppState>,
+) -> Result<ComputeNodeStatus, String> {
+    Ok(state.compute_node.status.lock().await.clone())
+}
+
+#[tauri::command]
 fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
     run_model_bridge("inspect")
 }
@@ -230,6 +258,9 @@ pub fn run() {
             save_config,
             start_inference,
             cancel_inference,
+            start_compute_node,
+            stop_compute_node,
+            get_compute_node_status,
             encrypt_and_forward,
             inspect_model_artifact,
             download_model_artifact

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -18,6 +18,15 @@ interface DesktopConfig {
   preferred_mode: BackendMode;
 }
 
+interface ComputeNodeStatus {
+  running: boolean;
+  registered: boolean;
+  active_relay_url: string;
+  backend_mode: string;
+  model_path: string;
+  last_error: string | null;
+}
+
 interface ModelArtifactInfo {
   canonical_family_url: string;
   filename: string;
@@ -36,6 +45,15 @@ interface SidecarEvent {
   message?: string;
 }
 
+const defaultComputeStatus: ComputeNodeStatus = {
+  running: false,
+  registered: false,
+  active_relay_url: '',
+  backend_mode: 'auto',
+  model_path: '',
+  last_error: null,
+};
+
 export function selectedModelPath(selection: string | string[] | null): string {
   if (typeof selection === 'string') {
     return selection;
@@ -53,6 +71,7 @@ export function App() {
     relay_base_url: 'https://token.place',
     preferred_mode: 'auto',
   });
+  const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
   const [prompt, setPrompt] = useState('');
   const [output, setOutput] = useState('');
   const [requestId, setRequestId] = useState<string>('');
@@ -71,6 +90,8 @@ export function App() {
       try {
         const loadedConfig = await invoke<DesktopConfig>('load_config');
         setConfig(loadedConfig);
+        const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
+        setComputeStatus(nodeStatus);
 
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
         setArtifact(info);
@@ -119,6 +140,33 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    const unlisten = listen<Record<string, unknown>>('compute_node_event', (evt) => {
+      const payload = evt.payload;
+      setComputeStatus((prev) => ({
+        running: typeof payload.running === 'boolean' ? payload.running : prev.running,
+        registered: typeof payload.registered === 'boolean' ? payload.registered : prev.registered,
+        active_relay_url:
+          typeof payload.active_relay_url === 'string'
+            ? payload.active_relay_url
+            : prev.active_relay_url,
+        backend_mode:
+          typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
+        model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
+        last_error:
+          typeof payload.last_error === 'string'
+            ? payload.last_error
+            : typeof payload.message === 'string'
+              ? payload.message
+              : prev.last_error,
+      }));
+    });
+
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  useEffect(() => {
     return () => {
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current);
@@ -127,8 +175,17 @@ export function App() {
   }, []);
 
   const canStart = useMemo(
-    () => Boolean(config.model_path.trim()) && Boolean(prompt.trim()) && status !== 'starting' && status !== 'streaming',
+    () =>
+      Boolean(config.model_path.trim()) &&
+      Boolean(prompt.trim()) &&
+      status !== 'starting' &&
+      status !== 'streaming',
     [config.model_path, prompt, status]
+  );
+
+  const canStartComputeNode = useMemo(
+    () => Boolean(config.model_path.trim()) && !computeStatus.running,
+    [config.model_path, computeStatus.running]
   );
 
   const scheduleConfigSave = (next: DesktopConfig) => {
@@ -202,6 +259,21 @@ export function App() {
     await invoke('cancel_inference', { request_id: requestIdRef.current });
   };
 
+  const startComputeNode = async () => {
+    setError('');
+    await invoke('start_compute_node', {
+      request: {
+        model_path: config.model_path,
+        relay_base_url: config.relay_base_url,
+        mode: config.preferred_mode,
+      },
+    });
+  };
+
+  const stopComputeNode = async () => {
+    await invoke('stop_compute_node');
+  };
+
   const forwardEncrypted = async () => {
     try {
       setIsForwarding(true);
@@ -219,7 +291,7 @@ export function App() {
 
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
-      <h1>token.place desktop (Tauri MVP)</h1>
+      <h1>token.place desktop compute node</h1>
       <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
@@ -258,26 +330,53 @@ export function App() {
       )}
 
       <label style={{ display: 'block', marginTop: 12 }}>Compute mode</label>
-      <select value={config.preferred_mode} onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}>
+      <select
+        value={config.preferred_mode}
+        onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
+      >
         <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
         <option value="cpu">CPU fallback</option>
       </select>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Prompt</label>
-      <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={6} style={{ width: '100%' }} />
+      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
+      <input
+        value={config.relay_base_url}
+        style={{ width: '100%' }}
+        onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })}
+      />
 
-      <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
-        <button disabled={!canStart} onClick={startInference}>Start inference</button>
-        <button disabled={status !== 'starting' && status !== 'streaming'} onClick={cancelInference}>Cancel</button>
-        <button disabled={!output || isForwarding} onClick={forwardEncrypted}>Encrypt + forward output</button>
-      </div>
+      <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
+        <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
+          <button disabled={!computeStatus.running} onClick={stopComputeNode}>Stop operator</button>
+        </div>
+        <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
+        <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
+      </section>
 
-      <p>Status: <strong>{status}</strong></p>
+      <section style={{ marginTop: 14, borderTop: '1px solid #ddd', paddingTop: 12 }}>
+        <h2 style={{ marginTop: 0 }}>Local prompt smoke test</h2>
+        <label style={{ display: 'block', marginTop: 12 }}>Prompt</label>
+        <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={6} style={{ width: '100%' }} />
+
+        <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
+          <button disabled={!canStart} onClick={startInference}>Start local inference</button>
+          <button disabled={status !== 'starting' && status !== 'streaming'} onClick={cancelInference}>Cancel</button>
+          <button disabled={!output || isForwarding} onClick={forwardEncrypted}>
+            Debug relay forward (legacy /next_server + /faucet)
+          </button>
+        </div>
+
+        <p>Status: <strong>{status}</strong></p>
+      </section>
+
       {error && <p style={{ color: 'crimson' }}>Error: {error}</p>}
       <pre style={{ whiteSpace: 'pre-wrap', padding: 12, border: '1px solid #ddd' }}>{output}</pre>
-
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
-      <input value={config.relay_base_url} style={{ width: '100%' }} onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })} />
     </main>
   );
 }

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -153,11 +153,13 @@ export function App() {
           typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         last_error:
-          typeof payload.last_error === 'string'
-            ? payload.last_error
-            : typeof payload.message === 'string'
-              ? payload.message
-              : prev.last_error,
+          payload.last_error === null
+            ? null
+            : typeof payload.last_error === 'string'
+              ? payload.last_error
+              : typeof payload.message === 'string'
+                ? payload.message
+                : prev.last_error,
       }));
     });
 
@@ -260,18 +262,26 @@ export function App() {
   };
 
   const startComputeNode = async () => {
-    setError('');
-    await invoke('start_compute_node', {
-      request: {
-        model_path: config.model_path,
-        relay_base_url: config.relay_base_url,
-        mode: config.preferred_mode,
-      },
-    });
+    try {
+      setError('');
+      await invoke('start_compute_node', {
+        request: {
+          model_path: config.model_path,
+          relay_base_url: config.relay_base_url,
+          mode: config.preferred_mode,
+        },
+      });
+    } catch (e) {
+      setError(String(e));
+    }
   };
 
   const stopComputeNode = async () => {
-    await invoke('stop_compute_node');
+    try {
+      await invoke('stop_compute_node');
+    } catch (e) {
+      setError(String(e));
+    }
   };
 
   const forwardEncrypted = async () => {

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1,0 +1,140 @@
+"""Unit tests for the desktop compute-node bridge."""
+
+import importlib.util
+import json
+import queue
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'src-tauri'
+    / 'python'
+    / 'compute_node_bridge.py'
+)
+SPEC = importlib.util.spec_from_file_location('desktop_compute_node_bridge', MODULE_PATH)
+compute_node_bridge = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(compute_node_bridge)
+
+
+class FakeModelManager:
+    def __init__(self):
+        self.model_path = ''
+        self.default_n_gpu_layers = -1
+
+
+class FakeRelayClient:
+    relay_url = 'https://token.place'
+
+
+class FakeRuntime:
+    def __init__(self, _config):
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClient()
+        self._responses = [
+            {'next_ping_in_x_seconds': 0, 'error': 'temporary outage'},
+            {
+                'next_ping_in_x_seconds': 0,
+                'client_public_key': 'abc',
+                'chat_history': 'ciphertext',
+                'cipherkey': 'key',
+                'iv': 'iv',
+            },
+        ]
+        self._processed = []
+
+    def ensure_model_ready(self):
+        return True
+
+    def register_and_poll_once(self):
+        if self._responses:
+            return self._responses.pop(0)
+        return {'next_ping_in_x_seconds': 0}
+
+    def process_relay_request(self, payload):
+        self._processed.append(payload)
+        return True
+
+    def stop(self):
+        return None
+
+
+def _install_fake_runtime_module():
+    module = ModuleType('utils.compute_node_runtime')
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
+        relay_url=relay_url,
+        relay_port=relay_port,
+    )
+    module.ComputeNodeRuntime = FakeRuntime
+    module.resolve_relay_url = lambda relay_url: relay_url
+    module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    sys.modules['utils.compute_node_runtime'] = module
+
+
+def _reset_cancel_queue():
+    compute_node_bridge._stdin_lines = queue.Queue()
+    compute_node_bridge._stdin_reader_started = True
+
+
+def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module()
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 4
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    event_types = [event['type'] for event in events]
+    assert event_types[0] == 'started'
+    assert 'status' in event_types
+    assert event_types[-1] == 'stopped'
+    assert any(event.get('registered') is False for event in events if event['type'] == 'status')
+    assert any(event.get('registered') is True for event in events if event['type'] == 'status')
+
+
+def test_run_reports_model_initialization_failures(capsys):
+    _reset_cancel_queue()
+
+    class FailingRuntime(FakeRuntime):
+        def ensure_model_ready(self):
+            return False
+
+    module = ModuleType('utils.compute_node_runtime')
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
+        relay_url=relay_url,
+        relay_port=relay_port,
+    )
+    module.ComputeNodeRuntime = FailingRuntime
+    module.resolve_relay_url = lambda relay_url: relay_url
+    module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    sys.modules['utils.compute_node_runtime'] = module
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 1
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload['type'] == 'error'
+    assert 'failed to initialize model runtime' in payload['message']

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -30,6 +30,18 @@ class FakeRelayClient:
     relay_url = 'https://token.place'
 
 
+class FakeRelayClientRouting(FakeRelayClient):
+    def __init__(self):
+        self.endpoint_calls = []
+
+    def process_client_request(self, payload):
+        endpoint = '/source'
+        if payload.get('stream') is True and payload.get('stream_session_id'):
+            endpoint = '/stream/source'
+        self.endpoint_calls.append((endpoint, payload))
+        return True
+
+
 class FakeRuntime:
     def __init__(self, _config):
         self.model_manager = FakeModelManager()
@@ -60,6 +72,31 @@ class FakeRuntime:
 
     def stop(self):
         return None
+
+
+class StreamingRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        StreamingRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClientRouting()
+        self._responses = [
+            {
+                'next_ping_in_x_seconds': 0,
+                'client_public_key': 'abc',
+                'chat_history': 'ciphertext',
+                'cipherkey': 'key',
+                'iv': 'iv',
+                'stream': True,
+                'stream_session_id': 'session-123',
+            },
+        ]
+        self._processed = []
+
+    def process_relay_request(self, payload):
+        self._processed.append(payload)
+        return self.relay_client.process_client_request(payload)
 
 
 def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
@@ -130,3 +167,41 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
     assert 'failed to initialize model runtime' in payload['message']
+
+
+def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+
+    runtime = StreamingRuntime.last_instance
+    assert runtime is not None
+    assert len(runtime._processed) == 1
+    assert runtime._processed[0]['stream'] is True
+    assert runtime._processed[0]['stream_session_id'] == 'session-123'
+
+    assert len(runtime.relay_client.endpoint_calls) == 1
+    endpoint, payload = runtime.relay_client.endpoint_calls[0]
+    assert endpoint == '/stream/source'
+    assert payload['stream'] is True
+    assert payload['stream_session_id'] == 'session-123'
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    status_events = [event for event in events if event['type'] == 'status']
+    assert any(event.get('registered') is True for event in status_events)

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -62,16 +62,16 @@ class FakeRuntime:
         return None
 
 
-def _install_fake_runtime_module():
+def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     module = ModuleType('utils.compute_node_runtime')
     module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
         relay_url=relay_url,
         relay_port=relay_port,
     )
-    module.ComputeNodeRuntime = FakeRuntime
+    module.ComputeNodeRuntime = runtime_cls
     module.resolve_relay_url = lambda relay_url: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
-    sys.modules['utils.compute_node_runtime'] = module
+    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
 
 def _reset_cancel_queue():
@@ -81,7 +81,7 @@ def _reset_cancel_queue():
 
 def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeypatch):
     _reset_cancel_queue()
-    _install_fake_runtime_module()
+    _install_fake_runtime_module(monkeypatch)
 
     stop_counter = {'count': 0}
 
@@ -109,22 +109,14 @@ def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeyp
     assert any(event.get('registered') is True for event in events if event['type'] == 'status')
 
 
-def test_run_reports_model_initialization_failures(capsys):
+def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     _reset_cancel_queue()
 
     class FailingRuntime(FakeRuntime):
         def ensure_model_ready(self):
             return False
 
-    module = ModuleType('utils.compute_node_runtime')
-    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
-        relay_url=relay_url,
-        relay_port=relay_port,
-    )
-    module.ComputeNodeRuntime = FailingRuntime
-    module.resolve_relay_url = lambda relay_url: relay_url
-    module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
-    sys.modules['utils.compute_node_runtime'] = module
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRuntime)
 
     args = SimpleNamespace(
         model='/tmp/model.gguf',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -684,6 +684,75 @@ class TestRelayClient:
             timeout=relay_client._request_timeout
         )
 
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_streaming_posts_to_stream_source(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+        mock_http_response,
+    ):
+        """Streaming relay requests should publish chunks to /stream/source."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        request_data['stream'] = True
+        request_data['stream_session_id'] = 'session-123'
+
+        mock_http_response.status_code = 200
+        mock_http_response.text = 'ok'
+        mock_post.return_value = mock_http_response
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is True
+        mock_post.assert_called_once()
+        call = mock_post.call_args
+        assert call.args[0] == 'http://localhost:5000/stream/source'
+        assert call.kwargs['json']['session_id'] == 'session-123'
+        assert call.kwargs['json']['final'] is True
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_streaming_uses_registration_token_header(
+        self,
+        mock_post,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Streaming posts should include the relay registration token when configured."""
+
+        config_values = {
+            'relay.request_timeout': 15,
+            'relay.server_registration_token': 'alpha-token',
+        }
+
+        with patch('utils.networking.relay_client.get_config_lazy') as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.is_production = False
+            mock_config.get.side_effect = lambda key, default=None: config_values.get(key, default)
+            mock_get_config.return_value = mock_config
+
+            client = RelayClient(
+                base_url='http://localhost',
+                port=5000,
+                crypto_manager=mock_crypto_manager,
+                model_manager=mock_model_manager,
+            )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = 'OK'
+        mock_post.return_value = mock_response
+
+        payload = TEST_VALID_RESPONSE.copy()
+        payload['stream'] = True
+        payload['stream_session_id'] = 'session-123'
+        result = client.process_client_request(payload)
+
+        assert result is True
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs['headers'] == {'X-Relay-Server-Token': 'alpha-token'}
+
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_uses_registration_token(
         self,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -482,21 +482,8 @@ class RelayClient:
 
         Returns:
             bool: True if processing succeeded, False otherwise
-
-        Example:
-            ```python
-            # Process data from relay
-            request_data = {
-                'client_public_key': 'base64_encoded_client_key',
-                'chat_history': 'encrypted_data',
-                'cipherkey': 'encrypted_key',
-                'iv': 'initialization_vector'
-            }
-            success = relay_client.process_client_request(request_data)
-            ```
         """
         try:
-            # Validate request data against schema
             try:
                 jsonschema.validate(instance=request_data, schema=MESSAGE_SCHEMA)
             except jsonschema.exceptions.ValidationError as e:
@@ -504,38 +491,65 @@ class RelayClient:
                 return False
 
             client_pub_key_b64 = request_data['client_public_key']
+            stream_requested = bool(request_data.get('stream', False))
+            stream_session_id = request_data.get('stream_session_id')
 
-            # Decrypt the request
             log_info("Decrypting client request...")
             decrypted_chat_history = self.crypto_manager.decrypt_message(request_data)
-
             if decrypted_chat_history is None:
                 log_info("Decryption failed. Skipping.")
                 return False
 
             log_info("Decrypted client request")
+            client_pub_key = base64.b64decode(client_pub_key_b64)
 
-            # Process with LLM
+            if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
+                log_info("Processing streaming relay request for session {}", stream_session_id)
+                response_history = self.model_manager.llama_cpp_get_response(decrypted_chat_history)
+                encrypted_response = self.crypto_manager.encrypt_message(response_history, client_pub_key)
+                chunk_payload = {
+                    'session_id': stream_session_id,
+                    'chunk': {
+                        'client_public_key': client_pub_key_b64,
+                        **encrypted_response,
+                    },
+                    'final': True,
+                }
+
+                request_kwargs = {
+                    'json': chunk_payload,
+                    'timeout': self._request_timeout,
+                }
+                headers = self._auth_headers()
+                if headers:
+                    request_kwargs['headers'] = headers
+
+                timeout = request_kwargs.pop('timeout', self._request_timeout)
+                stream_response = requests.post(
+                    f'{self.relay_url}/stream/source',
+                    timeout=timeout,
+                    **request_kwargs,
+                )
+                if stream_response.status_code != 200:
+                    log_error("Error status from /stream/source: {}", stream_response.status_code)
+                    return False
+                return True
+
             log_info("Getting response from LLM...")
             response_history = self.model_manager.llama_cpp_get_response(decrypted_chat_history)
             log_info("LLM generated response")
 
-            # Encrypt the response for the client
             log_info("Encrypting response for client...")
-            client_pub_key = base64.b64decode(client_pub_key_b64)
-
             encrypted_response = self.crypto_manager.encrypt_message(
                 response_history,
                 client_pub_key
             )
 
-            # Create the payload for the source endpoint
             source_payload = {
                 'client_public_key': client_pub_key_b64,
-                **encrypted_response  # Include chat_history, cipherkey, and iv
+                **encrypted_response
             }
 
-            # Validate the outgoing payload
             try:
                 jsonschema.validate(instance=source_payload, schema=MESSAGE_SCHEMA)
             except jsonschema.exceptions.ValidationError as e:
@@ -544,52 +558,47 @@ class RelayClient:
 
             log_info("Posting response to {}/source. Payload keys: {}", self.relay_url, list(source_payload.keys()))
 
-            # Send the response to the relay
-            try:
-                request_kwargs = {
-                    'json': source_payload,
-                    'timeout': self._request_timeout,
-                }
-                headers = self._auth_headers()
-                if headers:
-                    request_kwargs['headers'] = headers
+            request_kwargs = {
+                'json': source_payload,
+                'timeout': self._request_timeout,
+            }
+            headers = self._auth_headers()
+            if headers:
+                request_kwargs['headers'] = headers
 
-                timeout = request_kwargs.pop('timeout', self._request_timeout)
-                source_response = requests.post(
-                    f'{self.relay_url}/source',
-                    timeout=timeout,
-                    **request_kwargs
-                )
+            timeout = request_kwargs.pop('timeout', self._request_timeout)
+            source_response = requests.post(
+                f'{self.relay_url}/source',
+                timeout=timeout,
+                **request_kwargs
+            )
 
-                log_info(
-                    "Response sent to /source. Status: {}, body length: {}",
-                    source_response.status_code,
-                    len(source_response.text)
-                )
+            log_info(
+                "Response sent to /source. Status: {}, body length: {}",
+                source_response.status_code,
+                len(source_response.text)
+            )
 
-                # Validate response beyond just status code
-                if source_response.status_code != 200:
-                    log_error("Error status from /source: {}", source_response.status_code)
-                    return False
-
-                # Check if response has valid content
-                response_content = source_response.text.strip()
-                if not response_content:
-                    log_error("Empty response from /source")
-                    return False
-
-                return True
-
-            except requests.ConnectionError as e:
-                log_error("Connection error when posting to /source: {}", str(e), exc_info=True)
-                return False
-            except requests.Timeout as e:
-                log_error("Request timeout when posting to /source: {}", str(e), exc_info=True)
-                return False
-            except requests.RequestException as e:
-                log_error("Request exception when posting to /source: {}", str(e), exc_info=True)
+            if source_response.status_code != 200:
+                log_error("Error status from /source: {}", source_response.status_code)
                 return False
 
+            response_content = source_response.text.strip()
+            if not response_content:
+                log_error("Empty response from /source")
+                return False
+
+            return True
+
+        except requests.ConnectionError as e:
+            log_error("Connection error when posting to relay source endpoint: {}", str(e), exc_info=True)
+            return False
+        except requests.Timeout as e:
+            log_error("Request timeout when posting to relay source endpoint: {}", str(e), exc_info=True)
+            return False
+        except requests.RequestException as e:
+            log_error("Request exception when posting to relay source endpoint: {}", str(e), exc_info=True)
+            return False
         except Exception as e:
             log_error("Exception during request processing: {}", str(e), exc_info=True)
             return False

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -491,7 +491,7 @@ class RelayClient:
                 return False
 
             client_pub_key_b64 = request_data['client_public_key']
-            stream_requested = bool(request_data.get('stream', False))
+            stream_requested = request_data.get('stream') is True
             stream_session_id = request_data.get('stream_session_id')
 
             log_info("Decrypting client request...")


### PR DESCRIPTION
### Motivation
- Provide a desktop operator that is a drop-in replacement for `server.py`’s legacy relay `/sink`→`/source` flow using the shared compute runtime. 
- Make the background compute-node the primary production path and retain the local prompt UI only as a smoke-test/debug tool. 
- Support streaming relay responses and preserve relay registration/token behavior while avoiding accidental claims of server parity for the old `/next_server`+`/faucet` debug flow.

### Description
- Add a Python compute-node bridge `desktop-tauri/src-tauri/python/compute_node_bridge.py` that reuses `utils.compute_node_runtime` to register/poll `/sink`, decrypt requests, run inference, and post results to `/source` or `/stream/source` when streaming is requested. 
- Add a Tauri-side process manager `desktop-tauri/src-tauri/src/compute_node.rs` and wire commands (`start_compute_node`, `stop_compute_node`, `get_compute_node_status`) into `main.rs` so the UI can start/stop the bridge and receive status events. 
- Update the desktop UI (`desktop-tauri/src/App.tsx`) to surface operator status (running/registered, active relay URL, backend mode, model path, last error) and make the compute-node operator the primary path while relabeling the old encrypt+forward behavior as a debug-only action. 
- Extend `utils/networking/relay_client.py` to support posting streaming chunks to `/stream/source` when `stream` + `stream_session_id` are present while preserving existing `/source` behavior for non-streaming replies. 
- Add focused unit tests: `tests/unit/test_desktop_compute_node_bridge.py` (bridge event/status flow) and streaming-related relay client tests added to `tests/unit/test_relay_client.py`.

### Testing
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` — attempted but failed in this environment due to missing system `glib-2.0` / pkg-config metadata required by `glib-sys` (build-time system dependency). 
- `cd desktop-tauri && npm run build` — succeeded (`vite build` completed). 
- `python -m pytest -q` — full test run attempted but Python test collection failed in this container due to missing Python test runtime dependencies (for example `PIL`, `flask`, `openai`, `bandit`), so the full suite did not complete here. 
- `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_relay_client.py` — succeeded (targeted unit tests for the new bridge and relay-client streaming behavior passed). 
- `npm run lint` — succeeded. 
- `npm run test:ci` — executed; JavaScript suites and many crypto tests passed, but the integrated CI runner failed final Python suites / Bandit in this environment due to missing packages and tooling (see above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74bf23104832f891fbd56ddcb8c50)