### PR TITLE
Fix desktop Tauri compile regression by importing `Emitter` and add `cargo check` guard

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop-tauri/src-tauri -> target
+
       - name: Add macOS arm64 Rust target
         if: matrix.tauri_target != ''
         run: rustup target add ${{ matrix.tauri_target }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -66,6 +66,15 @@ jobs:
         # before Tauri's internal beforeBuildCommand hook on clean runners.
         run: npm run build
 
+      - name: Compile desktop Rust crate
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_target }}" ]; then
+            cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.tauri_target }}
+          else
+            cargo check --manifest-path src-tauri/Cargo.toml
+          fi
+
       - name: Build Tauri bundles
         shell: bash
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -75,9 +75,9 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ matrix.tauri_target }}" ]; then
-            cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.tauri_target }}
+            cargo check --release --manifest-path src-tauri/Cargo.toml --target ${{ matrix.tauri_target }}
           else
-            cargo check --manifest-path src-tauri/Cargo.toml
+            cargo check --release --manifest-path src-tauri/Cargo.toml
           fi
 
       - name: Build Tauri bundles

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -14,7 +14,7 @@ use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
 #[derive(Default)]


### PR DESCRIPTION
### Motivation
- Fix a Rust compile failure (`E0599`) where `app.emit(...)` calls required the `Emitter` trait to be in scope.  
- Prevent the release workflow from proceeding to Tauri bundling when the desktop Rust crate fails to compile by adding a minimal pre-bundle compile check.

### Description
- Import the missing trait by changing `desktop-tauri/src-tauri/src/main.rs` to `use tauri::{Emitter, Manager};` so `app.emit(...)` resolves.  
- Add a `Compile desktop Rust crate` step to `.github/workflows/desktop-release.yml` that runs `cargo check --manifest-path src-tauri/Cargo.toml` (using `--target` for matrix entries that set `tauri_target`).

### Testing
- Ran `cargo check --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which exercised the new check but failed in this Linux container due to a missing system `glib-2.0` dependency unrelated to the change (expected environment limitation).  
- Ran `cargo build --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which hit the same system-library limitation as `cargo check`.  
- Ran `cd desktop-tauri && npm ci`, which completed successfully.  
- Ran `cd desktop-tauri && npm run build`, which completed successfully and verified the frontend build step remains intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f2391abc832fbf3a866c13213e27)