### PR TITLE
Align workstation parity contract and normalize compute-mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,14 @@ See also:
   parity) register through `relay.py` using the same legacy contract.
 - **Future distributed API v1 flow (post-parity):** distributed compute migrates to API v1-aligned
   contracts after parity and operational readiness gates are complete.
+- **Operator platform targets:** Windows 11 + NVIDIA/CUDA and macOS Apple Silicon + Metal first,
+  CPU fallback always supported, Raspberry Pi as a later low-power compute-node target.
 
 ## sugarkube deployment
 
 `relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
 operationally separate from GPU-heavy compute nodes.
+In the short-to-medium term architecture, sugarkube scope remains relay-only.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -60,14 +60,6 @@ def emit(payload: Dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
-def _apply_compute_mode(manager: Any, mode: str) -> None:
-    selected = (mode or "auto").lower()
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    elif selected in {"metal", "cuda"}:
-        manager.default_n_gpu_layers = -1
-
-
 def _sleep_with_cancel(seconds: float) -> bool:
     deadline = time.time() + max(seconds, 0)
     while time.time() < deadline:
@@ -80,9 +72,11 @@ def _sleep_with_cancel(seconds: float) -> bool:
 def run(args: argparse.Namespace) -> int:
     try:
         from utils.compute_node_runtime import (
+            apply_compute_mode,
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
+            normalize_compute_mode,
             resolve_relay_port,
             resolve_relay_url,
         )
@@ -101,7 +95,7 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    _apply_compute_mode(runtime.model_manager, args.mode)
+    resolved_mode = apply_compute_mode(runtime.model_manager, args.mode)
 
     if not runtime.ensure_model_ready():
         emit(
@@ -120,7 +114,7 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": args.mode,
+            "backend_mode": resolved_mode,
             "model_path": args.model,
             "last_error": None,
         }
@@ -150,7 +144,7 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
-                    "backend_mode": args.mode,
+                    "backend_mode": resolved_mode,
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -168,7 +162,7 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": args.mode,
+            "backend_mode": resolved_mode,
             "model_path": args.model,
             "last_error": None,
         }
@@ -177,14 +171,17 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
+    from utils.compute_node_runtime import normalize_compute_mode
+
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--model", required=True)
-    parser.add_argument("--mode", default="auto", choices=["auto", "metal", "cuda", "cpu"])
+    parser.add_argument("--mode", default="auto")
     parser.add_argument("--relay-url", default="https://token.place")
     parser.add_argument("--relay-port", type=int, default=None)
     args = parser.parse_args()
 
     try:
+        args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
         emit({"type": "error", "message": f"bridge failure: {exc}"})

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -76,7 +76,6 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
-            normalize_compute_mode,
             resolve_relay_port,
             resolve_relay_url,
         )
@@ -171,8 +170,6 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
-    from utils.compute_node_runtime import normalize_compute_mode
-
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--model", required=True)
     parser.add_argument("--mode", default="auto")
@@ -181,6 +178,8 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
+        from utils.compute_node_runtime import normalize_compute_mode
+
         args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -122,19 +122,12 @@ def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
     return message.get("content", "") if isinstance(message, dict) else ""
 
 
-def _apply_compute_mode(manager: Any, mode: str) -> None:
-    selected = (mode or "auto").lower()
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    elif selected in {"metal", "cuda"}:
-        manager.default_n_gpu_layers = -1
-
-
 def run(args: argparse.Namespace) -> int:
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
 
     try:
+        from utils.compute_node_runtime import apply_compute_mode
         from utils.llm.model_manager import ModelManager, get_model_manager
     except ModuleNotFoundError as exc:
         return emit_error(
@@ -144,7 +137,7 @@ def run(args: argparse.Namespace) -> int:
 
     manager = get_model_manager()
     manager.model_path = args.model
-    _apply_compute_mode(manager, args.mode)
+    apply_compute_mode(manager, args.mode)
 
     llm = manager.get_llm_instance()
     if llm is None:
@@ -200,12 +193,15 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
+    from utils.compute_node_runtime import normalize_compute_mode
+
     parser = argparse.ArgumentParser(description="token.place desktop inference sidecar")
     parser.add_argument("--model", required=True)
-    parser.add_argument("--mode", default="auto", choices=["auto", "metal", "cuda", "cpu"])
+    parser.add_argument("--mode", default="auto")
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
     try:
+        args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort error handling
         return emit_error("inference_failed", f"bridge failure: {exc}")

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -48,7 +48,7 @@ def emit_error(code: str, message: str) -> int:
     return 1
 
 
-def canceled_requested() -> bool:
+def cancel_requested() -> bool:
     _start_stdin_reader()
     while True:
         try:
@@ -91,7 +91,7 @@ def _stream_content(
     full_text = []
     emitted = False
     for raw_chunk in completion:
-        if canceled_requested():
+        if cancel_requested():
             emit({"type": "canceled"})
             return "", True
 
@@ -144,7 +144,7 @@ def run(args: argparse.Namespace) -> int:
         return emit_error("bad_model", "unable to initialize model runtime")
 
     emit({"type": "started"})
-    if canceled_requested():
+    if cancel_requested():
         emit({"type": "canceled"})
         return 0
 
@@ -193,14 +193,14 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
-    from utils.compute_node_runtime import normalize_compute_mode
-
     parser = argparse.ArgumentParser(description="token.place desktop inference sidecar")
     parser.add_argument("--model", required=True)
     parser.add_argument("--mode", default="auto")
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
     try:
+        from utils.compute_node_runtime import normalize_compute_mode
+
         args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort error handling

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -357,6 +357,11 @@ export function App() {
         <option value="cuda" disabled={!cudaSupported}>CUDA GPU (Windows/NVIDIA)</option>
         <option value="cpu">CPU fallback</option>
       </select>
+      <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
+        Operator note: <code>cuda</code> is for Windows/NVIDIA workstations, <code>metal</code> is
+        for macOS/Apple Silicon, and <code>cpu</code> is fallback. Raspberry Pi remains a later
+        low-power workstation target and is not part of the current sugarkube relay rollout.
+      </p>
 
       <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
       <input

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -353,8 +353,8 @@ export function App() {
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
         <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
-        <option value="metal" disabled={!metalSupported}>Metal GPU</option>
-        <option value="cuda" disabled={!cudaSupported}>CUDA GPU</option>
+        <option value="metal" disabled={!metalSupported}>Metal GPU (macOS Apple Silicon)</option>
+        <option value="cuda" disabled={!cudaSupported}>CUDA GPU (Windows/NVIDIA)</option>
         <option value="cpu">CPU fallback</option>
       </select>
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,14 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [server.py](../server.py): Main server implementation for the proxy service
 - [relay.py](../relay.py): Middleware server that forwards encrypted messages between clients and servers
 
+## Architecture guardrails (release-readiness)
+
+- Treat repository-root `server.py` as the canonical compute-node entrypoint.
+- Keep `server/server_app.py` as compatibility-only shim behavior.
+- Keep sugarkube/k3s scope relay-only (`relay.py`) in short-to-medium-term planning.
+- Keep desktop/server parity work on the legacy relay sink/source contract until explicitly
+  approved API v1 distributed migration phase.
+
 ## Documentation
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md): Contribution guidelines for developers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,8 +146,10 @@ Canonical sequencing lives in [roadmap/desktop_compute_node_migration.md](roadma
 - **Legacy compatibility:** `server/server_app.py` is shim-only and delegates into `server.py` to
   prevent dual server implementations from drifting.
 - **Near-term:** `server.py` and desktop-tauri co-evolve through a shared compute-node runtime while
-  relay operations move onto sugarkube.
+  relay operations move onto sugarkube (`relay.py` only).
 - **Target state (later):** post-parity migration to API v1-aligned distributed compute contracts.
+- **Operator platform focus:** Windows 11 + CUDA/NVIDIA and macOS Apple Silicon + Metal, with CPU
+  fallback and later Raspberry Pi support.
 
 Related operations docs:
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -24,7 +24,7 @@ near-term, and target architecture.
   - Package utilities and compatibility imports.
 - `relay.py`
   - Lightweight relay handling legacy sink/source and multi-node registration.
-  - First deployment candidate for sugarkube.
+  - First (and short-to-medium-term only) deployment candidate for sugarkube.
 - `api/`
   - FastAPI implementation and experimental API surface for contributors evaluating API-facing
     runtime paths.
@@ -39,6 +39,8 @@ near-term, and target architecture.
 
 - **Current contract:** legacy relay sink/source flows used by `server.py` and relay nodes.
 - **Planned runtime alignment:** shared compute-node runtime co-used by `server.py` and desktop-tauri.
+- **Platform focus during parity:** workstation compute nodes on Windows 11 CUDA, macOS Metal, and
+  CPU fallback; Raspberry Pi later.
 - **Future contract:** API v1-aligned distributed compute after parity and operations readiness.
 
 ## Deployment and operations docs

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -30,6 +30,8 @@ migration.
 - `server/server_app.py` is compatibility-only and delegates to `server.py`.
 - `relay.py` supports legacy sink/source contract and multi-node registration.
 - desktop-tauri provides MVP scaffolding but does not yet replace `server.py`.
+- Workstation platform targets are Windows 11 (CUDA), macOS Apple Silicon (Metal), then later
+  Raspberry Pi (CPU-focused/low-power).
 
 ### Near-term state (post-parity goal)
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -22,6 +22,7 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 
 - In-cluster: `relay.py` deployment + service + ingress
 - External: `server.py` and/or desktop compute nodes using legacy relay contract
+  - Typical external operators: Windows 11 CUDA or macOS Apple Silicon Metal; CPU fallback valid.
 
 ## Release model
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -21,6 +21,7 @@ until parity and later API v1 migration phases are complete.
 - Public ingress terminates through Cloudflare+tunnel to sugarkube Traefik
 - relay pods run in dedicated namespace with health probes and resource limits
 - external compute nodes connect via approved relay URL
+  - workstation focus remains Windows CUDA / macOS Metal; Raspberry Pi remains a later target
 
 ## Release model
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -19,6 +19,7 @@ compute nodes still using legacy sink/source contract.
 
 - Client -> Cloudflare -> tunnel -> Traefik ingress -> relay service/pod
 - compute nodes (`server.py`, later desktop parity nodes) remain external
+  - expected operators are workstation nodes (Windows CUDA, macOS Metal, CPU fallback)
 
 ## Release model
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -14,6 +14,8 @@ migration is complete.
 
 This allows token.place to improve relay availability and operator workflows while GPU-heavy
 compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
+Workstation targets for those external compute nodes are Windows 11 + CUDA/NVIDIA and macOS Apple
+Silicon + Metal, with CPU fallback available and Raspberry Pi planned later.
 
 Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
 

--- a/docs/roadmap/desktop_compute_node_migration.md
+++ b/docs/roadmap/desktop_compute_node_migration.md
@@ -6,6 +6,8 @@ This is the canonical migration plan for moving token.place from today's
 - **Current state:** desktop-tauri is an MVP and is **not** feature-parity with `server.py`.
 - **Near-term target:** achieve desktop parity on the legacy relay sink/source contract first.
 - **Future target:** migrate distributed compute to API v1 **after** parity is complete.
+- **Deployment boundary (short-to-medium term):** sugarkube/k3s runs `relay.py` only; compute nodes
+  run on operator workstations (`server.py`, desktop-tauri).
 
 See also:
 
@@ -116,6 +118,26 @@ Desktop is considered parity-ready only when all of the following are true:
   - explicit GGUF artifact selection used by runtime
   - model browse + download flow
   - default relay URL `https://token.place` with user override support
