### PR TITLE
🛡️ fix: bind relay client key in encrypted legacy faucet payload

### DIFF
--- a/client.py
+++ b/client.py
@@ -314,7 +314,14 @@ class ChatClient:
         logger.debug("Retrieved server public key (%d bytes)", len(server_public_key))
 
         if server_public_key:
-            ciphertext_dict, cipherkey, iv = encrypt(json.dumps(self.chat_history).encode('utf-8'), server_public_key)
+            bound_payload = {
+                "chat_history": self.chat_history,
+                "client_public_key": self.public_key_b64,
+            }
+            ciphertext_dict, cipherkey, iv = encrypt(
+                json.dumps(bound_payload).encode('utf-8'),
+                server_public_key,
+            )
             encrypted_chat_history_b64 = base64.b64encode(ciphertext_dict['ciphertext']).decode('utf-8')
             iv_b64 = base64.b64encode(iv).decode('utf-8')
             encrypted_cipherkey_b64 = base64.b64encode(cipherkey).decode('utf-8')

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -684,6 +684,49 @@ class TestRelayClient:
             timeout=relay_client._request_timeout
         )
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_rejects_mismatched_bound_client_key(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """Requests are rejected when encrypted payload key binding mismatches relay key."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "chat_history": [{"role": "user", "content": "hello"}],
+            "client_public_key": "different-client-key",
+        }
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is False
+        mock_post.assert_not_called()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_accepts_matching_bound_client_key(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+        mock_http_response,
+    ):
+        """Requests with matching encrypted key binding are processed normally."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        chat_history = [{"role": "user", "content": "hello"}]
+        mock_crypto_manager.decrypt_message.return_value = {
+            "chat_history": chat_history,
+            "client_public_key": request_data["client_public_key"],
+        }
+        mock_http_response.status_code = 200
+        mock_post.return_value = mock_http_response
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is True
+        mock_model_manager.llama_cpp_get_response.assert_called_once_with(chat_history)
+
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_streaming_posts_to_stream_source(

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -727,6 +727,42 @@ class TestRelayClient:
         assert result is True
         mock_model_manager.llama_cpp_get_response.assert_called_once_with(chat_history)
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_rejects_bound_payload_missing_chat_history(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """Bound payloads without chat_history are rejected."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "client_public_key": request_data["client_public_key"],
+        }
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is False
+        mock_post.assert_not_called()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_rejects_invalid_chat_history_shape(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """Decrypted payloads with invalid chat message shape are rejected."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "chat_history": [{"role": "user", "content": 123}],
+        }
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is False
+        mock_post.assert_not_called()
+
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_streaming_posts_to_stream_source(

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -304,9 +304,14 @@ class CryptoClient:
 
         logger.debug("Sending chat message with %d entries", len(chat_history))
 
+        wrapped_payload = {
+            "chat_history": chat_history,
+            "client_public_key": self.client_public_key_b64,
+        }
+
         # Encrypt the chat history
         try:
-            encrypted_data = self.encrypt_message(chat_history)
+            encrypted_data = self.encrypt_message(wrapped_payload)
         except Exception as e:
             logger.error(
                 "Failed to encrypt message: %s",

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -114,6 +114,27 @@ def log_error(message, *args, exc_info: bool = False) -> None:
     """Log errors only in non-production environments using consistent formatting"""
     _log("error", message, *args, exc_info=exc_info)
 
+
+def _extract_chat_history_and_validate_key_binding(
+    decrypted_payload: Any,
+    relay_client_public_key_b64: str,
+) -> Optional[Any]:
+    """Validate optional encrypted key-binding metadata and return chat history."""
+
+    if isinstance(decrypted_payload, dict):
+        bound_client_key = decrypted_payload.get("client_public_key")
+        if bound_client_key is None:
+            return decrypted_payload.get("chat_history", decrypted_payload)
+        if not isinstance(bound_client_key, str):
+            log_error("Invalid encrypted payload: client_public_key binding must be a string")
+            return None
+        if bound_client_key != relay_client_public_key_b64:
+            log_error("Rejected request: relay client key does not match encrypted key binding")
+            return None
+        return decrypted_payload.get("chat_history")
+
+    return decrypted_payload
+
 class RelayClient:
     """
     Client for communicating with relay servers.
@@ -501,11 +522,17 @@ class RelayClient:
                 return False
 
             log_info("Decrypted client request")
+            chat_history = _extract_chat_history_and_validate_key_binding(
+                decrypted_chat_history,
+                client_pub_key_b64,
+            )
+            if chat_history is None:
+                return False
             client_pub_key = base64.b64decode(client_pub_key_b64)
 
             if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
                 log_info("Processing streaming relay request for session {}", stream_session_id)
-                response_history = self.model_manager.llama_cpp_get_response(decrypted_chat_history)
+                response_history = self.model_manager.llama_cpp_get_response(chat_history)
                 encrypted_response = self.crypto_manager.encrypt_message(response_history, client_pub_key)
                 chunk_payload = {
                     'session_id': stream_session_id,
@@ -536,7 +563,7 @@ class RelayClient:
                 return True
 
             log_info("Getting response from LLM...")
-            response_history = self.model_manager.llama_cpp_get_response(decrypted_chat_history)
+            response_history = self.model_manager.llama_cpp_get_response(chat_history)
             log_info("LLM generated response")
 
             log_info("Encrypting response for client...")

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -117,23 +117,54 @@ def log_error(message, *args, exc_info: bool = False) -> None:
 
 def _extract_chat_history_and_validate_key_binding(
     decrypted_payload: Any,
-    relay_client_public_key_b64: str,
+    expected_client_public_key_b64: str,
 ) -> Optional[Any]:
     """Validate optional encrypted key-binding metadata and return chat history."""
 
+    def _is_valid_chat_history(chat_history: Any) -> bool:
+        if not isinstance(chat_history, list):
+            return False
+
+        for message in chat_history:
+            if not isinstance(message, dict):
+                return False
+            if not isinstance(message.get("role"), str):
+                return False
+            if not isinstance(message.get("content"), str):
+                return False
+
+        return True
+
     if isinstance(decrypted_payload, dict):
         bound_client_key = decrypted_payload.get("client_public_key")
-        if bound_client_key is None:
-            return decrypted_payload.get("chat_history", decrypted_payload)
-        if not isinstance(bound_client_key, str):
-            log_error("Invalid encrypted payload: client_public_key binding must be a string")
-            return None
-        if bound_client_key != relay_client_public_key_b64:
-            log_error("Rejected request: relay client key does not match encrypted key binding")
-            return None
-        return decrypted_payload.get("chat_history")
+        if bound_client_key is not None:
+            if not isinstance(bound_client_key, str):
+                log_error("Invalid encrypted payload: client_public_key binding must be a string")
+                return None
+            if bound_client_key != expected_client_public_key_b64:
+                log_error("Rejected request: relay client key does not match encrypted key binding")
+                return None
+        else:
+            # Legacy clients may still send unbound payloads; continue to accept for compatibility.
+            pass
 
-    return decrypted_payload
+        if "chat_history" not in decrypted_payload:
+            log_error("Invalid encrypted payload: missing chat_history")
+            return None
+
+        chat_history = decrypted_payload.get("chat_history")
+        if not _is_valid_chat_history(chat_history):
+            log_error("Invalid encrypted payload: chat_history must be a list of role/content message objects")
+            return None
+
+        return chat_history
+
+    if _is_valid_chat_history(decrypted_payload):
+        return decrypted_payload
+
+    log_error("Invalid encrypted payload: expected chat_history list or payload containing chat_history")
+    return None
+
 
 class RelayClient:
     """


### PR DESCRIPTION
### Motivation

- The legacy `/faucet` flow trusted relay-supplied public keys for encrypting requests/responses which allowed key-substitution by a malicious relay or MITM and broke end-to-end confidentiality.

### Description

- Bind the client's public key inside the encrypted request payload sent to the relay by wrapping `chat_history` with `client_public_key` before encryption in `client.py` and `utils/crypto_helpers.py`.
- Add `_extract_chat_history_and_validate_key_binding` in `utils/networking/relay_client.py` to validate that the decrypted payload's embedded `client_public_key` matches the relay-provided metadata and reject requests if they differ, and use the validated `chat_history` for LLM calls (including streaming path).
- Add unit tests in `tests/unit/test_relay_client.py` that assert mismatched bindings are rejected and matching bindings are accepted.
- Changes touch `client.py`, `utils/crypto_helpers.py`, `utils/networking/relay_client.py`, and `tests/unit/test_relay_client.py` to implement the protection and coverage.

### Testing

- Ran `npm run lint` which completed successfully.
- Ran the project test runner via `npm run test:ci`, which failed in this execution environment due to missing/incompatible Python test dependencies (Python unit/integration test stages and crypto compatibility tests failed in-container).
- Executed `pytest -q tests/unit/test_relay_client.py` attempts but the local container initially lacked Python test dependencies (`requests`, `playwright`, `psutil`, `dotenv`, etc.), so the Python unit tests could not be executed end-to-end here; the new unit cases were added and are present for CI to run where the full Python test stack is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d64ce6d0832f8c55b89dacb99386)