### PR TITLE
Align relay-only docs and normalize workstation compute-mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ pre-commit run --all-files
   formatting, linting, and quick tests.
 - **Full test sweep** — `./run_all_tests.sh` (or `make test`) calls pytest, Playwright, npm checks,
   and Bandit just like CI.
-- **Deploy Kubernetes manifests** — `make k8s-deploy` applies everything under `k8s/` to the active
-  cluster context.
+- **Deploy relay Kubernetes manifests** — `make k8s-deploy` applies the relay-focused manifests
+  under `k8s/` to the active cluster context.
 
 Make targets surface the same workflows in shorthand:
 
@@ -156,6 +156,12 @@ For a directory-by-directory atlas, visit [docs/REPO_MAP.md](docs/REPO_MAP.md).
 The `desktop-tauri/` app is the forward-looking desktop path, but it is currently an MVP and does
 **not** yet replace `server.py`. The canonical migration sequence is documented in
 [`docs/roadmap/desktop_compute_node_migration.md`](docs/roadmap/desktop_compute_node_migration.md).
+Short-to-medium-term runtime targets are:
+
+- Windows 11 workstations with NVIDIA GPUs (`cuda` mode)
+- macOS workstations on Apple Silicon (`metal` mode)
+- CPU fallback for unsupported hosts (`cpu` mode)
+- Raspberry Pi later as a low-power workstation/server target (not part of sugarkube relay rollout)
 
 See also:
 
