### PR TITLE
Make server.py the canonical compute-node entrypoint; add legacy shim, desktop parity UX, and relay readiness polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ See also:
 - [`docs/design/tauri_desktop_client.md`](docs/design/tauri_desktop_client.md)
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
+## Canonical entrypoints
+
+- `server.py` is the canonical compute-node server entrypoint.
+- `relay.py` is the canonical relay entrypoint.
+- `server/server_app.py` is retained only as a legacy compatibility shim that delegates to `server.py`.
+
 ## Deployment topology
 
 - **Current / legacy local flow (today):** local or self-hosted `relay.py` + `server.py` on the

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -9,10 +9,7 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
   shared Python config/runtime logic.
 - Lets users either browse to an existing GGUF or download the configured GGUF
   artifact into the shared models directory.
-- Runtime backend preference display:
-  - macOS arm64 => `Metal / Apple Silicon`
-  - Windows x64 => `CUDA / NVIDIA`
-  - other targets => `CPU fallback`
+- Runtime backend preference controls expose `auto`, `metal`, `cuda`, and `cpu` modes.
 - Background compute-node mode that registers and polls via `/sink`, decrypts requests, runs local inference, and posts responses to `/source` (or `/stream/source` when streaming is requested by the relay contract).
 - Sidecar-driven local prompt smoke-test output with explicit cancellation.
 - Optional debug-only relay forward action for manual `/next_server` + `/faucet` checks.
@@ -23,6 +20,7 @@ Desktop includes a Python compute-node bridge
 (`src-tauri/python/compute_node_bridge.py`) that reuses
 `utils.compute_node_runtime` for the legacy relay `/sink` + `/source` flow used by `server.py`.
 The bridge runs as the primary operator path and emits status events (running/registered, active relay URL, backend mode, model path, and last error).
+Root `server.py` remains the canonical compute-node entrypoint; this desktop path must stay parity-aligned on the same legacy relay contract until post-parity API v1 migration work begins.
 
 The fake sidecar remains available at `sidecar/fake_llama_sidecar.py` for CI
 and fast local testing:

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -189,6 +189,9 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running,
     [config.model_path, computeStatus.running]
   );
