### PR TITLE
🛠️ Fix Desktop Tauri release rust-toolchain input and add PR-time build coverage

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'desktop-v*'
+  pull_request:
+    paths:
+      - '.github/workflows/desktop-release.yml'
+      - 'desktop-tauri/**'
   workflow_dispatch:
     inputs:
       tag_name:
@@ -53,6 +57,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -158,7 +164,7 @@ jobs:
     name: Publish GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+    if: ${{ github.event_name != 'pull_request' && (github.event_name == 'push' || !inputs.dry_run) }}
     steps:
       - name: Resolve release tag
         id: tag


### PR DESCRIPTION
### Motivation
- The desktop release workflow was failing at the early `Setup Rust` step because the pinned `dtolnay/rust-toolchain` revision requires an explicit `toolchain` input, which was not being provided. 
- Add PR-time coverage so the same build path (`Setup Rust` → `npm ci` → frontend build → `cargo check` → `tauri build`) is exercised on pull requests and similar workflow-input regressions are caught before merge.

### Description
- Pass the required input to the pinned Rust action by adding `with:
  toolchain: stable` to the `dtolnay/rust-toolchain` step in `.github/workflows/desktop-release.yml`.
- Add a `pull_request` trigger scoped to `'.github/workflows/desktop-release.yml'` and `desktop-tauri/**` so PRs exercise the desktop build job without publishing releases. 
- Guard the `publish` job so it does not run on PR events by changing its `if` to `github.event_name != 'pull_request' && (github.event_name == 'push' || !inputs.dry_run)`.
- Scope of change: a single file modified: ` .github/workflows/desktop-release.yml`, reusing the existing build job rather than introducing a separate duplicated workflow.

### Testing
- Ran repository checks with `git grep` to confirm workflow references and locations, and these succeeded. 
- Verified the `git diff` of the modified file and staged commit (`git diff -- .github/workflows/desktop-release.yml` and `git commit`) succeeded. 
- Parsed the updated workflow YAML using Ruby with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/desktop-release.yml')"` which reported `YAML parse ok`. 
- Attempted `actionlint .github/workflows/desktop-release.yml` and `pre-commit run --all-files` but those tools are not installed in the current environment so they could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad94bab54832f8ce2a7b5cef7bf4b)