### PR TITLE
🛠️ RC polish: canonical server entrypoint, relay readiness, desktop parity status

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ For a directory-by-directory atlas, visit [docs/REPO_MAP.md](docs/REPO_MAP.md).
 The `desktop-tauri/` app is the forward-looking desktop path, but it is currently an MVP and does
 **not** yet replace `server.py`. The canonical migration sequence is documented in
 [`docs/roadmap/desktop_compute_node_migration.md`](docs/roadmap/desktop_compute_node_migration.md).
+`server.py` remains the canonical compute-node entrypoint, while `server/server_app.py` is retained
+as a legacy compatibility shim that delegates to `server.py`.
 
 See also:
 
@@ -175,6 +177,7 @@ See also:
 
 `relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
 operationally separate from GPU-heavy compute nodes.
+`relay.py` is the canonical relay entrypoint.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -23,6 +23,14 @@ Desktop includes a Python compute-node bridge
 (`src-tauri/python/compute_node_bridge.py`) that reuses
 `utils.compute_node_runtime` for the legacy relay `/sink` + `/source` flow used by `server.py`.
 The bridge runs as the primary operator path and emits status events (running/registered, active relay URL, backend mode, model path, and last error).
+Operator status now also includes the resolved relay target and relay port selected by shared
+runtime URL/port resolution.
+
+Canonical entrypoints in the repository remain:
+
+- compute nodes: `server.py`
+- relay: `relay.py`
+- `server/server_app.py`: legacy compatibility shim only
 
 The fake sidecar remains available at `sidecar/fake_llama_sidecar.py` for CI
 and fast local testing:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -109,6 +109,8 @@ def run(args: argparse.Namespace) -> int:
                 "type": "error",
                 "message": "failed to initialize model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
+                "relay_port": relay_port,
+                "relay_target": runtime.relay_client.relay_url,
             }
         )
         return 1
@@ -120,6 +122,8 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
+            "relay_port": relay_port,
+            "relay_target": runtime.relay_client.relay_url,
             "backend_mode": args.mode,
             "model_path": args.model,
             "last_error": None,
@@ -150,6 +154,8 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
+                    "relay_port": relay_port,
+                    "relay_target": active_relay_url,
                     "backend_mode": args.mode,
                     "model_path": args.model,
                     "last_error": last_error,
@@ -168,6 +174,8 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
+            "relay_port": relay_port,
+            "relay_target": runtime.relay_client.relay_url,
             "backend_mode": args.mode,
             "model_path": args.model,
             "last_error": None,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -82,6 +82,7 @@ def run(args: argparse.Namespace) -> int:
         from utils.compute_node_runtime import (
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
+            format_relay_target,
             is_legacy_relay_payload,
             resolve_relay_port,
             resolve_relay_url,
@@ -92,6 +93,7 @@ def run(args: argparse.Namespace) -> int:
 
     relay_url = resolve_relay_url(args.relay_url)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
+    relay_target = format_relay_target(relay_url, relay_port)
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(
@@ -110,7 +112,7 @@ def run(args: argparse.Namespace) -> int:
                 "message": "failed to initialize model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
                 "relay_port": relay_port,
-                "relay_target": runtime.relay_client.relay_url,
+                "relay_target": relay_target,
             }
         )
         return 1
@@ -123,7 +125,7 @@ def run(args: argparse.Namespace) -> int:
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
             "relay_port": relay_port,
-            "relay_target": runtime.relay_client.relay_url,
+            "relay_target": relay_target,
             "backend_mode": args.mode,
             "model_path": args.model,
             "last_error": None,
@@ -155,7 +157,7 @@ def run(args: argparse.Namespace) -> int:
                     "registered": registered,
                     "active_relay_url": active_relay_url,
                     "relay_port": relay_port,
-                    "relay_target": active_relay_url,
+                    "relay_target": relay_target,
                     "backend_mode": args.mode,
                     "model_path": args.model,
                     "last_error": last_error,
@@ -175,7 +177,7 @@ def run(args: argparse.Namespace) -> int:
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
             "relay_port": relay_port,
-            "relay_target": runtime.relay_client.relay_url,
+            "relay_target": relay_target,
             "backend_mode": args.mode,
             "model_path": args.model,
             "last_error": None,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -22,6 +22,8 @@ pub struct ComputeNodeStatus {
     pub running: bool,
     pub registered: bool,
     pub active_relay_url: String,
+    pub relay_target: String,
+    pub relay_port: Option<i64>,
     pub backend_mode: String,
     pub model_path: String,
     pub last_error: Option<String>,
@@ -107,6 +109,12 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     if let Some(active_relay_url) = payload.get("active_relay_url").and_then(Value::as_str) {
         status.active_relay_url = active_relay_url.into();
     }
+    if let Some(relay_target) = payload.get("relay_target").and_then(Value::as_str) {
+        status.relay_target = relay_target.into();
+    }
+    if payload.get("relay_port").is_some() {
+        status.relay_port = payload.get("relay_port").and_then(Value::as_i64);
+    }
     if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
         status.backend_mode = backend_mode.into();
     }
@@ -168,10 +176,12 @@ pub async fn start_compute_node(
                 *status = ComputeNodeStatus {
                     running: false,
                     registered: false,
-                    active_relay_url: request.relay_base_url.clone(),
-                    backend_mode: format!("{:?}", request.mode).to_lowercase(),
-                    model_path: request.model_path.clone(),
-                    last_error: Some(format!("failed to start compute-node bridge: {err}")),
+            active_relay_url: request.relay_base_url.clone(),
+            relay_target: request.relay_base_url.clone(),
+            relay_port: None,
+            backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            model_path: request.model_path.clone(),
+            last_error: Some(format!("failed to start compute-node bridge: {err}")),
                 };
             }
             *state.child.lock().await = None;
@@ -199,6 +209,8 @@ pub async fn start_compute_node(
             running: true,
             registered: false,
             active_relay_url: request.relay_base_url.clone(),
+            relay_target: request.relay_base_url.clone(),
+            relay_port: None,
             backend_mode: format!("{:?}", request.mode).to_lowercase(),
             model_path: request.model_path.clone(),
             last_error: None,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -112,8 +112,8 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     if let Some(relay_target) = payload.get("relay_target").and_then(Value::as_str) {
         status.relay_target = relay_target.into();
     }
-    if payload.get("relay_port").is_some() {
-        status.relay_port = payload.get("relay_port").and_then(Value::as_i64);
+    if let Some(relay_port_val) = payload.get("relay_port") {
+        status.relay_port = relay_port_val.as_i64();
     }
     if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
         status.backend_mode = backend_mode.into();
@@ -176,12 +176,12 @@ pub async fn start_compute_node(
                 *status = ComputeNodeStatus {
                     running: false,
                     registered: false,
-            active_relay_url: request.relay_base_url.clone(),
-            relay_target: request.relay_base_url.clone(),
-            relay_port: None,
-            backend_mode: format!("{:?}", request.mode).to_lowercase(),
-            model_path: request.model_path.clone(),
-            last_error: Some(format!("failed to start compute-node bridge: {err}")),
+                    active_relay_url: request.relay_base_url.clone(),
+                    relay_target: request.relay_base_url.clone(),
+                    relay_port: None,
+                    backend_mode: format!("{:?}", request.mode).to_lowercase(),
+                    model_path: request.model_path.clone(),
+                    last_error: Some(format!("failed to start compute-node bridge: {err}")),
                 };
             }
             *state.child.lock().await = None;

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -22,6 +22,8 @@ interface ComputeNodeStatus {
   running: boolean;
   registered: boolean;
   active_relay_url: string;
+  relay_target: string;
+  relay_port: number | null;
   backend_mode: string;
   model_path: string;
   last_error: string | null;
@@ -49,6 +51,8 @@ const defaultComputeStatus: ComputeNodeStatus = {
   running: false,
   registered: false,
   active_relay_url: '',
+  relay_target: '',
+  relay_port: null,
   backend_mode: 'auto',
   model_path: '',
   last_error: null,
@@ -149,6 +153,9 @@ export function App() {
           typeof payload.active_relay_url === 'string'
             ? payload.active_relay_url
             : prev.active_relay_url,
+        relay_target:
+          typeof payload.relay_target === 'string' ? payload.relay_target : prev.relay_target,
+        relay_port: typeof payload.relay_port === 'number' ? payload.relay_port : prev.relay_port,
         backend_mode:
           typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
@@ -345,6 +352,8 @@ export function App() {
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
         <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
+        <option value="metal">Metal (Apple Silicon)</option>
+        <option value="cuda">CUDA (NVIDIA)</option>
         <option value="cpu">CPU fallback</option>
       </select>
 
@@ -364,6 +373,8 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
+        <p style={{ marginBottom: 0 }}>Resolved relay target: <code>{computeStatus.relay_target || computeStatus.active_relay_url || config.relay_base_url}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay port: <code>{computeStatus.relay_port ?? 'auto'}</code></p>
         <p style={{ marginBottom: 0 }}>Backend mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -155,7 +155,12 @@ export function App() {
             : prev.active_relay_url,
         relay_target:
           typeof payload.relay_target === 'string' ? payload.relay_target : prev.relay_target,
-        relay_port: typeof payload.relay_port === 'number' ? payload.relay_port : prev.relay_port,
+        relay_port:
+          payload.relay_port === null
+            ? null
+            : typeof payload.relay_port === 'number'
+              ? payload.relay_port
+              : prev.relay_port,
         backend_mode:
           typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,6 +143,8 @@ Canonical sequencing lives in [roadmap/desktop_compute_node_migration.md](roadma
 
 - **Current state:** `server.py` is the primary compute-node runtime; `relay.py` handles legacy
   sink/source and multi-node registration; desktop-tauri is MVP only.
+- **Canonical entrypoints:** `server.py` for compute-node runtime and `relay.py` for relay runtime.
+  `server/server_app.py` is compatibility-only and delegates to `server.py`.
 - **Near-term:** `server.py` and desktop-tauri co-evolve through a shared compute-node runtime while
   relay operations move onto sugarkube.
 - **Target state (later):** post-parity migration to API v1-aligned distributed compute contracts.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -17,9 +17,10 @@ near-term, and target architecture.
 ## Applications
 
 - `server/` and `server.py`
-  - Current compute-node baseline.
+  - `server.py` is the canonical compute-node entrypoint.
+  - `server/server_app.py` is a legacy compatibility shim that delegates to `server.py`.
 - `relay.py`
-  - Lightweight relay handling legacy sink/source and multi-node registration.
+  - Canonical relay entrypoint handling legacy sink/source and multi-node registration.
   - First deployment candidate for sugarkube.
 - `api/`
   - FastAPI implementation and experimental API surface for contributors evaluating API-facing

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -26,7 +26,8 @@ migration.
 
 ### Current state
 
-- `server.py` is the primary compute-node implementation.
+- `server.py` is the canonical compute-node implementation.
+- `server/server_app.py` is legacy compatibility-only and delegates to `server.py`.
 - `relay.py` supports legacy sink/source contract and multi-node registration.
 - desktop-tauri provides MVP scaffolding but does not yet replace `server.py`.
 
@@ -63,7 +64,7 @@ Desktop parity includes model-management behaviors, not just prompt UI.
   - <https://www.llama.com/models/>
 - Show the actual GGUF artifact the runtime is using (path/name/version where available).
 - Support model browse + download UX (with explicit status/progress/error handling).
-- Default relay URL should be `https://token.place`, but must remain overrideable for local/staging.
+- Default relay URL should be `https://token.place`, but must remain overridable for local/staging.
 
 ## Operational alignment
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -43,13 +43,14 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 - [ ] `kubectl get pods` shows ready relay pod(s)
 - [ ] ingress host resolves in dev