+  const platformLabel = (backend?.platform_label ?? '').toLowerCase();
+  const metalSupported = platformLabel.includes('apple') || platformLabel.includes('mac');
+  const cudaSupported = platformLabel.includes('nvidia') || platformLabel.includes('cuda');
 
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {
@@ -345,8 +348,8 @@ export function App() {
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
         <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
-        <option value="metal">Metal GPU</option>
-        <option value="cuda">CUDA GPU</option>
+        <option value="metal" disabled={!metalSupported}>Metal GPU</option>
+        <option value="cuda" disabled={!cudaSupported}>CUDA GPU</option>
         <option value="cpu">CPU fallback</option>
       </select>
 

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -190,8 +190,13 @@ export function App() {
     [config.model_path, computeStatus.running]
   );
   const platformLabel = (backend?.platform_label ?? '').toLowerCase();
+  const backendDisplayLabel = (backend?.display_label ?? '').toLowerCase();
   const metalSupported = platformLabel.includes('apple') || platformLabel.includes('mac');
-  const cudaSupported = platformLabel.includes('nvidia') || platformLabel.includes('cuda');
+  const cudaSupported =
+    backend?.preferred_mode === 'cuda' ||
+    backendDisplayLabel.includes('cuda') ||
+    platformLabel.includes('nvidia') ||
+    platformLabel.includes('cuda');
 
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -345,6 +345,8 @@ export function App() {
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
         <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
+        <option value="metal">Metal GPU</option>
+        <option value="cuda">CUDA GPU</option>
         <option value="cpu">CPU fallback</option>
       </select>
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -121,7 +121,7 @@ For convenience, you can execute all available test suites with `./run_all_tests
 ## Configuration
 
 - [config.py](../config.py): Configuration management for different environments
-- [server/server_app.py](../server/server_app.py): Logging infrastructure for the application
+- [server/server_app.py](../server/server_app.py): Legacy compatibility shim delegating to canonical `server.py`
 - [pytest.ini](../pytest.ini): Configuration for Python test suite
 - **Privacy**: Do not log plaintext or ciphertext of user messages. Remove debugging statements that could leak sensitive data.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,8 +141,10 @@ The system is tested at multiple levels:
 
 Canonical sequencing lives in [roadmap/desktop_compute_node_migration.md](roadmap/desktop_compute_node_migration.md).
 
-- **Current state:** `server.py` is the primary compute-node runtime; `relay.py` handles legacy
-  sink/source and multi-node registration; desktop-tauri is MVP only.
+- **Current state:** `server.py` is the canonical compute-node runtime/entrypoint; `relay.py` is
+  the canonical relay entrypoint; desktop-tauri is MVP only.
+- **Legacy compatibility:** `server/server_app.py` is shim-only and delegates into `server.py` to
+  prevent dual server implementations from drifting.
 - **Near-term:** `server.py` and desktop-tauri co-evolve through a shared compute-node runtime while
   relay operations move onto sugarkube.
 - **Target state (later):** post-parity migration to API v1-aligned distributed compute contracts.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -16,8 +16,12 @@ near-term, and target architecture.
 
 ## Applications
 
-- `server/` and `server.py`
-  - Current compute-node baseline.
+- `server.py`
+  - Canonical compute-node entrypoint and shared-runtime wrapper.
+- `server/server_app.py`
+  - Legacy compatibility shim that delegates to `server.py` (non-canonical).
+- `server/`
+  - Package utilities and compatibility imports.
 - `relay.py`
   - Lightweight relay handling legacy sink/source and multi-node registration.
   - First deployment candidate for sugarkube.

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -26,7 +26,8 @@ migration.
 
 ### Current state
 
-- `server.py` is the primary compute-node implementation.
+- `server.py` is the canonical compute-node implementation/entrypoint.
+- `server/server_app.py` is compatibility-only and delegates to `server.py`.
 - `relay.py` supports legacy sink/source contract and multi-node registration.
 - desktop-tauri provides MVP scaffolding but does not yet replace `server.py`.
 
@@ -63,7 +64,7 @@ Desktop parity includes model-management behaviors, not just prompt UI.
   - <https://www.llama.com/models/>
 - Show the actual GGUF artifact the runtime is using (path/name/version where available).
 - Support model browse + download UX (with explicit status/progress/error handling).
-- Default relay URL should be `https://token.place`, but must remain overrideable for local/staging.
+- Default relay URL should be `https://token.place`, but must remain overridable for local/staging.
 
 ## Operational alignment
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -43,10 +43,13 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 - [ ] `kubectl get pods` shows ready relay pod(s)
 - [ ] ingress host resolves in dev
-- [ ] `GET /healthz` returns success
+- [ ] `GET /livez` returns `{"status":"alive"}`
+- [ ] `GET /healthz` returns ready status (200)
 - [ ] external compute node can register/poll relay
 
 ## Rollback
+
+Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
 
 - Roll back to previous image tag and/or Helm revision.
 - Verify readiness and `/healthz` immediately after rollback.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -46,6 +46,8 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 ## Rollback
 
+Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+
 - immediate rollback to prior known-good Helm revision/image tag
 - validate health and request flow
 - record deployment outcome and follow-up actions

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -50,6 +50,8 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 ## Rollback
 
+Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+
 - revert Helm release revision and/or pinned image tag
 - confirm health endpoint and registration flow after rollback
 - capture incident notes in outages/ if customer-visible

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -9,7 +9,7 @@ migration is complete.
 
 - stateless request relay behavior
 - modest CPU/memory footprint
-- clear health endpoint (`/healthz`)
+- clear readiness endpoint (`/healthz`) and liveness endpoint (`/livez`)
 - easier centralized ingress/tunnel management
 
 This allows token.place to improve relay availability and operator workflows while GPU-heavy
@@ -55,6 +55,12 @@ than inventing values.
 
 ## Health checks and validation
 
+`relay.py` probe semantics:
+
+- `GET /livez` returns `200 {"status":"alive"}` while process is alive.
+- `GET /healthz` returns `200` when ready, `503` when draining or degraded.
+- When relay is shutting down (SIGTERM/SIGINT), `/healthz` returns `status=draining` and `Retry-After: 0` to speed pod replacement.
+
 Minimum operator checks after deploy:
 
 1. Pod readiness and restart counts are stable.
@@ -66,6 +72,7 @@ Example checks:
 ```bash
 kubectl -n tokenplace get pods
 kubectl -n tokenplace get ingress
+curl -fsS https://<env-host>/livez
 curl -fsS https://<env-host>/healthz
 ```
 

--- a/docs/roadmap/desktop_compute_node_migration.md
+++ b/docs/roadmap/desktop_compute_node_migration.md
@@ -151,6 +151,7 @@ Desktop is considered parity-ready only when all of the following are true:
 ## Current vs target summary
 
 - **Current:** `relay.py` + `server.py` legacy flow is the production baseline; desktop-tauri is MVP.
+  `server/server_app.py` remains compatibility-only and should not diverge from `server.py`.
 - **Near-term:** desktop and `server.py` co-evolve through a shared runtime while relay moves onto
   sugarkube.
 - **Target:** post-parity, post-API-v1 distributed compute with secure API v1-aligned components.

--- a/server.py
+++ b/server.py
@@ -25,6 +25,7 @@ from utils.compute_node_runtime import (
     resolve_relay_url,
 )
 from utils.networking.relay_client import RelayClient
+from utils.system import collect_resource_usage
 
 # Import config
 from config import get_config
@@ -134,6 +135,12 @@ class ServerApp:
                 'version': config.get('version', 'dev'),
                 'mock_mode': get_model_manager().use_mock_llm
             })
+
+        @self.app.route('/metrics/resource')
+        def resource_metrics():
+            """Expose basic CPU and memory usage metrics for cross-platform monitoring."""
+            usage = collect_resource_usage()
+            return jsonify(usage)
 
         # Endpoints for direct API access (if needed)
         # These endpoints might be unused if all communication goes through the relay

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
 
@@ -58,12 +59,40 @@ def _sync_patch_points() -> ModuleType:
     return canonical
 
 
+@contextmanager
+def _patched_runtime_constructor(canonical: ModuleType):
+    """Inject legacy patch hooks into canonical runtime construction."""
+
+    original_runtime = canonical.ComputeNodeRuntime
+
+    def _shim_runtime(runtime_config, *args, **kwargs):
+        kwargs.setdefault("model_manager", get_model_manager())
+        kwargs.setdefault("crypto_manager", get_crypto_manager())
+        kwargs.setdefault(
+            "relay_client",
+            RelayClient(
+                base_url=runtime_config.relay_url,
+                port=runtime_config.relay_port,
+                crypto_manager=kwargs["crypto_manager"],
+                model_manager=kwargs["model_manager"],
+            ),
+        )
+        return original_runtime(runtime_config, *args, **kwargs)
+
+    canonical.ComputeNodeRuntime = _shim_runtime
+    try:
+        yield
+    finally:
+        canonical.ComputeNodeRuntime = original_runtime
+
+
 class ServerApp:
     """Compatibility wrapper that returns canonical ServerApp instances lazily."""
 
     def __new__(cls, *args, **kwargs):
         canonical = _sync_patch_points()
-        return canonical.ServerApp(*args, **kwargs)
+        with _patched_runtime_constructor(canonical):
+            return canonical.ServerApp(*args, **kwargs)
 
 
 def parse_args():

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -1,183 +1,86 @@
+"""Compatibility shim for legacy ``server.server_app`` imports.
+
+Canonical compute-node entrypoint: repository-root ``server.py``.
+This module stays intentionally thin and forwards legacy patch points into the
+canonical implementation so behavior cannot drift.
 """
-Main server application module that integrates all components.
-"""
-import os
-import threading
-import argparse
-import logging
-from urllib.parse import urlparse
-from flask import Flask, request, jsonify
-from typing import Dict, Any, List, Optional
 
-# Import our refactored modules
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
-from utils.system import collect_resource_usage
+from __future__ import annotations
 
-# Import config
-from config import get_config
-
-# Get configuration instance
-config = get_config()
-
-# Configure logging
-logging.basicConfig(level=logging.INFO if not config.is_production else logging.ERROR,
-                   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger('server_app')
-
-def log_info(message):
-    """Log info only in non-production environments"""
-    if not config.is_production:
-        logger.info(message)
-
-def log_error(message, exc_info=False):
-    """Log errors only in non-production environments"""
-    if not config.is_production:
-        logger.error(message, exc_info=exc_info)
+import importlib.util
+from pathlib import Path
+from types import ModuleType
 
 
-def _format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
-    """Create a display-ready relay target without duplicating explicit URL ports."""
+def _load_canonical_server_module() -> ModuleType:
+    repo_root = Path(__file__).resolve().parents[1]
+    canonical_path = repo_root / "server.py"
+    spec = importlib.util.spec_from_file_location("tokenplace_canonical_server", canonical_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load canonical server module from {canonical_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
-    parsed = urlparse(relay_url if "://" in relay_url else f"http://{relay_url}")
-    if relay_port is None or parsed.port is not None:
-        return relay_url
-    return f"{relay_url}:{relay_port}"
 
-class ServerApp:
-    """
-    Main server application that integrates all components.
-    """
-    def __init__(
-        self,
-        server_port: int = 3000,
-        relay_port: Optional[int] = None,
-        relay_url: str = "https://token.place",
-    ):
-        """
-        Initialize the server application.
+_canonical = _load_canonical_server_module()
+_canonical_parse_args = _canonical.parse_args
 
-        Args:
-            server_port: Port to run the server on
-            relay_port: Port the relay server is running on
-            relay_url: URL of the relay server
-        """
-        self.server_port = server_port
-        self.relay_port = relay_port
-        self.relay_url = relay_url
-        self.server_host = config.get('server.host', '127.0.0.1')
+# Re-export legacy patch points used by existing tests/callers.
+get_model_manager = _canonical.get_model_manager
+get_crypto_manager = getattr(_canonical, "get_crypto_manager", None)
+RelayClient = _canonical.RelayClient
+log_error = _canonical.log_error
+collect_resource_usage = _canonical.collect_resource_usage
 
-        # Create Flask app
-        self.app = Flask(__name__)
 
-        # Set up endpoints
-        self.setup_routes()
+class ServerApp(_canonical.ServerApp):
+    """Compatibility wrapper that keeps canonical behavior and patch hooks in sync."""
 
-        # Create relay client
-        self.relay_client = RelayClient(
-            base_url=relay_url,
-            port=relay_port,
-            crypto_manager=get_crypto_manager(),
-            model_manager=get_model_manager()
-        )
+    def __init__(self, *args, **kwargs):
+        _canonical.get_model_manager = get_model_manager
+        if get_crypto_manager is not None:
+            _canonical.get_crypto_manager = get_crypto_manager
+        _canonical.RelayClient = RelayClient
+        _canonical.collect_resource_usage = collect_resource_usage
+        super().__init__(*args, **kwargs)
 
-        # Initialize LLM by downloading model if needed
-        self.initialize_llm()
 
-    def initialize_llm(self):
-        """Initialize the LLM by downloading the model if needed."""
-        log_info("Initializing LLM...")
-        model_mgr = get_model_manager()
-        if model_mgr.use_mock_llm:
-            log_info("Using mock LLM based on configuration")
-        else:
-            # Download model if needed
-            if model_mgr.download_model_if_needed():
-                log_info("Model ready for inference")
-            else:
-                log_error("Failed to download or verify model")
+def parse_args():
+    return _canonical_parse_args()
 
-    def setup_routes(self):
-        """Set up Flask routes for the server."""
-        # Root endpoint
-        @self.app.route('/')
-        def index():
-            return jsonify({
-                'status': 'ok',
-                'message': 'token.place server is running'
-            })
 
-        # Health check endpoint
-        @self.app.route('/health')
-        def health():
-            return jsonify({
-                'status': 'ok',
-                'version': config.get('version', 'dev'),
-                'mock_mode': get_model_manager().use_mock_llm
-            })
-
-        @self.app.route('/metrics/resource')
-        def resource_metrics():
-            """Expose basic CPU and memory usage metrics for cross-platform monitoring."""
-            usage = collect_resource_usage()
-            return jsonify(usage)
-
-        # Endpoints for direct API access (if needed)
-        # These endpoints might be unused if all communication goes through the relay
-
-    def start_relay_polling(self):  # pragma: no cover
-        """Start polling the relay in a background thread."""
-        relay_thread = threading.Thread(
-            target=self.relay_client.poll_relay_continuously,
-            daemon=True
-        )
-        relay_thread.start()
-        relay_target = _format_relay_target(self.relay_url, self.relay_port)
-        log_info(f"Started relay polling thread for {relay_target}")
-
-    def run(self):  # pragma: no cover
-        """Run the server application."""
-        log_info(f"Starting server on {self.server_host}:{self.server_port}")
-
-        # Start relay polling in a background thread
-        self.start_relay_polling()
-
-        # Run the Flask app. Bind to localhost by default to avoid exposing the
-        # service unintentionally; allow override via configuration.
-        host = config.get('server.host', '127.0.0.1')
-        self.app.run(
-            host=self.server_host,
-            port=self.server_port,
-            debug=not config.is_production,
-            use_reloader=False  # Disable reloader to avoid duplicate threads
-        )
-
-def parse_args():  # pragma: no cover
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="token.place server")
-    parser.add_argument("--server_port", type=int, default=3000, help="Port to run the server on")
-    parser.add_argument("--relay_port", type=int, default=None, help="Port the relay server is running on")
-    parser.add_argument("--relay_url", type=str, default="https://token.place", help="URL of the relay server")
-    parser.add_argument("--use_mock_llm", action="store_true", help="Use mock LLM for testing")
-    return parser.parse_args()
-
-def main():  # pragma: no cover
-    """Main entry point for the server application."""
+def main():
     args = parse_args()
 
-    # Set USE_MOCK_LLM environment variable if flag is set
-    if args.use_mock_llm:
-        os.environ['USE_MOCK_LLM'] = '1'
-        print("Running in mock LLM mode")
+    if getattr(args, "use_mock_llm", False):
+        import os
 
-    # Create and run the server
+        os.environ["USE_MOCK_LLM"] = "1"
+
     server = ServerApp(
         server_port=args.server_port,
+        server_host=getattr(args, "server_host", "127.0.0.1"),
         relay_port=args.relay_port,
-        relay_url=args.relay_url
+        relay_url=args.relay_url,
     )
     server.run()
 
-if __name__ == "__main__":  # pragma: no cover
-    main()
+
+config = _canonical.config
+argparse = _canonical.argparse
+_format_relay_target = _canonical._format_relay_target
+
+__all__ = [
+    "ServerApp",
+    "parse_args",
+    "main",
+    "config",
+    "argparse",
+    "_format_relay_target",
+    "get_model_manager",
+    "get_crypto_manager",
+    "RelayClient",
+    "log_error",
+    "collect_resource_usage",
+]

--- a/server/server_app.py
+++ b/server/server_app.py
@@ -8,68 +8,84 @@ canonical implementation so behavior cannot drift.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
+
+from utils.crypto.crypto_manager import get_crypto_manager as _default_get_crypto_manager
+from utils.llm.model_manager import get_model_manager as _default_get_model_manager
+from utils.networking.relay_client import RelayClient as _default_relay_client
+from utils.system import collect_resource_usage as _default_collect_resource_usage
+
+_CANONICAL_MODULE_NAME = "tokenplace_canonical_server"
+_canonical: ModuleType | None = None
 
 
 def _load_canonical_server_module() -> ModuleType:
     repo_root = Path(__file__).resolve().parents[1]
     canonical_path = repo_root / "server.py"
-    spec = importlib.util.spec_from_file_location("tokenplace_canonical_server", canonical_path)
+    spec = importlib.util.spec_from_file_location(_CANONICAL_MODULE_NAME, canonical_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load canonical server module from {canonical_path}")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[_CANONICAL_MODULE_NAME] = module
     spec.loader.exec_module(module)
     return module
 
 
-_canonical = _load_canonical_server_module()
-_canonical_parse_args = _canonical.parse_args
+def _get_canonical() -> ModuleType:
+    global _canonical
+    if _canonical is None:
+        _canonical = sys.modules.get(_CANONICAL_MODULE_NAME)
+    if _canonical is None:
+        _canonical = _load_canonical_server_module()
+    return _canonical
+
 
 # Re-export legacy patch points used by existing tests/callers.
-get_model_manager = _canonical.get_model_manager
-get_crypto_manager = getattr(_canonical, "get_crypto_manager", None)
-RelayClient = _canonical.RelayClient
-log_error = _canonical.log_error
-collect_resource_usage = _canonical.collect_resource_usage
+get_model_manager = _default_get_model_manager
+get_crypto_manager = _default_get_crypto_manager
+RelayClient = _default_relay_client
+collect_resource_usage = _default_collect_resource_usage
 
 
-class ServerApp(_canonical.ServerApp):
-    """Compatibility wrapper that keeps canonical behavior and patch hooks in sync."""
+def _sync_patch_points() -> ModuleType:
+    canonical = _get_canonical()
+    canonical.get_model_manager = get_model_manager
+    canonical.get_crypto_manager = get_crypto_manager
+    canonical.RelayClient = RelayClient
+    canonical.collect_resource_usage = collect_resource_usage
+    return canonical
 
-    def __init__(self, *args, **kwargs):
-        _canonical.get_model_manager = get_model_manager
-        if get_crypto_manager is not None:
-            _canonical.get_crypto_manager = get_crypto_manager
-        _canonical.RelayClient = RelayClient
-        _canonical.collect_resource_usage = collect_resource_usage
-        super().__init__(*args, **kwargs)
+
+class ServerApp:
+    """Compatibility wrapper that returns canonical ServerApp instances lazily."""
+
+    def __new__(cls, *args, **kwargs):
+        canonical = _sync_patch_points()
+        return canonical.ServerApp(*args, **kwargs)
 
 
 def parse_args():
-    return _canonical_parse_args()
+    return _get_canonical().parse_args()
 
 
 def main():
-    args = parse_args()
-
-    if getattr(args, "use_mock_llm", False):
-        import os
-
-        os.environ["USE_MOCK_LLM"] = "1"
-
-    server = ServerApp(
-        server_port=args.server_port,
-        server_host=getattr(args, "server_host", "127.0.0.1"),
-        relay_port=args.relay_port,
-        relay_url=args.relay_url,
-    )
-    server.run()
+    canonical = _sync_patch_points()
+    return canonical.main()
 
 
-config = _canonical.config
-argparse = _canonical.argparse
-_format_relay_target = _canonical._format_relay_target
+def __getattr__(name: str):
+    if name == "config":
+        return _get_canonical().config
+    if name == "argparse":
+        return _get_canonical().argparse
+    if name == "_format_relay_target":
+        return _get_canonical()._format_relay_target
+    if name == "log_error":
+        return _get_canonical().log_error
+    raise AttributeError(name)
+
 
 __all__ = [
     "ServerApp",

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -328,6 +328,37 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client):
         node["server_public_key"] for node in payload["registeredServers"]
     }
 
+
+def test_healthz_returns_draining_when_shutdown_flag_set(client):
+    """healthz should switch to draining status and 503 during shutdown."""
+    from relay import DRAINING
+
+    DRAINING.set()
+    try:
+        response = client.get("/healthz")
+    finally:
+        DRAINING.clear()
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "0"
+    payload = response.get_json()
+    assert payload["status"] == "draining"
+    assert payload["details"]["shutdown"] is True
+
+
+def test_livez_remains_alive_when_draining(client):
+    """livez should stay green so orchestrators can distinguish readiness from liveness."""
+    from relay import DRAINING
+
+    DRAINING.set()
+    try:
+        response = client.get("/livez")
+    finally:
+        DRAINING.clear()
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "alive"
+
 # --- Test /source ---
 
 def test_source_submit_response(client):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -69,7 +69,7 @@ def test_next_server_one_server(client):
     # Simulate server registration (directly modifying state for setup)
     known_servers[DUMMY_SERVER_PUB_KEY] = {
         'public_key': DUMMY_SERVER_PUB_KEY,
-        'last_ping': time.time(),
+        'last_ping': datetime.now(),
         'last_ping_duration': 10
     }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -120,8 +120,8 @@ def test_initialize_llm_real_mode(server_app):
         mock_model_manager.download_model_if_needed.return_value = True
         mock_get_model_manager.return_value = mock_model_manager
         server_app.initialize_llm()
-        # Verify that download_model_if_needed was called
-        mock_model_manager.download_model_if_needed.assert_called_once()
+        # Runtime wiring now delegates through shared compute runtime; ensure method runs without error.
+        assert server_app.runtime is not None
 
 
 def test_initialize_llm_real_mode_failure(server_app):
@@ -135,5 +135,5 @@ def test_initialize_llm_real_mode_failure(server_app):
 
         server_app.initialize_llm()
 
-        mock_model_manager.download_model_if_needed.assert_called_once()
-        mock_log_error.assert_called_once_with("Failed to download or verify model")
+        # Runtime now logs through shared runtime internals; preserve smoke coverage only.
+        assert server_app.runtime is not None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -104,36 +104,19 @@ def test_setup_routes(server_app):
 
 def test_initialize_llm_mock_mode(server_app):
     """Test the initialize_llm method in mock mode."""
-    with patch('server.server_app.get_model_manager') as mock_get_model_manager:
-        mock_model_manager = MagicMock()
-        mock_model_manager.use_mock_llm = True
-        mock_get_model_manager.return_value = mock_model_manager
+    with patch.object(server_app.runtime, "ensure_model_ready") as mock_ensure_model_ready:
         server_app.initialize_llm()
-        # Verify that download_model_if_needed was not called
-        mock_model_manager.download_model_if_needed.assert_not_called()
+        mock_ensure_model_ready.assert_called_once_with()
 
 def test_initialize_llm_real_mode(server_app):
     """Test the initialize_llm method in real mode."""
-    with patch('server.server_app.get_model_manager') as mock_get_model_manager:
-        mock_model_manager = MagicMock()
-        mock_model_manager.use_mock_llm = False
-        mock_model_manager.download_model_if_needed.return_value = True
-        mock_get_model_manager.return_value = mock_model_manager
+    with patch.object(server_app.runtime, "ensure_model_ready", return_value=True) as mock_ensure_model_ready:
         server_app.initialize_llm()
-        # Runtime wiring now delegates through shared compute runtime; ensure method runs without error.
-        assert server_app.runtime is not None
+        mock_ensure_model_ready.assert_called_once_with()
 
 
 def test_initialize_llm_real_mode_failure(server_app):
-    """Log an error when model download fails."""
-    with patch('server.server_app.get_model_manager') as mock_get_model_manager, \
-         patch('server.server_app.log_error') as mock_log_error:
-        mock_model_manager = MagicMock()
-        mock_model_manager.use_mock_llm = False
-        mock_model_manager.download_model_if_needed.return_value = False
-        mock_get_model_manager.return_value = mock_model_manager
-
-        server_app.initialize_llm()
-
-        # Runtime now logs through shared runtime internals; preserve smoke coverage only.
-        assert server_app.runtime is not None
+    """Ensure initialize_llm surfaces runtime failures."""
+    with patch.object(server_app.runtime, "ensure_model_ready", side_effect=RuntimeError("model download failed")):
+        with pytest.raises(RuntimeError, match="model download failed"):
+            server_app.initialize_llm()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -208,3 +208,16 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert any(event.get('registered') is True for event in status_events)
+
+
+def test_apply_compute_mode_supports_gpu_and_cpu_modes():
+    manager = FakeModelManager()
+
+    compute_node_bridge._apply_compute_mode(manager, 'metal')
+    assert manager.default_n_gpu_layers == -1
+
+    compute_node_bridge._apply_compute_mode(manager, 'cuda')
+    assert manager.default_n_gpu_layers == -1
+
+    compute_node_bridge._apply_compute_mode(manager, 'cpu')
+    assert manager.default_n_gpu_layers == 0

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -214,7 +214,7 @@ def test_apply_compute_mode_supports_gpu_and_cpu_modes():
     manager = FakeModelManager()
 
     compute_node_bridge._apply_compute_mode(manager, 'auto')
-    assert manager.default_n_gpu_layers == 0
+    assert manager.default_n_gpu_layers == -1
 
     compute_node_bridge._apply_compute_mode(manager, 'metal')
     assert manager.default_n_gpu_layers == -1

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -213,6 +213,9 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
 def test_apply_compute_mode_supports_gpu_and_cpu_modes():
     manager = FakeModelManager()
 
+    compute_node_bridge._apply_compute_mode(manager, 'auto')
+    assert manager.default_n_gpu_layers == 0
+
     compute_node_bridge._apply_compute_mode(manager, 'metal')
     assert manager.default_n_gpu_layers == -1
 

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -2,42 +2,26 @@
 
 from __future__ import annotations
 
-import importlib
 from unittest.mock import MagicMock
 
 import server.server_app as sa
 
 
 def test_server_app_shim_reexports_canonical_symbols():
-    canonical = sa._canonical
-    assert issubclass(sa.ServerApp, canonical.ServerApp)
+    canonical = sa._get_canonical()
+    assert callable(canonical.ServerApp)
     assert callable(sa.parse_args)
     assert callable(sa.main)
 
 
 def test_server_app_main_delegates_to_canonical(monkeypatch):
-    args = sa.argparse.Namespace(
-        server_port=1111,
-        server_host="127.0.0.1",
-        relay_port=2222,
-        relay_url="http://foo",
-        use_mock_llm=True,
-    )
-    monkeypatch.setattr(sa, "parse_args", lambda: args)
-
-    mock_app = MagicMock()
-    monkeypatch.setattr(sa, "ServerApp", MagicMock(return_value=mock_app))
-    monkeypatch.delenv("USE_MOCK_LLM", raising=False)
+    canonical = sa._get_canonical()
+    mock_main = MagicMock()
+    monkeypatch.setattr(canonical, "main", mock_main)
 
     sa.main()
 
-    sa.ServerApp.assert_called_once_with(
-        server_port=1111,
-        server_host="127.0.0.1",
-        relay_port=2222,
-        relay_url="http://foo",
-    )
-    mock_app.run.assert_called_once()
+    mock_main.assert_called_once_with()
 
 
 def test_parse_args_still_available(monkeypatch):

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -1,93 +1,48 @@
-from unittest.mock import MagicMock, patch
-import os
+"""Compatibility tests for legacy server.server_app shim."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
 
 import server.server_app as sa
 
 
-def test_parse_args_defaults(monkeypatch):
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["server.py"])
-    args = sa.parse_args()
-    assert args.server_port == 3000
-    assert args.relay_port is None
-    assert args.relay_url == "https://token.place"
-    assert args.use_mock_llm is False
+def test_server_app_shim_reexports_canonical_symbols():
+    canonical = sa._canonical
+    assert issubclass(sa.ServerApp, canonical.ServerApp)
+    assert callable(sa.parse_args)
+    assert callable(sa.main)
 
 
-def test_parse_args_custom(monkeypatch):
-    import sys
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "server.py",
-            "--server_port",
-            "1234",
-            "--relay_port",
-            "7777",
-            "--relay_url",
-            "http://example.com",
-            "--use_mock_llm",
-        ],
-    )
-    args = sa.parse_args()
-    assert args.server_port == 1234
-    assert args.relay_port == 7777
-    assert args.relay_url == "http://example.com"
-    assert args.use_mock_llm is True
-
-
-def test_initialize_llm_mock():
-    with patch("server.server_app.get_model_manager") as gm:
-        gm.return_value.use_mock_llm = True
-        app = sa.ServerApp()
-        # initialize_llm called in __init__; ensure method executed
-        gm.assert_called()
-
-
-def test_initialize_llm_download():
-    mm = MagicMock()
-    mm.use_mock_llm = False
-    mm.download_model_if_needed.return_value = True
-    with patch("server.server_app.get_model_manager", return_value=mm):
-        app = sa.ServerApp()
-        mm.download_model_if_needed.assert_called_once()
-
-
-def test_start_relay_polling():
-    with patch("server.server_app.RelayClient") as rc:
-        instance = rc.return_value
-        instance.poll_relay_continuously = MagicMock()
-        app = sa.ServerApp()
-        with patch("threading.Thread") as th:
-            thread = MagicMock()
-            th.return_value = thread
-            app.start_relay_polling()
-            thread.start.assert_called_once()
-
-
-def test_main_invocation(monkeypatch):
+def test_server_app_main_delegates_to_canonical(monkeypatch):
     args = sa.argparse.Namespace(
         server_port=1111,
+        server_host="127.0.0.1",
         relay_port=2222,
         relay_url="http://foo",
         use_mock_llm=True,
     )
     monkeypatch.setattr(sa, "parse_args", lambda: args)
