### PR TITLE
Add distributed API v1 compute adapter with legacy fallback

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -11,6 +11,7 @@ import uuid
 import logging
 import os
 import math
+import requests
 
 from api.v1.encryption import encryption_manager
 from api.security import ensure_operator_access
@@ -43,6 +44,11 @@ from utils.providers import (
     ProviderRegistryError,
 )
 from utils.vision import ImageGenerationError, LocalImageGenerator
+from utils.distributed_api_v1 import (
+    build_chat_completion_response,
+    completion_prompt_to_messages,
+    extract_assistant_message,
+)
 
 # Expose directory loaders for tests and backwards compatibility
 get_community_provider_directory = _get_community_provider_directory
@@ -109,6 +115,55 @@ def _configured_relay_servers() -> list[str]:
 
 
 _image_generator = LocalImageGenerator()
+
+
+def _distributed_api_v1_base_url() -> str | None:
+    configured = os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_URL", "").strip()
+    if configured:
+        return configured.rstrip("/")
+    return None
+
+
+def _generate_response_with_provider(model_id, messages, **options):
+    """Dispatch API v1 inference via distributed provider when configured."""
+
+    distributed_base_url = _distributed_api_v1_base_url()
+    if not distributed_base_url:
+        return generate_response(model_id, messages, **options)
+
+    payload = {
+        "model": model_id,
+        "messages": messages,
+        **options,
+    }
+    timeout = float(os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS", "20"))
+
+    try:
+        response = requests.post(
+            f"{distributed_base_url}/api/v1/chat/completions",
+            json=payload,
+            timeout=timeout,
+        )
+        if response.status_code == 200:
+            body = response.json()
+            assistant = body.get("choices", [{}])[0].get("message", {})
+            updated_messages = list(messages)
+            updated_messages.append(
+                {
+                    "role": assistant.get("role", "assistant"),
+                    "content": assistant.get("content", ""),
+                    **({"tool_calls": assistant.get("tool_calls")} if assistant.get("tool_calls") else {}),
+                }
+            )
+            return updated_messages
+        log_warning(
+            f"Distributed API v1 compute provider returned status {response.status_code}; "
+            "falling back to legacy local generation"
+        )
+    except requests.RequestException:
+        log_warning("Distributed API v1 compute provider unavailable; falling back to local generation")
+
+    return generate_response(model_id, messages, **options)
 
 
 def format_error_response(message, error_type="invalid_request_error", param=None, code=None, status_code=400):
@@ -293,9 +348,9 @@ def _handle_chat_completion_request(data):
             ]
 
         log_info(f"Generating response using model {model_id}")
-        updated_messages = generate_response(model_id, messages)
+        updated_messages = _generate_response_with_provider(model_id, messages)
 
-        assistant_message = updated_messages[-1]
+        assistant_message = extract_assistant_message(updated_messages)
         log_info("Response generated successfully")
 
         tool_calls = assistant_message.get("tool_calls")
@@ -317,23 +372,14 @@ def _handle_chat_completion_request(data):
         prompt_tokens = sum(_estimate_token_length(text) for text in prompt_contents_for_usage)
         completion_tokens = _estimate_token_length("\n".join(filter(None, completion_segments)))
 
-        response_data = {
-            "id": f"chatcmpl-{uuid.uuid4()}",
-            "object": "chat.completion",
-            "created": int(time.time()),
-            "model": response_model_id,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": message_payload,
-                    "finish_reason": finish_reason,
-                }
-            ],
-            "usage": {
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": prompt_tokens + completion_tokens,
-            },
+        response_data = build_chat_completion_response(
+            model=response_model_id,
+            assistant_message=message_payload,
+        )
+        response_data["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
         }
 
         request_metadata = data.get("metadata")
@@ -430,7 +476,7 @@ def _handle_text_completion_request(data):
                 status_code=e.status_code,
             )
 
-        messages = [{"role": "user", "content": prompt}]
+        messages = completion_prompt_to_messages(prompt)
 
         decision = evaluate_messages_for_policy(messages)
         if not decision.allowed:
@@ -446,9 +492,9 @@ def _handle_text_completion_request(data):
             )
 
         log_info(f"Generating response using model {model_id}")
-        updated_messages = generate_response(model_id, messages)
+        updated_messages = _generate_response_with_provider(model_id, messages)
 