+- Enforces consistent compute-mode normalization (`auto`, `cpu`, `metal`, `cuda`) and status
+  reporting across desktop UI, bridge, sidecar, and shared runtime.
+
+## Platform readiness contract (short-to-medium term)
+
+- **Windows 11 + NVIDIA (CUDA):** primary workstation target for high-throughput operators.
+- **macOS Apple Silicon / Mac mini M4 (Metal):** primary workstation target for Apple hardware.
+- **CPU fallback:** always valid when GPU backends are unavailable.
+- **Raspberry Pi:** later low-power workstation/server target; not part of sugarkube relay rollout.
+
+## Parity status snapshot (April 2026)
+
+- ✅ Completed in parity scope:
+  - Shared runtime relay/model configuration reuse between `server.py` and desktop Python helpers.
+  - Compute-mode normalization contract and tests (`auto`/`cpu`/`metal`/`cuda`).
+  - Operator-visible bridge status payload includes relay URL, backend mode, model path, and error
+    state.
+- 🟡 Still intentionally deferred (out of this parity PR scope):
+  - Full API v1 distributed compute migration and legacy sink/source retirement.
+  - Non-legacy distributed protocol redesign beyond current compatibility adapters.
 
 ## Readiness checklists
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,12 +1,14 @@
 from unittest.mock import MagicMock
 
 from utils.compute_node_runtime import (
+    apply_compute_mode,
     ComputeNodeRuntime,
     ComputeNodeRuntimeConfig,
     LegacyRelayRequestAdapter,
     first_env,
     format_relay_target,
     is_legacy_relay_payload,
+    normalize_compute_mode,
     resolve_relay_port,
     resolve_relay_url,
 )
