### PR TITLE
Desktop Tauri: add compute-node operator mode on legacy sink/source relay flow

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -4,7 +4,7 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
 
 ## Scope of this MVP
 
-- Single-screen UI for BYO GGUF model path + prompt entry.
+- Single-screen UI for BYO GGUF model path + operator controls.
 - Shows the canonical model family page and runtime GGUF artifact metadata from
   shared Python config/runtime logic.
 - Lets users either browse to an existing GGUF or download the configured GGUF
@@ -13,9 +13,12 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
   - macOS arm64 => `Metal / Apple Silicon`
   - Windows x64 => `CUDA / NVIDIA`
   - other targets => `CPU fallback`
-- Sidecar-driven streaming output with explicit cancellation.
-- Optional `Encrypt + forward output` action that sends the final output through
-  the existing relay-compatible encrypted `/next_server` + `/faucet` flow.
+- Desktop compute-node mode that registers via `/sink`, decrypts relay work,
+  runs local inference, and posts responses through `/source` (or
+  `/stream/source` when streaming is enabled).
+- Local prompt + output panel retained as a smoke-test/debug tool.
+- Legacy `Encrypt + forward output` path remains debug-only and does not imply
+  parity with `server.py` operator semantics.
 
 ## Inference sidecar behavior
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Desktop compute-node bridge for legacy relay /sink -> /source flow."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import requests
+
+from encrypt import encrypt_stream_chunk
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from utils.compute_node_runtime import (  # noqa: E402
+    ComputeNodeRuntime,
+    ComputeNodeRuntimeConfig,
+    format_relay_target,
+    resolve_relay_port,
+)
+
+_stdin_lines: queue.Queue[str] = queue.Queue()
+_stdin_reader_started = False
+_stdin_reader_lock = threading.Lock()
+
+
+def _start_stdin_reader() -> None:
+    global _stdin_reader_started
+    with _stdin_reader_lock:
+        if _stdin_reader_started:
+            return
+
+        def _reader() -> None:
+            while True:
+                line = sys.stdin.readline()
+                if line == "":
+                    break
+                _stdin_lines.put(line)
+
+        threading.Thread(target=_reader, daemon=True).start()
+        _stdin_reader_started = True
+
+
+def _emit(payload: Dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _emit_error(message: str) -> None:
+    _emit({"type": "error", "message": message})
+
+
+def _cancel_requested() -> bool:
+    _start_stdin_reader()
+    while True:
+        try:
+            line = _stdin_lines.get_nowait().strip()
+        except queue.Empty:
+            return False
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("type") == "cancel":
+            return True
+
+
+def _normalize_stream_chunk(chunk: Any) -> Dict[str, Any]:
+    if isinstance(chunk, dict):
+        return chunk
+
+    for attr in ("to_dict", "model_dump", "dict"):
+        handler = getattr(chunk, attr, None)
+        if callable(handler):
+            try:
+                parsed = handler()
+            except TypeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+
+    if hasattr(chunk, "__dict__") and isinstance(chunk.__dict__, dict):
+        return chunk.__dict__
+    return {}
+
+
+class ComputeNodeBridge:
+    def __init__(
+        self,
+        runtime: ComputeNodeRuntime,
+        *,
+        stream_enabled: bool,
+        mode: str,
+        model_path: str,
+    ):
+        self.runtime = runtime
+        self.stream_enabled = stream_enabled
+        self.mode = mode
+        self.model_path = model_path
+        self.last_error = ""
+        self.registered = False
+
+    def _status(self) -> Dict[str, Any]:
+        relay_client = self.runtime.relay_client
+        return {
+            "type": "status",
+            "registered": self.registered,
+            "running": True,
+            "active_relay_url": relay_client.relay_url,
+            "backend_mode": self.mode,
+            "model_path": self.model_path,
+            "stream_enabled": self.stream_enabled,
+            "last_error": self.last_error,
+        }
+
+    def _post_stream_chunk(self, session_id: str, chunk: Dict[str, Any], final: bool = False) -> None:
+        response = requests.post(
+            f"{self.runtime.relay_client.relay_url}/stream/source",
+            json={"session_id": session_id, "chunk": chunk, "final": final},
+            headers=self.runtime.relay_client._auth_headers() or None,
+            timeout=10,
+        )
+        response.raise_for_status()
+
+    def _stream_request(self, request_data: Dict[str, Any]) -> bool:
+        decrypted = self.runtime.crypto_manager.decrypt_message(request_data)
+        if not isinstance(decrypted, list):
+            return False
+
+        llm = self.runtime.model_manager.get_llm_instance()
+        if llm is None:
+            return False
+
+        completion = llm.create_chat_completion(
+            messages=decrypted,
+            max_tokens=self.runtime.model_manager.config.get("model.max_tokens", 512),
+            temperature=self.runtime.model_manager.config.get("model.temperature", 0.7),
+            top_p=self.runtime.model_manager.config.get("model.top_p", 0.9),
+            stop=self.runtime.model_manager.config.get("model.stop_tokens", []),
+            stream=True,
+        )
+
+        client_public_key_b64 = request_data["client_public_key"]
+        session_id = request_data.get("stream_session_id")
+        if not isinstance(session_id, str) or not session_id:
+            return self.runtime.process_relay_request(request_data)
+
+        client_key = base64.b64decode(client_public_key_b64)
+        stream_session = None
+
+        if isinstance(completion, dict):
+            content = (
+                completion.get("choices", [{}])[0]
+                .get("message", {})
+                .get("content", "")
+            )
+            if not content:
+                return self.runtime.process_relay_request(request_data)
+            ciphertext_dict, encrypted_key, stream_session = encrypt_stream_chunk(
+                content.encode("utf-8"),
+                client_key,
+                session=stream_session,
+            )
+            payload = {
+                "encrypted": True,
+                "stream_session_id": session_id,
+                "data": {
+                    "chat_history": base64.b64encode(ciphertext_dict["ciphertext"]).decode("utf-8"),
+                    "iv": base64.b64encode(ciphertext_dict["iv"]).decode("utf-8"),
+                    "cipherkey": base64.b64encode(encrypted_key).decode("utf-8") if encrypted_key else None,
+                },
+            }
+            self._post_stream_chunk(session_id, payload, final=True)
+            return True
+
+        saw_chunk = False
+        for raw_chunk in completion:
+            parsed = _normalize_stream_chunk(raw_chunk)
+            choices = parsed.get("choices") or []
+            if not choices:
+                continue
+            delta = (choices[0] or {}).get("delta") or {}
+            content = delta.get("content") if isinstance(delta, dict) else None
+            if content:
+                saw_chunk = True
+                ciphertext_dict, encrypted_key, stream_session = encrypt_stream_chunk(
+                    content.encode("utf-8"),
+                    client_key,
+                    session=stream_session,
+                )
+                encrypted_payload = {
+                    "chat_history": base64.b64encode(ciphertext_dict["ciphertext"]).decode("utf-8"),
+                    "iv": base64.b64encode(ciphertext_dict["iv"]).decode("utf-8"),
+                }
+                if encrypted_key is not None:
+                    encrypted_payload["cipherkey"] = base64.b64encode(encrypted_key).decode("utf-8")
+
+                envelope = {
+                    "encrypted": True,
+                    "stream_session_id": session_id,
+                    "data": encrypted_payload,
+                }
+                self._post_stream_chunk(session_id, envelope)
+
+            if (choices[0] or {}).get("finish_reason"):
+                break
+
+        if saw_chunk:
+            self._post_stream_chunk(session_id, {"event": "done"}, final=True)
+            return True
+
+        return self.runtime.process_relay_request(request_data)
+
+    def process_sink_payload(self, sink_payload: Dict[str, Any]) -> bool:
+        requests_to_process = []
+        if all(
+            field in sink_payload
+            for field in ("client_public_key", "chat_history", "cipherkey", "iv")
+        ):
+            requests_to_process.append(sink_payload)
+
+        batch = sink_payload.get("batch")
+        if isinstance(batch, list):
+            for entry in batch:
+                if isinstance(entry, dict):
+                    requests_to_process.append(entry)
+
+        overall_success = True
+        for request_data in requests_to_process:
+            should_stream = bool(request_data.get("stream")) and self.stream_enabled
+            if should_stream:
+                success = self._stream_request(request_data)
+            else:
+                success = self.runtime.process_relay_request(request_data)
+            overall_success = overall_success and success
+        return overall_success
+
+    def run(self) -> int:
+        if not self.runtime.ensure_model_ready():
+            _emit_error("model_not_ready")
+            return 1
+
+        _emit(self._status())
+        while True:
+            if _cancel_requested():
+                self.runtime.stop()
+                _emit({"type": "stopped"})
+                return 0
+
+            try:
+                sink_payload = self.runtime.register_and_poll_once()
+                self.registered = True
+                if isinstance(sink_payload, dict):
+                    if "error" in sink_payload:
+                        self.last_error = str(sink_payload.get("error", ""))
+                    else:
+                        self.last_error = ""
+                        self.process_sink_payload(sink_payload)
+                    _emit(self._status())
+                    sleep_seconds = sink_payload.get("next_ping_in_x_seconds", 1)
+                else:
+                    sleep_seconds = 1
+            except Exception as exc:  # pragma: no cover
+                self.last_error = str(exc)
+                _emit_error(self.last_error)
+                _emit(self._status())
+                sleep_seconds = 2
+
+            time.sleep(max(float(sleep_seconds), 0.05))
+
+
+def _apply_compute_mode(model_manager: Any, mode: str) -> None:
+    selected = (mode or "auto").lower()
+    if selected == "cpu":
+        model_manager.default_n_gpu_layers = 0
+    elif selected in {"metal", "cuda"}:
+        model_manager.default_n_gpu_layers = -1
+
+
+def _build_runtime(relay_url: str, relay_port: Optional[int]) -> ComputeNodeRuntime:
+    return ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url=relay_url, relay_port=relay_port),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="token.place desktop compute node bridge")
+    parser.add_argument("--relay-url", required=True)
+    parser.add_argument("--relay-port", type=int, default=None)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mode", default="auto", choices=["auto", "metal", "cuda", "cpu"])
+    parser.add_argument("--stream-enabled", action="store_true")
+    args = parser.parse_args()
+
+    relay_port = resolve_relay_port(args.relay_port, args.relay_url)
+    runtime = _build_runtime(args.relay_url, relay_port)
+
+    runtime.model_manager.model_path = args.model
+    _apply_compute_mode(runtime.model_manager, args.mode)
+
+    target = format_relay_target(args.relay_url, relay_port)
+    _emit({"type": "started", "relay_target": target})
+
+    bridge = ComputeNodeBridge(
+        runtime,
+        stream_enabled=args.stream_enabled,
+        mode=args.mode,
+        model_path=args.model,
+    )
+    return bridge.run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,0 +1,225 @@
+use crate::backend::ComputeMode;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputeNodeRequest {
+    pub relay_base_url: String,
+    pub model_path: String,
+    pub mode: ComputeMode,
+    pub stream_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ComputeNodeStatus {
+    pub registered: bool,
+    pub running: bool,
+    pub active_relay_url: String,
+    pub backend_mode: String,
+    pub model_path: String,
+    pub stream_enabled: bool,
+    pub last_error: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+enum BridgeEvent {
+    #[serde(rename = "status")]
+    Status {
+        registered: bool,
+        running: bool,
+        active_relay_url: String,
+        backend_mode: String,
+        model_path: String,
+        stream_enabled: bool,
+        last_error: String,
+    },
+    #[serde(rename = "error")]
+    Error { message: String },
+    #[serde(rename = "stopped")]
+    Stopped,
+    #[serde(rename = "started")]
+    Started { relay_target: String },
+}
+
+#[derive(Clone, Default)]
+pub struct ComputeNodeState {
+    pub child: Arc<Mutex<Option<Child>>>,
+    pub stdin: Arc<Mutex<Option<ChildStdin>>>,
+    pub status: Arc<Mutex<ComputeNodeStatus>>,
+}
+
+fn build_bridge_command(bridge_path: &str) -> Command {
+    let path = Path::new(bridge_path);
+    let is_python = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
+
+    if is_python {
+        let python_bin =
+            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
+        let mut cmd = Command::new(python_bin);
+        cmd.arg(bridge_path);
+        return cmd;
+    }
+
+    Command::new(bridge_path)
+}
+
+fn resolve_compute_bridge_script() -> String {
+    let mut candidates = Vec::new();
+
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
+            candidates.push(
+                exe_dir
+                    .join("resources")
+                    .join("python")
+                    .join("compute_node_bridge.py"),
+            );
+            if let Some(parent_dir) = exe_dir.parent() {
+                candidates.push(
+                    parent_dir
+                        .join("Resources")
+                        .join("python")
+                        .join("compute_node_bridge.py"),
+                );
+            }
+        }
+    }
+
+    candidates.push(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("python")
+            .join("compute_node_bridge.py"),
+    );
+
+    for candidate in candidates {
+        if candidate.is_file() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+
+    "python/compute_node_bridge.py".into()
+}
+
+pub async fn start_compute_node(
+    app: AppHandle,
+    state: ComputeNodeState,
+    request: ComputeNodeRequest,
+) -> anyhow::Result<()> {
+    {
+        let mut child_slot = state.child.lock().await;
+        if child_slot
+            .as_mut()
+            .is_some_and(|child| child.try_wait().ok().flatten().is_none())
+        {
+            anyhow::bail!("compute node already running; stop before starting a new one");
+        }
+        *child_slot = None;
+        *state.stdin.lock().await = None;
+    }
+
+    let bridge_script = std::env::var("TOKEN_PLACE_COMPUTE_BRIDGE")
+        .unwrap_or_else(|_| resolve_compute_bridge_script());
+
+    let mut cmd = build_bridge_command(&bridge_script);
+    cmd.arg("--relay-url")
+        .arg(&request.relay_base_url)
+        .arg("--model")
+        .arg(&request.model_path)
+        .arg("--mode")
+        .arg(format!("{:?}", request.mode).to_lowercase());
+    if request.stream_enabled {
+        cmd.arg("--stream-enabled");
+    }
+
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing compute bridge stdout"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing compute bridge stdin"))?;
+
+    {
+        let mut child_slot = state.child.lock().await;
+        *child_slot = Some(child);
+        *state.stdin.lock().await = Some(stdin);
+    }
+
+    let mut lines = BufReader::new(stdout).lines();
+    while let Some(line) = lines.next_line().await? {
+        if let Ok(event) = serde_json::from_str::<BridgeEvent>(&line) {
+            let mut status = state.status.lock().await;
+            match event {
+                BridgeEvent::Status {
+                    registered,
+                    running,
+                    active_relay_url,
+                    backend_mode,
+                    model_path,
+                    stream_enabled,
+                    last_error,
+                } => {
+                    *status = ComputeNodeStatus {
+                        registered,
+                        running,
+                        active_relay_url,
+                        backend_mode,
+                        model_path,
+                        stream_enabled,
+                        last_error,
+                    };
+                }
+                BridgeEvent::Error { message } => {
+                    status.last_error = message;
+                }
+                BridgeEvent::Stopped => {
+                    status.running = false;
+                }
+                BridgeEvent::Started { relay_target } => {
+                    status.running = true;
+                    status.active_relay_url = relay_target;
+                }
+            }
+            app.emit("compute_node_status", status.clone())?;
+        }
+    }
+
+    *state.child.lock().await = None;
+    *state.stdin.lock().await = None;
+    state.status.lock().await.running = false;
+    Ok(())
+}
+
+pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
+    if let Some(stdin) = state.stdin.lock().await.as_mut() {
+        stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
+        stdin.flush().await?;
+    }
+
+    if let Some(child) = state.child.lock().await.as_mut() {
+        let _ = child.kill().await;
+    }
+
+    *state.child.lock().await = None;
+    *state.stdin.lock().await = None;
+    state.status.lock().await.running = false;
+    Ok(())
+}

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -7,6 +7,7 @@ pub struct DesktopConfig {
     pub model_path: String,
     pub relay_base_url: String,
     pub preferred_mode: ComputeMode,
+    pub stream_enabled: bool,
 }
 
 impl Default for DesktopConfig {
@@ -15,6 +16,7 @@ impl Default for DesktopConfig {
             model_path: String::new(),
             relay_base_url: "https://token.place".into(),
             preferred_mode: ComputeMode::Auto,
+            stream_enabled: false,
         }
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod compute_node;
 mod config;
 mod forward;
 mod keygen;
@@ -6,6 +7,7 @@ mod logging;
 mod sidecar;
 
 use backend::{detect_backend_for, BackendInfo};
+use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
 use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
@@ -18,6 +20,7 @@ use tokio::sync::Mutex;
 #[derive(Default)]
 struct AppState {
     sidecar: SidecarState,
+    compute_node: ComputeNodeState,
     config_dir: Mutex<Option<PathBuf>>,
 }
 
@@ -208,6 +211,31 @@ async fn encrypt_and_forward(relay_base_url: String, final_output: String) -> Re
 }
 
 #[tauri::command]