@@ -181,6 +187,7 @@ See also:
 
 `relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
 operationally separate from GPU-heavy compute nodes.
+`server.py` and desktop-tauri compute runtimes are intentionally out of current sugarkube scope.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -60,14 +60,6 @@ def emit(payload: Dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
-def _apply_compute_mode(manager: Any, mode: str) -> None:
-    selected = (mode or "auto").lower()
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    elif selected in {"metal", "cuda"}:
-        manager.default_n_gpu_layers = -1
-
-
 def _sleep_with_cancel(seconds: float) -> bool:
     deadline = time.time() + max(seconds, 0)
     while time.time() < deadline:
@@ -83,6 +75,7 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
+            apply_compute_mode_to_model_manager,
             resolve_relay_port,
             resolve_relay_url,
         )
@@ -101,7 +94,7 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    _apply_compute_mode(runtime.model_manager, args.mode)
+    normalized_mode = apply_compute_mode_to_model_manager(runtime.model_manager, args.mode)
 
     if not runtime.ensure_model_ready():
         emit(
@@ -120,7 +113,7 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": args.mode,
+            "backend_mode": normalized_mode,
             "model_path": args.model,
             "last_error": None,
         }
@@ -150,7 +143,7 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
-                    "backend_mode": args.mode,
+                    "backend_mode": normalized_mode,
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -168,7 +161,7 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": args.mode,
+            "backend_mode": normalized_mode,
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -122,19 +122,12 @@ def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
     return message.get("content", "") if isinstance(message, dict) else ""
 
 
-def _apply_compute_mode(manager: Any, mode: str) -> None:
-    selected = (mode or "auto").lower()
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    elif selected in {"metal", "cuda"}:
-        manager.default_n_gpu_layers = -1
-
-
 def run(args: argparse.Namespace) -> int:
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
 
     try:
+        from utils.compute_node_runtime import apply_compute_mode_to_model_manager
         from utils.llm.model_manager import ModelManager, get_model_manager
     except ModuleNotFoundError as exc:
         return emit_error(
@@ -144,7 +137,7 @@ def run(args: argparse.Namespace) -> int:
 
     manager = get_model_manager()
     manager.model_path = args.model
-    _apply_compute_mode(manager, args.mode)
+    apply_compute_mode_to_model_manager(manager, args.mode)
 
     llm = manager.get_llm_instance()
     if llm is None:

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -357,6 +357,10 @@ export function App() {
         <option value="cuda" disabled={!cudaSupported}>CUDA GPU</option>
         <option value="cpu">CPU fallback</option>
       </select>
+      <p style={{ marginTop: 6, marginBottom: 0, fontSize: 13 }}>
+        Mode guidance: CUDA for Windows/NVIDIA workstations, Metal for macOS Apple Silicon,
+        CPU as fallback.
+      </p>
 
       <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
       <input

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,14 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [server.py](../server.py): Main server implementation for the proxy service
 - [relay.py](../relay.py): Middleware server that forwards encrypted messages between clients and servers
 
+## Architecture guardrails (release-readiness)
+
+- Treat short-to-medium-term deployment scope as **relay-only on sugarkube/k3s** (`relay.py`).
+- Treat `server.py` and `desktop-tauri/` as workstation compute-node runtimes.
+- Keep `server.py` canonical; keep `server/server_app.py` compatibility-only.
+- Keep legacy relay sink/source contract active through parity; defer API v1 distributed migration
+  until parity is accepted.
+
 ## Documentation
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md): Contribution guidelines for developers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,7 +146,9 @@ Canonical sequencing lives in [roadmap/desktop_compute_node_migration.md](roadma
 - **Legacy compatibility:** `server/server_app.py` is shim-only and delegates into `server.py` to
   prevent dual server implementations from drifting.
 - **Near-term:** `server.py` and desktop-tauri co-evolve through a shared compute-node runtime while
-  relay operations move onto sugarkube.
+  relay operations move onto sugarkube (relay-only in-cluster scope).
+- **Workstation targets:** Windows 11 + NVIDIA/CUDA, macOS + Apple Silicon/Metal, with CPU fallback
+  and later Raspberry Pi low-power runtime support.
 - **Target state (later):** post-parity migration to API v1-aligned distributed compute contracts.
 
 Related operations docs:

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -24,7 +24,7 @@ near-term, and target architecture.
   - Package utilities and compatibility imports.
 - `relay.py`
   - Lightweight relay handling legacy sink/source and multi-node registration.
-  - First deployment candidate for sugarkube.
+  - First and only short/medium-term deployment candidate for sugarkube.
 - `api/`
   - FastAPI implementation and experimental API surface for contributors evaluating API-facing
     runtime paths.
@@ -32,6 +32,8 @@ near-term, and target architecture.
   - Forward-looking desktop client path.
   - Must reach feature parity with `server.py` via shared compute-node runtime before API v1
     distributed migration.
+  - Primary workstation targets: Windows 11 (CUDA/NVIDIA) and macOS Apple Silicon (Metal), with
+    CPU fallback and later Raspberry Pi support.
 - `desktop/`
   - Deprecated Electron prototype retained as historical context.
 

--- a/docs/design/tauri_desktop_client.md
+++ b/docs/design/tauri_desktop_client.md
@@ -21,6 +21,8 @@ migration.
 1. `server.py` and desktop-tauri must co-evolve in lockstep through a **shared compute-node runtime**.
 2. Desktop parity on the **legacy relay sink/source contract** comes before API v1 distributed migration.
 3. Relay operations can move to sugarkube earlier because `relay.py` is lightweight and stateless.
+4. Workstation backend modes must stay explicit and consistent across UI and Python runtime:
+   `cuda` (Windows 11/NVIDIA), `metal` (macOS/Apple Silicon), `cpu` fallback, `auto` normalized.
 
 ## Current vs near-term vs target
 
@@ -36,6 +38,7 @@ migration.
 - Desktop-tauri runs shared compute-node runtime behaviors equivalent to `server.py`.
 - Desktop nodes and `server.py` can both operate on legacy relay flows.
 - `relay.py` is deployed on sugarkube for dev/staging/prod operations.
+- Raspberry Pi support is tracked as a later low-power workstation/server target.
 
 ### Target state (later)
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -22,6 +22,7 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 
 - In-cluster: `relay.py` deployment + service + ingress
 - External: `server.py` and/or desktop compute nodes using legacy relay contract
+  (`cuda` Windows/NVIDIA, `metal` macOS/Apple Silicon, `cpu` fallback)
 
 ## Release model
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -7,6 +7,7 @@
 
 Run `relay.py` on sugarkube production with strict change control. Compute nodes remain external
 until parity and later API v1 migration phases are complete.
+This runbook does not move compute runtimes into k3s.
 
 ## Prerequisites
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -7,6 +7,7 @@
 
 Relay-only staging at `staging.token.place` (or equivalent environment hostname), with external
 compute nodes still using legacy sink/source contract.
+Compute runtimes are workstation-hosted in this phase (not in-cluster workloads).
 
 ## Prerequisites
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -1,7 +1,7 @@
 # Relay on sugarkube onboarding (token.place)
 
-This guide explains how and why to run `relay.py` on sugarkube before full desktop/server
-migration is complete.
+This guide explains how and why to run `relay.py` on sugarkube while compute runtimes stay on
+operator workstations during the parity phase.
 
 ## Why relay.py belongs on sugarkube
 
@@ -13,7 +13,9 @@ migration is complete.
 - easier centralized ingress/tunnel management
 
 This allows token.place to improve relay availability and operator workflows while GPU-heavy
-compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
+compute nodes (`server.py` and desktop compute nodes) remain external during parity phases.
+Initial workstation targets are Windows 11 + NVIDIA/CUDA and macOS + Apple Silicon/Metal, with
+Raspberry Pi as a later low-power target.
 
 Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
 
@@ -21,7 +23,7 @@ Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_comp
 
 - **Current:** relay can run locally or in Kubernetes; staging-oriented docs exist.
 - **Planned near-term:** standardized dev/staging/prod sugarkube runbooks for relay.
-- **Not yet:** full post-API-v1 distributed deployment model.
+- **Not yet:** full post-parity API v1 distributed compute migration/deployment model.
 
 ## Minimal requirements
 

--- a/docs/roadmap/desktop_compute_node_migration.md
+++ b/docs/roadmap/desktop_compute_node_migration.md
@@ -6,6 +6,8 @@ This is the canonical migration plan for moving token.place from today's
 - **Current state:** desktop-tauri is an MVP and is **not** feature-parity with `server.py`.
 - **Near-term target:** achieve desktop parity on the legacy relay sink/source contract first.
 - **Future target:** migrate distributed compute to API v1 **after** parity is complete.
+- **Deployment boundary (short/medium term):** sugarkube/k3s is relay-only (`relay.py`);
+  compute runtimes (`server.py`, desktop-tauri) stay on operator workstations.
 
 See also:
 
@@ -121,11 +123,12 @@ Desktop is considered parity-ready only when all of the following are true:
 
 ### Desktop parity readiness
 
-- [ ] Shared compute-node runtime is consumed by both `server.py` and desktop-tauri.
+- [x] Shared compute-node runtime is consumed by both `server.py` and desktop-tauri.
 - [ ] Desktop executes real inference workloads (not fake sidecar only).
 - [ ] Streaming and cancellation match server runtime behavior.
 - [ ] Relay integration passes legacy contract integration tests.
-- [ ] Model-management parity requirements are implemented.
+- [x] Compute-mode contract is normalized across desktop UI/bridge/sidecar/runtime (`auto`, `cpu`, `metal`, `cuda`).
+- [ ] Model-management parity requirements are fully implemented.
 
 ### Legacy multi-node relay readiness
 
@@ -153,5 +156,7 @@ Desktop is considered parity-ready only when all of the following are true:
 - **Current:** `relay.py` + `server.py` legacy flow is the production baseline; desktop-tauri is MVP.
   `server/server_app.py` remains compatibility-only and should not diverge from `server.py`.
 - **Near-term:** desktop and `server.py` co-evolve through a shared runtime while relay moves onto
-  sugarkube.
-- **Target:** post-parity, post-API-v1 distributed compute with secure API v1-aligned components.
+  sugarkube. Workstation targets are Windows 11 (CUDA/NVIDIA), macOS (Metal/Apple Silicon), and
+  later Raspberry Pi as a low-power workstation/server target.
+- **Target (deferred until after parity):** post-API-v1 distributed compute with secure API
+  v1-aligned components.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,12 +1,15 @@
 from unittest.mock import MagicMock
 
 from utils.compute_node_runtime import (
+    SUPPORTED_COMPUTE_MODES,
     ComputeNodeRuntime,
     ComputeNodeRuntimeConfig,
     LegacyRelayRequestAdapter,
+    apply_compute_mode_to_model_manager,
     first_env,
     format_relay_target,
     is_legacy_relay_payload,
+    normalize_compute_mode,
     resolve_relay_port,
     resolve_relay_url,
 )
@@ -17,6 +20,29 @@ def test_first_env_skips_blank_values(monkeypatch):
     monkeypatch.setenv("TOKEN_PLACE_RELAY_URL", "https://fallback.example")
 
     assert first_env(["TOKENPLACE_RELAY_URL", "TOKEN_PLACE_RELAY_URL"]) == "https://fallback.example"
+
+
+def test_normalize_compute_mode_matches_supported_workstation_modes():
+    assert tuple(SUPPORTED_COMPUTE_MODES) == ("auto", "cpu", "metal", "cuda")
+    assert normalize_compute_mode(None) == "auto"
+    assert normalize_compute_mode(" CUDA ") == "cuda"
+    assert normalize_compute_mode("metal") == "metal"
+    assert normalize_compute_mode("CPU") == "cpu"
+    assert normalize_compute_mode("unsupported") == "auto"
+
+
+def test_apply_compute_mode_to_model_manager_updates_gpu_layers():
+    manager = MagicMock()
+    manager.default_n_gpu_layers = -999
+
+    assert apply_compute_mode_to_model_manager(manager, "cpu") == "cpu"
+    assert manager.default_n_gpu_layers == 0
+
+    assert apply_compute_mode_to_model_manager(manager, "cuda") == "cuda"
+    assert manager.default_n_gpu_layers == -1
+
+    assert apply_compute_mode_to_model_manager(manager, "bad-value") == "auto"
+    assert manager.default_n_gpu_layers == -1
 
 
 def test_compute_node_runtime_ensure_model_ready_download_success():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -111,6 +111,13 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     )
     module.resolve_relay_url = lambda relay_url: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    def apply_compute_mode_to_model_manager(manager, mode):
+        selected = (mode or "auto").strip().lower()
+        normalized = selected if selected in {"auto", "cpu", "metal", "cuda"} else "auto"
+        manager.default_n_gpu_layers = 0 if normalized == "cpu" else -1
+        return normalized
+
+    module.apply_compute_mode_to_model_manager = apply_compute_mode_to_model_manager
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
 
@@ -210,17 +217,22 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
     assert any(event.get('registered') is True for event in status_events)
 
 
-def test_apply_compute_mode_supports_gpu_and_cpu_modes():
-    manager = FakeModelManager()
+def test_run_reports_normalized_backend_mode_and_gpu_layer_contract(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
 
-    compute_node_bridge._apply_compute_mode(manager, 'auto')
-    assert manager.default_n_gpu_layers == -1
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
 
-    compute_node_bridge._apply_compute_mode(manager, 'metal')
-    assert manager.default_n_gpu_layers == -1
+    status = compute_node_bridge.run(
+        SimpleNamespace(
+            model='/tmp/model.gguf',
+            mode='CUDA',
+            relay_url='https://token.place',
+            relay_port=None,
+        )
+    )
+    assert status == 0
 
-    compute_node_bridge._apply_compute_mode(manager, 'cuda')
-    assert manager.default_n_gpu_layers == -1
-
-    compute_node_bridge._apply_compute_mode(manager, 'cpu')
-    assert manager.default_n_gpu_layers == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['backend_mode'] == 'cuda'
+    assert events[-1]['backend_mode'] == 'cuda'

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -179,7 +179,7 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
 
 @pytest.mark.parametrize(
     ('mode', 'expected'),
-    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+    [('cpu', 0), ('metal', -1), ('cuda', -1), ('CUDA', -1), ('auto', -1), ('bogus', -1)],
 )
 def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
     _reset_cancel_queue()
@@ -312,7 +312,7 @@ def test_extract_text_from_completion_handles_empty_choices():
 
 def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
     class WithBadDict:
-        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+        def dict(self, _required):  # pragma: no cover - signature intentionally incompatible
             return {'choices': []}
 
     class UnknownShape:

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -41,6 +41,7 @@ class ComputeNodeRuntimeConfig:
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
+SUPPORTED_COMPUTE_MODES = ("auto", "cpu", "metal", "cuda")
 
 
 def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
@@ -49,6 +50,26 @@ def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
     if not isinstance(payload, dict):
         return False
     return LEGACY_RELAY_REQUIRED_FIELDS.issubset(payload.keys())
+
+
+def normalize_compute_mode(mode: Optional[str]) -> str:
+    """Normalize requested compute mode to the supported workstation contract."""
+
+    candidate = (mode or "auto").strip().lower()
+    if candidate in SUPPORTED_COMPUTE_MODES:
+        return candidate
+    return "auto"
+
+
+def apply_compute_mode_to_model_manager(manager: Any, mode: Optional[str]) -> str:
+    """Apply normalized compute mode to a model manager and return the mode used."""
+
+    normalized = normalize_compute_mode(mode)
+    if normalized == "cpu":
+        manager.default_n_gpu_layers = 0
+    elif normalized in {"metal", "cuda", "auto"}:
+        manager.default_n_gpu_layers = -1
+    return normalized
 
 
 class RelayRequestAdapter(Protocol):


### PR DESCRIPTION
### Motivation

- Prevent architecture drift by making it explicit that sugarkube/k3s hosts only `relay.py` in the short-to-medium term while compute runtimes (`server.py`, desktop-tauri) run on operator workstations.
- Reduce parity drift between `server.py` and desktop runtimes by centralizing compute-mode normalization and applying it consistently to bridge/sidecar/model manager paths.
- Make workstation platform guidance and the canonical entrypoint message unambiguous in docs.

### Description

- Added compute-mode contract and helpers in `utils/compute_node_runtime.py`: `SUPPORTED_COMPUTE_MODES`, `normalize_compute_mode`, and `apply_compute_mode_to_model_manager` to centralize normalization and application to model managers.
- Replaced ad-hoc compute mode logic in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and `desktop-tauri/src-tauri/python/inference_sidecar.py` to call the shared `apply_compute_mode_to_model_manager` and emit a normalized `backend_mode` in bridge lifecycle events.
- Updated desktop UI `desktop-tauri/src/App.tsx` to add operator guidance about `cuda` (Windows/NVIDIA), `metal` (macOS/Apple Silicon) and `cpu` fallback.
- Strengthened documentation to explicitly state release-readiness architecture and boundaries across: `README.md`, `docs/ARCHITECTURE.md`, `docs/REPO_MAP.md`, `docs/design/tauri_desktop_client.md`, `docs/roadmap/desktop_compute_node_migration.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-*.md`, and `docs/AGENTS.md` clarifying that sugarkube is relay-only now and that `server.py` is canonical while `server/server_app.py` is a compatibility shim.
- Added and adapted unit tests to lock the normalized compute-mode contract and verify bridge/sidecar behavior: updates in `tests/unit/test_compute_node_runtime.py`, `tests/unit/test_desktop_compute_node_bridge.py`, and `tests/unit/test_desktop_inference_sidecar.py`.

### Testing

- Ran focused unit suites and integration/API tests: `pytest -q tests/unit/test_desktop_compute_node_bridge.py` (passed), `pytest -q tests/unit/test_desktop_inference_sidecar.py` (passed), `pytest -q tests/unit/test_server_app.py` (passed), `pytest -q tests/test_api.py` (passed), and `pytest -q tests/test_relay.py` (passed).
- Executed the repository test runner `./run_all_tests.sh` which completed successfully in this environment (unit, integration, API, JS, and Bandit checks passed); `pre-commit run --all-files` also passed locally.
- Note: During local test runs auxiliary tooling was installed (Playwright/browser binaries, Bandit, etc.) to satisfy the runner; the repo script `./scripts/scan-secrets.py` was not present in the checkout so that one scan command could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8aa422214832f9ee14e0cb441399b)