### PR TITLE
Bundle desktop Python bridge scripts and prefer packaged resource paths

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -61,18 +61,13 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_bridge_script() -> String {
+fn bridge_script_candidates(current_exe: Option<&Path>) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = current_exe {
         if let Some(exe_dir) = exe_path.parent() {
+            candidates.push(exe_dir.join("resources").join("python").join("compute_node_bridge.py"));
             candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
-            candidates.push(
-                exe_dir
-                    .join("resources")
-                    .join("python")
-                    .join("compute_node_bridge.py"),
-            );
             if let Some(parent_dir) = exe_dir.parent() {
                 candidates.push(
                     parent_dir
@@ -96,7 +91,11 @@ fn resolve_bridge_script() -> String {
             .join("compute_node_bridge.py"),
     );
 
-    for candidate in candidates {
+    candidates
+}
+
+fn resolve_bridge_script() -> String {
+    for candidate in bridge_script_candidates(std::env::current_exe().ok().as_deref()) {
         if candidate.is_file() {
             return candidate.to_string_lossy().into_owned();
         }
@@ -399,6 +398,8 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use tokio::io::AsyncBufReadExt;
     use tokio::process::Command;
@@ -468,5 +469,54 @@ mod tests {
         );
         assert_eq!(status.active_relay_url, request.relay_base_url);
         assert_eq!(status.model_path, request.model_path);
+    }
+
+    #[test]
+    fn bridge_script_candidates_include_packaged_and_dev_paths() {
+        let exe = Path::new(r"C:\Users\tester\AppData\Local\token.place desktop\token.place desktop.exe");
+        let candidates = bridge_script_candidates(Some(exe));
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from(
+                    r"C:\Users\tester\AppData\Local\token.place desktop\resources\python\compute_node_bridge.py",
+                ),
+                PathBuf::from(
+                    r"C:\Users\tester\AppData\Local\token.place desktop\python\compute_node_bridge.py",
+                ),
+                PathBuf::from(
+                    r"C:\Users\tester\AppData\Local\Resources\python\compute_node_bridge.py",
+                ),
+                PathBuf::from(
+                    r"C:\Users\tester\AppData\Local\resources\python\compute_node_bridge.py",
+                ),
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("python")
+                    .join("compute_node_bridge.py"),
+            ]
+        );
+    }
+
+    #[test]
+    fn tauri_bundle_resources_include_python_bridges() {
+        let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+        let raw = std::fs::read_to_string(config_path).expect("read tauri.conf.json");
+        let parsed: Value = serde_json::from_str(&raw).expect("parse tauri.conf.json");
+
+        let resources = parsed
+            .get("bundle")
+            .and_then(|bundle| bundle.get("resources"))
+            .and_then(Value::as_array)
+            .expect("bundle.resources array");
+
+        let resource_values = resources
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+
+        assert!(resource_values.contains(&"python/compute_node_bridge.py"));
+        assert!(resource_values.contains(&"python/inference_sidecar.py"));
+        assert!(resource_values.contains(&"python/model_bridge.py"));
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -43,21 +43,34 @@ struct BridgeResponse {
 }
 
 fn find_existing_bridge_script_path() -> Option<PathBuf> {
+    model_bridge_script_candidates(std::env::current_exe().ok().as_deref())
+        .into_iter()
+        .find(|path| path.is_file())
+}
+
+fn model_bridge_script_candidates(current_exe: Option<&Path>) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(current_exe) = std::env::current_exe() {
+    if let Some(current_exe) = current_exe {
         if let Some(exe_dir) = current_exe.parent() {
-            candidates.push(exe_dir.join("python").join("model_bridge.py"));
             candidates.push(
                 exe_dir
                     .join("resources")
                     .join("python")
                     .join("model_bridge.py"),
             );
+            candidates.push(exe_dir.join("python").join("model_bridge.py"));
             candidates.push(
                 exe_dir
                     .join("..")
                     .join("Resources")
+                    .join("python")
+                    .join("model_bridge.py"),
+            );
+            candidates.push(
+                exe_dir
+                    .join("..")
+                    .join("resources")
                     .join("python")
                     .join("model_bridge.py"),
             );
@@ -70,7 +83,7 @@ fn find_existing_bridge_script_path() -> Option<PathBuf> {
             .join("model_bridge.py"),
     );
 
-    candidates.into_iter().find(|path| path.is_file())
+    candidates
 }
 
 fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
@@ -312,4 +325,23 @@ pub fn run() {
 
 fn main() {
     run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_bridge_candidates_include_packaged_resource_path() {
+        let exe = Path::new(
+            r"C:\Users\tester\AppData\Local\token.place desktop\token.place desktop.exe",
+        );
+        let candidates = model_bridge_script_candidates(Some(exe));
+        assert_eq!(
+            candidates[0],
+            PathBuf::from(
+                r"C:\Users\tester\AppData\Local\token.place desktop\resources\python\model_bridge.py",
+            )
+        );
+    }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -95,18 +95,18 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_default_sidecar_script() -> String {
+fn default_sidecar_script_candidates(current_exe: Option<&Path>) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = current_exe {
         if let Some(exe_dir) = exe_path.parent() {
-            candidates.push(exe_dir.join("python").join("inference_sidecar.py"));
             candidates.push(
                 exe_dir
                     .join("resources")
                     .join("python")
                     .join("inference_sidecar.py"),
             );
+            candidates.push(exe_dir.join("python").join("inference_sidecar.py"));
             candidates.push(
                 exe_dir
                     .join("resources")
@@ -157,7 +157,11 @@ fn resolve_default_sidecar_script() -> String {
             .join("fake_llama_sidecar.py"),
     );
 
-    for candidate in candidates {
+    candidates
+}
+
+fn resolve_default_sidecar_script() -> String {
+    for candidate in default_sidecar_script_candidates(std::env::current_exe().ok().as_deref()) {
         if candidate.is_file() {
             return candidate.to_string_lossy().into_owned();
         }
@@ -340,6 +344,7 @@ pub async fn cancel_sidecar(state: SidecarState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use tokio::process::Command;
 
@@ -455,6 +460,21 @@ mod tests {
                 SidecarEvent::Token { text: "ok".into() },
                 SidecarEvent::Done
             ]
+        );
+    }
+
+    #[test]
+    fn default_sidecar_candidates_include_packaged_resource_path() {
+        let exe = Path::new(
+            r"C:\Users\tester\AppData\Local\token.place desktop\token.place desktop.exe",
+        );
+        let candidates = default_sidecar_script_candidates(Some(exe));
+
+        assert_eq!(
+            candidates[0],
+            PathBuf::from(
+                r"C:\Users\tester\AppData\Local\token.place desktop\resources\python\inference_sidecar.py"
+            )
         );
     }
 }

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -24,6 +24,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": [
+      "python/compute_node_bridge.py",
+      "python/inference_sidecar.py",
+      "python/model_bridge.py"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
### Motivation
- Packaged Windows installs failed to start the operator because the app resolved `compute_node_bridge.py` at runtime but the script was not included in the Tauri bundle, causing a "can't open file ... compute_node_bridge.py" error.
- The runtime path resolution relied on development-tree fallbacks and did not prioritize bundled app resource locations, making packaged apps unable to find Python bridge entrypoints.

### Description
- Add Tauri bundle resources so packaged apps include the Python bridge scripts: `python/compute_node_bridge.py`, `python/inference_sidecar.py`, and `python/model_bridge.py` by updating `desktop-tauri/src-tauri/tauri.conf.json`.
- Replace inline path probing with small, testable candidate-list helpers and prefer `resources/python/...` packaged locations before the development-tree fallback in the compute-node, sidecar, and model-bridge code paths (`desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`, `desktop-tauri/src-tauri/src/main.rs`).
- Add focused unit tests that assert the candidate lists include packaged `resources/python/...` entries and a test that asserts the Tauri `bundle.resources` array contains the required Python bridge scripts (tests live under the existing Rust test modules in the three files above).
- Files changed: `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`, `desktop-tauri/src-tauri/src/main.rs`.

### Testing
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`; build/test run could not complete in this environment due to missing system desktop libs required for some crates (pkg-config / `glib` / `gdk` / `libsoup` variants), so full Rust test execution failed here (see logs).]
- Ran `cd desktop-tauri && npm ci` and `cd desktop-tauri && npm run build`, both succeeded in this environment.
- Ran the repository test runner (`npm run test:ci`) and `pre-commit run --all-files`; these failed here due to missing Python test dependencies (`requests`, `cryptography`) and `pre-commit` not being installed in the container, not due to the change itself.

Final summary (acceptance checklist):
- Confirmed root cause: Python bridge scripts were not declared as bundled resources in `tauri.conf.json`, so packaged installs could not locate them at runtime.
- Exact files changed: `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`, `desktop-tauri/src-tauri/src/main.rs`.
- Resources added to Tauri bundle config: `python/compute_node_bridge.py`, `python/inference_sidecar.py`, `python/model_bridge.py`.
- Tests added: unit tests covering candidate path construction for compute-node/sidecar/model-bridge, and a test asserting `bundle.resources` contains the three Python bridge scripts (added to the Rust test modules in the modified files).
- Exact verification commands run in this environment: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, `cd desktop-tauri && npm ci`, `cd desktop-tauri && npm run build`, `npm run lint`, `npm run test:ci`, and `pre-commit run --all-files` (see notes above about environment failures).

If you want, I can (1) update packaging docs with a short verification note for building installers, or (2) run the Rust unit tests in a CI runner that has the desktop native deps installed so the new tests can be fully validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae5277ef8832fb0a9c94e4dfa13cc)