@@ -214,6 +216,24 @@ def test_compute_node_runtime_relay_port_returns_none_when_no_values(monkeypatch
 
 def test_compute_node_runtime_format_relay_target_preserves_explicit_url_port():
     assert format_relay_target("https://token.place:7443", 9999) == "https://token.place:7443"
+
+
+def test_normalize_compute_mode_is_case_insensitive_and_falls_back_to_auto():
+    assert normalize_compute_mode("CUDA") == "cuda"
+    assert normalize_compute_mode("  metal ") == "metal"
+    assert normalize_compute_mode("unknown") == "auto"
+    assert normalize_compute_mode("") == "auto"
+    assert normalize_compute_mode(None) == "auto"
+
+
+def test_apply_compute_mode_sets_expected_gpu_layer_defaults():
+    manager = MagicMock()
+
+    assert apply_compute_mode(manager, "cpu") == "cpu"
+    assert manager.default_n_gpu_layers == 0
+
+    assert apply_compute_mode(manager, "auto") == "auto"
+    assert manager.default_n_gpu_layers == -1
 
 
 def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -282,3 +282,32 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
     assert 'bridge failure:' in payload['message']
+
+
+def test_main_normalizes_mode_before_run(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured['mode'] = args.mode
+        return 0
+
+    monkeypatch.setattr(compute_node_bridge, 'run', fake_run)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'CUDA'],
+    )
+
+    status = compute_node_bridge.main()
+    assert status == 0
+    assert captured['mode'] == 'cuda'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'unsupported'],
+    )
+
+    status = compute_node_bridge.main()
+    assert status == 0
+    assert captured['mode'] == 'auto'

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -100,6 +100,12 @@ class StreamingRuntime(FakeRuntime):
 
 
 def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