+async fn start_compute_node(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    request: ComputeNodeRequest,
+) -> Result<(), String> {
+    compute_node::start_compute_node(app, state.compute_node.clone(), request)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn stop_compute_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    compute_node::stop_compute_node(state.compute_node.clone())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_compute_node_status(
+    state: tauri::State<'_, AppState>,
+) -> Result<ComputeNodeStatus, String> {
+    Ok(state.compute_node.status.lock().await.clone())
+}
+
+#[tauri::command]
 fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
     run_model_bridge("inspect")
 }
@@ -231,6 +259,9 @@ pub fn run() {
             start_inference,
             cancel_inference,
             encrypt_and_forward,
+            start_compute_node,
+            stop_compute_node,
+            get_compute_node_status,
             inspect_model_artifact,
             download_model_artifact
         ])

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -16,6 +16,7 @@ interface DesktopConfig {
   model_path: string;
   relay_base_url: string;
   preferred_mode: BackendMode;
+  stream_enabled?: boolean;
 }
 
 interface ModelArtifactInfo {
@@ -36,6 +37,16 @@ interface SidecarEvent {
   message?: string;
 }
 
+interface ComputeNodeStatus {
+  registered: boolean;
+  running: boolean;
+  active_relay_url: string;
+  backend_mode: string;
+  model_path: string;
+  stream_enabled: boolean;
+  last_error: string;
+}
+
 export function selectedModelPath(selection: string | string[] | null): string {
   if (typeof selection === 'string') {
     return selection;
@@ -52,12 +63,22 @@ export function App() {
     model_path: '',
     relay_base_url: 'https://token.place',
     preferred_mode: 'auto',
+    stream_enabled: false,
   });
   const [prompt, setPrompt] = useState('');
   const [output, setOutput] = useState('');
   const [requestId, setRequestId] = useState<string>('');
   const [status, setStatus] = useState<UiState>('idle');
   const [artifact, setArtifact] = useState<ModelArtifactInfo | null>(null);
+  const [operatorStatus, setOperatorStatus] = useState<ComputeNodeStatus>({
+    registered: false,
+    running: false,
+    active_relay_url: '',
+    backend_mode: 'auto',
+    model_path: '',
+    stream_enabled: false,
+    last_error: '',
+  });
   const [isDownloadingModel, setIsDownloadingModel] = useState(false);
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
@@ -70,7 +91,7 @@ export function App() {
     const initializeConfigAndArtifact = async () => {
       try {
         const loadedConfig = await invoke<DesktopConfig>('load_config');
-        setConfig(loadedConfig);
+        setConfig({ ...loadedConfig, stream_enabled: loadedConfig.stream_enabled ?? false });
 
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
         setArtifact(info);
@@ -88,6 +109,7 @@ export function App() {
     };
 
     initializeConfigAndArtifact();
+    invoke<ComputeNodeStatus>('get_compute_node_status').then(setOperatorStatus).catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -113,8 +135,12 @@ export function App() {
         setError(payload.message ?? payload.code ?? 'unknown error');
       }
     });
+    const unlistenComputeNode = listen<ComputeNodeStatus>('compute_node_status', (evt) => {
+      setOperatorStatus(evt.payload);
+    });
     return () => {
       unlisten.then((f) => f());
+      unlistenComputeNode.then((f) => f());
     };
   }, []);
 
@@ -217,9 +243,33 @@ export function App() {
     }
   };
 