-        assistant_message = updated_messages[-1]
+        assistant_message = extract_assistant_message(updated_messages)
         log_info("Response generated successfully")
 
         response_data = {

--- a/relay.py
+++ b/relay.py
@@ -664,7 +664,17 @@ def faucet():
     # Parse the request data
     data = request.get_json()
 
-    if not data or 'server_public_key' not in data or 'chat_history' not in data or 'cipherkey' not in data or 'iv' not in data:
+    if not data or 'server_public_key' not in data:
+        return jsonify({
+            'error': {
+                'message': 'Invalid request data',
+                'code': 400
+            }
+        }), 400
+
+    is_legacy_encrypted = all(field in data for field in ('chat_history', 'cipherkey', 'iv'))
+    is_distributed_v1 = isinstance(data.get('api_v1_request'), dict)
+    if not is_legacy_encrypted and not is_distributed_v1:
         return jsonify({
             'error': {
                 'message': 'Invalid request data',
@@ -673,9 +683,9 @@ def faucet():
         }), 400
 
     server_public_key = data['server_public_key']
-    chat_history_ciphertext = data['chat_history']
-    cipherkey = data['cipherkey']
-    iv = data['iv']  # Extract the IV from the request data
+    chat_history_ciphertext = data.get('chat_history')
+    cipherkey = data.get('cipherkey')
+    iv = data.get('iv', '')  # Extract the IV from the request data
     stream_requested = bool(data.get('stream', False))
     client_public_key = data.get('client_public_key', None)
 
@@ -694,13 +704,16 @@ def faucet():
     # Append the client's request to the list of requests for the server
     if server_public_key not in client_inference_requests:
         client_inference_requests[server_public_key] = []
-    client_inference_requests[server_public_key].append({
+    queued_request = {
         'chat_history': chat_history_ciphertext,
         'client_public_key': client_public_key,
         'cipherkey': cipherkey,
         'iv': iv,  # Include the IV in the saved client's request
         'stream': stream_requested,
-    })
+    }
+    if is_distributed_v1:
+        queued_request['api_v1_request'] = data.get('api_v1_request')
+    client_inference_requests[server_public_key].append(queued_request)
     return jsonify({'message': 'Request received'}), 200
 
 @app.route('/sink', methods=['POST'])
@@ -776,6 +789,8 @@ def sink():
             'cipherkey': first_request['cipherkey'],
             'iv': first_request.get('iv', ''),
         })
+        if isinstance(first_request.get('api_v1_request'), dict):
+            response_data['api_v1_request'] = first_request['api_v1_request']
 
         if first_request.get('stream') and first_request.get('stream_session_id'):
             response_data['stream'] = True
@@ -796,20 +811,29 @@ def source():
         return auth_error
 
     data = request.get_json()
-    if not data or 'client_public_key' not in data or 'chat_history' not in data or 'cipherkey' not in data or 'iv' not in data:
+    if not data or 'client_public_key' not in data:
         return jsonify({'error': 'Invalid request data'}), 400
 
     client_public_key = data['client_public_key']
-    encrypted_chat_history = data['chat_history']
-    encrypted_cipherkey = data['cipherkey']
-    iv = data['iv']
+    has_legacy_payload = all(field in data for field in ('chat_history', 'cipherkey', 'iv'))
+    has_distributed_payload = isinstance(data.get('api_v1_response'), dict)
+    if not has_legacy_payload and not has_distributed_payload:
+        return jsonify({'error': 'Invalid request data'}), 400
 
     # Store the response in the client_responses dictionary
-    client_responses[client_public_key] = {
-        'chat_history': encrypted_chat_history,
-        'cipherkey': encrypted_cipherkey,
-        'iv': iv
-    }
+    if has_distributed_payload:
+        client_responses[client_public_key] = {
+            'api_v1_response': data['api_v1_response'],
+        }
+    else:
+        encrypted_chat_history = data['chat_history']
+        encrypted_cipherkey = data['cipherkey']
+        iv = data['iv']
+        client_responses[client_public_key] = {
+            'chat_history': encrypted_chat_history,
+            'cipherkey': encrypted_cipherkey,
+            'iv': iv
+        }
     return jsonify({'message': 'Response received and queued for client'}), 200
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -240,6 +240,30 @@ def test_faucet_submit_request(client):
     assert queued_req['client_public_key'] == DUMMY_CLIENT_PUB_KEY
     assert queued_req['chat_history'] == "encrypted_chat_history_data"
 
