### PR TITLE
Fix Windows Python launcher resolution for desktop operator and sidecar

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime::resolve_python_launcher;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -39,7 +40,7 @@ fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error>
     serde_json::from_str::<Value>(line)
 }
 
-fn build_bridge_command(bridge_path: &str) -> Command {
+fn build_bridge_command(bridge_path: &str) -> anyhow::Result<Command> {
     let path = Path::new(bridge_path);
     let is_python = path
         .extension()
@@ -47,14 +48,11 @@ fn build_bridge_command(bridge_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
-        cmd.arg(bridge_path);
-        return cmd;
+        let launcher = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON")?;
+        return Ok(launcher.command_for_script(bridge_path));
     }
 
-    Command::new(bridge_path)
+    Ok(Command::new(bridge_path))
 }
 
 fn resolve_bridge_script() -> String {
@@ -162,7 +160,25 @@ pub async fn start_compute_node(
     }
 
     let bridge_script = resolve_bridge_script();
-    let spawn_result = build_bridge_command(&bridge_script)
+    let mut bridge_command = match build_bridge_command(&bridge_script) {
+        Ok(command) => command,
+        Err(err) => {
+            {
+                let mut status = state.status.lock().await;
+                *status = ComputeNodeStatus {
+                    running: false,
+                    registered: false,
+                    active_relay_url: request.relay_base_url.clone(),
+                    backend_mode: format!("{:?}", request.mode).to_lowercase(),
+                    model_path: request.model_path.clone(),
+                    last_error: Some(err.to_string()),
+                };
+            }
+            anyhow::bail!(err);
+        }
+    };
+
+    let spawn_result = bridge_command
         .arg("--model")
         .arg(&request.model_path)
         .arg("--mode")

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -105,6 +105,17 @@ fn resolve_bridge_script() -> String {
     "python/compute_node_bridge.py".into()
 }
 
+fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
+    ComputeNodeStatus {
+        running: false,
+        registered: false,
+        active_relay_url: request.relay_base_url.clone(),
+        backend_mode: format!("{:?}", request.mode).to_lowercase(),
+        model_path: request.model_path.clone(),
+        last_error: Some(last_error),
+    }
+}
+
 fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     if let Some(running) = payload.get("running").and_then(Value::as_bool) {
         status.running = running;
@@ -175,14 +186,7 @@ pub async fn start_compute_node(
                 Err(err) => {
                     {
                         let mut status = state.status.lock().await;
-                        *status = ComputeNodeStatus {
-                            running: false,
-                            registered: false,
-                            active_relay_url: request.relay_base_url.clone(),
-                            backend_mode: format!("{:?}", request.mode).to_lowercase(),
-                            model_path: request.model_path.clone(),
-                            last_error: Some(err.to_string()),
-                        };
+                        *status = startup_failure_status(&request, err.to_string());
                     }
                     return Err(err);
                 }
@@ -191,14 +195,7 @@ pub async fn start_compute_node(
                 let err = anyhow::anyhow!("python launcher resolver task failed: {err}");
                 {
                     let mut status = state.status.lock().await;
-                    *status = ComputeNodeStatus {
-                        running: false,
-                        registered: false,
-                        active_relay_url: request.relay_base_url.clone(),
-                        backend_mode: format!("{:?}", request.mode).to_lowercase(),
-                        model_path: request.model_path.clone(),
-                        last_error: Some(err.to_string()),
-                    };
+                    *status = startup_failure_status(&request, err.to_string());
                 }
                 return Err(err);
             }
@@ -212,14 +209,7 @@ pub async fn start_compute_node(
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = ComputeNodeStatus {
-                    running: false,
-                    registered: false,
-                    active_relay_url: request.relay_base_url.clone(),
-                    backend_mode: format!("{:?}", request.mode).to_lowercase(),
-                    model_path: request.model_path.clone(),
-                    last_error: Some(err.to_string()),
-                };
+                *status = startup_failure_status(&request, err.to_string());
             }
             return Err(err);
         }
@@ -242,14 +232,10 @@ pub async fn start_compute_node(
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = ComputeNodeStatus {
-                    running: false,
-                    registered: false,
-                    active_relay_url: request.relay_base_url.clone(),
-                    backend_mode: format!("{:?}", request.mode).to_lowercase(),
-                    model_path: request.model_path.clone(),
-                    last_error: Some(format!("failed to start compute-node bridge: {err}")),
-                };
+                *status = startup_failure_status(
+                    &request,
+                    format!("failed to start compute-node bridge: {err}"),
+                );
             }
             *state.child.lock().await = None;
             *state.stdin.lock().await = None;
@@ -460,5 +446,27 @@ mod tests {
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[test]
+    fn startup_failure_status_records_resolver_error_and_not_running() {
+        let request = ComputeNodeRequest {
+            model_path: "model.gguf".into(),
+            relay_base_url: "https://relay.example".into(),
+            mode: ComputeMode::Cpu,
+        };
+        let status = startup_failure_status(
+            &request,
+            "no usable Python 3 interpreter found for desktop Python subprocess".into(),
+        );
+
+        assert!(!status.running);
+        assert!(!status.registered);
+        assert_eq!(
+            status.last_error.as_deref(),
+            Some("no usable Python 3 interpreter found for desktop Python subprocess")
+        );
+        assert_eq!(status.active_relay_url, request.relay_base_url);
+        assert_eq!(status.model_path, request.model_path);
     }
 }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,5 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::resolve_python_launcher;
+use crate::python_runtime::{resolve_python_launcher, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -40,19 +40,25 @@ fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error>
     serde_json::from_str::<Value>(line)
 }
 
-fn build_bridge_command(bridge_path: &str) -> anyhow::Result<Command> {
-    let path = Path::new(bridge_path);
-    let is_python = path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
-
-    if is_python {
-        let launcher = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON")?;
+fn build_bridge_command(
+    bridge_path: &str,
+    launcher: Option<PythonLauncher>,
+) -> anyhow::Result<Command> {
+    if is_python_script(bridge_path) {
+        let launcher = launcher.ok_or_else(|| {
+            anyhow::anyhow!("missing resolved Python launcher for compute-node bridge script")
+        })?;
         return Ok(launcher.command_for_script(bridge_path));
     }
 
     Ok(Command::new(bridge_path))
+}
+
+fn is_python_script(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
 fn resolve_bridge_script() -> String {
@@ -160,7 +166,48 @@ pub async fn start_compute_node(
     }
 
     let bridge_script = resolve_bridge_script();
-    let mut bridge_command = match build_bridge_command(&bridge_script) {
+    let launcher = if is_python_script(&bridge_script) {
+        match tokio::task::spawn_blocking(|| resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON"))
+            .await
+        {
+            Ok(result) => match result {
+                Ok(launcher) => Some(launcher),
+                Err(err) => {
+                    {
+                        let mut status = state.status.lock().await;
+                        *status = ComputeNodeStatus {
+                            running: false,
+                            registered: false,
+                            active_relay_url: request.relay_base_url.clone(),
+                            backend_mode: format!("{:?}", request.mode).to_lowercase(),
+                            model_path: request.model_path.clone(),
+                            last_error: Some(err.to_string()),
+                        };
+                    }
+                    return Err(err);
+                }
+            },
+            Err(err) => {
+                let err = anyhow::anyhow!("python launcher resolver task failed: {err}");
+                {
+                    let mut status = state.status.lock().await;
+                    *status = ComputeNodeStatus {
+                        running: false,
+                        registered: false,
+                        active_relay_url: request.relay_base_url.clone(),
+                        backend_mode: format!("{:?}", request.mode).to_lowercase(),
+                        model_path: request.model_path.clone(),
+                        last_error: Some(err.to_string()),
+                    };
+                }
+                return Err(err);
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut bridge_command = match build_bridge_command(&bridge_script, launcher) {
         Ok(command) => command,
         Err(err) => {
             {
@@ -174,7 +221,7 @@ pub async fn start_compute_node(
                     last_error: Some(err.to_string()),
                 };
             }
-            anyhow::bail!(err);
+            return Err(err);
         }
     };
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
@@ -81,10 +80,11 @@ fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
 }
 
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
-    let python_bin = std::env::var("TOKEN_PLACE_PYTHON").unwrap_or_else(|_| "python".into());
+    let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
+        .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path()?;
-    let output = Command::new(python_bin)
-        .arg(&bridge_script)
+    let output = launcher
+        .command_for_script_blocking(bridge_script.to_str().unwrap_or_default())
         .arg(action)
         .output()
         .map_err(|e| format!("unable to run model bridge: {e}"))?;

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod forward;
 mod keygen;
 mod logging;
+mod python_runtime;
 mod sidecar;
 
 use backend::{detect_backend_for, BackendInfo};

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -66,6 +66,15 @@ fn env_python_candidate(var_name: &str) -> Option<PythonLauncher> {
     })
 }
 
+fn python_candidates(var_name: &str) -> Vec<PythonLauncher> {
+    let mut candidates = Vec::new();
+    if let Some(env_candidate) = env_python_candidate(var_name) {
+        candidates.push(env_candidate);
+    }
+    candidates.extend(default_python_candidates());
+    candidates
+}
+
 fn looks_like_windows_store_alias(stderr: &str) -> bool {
     stderr.to_ascii_lowercase().contains("python was not found")
 }
@@ -78,18 +87,19 @@ fn is_python_3_version(stdout: &str, stderr: &str) -> bool {
         .any(|line| line.starts_with("Python 3."))
 }
 
-pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher> {
-    let mut candidates = Vec::new();
-    if let Some(env_candidate) = env_python_candidate(var_name) {
-        candidates.push(env_candidate);
-    }
-    candidates.extend(default_python_candidates());
-
+fn resolve_python_launcher_with_probe<F>(
+    var_name: &str,
+    candidates: Vec<PythonLauncher>,
+    mut probe: F,
+) -> anyhow::Result<PythonLauncher>
+where
+    F: FnMut(&PythonLauncher) -> std::io::Result<std::process::Output>,
+{
     let mut attempts = Vec::new();
 
     for candidate in candidates {
-        let output = candidate.command_for_version_check().output();
-        match output {
+        let probe_result = probe(&candidate);
+        match probe_result {
             Ok(output) => {
                 let stderr = String::from_utf8_lossy(&output.stderr).to_string();
                 let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -127,9 +137,33 @@ pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher>
     )
 }
 
+pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher> {
+    let candidates = python_candidates(var_name);
+    resolve_python_launcher_with_probe(var_name, candidates, |candidate| {
+        candidate.command_for_version_check().output()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+    #[cfg(windows)]
+    use std::os::windows::process::ExitStatusExt;
+    use std::process::ExitStatus;
+
+    fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
+        std::process::Output {
+            status: if success {
+                ExitStatus::from_raw(0)
+            } else {
+                ExitStatus::from_raw(1 << 8)
+            },
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
 
     #[test]
     fn windows_store_alias_detector_matches_expected_message() {
@@ -152,5 +186,126 @@ mod tests {
         assert!(is_python_3_version("Python 3.12.1", ""));
         assert!(is_python_3_version("", "Python 3.11.9"));
         assert!(!is_python_3_version("Python 2.7.18", ""));
+    }
+
+    #[test]
+    fn resolver_prefers_first_working_windows_candidate_order() {
+        let candidates = vec![
+            PythonLauncher {
+                program: "py".into(),
+                args: vec!["-3".into()],
+            },
+            PythonLauncher {
+                program: "python".into(),
+                args: vec![],
+            },
+            PythonLauncher {
+                program: "python3".into(),
+                args: vec![],
+            },
+        ];
+
+        let mut probe_calls = Vec::new();
+        let launcher =
+            resolve_python_launcher_with_probe("TOKEN_PLACE_SIDECAR_PYTHON", candidates, |c| {
+                probe_calls.push(
+                    format!("{} {}", c.program, c.args.join(" "))
+                        .trim()
+                        .to_string(),
+                );
+                Ok(fake_output(true, "Python 3.12.2", ""))
+            })
+            .expect("resolve launcher");
+
+        assert_eq!(launcher.program, "py");
+        assert_eq!(launcher.args, vec!["-3".to_string()]);
+        assert_eq!(probe_calls, vec!["py -3".to_string()]);
+    }
+
+    #[test]
+    fn invalid_env_override_is_reported_when_all_candidates_fail() {
+        let candidates = vec![
+            PythonLauncher {
+                program: "definitely-missing-python".into(),
+                args: vec![],
+            },
+            PythonLauncher {
+                program: "python3".into(),
+                args: vec![],
+            },
+        ];
+
+        let err =
+            resolve_python_launcher_with_probe("TOKEN_PLACE_SIDECAR_PYTHON", candidates, |c| {
+                if c.program == "definitely-missing-python" {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "not found",
+                    ));
+                }
+                Ok(fake_output(false, "", "not executable"))
+            })
+            .expect_err("expected failure");
+
+        let message = err.to_string();
+        assert!(message.contains("TOKEN_PLACE_SIDECAR_PYTHON"));
+        assert!(message.contains("definitely-missing-python"));
+        assert!(message.contains("spawn failed"));
+    }
+
+    #[test]
+    fn windows_store_alias_message_falls_through_to_next_candidate() {
+        let candidates = vec![
+            PythonLauncher {
+                program: "python".into(),
+                args: vec![],
+            },
+            PythonLauncher {
+                program: "python3".into(),
+                args: vec![],
+            },
+        ];
+
+        let launcher = resolve_python_launcher_with_probe("TOKEN_PLACE_SIDECAR_PYTHON", candidates, |c| {
+            if c.program == "python" {
+                return Ok(fake_output(
+                    false,
+                    "",
+                    "Python was not found; run without arguments to install from the Microsoft Store",
+                ));
+            }
+            Ok(fake_output(true, "Python 3.12.2", ""))
+        })
+        .expect("fallback to python3");
+
+        assert_eq!(launcher.program, "python3");
+    }
+
+    #[test]
+    fn final_error_contains_attempted_launcher_details() {
+        let candidates = vec![
+            PythonLauncher {
+                program: "python".into(),
+                args: vec![],
+            },
+            PythonLauncher {
+                program: "python3".into(),
+                args: vec![],
+            },
+        ];
+
+        let err =
+            resolve_python_launcher_with_probe("TOKEN_PLACE_SIDECAR_PYTHON", candidates, |c| {
+                if c.program == "python" {
+                    return Ok(fake_output(true, "Python 2.7.18", ""));
+                }
+                Err(std::io::Error::new(std::io::ErrorKind::NotFound, "missing"))
+            })
+            .expect_err("expected detailed failure");
+
+        let msg = err.to_string();
+        assert!(msg.contains("python  -> status="));
+        assert!(msg.contains("Python 2.7.18"));
+        assert!(msg.contains("python3  -> spawn failed"));
     }
 }

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,0 +1,131 @@
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct PythonLauncher {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl PythonLauncher {
+    fn command_for_version_check(&self) -> Command {
+        let mut cmd = Command::new(&self.program);
+        cmd.args(&self.args);
+        cmd.arg("--version");
+        cmd
+    }
+
+    pub fn command_for_script(&self, script_path: &str) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(&self.program);
+        cmd.args(&self.args);
+        cmd.arg(script_path);
+        cmd
+    }
+}
+
+fn default_python_candidates() -> Vec<PythonLauncher> {
+    if cfg!(target_os = "windows") {
+        return vec![
+            PythonLauncher {
+                program: "py".into(),
+                args: vec!["-3".into()],
+            },
+            PythonLauncher {
+                program: "python".into(),
+                args: vec![],
+            },
+            PythonLauncher {
+                program: "python3".into(),
+                args: vec![],
+            },
+        ];
+    }
+
+    vec![
+        PythonLauncher {
+            program: "python3".into(),
+            args: vec![],
+        },
+        PythonLauncher {
+            program: "python".into(),
+            args: vec![],
+        },
+    ]
+}
+
+fn env_python_candidate(var_name: &str) -> Option<PythonLauncher> {
+    std::env::var(var_name).ok().map(|value| PythonLauncher {
+        program: value,
+        args: vec![],
+    })
+}
+
+fn looks_like_windows_store_alias(stderr: &str) -> bool {
+    stderr.to_ascii_lowercase().contains("python was not found")
+}
+
+pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher> {
+    let mut candidates = Vec::new();
+    if let Some(env_candidate) = env_python_candidate(var_name) {
+        candidates.push(env_candidate);
+    }
+    candidates.extend(default_python_candidates());
+
+    let mut attempts = Vec::new();
+
+    for candidate in candidates {
+        let output = candidate.command_for_version_check().output();
+        match output {
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                if output.status.success() && !looks_like_windows_store_alias(&stderr) {
+                    return Ok(candidate);
+                }
+
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                attempts.push(format!(
+                    "{} {} -> status={} stdout='{}' stderr='{}'",
+                    candidate.program,
+                    candidate.args.join(" "),
+                    output.status,
+                    stdout,
+                    stderr.trim()
+                ));
+            }
+            Err(err) => {
+                attempts.push(format!(
+                    "{} {} -> spawn failed: {}",
+                    candidate.program,
+                    candidate.args.join(" "),
+                    err
+                ));
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "no usable Python 3 interpreter found for desktop sidecar bridge; tried: {}",
+        attempts.join("; ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_store_alias_detector_matches_expected_message() {
+        assert!(looks_like_windows_store_alias(
+            "Python was not found; run without arguments to install from the Microsoft Store"
+        ));
+        assert!(!looks_like_windows_store_alias("Python 3.12.0"));
+    }
+
+    #[test]
+    fn includes_windows_launcher_candidates() {
+        if cfg!(target_os = "windows") {
+            let candidates = default_python_candidates();
+            assert_eq!(candidates[0].program, "py");
+            assert_eq!(candidates[0].args, vec!["-3".to_string()]);
+        }
+    }
+}

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -20,6 +20,13 @@ impl PythonLauncher {
         cmd.arg(script_path);
         cmd
     }
+
+    pub fn command_for_script_blocking(&self, script_path: &str) -> Command {
+        let mut cmd = Command::new(&self.program);
+        cmd.args(&self.args);
+        cmd.arg(script_path);
+        cmd
+    }
 }
 
 fn default_python_candidates() -> Vec<PythonLauncher> {
@@ -63,6 +70,14 @@ fn looks_like_windows_store_alias(stderr: &str) -> bool {
     stderr.to_ascii_lowercase().contains("python was not found")
 }
 
+fn is_python_3_version(stdout: &str, stderr: &str) -> bool {
+    let combined = format!("{stdout}\n{stderr}");
+    combined
+        .lines()
+        .map(str::trim)
+        .any(|line| line.starts_with("Python 3."))
+}
+
 pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher> {
     let mut candidates = Vec::new();
     if let Some(env_candidate) = env_python_candidate(var_name) {
@@ -77,11 +92,14 @@ pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher>
         match output {
             Ok(output) => {
                 let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                if output.status.success() && !looks_like_windows_store_alias(&stderr) {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if output.status.success()
+                    && !looks_like_windows_store_alias(&stderr)
+                    && is_python_3_version(&stdout, &stderr)
+                {
                     return Ok(candidate);
                 }
 
-                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 attempts.push(format!(
                     "{} {} -> status={} stdout='{}' stderr='{}'",
                     candidate.program,
@@ -103,7 +121,8 @@ pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher>
     }
 
     anyhow::bail!(
-        "no usable Python 3 interpreter found for desktop sidecar bridge; tried: {}",
+        "no usable Python 3 interpreter found for desktop Python subprocess (consulted override env var: {}); tried: {}",
+        var_name,
         attempts.join("; ")
     )
 }
@@ -121,11 +140,17 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "windows")]
     fn includes_windows_launcher_candidates() {
-        if cfg!(target_os = "windows") {
-            let candidates = default_python_candidates();
-            assert_eq!(candidates[0].program, "py");
-            assert_eq!(candidates[0].args, vec!["-3".to_string()]);
-        }
+        let candidates = default_python_candidates();
+        assert_eq!(candidates[0].program, "py");
+        assert_eq!(candidates[0].args, vec!["-3".to_string()]);
+    }
+
+    #[test]
+    fn requires_python_3_version() {
+        assert!(is_python_3_version("Python 3.12.1", ""));
+        assert!(is_python_3_version("", "Python 3.11.9"));
+        assert!(!is_python_3_version("Python 2.7.18", ""));
     }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::python_runtime::resolve_python_launcher;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -73,7 +74,7 @@ async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     Ok(())
 }
 
-fn build_sidecar_command(sidecar_path: &str) -> Command {
+fn build_sidecar_command(sidecar_path: &str) -> anyhow::Result<Command> {
     let path = Path::new(sidecar_path);
     let is_python = path
         .extension()
@@ -81,14 +82,11 @@ fn build_sidecar_command(sidecar_path: &str) -> Command {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
 
     if is_python {
-        let python_bin =
-            std::env::var("TOKEN_PLACE_SIDECAR_PYTHON").unwrap_or_else(|_| "python3".into());
-        let mut cmd = Command::new(python_bin);
-        cmd.arg(sidecar_path);
-        return cmd;
+        let launcher = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON")?;
+        return Ok(launcher.command_for_script(sidecar_path));
     }
 
-    Command::new(sidecar_path)
+    Ok(Command::new(sidecar_path))
 }
 
 fn resolve_default_sidecar_script() -> String {
@@ -194,7 +192,9 @@ pub async fn start_sidecar(
         }
     });
 
-    let mut child = build_sidecar_command(&sidecar_script)
+    let mut sidecar_command = build_sidecar_command(&sidecar_script)?;
+
+    let mut child = sidecar_command
         .arg("--model")
         .arg(&request.model_path)
         .arg("--mode")

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,5 +1,5 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::resolve_python_launcher;
+use crate::python_runtime::{resolve_python_launcher, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -74,19 +74,25 @@ async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     Ok(())
 }
 
-fn build_sidecar_command(sidecar_path: &str) -> anyhow::Result<Command> {
-    let path = Path::new(sidecar_path);
-    let is_python = path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
-
-    if is_python {
-        let launcher = resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON")?;
+fn build_sidecar_command(
+    sidecar_path: &str,
+    launcher: Option<PythonLauncher>,
+) -> anyhow::Result<Command> {
+    if is_python_script(sidecar_path) {
+        let launcher = launcher.ok_or_else(|| {
+            anyhow::anyhow!("missing resolved Python launcher for sidecar script")
+        })?;
         return Ok(launcher.command_for_script(sidecar_path));
     }
 
     Ok(Command::new(sidecar_path))
+}
+
+fn is_python_script(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
 fn resolve_default_sidecar_script() -> String {
@@ -192,7 +198,17 @@ pub async fn start_sidecar(
         }
     });
 
-    let mut sidecar_command = build_sidecar_command(&sidecar_script)?;
+    let launcher = if is_python_script(&sidecar_script) {
+        Some(
+            tokio::task::spawn_blocking(|| resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON"))
+                .await
+                .map_err(|e| anyhow::anyhow!("python launcher resolver task failed: {e}"))??,
+        )
+    } else {
+        None
+    };
+
+    let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
 
     let mut child = sidecar_command
         .arg("--model")

--- a/outages/2026-04-11-desktop-tauri-operator-python-launcher-windows.json
+++ b/outages/2026-04-11-desktop-tauri-operator-python-launcher-windows.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-11",
+  "slug": "desktop-tauri-operator-python-launcher-windows",
+  "summary": "Desktop-tauri operator startup failed on affected Windows hosts because Python launcher resolution could select an unusable command (Microsoft Store alias or missing python3), causing immediate bridge exit.",
+  "impact": "Users could not keep the compute-node operator running; the UI briefly showed running=true before resetting and reporting bridge exit.",
+  "fix": "Introduced shared platform-aware Python launcher resolution with validation and fallback (including Windows py -3), rejected known Store-alias failure signatures, and reused the resolver for both compute-node and inference sidecar startups.",
+  "lessons": "Desktop subprocess launchers should be validated before spawn and selected through a single, tested resolver rather than one hard-coded interpreter name."
+}

--- a/outages/2026-04-11-desktop-tauri-operator-python-launcher-windows.md
+++ b/outages/2026-04-11-desktop-tauri-operator-python-launcher-windows.md
@@ -1,0 +1,42 @@
+# Outage: desktop-tauri operator start failed on Windows without a usable Python launcher
+
+- **Date:** 2026-04-11
+- **Slug:** `desktop-tauri-operator-python-launcher-windows`
+- **Affected area:** desktop-tauri `Start operator` flow (`compute_node_bridge.py`)
+
+## Summary
+On Windows hosts where `python` resolves to the Microsoft Store execution alias (or where
+`python3` is not installed), clicking **Start operator** briefly set `Running: yes` and then
+immediately reverted to `Running: no`.
+
+## Symptoms
+- `Running` flips to `yes` and immediately back to `no`.
+- `Registered` stays `no`.
+- Desktop log window shows:
+  `Python was not found; run without arguments to install from the Microsoft Store ...`
+- UI `Last error` reports bridge exit status (`exit code: 9009` on affected Windows systems).
+
+## Impact
+Operator onboarding was blocked for affected Windows users even when the rest of the desktop app
+was functional.
+
+## Root cause
+The Rust host launched Python bridge scripts using a single hard-coded launcher expectation
+(`python3` default or an env override) and did not proactively validate interpreter usability.
+On affected Windows setups, launcher resolution selected an unusable command path that exited
+immediately.
+
+## Remediation
+- Added shared Python launcher resolution with platform-aware fallback candidates.
+  - Windows order: `py -3`, `python`, `python3`.
+  - Non-Windows order: `python3`, `python`.
+- Added active launcher validation (`--version`) before spawning bridge scripts.
+- Added explicit detection of the Windows Store alias failure string and automatic fallback to the
+  next candidate.
+- Wired both operator bridge and local inference sidecar startup through the same robust launcher
+  resolver.
+
+## Follow-up / prevention
+- Keep a single launcher-resolution path for all desktop Python subprocesses.
+- Continue surfacing concrete startup diagnostics in UI and stderr logs.
+- Preserve regression tests around launcher failure signatures and fallback behavior.


### PR DESCRIPTION
### Motivation
- Users clicking `Start operator` on Windows saw `Running` flip to `yes` then immediately back to `no` because the spawned Python process exited instantly (Windows Store alias / missing `python3`).
- The host previously assumed a single interpreter (`python3` or env override) without validating the launcher, producing silent/ambiguous failures and poor UX.
- The goal is to reliably select and validate a usable Python 3 launcher on all platforms and surface actionable errors when none is available.

### Description
- Add a shared Python launcher resolver in `desktop-tauri/src-tauri/src/python_runtime.rs` that probes candidates and rejects known Windows Store alias failures, exposing `resolve_python_launcher` and `PythonLauncher` helpers.
- Wire resolver into both operator and sidecar startup: replace hard-coded interpreter use with the resolver in `compute_node.rs` and `sidecar.rs`, and register the module in `main.rs`.
- Improve startup error handling by validating the launcher before spawn and writing a clear `last_error` into `ComputeNodeStatus` when launcher resolution or spawn fails.
- Document the investigation, root cause, remediation, and follow-up in a new outage entry at `outages/2026-04-11-desktop-tauri-operator-python-launcher-windows.*`.

### Testing
- Ran desktop JS unit tests with `cd desktop-tauri && npm test -- --run`, and those tests passed.
- Attempted Rust tests with `cd desktop-tauri/src-tauri && cargo test`; build progressed but full native test run is blocked in this container until GTK/libsoup system dev packages are present (native crate build failures observed), so Rust tests are not fully green here.
- Ran Python unit/integration tests with `python -m pytest` but several suites failed in this environment due to missing or incompatible Python dependencies (`cryptography`, `numpy==2.3.4` and others); some helper packages (`requests`, `playwright`, `psutil`) were installed during investigation but the full Python test matrix could not be completed here.
- Executed `pre-commit run --all-files`; the hook runner executed but returned failures from pre-existing repo-wide checks (codespell, vulture, run-checks) unrelated to this change.

If you want, I can follow up with a smaller PR that adds a smoke integration test for the launcher resolver and documents the exact system packages required to run `cargo test` in CI (GTK/libsoup/dev packages) and the Python dependency constraints for running `pytest` locally/CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa6e216c0832f9eb6a67e4aa12401)