### PR TITLE
🐛 fix: harden desktop Python runtime resolution

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime::resolve_python_launcher;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -47,11 +48,9 @@ fn build_bridge_command(bridge_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
-        cmd.arg(bridge_path);
-        return cmd;
+        if let Ok(launcher) = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON") {
+            return launcher.into_command_for_script(bridge_path);
+        }
     }
 
     Command::new(bridge_path)
@@ -162,7 +161,27 @@ pub async fn start_compute_node(
     }
 
     let bridge_script = resolve_bridge_script();
-    let spawn_result = build_bridge_command(&bridge_script)
+    let mut bridge_command = build_bridge_command(&bridge_script);
+    if Path::new(&bridge_script)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
+    {
+        if let Err(err) = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON") {
+            let mut status = state.status.lock().await;
+            *status = ComputeNodeStatus {
+                running: false,
+                registered: false,
+                active_relay_url: request.relay_base_url.clone(),
+                backend_mode: format!("{:?}", request.mode).to_lowercase(),
+                model_path: request.model_path.clone(),
+                last_error: Some(format!("failed to locate Python runtime: {err}")),
+            };
+            anyhow::bail!("failed to locate Python runtime: {err}");
+        }
+    }
+
+    let spawn_result = bridge_command
         .arg("--model")
         .arg(&request.model_path)
         .arg("--mode")

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod forward;
 mod keygen;
 mod logging;
+mod python_runtime;
 mod sidecar;
 
 use backend::{detect_backend_for, BackendInfo};

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,0 +1,109 @@
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct PythonLauncher {
+    pub program: String,
+    pub pre_args: Vec<String>,
+}
+
+impl PythonLauncher {
+    pub fn into_command_for_script(self, script_path: &str) -> Command {
+        let mut cmd = Command::new(self.program);
+        for arg in self.pre_args {
+            cmd.arg(arg);
+        }
+        cmd.arg(script_path);
+        cmd
+    }
+}
+
+fn candidate_launchers() -> Vec<PythonLauncher> {
+    if cfg!(target_os = "windows") {
+        vec![
+            PythonLauncher {
+                program: "py".into(),
+                pre_args: vec!["-3".into()],
+            },
+            PythonLauncher {
+                program: "python".into(),
+                pre_args: Vec::new(),
+            },
+            PythonLauncher {
+                program: "python3".into(),
+                pre_args: Vec::new(),
+            },
+        ]
+    } else {
+        vec![
+            PythonLauncher {
+                program: "python3".into(),
+                pre_args: Vec::new(),
+            },
+            PythonLauncher {
+                program: "python".into(),
+                pre_args: Vec::new(),
+            },
+        ]
+    }
+}
+
+fn launcher_is_usable(launcher: &PythonLauncher) -> bool {
+    let mut cmd = Command::new(&launcher.program);
+    for arg in &launcher.pre_args {
+        cmd.arg(arg);
+    }
+    cmd.arg("--version");
+    cmd.output().is_ok_and(|output| output.status.success())
+}
+
+pub fn resolve_python_launcher(env_var: &str) -> Result<PythonLauncher, String> {
+    if let Ok(configured_python) = std::env::var(env_var) {
+        let launcher = PythonLauncher {
+            program: configured_python,
+            pre_args: Vec::new(),
+        };
+        if launcher_is_usable(&launcher) {
+            return Ok(launcher);
+        }
+
+        return Err(format!(
+            "{env_var} is set but '{}' is not executable or failed '--version'",
+            launcher.program
+        ));
+    }
+
+    for launcher in candidate_launchers() {
+        if launcher_is_usable(&launcher) {
+            return Ok(launcher);
+        }
+    }
+
+    Err(format!(
+        "unable to locate a usable Python 3 interpreter; tried {}",
+        candidate_launchers()
+            .into_iter()
+            .map(|launcher| {
+                if launcher.pre_args.is_empty() {
+                    launcher.program
+                } else {
+                    format!("{} {}", launcher.program, launcher.pre_args.join(" "))
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_env_var_reports_clear_error_when_unusable() {
+        let key = "TOKEN_PLACE_TEST_SIDE_PYTHON";
+        std::env::set_var(key, "__missing_python__");
+        let error = resolve_python_launcher(key).expect_err("expected failed launcher resolution");
+        assert!(error.contains("__missing_python__"));
+        std::env::remove_var(key);
+    }
+}

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime::resolve_python_launcher;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -81,11 +82,9 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
-        cmd.arg(sidecar_path);
-        return cmd;
+        if let Ok(launcher) = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON") {
+            return launcher.into_command_for_script(sidecar_path);
+        }
     }
 
     Command::new(sidecar_path)
@@ -193,6 +192,16 @@ pub async fn start_sidecar(
             resolve_default_sidecar_script()
         }
     });
+
+    if Path::new(&sidecar_script)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
+    {
+        if let Err(err) = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON") {
+            anyhow::bail!("failed to locate Python runtime: {err}");
+        }
+    }
 
     let mut child = build_sidecar_command(&sidecar_script)
         .arg("--model")