-- [ ] `GET /healthz` returns success
+- [ ] `GET /livez` returns `{"status":"alive"}`
+- [ ] `GET /healthz` returns success/readiness JSON
 - [ ] external compute node can register/poll relay
 
 ## Rollback
 
 - Roll back to previous image tag and/or Helm revision.
-- Verify readiness and `/healthz` immediately after rollback.
+- Verify `/livez` and `/healthz` immediately after rollback.
 
 ## Operator notes
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -40,6 +40,8 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 ## Validation checklist
 
 - [ ] production relay endpoints reachable and healthy
+- [ ] `GET /livez` confirms process liveness
+- [ ] `GET /healthz` confirms readiness (non-draining)
 - [ ] registration/polling from external compute nodes succeeds
 - [ ] error rate/latency within expected baseline
 - [ ] rollback command and previous revision confirmed before sign-off
@@ -47,7 +49,7 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 ## Rollback
 
 - immediate rollback to prior known-good Helm revision/image tag
-- validate health and request flow
+- validate `/livez`, `/healthz`, and request flow
 - record deployment outcome and follow-up actions
 
 ## Operator notes

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -44,6 +44,7 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 ## Validation checklist
 
 - [ ] relay pod(s) healthy and stable
+- [ ] ingress route serves `https://staging.token.place/livez`
 - [ ] ingress route serves `https://staging.token.place/healthz`
 - [ ] relay receives expected registration/poll traffic from external nodes
 - [ ] smoke test request flow succeeds end-to-end on legacy contract
