### PR TITLE
Introduce API v1 compute-provider abstraction with distributed fallback

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -43,6 +43,7 @@ from utils.providers import (
     ProviderRegistryError,
 )
 from utils.vision import ImageGenerationError, LocalImageGenerator
+from utils.compute_provider import build_chat_compute_provider
 
 # Expose directory loaders for tests and backwards compatibility
 get_community_provider_directory = _get_community_provider_directory
@@ -109,6 +110,15 @@ def _configured_relay_servers() -> list[str]:
 
 
 _image_generator = LocalImageGenerator()
+
+
+def _chat_compute_provider():
+    """Resolve the API v1 chat compute provider for this request."""
+
+    return build_chat_compute_provider(
+        local_handler=generate_response,
+        warning_logger=log_warning,
+    )
 
 
 def format_error_response(message, error_type="invalid_request_error", param=None, code=None, status_code=400):
@@ -200,8 +210,10 @@ def _handle_chat_completion_request(data):
 
         validate_model_name(model_id, available_model_ids)
 
-        model_instance = get_model_instance(model_id)
-        log_info(f"Model instance obtained for {model_id}")
+        compute_provider = _chat_compute_provider()
+        if compute_provider.requires_local_model_validation:
+            get_model_instance(model_id)
+            log_info(f"Model instance obtained for {model_id}")
 
         messages = None
         client_public_key = None
@@ -293,7 +305,7 @@ def _handle_chat_completion_request(data):
             ]
 
         log_info(f"Generating response using model {model_id}")
-        updated_messages = generate_response(model_id, messages)
+        updated_messages = compute_provider.generate(model_id, messages)
 
         assistant_message = updated_messages[-1]
         log_info("Response generated successfully")
@@ -417,18 +429,20 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
-        try:
-            get_model_instance(model_id)
-            log_info(f"Model instance obtained for {model_id}")
-        except ModelError as e:
-            log_warning(f"Model error: {e.message}")
-            return format_error_response(
-                e.message,
-                error_type=e.error_type,
-                param="model",
-                code="model_not_found" if e.error_type == "model_not_found" else None,
-                status_code=e.status_code,
-            )
+        compute_provider = _chat_compute_provider()
+        if compute_provider.requires_local_model_validation:
+            try:
+                get_model_instance(model_id)
+                log_info(f"Model instance obtained for {model_id}")
+            except ModelError as e:
+                log_warning(f"Model error: {e.message}")
+                return format_error_response(
+                    e.message,
+                    error_type=e.error_type,
+                    param="model",
+                    code="model_not_found" if e.error_type == "model_not_found" else None,
+                    status_code=e.status_code,
+                )
 
         messages = [{"role": "user", "content": prompt}]
 
@@ -446,7 +460,7 @@ def _handle_text_completion_request(data):
             )
 
         log_info(f"Generating response using model {model_id}")
-        updated_messages = generate_response(model_id, messages)
+        updated_messages = compute_provider.generate(model_id, messages)
 
         assistant_message = updated_messages[-1]
         log_info("Response generated successfully")

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -134,8 +134,7 @@ def run(args: argparse.Namespace) -> int:
             if not registered:
                 last_error = str(relay_response.get("error", "relay registration failed"))
             else:
-                required_fields = {"client_public_key", "chat_history", "cipherkey", "iv"}
-                if required_fields.issubset(relay_response.keys()):
+                if runtime.has_relay_assignment(relay_response):
                     processed = runtime.process_relay_request(relay_response)
                     if not processed:
                         last_error = "failed to process relay request"

--- a/tests/unit/test_api_v1_distributed_compute_provider.py
+++ b/tests/unit/test_api_v1_distributed_compute_provider.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from api.v1 import routes
+from relay import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def _allow_policy(_messages):
+    return SimpleNamespace(allowed=True, matched_term=None, reason=None)
+
+
+def test_chat_completions_supports_distributed_provider_happy_path(client, monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_URL", "https://distributed.example")
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "resolve_model_alias", lambda model_id: None)
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", _allow_policy)
+    monkeypatch.setattr(
+        routes,
+        "get_model_instance",
+        lambda _model_id: (_ for _ in ()).throw(AssertionError("should not require local model")),
+    )
+
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "Distributed hello",
+                        }
+                    }
+                ]
+            }
+
+    def fake_post(url, json, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("utils.compute_provider.requests.post", fake_post)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["choices"][0]["message"]["content"] == "Distributed hello"
+    assert captured["url"] == "https://distributed.example/api/v1/chat/completions"
+
+
+def test_chat_completions_distributed_provider_falls_back_to_local_generation(client, monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_URL", "https://distributed.example")
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "resolve_model_alias", lambda model_id: None)
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", _allow_policy)
+
+    monkeypatch.setattr(
+        "utils.compute_provider.requests.post",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("network down")),
+    )
+
+    def fake_local_generate(_model_id, messages, **_options):
+        return list(messages) + [{"role": "assistant", "content": "Local fallback"}]
+
+    monkeypatch.setattr(routes, "generate_response", fake_local_generate)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["choices"][0]["message"]["content"] == "Local fallback"

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -70,6 +70,11 @@ class FakeRuntime:
         self._processed.append(payload)
         return True
 