+
     mock_app = MagicMock()
     monkeypatch.setattr(sa, "ServerApp", MagicMock(return_value=mock_app))
     monkeypatch.delenv("USE_MOCK_LLM", raising=False)
+
     sa.main()
+
     sa.ServerApp.assert_called_once_with(
         server_port=1111,
+        server_host="127.0.0.1",
         relay_port=2222,
         relay_url="http://foo",
     )
     mock_app.run.assert_called_once()
-    assert os.environ["USE_MOCK_LLM"] == "1"
 
 
-def test_format_relay_target_avoids_duplicate_port():
-    assert sa._format_relay_target("http://localhost:5000", 5000) == "http://localhost:5000"
+def test_parse_args_still_available(monkeypatch):
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["server.py", "--server_port", "3333"])
+    args = sa.parse_args()
+    assert args.server_port == 3333

--- a/tests/unit/test_server_app.py
+++ b/tests/unit/test_server_app.py
@@ -30,3 +30,28 @@ def test_parse_args_still_available(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["server.py", "--server_port", "3333"])
     args = sa.parse_args()
     assert args.server_port == 3333
+
+
+def test_server_app_uses_legacy_patch_hooks_for_runtime(monkeypatch):
+    canonical = sa._get_canonical()
+    model_manager = MagicMock(use_mock_llm=True)
+    crypto_manager = MagicMock()
+    relay_client = MagicMock()
+    relay_ctor = MagicMock(return_value=relay_client)
+
+    monkeypatch.setattr(canonical.ServerApp, "initialize_llm", lambda self: None)
+    monkeypatch.setattr(sa, "get_model_manager", lambda: model_manager)
+    monkeypatch.setattr(sa, "get_crypto_manager", lambda: crypto_manager)
+    monkeypatch.setattr(sa, "RelayClient", relay_ctor)
+
+    app = sa.ServerApp(server_port=3333, relay_url="http://localhost", relay_port=5555)
+
+    assert app.runtime.model_manager is model_manager
+    assert app.runtime.crypto_manager is crypto_manager
+    assert app.runtime.relay_client is relay_client
+    relay_ctor.assert_called_once_with(
+        base_url="http://localhost",
+        port=5555,
+        crypto_manager=crypto_manager,
+        model_manager=model_manager,
+    )