+  const startComputeNode = async () => {
+    try {
+      setError('');
+      await invoke('start_compute_node', {
+        request: {
+          relay_base_url: config.relay_base_url,
+          model_path: config.model_path,
+          mode: config.preferred_mode,
+          stream_enabled: Boolean(config.stream_enabled),
+        },
+      });
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const stopComputeNode = async () => {
+    try {
+      await invoke('stop_compute_node');
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
-      <h1>token.place desktop (Tauri MVP)</h1>
+      <h1>token.place desktop compute node</h1>
       <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
@@ -263,21 +313,46 @@ export function App() {
         <option value="cpu">CPU fallback</option>
       </select>
 
+      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
+      <input value={config.relay_base_url} style={{ width: '100%' }} onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })} />
+
+      <label style={{ display: 'block', marginTop: 12 }}>
+        <input
+          type="checkbox"
+          checked={Boolean(config.stream_enabled)}
+          onChange={(e) => updateConfig({ ...config, stream_enabled: e.target.checked })}
+        />{' '}
+        Use /stream/source for streaming relay requests
+      </label>
+
+      <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
+        <button disabled={operatorStatus.running || !config.model_path} onClick={startComputeNode}>Start compute node</button>
+        <button disabled={!operatorStatus.running} onClick={stopComputeNode}>Stop compute node</button>
+      </div>
+
+      <section style={{ marginTop: 12, border: '1px solid #ddd', padding: 12 }}>
+        <h2 style={{ marginTop: 0 }}>Operator status</h2>
+        <div>Registered/running: <strong>{operatorStatus.registered ? 'registered' : 'not registered'}</strong> / <strong>{operatorStatus.running ? 'running' : 'stopped'}</strong></div>
+        <div>Active relay URL: <code>{operatorStatus.active_relay_url || config.relay_base_url}</code></div>
+        <div>Backend mode: <code>{operatorStatus.backend_mode || config.preferred_mode}</code></div>
+        <div>Model path: <code>{operatorStatus.model_path || config.model_path || '(not set)'}</code></div>
+        <div>Last error: <code>{operatorStatus.last_error || 'none'}</code></div>
+      </section>
+
+      <h2 style={{ marginTop: 18 }}>Local prompt smoke test</h2>
+      <p style={{ marginTop: 0, color: '#555' }}>Use this only for local debugging. Production relay work runs through compute-node mode above.</p>
       <label style={{ display: 'block', marginTop: 12 }}>Prompt</label>
       <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={6} style={{ width: '100%' }} />
 
       <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
         <button disabled={!canStart} onClick={startInference}>Start inference</button>
         <button disabled={status !== 'starting' && status !== 'streaming'} onClick={cancelInference}>Cancel</button>
-        <button disabled={!output || isForwarding} onClick={forwardEncrypted}>Encrypt + forward output</button>
+        <button disabled={!output || isForwarding} onClick={forwardEncrypted}>Legacy debug forward output</button>
       </div>
 
       <p>Status: <strong>{status}</strong></p>
       {error && <p style={{ color: 'crimson' }}>Error: {error}</p>}
       <pre style={{ whiteSpace: 'pre-wrap', padding: 12, border: '1px solid #ddd' }}>{output}</pre>
-
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
-      <input value={config.relay_base_url} style={{ width: '100%' }} onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })} />
     </main>
   );
 }

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1,0 +1,141 @@
+"""Integration-style tests for desktop compute-node bridge with mocked runtime."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'src-tauri'
+    / 'python'
+    / 'compute_node_bridge.py'
+)
+SPEC = importlib.util.spec_from_file_location('desktop_compute_node_bridge', MODULE_PATH)
+compute_node_bridge = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(compute_node_bridge)
+
+
+class FakeRelayClient:
+    relay_url = 'https://relay.test'
+
+    def __init__(self):
+        self.calls = []
+
+    def _auth_headers(self):
+        return {}
+
+
+class FakeRuntime:
+    def __init__(self):
+        self.relay_client = FakeRelayClient()
+        self.processed = []
+        self.crypto_manager = SimpleNamespace(decrypt_message=lambda _payload: [{'role': 'user', 'content': 'hi'}])
+        self.model_manager = SimpleNamespace(
+            get_llm_instance=lambda: SimpleNamespace(
+                create_chat_completion=lambda **_kwargs: iter([
+                    {'choices': [{'delta': {'content': 'hello'}, 'finish_reason': None}]},
+                    {'choices': [{'delta': {}, 'finish_reason': 'stop'}]},
+                ])
+            ),
+            config=SimpleNamespace(get=lambda _key, default=None: default),
+        )
+
+    def process_relay_request(self, payload):
+        self.processed.append(payload)
+        return True
+
+
+class FakeResponse:
+    def raise_for_status(self):
+        return None
+
+
+def test_process_sink_payload_uses_source_flow_for_non_streaming_requests(monkeypatch):
+    runtime = FakeRuntime()
+    bridge = compute_node_bridge.ComputeNodeBridge(
+        runtime,
+        stream_enabled=False,
+        mode='auto',
+        model_path='/tmp/model.gguf',
+    )
+
+    payload = {
+        'client_public_key': 'client-key',
+        'chat_history': 'cipher',
+        'cipherkey': 'key',
+        'iv': 'iv',
+    }
+
+    assert bridge.process_sink_payload(payload) is True
+    assert runtime.processed == [payload]
+
+
+def test_process_sink_payload_posts_stream_chunks_when_enabled(monkeypatch):
+    runtime = FakeRuntime()
+    bridge = compute_node_bridge.ComputeNodeBridge(
+        runtime,
+        stream_enabled=True,
+        mode='auto',
+        model_path='/tmp/model.gguf',
+    )
+
+    posted = []
+
+    def fake_post(url, json=None, headers=None, timeout=10):
+        posted.append((url, json, headers, timeout))
+        return FakeResponse()
+
+    def fake_encrypt_stream_chunk(plaintext, _public_key, *, session=None, **_kwargs):
+        ciphertext_dict = {'ciphertext': plaintext, 'iv': b'iv-bytes'}
+        encrypted_key = b'cipherkey' if session is None else None
+        return ciphertext_dict, encrypted_key, object()
+
+    monkeypatch.setattr(compute_node_bridge.requests, 'post', fake_post)
+    monkeypatch.setattr(compute_node_bridge, 'encrypt_stream_chunk', fake_encrypt_stream_chunk)
+
+    payload = {
+        'client_public_key': 'Y2xpZW50LWtleQ==',
+        'chat_history': 'cipher',
+        'cipherkey': 'key',
+        'iv': 'iv',
+        'stream': True,
+        'stream_session_id': 'sess-1',
+    }
+
+    assert bridge.process_sink_payload(payload) is True
+    assert posted, 'expected /stream/source POST calls'
+    assert posted[0][0].endswith('/stream/source')
+    assert posted[-1][1]['final'] is True
+
+
+def test_process_sink_payload_uses_batch_entries(monkeypatch):
+    runtime = FakeRuntime()
+    bridge = compute_node_bridge.ComputeNodeBridge(
+        runtime,
+        stream_enabled=False,
+        mode='auto',
+        model_path='/tmp/model.gguf',
+    )
+
+    payload = {
+        'next_ping_in_x_seconds': 1,
+        'batch': [
+            {
+                'client_public_key': 'a',
+                'chat_history': 'b',
+                'cipherkey': 'c',
+                'iv': 'd',
+            },
+            {
+                'client_public_key': 'e',
+                'chat_history': 'f',
+                'cipherkey': 'g',
+                'iv': 'h',
+            },
+        ],
+    }
+
+    assert bridge.process_sink_payload(payload) is True
+    assert len(runtime.processed) == 2


### PR DESCRIPTION
### Motivation
- Provide a production-ready desktop compute-node operator that can replace `server.py` for the legacy relay `/sink` → `/source` contract without changing the relay encryption or migrating to API v1.
- Surface basic operator status in the desktop UI while keeping the local prompt UI only as a smoke-test/debug path.

### Description
- Add a Python compute-node bridge `desktop-tauri/src-tauri/python/compute_node_bridge.py` that reuses the shared `ComputeNodeRuntime` to register/poll via `/sink`, decrypt requests, run local inference, and post results to `/source` (and to `/stream/source` when streaming is enabled). 
- Add a Tauri backend bridge `desktop-tauri/src-tauri/src/compute_node.rs` and wire start/stop/status commands into `desktop-tauri/src-tauri/src/main.rs` to manage the bridge process from the UI. 
- Update desktop config (`desktop-tauri/src-tauri/src/config.rs`) and UI (`desktop-tauri/src/App.tsx`) to make compute-node operation primary, expose operator status (registered/running, active relay URL, backend mode, model path, last error), and relabel the legacy forward action as a debug-only path.
- Add focused integration-style tests `tests/unit/test_desktop_compute_node_bridge.py` that mock the runtime and assert non-stream, batch, and streaming chunk posting behavior, and update `desktop-tauri/README.md` to document the operator-first behavior.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which failed in this container due to missing system `glib-2.0` / `pkg-config` (native dependency for the Rust build). 
- Built the frontend with `cd desktop-tauri && npm run build`, which succeeded. 
- Ran `npm run lint`, which passed. 
- Ran full JS+Python test runner via `npm run test:ci`; the JavaScript sub-suite passed but the overall run failed because Python test matrix imports (`playwright`, `cryptography`, etc.) are missing in this environment. 
- Attempted `python -m pytest -q` (and targeted pytest for the new bridge tests) but the run failed due to missing Python test dependencies (notably `playwright` and `cryptography`) required by the repository test harness, so the Python tests could not be executed here.

Notes: `pre-commit` and the repository secret-scan helper referenced by local SOP were not available in this environment, so those checks were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74bf23104832f891fbd56ddcb8c50)