### PR TITLE
Fix desktop Tauri release compile regression from missing Emitter import

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -66,6 +66,15 @@ jobs:
         # before Tauri's internal beforeBuildCommand hook on clean runners.
         run: npm run build
 
+      - name: Rust compile check (pre-bundle)
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_target }}" ]; then
+            cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.tauri_target }}
+          else
+            cargo check --manifest-path src-tauri/Cargo.toml
+          fi
+
       - name: Build Tauri bundles
         shell: bash
         run: |

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -14,7 +14,7 @@ use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
 #[derive(Default)]


### PR DESCRIPTION
### Motivation
- The release build was failing at Rust compile time with `no method named emit` because the `Emitter` trait was not in scope for new `app.emit(...)` calls, so the desktop release must import the trait and catch similar regressions earlier.

### Description
- Import `tauri::Emitter` alongside `Manager` in `desktop-tauri/src-tauri/src/main.rs` so `app.emit(...)` resolves during compilation.
- Add a minimal pre-bundle `cargo check --manifest-path src-tauri/Cargo.toml` step to `.github/workflows/desktop-release.yml`, using `--target` for macOS arm64 matrix runs, to fail fast on Rust compile errors before bundle creation.

### Testing
- Ran `cargo check --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which failed in this Linux environment due to missing system `glib-2.0` pkg-config libs and not because of the source change.
- Ran `cargo build --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which failed for the same system library reason in this environment.
- Ran `cd desktop-tauri && npm ci` and `cd desktop-tauri && npm run build`, and both completed successfully.
- `pre-commit run --all-files` was attempted but `pre-commit` was not installed in the CI container, so it did not run here.

Files changed: `desktop-tauri/src-tauri/src/main.rs` and `.github/workflows/desktop-release.yml`.
Pre-bundle compile guard: added (`cargo check`) to the Desktop Tauri Release workflow.
Verification commands: `cargo check --manifest-path desktop-tauri/src-tauri/Cargo.toml`, `cargo build --manifest-path desktop-tauri/src-tauri/Cargo.toml`, `cd desktop-tauri && npm ci`, `cd desktop-tauri && npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f2391abc832fbf3a866c13213e27)