### PR TITLE
Fix Desktop Tauri Release rust-toolchain input and add PR build coverage

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'desktop-v*'
+  pull_request:
   workflow_dispatch:
     inputs:
       tag_name:
@@ -53,6 +54,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -158,7 +161,7 @@ jobs:
     name: Publish GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
     steps:
       - name: Resolve release tag
         id: tag


### PR DESCRIPTION
### Motivation
- The pinned `dtolnay/rust-toolchain` action revision requires an explicit `toolchain` input and the missing input caused an early `'toolchain' is a required input` failure before any desktop build steps run.
- Add PR-time coverage so this class of workflow wiring regressions is caught before merge without changing tag-driven release semantics.

### Description
- Added a `pull_request` trigger to `.github/workflows/desktop-release.yml` so PRs exercise the same desktop build matrix path (`Setup Rust` → `npm ci` → frontend build → `cargo check` → `tauri build`).
- Updated the `Setup Rust` step to pass `with: toolchain: stable` to the pinned `dtolnay/rust-toolchain` action to satisfy the required input.
- Tightened the `publish` job condition to `if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}` so PR runs do not create or update GitHub Releases.
- All changes are limited to the single file `.github/workflows/desktop-release.yml` and reuse the existing build job rather than creating a separate reusable workflow.

### Testing
- Ran `git grep` checks confirming presence of `pull_request:` and `toolchain: stable` in `.github/workflows/desktop-release.yml`, which succeeded.
- Attempted to run `npx --yes actionlint .github/workflows/desktop-release.yml` but it failed in this environment due to local `npm` execution errors, so full action linting could not be completed here.
- Attempted `pre-commit run --all-files` and a local YAML parse check but both could not run in this container (`pre-commit: command not found` and `ModuleNotFoundError: No module named 'yaml'`), so those automated checks should be validated in CI or a developer environment before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad94bab54832f8ce2a7b5cef7bf4b)