### PR TITLE
Fix desktop-tauri Python runtime resolution (avoid Windows App Execution Alias)

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -47,9 +48,9 @@ fn build_bridge_command(bridge_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
+        let runtime = python_runtime::resolve_python_runtime("TOKEN_PLACE_SIDECAR_PYTHON");
+        let mut cmd = Command::new(runtime.program);
+        runtime.apply_to(&mut cmd);
         cmd.arg(bridge_path);
         return cmd;
     }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod forward;
 mod keygen;
 mod logging;
+mod python_runtime;
 mod sidecar;
 
 use backend::{detect_backend_for, BackendInfo};
@@ -80,10 +81,11 @@ fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
 }
 
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
-    let python_bin = std::env::var("TOKEN_PLACE_PYTHON").unwrap_or_else(|_| "python".into());
+    let runtime = python_runtime::resolve_python_runtime("TOKEN_PLACE_PYTHON");
     let bridge_script = resolve_model_bridge_script_path()?;
-    let output = Command::new(python_bin)
-        .arg(&bridge_script)
+    let mut command = Command::new(&runtime.program);
+    command.args(&runtime.prefix_args).arg(&bridge_script);
+    let output = command
         .arg(action)
         .output()
         .map_err(|e| format!("unable to run model bridge: {e}"))?;

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,0 +1,119 @@
+use std::process::{Command, Stdio};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonRuntime {
+    pub program: String,
+    pub prefix_args: Vec<String>,
+}
+
+impl PythonRuntime {
+    pub fn apply_to(&self, command: &mut tokio::process::Command) {
+        command.args(&self.prefix_args);
+    }
+}
+
+fn candidate_commands_for_platform() -> Vec<PythonRuntime> {
+    if cfg!(target_os = "windows") {
+        return vec![
+            PythonRuntime {
+                program: "py".into(),
+                prefix_args: vec!["-3".into()],
+            },
+            PythonRuntime {
+                program: "python".into(),
+                prefix_args: Vec::new(),
+            },
+            PythonRuntime {
+                program: "python3".into(),
+                prefix_args: Vec::new(),
+            },
+        ];
+    }
+
+    vec![
+        PythonRuntime {
+            program: "python3".into(),
+            prefix_args: Vec::new(),
+        },
+        PythonRuntime {
+            program: "python".into(),
+            prefix_args: Vec::new(),
+        },
+        PythonRuntime {
+            program: "py".into(),
+            prefix_args: vec!["-3".into()],
+        },
+    ]
+}
+
+fn can_execute_python(runtime: &PythonRuntime) -> bool {
+    let mut cmd = Command::new(&runtime.program);
+    cmd.args(&runtime.prefix_args)
+        .arg("-c")
+        .arg("import sys; print(sys.version)")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    cmd.status().is_ok_and(|status| status.success())
+}
+
+pub fn resolve_python_runtime(env_var: &str) -> PythonRuntime {
+    if let Ok(explicit) = std::env::var(env_var) {
+        let explicit_runtime = PythonRuntime {
+            program: explicit,
+            prefix_args: Vec::new(),
+        };
+        if can_execute_python(&explicit_runtime) {
+            return explicit_runtime;
+        }
+    }
+
+    for candidate in candidate_commands_for_platform() {
+        if can_execute_python(&candidate) {
+            return candidate;
+        }
+    }
+
+    if cfg!(target_os = "windows") {
+        return PythonRuntime {
+            program: "py".into(),
+            prefix_args: vec!["-3".into()],
+        };
+    }
+
+    PythonRuntime {
+        program: "python3".into(),
+        prefix_args: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_python_runtime_prefers_explicit_when_valid() {
+        let key = "TOKEN_PLACE_TEST_PYTHON_RUNTIME";
+        let known_good = candidate_commands_for_platform()
+            .into_iter()
+            .find(can_execute_python)
+            .expect("expected at least one python runtime during tests");
+
+        unsafe { std::env::set_var(key, &known_good.program) };
+        let runtime = resolve_python_runtime(key);
+        unsafe { std::env::remove_var(key) };
+
+        assert_eq!(runtime.program, known_good.program);
+    }
+
+    #[test]
+    fn resolve_python_runtime_skips_invalid_explicit_binary() {
+        let key = "TOKEN_PLACE_TEST_PYTHON_RUNTIME";
+        unsafe { std::env::set_var(key, "definitely-not-a-real-python-binary") };
+        let runtime = resolve_python_runtime(key);
+        unsafe { std::env::remove_var(key) };
+
+        assert_ne!(runtime.program, "definitely-not-a-real-python-binary");
+    }
+}

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -81,9 +82,9 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
+        let runtime = python_runtime::resolve_python_runtime("TOKEN_PLACE_SIDECAR_PYTHON");
+        let mut cmd = Command::new(runtime.program);
+        runtime.apply_to(&mut cmd);
         cmd.arg(sidecar_path);
         return cmd;
     }

