### PR TITLE
Desktop Tauri: add compute-node operator parity for legacy relay sink/source

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -13,9 +13,11 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
   - macOS arm64 => `Metal / Apple Silicon`
   - Windows x64 => `CUDA / NVIDIA`
   - other targets => `CPU fallback`
-- Sidecar-driven streaming output with explicit cancellation.
-- Optional `Encrypt + forward output` action that sends the final output through
-  the existing relay-compatible encrypted `/next_server` + `/faucet` flow.
+- Desktop compute-node operator mode that uses legacy relay `/sink` polling and
+  posts results via `/source` (`/stream/source` for streaming requests).
+- Sidecar-driven local prompt output with explicit cancellation as a smoke test.
+- Optional debug-only `encrypt + forward local output` action that sends the
+  local prompt output through `/next_server` + `/faucet`.
 
 ## Inference sidecar behavior
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Desktop compute-node bridge for legacy relay /sink + /source flow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from utils.compute_node_runtime import (  # noqa: E402
+    ComputeNodeRuntime,
+    ComputeNodeRuntimeConfig,
+    first_env,
+    format_relay_target,
+    resolve_relay_port,
+    resolve_relay_url,
+)
+
+
+def emit(payload: Dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def emit_status(**payload: Any) -> None:
+    emit({"type": "status", **payload})
+
+
+def read_stdin_stop_signal(timeout_seconds: float = 0.1) -> bool:
+    """Return True when a stop command has been sent on stdin."""
+
+    import select
+
+    readable, _, _ = select.select([sys.stdin], [], [], timeout_seconds)
+    if not readable:
+        return False
+
+    line = sys.stdin.readline()
+    if line == "":
+        return False
+
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return False
+
+    return payload.get("type") == "stop"
+
+
+def bridge_mode_from_env(fallback: str | None = None) -> str:
+    mode = first_env(["TOKEN_PLACE_DESKTOP_BRIDGE_MODE", "TOKENPLACE_DESKTOP_BRIDGE_MODE"])
+    if mode:
+        return mode
+    if os.environ.get("TOKEN_PLACE_USE_FAKE_SIDECAR") == "1":
+        return "mock"
+    return fallback or "llama-cpp"
+
+
+def run(args: argparse.Namespace) -> int:
+    relay_url = resolve_relay_url(args.relay_url)
+    relay_port = resolve_relay_port(args.relay_port, relay_url)
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url=relay_url, relay_port=relay_port)
+    )
+    runtime.model_manager.model_path = args.model
+
+    mode = bridge_mode_from_env(args.mode)
+    relay_target = format_relay_target(relay_url, relay_port)
+    last_error = ""
+
+    emit_status(
+        state="initializing",
+        registered=False,
+        running=False,
+        relay_url=relay_target,
+        backend_mode=mode,
+        model_path=args.model,
+        last_error="",
+    )
+
+    if not runtime.ensure_model_ready():
+        last_error = "model runtime failed to initialize"
+        emit_status(
+            state="failed",
+            registered=False,
+            running=False,
+            relay_url=relay_target,
+            backend_mode=mode,
+            model_path=args.model,
+            last_error=last_error,
+        )
+        return 1
+
+    emit_status(
+        state="running",
+        registered=False,
+        running=True,
+        relay_url=relay_target,
+        backend_mode=mode,
+        model_path=args.model,
+        last_error="",
+    )
+
+    try:
+        while True:
+            if read_stdin_stop_signal(timeout_seconds=0):
+                break
+
+            relay_response = runtime.register_and_poll_once()
+            sleep_seconds = float(relay_response.get("next_ping_in_x_seconds", 10))
+
+            if "error" in relay_response:
+                last_error = str(relay_response["error"])
+                emit_status(
+                    state="running",
+                    registered=False,
+                    running=True,
+                    relay_url=runtime.relay_client.relay_url,
+                    backend_mode=mode,
+                    model_path=args.model,
+                    last_error=last_error,
+                )
+            else:
+                last_error = ""
+                emit_status(
+                    state="running",
+                    registered=True,
+                    running=True,
+                    relay_url=runtime.relay_client.relay_url,
+                    backend_mode=mode,
+                    model_path=args.model,
+                    last_error="",
+                )
+
+                required = {"client_public_key", "chat_history", "cipherkey", "iv"}
+                if required.issubset(relay_response):
+                    ok = runtime.process_relay_request(relay_response)
+                    if not ok:
+                        last_error = "failed to process relay request"
+                        emit_status(
+                            state="running",
+                            registered=True,
+                            running=True,
+                            relay_url=runtime.relay_client.relay_url,
+                            backend_mode=mode,
+                            model_path=args.model,
+                            last_error=last_error,
+                        )
+
+            if read_stdin_stop_signal(timeout_seconds=min(sleep_seconds, 0.5)):
+                break
+
+            if sleep_seconds > 0.5:
+                remaining = sleep_seconds - 0.5
+                while remaining > 0:
+                    if read_stdin_stop_signal(timeout_seconds=min(remaining, 0.5)):
+                        return 0
+                    remaining -= 0.5
+    finally:
+        runtime.stop()
+
+    emit_status(
+        state="stopped",
+        registered=False,
+        running=False,
+        relay_url=runtime.relay_client.relay_url,
+        backend_mode=mode,
+        model_path=args.model,
+        last_error=last_error,
+    )
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="token.place desktop compute node bridge")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--relay-url", default="https://token.place")
+    parser.add_argument("--relay-port", type=int, default=None)
+    parser.add_argument("--mode", default="auto")
+    args = parser.parse_args()
+
+    try:
+        return run(args)
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:  # pragma: no cover
+        emit_status(
+            state="failed",
+            registered=False,
+            running=False,
+            relay_url=args.relay_url,
+            backend_mode=bridge_mode_from_env(),
+            model_path=args.model,
+            last_error=str(exc),
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,0 +1,208 @@
+use crate::backend::ComputeMode;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputeNodeStatus {
+    pub state: String,
+    pub registered: bool,
+    pub running: bool,
+    pub relay_url: String,
+    pub backend_mode: String,
+    pub model_path: String,
+    pub last_error: String,
+}
+
+impl Default for ComputeNodeStatus {
+    fn default() -> Self {
+        Self {
+            state: "stopped".into(),
+            registered: false,
+            running: false,
+            relay_url: String::new(),
+            backend_mode: "unknown".into(),
+            model_path: String::new(),
+            last_error: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputeNodeStartRequest {
+    pub model_path: String,
+    pub relay_base_url: String,
+    pub preferred_mode: ComputeMode,
+}
+
+#[derive(Clone, Default)]
+pub struct ComputeNodeState {
+    child: Arc<Mutex<Option<Child>>>,
+    stdin: Arc<Mutex<Option<ChildStdin>>>,
+    latest_status: Arc<Mutex<ComputeNodeStatus>>,
+}
+
+fn resolve_bridge_script() -> String {
+    let mut candidates = Vec::new();
+
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
+            candidates.push(
+                exe_dir
+                    .join("resources")
+                    .join("python")
+                    .join("compute_node_bridge.py"),
+            );
+            if let Some(parent_dir) = exe_dir.parent() {
+                candidates.push(
+                    parent_dir
+                        .join("Resources")
+                        .join("python")
+                        .join("compute_node_bridge.py"),
+                );
+            }
+        }
+    }
+
+    candidates.push(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("python")
+            .join("compute_node_bridge.py"),
+    );
+
+    for candidate in candidates {
+        if candidate.is_file() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("python")
+        .join("compute_node_bridge.py")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn build_bridge_command(script: &str) -> Command {
+    let python_bin = std::env::var("TOKEN_PLACE_COMPUTE_NODE_PYTHON")
+        .or_else(|_| std::env::var("TOKEN_PLACE_SIDECAR_PYTHON"))
+        .unwrap_or_else(|_| "python3".into());
+
+    let mut cmd = Command::new(python_bin);
+    cmd.arg(script);
+    cmd
+}
+
+pub async fn start_compute_node(
+    app: AppHandle,
+    state: ComputeNodeState,
+    request: ComputeNodeStartRequest,
+) -> anyhow::Result<()> {
+    {
+        let mut child_slot = state.child.lock().await;
+        if child_slot
+            .as_mut()
+            .is_some_and(|child| child.try_wait().ok().flatten().is_none())
+        {
+            anyhow::bail!("compute node already running");
+        }
+        *child_slot = None;
+        *state.stdin.lock().await = None;
+    }
+
+    let script = resolve_bridge_script();
+    let mut child = build_bridge_command(&script)
+        .arg("--model")
+        .arg(&request.model_path)
+        .arg("--relay-url")
+        .arg(&request.relay_base_url)
+        .arg("--mode")
+        .arg(format!("{:?}", request.preferred_mode).to_lowercase())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing compute node bridge stdout"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing compute node bridge stdin"))?;
+
+    {
+        let mut child_slot = state.child.lock().await;
+        *child_slot = Some(child);
+        *state.stdin.lock().await = Some(stdin);
+    }
+
+    let state_clone = state.clone();
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let parsed = serde_json::from_str::<serde_json::Value>(&line);
+            if let Ok(value) = parsed {
+                if value.get("type").and_then(|v| v.as_str()) == Some("status") {
+                    if let Ok(status) = serde_json::from_value::<ComputeNodeStatus>(value.clone()) {
+                        *state_clone.latest_status.lock().await = status.clone();
+                        let _ = app.emit("compute_node_status", status);
+                    }
+                }
+            }
+        }
+
+        state_clone.child.lock().await.take();
+        state_clone.stdin.lock().await.take();
+    });
+
+    Ok(())
+}
+
+pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
+    if let Some(stdin) = state.stdin.lock().await.as_mut() {
+        stdin.write_all(b"{\"type\":\"stop\"}\n").await?;
+        stdin.flush().await?;
+    }
+
+    if let Some(child) = state.child.lock().await.as_mut() {
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), child.wait()).await;
+        if child.try_wait()?.is_none() {
+            let _ = child.kill().await;
+        }
+    }
+
+    state.child.lock().await.take();
+    state.stdin.lock().await.take();
+
+    let mut status = state.latest_status.lock().await;
+    status.running = false;
+    status.registered = false;
+    if status.state != "failed" {
+        status.state = "stopped".into();
+    }
+
+    Ok(())
+}
+
+pub async fn latest_status(state: ComputeNodeState) -> ComputeNodeStatus {
+    state.latest_status.lock().await.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_bridge_script;
+
+    #[test]
+    fn resolves_compute_node_bridge_script_path() {
+        let script = resolve_bridge_script();
+        assert!(script.ends_with("compute_node_bridge.py"));
+    }
+}

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod compute_node;
 mod config;
 mod forward;
 mod keygen;