+    from utils.compute_node_runtime import (
+        SUPPORTED_COMPUTE_MODES as _SUPPORTED_COMPUTE_MODES,
+        apply_compute_mode as _apply_compute_mode,
+        normalize_compute_mode as _normalize_compute_mode,
+    )
+
     module = ModuleType('utils.compute_node_runtime')
     module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
         relay_url=relay_url,
@@ -111,19 +117,8 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     )
     module.resolve_relay_url = lambda relay_url: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
-    def _normalize_compute_mode(mode):
-        selected = (mode or 'auto').strip().lower()
-        if selected in {'auto', 'cpu', 'metal', 'cuda'}:
-            return selected
-        return 'auto'
-
+    module.SUPPORTED_COMPUTE_MODES = _SUPPORTED_COMPUTE_MODES
     module.normalize_compute_mode = _normalize_compute_mode
-
-    def _apply_compute_mode(manager, mode):
-        selected = module.normalize_compute_mode(mode)
-        manager.default_n_gpu_layers = 0 if selected == 'cpu' else -1
-        return selected
-
     module.apply_compute_mode = _apply_compute_mode
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
@@ -258,3 +253,32 @@ def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert events[0]['type'] == 'started'
     assert events[0]['backend_mode'] == 'auto'
+
+
+def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'utils.compute_node_runtime':
+            raise ModuleNotFoundError("No module named 'utils.compute_node_runtime'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'compute_node_bridge.py',
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'auto',
+        ],
+    )
+
+    status = compute_node_bridge.main()
+
+    assert status == 1
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload['type'] == 'error'
+    assert 'bridge failure:' in payload['message']

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -111,6 +111,20 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     )
     module.resolve_relay_url = lambda relay_url: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    def _normalize_compute_mode(mode):