+
+def test_faucet_accepts_distributed_api_v1_request(client):
+    """Test distributed API v1 work can be queued via /faucet during migration."""
+    known_servers[DUMMY_SERVER_PUB_KEY] = {
+        'public_key': DUMMY_SERVER_PUB_KEY,
+        'last_ping': time.time(),
+        'last_ping_duration': 10,
+    }
+
+    payload = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "server_public_key": DUMMY_SERVER_PUB_KEY,
+        "api_v1_request": {
+            "request_id": "req-123",
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    }
+    response = client.post("/faucet", json=payload)
+    assert response.status_code == 200
+
+    queued_req = client_inference_requests[DUMMY_SERVER_PUB_KEY][0]
+    assert queued_req["api_v1_request"]["request_id"] == "req-123"
+
 def test_faucet_invalid_payload(client):
     """Test /faucet with missing fields."""
     # Register server
@@ -348,6 +372,28 @@ def test_source_submit_response(client):
     queued_resp = client_responses[DUMMY_CLIENT_PUB_KEY]
     assert queued_resp['chat_history'] == "server_encrypted_response_history"
 
+
+def test_source_accepts_distributed_api_v1_response(client):
+    """Test /source accepts distributed API v1 response envelopes."""
+    payload = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "api_v1_response": {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "model": "llama-3-8b-instruct",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "distributed"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+    }
+    response = client.post("/source", json=payload)
+    assert response.status_code == 200
+    assert client_responses[DUMMY_CLIENT_PUB_KEY]["api_v1_response"]["id"] == "chatcmpl-123"
+
 def test_source_invalid_payload(client):
     """Test /source with missing fields."""
     payload = { "client_public_key": DUMMY_CLIENT_PUB_KEY } # Missing other fields
@@ -379,6 +425,21 @@ def test_retrieve_get_response(client):
 
     # Check state - response should be removed after retrieval
     assert DUMMY_CLIENT_PUB_KEY not in client_responses