### PR DESCRIPTION
### Motivation
- Ensure there is a single canonical compute-node entrypoint (`server.py`) so two server implementations cannot drift and operators/contributors know the correct path. 
- Finish parity/readiness work required for relay-on-sugarkube rollout while preserving the legacy relay sink/source contract and deferring API v1 migration. 
- Tighten desktop operator UX and a few small runtime surfaces so desktop-tauri and `server.py` converge on critical operator-visible behavior without introducing broad architecture churn.

### Description
- Replace `server/server_app.py` with a thin compatibility shim that lazily loads and delegates to the canonical root `server.py` and re-exports legacy patch points so the legacy import path cannot drift. 
- Keep `server.py` canonical and restore a `/metrics/resource` endpoint that delegates to `utils.system.collect_resource_usage` so server and desktop runtime parity expose the same operator metrics. 
- Surface full backend-mode parity in the desktop UI by adding `metal` and `cuda` options to `desktop-tauri/src/App.tsx` so desktop operators can choose the same runtime modes as the shared compute runtime. 
- Tighten relay readiness/liveness semantics and runbook text, and add tests for draining semantics so sugarkube onboarding docs and runbooks match actual `relay.py` behaviour. 
- Add focused regression tests and small test updates that prove the shim delegates to the canonical implementation and that desktop/relay parity conditions behave as expected; update a handful of docs (README, ARCHITECTURE, REPO_MAP, design/roadmap/runbooks) to call out canonical entrypoints and scope/limitations explicitly.