+        selected = (mode or 'auto').strip().lower()
+        if selected in {'auto', 'cpu', 'metal', 'cuda'}:
+            return selected
+        return 'auto'
+
+    module.normalize_compute_mode = _normalize_compute_mode
+
+    def _apply_compute_mode(manager, mode):
+        selected = module.normalize_compute_mode(mode)
+        manager.default_n_gpu_layers = 0 if selected == 'cpu' else -1
+        return selected
+
+    module.apply_compute_mode = _apply_compute_mode
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
 
@@ -212,15 +226,35 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
 
 def test_apply_compute_mode_supports_gpu_and_cpu_modes():
     manager = FakeModelManager()
+    from utils.compute_node_runtime import apply_compute_mode
 
-    compute_node_bridge._apply_compute_mode(manager, 'auto')
+    assert apply_compute_mode(manager, 'auto') == 'auto'
     assert manager.default_n_gpu_layers == -1
 
-    compute_node_bridge._apply_compute_mode(manager, 'metal')
+    assert apply_compute_mode(manager, 'metal') == 'metal'
     assert manager.default_n_gpu_layers == -1
 
-    compute_node_bridge._apply_compute_mode(manager, 'cuda')
+    assert apply_compute_mode(manager, 'cuda') == 'cuda'
     assert manager.default_n_gpu_layers == -1
 
-    compute_node_bridge._apply_compute_mode(manager, 'cpu')
+    assert apply_compute_mode(manager, 'cpu') == 'cpu'
     assert manager.default_n_gpu_layers == 0
+
+
+def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='UNSUPPORTED',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+    assert events[0]['backend_mode'] == 'auto'

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -350,6 +350,51 @@ def test_main_emits_inference_failed_when_compute_runtime_missing(capsys, monkey
     assert 'bridge failure:' in event['message']
 
 
+def test_main_normalizes_mode_before_run(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured['mode'] = args.mode
+        return 0
+
+    monkeypatch.setattr(inference_sidecar, 'run', fake_run)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'inference_sidecar.py',
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'CUDA',
+            '--prompt',
+            'hello',
+        ],
+    )
+
+    status = inference_sidecar.main()
+    assert status == 0
+    assert captured['mode'] == 'cuda'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'inference_sidecar.py',
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'unsupported',
+            '--prompt',
+            'hello',
+        ],
+    )
+
+    status = inference_sidecar.main()
+    assert status == 0
+    assert captured['mode'] == 'auto'
+
+
 def test_extract_text_from_completion_handles_non_dict_message():
     assert inference_sidecar._extract_text_from_completion({'choices': [{'message': 'x'}]}) == ''
 

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -318,6 +318,38 @@ def test_run_cancels_during_streaming_after_started(tmp_path, capsys):
     assert [event['type'] for event in events] == ['started', 'canceled']
 
 
+def test_main_emits_inference_failed_when_compute_runtime_missing(capsys, monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'utils.compute_node_runtime':
+            raise ModuleNotFoundError("No module named 'utils.compute_node_runtime'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'inference_sidecar.py',
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'auto',
+            '--prompt',
+            'hello',
+        ],
+    )
+
+    status = inference_sidecar.main()
+
+    assert status == 1
+    event = json.loads(capsys.readouterr().out.strip())
+    assert event['type'] == 'error'
+    assert event['code'] == 'inference_failed'
+    assert 'bridge failure:' in event['message']
+
+
 def test_extract_text_from_completion_handles_non_dict_message():
     assert inference_sidecar._extract_text_from_completion({'choices': [{'message': 'x'}]}) == ''
 

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -214,6 +214,22 @@ def test_run_handles_dict_completion_payload(tmp_path, capsys):
     assert events[1]['text'] == 'dict response'
 
 
