### PR TITLE
Bundle Python bridge scripts and add packaged-path resolution tests

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -483,10 +483,16 @@ mod tests {
 
     #[test]
     fn bridge_script_candidates_include_packaged_resource_locations() {
-        let exe_path =
-            Path::new("C:\\Users\\danie\\AppData\\Local\\token.place desktop\\token.place.exe");
-        let manifest_dir = Path::new("C:\\repo\\desktop-tauri\\src-tauri");
-        let candidates = bridge_script_candidates(Some(exe_path), manifest_dir);
+        let temp = TempDir::new().expect("tempdir");
+        let app_root = temp.path().join("Token Place.app");
+        let exe_dir = app_root.join("Contents").join("MacOS");
+        let exe_path = exe_dir.join("token.place");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let candidates = bridge_script_candidates(Some(&exe_path), &manifest_dir);
 
         assert!(candidates
             .iter()

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -61,10 +61,13 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_bridge_script() -> String {
+fn bridge_script_candidates(
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = exe_path {
         if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
             candidates.push(
@@ -90,19 +93,27 @@ fn resolve_bridge_script() -> String {
         }
     }
 
-    candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("python")
-            .join("compute_node_bridge.py"),
-    );
+    candidates.push(manifest_dir.join("python").join("compute_node_bridge.py"));
+    candidates
+}
 
-    for candidate in candidates {
-        if candidate.is_file() {
-            return candidate.to_string_lossy().into_owned();
-        }
+fn resolve_bridge_script() -> String {
+    let exe_path = std::env::current_exe().ok();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let candidates = bridge_script_candidates(exe_path.as_deref(), manifest_dir);
+
+    if let Some(path) = first_existing_script(candidates) {
+        return path;
     }
 
     "python/compute_node_bridge.py".into()
+}
+
+fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> {
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
 fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
@@ -399,7 +410,7 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
     use tokio::io::AsyncBufReadExt;
     use tokio::process::Command;
 
@@ -468,5 +479,40 @@ mod tests {
         );
         assert_eq!(status.active_relay_url, request.relay_base_url);
         assert_eq!(status.model_path, request.model_path);
+    }
+
+    #[test]
+    fn bridge_script_candidates_include_packaged_resource_locations() {
+        let exe_path =
+            Path::new("C:\\Users\\danie\\AppData\\Local\\token.place desktop\\token.place.exe");
+        let manifest_dir = Path::new("C:\\repo\\desktop-tauri\\src-tauri");
+        let candidates = bridge_script_candidates(Some(exe_path), manifest_dir);
+
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("resources/python/compute_node_bridge.py")));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("Resources/python/compute_node_bridge.py")));
+        assert_eq!(
+            candidates.last().expect("manifest candidate"),
+            &manifest_dir.join("python").join("compute_node_bridge.py")
+        );
+    }
+
+    #[test]
+    fn first_existing_script_finds_packaged_resource_bridge_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe_dir = temp.path().join("bin");
+        let resources_dir = exe_dir.join("resources").join("python");
+        std::fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let bridge = resources_dir.join("compute_node_bridge.py");
+        std::fs::write(&bridge, "print('ok')\n").expect("write bridge");
+
+        let exe_path = exe_dir.join("token.place.exe");
+        let candidates = bridge_script_candidates(Some(&exe_path), temp.path());
+        let resolved = first_existing_script(candidates).expect("resolved bridge path");
+
+        assert_eq!(Path::new(&resolved), bridge);
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -43,13 +43,29 @@ struct BridgeResponse {
 }
 
 fn find_existing_bridge_script_path() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok();
+    let candidates = model_bridge_script_candidates(
+        current_exe.as_deref(),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+fn model_bridge_script_candidates(exe_path: Option<&Path>, manifest_dir: &Path) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(current_exe) = std::env::current_exe() {
+    if let Some(current_exe) = exe_path {
         if let Some(exe_dir) = current_exe.parent() {
             candidates.push(exe_dir.join("python").join("model_bridge.py"));
             candidates.push(
                 exe_dir
+                    .join("resources")
+                    .join("python")
+                    .join("model_bridge.py"),
+            );
+            candidates.push(
+                exe_dir
+                    .join("..")
                     .join("resources")
                     .join("python")
                     .join("model_bridge.py"),
@@ -64,13 +80,8 @@ fn find_existing_bridge_script_path() -> Option<PathBuf> {
         }
     }
 
-    candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("python")
-            .join("model_bridge.py"),
-    );
-
-    candidates.into_iter().find(|path| path.is_file())
+    candidates.push(manifest_dir.join("python").join("model_bridge.py"));
+    candidates
 }
 
 fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
@@ -312,4 +323,52 @@ pub fn run() {
 
 fn main() {
     run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_bridge_candidates_include_packaged_resources() {
+        let exe_path =
+            Path::new("C:\\Users\\danie\\AppData\\Local\\token.place desktop\\token.place.exe");
+        let manifest_dir = Path::new("C:\\repo\\desktop-tauri\\src-tauri");
+        let candidates = model_bridge_script_candidates(Some(exe_path), manifest_dir);
+
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("resources/python/model_bridge.py")));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("Resources/python/model_bridge.py")));
+        assert_eq!(
+            candidates.last().expect("manifest candidate"),
+            &manifest_dir.join("python").join("model_bridge.py")
+        );
+    }
+
+    #[test]
+    fn tauri_bundle_resources_include_python_bridge_scripts() {
+        let config: serde_json::Value =
+            serde_json::from_str(include_str!("../tauri.conf.json")).expect("parse tauri config");
+        let resources = config
+            .get("bundle")
+            .and_then(|bundle| bundle.get("resources"))
+            .and_then(serde_json::Value::as_array)
+            .expect("bundle.resources array");
+
+        let required = [
+            "python/compute_node_bridge.py",
+            "python/inference_sidecar.py",
+            "python/model_bridge.py",
+        ];
+
+        for script in required {
+            assert!(
+                resources.iter().any(|entry| entry.as_str() == Some(script)),
+                "missing bundled python resource: {script}"
+            );
+        }
+    }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -356,6 +356,25 @@ mod tests {
     }
 
     #[test]
+    fn model_bridge_candidates_select_packaged_resource_path_when_present() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe_dir = temp.path().join("bin");
+        let resources_dir = exe_dir.join("resources").join("python");
+        std::fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let bridge = resources_dir.join("model_bridge.py");
+        std::fs::write(&bridge, "print('ok')\n").expect("write model bridge");
+
+        let exe_path = exe_dir.join("token.place.exe");
+        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path());
+        let resolved = candidates
+            .into_iter()
+            .find(|candidate| candidate.is_file())
+            .expect("resolved bridge path");
+
+        assert_eq!(resolved, bridge);
+    }
+
+    #[test]
     fn tauri_bundle_resources_include_python_bridge_scripts() {
         let config: serde_json::Value =
             serde_json::from_str(include_str!("../tauri.conf.json")).expect("parse tauri config");
@@ -370,6 +389,12 @@ mod tests {
             "python/inference_sidecar.py",
             "python/model_bridge.py",
         ];
+
+        assert_eq!(
+            resources.len(),
+            required.len(),
+            "bundle.resources should only include required python bridge scripts"
+        );
 
         for script in required {
             assert!(

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -328,13 +328,20 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn model_bridge_candidates_include_packaged_resources() {
-        let exe_path =
-            Path::new("C:\\Users\\danie\\AppData\\Local\\token.place desktop\\token.place.exe");
-        let manifest_dir = Path::new("C:\\repo\\desktop-tauri\\src-tauri");
-        let candidates = model_bridge_script_candidates(Some(exe_path), manifest_dir);
+        let temp = TempDir::new().expect("tempdir");
+        let app_root = temp.path().join("Token Place.app");
+        let exe_dir = app_root.join("Contents").join("MacOS");
+        let exe_path = exe_dir.join("token.place");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let candidates = model_bridge_script_candidates(Some(&exe_path), &manifest_dir);
 
         assert!(candidates
             .iter()

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -163,13 +163,18 @@ fn resolve_default_sidecar_script() -> String {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let candidates = default_sidecar_script_candidates(exe_path.as_deref(), manifest_dir);
 
-    for candidate in candidates {
-        if candidate.is_file() {
-            return candidate.to_string_lossy().into_owned();
-        }
+    if let Some(path) = first_existing_script(candidates) {
+        return path;
     }
 
     "../sidecar/fake_llama_sidecar.py".into()
+}
+
+fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> {
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
 fn should_force_fake_sidecar() -> bool {
@@ -346,7 +351,7 @@ pub async fn cancel_sidecar(state: SidecarState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
     use tokio::process::Command;
 
     #[test]
@@ -466,10 +471,16 @@ mod tests {
 
     #[test]
     fn sidecar_candidates_include_packaged_resource_locations() {
-        let exe_path =
-            Path::new("C:\\Users\\danie\\AppData\\Local\\token.place desktop\\token.place.exe");
-        let manifest_dir = Path::new("C:\\repo\\desktop-tauri\\src-tauri");
-        let candidates = default_sidecar_script_candidates(Some(exe_path), manifest_dir);
+        let temp = TempDir::new().expect("tempdir");
+        let app_root = temp.path().join("Token Place.app");
+        let exe_dir = app_root.join("Contents").join("MacOS");
+        let exe_path = exe_dir.join("token.place");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let candidates = default_sidecar_script_candidates(Some(&exe_path), &manifest_dir);
 
         assert!(candidates
             .iter()
@@ -477,9 +488,8 @@ mod tests {
         assert!(candidates
             .iter()
             .any(|candidate| candidate.ends_with("Resources/python/inference_sidecar.py")));
-        assert_eq!(
-            candidates[candidates.len() - 2],
-            manifest_dir.join("python").join("inference_sidecar.py")
-        );
+        assert!(candidates.iter().any(
+            |candidate| candidate == &manifest_dir.join("python").join("inference_sidecar.py")
+        ));
     }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -95,10 +95,13 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_default_sidecar_script() -> String {
+fn default_sidecar_script_candidates(
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = exe_path {
         if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("inference_sidecar.py"));
             candidates.push(
@@ -145,17 +148,20 @@ fn resolve_default_sidecar_script() -> String {
         }
     }
 
+    candidates.push(manifest_dir.join("python").join("inference_sidecar.py"));
     candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("python")
-            .join("inference_sidecar.py"),
-    );
-    candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
+        manifest_dir
             .join("..")
             .join("sidecar")
             .join("fake_llama_sidecar.py"),
     );
+    candidates
+}
+
+fn resolve_default_sidecar_script() -> String {
+    let exe_path = std::env::current_exe().ok();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let candidates = default_sidecar_script_candidates(exe_path.as_deref(), manifest_dir);
 
     for candidate in candidates {
         if candidate.is_file() {
@@ -455,6 +461,25 @@ mod tests {
                 SidecarEvent::Token { text: "ok".into() },
                 SidecarEvent::Done
             ]
+        );
+    }
+
+    #[test]
+    fn sidecar_candidates_include_packaged_resource_locations() {
+        let exe_path =
+            Path::new("C:\\Users\\danie\\AppData\\Local\\token.place desktop\\token.place.exe");
+        let manifest_dir = Path::new("C:\\repo\\desktop-tauri\\src-tauri");
+        let candidates = default_sidecar_script_candidates(Some(exe_path), manifest_dir);
+
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("resources/python/inference_sidecar.py")));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("Resources/python/inference_sidecar.py")));
+        assert_eq!(
+            candidates[candidates.len() - 2],
+            manifest_dir.join("python").join("inference_sidecar.py")
         );
     }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -492,4 +492,20 @@ mod tests {
             |candidate| candidate == &manifest_dir.join("python").join("inference_sidecar.py")
         ));
     }
+
+    #[test]
+    fn first_existing_script_finds_packaged_resource_sidecar_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe_dir = temp.path().join("bin");
+        let resources_dir = exe_dir.join("resources").join("python");
+        std::fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let sidecar = resources_dir.join("inference_sidecar.py");
+        std::fs::write(&sidecar, "print('ok')\n").expect("write sidecar");
+
+        let exe_path = exe_dir.join("token.place.exe");
+        let candidates = default_sidecar_script_candidates(Some(&exe_path), temp.path());
+        let resolved = first_existing_script(candidates).expect("resolved sidecar path");
+
+        assert_eq!(Path::new(&resolved), sidecar);
+    }
 }

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -24,6 +24,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": [
+      "python/compute_node_bridge.py",
+      "python/inference_sidecar.py",
+      "python/model_bridge.py"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
### Motivation
- Packaged desktop builds failed to start the compute-node because the bridge script was resolved under the installed app layout but the Python bridge files were not bundled into the Tauri package, producing "can't open file ... compute_node_bridge.py" errors.
- The intent is to ensure runtime path resolution matches the actual packaged layout on Windows/macOS and to avoid relying on dev-tree-only fallbacks for installed apps.

### Description
- Added `bundle.resources` entries for `python/compute_node_bridge.py`, `python/inference_sidecar.py`, and `python/model_bridge.py` in `desktop-tauri/src-tauri/tauri.conf.json` so the Python bridge scripts are included in packaged builds.
- Refactored candidate construction for bridge script discovery into testable helpers: `bridge_script_candidates` in `desktop-tauri/src-tauri/src/compute_node.rs`, `default_sidecar_script_candidates` in `desktop-tauri/src-tauri/src/sidecar.rs`, and `model_bridge_script_candidates` in `desktop-tauri/src-tauri/src/main.rs`, preserving existing development fallbacks.
- Added `first_existing_script` and used it to centralize the first-existing selection logic to avoid duplicate scanning behavior.
- Added focused regression unit tests that assert packaged-style candidate paths are present and that the Tauri `bundle.resources` includes the required Python scripts.
- Files changed: `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`, and `desktop-tauri/src-tauri/src/main.rs`.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which attempted to run the new unit tests but the container environment lacks the system `glib-2.0` pkg-config dependency so the build failed early with a native dependency error (not a code regression).
- Ran `cd desktop-tauri && npm ci` which completed successfully and `cd desktop-tauri && npm run build` which also completed successfully producing the frontend bundle.
- Attempted `pre-commit run --all-files` but `pre-commit` is not available in the environment and reported `pre-commit: command not found`.

Summary of confirmation for acceptance criteria:
- Confirmed root cause: Python bridge scripts were not declared as bundled resources and therefore were absent from installed app layouts causing the "can't open file ... compute_node_bridge.py" failure.
- Exact files changed: `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`, `desktop-tauri/src-tauri/src/main.rs`.
- Resources added to Tauri bundle: `python/compute_node_bridge.py`, `python/inference_sidecar.py`, `python/model_bridge.py`.
- Tests added: unit tests for `bridge_script_candidates`, `default_sidecar_script_candidates`, `model_bridge_script_candidates`, `first_existing_script` selection, and an assertion that `tauri.conf.json` `bundle.resources` contains the required scripts.
- Exact verification commands used: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, `cd desktop-tauri && npm ci`, and `cd desktop-tauri && npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae5277ef8832fb0a9c94e4dfa13cc)