+    @staticmethod
+    def has_relay_assignment(payload):
+        required_fields = {"client_public_key", "chat_history", "cipherkey", "iv"}
+        return required_fields.issubset(payload.keys())
+
     def stop(self):
         return None
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Any
+from typing import Callable, Dict, List, Optional, Any, Protocol
 from urllib.parse import urlparse
 
 from utils.crypto.crypto_manager import get_crypto_manager
@@ -39,6 +39,44 @@ class ComputeNodeRuntimeConfig:
 
     relay_url: str
     relay_port: Optional[int]
+
+
+RELAY_ASSIGNMENT_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
+
+
+def has_relay_assignment(payload: Dict[str, Any]) -> bool:
+    """Return ``True`` when the relay payload includes an inference assignment."""
+
+    return RELAY_ASSIGNMENT_REQUIRED_FIELDS.issubset(payload.keys())
+
+
+class RelayTransport(Protocol):
+    """Abstraction over relay request polling and source publishing."""
+
+    def poll_once(self) -> Dict[str, Any]:
+        ...
+
+    def process_request(self, request_data: Dict[str, Any]) -> bool:
+        ...
+
+    def stop(self) -> None:
+        ...
+
+
+class LegacyRelaySinkSourceAdapter:
+    """Adapter preserving the legacy sink/source transport during migration."""
+
+    def __init__(self, relay_client: RelayClient):
+        self._relay_client = relay_client
+
+    def poll_once(self) -> Dict[str, Any]:
+        return self._relay_client.ping_relay()
+
+    def process_request(self, request_data: Dict[str, Any]) -> bool:
+        return self._relay_client.process_client_request(request_data)
+
+    def stop(self) -> None:
+        self._relay_client.stop()
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -112,6 +150,7 @@ class ComputeNodeRuntime:
         crypto_manager=None,
         model_manager=None,
         thread_factory: Callable[..., threading.Thread] = threading.Thread,
+        relay_transport: Optional[RelayTransport] = None,
     ):
         self.config = runtime_config
         self._thread_factory = thread_factory
@@ -122,6 +161,9 @@ class ComputeNodeRuntime:
             port=runtime_config.relay_port,
             crypto_manager=self.crypto_manager,
             model_manager=self.model_manager,
+        )
+        self.relay_transport: RelayTransport = (
+            relay_transport or LegacyRelaySinkSourceAdapter(self.relay_client)
         )
 
     def ensure_model_ready(self) -> bool:
@@ -154,14 +196,20 @@ class ComputeNodeRuntime:
     def process_relay_request(self, request_data: Dict[str, Any]) -> bool:
         """Process a relay payload via decrypt -> infer -> encrypt -> respond flow."""
 
-        return self.relay_client.process_client_request(request_data)
+        return self.relay_transport.process_request(request_data)
 
     def register_and_poll_once(self) -> Dict[str, Any]:
         """Ping relay /sink and return response data."""
 
-        return self.relay_client.ping_relay()
+        return self.relay_transport.poll_once()
+
+    @staticmethod
+    def has_relay_assignment(response_data: Dict[str, Any]) -> bool:
+        """Check whether a relay response includes a compute request assignment."""
+
+        return has_relay_assignment(response_data)
 
     def stop(self) -> None:
         """Stop relay polling and network activity."""
 
-        self.relay_client.stop()
+        self.relay_transport.stop()