@@ -51,7 +52,7 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 ## Rollback
 
 - revert Helm release revision and/or pinned image tag
-- confirm health endpoint and registration flow after rollback
+- confirm `/livez`, `/healthz`, and registration flow after rollback
 - capture incident notes in outages/ if customer-visible
 
 ## Operator notes

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -9,7 +9,7 @@ migration is complete.
 
 - stateless request relay behavior
 - modest CPU/memory footprint
-- clear health endpoint (`/healthz`)
+- clear health/readiness endpoints (`/livez` and `/healthz`)
 - easier centralized ingress/tunnel management
 
 This allows token.place to improve relay availability and operator workflows while GPU-heavy
@@ -58,8 +58,16 @@ than inventing values.
 Minimum operator checks after deploy:
 
 1. Pod readiness and restart counts are stable.
-2. Ingress host resolves and serves `/healthz`.
+2. Ingress host resolves and serves both `/livez` and `/healthz`.
 3. Relay can accept registration/polling traffic from external compute nodes.
+
+`relay.py` semantics used by sugarkube probes:
+
+- `/livez` is process liveness (`200` with `{"status":"alive"}` when the process is up).
+- `/healthz` is readiness/operational status:
+  - `200` when relay is ready (can include warning details like empty known server pool).
+  - `503` with `status=draining` during SIGTERM/SIGINT shutdown drain.
+  - `503` with `status=degraded` if configured GPU upstream hostname resolution fails.
 
 Example checks:
 
@@ -67,6 +75,7 @@ Example checks:
 kubectl -n tokenplace get pods
 kubectl -n tokenplace get ingress
 curl -fsS https://<env-host>/healthz