@@ -6,6 +7,7 @@ mod logging;
 mod sidecar;
 
 use backend::{detect_backend_for, BackendInfo};
+use compute_node::{ComputeNodeStartRequest, ComputeNodeState, ComputeNodeStatus};
 use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
@@ -18,6 +20,7 @@ use tokio::sync::Mutex;
 #[derive(Default)]
 struct AppState {
     sidecar: SidecarState,
+    compute_node: ComputeNodeState,
     config_dir: Mutex<Option<PathBuf>>,
 }
 
@@ -208,6 +211,31 @@ async fn encrypt_and_forward(relay_base_url: String, final_output: String) -> Re
 }
 
 #[tauri::command]
+async fn start_compute_node(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    request: ComputeNodeStartRequest,
+) -> Result<(), String> {
+    compute_node::start_compute_node(app, state.compute_node.clone(), request)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn stop_compute_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    compute_node::stop_compute_node(state.compute_node.clone())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn compute_node_status(
+    state: tauri::State<'_, AppState>,
+) -> Result<ComputeNodeStatus, String> {
+    Ok(compute_node::latest_status(state.compute_node.clone()).await)
+}
+
+#[tauri::command]
 fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
     run_model_bridge("inspect")
 }
@@ -231,6 +259,9 @@ pub fn run() {
             start_inference,
             cancel_inference,
             encrypt_and_forward,
+            start_compute_node,
+            stop_compute_node,
+            compute_node_status,
             inspect_model_artifact,
             download_model_artifact
         ])

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -36,6 +36,16 @@ interface SidecarEvent {
   message?: string;
 }
 
