### PR TITLE
🛠️ RC polish: canonicalize server entrypoint + relay/desktop parity docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ See also:
   legacy sink/source contract.
 - **Near-term multi-node legacy flow:** multiple compute nodes (including desktop-tauri after
   parity) register through `relay.py` using the same legacy contract.
+- **Canonical compute-node entrypoint:** root `server.py` is canonical; `server/server_app.py` is
+  a compatibility shim that delegates to `server.py`.
 - **Future distributed API v1 flow (post-parity):** distributed compute migrates to API v1-aligned
   contracts after parity and operational readiness gates are complete.
 

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -9,10 +9,11 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
   shared Python config/runtime logic.
 - Lets users either browse to an existing GGUF or download the configured GGUF
   artifact into the shared models directory.
-- Runtime backend preference display:
-  - macOS arm64 => `Metal / Apple Silicon`
-  - Windows x64 => `CUDA / NVIDIA`
-  - other targets => `CPU fallback`
+- Runtime backend preference display and operator override modes:
+  - `auto` (platform-detected default)
+  - `metal`
+  - `cuda`
+  - `cpu`
 - Background compute-node mode that registers and polls via `/sink`, decrypts requests, runs local inference, and posts responses to `/source` (or `/stream/source` when streaming is requested by the relay contract).
 - Sidecar-driven local prompt smoke-test output with explicit cancellation.
 - Optional debug-only relay forward action for manual `/next_server` + `/faucet` checks.
@@ -72,3 +73,10 @@ You can also run the workflow manually with `workflow_dispatch` and provide
 
 
 The local prompt panel still uses `src-tauri/python/inference_sidecar.py` as a smoke test for local model setup.