Files changed (representative): `server/server_app.py`, `server.py`, `desktop-tauri/src/App.tsx`, `README.md`, `docs/ARCHITECTURE.md`, `docs/REPO_MAP.md`, `docs/design/tauri_desktop_client.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-*.md`, `docs/roadmap/desktop_compute_node_migration.md`, `docs/AGENTS.md`, `tests/unit/test_server_app.py`, `tests/test_server.py`, `tests/test_relay.py`, `tests/unit/test_desktop_compute_node_bridge.py`, plus a few small test tweaks and minor copy edits. 

### Testing
- Ran focused desktop/unit suites and shim/relay tests and they passed locally: `pytest -q tests/unit/test_desktop_compute_node_bridge.py` (PASSED), `pytest -q tests/unit/test_desktop_inference_sidecar.py` (PASSED), `pytest -q tests/unit/test_desktop_model_bridge.py` (PASSED). 
- Verified shim and server/relay behaviour with unit/integration suites: `pytest -q tests/unit/test_server_app.py` (PASSED), `pytest -q tests/unit/test_relay_binary_signing.py tests/test_relay.py` (PASSED), `pytest -q tests/integration/test_dspace_chat_alias.py` (PASSED), `pytest -q tests/test_api.py` (PASSED). 
- Attempted aggregate run `./run_all_tests.sh`; the full aggregate required a few system/toolchain installs (Playwright browser binaries, bandit, other environment deps) that were resolved for focused suites but can be heavy in some environments; focused test suites above were used as the primary verification signal. 

Notes and deferred work
- Deferred: API v1 distributed-compute migration and any retirement of the legacy sink/source contract (intentionally out-of-scope for this PR). 
- The shim keeps legacy import compatibility while forcing runtime delegation to `server.py`; contributors/operators should now use `server.py` as the canonical compute-node entrypoint and `relay.py` as the canonical relay entrypoint (docs updated accordingly).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d890a07cbc832f88bf3d8ae6f76d86)