+curl -fsS https://<env-host>/livez
 ```
 
 ## Current limitations

--- a/docs/roadmap/desktop_compute_node_migration.md
+++ b/docs/roadmap/desktop_compute_node_migration.md
@@ -4,6 +4,8 @@ This is the canonical migration plan for moving token.place from today's
 `server.py`-centered runtime toward a desktop-led compute-node architecture.
 
 - **Current state:** desktop-tauri is an MVP and is **not** feature-parity with `server.py`.
+- **Canonical entrypoints:** `server.py` is the canonical compute-node entrypoint and `relay.py` is
+  the canonical relay entrypoint. `server/server_app.py` is compatibility-only.
 - **Near-term target:** achieve desktop parity on the legacy relay sink/source contract first.
 - **Future target:** migrate distributed compute to API v1 **after** parity is complete.
 

--- a/relay.py
+++ b/relay.py
@@ -503,6 +503,8 @@ def healthz():
 @app.route("/livez", methods=["GET"])
 def livez():
     return jsonify({"status": "alive"})
+
+
 def _register_stream_session(server_public_key, client_public_key):
     """Create or replace the streaming session for a client/server pair."""
 

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -8,49 +8,58 @@ retained to keep older imports working while delegating all behavior to
 from __future__ import annotations
 
 import importlib.util
-import os
 from pathlib import Path
+from types import ModuleType
 
 
 _CANONICAL_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
-_CANONICAL_SERVER_SPEC = importlib.util.spec_from_file_location(
-    "tokenplace_canonical_server",
-    _CANONICAL_SERVER_PATH,
-)
-if _CANONICAL_SERVER_SPEC is None or _CANONICAL_SERVER_SPEC.loader is None:  # pragma: no cover
-    raise RuntimeError(f"unable to load canonical server module from {_CANONICAL_SERVER_PATH}")
+_canonical_server: ModuleType | None = None
 
-_canonical_server = importlib.util.module_from_spec(_CANONICAL_SERVER_SPEC)
-_CANONICAL_SERVER_SPEC.loader.exec_module(_canonical_server)
 
-ServerApp = _canonical_server.ServerApp
-_first_env = _canonical_server._first_env
-_resolve_relay_url = _canonical_server._resolve_relay_url
-_resolve_relay_port = _canonical_server._resolve_relay_port
-_format_relay_target = _canonical_server._format_relay_target
+def _load_canonical() -> ModuleType:
+    """Load and cache the canonical server module on first use."""
+
+    global _canonical_server
+    if _canonical_server is not None:
+        return _canonical_server
+
+    canonical_spec = importlib.util.spec_from_file_location(
+        "tokenplace_canonical_server",
+        _CANONICAL_SERVER_PATH,
+    )
+    if canonical_spec is None or canonical_spec.loader is None:  # pragma: no cover
+        raise RuntimeError(
+            f"unable to load canonical server module from {_CANONICAL_SERVER_PATH}"
+        )
+
+    canonical_module = importlib.util.module_from_spec(canonical_spec)
+    canonical_spec.loader.exec_module(canonical_module)
+    _canonical_server = canonical_module
+    return canonical_module
+
+
+def __getattr__(name: str):
+    if name in {
+        "ServerApp",
+        "_first_env",
+        "_resolve_relay_url",
+        "_resolve_relay_port",
+        "_format_relay_target",
+    }:
+        return getattr(_load_canonical(), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def parse_args():
     """Compatibility wrapper around canonical CLI parsing."""
 
-    return _canonical_server.parse_args()
+    return _load_canonical().parse_args()
 
 
 def main() -> None:
     """Compatibility wrapper that delegates startup to ``server.py``."""
 
-    args = parse_args()
-    if args.use_mock_llm:
-        os.environ["USE_MOCK_LLM"] = "1"
-    relay_url = _resolve_relay_url(args.relay_url)
-    relay_port = _resolve_relay_port(args.relay_port, relay_url)
-    server = ServerApp(
-        server_port=args.server_port,
-        server_host=args.server_host,
-        relay_port=relay_port,
-        relay_url=relay_url,
-    )
-    server.run()
+    _load_canonical().main()
 
 __all__ = [
     "ServerApp",

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -1,183 +1,67 @@
+"""Legacy compatibility shim for the canonical compute-node entrypoint.
+
+`server.py` is the only canonical compute-node implementation.  This module is
+retained to keep older imports working while delegating all behavior to
+`server.py` so compatibility paths cannot drift.
 """
-Main server application module that integrates all components.
-"""
+
+from __future__ import annotations
+
+import importlib.util
 import os
-import threading
-import argparse
-import logging
-from urllib.parse import urlparse
-from flask import Flask, request, jsonify
-from typing import Dict, Any, List, Optional
-
-# Import our refactored modules
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
-from utils.system import collect_resource_usage
-
-# Import config
-from config import get_config
-
-# Get configuration instance
-config = get_config()
-
-# Configure logging
-logging.basicConfig(level=logging.INFO if not config.is_production else logging.ERROR,
-                   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger('server_app')
-
-def log_info(message):
-    """Log info only in non-production environments"""
-    if not config.is_production:
-        logger.info(message)
-
-def log_error(message, exc_info=False):
-    """Log errors only in non-production environments"""
-    if not config.is_production:
-        logger.error(message, exc_info=exc_info)
+from pathlib import Path
 
 
-def _format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
-    """Create a display-ready relay target without duplicating explicit URL ports."""
+_CANONICAL_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_CANONICAL_SERVER_SPEC = importlib.util.spec_from_file_location(
+    "tokenplace_canonical_server",
+    _CANONICAL_SERVER_PATH,
+)
+if _CANONICAL_SERVER_SPEC is None or _CANONICAL_SERVER_SPEC.loader is None:  # pragma: no cover
+    raise RuntimeError(f"unable to load canonical server module from {_CANONICAL_SERVER_PATH}")
 
-    parsed = urlparse(relay_url if "://" in relay_url else f"http://{relay_url}")
-    if relay_port is None or parsed.port is not None:
-        return relay_url
-    return f"{relay_url}:{relay_port}"
+_canonical_server = importlib.util.module_from_spec(_CANONICAL_SERVER_SPEC)
+_CANONICAL_SERVER_SPEC.loader.exec_module(_canonical_server)
 
-class ServerApp:
-    """
-    Main server application that integrates all components.
-    """
-    def __init__(
-        self,
-        server_port: int = 3000,
-        relay_port: Optional[int] = None,
-        relay_url: str = "https://token.place",
-    ):
-        """
-        Initialize the server application.
+ServerApp = _canonical_server.ServerApp
+_first_env = _canonical_server._first_env
+_resolve_relay_url = _canonical_server._resolve_relay_url
+_resolve_relay_port = _canonical_server._resolve_relay_port
+_format_relay_target = _canonical_server._format_relay_target
 
-        Args:
-            server_port: Port to run the server on
-            relay_port: Port the relay server is running on
-            relay_url: URL of the relay server
-        """
-        self.server_port = server_port
-        self.relay_port = relay_port
-        self.relay_url = relay_url
-        self.server_host = config.get('server.host', '127.0.0.1')
 
-        # Create Flask app
-        self.app = Flask(__name__)
+def parse_args():
+    """Compatibility wrapper around canonical CLI parsing."""
 
-        # Set up endpoints
-        self.setup_routes()
+    return _canonical_server.parse_args()
 
-        # Create relay client
-        self.relay_client = RelayClient(
-            base_url=relay_url,
-            port=relay_port,
-            crypto_manager=get_crypto_manager(),
-            model_manager=get_model_manager()
-        )
 
-        # Initialize LLM by downloading model if needed
-        self.initialize_llm()
+def main() -> None:
+    """Compatibility wrapper that delegates startup to ``server.py``."""
 
-    def initialize_llm(self):
-        """Initialize the LLM by downloading the model if needed."""
-        log_info("Initializing LLM...")
-        model_mgr = get_model_manager()
-        if model_mgr.use_mock_llm:
-            log_info("Using mock LLM based on configuration")
-        else:
-            # Download model if needed
-            if model_mgr.download_model_if_needed():
-                log_info("Model ready for inference")
-            else:
-                log_error("Failed to download or verify model")
-
-    def setup_routes(self):
-        """Set up Flask routes for the server."""
-        # Root endpoint
-        @self.app.route('/')
-        def index():
-            return jsonify({
-                'status': 'ok',
-                'message': 'token.place server is running'
-            })
-
-        # Health check endpoint
-        @self.app.route('/health')
-        def health():
-            return jsonify({
-                'status': 'ok',
-                'version': config.get('version', 'dev'),
-                'mock_mode': get_model_manager().use_mock_llm
-            })
-
-        @self.app.route('/metrics/resource')
-        def resource_metrics():
-            """Expose basic CPU and memory usage metrics for cross-platform monitoring."""
-            usage = collect_resource_usage()
-            return jsonify(usage)
-
-        # Endpoints for direct API access (if needed)
-        # These endpoints might be unused if all communication goes through the relay
-
-    def start_relay_polling(self):  # pragma: no cover
-        """Start polling the relay in a background thread."""
-        relay_thread = threading.Thread(
-            target=self.relay_client.poll_relay_continuously,
-            daemon=True
-        )
-        relay_thread.start()
-        relay_target = _format_relay_target(self.relay_url, self.relay_port)
-        log_info(f"Started relay polling thread for {relay_target}")
-
-    def run(self):  # pragma: no cover
-        """Run the server application."""
-        log_info(f"Starting server on {self.server_host}:{self.server_port}")
-
-        # Start relay polling in a background thread
-        self.start_relay_polling()
-
-        # Run the Flask app. Bind to localhost by default to avoid exposing the
-        # service unintentionally; allow override via configuration.
-        host = config.get('server.host', '127.0.0.1')
-        self.app.run(
-            host=self.server_host,
-            port=self.server_port,
-            debug=not config.is_production,
-            use_reloader=False  # Disable reloader to avoid duplicate threads
-        )
-
-def parse_args():  # pragma: no cover
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="token.place server")
-    parser.add_argument("--server_port", type=int, default=3000, help="Port to run the server on")
-    parser.add_argument("--relay_port", type=int, default=None, help="Port the relay server is running on")
-    parser.add_argument("--relay_url", type=str, default="https://token.place", help="URL of the relay server")
-    parser.add_argument("--use_mock_llm", action="store_true", help="Use mock LLM for testing")
-    return parser.parse_args()
-
-def main():  # pragma: no cover
-    """Main entry point for the server application."""
     args = parse_args()
-
-    # Set USE_MOCK_LLM environment variable if flag is set
     if args.use_mock_llm:
-        os.environ['USE_MOCK_LLM'] = '1'
-        print("Running in mock LLM mode")
-
-    # Create and run the server
+        os.environ["USE_MOCK_LLM"] = "1"
+    relay_url = _resolve_relay_url(args.relay_url)
+    relay_port = _resolve_relay_port(args.relay_port, relay_url)
     server = ServerApp(
         server_port=args.server_port,
-        relay_port=args.relay_port,
-        relay_url=args.relay_url
+        server_host=args.server_host,
+        relay_port=relay_port,
+        relay_url=relay_url,
     )
     server.run()
+
+__all__ = [
+    "ServerApp",
+    "parse_args",
+    "main",
+    "_first_env",
+    "_resolve_relay_url",
+    "_resolve_relay_port",
+    "_format_relay_target",
+]
+
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -39,13 +39,7 @@ def _load_canonical() -> ModuleType:
 
 
 def __getattr__(name: str):
-    if name in {
-        "ServerApp",
-        "_first_env",
-        "_resolve_relay_url",
-        "_resolve_relay_port",
-        "_format_relay_target",
-    }:
+    if name == "ServerApp":
         return getattr(_load_canonical(), name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -65,10 +59,6 @@ __all__ = [
     "ServerApp",
     "parse_args",
     "main",
-    "_first_env",
-    "_resolve_relay_url",
-    "_resolve_relay_port",
-    "_format_relay_target",
 ]
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -13,6 +13,7 @@ from relay import app
 # Import the global dictionaries from relay to inspect/manipulate state if needed
 # Be cautious with direct manipulation in tests, prefer using API endpoints
 from relay import (
+    DRAINING,
     known_servers,
     client_inference_requests,
     client_responses,
@@ -327,6 +328,26 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client):
     assert "https://configured-one.example.com:8000" not in {
         node["server_public_key"] for node in payload["registeredServers"]
     }
+
+
+def test_livez_reports_process_liveness(client):
+    response = client.get("/livez")
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "alive"}
+
+
+def test_healthz_reports_draining_state(client):
+    DRAINING.set()
+    try:
+        response = client.get("/healthz")
+    finally:
+        DRAINING.clear()
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["status"] == "draining"
+    assert payload["details"]["shutdown"] is True
+    assert response.headers["Retry-After"] == "0"
 
 # --- Test /source ---
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -148,8 +148,18 @@ def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeyp
     assert event_types[0] == 'started'
     assert 'status' in event_types
     assert event_types[-1] == 'stopped'
+    assert events[0]['relay_port'] is None
+    assert events[0]['relay_target'] == 'https://token.place'
     assert any(event.get('registered') is False for event in events if event['type'] == 'status')
     assert any(event.get('registered') is True for event in events if event['type'] == 'status')
+    assert all(event.get('relay_port') is None for event in events if event['type'] == 'status')
+    assert all(
+        event.get('relay_target') == 'https://token.place'
+        for event in events
+        if event['type'] == 'status'
+    )
+    assert events[-1]['relay_port'] is None
+    assert events[-1]['relay_target'] == 'https://token.place'
 
 
 def test_run_reports_model_initialization_failures(capsys, monkeypatch):
@@ -173,6 +183,8 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
     assert 'failed to initialize model runtime' in payload['message']
+    assert payload['relay_port'] is None
+    assert payload['relay_target'] == 'https://token.place'
 
 
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -111,6 +111,9 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     )
     module.resolve_relay_url = lambda relay_url: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    module.format_relay_target = (
+        lambda relay_url, relay_port: f"{relay_url}:{relay_port}" if relay_port else relay_url
+    )
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
 

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -312,7 +312,7 @@ def test_extract_text_from_completion_handles_empty_choices():
 
 def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
     class WithBadDict:
-        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+        def dict(self, _required):  # pragma: no cover - signature intentionally incompatible
             return {'choices': []}
 
     class UnknownShape:

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -30,5 +30,5 @@ def test_shim_main_delegates_to_canonical_server():
     canonical_module.main.assert_called_once_with()
 
 
-def test_shim_relay_target_format_helper_is_canonical():
-    assert shim._format_relay_target("http://localhost:5000", 5000) == "http://localhost:5000"
+def test_shim_limits_exports_to_compat_entrypoints():
+    assert shim.__all__ == ["ServerApp", "parse_args", "main"]

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -1,93 +1,52 @@
-from unittest.mock import MagicMock, patch
-import os
+"""Tests for the legacy ``server.server_app`` compatibility shim."""
 
-import server.server_app as sa
+import argparse
+from unittest.mock import patch
+from unittest.mock import MagicMock
+
+import server
+import server.server_app as shim
 
 
-def test_parse_args_defaults(monkeypatch):
+def test_shim_re_exports_canonical_entrypoints():
+    assert shim.ServerApp is server.ServerApp
+    assert callable(shim.parse_args)
+    assert callable(shim.main)
+
+
+def test_shim_parse_args_matches_canonical_defaults(monkeypatch):
     import sys
 
     monkeypatch.setattr(sys, "argv", ["server.py"])
-    args = sa.parse_args()
+    args = shim.parse_args()
     assert args.server_port == 3000
+    assert args.server_host == "127.0.0.1"
     assert args.relay_port is None
-    assert args.relay_url == "https://token.place"
     assert args.use_mock_llm is False
 
 
-def test_parse_args_custom(monkeypatch):
-    import sys
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "server.py",
-            "--server_port",
-            "1234",
-            "--relay_port",
-            "7777",
-            "--relay_url",
-            "http://example.com",
-            "--use_mock_llm",
-        ],
-    )
-    args = sa.parse_args()
-    assert args.server_port == 1234
-    assert args.relay_port == 7777
-    assert args.relay_url == "http://example.com"
-    assert args.use_mock_llm is True
-
-
-def test_initialize_llm_mock():
-    with patch("server.server_app.get_model_manager") as gm:
-        gm.return_value.use_mock_llm = True
-        app = sa.ServerApp()
-        # initialize_llm called in __init__; ensure method executed
-        gm.assert_called()
-
-
-def test_initialize_llm_download():
-    mm = MagicMock()
-    mm.use_mock_llm = False
-    mm.download_model_if_needed.return_value = True
-    with patch("server.server_app.get_model_manager", return_value=mm):
-        app = sa.ServerApp()
-        mm.download_model_if_needed.assert_called_once()
-
-
-def test_start_relay_polling():
-    with patch("server.server_app.RelayClient") as rc:
-        instance = rc.return_value
-        instance.poll_relay_continuously = MagicMock()
-        app = sa.ServerApp()
-        with patch("threading.Thread") as th:
-            thread = MagicMock()
-            th.return_value = thread
-            app.start_relay_polling()
-            thread.start.assert_called_once()
-
-
-def test_main_invocation(monkeypatch):
-    args = sa.argparse.Namespace(
+def test_shim_main_delegates_to_canonical_server(monkeypatch):
+    args = argparse.Namespace(
         server_port=1111,
+        server_host="0.0.0.0",
         relay_port=2222,
-        relay_url="http://foo",
-        use_mock_llm=True,
+        relay_url="http://relay.example.com",
+        use_mock_llm=False,
     )
-    monkeypatch.setattr(sa, "parse_args", lambda: args)
-    mock_app = MagicMock()
-    monkeypatch.setattr(sa, "ServerApp", MagicMock(return_value=mock_app))
-    monkeypatch.delenv("USE_MOCK_LLM", raising=False)
-    sa.main()
-    sa.ServerApp.assert_called_once_with(
+    mock_server = MagicMock()
+
+    monkeypatch.setattr(shim, "parse_args", lambda: args)
+    with patch("server.server_app.ServerApp", return_value=mock_server) as server_ctor:
+        shim.main()
+
+    server_ctor.assert_called_once_with(
         server_port=1111,
+        server_host="0.0.0.0",
         relay_port=2222,
-        relay_url="http://foo",
+        relay_url="http://relay.example.com",
     )
-    mock_app.run.assert_called_once()
-    assert os.environ["USE_MOCK_LLM"] == "1"
+    mock_server.run.assert_called_once()
 
 
-def test_format_relay_target_avoids_duplicate_port():
-    assert sa._format_relay_target("http://localhost:5000", 5000) == "http://localhost:5000"
+def test_shim_relay_target_format_helper_is_canonical():
+    assert shim._format_relay_target("http://localhost:5000", 5000) == "http://localhost:5000"

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -1,8 +1,6 @@
 """Tests for the legacy ``server.server_app`` compatibility shim."""
 
-import argparse
 from unittest.mock import patch
-from unittest.mock import MagicMock
 
 import server
 import server.server_app as shim
@@ -25,27 +23,11 @@ def test_shim_parse_args_matches_canonical_defaults(monkeypatch):
     assert args.use_mock_llm is False
 
 
-def test_shim_main_delegates_to_canonical_server(monkeypatch):
-    args = argparse.Namespace(
-        server_port=1111,
-        server_host="0.0.0.0",
-        relay_port=2222,
-        relay_url="http://relay.example.com",
-        use_mock_llm=False,
-    )
-    mock_server = MagicMock()
-
-    monkeypatch.setattr(shim, "parse_args", lambda: args)
-    with patch("server.server_app.ServerApp", return_value=mock_server) as server_ctor:
+def test_shim_main_delegates_to_canonical_server():
+    with patch("server.server_app._load_canonical") as load_canonical:
+        canonical_module = load_canonical.return_value
         shim.main()
-
-    server_ctor.assert_called_once_with(
-        server_port=1111,
-        server_host="0.0.0.0",
-        relay_port=2222,
-        relay_url="http://relay.example.com",
-    )
-    mock_server.run.assert_called_once()
+    canonical_module.main.assert_called_once_with()
 
 
 def test_shim_relay_target_format_helper_is_canonical():

--- a/tests/unit/test_server_app_additional.py
+++ b/tests/unit/test_server_app_additional.py
@@ -1,73 +1,13 @@
-import server.server_app as sa
-from unittest.mock import MagicMock, patch
+"""Additional drift-guard tests for ``server.server_app`` compatibility shim."""
+
+import server
+import server.server_app as shim
 
 
-def test_health_route():
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    mm.download_model_if_needed.return_value = True
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'):
-        app = sa.ServerApp()
-        client = app.app.test_client()
-        res = client.get('/health')
-        assert res.status_code == 200
-        data = res.get_json()
-        assert data['mock_mode'] is True
+def test_shim_server_class_name_matches_canonical():
+    assert shim.ServerApp.__name__ == server.ServerApp.__name__
 
 
-def test_root_route():
-    """Verify that the root route returns a simple status."""
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    mm.download_model_if_needed.return_value = True
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'):
-        app = sa.ServerApp()
-        client = app.app.test_client()
-        res = client.get('/')
-        assert res.status_code == 200
-        data = res.get_json()
-        assert data['status'] == 'ok'
-
-
-def test_run_method(monkeypatch):
-    """Ensure the run method starts polling and launches Flask."""
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'):
-        app = sa.ServerApp()
-
-        poller = MagicMock()
-        monkeypatch.setattr(app, 'start_relay_polling', poller)
-        flask_runner = MagicMock()
-        monkeypatch.setattr(app.app, 'run', flask_runner)
-
-        app.run()
-
-        poller.assert_called_once()
-        flask_runner.assert_called_once_with(
-            host='127.0.0.1',
-            port=app.server_port,
-            debug=not sa.config.is_production,
-            use_reloader=False,
-        )
-
-
-def test_resource_metrics_route():
-    """The resource metrics endpoint should expose CPU and memory usage."""
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    mm.download_model_if_needed.return_value = True
-
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'), \
-         patch('server.server_app.collect_resource_usage', return_value={'cpu_percent': 4.2, 'memory_percent': 73.1}):
-        app = sa.ServerApp()
-        client = app.app.test_client()
-        response = client.get('/metrics/resource')
-
-    assert response.status_code == 200
-    payload = response.get_json()
-    assert payload == {'cpu_percent': 4.2, 'memory_percent': 73.1}
+def test_shim_exports_no_shadow_server_app_implementation():
+    assert "ServerApp" in shim.__all__
+    assert shim.ServerApp is server.ServerApp


### PR DESCRIPTION
### Motivation
- Make the repo internally consistent for release-candidate use by making `server.py` the single canonical compute-node entrypoint, hardening `relay.py` for sugarkube onboarding, and surfacing desktop/server parity-critical status in the Tauri UI.
- Prevent accidental drift by turning the previous `server/server_app.py` implementation surface into a small compatibility shim that delegates to the canonical implementation.
- Tighten relay readiness semantics and documentation so sugarkube probes and operator runbooks are accurate without changing the legacy relay contract or introducing API v1 migration work.

### Description
- Replace `server/server_app.py` with a lightweight compatibility shim that dynamically imports and delegates `ServerApp`, `parse_args`, and `main` to the canonical `server.py`, preventing a second drifting implementation. (files: `server/server_app.py`) 
- Surface relay resolution details in the desktop operator flow by emitting `relay_port` and `relay_target` from the Python compute bridge, propagate those fields into the Tauri Rust state, and display them in the UI plus add matching backend-mode options (`metal`/`cuda`/`cpu`). (files: `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src/App.tsx`, `desktop-tauri/README.md`) 
- Add relay readiness/liveness semantics and regression coverage for `/livez` and draining `/healthz`, and update onboarding/runbooks/docs to reflect canonical entrypoints and sugarkube probe expectations. (files: `relay.py` tests, `tests/test_relay.py`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-*.md`, `docs/ARCHITECTURE.md`, `docs/REPO_MAP.md`, `docs/design/tauri_desktop_client.md`, `docs/roadmap/desktop_compute_node_migration.md`, `README.md`) 
- Add drift-guard unit tests proving the shim delegates to the canonical server and small test fixes (typo / unused-variable) to keep the focused suites green. (files: `tests/unit/test_server_app.py`, `tests/unit/test_server_app_additional.py`, `tests/unit/test_desktop_inference_sidecar.py`) 

### Testing
- Ran focused desktop and bridge unit suites: `pytest -q tests/unit/test_desktop_compute_node_bridge.py`, `pytest -q tests/unit/test_desktop_inference_sidecar.py`, and `pytest -q tests/unit/test_desktop_model_bridge.py`, all of which passed. 
- Ran shim and relay-focused tests: `pytest -q tests/unit/test_server_app.py` and `pytest -q tests/unit/test_relay_binary_signing.py tests/test_relay.py`, both passed and include new liveness/draining assertions. 
- Ran higher-level integration and API suites: `pytest -q tests/integration/test_dspace_chat_alias.py` and `pytest -q tests/test_api.py`, both passed in this environment. 
- Executed the aggregate runner `./run_all_tests.sh` (and attempted `pre-commit run --all-files`); the full aggregate run surfaced environment/tooling gaps in this runner (Bandit not installed in the environment invoked by the script and an earlier pre-commit codespell/vulture failure that was fixed), so the aggregate script reported failures unrelated to the functional changes here; focused tests covering the changed areas passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d890a07cbc832f88bf3d8ae6f76d86)