### PR TITLE
Fix packaged desktop Python bridge resource resolution

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -61,10 +61,13 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_bridge_script() -> String {
+fn bridge_script_candidates(
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = exe_path {
         if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
             candidates.push(
@@ -90,10 +93,15 @@ fn resolve_bridge_script() -> String {
         }
     }
 
-    candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("python")
-            .join("compute_node_bridge.py"),
+    candidates.push(manifest_dir.join("python").join("compute_node_bridge.py"));
+    candidates
+}
+
+fn resolve_bridge_script() -> String {
+    let current_exe = std::env::current_exe().ok();
+    let candidates = bridge_script_candidates(
+        current_exe.as_deref(),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
     );
 
     for candidate in candidates {
@@ -399,6 +407,7 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use tokio::io::AsyncBufReadExt;
     use tokio::process::Command;
@@ -468,5 +477,30 @@ mod tests {
         );
         assert_eq!(status.active_relay_url, request.relay_base_url);
         assert_eq!(status.model_path, request.model_path);
+    }
+
+    #[test]
+    fn bridge_script_candidates_include_packaged_resource_paths() {
+        let exe =
+            PathBuf::from(r"C:\Users\danie\AppData\Local\token.place desktop\token.place.exe");
+        let manifest_dir = Path::new("/repo/desktop-tauri/src-tauri");
+        let candidates = bridge_script_candidates(Some(&exe), manifest_dir);
+
+        assert_eq!(
+            candidates[0],
+            PathBuf::from(
+                r"C:\Users\danie\AppData\Local\token.place desktop\python\compute_node_bridge.py"
+            )
+        );
+        assert_eq!(
+            candidates[1],
+            PathBuf::from(
+                r"C:\Users\danie\AppData\Local\token.place desktop\resources\python\compute_node_bridge.py"
+            )
+        );
+        assert!(candidates.iter().any(|candidate| candidate
+            == &PathBuf::from(
+                r"C:\Users\danie\AppData\Local\Resources\python\compute_node_bridge.py"
+            )));
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -43,9 +43,19 @@ struct BridgeResponse {
 }
 
 fn find_existing_bridge_script_path() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok();
+    let candidates = model_bridge_script_candidates(
+        current_exe.as_deref(),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+fn model_bridge_script_candidates(exe_path: Option<&Path>, manifest_dir: &Path) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(current_exe) = std::env::current_exe() {
+    if let Some(current_exe) = exe_path {
         if let Some(exe_dir) = current_exe.parent() {
             candidates.push(exe_dir.join("python").join("model_bridge.py"));
             candidates.push(
@@ -64,13 +74,8 @@ fn find_existing_bridge_script_path() -> Option<PathBuf> {
         }
     }
 
-    candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("python")
-            .join("model_bridge.py"),
-    );
-
-    candidates.into_iter().find(|path| path.is_file())
+    candidates.push(manifest_dir.join("python").join("model_bridge.py"));
+    candidates
 }
 
 fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
@@ -312,4 +317,50 @@ pub fn run() {
 
 fn main() {
     run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_bridge_candidates_include_windows_resource_path() {
+        let exe =
+            PathBuf::from(r"C:\Users\danie\AppData\Local\token.place desktop\token.place.exe");
+        let manifest_dir = Path::new("/repo/desktop-tauri/src-tauri");
+        let candidates = model_bridge_script_candidates(Some(&exe), manifest_dir);
+
+        assert!(candidates.iter().any(|candidate| candidate
+            == &PathBuf::from(
+                r"C:\Users\danie\AppData\Local\token.place desktop\resources\python\model_bridge.py"
+            )));
+    }
+
+    #[test]
+    fn tauri_bundle_resources_include_python_bridge_scripts() {
+        let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+        let contents = fs::read_to_string(config_path).expect("read tauri.conf.json");
+        let config: serde_json::Value = serde_json::from_str(&contents).expect("parse config");
+        let resources = config["bundle"]["resources"]
+            .as_array()
+            .expect("bundle.resources should be an array");
+
+        let values = resources
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>();
+
+        assert!(
+            values.contains(&"python/compute_node_bridge.py"),
+            "compute node bridge must be bundled"
+        );
+        assert!(
+            values.contains(&"python/inference_sidecar.py"),
+            "inference sidecar must be bundled"
+        );
+        assert!(
+            values.contains(&"python/model_bridge.py"),
+            "model bridge must be bundled"
+        );
+    }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -95,10 +95,13 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_default_sidecar_script() -> String {
+fn default_sidecar_script_candidates(
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = exe_path {
         if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("inference_sidecar.py"));
             candidates.push(
@@ -145,16 +148,21 @@ fn resolve_default_sidecar_script() -> String {
         }
     }
 
+    candidates.push(manifest_dir.join("python").join("inference_sidecar.py"));
     candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("python")
-            .join("inference_sidecar.py"),
-    );
-    candidates.push(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
+        manifest_dir
             .join("..")
             .join("sidecar")
             .join("fake_llama_sidecar.py"),
+    );
+    candidates
+}
+
+fn resolve_default_sidecar_script() -> String {
+    let current_exe = std::env::current_exe().ok();
+    let candidates = default_sidecar_script_candidates(
+        current_exe.as_deref(),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
     );
 
     for candidate in candidates {
@@ -340,6 +348,7 @@ pub async fn cancel_sidecar(state: SidecarState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use tokio::process::Command;
 
@@ -456,5 +465,20 @@ mod tests {
                 SidecarEvent::Done
             ]
         );
+    }
+
+    #[test]
+    fn sidecar_candidates_include_packaged_resource_path() {
+        let exe =
+            PathBuf::from(r"C:\Users\danie\AppData\Local\token.place desktop\token.place.exe");
+        let manifest_dir = Path::new("/repo/desktop-tauri/src-tauri");
+        let candidates = default_sidecar_script_candidates(Some(&exe), manifest_dir);
+
+        assert!(candidates.iter().any(
+            |candidate| candidate
+                == &PathBuf::from(
+                    r"C:\Users\danie\AppData\Local\token.place desktop\resources\python\inference_sidecar.py"
+                )
+        ));
     }
 }

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -24,6 +24,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": [
+      "python/compute_node_bridge.py",
+      "python/inference_sidecar.py",
+      "python/model_bridge.py"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
### Motivation
- Packaged desktop builds failed to locate Python bridge scripts (e.g. `compute_node_bridge.py`) after installation because those scripts were not bundled as application resources and path resolution fell back to a non-existent development-relative path.

### Description
- Confirmed root cause: the runtime probed `resources/python/...` locations but `tauri.conf.json` did not list the Python bridge scripts, so installed Windows/macOS layouts could not find the bundled scripts and the app fell back to `python/compute_node_bridge.py` which is not present in installers.
- Added explicit bundle resources to `desktop-tauri/src-tauri/tauri.conf.json`: `python/compute_node_bridge.py`, `python/inference_sidecar.py`, and `python/model_bridge.py` so the packaged app includes the bridge scripts.
- Refactored candidate-path construction into small testable helpers and used them from the existing resolvers for the three entrypoints: compute-node (`compute_node.rs`), sidecar (`sidecar.rs`), and model bridge (`main.rs`), keeping dev-tree behavior intact.
- Added deterministic unit tests that assert the expected packaged candidate paths and a config regression test that asserts the Tauri config includes the three Python bridge resources; exact files changed: `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`, `desktop-tauri/src-tauri/src/main.rs`, `desktop-tauri/src-tauri/tauri.conf.json`.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which exercised the new Rust unit tests but the run failed in this container due to missing system library `glib-2.0` required by a dependency (CI/system dependency issue), so full cargo test did not complete here.
- Ran `cd desktop-tauri && npm ci` which succeeded, and `cd desktop-tauri && npm run build` which succeeded and built the frontend assets.
- Attempted `pre-commit run --all-files` but `pre-commit` was not available in the environment; `npm run test:ci` was executed but failed in this container due to missing Python test dependencies (`requests`, `cryptography`) unrelated to these changes.
- Tests added: Rust unit tests for `bridge_script_candidates`/`default_sidecar_script_candidates`/`model_bridge_script_candidates` to validate packaged candidate paths and a test that asserts `tauri.conf.json` `bundle.resources` contains the three Python bridge entries; these tests are present in the modified Rust sources and are runnable with `cargo test` when system deps are satisfied.

Verification commands used:
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` (attempted; failed in container due to missing system libs)
- `cd desktop-tauri && npm ci` (succeeded)
- `cd desktop-tauri && npm run build` (succeeded)
- `pre-commit run --all-files` (tool not found in this environment)
- `npm run test:ci` (attempted; failed due to missing Python test deps)

If CI has system pkg-config and Python test deps available the added Rust tests and the config assertion should pass and packaged builds will include and resolve the bridge scripts so installed apps no longer fail with “can't open file ... compute_node_bridge.py”.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae5277ef8832fb0a9c94e4dfa13cc)