### PR TITLE
Introduce API v1 compute-provider abstraction with distributed fallback

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -11,6 +11,9 @@ import uuid
 import logging
 import os
 import math
+from typing import Any, Callable, Dict, Optional
+
+import requests
 
 from api.v1.encryption import encryption_manager
 from api.security import ensure_operator_access
@@ -109,6 +112,106 @@ def _configured_relay_servers() -> list[str]:
 
 
 _image_generator = LocalImageGenerator()
+
+COMPUTE_PROVIDER_ENV = "TOKENPLACE_API_V1_COMPUTE_PROVIDER"
+COMPUTE_PROVIDER_DISTRIBUTED = "distributed"
+
+
+class ComputeProviderError(Exception):
+    """Raised when a compute provider cannot satisfy a request."""
+
+
+class ComputeProvider:
+    """Abstraction over local and distributed API v1 chat execution."""
+
+    def complete_chat(
+        self,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+
+class LocalComputeProvider(ComputeProvider):
+    """Adapter for the legacy in-process llama.cpp execution path."""
+
+    def __init__(self, generator: Callable[..., list[dict[str, Any]]]):
+        self._generator = generator
+
+    def complete_chat(
+        self,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        return self._generator(model_id, messages, **(options or {}))
+
+
+class DistributedComputeProvider(ComputeProvider):
+    """HTTP adapter for API v1-compatible remote compute nodes."""
+
+    def __init__(
+        self,
+        upstreams: list[str],
+        *,
+        timeout_seconds: float = 15.0,
+        session: Any = requests,
+    ):
+        self._upstreams = [candidate.rstrip("/") for candidate in upstreams if candidate]
+        self._timeout_seconds = timeout_seconds
+        self._session = session
+
+    def complete_chat(
+        self,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        if not self._upstreams:
+            raise ComputeProviderError("No distributed API v1 compute upstreams configured")
+
+        payload: Dict[str, Any] = {"model": model_id, "messages": messages}
+        payload.update(options or {})
+
+        last_error: Exception | None = None
+        for upstream in self._upstreams:
+            try:
+                response = self._session.post(
+                    f"{upstream}/v1/chat/completions",
+                    json=payload,
+                    timeout=self._timeout_seconds,
+                )
+                response.raise_for_status()
+                body = response.json()
+                choices = body.get("choices") if isinstance(body, dict) else None
+                if not isinstance(choices, list) or not choices:
+                    raise ComputeProviderError("Distributed provider returned no choices")
+                message = choices[0].get("message", {})
+                if not isinstance(message, dict):
+                    raise ComputeProviderError("Distributed provider returned an invalid message")
+                return messages + [message]
+            except Exception as exc:  # pragma: no cover - defensive network handling
+                last_error = exc
+
+        raise ComputeProviderError(f"Distributed compute failed: {last_error}")
+
+
+def _select_compute_provider() -> ComputeProvider:
+    """Return a compute provider, preserving legacy local execution by default."""
+
+    provider_mode = os.getenv(COMPUTE_PROVIDER_ENV, "").strip().lower()
+    if provider_mode != COMPUTE_PROVIDER_DISTRIBUTED:
+        return LocalComputeProvider(generate_response)
+
+    configured_servers = [candidate.strip() for candidate in _configured_relay_servers() if candidate]
+    if not configured_servers:
+        return LocalComputeProvider(generate_response)
+
+    return DistributedComputeProvider(configured_servers)
 
 
 def format_error_response(message, error_type="invalid_request_error", param=None, code=None, status_code=400):
@@ -293,7 +396,31 @@ def _handle_chat_completion_request(data):
             ]
 
         log_info(f"Generating response using model {model_id}")
-        updated_messages = generate_response(model_id, messages)
+        provider = _select_compute_provider()
+        provider_options = {
+            key: value
+            for key, value in data.items()
+            if key
+            not in {
+                "model",
+                "messages",
+                "encrypted",
+                "client_public_key",
+            }
+        }
+        try:
+            updated_messages = provider.complete_chat(
+                model_id,
+                messages,
+                options=provider_options,
+            )
+        except ComputeProviderError as exc:
+            log_warning(f"Distributed provider unavailable; falling back locally: {exc}")
+            updated_messages = LocalComputeProvider(generate_response).complete_chat(
+                model_id,
+                messages,
+                options=provider_options,
+            )
 
         assistant_message = updated_messages[-1]
         log_info("Response generated successfully")
@@ -445,8 +572,32 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
+        provider_options = {
+            key: value
+            for key, value in data.items()
+            if key
+            not in {
+                "model",
+                "prompt",
+                "encrypted",
+                "client_public_key",
+            }
+        }
+        provider = _select_compute_provider()
         log_info(f"Generating response using model {model_id}")
-        updated_messages = generate_response(model_id, messages)
+        try:
+            updated_messages = provider.complete_chat(
+                model_id,
+                messages,
+                options=provider_options,
+            )
+        except ComputeProviderError as exc:
+            log_warning(f"Distributed provider unavailable; falling back locally: {exc}")
+            updated_messages = LocalComputeProvider(generate_response).complete_chat(
+                model_id,
+                messages,
+                options=provider_options,
+            )
 
         assistant_message = updated_messages[-1]
         log_info("Response generated successfully")

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -85,6 +85,7 @@ def run(args: argparse.Namespace) -> int:
             resolve_relay_port,
             resolve_relay_url,
         )
+        from utils.distributed_api_v1 import has_distributed_v1_payload
     except ModuleNotFoundError as exc:
         emit({"type": "error", "message": f"runtime unavailable: {exc}"})
         return 1
@@ -134,8 +135,7 @@ def run(args: argparse.Namespace) -> int:
             if not registered:
                 last_error = str(relay_response.get("error", "relay registration failed"))
             else:
-                required_fields = {"client_public_key", "chat_history", "cipherkey", "iv"}
-                if required_fields.issubset(relay_response.keys()):
+                if has_distributed_v1_payload(relay_response):
                     processed = runtime.process_relay_request(relay_response)
                     if not processed:
                         last_error = "failed to process relay request"

--- a/relay.py
+++ b/relay.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
 from werkzeug.serving import make_server
+from utils.distributed_api_v1 import DISTRIBUTED_V1_REQUIRED_FIELDS
 
 # Logging --------------------------------------------------------------------
 
@@ -664,7 +665,8 @@ def faucet():
     # Parse the request data
     data = request.get_json()
 
-    if not data or 'server_public_key' not in data or 'chat_history' not in data or 'cipherkey' not in data or 'iv' not in data:
+    required_fields = {"server_public_key", *DISTRIBUTED_V1_REQUIRED_FIELDS[1:]}
+    if not isinstance(data, dict) or not required_fields.issubset(data.keys()):
         return jsonify({
             'error': {
                 'message': 'Invalid request data',
@@ -796,7 +798,7 @@ def source():
         return auth_error
 
     data = request.get_json()
-    if not data or 'client_public_key' not in data or 'chat_history' not in data or 'cipherkey' not in data or 'iv' not in data:
+    if not isinstance(data, dict) or not set(DISTRIBUTED_V1_REQUIRED_FIELDS).issubset(data.keys()):
         return jsonify({'error': 'Invalid request data'}), 400
 
     client_public_key = data['client_public_key']

--- a/tests/unit/test_api_v1_distributed_compute_provider.py
+++ b/tests/unit/test_api_v1_distributed_compute_provider.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from api.v1 import routes
+from relay import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def _patch_route_dependencies(monkeypatch):
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "get_model_instance", lambda model_id: object())
+    monkeypatch.setattr(routes, "resolve_model_alias", lambda model_id: None)
+    monkeypatch.setattr(
+        routes,
+        "evaluate_messages_for_policy",
+        lambda messages: SimpleNamespace(allowed=True),
+    )
+    monkeypatch.setattr(routes, "_configured_relay_servers", lambda: ["http://compute-1"])
+
+
+def test_chat_completion_uses_distributed_compute_provider(client, monkeypatch):
+    _patch_route_dependencies(monkeypatch)
+    monkeypatch.setenv(routes.COMPUTE_PROVIDER_ENV, routes.COMPUTE_PROVIDER_DISTRIBUTED)
+
+    def _unexpected_local(*args, **kwargs):
+        raise AssertionError("local generate_response should not be used in distributed happy path")
+
+    monkeypatch.setattr(routes, "generate_response", _unexpected_local)
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def raise_for_status():
+            return None
+
+        @staticmethod
+        def json():
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "Distributed provider response",
+                        }
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: _FakeResponse())
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={"model": "llama-3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["choices"][0]["message"]["content"] == "Distributed provider response"
+
+
+def test_chat_completion_distributed_fallbacks_to_local(client, monkeypatch):
+    _patch_route_dependencies(monkeypatch)
+    monkeypatch.setenv(routes.COMPUTE_PROVIDER_ENV, routes.COMPUTE_PROVIDER_DISTRIBUTED)
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: (_ for _ in ()).throw(requests.RequestException("boom")),
+    )
+    monkeypatch.setattr(
+        routes,
+        "generate_response",
+        lambda model_id, messages, **options: messages
+        + [{"role": "assistant", "content": "Local fallback response"}],
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={"model": "llama-3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["choices"][0]["message"]["content"] == "Local fallback response"

--- a/utils/distributed_api_v1.py
+++ b/utils/distributed_api_v1.py
@@ -1,0 +1,24 @@
+"""Shared schema helpers for distributed API v1 compute payloads.
+
+This module keeps relay, server runtime, and desktop compute-node mode in
+lockstep for the migration from local-only inference to distributed compute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+DISTRIBUTED_V1_REQUIRED_FIELDS = (
+    "client_public_key",
+    "chat_history",
+    "cipherkey",
+    "iv",
+)
+
+
+def has_distributed_v1_payload(payload: Mapping[str, Any] | None) -> bool:
+    """Return ``True`` when ``payload`` includes the distributed v1 fields."""
+
+    if not isinstance(payload, Mapping):
+        return False
+    return all(field in payload for field in DISTRIBUTED_V1_REQUIRED_FIELDS)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -12,6 +12,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
 import requests
+from utils.distributed_api_v1 import (
+    DISTRIBUTED_V1_REQUIRED_FIELDS,
+    has_distributed_v1_payload,
+)
 
 # Configure logging
 logger = logging.getLogger('relay_client')
@@ -24,7 +28,7 @@ def get_config_lazy():
 # Define JSON schema for messages
 MESSAGE_SCHEMA = {
     "type": "object",
-    "required": ["client_public_key", "chat_history", "cipherkey", "iv"],
+    "required": list(DISTRIBUTED_V1_REQUIRED_FIELDS),
     "properties": {
         "client_public_key": {"type": "string"},
         "chat_history": {"type": "string"},
@@ -659,8 +663,7 @@ class RelayClient:
                     )
 
                     # Check if there's a client request to process
-                    required_fields = ['client_public_key', 'chat_history', 'cipherkey', 'iv']
-                    if all(field in relay_response for field in required_fields):
+                    if has_distributed_v1_payload(relay_response):
                         log_info("Processing client request...")
                         self.process_client_request(relay_response)
                     else:


### PR DESCRIPTION
### Motivation
- Move API v1 chat/completions toward a distributed compute path while preserving the legacy local llama execution flow behind an adapter.
- Centralise the distributed v1 payload contract so relay, server runtime, and desktop compute-node mode agree on the same required fields.
- Provide a small, backward-compatible adapter surface to enable rolling migration and clear testing of the distributed path.

### Description
- Add `utils/distributed_api_v1.py` with `DISTRIBUTED_V1_REQUIRED_FIELDS` and `has_distributed_v1_payload` to centralise the distributed API v1 payload schema.
- Introduce a `ComputeProvider` abstraction in `api/v1/routes.py` with `LocalComputeProvider` (legacy `generate_response` adapter) and `DistributedComputeProvider` (HTTP adapter that posts to remote `/v1/chat/completions`), selected by `TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed` and falling back to local on errors.
- Wire the shared schema helper into the relay and runtime paths by updating `relay.py`, `utils/networking/relay_client.py`, and the desktop bridge `desktop-tauri/src-tauri/python/compute_node_bridge.py` to use the same distributed payload checks.
- Update `utils/networking/relay_client.py` to reference the shared required fields in `MESSAGE_SCHEMA` and to use `has_distributed_v1_payload` when deciding to process sink responses.
- Add focused contract tests `tests/unit/test_api_v1_distributed_compute_provider.py` covering the distributed happy path (mocked upstream) and the fallback-to-local behaviour when upstreams fail.

### Testing
- Ran `pre-commit run --all-files`, which could not run in this environment because `pre-commit` is not installed (failed).
- Ran `python -m pytest -q`, which failed in this environment due to a missing Python dependency (`requests`) required by the test harness (failed).
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which failed here due to missing system `glib-2.0` / `pkg-config` dependencies (failed).
- Ran `cd desktop-tauri && npm run build`, which completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7558c4740832fa2a291cba521d502)