### PR TITLE
fix(ci): add required rust-toolchain input and enable PR checks for desktop release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,6 +1,10 @@
 name: Desktop Tauri Release
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/desktop-release.yml'
+      - 'desktop-tauri/**'
   push:
     tags:
       - 'desktop-v*'
@@ -53,6 +57,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -158,7 +164,7 @@ jobs:
     name: Publish GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
     steps:
       - name: Resolve release tag
         id: tag


### PR DESCRIPTION
### Motivation
- Restore failing Desktop Tauri Release which errored at `Setup Rust` because the pinned `dtolnay/rust-toolchain` commit requires an explicit `toolchain` input (`'toolchain' is a required input`).
- Ensure the same desktop build path (`Setup Rust` / `npm ci` / frontend build / `cargo check` / `tauri build`) is exercised on pull requests so future workflow-wiring regressions are caught before merge.
- Preserve existing tag-driven release semantics while preventing publish steps from running on PRs.

### Description
- Added `with: toolchain: stable` to the `Setup Rust` step in `.github/workflows/desktop-release.yml` to satisfy the pinned action's required input. 
- Added a `pull_request` trigger scoped to `'.github/workflows/desktop-release.yml'` and `desktop-tauri/**` so PRs touching the workflow or desktop code exercise the build matrix without publishing.
- Tightened the `publish` job condition to `if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}` so publishing only occurs for tag pushes or explicit non-dry-run dispatches.
- Only `.github/workflows/desktop-release.yml` was changed and the existing build job was reused (no duplication of build logic).

### Testing
- Confirmed the diff: `git diff --stat` shows a single workflow file modified and local inspection of `.github/workflows/desktop-release.yml` reflects the changes.
- Attempted `pre-commit run --all-files` but `pre-commit` was not available in the execution environment so the hook did not run.
- Ran `npm run lint` (passed) and `npm run test:ci` (failed due to missing Python test dependencies such as `requests` and `cryptography` in the environment), and `actionlint` was not installed so full actionlint validation was skipped; these failures are environment-related and unrelated to the workflow YAML fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad94bab54832f8ce2a7b5cef7bf4b)