--- a/utils/compute_provider.py
+++ b/utils/compute_provider.py
@@ -1,0 +1,157 @@
+"""Internal compute-provider abstraction for API v1 request handling."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+import requests
+
+
+class ComputeProviderError(RuntimeError):
+    """Raised when a compute provider cannot produce a valid response."""
+
+
+class ChatComputeProvider:
+    """Protocol-like base class for API v1 chat generation providers."""
+
+    requires_local_model_validation: bool = True
+
+    def generate(
+        self,
+        model_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        raise NotImplementedError
+
+
+@dataclass
+class LocalChatComputeProvider(ChatComputeProvider):
+    """Adapter around the legacy in-process generation flow."""
+
+    local_handler: Callable[..., List[Dict[str, Any]]]
+    requires_local_model_validation: bool = True
+
+    def generate(
+        self,
+        model_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        return self.local_handler(model_id, messages, **(options or {}))
+
+
+@dataclass
+class DistributedApiV1ChatComputeProvider(ChatComputeProvider):
+    """Provider that forwards API v1 chat generation to a remote compute node."""
+
+    base_url: str
+    timeout_seconds: float = 30.0
+    requires_local_model_validation: bool = False
+
+    def _build_target_url(self) -> str:
+        base = self.base_url.strip().rstrip("/")
+        if base.endswith("/api/v1/chat/completions"):
+            return base
+        return f"{base}/api/v1/chat/completions"
+
+    def generate(
+        self,
+        model_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "messages": messages,
+        }
+        payload.update(options or {})
+
+        response = requests.post(
+            self._build_target_url(),
+            json=payload,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        choices = data.get("choices")
+        if not isinstance(choices, list) or not choices:
+            raise ComputeProviderError("Remote compute response missing choices")
+
+        message = choices[0].get("message") if isinstance(choices[0], dict) else None
+        if not isinstance(message, dict):
+            raise ComputeProviderError("Remote compute response missing assistant message")
+
+        return list(messages) + [message]
+
+
+@dataclass
+class FallbackChatComputeProvider(ChatComputeProvider):
+    """Use distributed provider first and fall back to local generation on error."""
+
+    primary: ChatComputeProvider
+    fallback: ChatComputeProvider
+    warning_logger: Optional[Callable[[str], None]] = None
+    requires_local_model_validation: bool = False
+
+    def generate(
+        self,
+        model_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        try:
+            return self.primary.generate(model_id, messages, options=options)
+        except Exception as exc:
+            if self.warning_logger:
+                self.warning_logger(
+                    "Distributed API v1 compute provider failed; falling back to local runtime: "
+                    f"{exc}"
+                )
+            return self.fallback.generate(model_id, messages, options=options)
+
+
+def build_chat_compute_provider(
+    *,
+    local_handler: Callable[..., List[Dict[str, Any]]],
+    warning_logger: Optional[Callable[[str], None]] = None,
+) -> ChatComputeProvider:
+    """Build a chat compute provider using env-driven distributed settings."""
+
+    local_provider = LocalChatComputeProvider(local_handler=local_handler)
+
+    distributed_url = os.getenv("TOKENPLACE_API_V1_DISTRIBUTED_URL", "").strip()
+    if not distributed_url:
+        return local_provider
+
+    timeout_raw = os.getenv("TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT", "30").strip()
+    try:
+        timeout_seconds = float(timeout_raw)
+    except ValueError:
+        timeout_seconds = 30.0
+
+    distributed_provider = DistributedApiV1ChatComputeProvider(
+        base_url=distributed_url,
+        timeout_seconds=max(timeout_seconds, 1.0),
+    )
+
+    if os.getenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return distributed_provider
+
+    return FallbackChatComputeProvider(
+        primary=distributed_provider,
+        fallback=local_provider,
+        warning_logger=warning_logger,
+    )


### PR DESCRIPTION
### Motivation

- Provide a single internal abstraction so API v1 chat/completions can target remote compute nodes without assuming local llama execution.  
- Preserve the legacy sink/source flow behind an adapter so existing users continue to work during migration.  
- Reduce duplicated request/response handling between `relay.py`, `server.py`/shared runtime, and desktop compute-node bridge.  

### Description

- Add `utils/compute_provider.py` which implements `LocalChatComputeProvider`, `DistributedApiV1ChatComputeProvider`, `FallbackChatComputeProvider`, and the `build_chat_compute_provider` factory driven by `TOKENPLACE_API_V1_DISTRIBUTED_URL`, timeout, and fallback flags.  
- Wire API v1 endpoints (`api/v1/routes.py`) to resolve a per-request compute provider via `_chat_compute_provider()` and call `compute_provider.generate(...)`, and only perform local model validation when the provider requires it.  
- Refactor `utils/compute_node_runtime.py` to introduce a `RelayTransport` protocol and a `LegacyRelaySinkSourceAdapter`, add `has_relay_assignment()` helper, and delegate polling/processing through the transport to preserve the legacy sink/source contract.  
- Update the desktop compute-node bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) to reuse `runtime.has_relay_assignment()` instead of duplicating required-field checks.  
- Add focused contract tests: `tests/unit/test_api_v1_distributed_compute_provider.py` (distributed happy-path + fallback) and update the desktop bridge unit test to match the shared runtime contract.  

### Testing

- `python -m py_compile api/v1/routes.py utils/compute_provider.py utils/compute_node_runtime.py desktop-tauri/src-tauri/python/compute_node_bridge.py tests/unit/test_api_v1_distributed_compute_provider.py tests/unit/test_desktop_compute_node_bridge.py` succeeded.  
- `python -m pytest -q` could not complete in this environment due to missing test dependencies (`playwright` imported by `tests/conftest.py`), so the full test suite was not executed.  
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not complete in this environment due to a missing system library (`glib-2.0` / pkg-config).  
- `cd desktop-tauri && npm run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7558c4740832fa2a291cba521d502)