--- a/outages/2026-04-11-desktop-operator-python-runtime-resolution.md
+++ b/outages/2026-04-11-desktop-operator-python-runtime-resolution.md
@@ -1,0 +1,42 @@
+# Outage: desktop operator start failed when Python runtime could not be resolved on Windows
+
+- **Date:** 2026-04-11
+- **Slug:** `desktop-operator-python-runtime-resolution`
+- **Affected area:** desktop-tauri compute-node operator startup (`Start operator`)
+
+## Summary
+On Windows desktop environments where `python3` is not available (or where only the Microsoft Store
+execution alias exists), clicking **Start operator** could briefly show `Running: yes` and then
+immediately return to `Running: no`.
+
+The command window displayed `Python was not found`, and the bridge process exited before
+registration.
+
+## Impact
+- Operator startup was unreliable on affected Windows hosts.
+- Users received a transient success state followed by failure.
+- The failure message in app status was less actionable than it could be.
+
+## Root cause
+The desktop compute-node and sidecar launch paths were hardcoded to prefer a Python launcher that
+was not robust across platforms and installation patterns. In affected Windows setups, the selected
+launcher was unavailable/invalid, so the Python bridge terminated at startup.
+
+## Resolution
+Added a shared Python runtime resolver for desktop-tauri:
+
+1. Honors explicit `TOKEN_PLACE_SIDECAR_PYTHON` override.
+2. Validates candidate launchers using `--version` before use.
+3. Uses platform-aware fallback order (`py -3`, `python`, `python3` on Windows; `python3`,
+   `python` elsewhere).
+4. Fails fast with explicit in-app error when no usable interpreter is found, rather than spawning a
+   broken process.
+
+Applied this resolver to both:
+- compute-node bridge startup (`Start operator` flow), and
+- local inference sidecar startup.
+
+## Preventive actions
+- Keep Python runtime selection centralized for all desktop Python child process launches.
+- Preserve fail-fast checks with explicit errors before spawning bridge/sidecar scripts.
+- Maintain unit coverage for interpreter resolution and error reporting behavior.


### PR DESCRIPTION
### Motivation
- The desktop Tauri app could briefly show `Running: yes` and then immediately `Running: no` when clicking `Start operator` because the spawned Python bridge exited with `Python was not found` on some Windows hosts. 
- The root cause was brittle Python launcher selection (hardcoded `python3`/`python`) that did not account for platform launcher variants or unusable execution aliases.

### Description
- Add a centralized Python runtime resolver (`desktop-tauri/src-tauri/src/python_runtime.rs`) that validates candidate launchers with `--version`, honors an explicit `TOKEN_PLACE_SIDECAR_PYTHON` override, and uses a platform-aware fallback order (`py -3`, `python`, `python3` on Windows; `python3`, `python` elsewhere).
- Wire the resolver into compute-node startup (`start_compute_node` / `compute_node.rs`) to fail fast and set a clear `last_error` status if no usable interpreter is found instead of spawning a broken process.
- Apply the same runtime validation to the local inference sidecar startup (`sidecar.rs`) and make `build_*_command` create launcher-backed commands when appropriate.
- Register the new module in the crate (`main.rs`) and add an outages entry documenting symptoms, root cause, mitigation, and preventive actions (`outages/2026-04-11-desktop-operator-python-runtime-resolution.md`).

### Testing
- `npm ci` in `desktop-tauri` completed successfully and `npm run test` in `desktop-tauri` passed (Vitest: `src/App.test.tsx` all tests ✅).
- `cargo fmt --all` completed successfully in `desktop-tauri/src-tauri` (formatting check ✅).
- Attempted `cargo test -p token-place-desktop-tauri` but the container lacks system `glib-2.0` development libraries required by Tauri/GTK build deps so Rust crate tests could not finish (environment limitation ⚠️).
- Ran Python unit test attempts with `pytest` but execution was blocked by missing or incompatible Python dependencies pinned by the project (installed `requests`, `playwright`, `psutil` to unblock some imports, but `pip install -r config/requirements_server.txt` failed due to `numpy==2.3.4` requiring Python ≥3.11, so full Python test runs are blocked in this environment ⚠️).
- `pre-commit run --all-files` was not executed because `pre-commit` is not installed in the current environment (tooling limitation ⚠️).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa6e216c0832f9eb6a67e4aa12401)