### PR TITLE
fix: unblock desktop release publish action

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -191,7 +191,7 @@ jobs:
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a7e09a9927dc4bc7a32c # v2
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
### Motivation
- Fix the Desktop Tauri Release publish step which was failing because the workflow pinned `softprops/action-gh-release` to an invalid/unresolvable commit.

### Description
- Replace `softprops/action-gh-release@c062e08bd532815e2082a7e09a9927dc4bc7a32c` with `softprops/action-gh-release@v2` in `.github/workflows/desktop-release.yml`, leaving tag-push and non-dry-run `workflow_dispatch` gating unchanged.

### Testing
- Ran `git ls-remote --refs --tags https://github.com/softprops/action-gh-release.git v2` and YAML validation via `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-release.yml")'` which both succeeded, and `git diff --stat` confirms a single-line workflow change; `pre-commit run --all-files` could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae119f210832f9a1034941148ea1b)