+
+
+def test_retrieve_get_distributed_api_v1_response(client):
+    """Test /retrieve returns distributed API v1 responses unchanged."""
+    client_responses[DUMMY_CLIENT_PUB_KEY] = {
+        "api_v1_response": {
+            "id": "chatcmpl-321",
+            "object": "chat.completion",
+        }
+    }
+    payload = {"client_public_key": DUMMY_CLIENT_PUB_KEY}
+    response = client.post("/retrieve", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["api_v1_response"]["id"] == "chatcmpl-321"
 
 def test_retrieve_no_response_available(client):
     """Test /retrieve when no response is queued for the client."""

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 import pytest
+import requests
 
 from relay import app
 from api.v1 import routes
@@ -142,3 +143,89 @@ def test_chat_completion_echoes_request_metadata(client, monkeypatch):
 
     body = response.get_json()
     assert body['metadata'] == payload['metadata']
+
+
+def test_chat_completion_uses_distributed_compute_provider(client, monkeypatch):
+    payload = {
+        'model': 'llama-3-8b-instruct',
+        'messages': [{'role': 'user', 'content': 'Hello distributed node'}],
+    }
+
+    monkeypatch.setattr(routes, 'get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr(routes, 'validate_model_name', lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, 'get_model_instance', lambda model_id: object())
+    monkeypatch.setattr(routes, 'resolve_model_alias', lambda model_id: None)
+    monkeypatch.setattr(
+        routes,
+        'evaluate_messages_for_policy',
+        lambda messages: SimpleNamespace(allowed=True),
+    )
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_URL", "https://compute.example")
+
+    called = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "remote response",
+                        }
+                    }
+                ]
+            }
+
+    def _fake_post(url, json, timeout):
+        called["url"] = url
+        called["json"] = json
+        called["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setattr(routes.requests, "post", _fake_post)
+
+    response = client.post('/api/v1/chat/completions', json=payload)
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert body["choices"][0]["message"]["content"] == "remote response"
+    assert called["url"] == "https://compute.example/api/v1/chat/completions"
+    assert called["json"]["messages"] == payload["messages"]
+
+
+def test_chat_completion_distributed_provider_falls_back_to_legacy(client, monkeypatch):
+    payload = {
+        'model': 'llama-3-8b-instruct',
+        'messages': [{'role': 'user', 'content': 'Hello fallback'}],
+    }
+
+    monkeypatch.setattr(routes, 'get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr(routes, 'validate_model_name', lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, 'get_model_instance', lambda model_id: object())
+    monkeypatch.setattr(routes, 'resolve_model_alias', lambda model_id: None)
+    monkeypatch.setattr(
+        routes,
+        'evaluate_messages_for_policy',
+        lambda messages: SimpleNamespace(allowed=True),
+    )
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_URL", "https://compute.example")
+    monkeypatch.setattr(
+        routes.requests,
+        "post",
+        lambda *args, **kwargs: (_ for _ in ()).throw(requests.Timeout("boom")),
+    )
+    monkeypatch.setattr(
+        routes,
+        "generate_response",
+        lambda model_id, messages, **kwargs: messages + [
+            {"role": "assistant", "content": "legacy fallback response"}
+        ],
+    )
+
+    response = client.post('/api/v1/chat/completions', json=payload)
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["choices"][0]["message"]["content"] == "legacy fallback response"

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -630,6 +630,41 @@ class TestRelayClient:
         # Check the result
         assert result is False
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_distributed_api_v1_success(
+        self,
+        mock_post,
+        relay_client,
+        mock_model_manager,
+        mock_http_response,
+    ):
+        """Distributed API v1 envelopes should be posted to /source as api_v1_response."""
+        mock_http_response.status_code = 200
+        mock_post.return_value = mock_http_response
+        mock_model_manager.llama_cpp_get_response.return_value = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello from compute node"},
+        ]
+
+        request_data = {
+            "client_public_key": "Y2xpZW50X2tleV9iNjQ=",
+            "api_v1_request": {
+                "request_id": "chatcmpl-test",
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        }
+        result = relay_client.process_client_request(request_data)
+
+        assert result is True
+        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
+            request_data["api_v1_request"]["messages"]
+        )
+        assert mock_post.call_args.args[0] == 'http://localhost:5000/source'
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["client_public_key"] == request_data["client_public_key"]
+        assert payload["api_v1_response"]["id"] == "chatcmpl-test"
+
     def test_process_client_request_decryption_failure(self, relay_client, mock_crypto_manager):
         """Test processing a client request with decryption failure."""
         # Setup

--- a/utils/distributed_api_v1.py
+++ b/utils/distributed_api_v1.py
@@ -1,0 +1,59 @@
+"""Shared helpers for distributed API v1 compute request/response handling."""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, List
+
+
+def build_chat_completion_response(
+    *,
+    model: str,
+    assistant_message: Dict[str, Any],
+    response_id: str | None = None,
+) -> Dict[str, Any]:
+    """Build an OpenAI-compatible chat completion response envelope."""
+
+    return {
+        "id": response_id or f"chatcmpl-{uuid.uuid4()}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": assistant_message.get("role", "assistant"),
+                    "content": assistant_message.get("content", ""),
+                    **(
+                        {"tool_calls": assistant_message.get("tool_calls")}
+                        if assistant_message.get("tool_calls")
+                        else {}
+                    ),
+                },
+                "finish_reason": "tool_calls" if assistant_message.get("tool_calls") else "stop",
+            }
+        ],
+    }
+
+
+def extract_assistant_message(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the last assistant message from a generated chat transcript."""
+
+    if not messages:
+        return {"role": "assistant", "content": ""}
+
+    candidate = messages[-1]
+    if isinstance(candidate, dict):
+        return candidate
+    return {"role": "assistant", "content": str(candidate)}
+
+
+def completion_prompt_to_messages(prompt: Any) -> List[Dict[str, str]]:
+    """Normalize v1 completion prompt input into chat message format."""
+
+    if isinstance(prompt, list):
+        prompt_text = "".join(str(part) for part in prompt)
+    else:
+        prompt_text = "" if prompt is None else str(prompt)
+    return [{"role": "user", "content": prompt_text}]

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
 import requests
+from utils.distributed_api_v1 import build_chat_completion_response, extract_assistant_message
 
 # Configure logging
 logger = logging.getLogger('relay_client')
@@ -484,6 +485,50 @@ class RelayClient:
             bool: True if processing succeeded, False otherwise
         """
         try:
+            distributed_request = request_data.get('api_v1_request')
+            if isinstance(distributed_request, dict):
+                client_public_key = request_data.get('client_public_key')
+                if not isinstance(client_public_key, str) or not client_public_key.strip():
+                    log_error("Distributed API v1 relay payload missing client_public_key")
+                    return False
+
+                request_messages = distributed_request.get('messages', [])
+                if not isinstance(request_messages, list):
+                    log_error("Distributed API v1 relay payload has invalid messages format")
+                    return False
+
+                response_model = str(distributed_request.get('model', 'llama-3-8b-instruct'))
+                generated = self.model_manager.llama_cpp_get_response(request_messages)
+                assistant_message = extract_assistant_message(generated)
+                api_response = build_chat_completion_response(
+                    model=response_model,
+                    assistant_message=assistant_message,
+                    response_id=distributed_request.get("request_id"),
+                )
+
+                source_payload = {
+                    'client_public_key': client_public_key,
+                    'api_v1_response': api_response,
+                }
+                request_kwargs = {
+                    'json': source_payload,
+                    'timeout': self._request_timeout,
+                }
+                headers = self._auth_headers()
+                if headers:
+                    request_kwargs['headers'] = headers
+
+                timeout = request_kwargs.pop('timeout', self._request_timeout)
+                source_response = requests.post(
+                    f'{self.relay_url}/source',
+                    timeout=timeout,
+                    **request_kwargs
+                )
+                if source_response.status_code != 200:
+                    log_error("Error status from /source for distributed API v1 request: {}", source_response.status_code)
+                    return False
+                return True
+
             try:
                 jsonschema.validate(instance=request_data, schema=MESSAGE_SCHEMA)
             except jsonschema.exceptions.ValidationError as e:


### PR DESCRIPTION
### Motivation
- Provide a shared path for API v1 distributed compute so chat/completions can target remote compute nodes while preserving the existing relay sink/source legacy flow.
- Introduce small, testable adapters and helpers rather than a big-bang rewrite to keep relay/server/desktop request/response schema compatible during migration.
- Allow compute nodes and the relay client to accept/emit API v1-style envelopes so desktop and server runtimes can converge on a single abstraction.

### Description
- Add `utils/distributed_api_v1.py` to centralize v1 response construction, assistant-message extraction, and prompt→messages normalization.
- Wire a distributed provider adapter into `api/v1/routes.py` that forwards `/api/v1/chat/completions` to a remote endpoint defined by `TOKENPLACE_API_V1_DISTRIBUTED_URL` and falls back to the local `generate_response` implementation when unavailable; responses continue to match the v1 schema and usage fields are preserved.
- Extend `relay.py` faucet/sink/source/retrieve handlers so `/faucet` can accept either legacy encrypted payloads or an `api_v1_request` envelope, `/sink` returns the same envelope to compute nodes, and `/source`/`/retrieve` support `api_v1_response` envelopes in addition to legacy encrypted replies.
- Update `utils/networking/relay_client.py` so `RelayClient.process_client_request` can execute distributed `api_v1_request` envelopes (local model invocation via the shared model manager) and post an `api_v1_response` to `/source`, while preserving the legacy decrypt→infer→encrypt→/source flow unchanged.
- Add focused tests that exercise the distributed happy path and the fallback behavior: `tests/unit/test_api_v1_routes_additional.py`, changes to `tests/unit/test_relay_client.py`, and additions to `tests/test_relay.py` to validate faucet/source/retrieve handling for API v1 envelopes.

### Testing
- Ran `python -m pytest -q` in this environment which failed to complete due to missing test dependencies (`playwright` required by `tests/conftest.py`), so full pytest suite could not be exercised here. (Attempt to install `requests` succeeded earlier.)
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` which failed in this environment due to missing system `glib-2.0`/pkg-config system libs required by the Tauri Rust toolchain.
- Built the desktop web assets with `cd desktop-tauri && npm run build`, which completed successfully.
- `pre-commit run --all-files` was not available in the execution environment (`pre-commit: command not found`).

Notes: the change intentionally preserves the legacy flow as a fallback and adds small adapters and shared helpers to keep relay, server, and desktop compute-node runtime in lockstep while enabling API v1 distributed compute testing and rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7558c4740832fa2a291cba521d502)