--- a/outages/2026-04-11-desktop-tauri-python-alias-runtime-failure.json
+++ b/outages/2026-04-11-desktop-tauri-python-alias-runtime-failure.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-11",
+  "slug": "desktop-tauri-python-alias-runtime-failure",
+  "summary": "Desktop operator startup on Windows failed when python resolved to the Microsoft Store App Execution Alias shim, causing immediate bridge exit after spawn.",
+  "impact": "Affected desktop users could not keep operator mode running or register compute nodes, with failures surfacing as non-zero bridge exits.",
+  "fix": "Added a shared Python runtime resolver with executable probing and platform-aware fallback order, then wired compute-node bridge, inference sidecar, and model bridge launches through it.",
+  "lessons": "Do not assume python/python3 on PATH is a real interpreter on Windows; probe runtime executability and centralize launcher selection in one shared helper."
+}

--- a/outages/2026-04-11-desktop-tauri-python-alias-runtime-failure.md
+++ b/outages/2026-04-11-desktop-tauri-python-alias-runtime-failure.md
@@ -1,0 +1,46 @@
+# Outage: desktop-tauri operator startup failed on Windows Python alias
+
+- **Date:** 2026-04-11
+- **Slug:** `desktop-tauri-python-alias-runtime-failure`
+- **Affected area:** desktop compute-node operator startup (`desktop-v0.1.0`)
+
+## Summary
+On Windows workstations without a real Python interpreter on PATH, clicking
+**Start operator** in the desktop app briefly showed `Running: yes`, then flipped back to
+`Running: no` with bridge exit code `9009`. The command window showed
+`Python was not found`.
+
+## Symptoms
+- `Start operator` appears to start and then immediately stops.
+- `Last error` reports bridge non-zero exit status.
+- Console shows Microsoft Store alias text:
+  `Python was not found; run without arguments to install from the Microsoft Store...`
+
+## Impact
+Desktop operators could not come online on affected Windows hosts, blocking compute-node
+registration and local operator workflows.
+
+## Root cause
+Python subprocess launching used hardcoded executable names (`python`/`python3`) and
+assumed PATH contained a working interpreter. On Windows, `python.exe` can resolve to an
+App Execution Alias shim that launches the Store prompt and exits with code `9009`.
+The desktop host treated spawn as successful (process started), then the bridge exited
+immediately.
+
+## Remediation
+- Added a shared Python runtime resolver in Tauri Rust code that probes candidates with a
+  lightweight execution check before use.
+- Resolver now prefers:
+  - explicit env override (`TOKEN_PLACE_PYTHON` / `TOKEN_PLACE_SIDECAR_PYTHON`) when valid,
+  - then platform-aware fallbacks (`py -3`, `python`, `python3` on Windows; `python3`,
+    `python`, `py -3` elsewhere).
+- Applied resolver to all desktop Python launch paths:
+  - compute-node bridge
+  - inference sidecar
+  - model bridge helper
+- Added unit coverage for explicit valid runtime and invalid override fallback behavior.
+
+## Follow-up / prevention
+- Keep all desktop Python entrypoints routed through one resolver to avoid drift.
+- Continue probing interpreter executables before long-running bridge startup.
+- Preserve operator smoke tests on Windows hosts where App Execution Aliases are enabled.


### PR DESCRIPTION
### Motivation
- Operator startup could spawn a non-interpreter Windows App Execution Alias for `python` which exited immediately (e.g. code `9009`) and made `Start operator` appear to start then immediately stop with `Python was not found` visible only in the console.
- Desktop Python launches were duplicated and assumed hardcoded binaries, so a single resolver was needed to probe and pick a working interpreter robustly.

### Description
- Added a shared Python runtime resolver in `desktop-tauri/src-tauri/src/python_runtime.rs` that defines `PythonRuntime` and `resolve_python_runtime(env_var)` and probes candidate runtimes with a lightweight `-c 'import sys'` check.
- Wired the resolver into all desktop Python launch paths by updating `compute_node` (`build_bridge_command`), `sidecar` (`build_sidecar_command`), and `main` (`run_model_bridge`) to use the resolved runtime and its prefix args instead of hardcoded `python`/`python3` binaries.
- Added unit tests in `python_runtime.rs` that cover a valid explicit override and skipping an invalid explicit override.
- Documented the investigation and root cause in a new outage entry `outages/2026-04-11-desktop-tauri-python-alias-runtime-failure.{md,json}` explaining symptoms, impact, remediation, and follow-ups.

### Testing
- Ran `cd desktop-tauri && npm test` and the desktop frontend unit tests (`vitest`) passed (1 test file, 3 tests) ✅.
- Attempted `cd desktop-tauri/src-tauri && cargo test` but it failed in the container due to missing system dependency (`glib-2.0` / `pkg-config`), so Rust tests could not be completed here ⚠️.
- `pre-commit` hooks were not executed in this environment because `pre-commit` is not installed, so repository-wide hooks were not run here ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa6e216c0832f9eb6a67e4aa12401)