### PR TITLE
🐛 Fix Tauri Python runtime resolution for operator startup

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime::command_for_python_script;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -39,7 +40,7 @@ fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error>
     serde_json::from_str::<Value>(line)
 }
 
-fn build_bridge_command(bridge_path: &str) -> Command {
+fn build_bridge_command(bridge_path: &str) -> anyhow::Result<Command> {
     let path = Path::new(bridge_path);
     let is_python = path
         .extension()
@@ -47,14 +48,10 @@ fn build_bridge_command(bridge_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
-        cmd.arg(bridge_path);
-        return cmd;
+        return command_for_python_script(bridge_path, "TOKEN_PLACE_SIDECAR_PYTHON");
     }
 
-    Command::new(bridge_path)
+    Ok(Command::new(bridge_path))
 }
 
 fn resolve_bridge_script() -> String {
@@ -162,7 +159,8 @@ pub async fn start_compute_node(
     }
 
     let bridge_script = resolve_bridge_script();
-    let spawn_result = build_bridge_command(&bridge_script)
+    let mut bridge_command = build_bridge_command(&bridge_script)?;
+    let spawn_result = bridge_command
         .arg("--model")
         .arg(&request.model_path)
         .arg("--mode")

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -4,8 +4,10 @@ mod config;
 mod forward;
 mod keygen;
 mod logging;
+mod python_runtime;
 mod sidecar;
 
+use crate::python_runtime::resolve_python_command;
 use backend::{detect_backend_for, BackendInfo};
 use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
 use config::{config_path, DesktopConfig};
@@ -80,9 +82,10 @@ fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
 }
 
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
-    let python_bin = std::env::var("TOKEN_PLACE_PYTHON").unwrap_or_else(|_| "python".into());
+    let python_spec = resolve_python_command("TOKEN_PLACE_PYTHON").map_err(|e| e.to_string())?;
     let bridge_script = resolve_model_bridge_script_path()?;
-    let output = Command::new(python_bin)
+    let output = Command::new(python_spec.program)
+        .args(python_spec.args)
         .arg(&bridge_script)
         .arg(action)
         .output()

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,0 +1,121 @@
+use anyhow::Context;
+use std::process::{Command as StdCommand, Stdio};
+use tokio::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonCommandSpec {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+fn python_candidates(env_override: Option<String>, os: &str) -> Vec<PythonCommandSpec> {
+    let mut candidates = Vec::new();
+
+    if let Some(program) = env_override {
+        let trimmed = program.trim();
+        if !trimmed.is_empty() {
+            candidates.push(PythonCommandSpec {
+                program: trimmed.to_string(),
+                args: vec![],
+            });
+        }
+    }
+
+    if os == "windows" {
+        candidates.push(PythonCommandSpec {
+            program: "py".into(),
+            args: vec!["-3".into()],
+        });
+        candidates.push(PythonCommandSpec {
+            program: "python".into(),
+            args: vec![],
+        });
+        candidates.push(PythonCommandSpec {
+            program: "python3".into(),
+            args: vec![],
+        });
+    } else {
+        candidates.push(PythonCommandSpec {
+            program: "python3".into(),
+            args: vec![],
+        });
+        candidates.push(PythonCommandSpec {
+            program: "python".into(),
+            args: vec![],
+        });
+    }
+
+    candidates
+}
+
+fn candidate_is_available(spec: &PythonCommandSpec) -> bool {
+    let mut cmd = StdCommand::new(&spec.program);
+    cmd.args(&spec.args)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd.status().is_ok_and(|status| status.success())
+}
+
+pub fn resolve_python_command(env_var_name: &str) -> anyhow::Result<PythonCommandSpec> {
+    let override_value = std::env::var(env_var_name).ok();
+    let candidates = python_candidates(override_value, std::env::consts::OS);
+    for candidate in candidates {
+        if candidate_is_available(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    anyhow::bail!(
+        "unable to find a working Python 3 runtime; install Python 3 or set {env_var_name} to \
+         a valid interpreter path"
+    )
+}
+
+pub fn command_for_python_script(script_path: &str, env_var_name: &str) -> anyhow::Result<Command> {
+    let spec = resolve_python_command(env_var_name)
+        .with_context(|| format!("failed to resolve Python runtime for script {script_path}"))?;
+    let mut cmd = Command::new(spec.program);
+    cmd.args(spec.args).arg(script_path);
+    Ok(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_candidates_prioritize_py_launcher_then_python_binaries() {
+        let candidates = python_candidates(None, "windows");
+        assert_eq!(
+            candidates,
+            vec![
+                PythonCommandSpec {
+                    program: "py".into(),
+                    args: vec!["-3".into()]
+                },
+                PythonCommandSpec {
+                    program: "python".into(),
+                    args: vec![]
+                },
+                PythonCommandSpec {
+                    program: "python3".into(),
+                    args: vec![]
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn env_override_is_first_candidate() {
+        let candidates = python_candidates(Some("C:/Python312/python.exe".into()), "windows");
+        assert_eq!(
+            candidates.first(),
+            Some(&PythonCommandSpec {
+                program: "C:/Python312/python.exe".into(),
+                args: vec![]
+            })
+        );
+    }
+}

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime::command_for_python_script;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -73,7 +74,7 @@ async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     Ok(())
 }
 
-fn build_sidecar_command(sidecar_path: &str) -> Command {
+fn build_sidecar_command(sidecar_path: &str) -> anyhow::Result<Command> {
     let path = Path::new(sidecar_path);
     let is_python = path
         .extension()
@@ -81,14 +82,10 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
-        cmd.arg(sidecar_path);
-        return cmd;
+        return command_for_python_script(sidecar_path, "TOKEN_PLACE_SIDECAR_PYTHON");
     }
 
-    Command::new(sidecar_path)
+    Ok(Command::new(sidecar_path))
 }
 
 fn resolve_default_sidecar_script() -> String {
@@ -194,7 +191,8 @@ pub async fn start_sidecar(
         }
     });
 
-    let mut child = build_sidecar_command(&sidecar_script)
+    let mut sidecar_command = build_sidecar_command(&sidecar_script)?;
+    let mut child = sidecar_command
         .arg("--model")
         .arg(&request.model_path)
         .arg("--mode")

--- a/outages/2026-04-11-desktop-tauri-python-runtime-resolution.json
+++ b/outages/2026-04-11-desktop-tauri-python-runtime-resolution.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-11",
+  "slug": "desktop-tauri-python-runtime-resolution",
+  "summary": "Desktop Tauri operator startup failed on Windows because Python sidecars were launched with a single hard-coded interpreter name that was not reliably available.",
+  "impact": "Clicking Start operator briefly showed running=true, then the bridge exited and operator registration failed with Python-not-found errors.",
+  "fix": "Introduced a shared Python runtime resolver that validates launchers, prioritizes env overrides, uses OS-specific fallback order (Windows: py -3, python, python3; non-Windows: python3, python), and updated compute-node sidecar, inference sidecar, and model bridge to use it.",
+  "lessons": "All Python subprocess entrypoints must share a single runtime-resolution path and include explicit fallback behavior for Windows launcher differences."
+}

--- a/outages/2026-04-11-desktop-tauri-python-runtime-resolution.md
+++ b/outages/2026-04-11-desktop-tauri-python-runtime-resolution.md
@@ -1,0 +1,41 @@
+# Outage: desktop-tauri operator startup failed when Python launcher was unresolved
+
+- **Date:** 2026-04-11
+- **Slug:** `desktop-tauri-python-runtime-resolution`
+- **Affected area:** desktop Tauri compute-node operator startup (`Start operator`)
+
+## Summary
+On Windows operator workstations, clicking **Start operator** briefly toggled `Running: yes`
+and then immediately returned to `Running: no`. The bridge process exited right away with
+`Python was not found`, leaving operators unable to register with the relay.
+
+## Symptoms
+- `Running` changed to `yes` and then back to `no` within seconds.
+- `Last error` in UI showed bridge exit status (for example, `exit code: 9009`).
+- Command window stderr showed: `Python was not found; run without arguments to install...`.
+
+## Impact
+Desktop operators could not start unless Python command names happened to match local PATH
+configuration, causing startup failures on otherwise valid desktop installs.
+
+## Root cause
+The Tauri host launched Python sidecars using a single hard-coded default command for `.py`
+entrypoints (`python3` in sidecar/compute paths, `python` in model bridge path). On Windows,
+that launcher name is not consistently available and may resolve to app-execution alias stubs that
+exit immediately with "Python was not found".
+
+## Remediation
+- Added shared Python runtime resolution in `src-tauri/src/python_runtime.rs`.
+- Runtime resolver now:
+  - honors explicit env override first (`TOKEN_PLACE_SIDECAR_PYTHON` / `TOKEN_PLACE_PYTHON`),
+  - probes candidate launchers with `--version`,
+  - uses Windows fallback order `py -3`, `python`, `python3`,
+  - uses non-Windows fallback order `python3`, `python`,
+  - returns actionable error text if no working Python 3 runtime is available.
+- Updated **both** operator/inference sidecar launchers and model bridge launcher to use the
+  shared resolver.
+
+## Follow-up / prevention
+- Keep all Python subprocess startup paths centralized in one resolver.
+- Add regression tests for candidate ordering and env override precedence.
+- During release QA on Windows, validate operator start with and without PATH `python` alias.


### PR DESCRIPTION
### Motivation
- Operator and local-inference startup could fail silently on Windows because `.py` entrypoints were launched with hard-coded interpreter names, triggering "Python was not found" and flipping `Running` back to `no` immediately. 
- Centralize and harden Python runtime selection so all Tauri-launched Python subprocesses probe and validate an interpreter before spawning.

### Description
- Add `desktop-tauri/src-tauri/src/python_runtime.rs` which implements a shared Python runtime resolver that honors an env override, probes candidates with `--version`, and uses OS-specific fallback order (Windows: `py -3`, `python`, `python3`; non-Windows: `python3`, `python`).
- Wire the resolver into existing launch paths by updating `compute_node.rs`, `sidecar.rs`, and `main.rs` to build `tokio::process::Command` instances via the resolver and return actionable errors when no suitable runtime is found.
- Make Python-command builders return `anyhow::Result<Command>` and adjust spawn logic to use the resolved command + args.
- Add outage documentation explaining the root cause and remediation at `outages/2026-04-11-desktop-tauri-python-runtime-resolution.{md,json}`.

### Testing
- Ran desktop UI unit tests with `cd desktop-tauri && npm test` and the suite passed.
- Ran the Python unit tests for the desktop sidecar/compute bridge with `pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py -q` and all collected tests passed (29 passed).
- Executed `python3 -m pre_commit run --all-files` which completed but reported existing repo-baseline failures (`codespell` / `vulture`) unrelated to these changes.
- Attempted `cd desktop-tauri/src-tauri && cargo test` but it could not complete in this CI environment due to missing system dev libs for `glib-2.0` (`pkg-config`/`glib-2.0.pc`) so native Tauri tests were not runnable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa6e216c0832f9eb6a67e4aa12401)