+interface ComputeNodeStatus {
+  state: string;
+  registered: boolean;
+  running: boolean;
+  relay_url: string;
+  backend_mode: string;
+  model_path: string;
+  last_error: string;
+}
+
 export function selectedModelPath(selection: string | string[] | null): string {
   if (typeof selection === 'string') {
     return selection;
@@ -61,6 +71,15 @@ export function App() {
   const [isDownloadingModel, setIsDownloadingModel] = useState(false);
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
+  const [operatorStatus, setOperatorStatus] = useState<ComputeNodeStatus>({
+    state: 'stopped',
+    registered: false,
+    running: false,
+    relay_url: '',
+    backend_mode: 'unknown',
+    model_path: '',
+    last_error: '',
+  });
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');
 
@@ -71,6 +90,8 @@ export function App() {
       try {
         const loadedConfig = await invoke<DesktopConfig>('load_config');
         setConfig(loadedConfig);
+        const status = await invoke<ComputeNodeStatus>('compute_node_status');
+        setOperatorStatus(status);
 
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
         setArtifact(info);
@@ -112,6 +133,15 @@ export function App() {
         setStatus('failed');
         setError(payload.message ?? payload.code ?? 'unknown error');
       }
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<ComputeNodeStatus>('compute_node_status', (evt) => {
+      setOperatorStatus(evt.payload);
     });
     return () => {
       unlisten.then((f) => f());
@@ -217,10 +247,57 @@ export function App() {
     }
   };
 
+  const startOperator = async () => {
+    setError('');
+    try {
+      await invoke('start_compute_node', {
+        request: {
+          model_path: config.model_path,
+          relay_base_url: config.relay_base_url,
+          preferred_mode: config.preferred_mode,
+        },
+      });
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const stopOperator = async () => {
+    setError('');
+    try {
+      await invoke('stop_compute_node');
+      const status = await invoke<ComputeNodeStatus>('compute_node_status');
+      setOperatorStatus(status);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
       <h1>token.place desktop (Tauri MVP)</h1>
       <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
+      <section style={{ border: '1px solid #ddd', padding: 12, marginBottom: 12 }}>
+        <h2 style={{ marginTop: 0 }}>Compute node operator (production path)</h2>
+        <p style={{ marginBottom: 8 }}>
+          Status: <strong>{operatorStatus.state}</strong> · Registered:{' '}
+          <strong>{operatorStatus.registered ? 'yes' : 'no'}</strong>
+        </p>
+        <ul style={{ marginTop: 0 }}>
+          <li>Active relay URL: <code>{operatorStatus.relay_url || config.relay_base_url}</code></li>
+          <li>Backend mode: <code>{operatorStatus.backend_mode}</code></li>
+          <li>Model path: <code>{operatorStatus.model_path || config.model_path || 'unset'}</code></li>
+          <li>Last error: <code>{operatorStatus.last_error || 'none'}</code></li>
+        </ul>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" onClick={startOperator} disabled={!config.model_path || operatorStatus.running}>
+            Start compute node
+          </button>
+          <button type="button" onClick={stopOperator} disabled={!operatorStatus.running}>
+            Stop compute node
+          </button>
+        </div>
+      </section>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
         <input
@@ -263,13 +340,13 @@ export function App() {
         <option value="cpu">CPU fallback</option>
       </select>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Prompt</label>
+      <label style={{ display: 'block', marginTop: 12 }}>Prompt (local smoke test)</label>
       <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={6} style={{ width: '100%' }} />
 
       <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
         <button disabled={!canStart} onClick={startInference}>Start inference</button>
         <button disabled={status !== 'starting' && status !== 'streaming'} onClick={cancelInference}>Cancel</button>
-        <button disabled={!output || isForwarding} onClick={forwardEncrypted}>Encrypt + forward output</button>
+        <button disabled={!output || isForwarding} onClick={forwardEncrypted}>Debug: encrypt + forward local output</button>
       </div>
 
       <p>Status: <strong>{status}</strong></p>

--- a/tests/integration/desktop_tauri_bridge_loader.py
+++ b/tests/integration/desktop_tauri_bridge_loader.py
@@ -1,0 +1,17 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def load_compute_node_bridge():
+    bridge_path = (
+        Path(__file__).resolve().parents[2]
+        / "desktop-tauri"
+        / "src-tauri"
+        / "python"
+        / "compute_node_bridge.py"
+    )
+    spec = spec_from_file_location("desktop_compute_node_bridge", bridge_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/integration/test_desktop_compute_node_bridge.py
+++ b/tests/integration/test_desktop_compute_node_bridge.py
@@ -1,0 +1,88 @@
+import argparse
+
+from desktop_tauri_bridge_loader import load_compute_node_bridge
+
+
+def test_compute_node_bridge_processes_sink_payload(monkeypatch):
+    bridge = load_compute_node_bridge()
+
+    status_events = []
+
+    class FakeRelayClient:
+        relay_url = "https://relay.example"
+
+    class FakeRuntime:
+        def __init__(self, *_args, **_kwargs):
+            self.relay_client = FakeRelayClient()
+            self.model_manager = type("ModelManager", (), {"model_path": ""})()
+            self._responses = [
+                {
+                    "next_ping_in_x_seconds": 0,
+                    "client_public_key": "client",
+                    "chat_history": "ct",
+                    "cipherkey": "key",
+                    "iv": "iv",
+                }
+            ]
+            self.processed = 0
+            self.stopped = 0
+
+        def ensure_model_ready(self):
+            return True
+
+        def register_and_poll_once(self):
+            if self._responses:
+                return self._responses.pop(0)
+            return {"next_ping_in_x_seconds": 0}
+
+        def process_relay_request(self, _payload):
+            self.processed += 1
+            return True
+
+        def stop(self):
+            self.stopped += 1
+
+    stop_sequence = iter([False, True])
+
+    monkeypatch.setattr(bridge, "ComputeNodeRuntime", FakeRuntime)
+    monkeypatch.setattr(bridge, "resolve_relay_url", lambda url: url)
+    monkeypatch.setattr(bridge, "resolve_relay_port", lambda port, _url: port)
+    monkeypatch.setattr(bridge, "format_relay_target", lambda url, _port: url)
+    monkeypatch.setattr(bridge, "emit_status", lambda **payload: status_events.append(payload))
+    monkeypatch.setattr(bridge, "read_stdin_stop_signal", lambda timeout_seconds=0.1: next(stop_sequence))
+
+    args = argparse.Namespace(model="/tmp/model.gguf", relay_url="https://relay.example", relay_port=None, mode="cpu")
+    code = bridge.run(args)
+
+    assert code == 0
+    assert any(event["state"] == "running" for event in status_events)
+    assert any(event["registered"] is True for event in status_events)
+
+
+def test_compute_node_bridge_reports_model_init_failure(monkeypatch):
+    bridge = load_compute_node_bridge()
+
+    status_events = []
+
+    class FailingRuntime:
+        def __init__(self, *_args, **_kwargs):
+            self.relay_client = type("RelayClient", (), {"relay_url": "https://relay.example"})()
+            self.model_manager = type("ModelManager", (), {"model_path": ""})()
+
+        def ensure_model_ready(self):
+            return False
+
+        def stop(self):
+            return None
+
+    monkeypatch.setattr(bridge, "ComputeNodeRuntime", FailingRuntime)
+    monkeypatch.setattr(bridge, "resolve_relay_url", lambda url: url)
+    monkeypatch.setattr(bridge, "resolve_relay_port", lambda port, _url: port)
+    monkeypatch.setattr(bridge, "format_relay_target", lambda url, _port: url)
+    monkeypatch.setattr(bridge, "emit_status", lambda **payload: status_events.append(payload))
+
+    args = argparse.Namespace(model="/tmp/model.gguf", relay_url="https://relay.example", relay_port=None, mode="cpu")
+    code = bridge.run(args)
+
+    assert code == 1
+    assert status_events[-1]["state"] == "failed"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -8,6 +8,7 @@ import jsonschema
 import logging
 import os
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
@@ -15,6 +16,20 @@ import requests
 
 # Configure logging
 logger = logging.getLogger('relay_client')
+
+try:
+    from encrypt import encrypt_stream_chunk, StreamSession
+except Exception:  # pragma: no cover - defensive import for degraded envs
+    encrypt_stream_chunk = None
+    StreamSession = None
+
+
+@dataclass
+class StreamingProcessingResult:
+    """Container for streamed response data."""
+
+    full_text: str
+    streamed_any: bool
 
 def get_config_lazy():
     """Lazy import of config to avoid circular imports"""
@@ -364,6 +379,123 @@ class RelayClient:
             return {}
         return {"X-Relay-Server-Token": self._registration_token}
 
+    def _post_stream_chunk(
+        self,
+        *,
+        session_id: str,
+        chunk: Dict[str, Any],
+        final: bool = False,
+    ) -> bool:
+        """Post a streaming chunk to relay /stream/source."""
+
+        payload: Dict[str, Any] = {
+            "session_id": session_id,
+            "chunk": chunk,
+        }
+        if final:
+            payload["final"] = True
+
+        try:
+            request_kwargs = {
+                'json': payload,
+                'timeout': self._request_timeout,
+            }
+            headers = self._auth_headers()
+            if headers:
+                request_kwargs['headers'] = headers
+
+            timeout = request_kwargs.pop('timeout', self._request_timeout)
+            response = requests.post(
+                f'{self.relay_url}/stream/source',
+                timeout=timeout,
+                **request_kwargs,
+            )
+            if response.status_code != 200:
+                log_error("Error status from /stream/source: {}", response.status_code)
+                return False
+            return True
+        except requests.RequestException as exc:
+            log_error("Failed posting /stream/source chunk: {}", str(exc), exc_info=True)
+            return False
+
+    def _emit_streaming_completion(
+        self,
+        *,
+        completion: Any,
+        client_pub_key_b64: str,
+        stream_session_id: str,
+    ) -> StreamingProcessingResult:
+        """Emit relay streaming chunks while aggregating final output text."""
+
+        streamed_any = False
+        text_parts: List[str] = []
+        stream_session: Optional[Any] = None
+
+        normalize_chunk = getattr(
+            self.model_manager,
+            "_normalize_stream_chunk",
+            lambda value: value if isinstance(value, dict) else {},
+        )
+
+        for raw_chunk in completion:
+            chunk = normalize_chunk(raw_chunk)
+            if not isinstance(chunk, dict):
+                continue
+
+            choices = chunk.get("choices") or []
+            if not choices:
+                continue
+
+            delta = (choices[0] or {}).get("delta") or {}
+            if not isinstance(delta, dict):
+                continue
+
+            content = delta.get("content")
+            if content:
+                streamed_any = True
+                text_parts.append(content)
+                stream_payload: Dict[str, Any] = {"content": content}
+
+                if encrypt_stream_chunk is not None and StreamSession is not None:
+                    try:
+                        client_pub_key = base64.b64decode(client_pub_key_b64)
+                        encrypted_chunk, cipherkey, stream_session = encrypt_stream_chunk(
+                            content.encode("utf-8"),
+                            client_pub_key,
+                            session=stream_session,
+                        )
+                        stream_payload = {
+                            "encrypted": True,
+                            "data": {
+                                "chat_history": base64.b64encode(
+                                    encrypted_chunk["ciphertext"]
+                                ).decode("utf-8"),
+                                "iv": base64.b64encode(encrypted_chunk["iv"]).decode("utf-8"),
+                            },
+                        }
+                        if cipherkey is not None:
+                            stream_payload["data"]["cipherkey"] = base64.b64encode(
+                                cipherkey
+                            ).decode("utf-8")
+                    except Exception as exc:
+                        log_error("Failed to encrypt streaming chunk: {}", str(exc), exc_info=True)
+
+                self._post_stream_chunk(session_id=stream_session_id, chunk=stream_payload)
+
+            finish_reason = (choices[0] or {}).get("finish_reason")
+            if finish_reason:
+                break
+
+        self._post_stream_chunk(
+            session_id=stream_session_id,
+            chunk={"done": True},
+            final=True,
+        )
+        return StreamingProcessingResult(
+            full_text="".join(text_parts),
+            streamed_any=streamed_any,
+        )
+
     def start(self):
         """Start the polling loop by setting stop_polling to False"""
         self.stop_polling = False
@@ -517,7 +649,34 @@ class RelayClient:
 
             # Process with LLM
             log_info("Getting response from LLM...")
-            response_history = self.model_manager.llama_cpp_get_response(decrypted_chat_history)
+            streaming_enabled = bool(request_data.get("stream"))
+            stream_session_id = request_data.get("stream_session_id")
+            response_history = None
+
+            if streaming_enabled and isinstance(stream_session_id, str) and stream_session_id:
+                llm_instance = self.model_manager.get_llm_instance()
+                if llm_instance is not None:
+                    completion = llm_instance.create_chat_completion(
+                        messages=decrypted_chat_history,
+                        max_tokens=self.model_manager.config.get("model.max_tokens", 512),
+                        temperature=self.model_manager.config.get("model.temperature", 0.7),
+                        top_p=self.model_manager.config.get("model.top_p", 0.9),
+                        stop=self.model_manager.config.get("model.stop_tokens", []),
+                        stream=True,
+                    )
+                    streamed = self._emit_streaming_completion(
+                        completion=completion,
+                        client_pub_key_b64=client_pub_key_b64,
+                        stream_session_id=stream_session_id,
+                    )
+                    response_history = list(decrypted_chat_history)
+                    response_history.append(
+                        {"role": "assistant", "content": streamed.full_text}
+                    )
+
+            if response_history is None:
+                response_history = self.model_manager.llama_cpp_get_response(decrypted_chat_history)
+
             log_info("LLM generated response")
 
             # Encrypt the response for the client


### PR DESCRIPTION
### Motivation
- Make the desktop-tauri app a drop-in replacement for the legacy `server.py` relay operator by implementing a background compute-node mode that registers with `/sink`, decrypts requests, runs local inference, and posts results to `/source` (and `/stream/source` when streaming).
- Reuse the shared `ComputeNodeRuntime` from `utils.compute_node_runtime.py` to avoid duplicating request-handling logic and preserve runtime/relay token behaviour.
- Keep the local prompt UI as a smoke-test and explicitly relabel the existing forward UI action to debug-only to avoid implying full server parity when using the client-side `/next_server`/`/faucet` flow.

### Description
- Add a Python compute-node bridge `desktop-tauri/src-tauri/python/compute_node_bridge.py` that runs the relay `/sink` poll loop, emits NDJSON status events for operator telemetry, supports stdin stop signalling, and reuses `ComputeNodeRuntime` for decrypt/infer/encrypt flows.
- Add a Tauri-side compute-node manager `desktop-tauri/src-tauri/src/compute_node.rs` exposing `start_compute_node`, `stop_compute_node`, and `compute_node_status`, piping bridge stdout events to the frontend and managing process lifecycle and status storage.
- Wire the new commands into the Tauri invoke handler (`main.rs`) and extend the desktop UI (`desktop-tauri/src/App.tsx`) to surface operator status (registered/running, relay URL, backend mode, model path, last error) and start/stop controls, while relabeling the local forward button to indicate debug usage.
- Enhance the relay client (`utils/networking/relay_client.py`) to support streaming requests by posting chunk updates to `/stream/source` (with optional per-chunk encryption when available) via `_post_stream_chunk` and `_emit_streaming_completion`, and integrate this streaming path into `process_client_request` while preserving the final `/source` submission.
- Update desktop README to document compute-node operator mode and add focused integration tests (`tests/integration/test_desktop_compute_node_bridge.py` and loader) that mock the runtime for the new bridge behaviour.

### Testing
- Ran `cd desktop-tauri && npm run build`, which succeeded and produced a production build of the frontend.
- Ran `npm run lint`, which completed successfully for the JS/TS code.
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, but the Rust tests could not complete in this environment due to missing system libraries for GTK/JavaScriptCore (pkg-config / native deps); build failed during native crate configuration.
- Ran `python -m pytest -q`, which initially failed due to missing Python packages in the environment; after installing `requests`, `cryptography`, and `playwright` some Python test phases still failed (additional native/python deps such as `psutil` and other system/runtime packages are required in this environment), so the full Python suite did not complete.
- Executed the repository CI script (`npm run test:ci`), where the JavaScript tests passed but multiple Python test sections failed for the same missing dependencies; these failures are environmental and not caused by the PR diff itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74bf23104832f891fbd56ddcb8c50)