### PR TITLE
🐛 fix: bundle packaged desktop Python bridge scripts

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -61,10 +61,10 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_bridge_script() -> String {
+fn bridge_script_candidates(current_exe: Option<&Path>) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = current_exe {
         if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
             candidates.push(
@@ -96,13 +96,20 @@ fn resolve_bridge_script() -> String {
             .join("compute_node_bridge.py"),
     );
 
-    for candidate in candidates {
-        if candidate.is_file() {
-            return candidate.to_string_lossy().into_owned();
-        }
-    }
+    candidates
+}
 
-    "python/compute_node_bridge.py".into()
+fn first_existing_candidate(candidates: &[std::path::PathBuf]) -> Option<String> {
+    candidates
+        .iter()
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned())
+}
+
+fn resolve_bridge_script() -> String {
+    let current_exe = std::env::current_exe().ok();
+    let candidates = bridge_script_candidates(current_exe.as_deref());
+    first_existing_candidate(&candidates).unwrap_or_else(|| "python/compute_node_bridge.py".into())
 }
 
 fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
@@ -399,6 +406,9 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
     use tempfile::NamedTempFile;
     use tokio::io::AsyncBufReadExt;
     use tokio::process::Command;
@@ -468,5 +478,50 @@ mod tests {
         );
         assert_eq!(status.active_relay_url, request.relay_base_url);
         assert_eq!(status.model_path, request.model_path);
+    }
+
+    #[test]
+    fn bridge_script_candidates_include_packaged_layouts() {
+        let candidates = bridge_script_candidates(Some(Path::new(
+            "C:/Program Files/token.place desktop/token.place desktop.exe",
+        )));
+        let candidate_strings: Vec<String> = candidates
+            .iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert!(candidate_strings
+            .iter()
+            .any(|path| path.ends_with("/resources/python/compute_node_bridge.py")));
+        assert!(candidate_strings
+            .iter()
+            .any(|path| path.ends_with("/Resources/python/compute_node_bridge.py")));
+    }
+
+    #[test]
+    fn first_existing_candidate_uses_packaged_resources_bridge() {
+        let temp = tempdir().expect("tempdir");
+        let exe = temp.path().join("token.place desktop.exe");
+        let resources_dir = temp.path().join("resources").join("python");
+        std::fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let packaged_bridge = resources_dir.join("compute_node_bridge.py");
+        std::fs::write(&packaged_bridge, "print('ok')").expect("write bridge");
+
+        let candidates = bridge_script_candidates(Some(&exe));
+        let selected = first_existing_candidate(&candidates).expect("select path");
+        assert_eq!(PathBuf::from(selected), packaged_bridge);
+    }
+
+    #[test]
+    fn tauri_bundle_resources_include_python_bridge_scripts() {
+        let config: Value = serde_json::from_str(include_str!("../tauri.conf.json")).expect("json");
+        let resources = config
+            .get("bundle")
+            .and_then(|bundle| bundle.get("resources"))
+            .and_then(Value::as_array)
+            .expect("bundle.resources array");
+        let resource_values: Vec<&str> = resources.iter().filter_map(Value::as_str).collect();
+        assert!(resource_values.contains(&"python/compute_node_bridge.py"));
+        assert!(resource_values.contains(&"python/inference_sidecar.py"));
+        assert!(resource_values.contains(&"python/model_bridge.py"));
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -43,10 +43,17 @@ struct BridgeResponse {
 }
 
 fn find_existing_bridge_script_path() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok();
+    model_bridge_script_candidates(current_exe.as_deref())
+        .into_iter()
+        .find(|path| path.is_file())
+}
+
+fn model_bridge_script_candidates(current_exe: Option<&Path>) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(exe_dir) = current_exe.parent() {
+    if let Some(exe_path) = current_exe {
+        if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("model_bridge.py"));
             candidates.push(
                 exe_dir
@@ -70,7 +77,7 @@ fn find_existing_bridge_script_path() -> Option<PathBuf> {
             .join("model_bridge.py"),
     );
 
-    candidates.into_iter().find(|path| path.is_file())
+    candidates
 }
 
 fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
@@ -312,4 +319,27 @@ pub fn run() {
 
 fn main() {
     run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::model_bridge_script_candidates;
+    use std::path::Path;
+
+    #[test]
+    fn model_bridge_candidates_include_packaged_layouts() {
+        let candidates = model_bridge_script_candidates(Some(Path::new(
+            "C:/Program Files/token.place desktop/token.place desktop.exe",
+        )));
+        let candidate_strings: Vec<String> = candidates
+            .iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert!(candidate_strings
+            .iter()
+            .any(|path| path.ends_with("/resources/python/model_bridge.py")));
+        assert!(candidate_strings
+            .iter()
+            .any(|path| path.ends_with("/Resources/python/model_bridge.py")));
+    }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -95,10 +95,10 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
-fn resolve_default_sidecar_script() -> String {
+fn sidecar_script_candidates(current_exe: Option<&Path>) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
 
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = current_exe {
         if let Some(exe_dir) = exe_path.parent() {
             candidates.push(exe_dir.join("python").join("inference_sidecar.py"));
             candidates.push(
@@ -156,6 +156,13 @@ fn resolve_default_sidecar_script() -> String {
             .join("sidecar")
             .join("fake_llama_sidecar.py"),
     );
+
+    candidates
+}
+
+fn resolve_default_sidecar_script() -> String {
+    let current_exe = std::env::current_exe().ok();
+    let candidates = sidecar_script_candidates(current_exe.as_deref());
 
     for candidate in candidates {
         if candidate.is_file() {
@@ -456,5 +463,22 @@ mod tests {
                 SidecarEvent::Done
             ]
         );
+    }
+
+    #[test]
+    fn sidecar_script_candidates_include_packaged_layouts() {
+        let candidates = sidecar_script_candidates(Some(Path::new(
+            "C:/Program Files/token.place desktop/token.place desktop.exe",
+        )));
+        let candidate_strings: Vec<String> = candidates
+            .iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert!(candidate_strings
+            .iter()
+            .any(|path| path.ends_with("/resources/python/inference_sidecar.py")));
+        assert!(candidate_strings
+            .iter()
+            .any(|path| path.ends_with("/Resources/python/inference_sidecar.py")));
     }
 }

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -24,6 +24,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": [
+      "python/compute_node_bridge.py",
+      "python/inference_sidecar.py",
+      "python/model_bridge.py"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
### Motivation
- Packaged desktop builds failed to locate `compute_node_bridge.py` because `tauri.conf.json` did not include the Python bridge scripts as bundled resources, forcing a non-existent development-relative fallback.
- The change ensures all desktop Python entrypoints used at runtime are discoverable in installed app layouts on Windows and macOS while preserving development-tree behavior.

### Description
- Add `bundle.resources` entries in `desktop-tauri/src-tauri/tauri.conf.json` for `python/compute_node_bridge.py`, `python/inference_sidecar.py`, and `python/model_bridge.py` so the scripts are included in packaged builds.
- Make path-resolution testable by extracting candidate builders and lookup helpers: `bridge_script_candidates` + `first_existing_candidate` in `desktop-tauri/src-tauri/src/compute_node.rs`.
- Apply the same candidate-helper pattern for the other entrypoints: `sidecar_script_candidates` in `desktop-tauri/src-tauri/src/sidecar.rs` and `model_bridge_script_candidates` in `desktop-tauri/src-tauri/src/main.rs`.
- Add focused unit tests that assert packaged candidate paths include installed-app layouts and that a packaged `resources/python/...` file is selected, and add a test that verifies the Tauri `bundle.resources` array contains the three Python scripts; changes are limited to `compute_node.rs`, `sidecar.rs`, `main.rs`, and `tauri.conf.json`.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which attempted to run unit tests but the run failed in this environment due to a missing system dependency (`glib-2.0` / `pkg-config`), so platform-specific build deps blocked full test completion.
- Ran `cd desktop-tauri && npm ci`, which completed successfully.
- Ran `cd desktop-tauri && npm run build`, which completed successfully and produced a frontend `dist` build.
- Ran `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which completed successfully; `pre-commit run --all-files` was not available in the environment (`pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae5277ef8832fb0a9c94e4dfa13cc)