+def test_run_normalizes_unknown_mode_to_auto_gpu_default(tmp_path, capsys):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+
+    args = SimpleNamespace(model=str(model_path), mode='UNSUPPORTED', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    _ = capsys.readouterr()
+    assert manager.default_n_gpu_layers == -1
+
+
 def test_normalize_chunk_fallback_handles_object_shapes():
     class WithToDict:
         def to_dict(self):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -134,6 +134,31 @@ def format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
     return f"{relay_url}:{relay_port}"
 
 
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "metal", "cuda"})
+
+
+def normalize_compute_mode(mode: Optional[str]) -> str:
+    """Normalize operator-provided compute mode values."""
+
+    selected = (mode or "auto").strip().lower()
+    if selected in SUPPORTED_COMPUTE_MODES:
+        return selected
+    return "auto"
+
+
+def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
+    """Apply normalized compute mode to model-manager GPU settings."""
+
+    selected = normalize_compute_mode(mode)
+    if selected == "cpu":
+        manager.default_n_gpu_layers = 0
+    else:
+        # ``auto`` follows runtime autodetection and maps to GPU-preferred layers where available.
+        # ``metal`` and ``cuda`` also request GPU-backed inference on supported hosts.
+        manager.default_n_gpu_layers = -1
+    return selected
+
+
 class ComputeNodeRuntime:
     """Reusable compute-node runtime that wraps relay + model lifecycle concerns."""
 


### PR DESCRIPTION
### Motivation

- Ensure desktop/`server.py` parity and operator expectations by centralizing compute-mode normalization and clarifying docs that sugarkube/k3s hosts only the relay (`relay.py`) in the short-to-medium term.

### Description

- Add `normalize_compute_mode` and `apply_compute_mode` helpers and a `SUPPORTED_COMPUTE_MODES` set in `utils/compute_node_runtime.py` to centralize compute-mode normalization and application.
- Update desktop compute-node bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) to use the shared helpers, normalize CLI `--mode` before running, and emit normalized `backend_mode` in status events.
- Update inference sidecar (`desktop-tauri/src-tauri/python/inference_sidecar.py`) to reuse `apply_compute_mode` and normalize CLI `--mode` similarly.
- Tighten desktop UI labels in `desktop-tauri/src/App.tsx` to clearly map `metal` → macOS Apple Silicon and `cuda` → Windows/NVIDIA.
- Add unit tests that assert compute-mode normalization and application behavior (`tests/unit/test_compute_node_runtime.py`, `tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_desktop_inference_sidecar.py`) and update bridge/sidecar tests to expect normalized `backend_mode` values.
- Revise documentation across README and docs (roadmap, onboarding, architecture, repo map, tauri design, and k3s runbooks) and `docs/AGENTS.md` to consistently state that:
  - sugarkube/k3s is relay-only in short-to-medium term (runs `relay.py`),
  - `server.py` and desktop-tauri are workstation compute runtimes (Windows 11 + CUDA/NVIDIA, macOS Apple Silicon + Metal, CPU fallback, Raspberry Pi later), and
  - API v1 distributed migration is explicitly deferred until after parity.

### Testing

- Ran unit tests for modified areas and related suites: `pytest -q tests/unit/test_desktop_compute_node_bridge.py` — passed; `pytest -q tests/unit/test_desktop_inference_sidecar.py` — passed; `pytest -q tests/unit/test_server_app.py` — passed; `pytest -q tests/test_api.py` — passed; `pytest -q tests/test_relay.py` — passed.
- Executed full test runner `./run_all_tests.sh`; most suites passed, but the script reported two environment-specific failures: the security audit (`bandit`) was not installed in this environment and a Python integration stage reported a script-level failure, so `./run_all_tests.sh` returned a non-zero status in this session. All focused unit tests touched by this PR passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8aa422214832f9ee14e0cb441399b)