### PR TITLE
Align relay-only docs and normalize workstation compute modes across runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,21 @@ See also:
 - **Future distributed API v1 flow (post-parity):** distributed compute migrates to API v1-aligned
   contracts after parity and operational readiness gates are complete.
 
+## Workstation compute targets (current phase)
+
+- `server.py` and desktop-tauri are workstation compute-node runtimes.
+- Preferred modes:
+  - `cuda`: Windows 11 + NVIDIA operators (for example RTX 4090 class)
+  - `metal`: macOS + Apple Silicon operators (including Mac Mini M4 class)
+  - `cpu`: portable fallback where GPU acceleration is unavailable
+- Raspberry Pi is a later low-power workstation/server target and is not part of the current
+  sugarkube relay rollout.
+
 ## sugarkube deployment
 
 `relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
-operationally separate from GPU-heavy compute nodes.
+operationally separate from GPU-heavy compute nodes. In the short-to-medium term, sugarkube is
+relay-only (`relay.py`), while compute nodes continue to run on operator workstations.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -60,14 +60,6 @@ def emit(payload: Dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
-def _apply_compute_mode(manager: Any, mode: str) -> None:
-    selected = (mode or "auto").lower()
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    elif selected in {"metal", "cuda"}:
-        manager.default_n_gpu_layers = -1
-
-
 def _sleep_with_cancel(seconds: float) -> bool:
     deadline = time.time() + max(seconds, 0)
     while time.time() < deadline:
@@ -83,6 +75,8 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
+            normalize_compute_mode,
+            apply_compute_mode,
             resolve_relay_port,
             resolve_relay_url,
         )
@@ -101,7 +95,8 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    _apply_compute_mode(runtime.model_manager, args.mode)
+    selected_mode = normalize_compute_mode(args.mode)
+    apply_compute_mode(runtime.model_manager, selected_mode)
 
     if not runtime.ensure_model_ready():
         emit(
@@ -120,7 +115,7 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": args.mode,
+            "backend_mode": selected_mode,
             "model_path": args.model,
             "last_error": None,
         }
@@ -150,7 +145,7 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
-                    "backend_mode": args.mode,
+                    "backend_mode": selected_mode,
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -168,7 +163,7 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": args.mode,
+            "backend_mode": selected_mode,
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -122,20 +122,13 @@ def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
     return message.get("content", "") if isinstance(message, dict) else ""
 
 
-def _apply_compute_mode(manager: Any, mode: str) -> None:
-    selected = (mode or "auto").lower()
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    elif selected in {"metal", "cuda"}:
-        manager.default_n_gpu_layers = -1
-
-
 def run(args: argparse.Namespace) -> int:
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
 
     try:
         from utils.llm.model_manager import ModelManager, get_model_manager
+        from utils.compute_node_runtime import apply_compute_mode, normalize_compute_mode
     except ModuleNotFoundError as exc:
         return emit_error(
             "runtime_unavailable",
@@ -144,7 +137,8 @@ def run(args: argparse.Namespace) -> int:
 
     manager = get_model_manager()
     manager.model_path = args.model
-    _apply_compute_mode(manager, args.mode)
+    selected_mode = normalize_compute_mode(args.mode)
+    apply_compute_mode(manager, selected_mode)
 
     llm = manager.get_llm_instance()
     if llm is None:

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -140,3 +140,15 @@ For convenience, you can execute all available test suites with `./run_all_tests
 - Tag **@claude** in a pull request or issue to invoke the Claude PR Assistant defined in `.github/workflows/claude.yml`.
 - Ensure the [Codecov GitHub App](https://github.com/marketplace/codecov) is installed on your fork so coverage badges and PR comments work reliably.
 - Real-world integration tests live in the [DSPACE project](https://github.com/democratizedspace/dspace); token.place acts as its OpenAI-compatible backend.
+
+## Architecture guardrails (current phase)
+
+- Keep `server.py` as the canonical compute-node entrypoint.
+- Keep `server/server_app.py` as compatibility-only shim behavior.
+- Keep sugarkube/k3s scope relay-only (`relay.py`) during parity work.
+- Keep workstation compute targets explicit in docs/code paths:
+  - Windows + CUDA/NVIDIA
+  - macOS + Metal/Apple Silicon
+  - CPU fallback
+  - Raspberry Pi later (not part of current relay rollout)
+- Do not start full API v1 distributed compute migration work until parity gates are complete.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,6 +147,12 @@ Canonical sequencing lives in [roadmap/desktop_compute_node_migration.md](roadma
   prevent dual server implementations from drifting.
 - **Near-term:** `server.py` and desktop-tauri co-evolve through a shared compute-node runtime while
   relay operations move onto sugarkube.
+- **Near-term deployment boundary:** sugarkube/k3s is relay-only (`relay.py`); workstation compute
+  runtimes (`server.py`, desktop-tauri) stay external.
+- **Workstation mode contract:** `auto|cpu|metal|cuda` with `cuda` targeting Windows/NVIDIA,
+  `metal` targeting macOS/Apple Silicon, and `cpu` as fallback.
+- **Deferred intentionally:** full API v1 distributed-compute migration happens only after parity
+  and relay runbooks are stable.
 - **Target state (later):** post-parity migration to API v1-aligned distributed compute contracts.
 
 Related operations docs:

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -39,6 +39,10 @@ near-term, and target architecture.
 
 - **Current contract:** legacy relay sink/source flows used by `server.py` and relay nodes.
 - **Planned runtime alignment:** shared compute-node runtime co-used by `server.py` and desktop-tauri.
+- **Current deployment boundary:** sugarkube/k3s hosts relay-only (`relay.py`); compute nodes stay
+  on operator workstations.
+- **Current workstation targets:** Windows 11 + CUDA/NVIDIA, macOS + Metal/Apple Silicon, CPU
+  fallback on either; Raspberry Pi later as a low-power workstation/server target.
 - **Future contract:** API v1-aligned distributed compute after parity and operations readiness.
 
 ## Deployment and operations docs

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -21,6 +21,8 @@ migration.
 1. `server.py` and desktop-tauri must co-evolve in lockstep through a **shared compute-node runtime**.
 2. Desktop parity on the **legacy relay sink/source contract** comes before API v1 distributed migration.
 3. Relay operations can move to sugarkube earlier because `relay.py` is lightweight and stateless.
+4. Compute-mode contract remains explicit and stable across UI/bridge/sidecar/runtime:
+   `auto|cpu|metal|cuda`.
 
 ## Current vs near-term vs target
 
@@ -36,6 +38,8 @@ migration.
 - Desktop-tauri runs shared compute-node runtime behaviors equivalent to `server.py`.
 - Desktop nodes and `server.py` can both operate on legacy relay flows.
 - `relay.py` is deployed on sugarkube for dev/staging/prod operations.
+- Workstation targets stay explicit: Windows 11 + NVIDIA (`cuda`), macOS + Apple Silicon
+  (`metal`), and `cpu` fallback. Raspberry Pi remains a later low-power target.
 
 ### Target state (later)
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -11,6 +11,8 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 - relay image/chart updates
 - registration and polling behavior with external compute nodes
 
+Out of scope in this runbook: moving `server.py` or desktop compute nodes into the k3s cluster.
+
 ## Prerequisites
 
 - sugarkube dev cluster access

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -8,6 +8,9 @@
 Run `relay.py` on sugarkube production with strict change control. Compute nodes remain external
 until parity and later API v1 migration phases are complete.
 
+Out of scope in this runbook: moving the compute plane (`server.py`/desktop) into k3s before
+post-parity API v1 migration planning.
+
 ## Prerequisites
 
 - production cluster access with audited credentials

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -8,6 +8,8 @@
 Relay-only staging at `staging.token.place` (or equivalent environment hostname), with external
 compute nodes still using legacy sink/source contract.
 
+Out of scope in this runbook: scheduling compute-node workloads inside sugarkube.
+
 ## Prerequisites
 
 - staging cluster namespace access

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -1,7 +1,7 @@
 # Relay on sugarkube onboarding (token.place)
 
-This guide explains how and why to run `relay.py` on sugarkube before full desktop/server
-migration is complete.
+This guide explains how and why to run `relay.py` on sugarkube while workstation compute runtimes
+(`server.py` and desktop-tauri) remain outside k3s during parity work.
 
 ## Why relay.py belongs on sugarkube
 
@@ -14,6 +14,13 @@ migration is complete.
 
 This allows token.place to improve relay availability and operator workflows while GPU-heavy
 compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
+
+Workstation target profile in this phase:
+
+- Windows 11 + NVIDIA (`cuda`)
+- macOS + Apple Silicon (`metal`)
+- CPU fallback on either platform
+- Raspberry Pi later as low-power workstation/server follow-on (not part of relay-on-k3s rollout)
 
 Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
 
@@ -80,6 +87,8 @@ curl -fsS https://<env-host>/healthz
 
 - Compute nodes are still external during parity phases.
 - Legacy sink/source contract remains active until post-parity API v1 migration.
+- `server.py` remains the canonical compute-node entrypoint; `server/server_app.py` remains a
+  compatibility shim only.
 - Final sugarkube automation wrappers may still be in progress per environment.
 
 ## How this fits the broader roadmap

--- a/docs/roadmap/desktop_compute_node_migration.md
+++ b/docs/roadmap/desktop_compute_node_migration.md
@@ -116,15 +116,28 @@ Desktop is considered parity-ready only when all of the following are true:
   - explicit GGUF artifact selection used by runtime
   - model browse + download flow
   - default relay URL `https://token.place` with user override support
+  - compute-mode contract parity (`auto|cpu|metal|cuda`) with normalized operator reporting
+
+## Workstation platform targeting (short-to-medium term)
+
+- `server.py` and desktop-tauri are the workstation compute-node runtimes in this phase.
+- Mode intent:
+  - `cuda` for Windows 11 + NVIDIA workstations (for example RTX 4090-class operators)
+  - `metal` for macOS on Apple Silicon (including Mac Mini M4-class hosts)
+  - `cpu` as portable fallback on any workstation
+  - Raspberry Pi remains a **later** low-power workstation/server target
+- sugarkube/k3s remains **relay-only** for this phase (`relay.py`), not compute-node hosting.
 
 ## Readiness checklists
 
 ### Desktop parity readiness
 
-- [ ] Shared compute-node runtime is consumed by both `server.py` and desktop-tauri.
+- [x] Shared compute-node runtime is consumed by both `server.py` and desktop-tauri.
 - [ ] Desktop executes real inference workloads (not fake sidecar only).
 - [ ] Streaming and cancellation match server runtime behavior.
 - [ ] Relay integration passes legacy contract integration tests.
+- [x] Compute-mode normalization and operator-visible mode/reporting are consistent (`auto|cpu|metal|cuda`).
+- [x] Relay URL + model path + backend mode are propagated in desktop operator status events.
 - [ ] Model-management parity requirements are implemented.
 
 ### Legacy multi-node relay readiness
@@ -152,6 +165,6 @@ Desktop is considered parity-ready only when all of the following are true:
 
 - **Current:** `relay.py` + `server.py` legacy flow is the production baseline; desktop-tauri is MVP.
   `server/server_app.py` remains compatibility-only and should not diverge from `server.py`.
-- **Near-term:** desktop and `server.py` co-evolve through a shared runtime while relay moves onto
-  sugarkube.
+- **Near-term:** desktop and `server.py` co-evolve through a shared runtime while **relay-only**
+  deployment moves onto sugarkube.
 - **Target:** post-parity, post-API-v1 distributed compute with secure API v1-aligned components.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -4,9 +4,11 @@ from utils.compute_node_runtime import (
     ComputeNodeRuntime,
     ComputeNodeRuntimeConfig,
     LegacyRelayRequestAdapter,
+    apply_compute_mode,
     first_env,
     format_relay_target,
     is_legacy_relay_payload,
+    normalize_compute_mode,
     resolve_relay_port,
     resolve_relay_url,
 )
@@ -214,6 +216,25 @@ def test_compute_node_runtime_relay_port_returns_none_when_no_values(monkeypatch
 
 def test_compute_node_runtime_format_relay_target_preserves_explicit_url_port():
     assert format_relay_target("https://token.place:7443", 9999) == "https://token.place:7443"
+
+
+def test_normalize_compute_mode_handles_case_and_unknown_inputs():
+    assert normalize_compute_mode("CuDa") == "cuda"
+    assert normalize_compute_mode(" metal ") == "metal"
+    assert normalize_compute_mode("unknown") == "auto"
+    assert normalize_compute_mode(None) == "auto"
+
+
+def test_apply_compute_mode_sets_cpu_fallback_layers():
+    manager = MagicMock()
+
+    selected_cpu = apply_compute_mode(manager, "cpu")
+    assert selected_cpu == "cpu"
+    assert manager.default_n_gpu_layers == 0
+
+    selected_auto = apply_compute_mode(manager, "not-real")
+    assert selected_auto == "auto"
+    assert manager.default_n_gpu_layers == -1
 
 
 def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -109,6 +109,10 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     module.is_legacy_relay_payload = (
         lambda payload: {"client_public_key", "chat_history", "cipherkey", "iv"}.issubset(payload)
     )
+    module.normalize_compute_mode = lambda mode: mode.lower() if isinstance(mode, str) else "auto"
+    module.apply_compute_mode = (
+        lambda manager, mode: setattr(manager, "default_n_gpu_layers", 0 if mode == "cpu" else -1)
+    )
     module.resolve_relay_url = lambda relay_url: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
@@ -210,17 +214,20 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
     assert any(event.get('registered') is True for event in status_events)
 
 
-def test_apply_compute_mode_supports_gpu_and_cpu_modes():
-    manager = FakeModelManager()
+def test_run_normalizes_mode_from_runtime_helper(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
 
-    compute_node_bridge._apply_compute_mode(manager, 'auto')
-    assert manager.default_n_gpu_layers == -1
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='CuDa',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
 
-    compute_node_bridge._apply_compute_mode(manager, 'metal')
-    assert manager.default_n_gpu_layers == -1
-
-    compute_node_bridge._apply_compute_mode(manager, 'cuda')
-    assert manager.default_n_gpu_layers == -1
-
-    compute_node_bridge._apply_compute_mode(manager, 'cpu')
-    assert manager.default_n_gpu_layers == 0
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['backend_mode'] == 'cuda'
+    assert events[-1]['backend_mode'] == 'cuda'

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -179,7 +179,7 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
 
 @pytest.mark.parametrize(
     ('mode', 'expected'),
-    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1), ('CuDa', -1), ('unknown', -1)],
 )
 def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
     _reset_cancel_queue()
@@ -312,7 +312,7 @@ def test_extract_text_from_completion_handles_empty_choices():
 
 def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
     class WithBadDict:
-        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+        def dict(self, _required):  # pragma: no cover - signature intentionally incompatible
             return {'choices': []}
 
     class UnknownShape:

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -134,6 +134,27 @@ def format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
     return f"{relay_url}:{relay_port}"
 
 
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "metal", "cuda"})
+
+
+def normalize_compute_mode(mode: Optional[str]) -> str:
+    """Normalize user/operator compute mode input to supported runtime values."""
+
+    selected = (mode or "auto").strip().lower()
+    return selected if selected in SUPPORTED_COMPUTE_MODES else "auto"
+
+
+def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
+    """Apply normalized compute mode defaults to a model manager-like object."""
+
+    selected = normalize_compute_mode(mode)
+    if selected == "cpu":
+        manager.default_n_gpu_layers = 0
+    else:
+        manager.default_n_gpu_layers = -1
+    return selected
+
+
 class ComputeNodeRuntime:
     """Reusable compute-node runtime that wraps relay + model lifecycle concerns."""
 


### PR DESCRIPTION
### Motivation

- Reduce drift between code, operator UX, and docs by centralizing compute-mode handling and explicitly documenting that sugarkube/k3s is relay-only in the short-to-medium term.
- Move parity work forward without changing relay protocol or attempting API v1 distributed migration.

### Description

- Add `normalize_compute_mode` and `apply_compute_mode` helpers to `utils/compute_node_runtime.py` and use them as the canonical compute-mode contract (`auto|cpu|metal|cuda`).
- Wire the desktop Python bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) and inference sidecar (`desktop-tauri/src-tauri/python/inference_sidecar.py`) to use the shared helpers and emit normalized, operator-visible backend mode values.
- Update and extend unit tests to cover normalization, fallback behavior, and normalized mode propagation across runtime, bridge, and sidecar paths (`tests/unit/test_compute_node_runtime.py`, `tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_desktop_inference_sidecar.py`).
- Tighten documentation and runbooks to codify the short/medium-term architecture: sugarkube/k3s is relay-only (`relay.py`), `server.py` (canonical) and desktop-tauri run on operator workstations, and platform targeting is explicit (`cuda` → Windows+NVIDIA, `metal` → macOS+Apple Silicon, `cpu` fallback; Raspberry Pi later).
- Add small housekeeping test fix in `tests/unit/test_desktop_inference_sidecar.py` to satisfy lint/hooks and pre-commit checks.

### Testing

- Ran focused unit tests; `pytest -q tests/unit/test_compute_node_runtime.py`, `pytest -q tests/unit/test_desktop_compute_node_bridge.py`, `pytest -q tests/unit/test_desktop_inference_sidecar.py`, and `pytest -q tests/unit/test_server_app.py` all passed.
- API and relay suites passed: `pytest -q tests/test_api.py` and `pytest -q tests/test_relay.py` passed (full API surface exercised by tests).
- Security scan test `tests/test_security_bandit.py` was run and passed after installing the required tooling in the test environment.
- `./run_all_tests.sh` and `pre-commit run --all-files` were exercised during development; environment-specific integration steps (Playwright browser binaries / some system-level deps) caused predictable, documented caveats in the CI-like local run but the targeted unit/api/relay suites and pre-commit hooks relevant to this change succeeded after fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8aa422214832f9ee14e0cb441399b)