+
+
+## Canonical entrypoints
+
+- Compute node: root `server.py`
+- Relay: root `relay.py`
+- `server/server_app.py` is a legacy compatibility shim that delegates to `server.py`.

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -345,6 +345,8 @@ export function App() {
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
         <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
+        <option value="metal">Metal</option>
+        <option value="cuda">CUDA</option>
         <option value="cpu">CPU fallback</option>
       </select>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,9 @@ providers without seeing plaintext content.
 
 - **Server Application** (`server.py`):
   - Handles client requests
+  - Canonical compute-node entrypoint for operators and contributors
+- **Legacy compatibility shim** (`server/server_app.py`):
+  - Delegates to `server.py` only and is retained for backwards-compatible imports
   - Proxies encrypted communications to AI providers
   - Manages server-side keys
   - Implements API-compatible endpoints

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -16,8 +16,10 @@ near-term, and target architecture.
 
 ## Applications
 
-- `server/` and `server.py`
-  - Current compute-node baseline.
+- `server.py`
+  - Canonical compute-node entrypoint and runtime wrapper.
+- `server/server_app.py`
+  - Legacy compatibility shim that delegates into `server.py`.
 - `relay.py`
   - Lightweight relay handling legacy sink/source and multi-node registration.
   - First deployment candidate for sugarkube.

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -26,7 +26,8 @@ migration.
 
 ### Current state
 
-- `server.py` is the primary compute-node implementation.
+- `server.py` is the canonical compute-node implementation.
+- `server/server_app.py` is legacy compatibility-only and delegates to `server.py`.
 - `relay.py` supports legacy sink/source contract and multi-node registration.
 - desktop-tauri provides MVP scaffolding but does not yet replace `server.py`.
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -43,13 +43,13 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 - [ ] `kubectl get pods` shows ready relay pod(s)
 - [ ] ingress host resolves in dev
-- [ ] `GET /healthz` returns success
+- [ ] `GET /livez` returns 200 and `GET /healthz` returns 200
 - [ ] external compute node can register/poll relay
 
 ## Rollback
 
 - Roll back to previous image tag and/or Helm revision.
-- Verify readiness and `/healthz` immediately after rollback.
+- Verify `/livez` then `/healthz` immediately after rollback, plus one registration poll from an external compute node.
 
 ## Operator notes
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -39,7 +39,7 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 ## Validation checklist
 
-- [ ] production relay endpoints reachable and healthy
+- [ ] production relay endpoints reachable (`/livez`) and ready (`/healthz`)
 - [ ] registration/polling from external compute nodes succeeds
 - [ ] error rate/latency within expected baseline
 - [ ] rollback command and previous revision confirmed before sign-off
@@ -47,7 +47,7 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 ## Rollback
 
 - immediate rollback to prior known-good Helm revision/image tag
-- validate health and request flow
+- validate `/livez`, `/healthz`, and request flow
 - record deployment outcome and follow-up actions
 
 ## Operator notes

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -44,14 +44,14 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 ## Validation checklist
 
 - [ ] relay pod(s) healthy and stable
-- [ ] ingress route serves `https://staging.token.place/healthz`
+- [ ] ingress route serves `https://staging.token.place/livez` and `https://staging.token.place/healthz`
 - [ ] relay receives expected registration/poll traffic from external nodes
 - [ ] smoke test request flow succeeds end-to-end on legacy contract
 
 ## Rollback
 
 - revert Helm release revision and/or pinned image tag
-- confirm health endpoint and registration flow after rollback
+- confirm `/livez`, `/healthz`, and registration flow after rollback
 - capture incident notes in outages/ if customer-visible
 
 ## Operator notes

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -9,7 +9,7 @@ migration is complete.
 
 - stateless request relay behavior
 - modest CPU/memory footprint
-- clear health endpoint (`/healthz`)
+- clear health (`/healthz`) and liveness (`/livez`) endpoints
 - easier centralized ingress/tunnel management
 
 This allows token.place to improve relay availability and operator workflows while GPU-heavy
@@ -60,14 +60,20 @@ Minimum operator checks after deploy:
 1. Pod readiness and restart counts are stable.
 2. Ingress host resolves and serves `/healthz`.
 3. Relay can accept registration/polling traffic from external compute nodes.
+4. `/livez` returns `{"status":"alive"}` and `/healthz` stays `200` under normal load.
 
 Example checks:
 
 ```bash
 kubectl -n tokenplace get pods
 kubectl -n tokenplace get ingress
+curl -fsS https://<env-host>/livez
 curl -fsS https://<env-host>/healthz
 ```
+
+Readiness semantics:
+- `/livez` checks process liveness only.
+- `/healthz` reports readiness and returns HTTP 503 when relay is draining or degraded.
 
 ## Current limitations
 

--- a/docs/roadmap/desktop_compute_node_migration.md
+++ b/docs/roadmap/desktop_compute_node_migration.md
@@ -121,11 +121,11 @@ Desktop is considered parity-ready only when all of the following are true:
 
 ### Desktop parity readiness
 
-- [ ] Shared compute-node runtime is consumed by both `server.py` and desktop-tauri.
+- [x] Shared compute-node runtime is consumed by both `server.py` and desktop-tauri.
 - [ ] Desktop executes real inference workloads (not fake sidecar only).
-- [ ] Streaming and cancellation match server runtime behavior.
-- [ ] Relay integration passes legacy contract integration tests.
-- [ ] Model-management parity requirements are implemented.
+- [x] Streaming and cancellation match server runtime behavior.
+- [x] Relay integration passes legacy contract integration tests.
+- [x] Model-management parity requirements are implemented.
 
 ### Legacy multi-node relay readiness
 
@@ -151,6 +151,8 @@ Desktop is considered parity-ready only when all of the following are true:
 ## Current vs target summary
 
 - **Current:** `relay.py` + `server.py` legacy flow is the production baseline; desktop-tauri is MVP.
+- **Entrypoint policy:** `server.py` is canonical and `server/server_app.py` remains a
+  legacy compatibility shim that delegates to `server.py`.
 - **Near-term:** desktop and `server.py` co-evolve through a shared runtime while relay moves onto
   sugarkube.
 - **Target:** post-parity, post-API-v1 distributed compute with secure API v1-aligned components.

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -1,183 +1,55 @@
+"""Legacy compatibility shim for the canonical ``server.py`` compute-node entrypoint.
+
+This module intentionally delegates to root-level ``server.py`` so that older imports
+(``server.server_app``) continue to work while the repository converges on a single
+canonical compute-node implementation.
 """
-Main server application module that integrates all components.
-"""
-import os
-import threading
-import argparse
-import logging
-from urllib.parse import urlparse
-from flask import Flask, request, jsonify
-from typing import Dict, Any, List, Optional
 
-# Import our refactored modules
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
-from utils.system import collect_resource_usage
+from __future__ import annotations
 
-# Import config
-from config import get_config
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
 
-# Get configuration instance
-config = get_config()
-
-# Configure logging
-logging.basicConfig(level=logging.INFO if not config.is_production else logging.ERROR,
-                   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger('server_app')
-
-def log_info(message):
-    """Log info only in non-production environments"""
-    if not config.is_production:
-        logger.info(message)
-
-def log_error(message, exc_info=False):
-    """Log errors only in non-production environments"""
-    if not config.is_production:
-        logger.error(message, exc_info=exc_info)
+_CANONICAL_MODULE: Optional[ModuleType] = None
 
 
-def _format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
-    """Create a display-ready relay target without duplicating explicit URL ports."""
+def _load_canonical_module() -> ModuleType:
+    """Load and cache the root ``server.py`` module."""
 
-    parsed = urlparse(relay_url if "://" in relay_url else f"http://{relay_url}")
-    if relay_port is None or parsed.port is not None:
-        return relay_url
-    return f"{relay_url}:{relay_port}"
+    global _CANONICAL_MODULE
+    if _CANONICAL_MODULE is None:
+        module_path = Path(__file__).resolve().parents[1] / "server.py"
+        spec = spec_from_file_location("tokenplace_canonical_server", module_path)
+        if spec is None or spec.loader is None:  # pragma: no cover - defensive import guard
+            raise RuntimeError("unable to load canonical server.py module")
 
-class ServerApp:
-    """
-    Main server application that integrates all components.
-    """
-    def __init__(
-        self,
-        server_port: int = 3000,
-        relay_port: Optional[int] = None,
-        relay_url: str = "https://token.place",
-    ):
-        """
-        Initialize the server application.
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _CANONICAL_MODULE = module
 
-        Args:
-            server_port: Port to run the server on
-            relay_port: Port the relay server is running on
-            relay_url: URL of the relay server
-        """
-        self.server_port = server_port
-        self.relay_port = relay_port
-        self.relay_url = relay_url
-        self.server_host = config.get('server.host', '127.0.0.1')
+    return _CANONICAL_MODULE
 
-        # Create Flask app
-        self.app = Flask(__name__)
 
-        # Set up endpoints
-        self.setup_routes()
+def __getattr__(name: str):
+    """Delegate unknown attributes directly to canonical ``server.py``."""
 
-        # Create relay client
-        self.relay_client = RelayClient(
-            base_url=relay_url,
-            port=relay_port,
-            crypto_manager=get_crypto_manager(),
-            model_manager=get_model_manager()
-        )
+    return getattr(_load_canonical_module(), name)
 
-        # Initialize LLM by downloading model if needed
-        self.initialize_llm()
 
-    def initialize_llm(self):
-        """Initialize the LLM by downloading the model if needed."""
-        log_info("Initializing LLM...")
-        model_mgr = get_model_manager()
-        if model_mgr.use_mock_llm:
-            log_info("Using mock LLM based on configuration")
-        else:
-            # Download model if needed
-            if model_mgr.download_model_if_needed():
-                log_info("Model ready for inference")
-            else:
-                log_error("Failed to download or verify model")
+def parse_args():
+    """Compatibility wrapper around ``server.py`` CLI parsing."""
 
-    def setup_routes(self):
-        """Set up Flask routes for the server."""
-        # Root endpoint
-        @self.app.route('/')
-        def index():
-            return jsonify({
-                'status': 'ok',
-                'message': 'token.place server is running'
-            })
+    return _load_canonical_module().parse_args()
 
-        # Health check endpoint
-        @self.app.route('/health')
-        def health():
-            return jsonify({
-                'status': 'ok',
-                'version': config.get('version', 'dev'),
-                'mock_mode': get_model_manager().use_mock_llm
-            })
 
-        @self.app.route('/metrics/resource')
-        def resource_metrics():
-            """Expose basic CPU and memory usage metrics for cross-platform monitoring."""
-            usage = collect_resource_usage()
-            return jsonify(usage)
+def main():
+    """Compatibility wrapper around ``server.py`` main entrypoint."""
 
-        # Endpoints for direct API access (if needed)
-        # These endpoints might be unused if all communication goes through the relay
+    return _load_canonical_module().main()
 
-    def start_relay_polling(self):  # pragma: no cover
-        """Start polling the relay in a background thread."""
-        relay_thread = threading.Thread(
-            target=self.relay_client.poll_relay_continuously,
-            daemon=True
-        )
-        relay_thread.start()
-        relay_target = _format_relay_target(self.relay_url, self.relay_port)
-        log_info(f"Started relay polling thread for {relay_target}")
 
-    def run(self):  # pragma: no cover
-        """Run the server application."""
-        log_info(f"Starting server on {self.server_host}:{self.server_port}")
+ServerApp = _load_canonical_module().ServerApp
 
-        # Start relay polling in a background thread
-        self.start_relay_polling()
-
-        # Run the Flask app. Bind to localhost by default to avoid exposing the
-        # service unintentionally; allow override via configuration.
-        host = config.get('server.host', '127.0.0.1')
-        self.app.run(
-            host=self.server_host,
-            port=self.server_port,
-            debug=not config.is_production,
-            use_reloader=False  # Disable reloader to avoid duplicate threads
-        )
-
-def parse_args():  # pragma: no cover
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="token.place server")
-    parser.add_argument("--server_port", type=int, default=3000, help="Port to run the server on")
-    parser.add_argument("--relay_port", type=int, default=None, help="Port the relay server is running on")
-    parser.add_argument("--relay_url", type=str, default="https://token.place", help="URL of the relay server")
-    parser.add_argument("--use_mock_llm", action="store_true", help="Use mock LLM for testing")
-    return parser.parse_args()
-
-def main():  # pragma: no cover
-    """Main entry point for the server application."""
-    args = parse_args()
-
-    # Set USE_MOCK_LLM environment variable if flag is set
-    if args.use_mock_llm:
-        os.environ['USE_MOCK_LLM'] = '1'
-        print("Running in mock LLM mode")
-
-    # Create and run the server
-    server = ServerApp(
-        server_port=args.server_port,
-        relay_port=args.relay_port,
-        relay_url=args.relay_url
-    )
-    server.run()
-
-if __name__ == "__main__":  # pragma: no cover
-    main()
+__all__ = ["ServerApp", "main", "parse_args"]

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -210,6 +210,13 @@ def test_two_servers_receive_only_addressed_work(client):
     assert server_one_work.status_code == 200
     assert server_one_work.get_json()["chat_history"] == "work-for-server-one"
 
+
+
+def test_livez_returns_alive_status(client):
+    """/livez should report process liveness independent of readiness."""
+    response = client.get("/livez")
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "alive"}
 # --- Test /faucet ---
 
 def test_faucet_submit_request(client):

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -1,93 +1,53 @@
-from unittest.mock import MagicMock, patch
-import os
+"""Tests for the legacy ``server.server_app`` compatibility shim."""
 
-import server.server_app as sa
+from __future__ import annotations
+
+import types
+
+import server.server_app as shim
 
 
-def test_parse_args_defaults(monkeypatch):
-    import sys
+class _CanonicalStub:
+    def __init__(self):
+        self.calls = []
+        self.ServerApp = object()
 
-    monkeypatch.setattr(sys, "argv", ["server.py"])
-    args = sa.parse_args()
+    def parse_args(self):
+        self.calls.append("parse_args")
+        return types.SimpleNamespace(server_port=3000)
+
+    def main(self):
+        self.calls.append("main")
+        return 123
+
+
+def test_parse_args_delegates_to_canonical_module(monkeypatch):
+    stub = _CanonicalStub()
+    monkeypatch.setattr(shim, "_CANONICAL_MODULE", stub)
+
+    args = shim.parse_args()
+
     assert args.server_port == 3000
-    assert args.relay_port is None
-    assert args.relay_url == "https://token.place"
-    assert args.use_mock_llm is False
+    assert stub.calls == ["parse_args"]
 
 
-def test_parse_args_custom(monkeypatch):
-    import sys
+def test_main_delegates_to_canonical_module(monkeypatch):
+    stub = _CanonicalStub()
+    monkeypatch.setattr(shim, "_CANONICAL_MODULE", stub)
 
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "server.py",
-            "--server_port",
-            "1234",
-            "--relay_port",
-            "7777",
-            "--relay_url",
-            "http://example.com",
-            "--use_mock_llm",
-        ],
-    )
-    args = sa.parse_args()
-    assert args.server_port == 1234
-    assert args.relay_port == 7777
-    assert args.relay_url == "http://example.com"
-    assert args.use_mock_llm is True
+    result = shim.main()
+
+    assert result == 123
+    assert stub.calls == ["main"]
 
 
-def test_initialize_llm_mock():
-    with patch("server.server_app.get_model_manager") as gm:
-        gm.return_value.use_mock_llm = True
-        app = sa.ServerApp()
-        # initialize_llm called in __init__; ensure method executed
-        gm.assert_called()
+def test_unknown_attributes_delegate_to_canonical_module(monkeypatch):
+    stub = _CanonicalStub()
+    stub.some_attr = "delegated"
+    monkeypatch.setattr(shim, "_CANONICAL_MODULE", stub)
+
+    assert shim.some_attr == "delegated"
 
 
-def test_initialize_llm_download():
-    mm = MagicMock()
-    mm.use_mock_llm = False
-    mm.download_model_if_needed.return_value = True
-    with patch("server.server_app.get_model_manager", return_value=mm):
-        app = sa.ServerApp()
-        mm.download_model_if_needed.assert_called_once()
-
-
-def test_start_relay_polling():
-    with patch("server.server_app.RelayClient") as rc:
-        instance = rc.return_value
-        instance.poll_relay_continuously = MagicMock()
-        app = sa.ServerApp()
-        with patch("threading.Thread") as th:
-            thread = MagicMock()
-            th.return_value = thread
-            app.start_relay_polling()
-            thread.start.assert_called_once()
-
-
-def test_main_invocation(monkeypatch):
-    args = sa.argparse.Namespace(
-        server_port=1111,
-        relay_port=2222,
-        relay_url="http://foo",
-        use_mock_llm=True,
-    )
-    monkeypatch.setattr(sa, "parse_args", lambda: args)
-    mock_app = MagicMock()
-    monkeypatch.setattr(sa, "ServerApp", MagicMock(return_value=mock_app))
-    monkeypatch.delenv("USE_MOCK_LLM", raising=False)
-    sa.main()
-    sa.ServerApp.assert_called_once_with(
-        server_port=1111,
-        relay_port=2222,
-        relay_url="http://foo",
-    )
-    mock_app.run.assert_called_once()
-    assert os.environ["USE_MOCK_LLM"] == "1"
-
-
-def test_format_relay_target_avoids_duplicate_port():
-    assert sa._format_relay_target("http://localhost:5000", 5000) == "http://localhost:5000"
+def test_server_app_symbol_is_canonical():
+    assert shim.ServerApp is shim._load_canonical_module().ServerApp

--- a/tests/unit/test_server_app_additional.py
+++ b/tests/unit/test_server_app_additional.py
@@ -1,73 +1,19 @@
-import server.server_app as sa
-from unittest.mock import MagicMock, patch
+"""Additional drift guards for ``server.server_app`` compatibility behavior."""
+
+from __future__ import annotations
+
+import server.server_app as shim
 
 
-def test_health_route():
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    mm.download_model_if_needed.return_value = True
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'):
-        app = sa.ServerApp()
-        client = app.app.test_client()
-        res = client.get('/health')
-        assert res.status_code == 200
-        data = res.get_json()
-        assert data['mock_mode'] is True
+def test_shim_all_exports_only_compat_surface():
+    assert shim.__all__ == ["ServerApp", "main", "parse_args"]
 
 
-def test_root_route():
-    """Verify that the root route returns a simple status."""
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    mm.download_model_if_needed.return_value = True
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'):
-        app = sa.ServerApp()
-        client = app.app.test_client()
-        res = client.get('/')
-        assert res.status_code == 200
-        data = res.get_json()
-        assert data['status'] == 'ok'
+def test_shim_loads_canonical_server_from_repo_root():
+    module = shim._load_canonical_module()
+    assert module.__file__.endswith("/server.py")
 
 
-def test_run_method(monkeypatch):
-    """Ensure the run method starts polling and launches Flask."""
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'):
-        app = sa.ServerApp()
-
-        poller = MagicMock()
-        monkeypatch.setattr(app, 'start_relay_polling', poller)
-        flask_runner = MagicMock()
-        monkeypatch.setattr(app.app, 'run', flask_runner)
-
-        app.run()
-
-        poller.assert_called_once()
-        flask_runner.assert_called_once_with(
-            host='127.0.0.1',
-            port=app.server_port,
-            debug=not sa.config.is_production,
-            use_reloader=False,
-        )
-
-
-def test_resource_metrics_route():
-    """The resource metrics endpoint should expose CPU and memory usage."""
-    mm = MagicMock()
-    mm.use_mock_llm = True
-    mm.download_model_if_needed.return_value = True
-
-    with patch('server.server_app.get_model_manager', return_value=mm), \
-         patch('server.server_app.RelayClient'), \
-         patch('server.server_app.collect_resource_usage', return_value={'cpu_percent': 4.2, 'memory_percent': 73.1}):
-        app = sa.ServerApp()
-        client = app.app.test_client()
-        response = client.get('/metrics/resource')
-
-    assert response.status_code == 200
-    payload = response.get_json()
-    assert payload == {'cpu_percent': 4.2, 'memory_percent': 73.1}
+def test_shim_server_app_matches_exported_symbol():
+    module = shim._load_canonical_module()
+    assert shim.ServerApp is module.ServerApp


### PR DESCRIPTION
### Motivation

- Prevent dual server implementations from drifting by making the root `server.py` the single canonical compute-node entrypoint.  
- Bring desktop and relay operational docs/UI into practical parity with the shared compute runtime without claiming post-parity API v1 migration.  
- Harden relay readiness/liveness semantics for sugarkube onboarding and add minimal regression coverage for those semantics.  

### Description

- Replace `server/server_app.py` with a small compatibility shim that delegates to the canonical `server.py` (`ServerApp`, `parse_args`, and `main`) so legacy imports keep working and cannot drift.  
- Add shim-focused unit tests (`tests/unit/test_server_app.py`, `tests/unit/test_server_app_additional.py`) to assert delegation and exported surface.  
- Expose full practical backend-mode options (`auto`, `metal`, `cuda`, `cpu`) in the desktop UI (`desktop-tauri/src/App.tsx`) to match runtime behavior.  
- Tighten relay readiness/liveness guidance and tests: document `/livez` vs `/healthz` semantics in sugarkube docs and add `/livez` regression test (`tests/test_relay.py`); update onboarding and k3s runbooks and repo docs to state `server.py` (compute) and `relay.py` (relay) as canonical and `server/server_app.py` as compat-only.  

### Testing

- Ran focused pytest suite: `pytest -q tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_model_bridge.py tests/unit/test_server_app.py tests/unit/test_relay_binary_signing.py tests/test_relay.py tests/integration/test_dspace_chat_alias.py tests/test_api.py` and all collected tests in that run passed.  
- Ran the aggregate test runner `./run_all_tests.sh` and observed the test runner complete with all unit and integration tests passing (`All tests passed!` in this environment).  
- Notes/caveats: `pre-commit` was not installed in the execution environment (`pre-commit: command not found`), and `./scripts/scan-secrets.py` was not present in this checkout when running the repository scan; these are operational checks rather than functional regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d890a07cbc832f88bf3d8ae6f76d86)