### PR TITLE
Fix packaged desktop Python imports and add operator-start e2e CI

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -1,0 +1,73 @@
+name: Desktop Operator E2E
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/desktop-operator-e2e.yml'
+      - 'desktop-tauri/**'
+      - 'relay.py'
+      - 'utils/**'
+      - 'config.py'
+
+jobs:
+  operator-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: desktop-tauri/package-lock.json
+
+      - name: Install desktop dependencies
+        working-directory: desktop-tauri
+        run: npm ci
+
+      - name: Start local relay
+        run: |
+          python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm > relay.log 2>&1 &
+          echo $! > relay.pid
+          for _ in {1..30}; do
+            if curl -fsS http://127.0.0.1:5010/ > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "relay failed to start" >&2
+          cat relay.log >&2
+          exit 1
+
+      - name: Run desktop operator e2e
+        working-directory: desktop-tauri
+        env:
+          RUN_DESKTOP_OPERATOR_E2E: '1'
+          DESKTOP_OPERATOR_E2E_RELAY_URL: http://127.0.0.1:5010
+        run: npm test -- src/operator.e2e.test.tsx
+
+      - name: Stop relay
+        if: always()
+        run: |
+          if [ -f relay.pid ]; then
+            kill "$(cat relay.pid)" || true
+          fi
+
+      - name: Upload relay log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-operator-e2e-relay-log
+          path: relay.log

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::{env, ffi::OsString, path::Path};
 
 #[derive(Debug, Clone)]
 pub struct PythonLauncher {
@@ -18,6 +19,7 @@ impl PythonLauncher {
         let mut cmd = tokio::process::Command::new(&self.program);
         cmd.args(&self.args);
         cmd.arg(script_path);
+        apply_pythonpath_env(script_path, &mut cmd);
         cmd
     }
 
@@ -25,7 +27,60 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         cmd.arg(script_path);
+        apply_pythonpath_env(script_path, &mut cmd);
         cmd
+    }
+}
+
+fn apply_pythonpath_env<T>(script_path: &str, cmd: &mut T)
+where
+    T: PythonPathCommand,
+{
+    if let Some(pythonpath) = resolved_pythonpath(script_path, env::var_os("PYTHONPATH")) {
+        cmd.set_pythonpath(pythonpath);
+    }
+}
+
+fn resolved_pythonpath(script_path: &str, existing: Option<OsString>) -> Option<OsString> {
+    let import_root = detect_python_import_root(script_path)?;
+    let mut entries = vec![import_root];
+    if let Some(existing) = existing {
+        entries.extend(env::split_paths(&existing));
+    }
+    env::join_paths(entries).ok()
+}
+
+fn detect_python_import_root(script_path: &str) -> Option<std::path::PathBuf> {
+    let script = Path::new(script_path);
+    let mut candidates = Vec::new();
+
+    if let Some(parent) = script.parent() {
+        candidates.push(parent.to_path_buf());
+        if let Some(parent_of_parent) = parent.parent() {
+            candidates.push(parent_of_parent.to_path_buf());
+        }
+    }
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    candidates.push(manifest_dir.join("..").join(".."));
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() && candidate.join("config.py").is_file())
+}
+
+trait PythonPathCommand {
+    fn set_pythonpath(&mut self, value: OsString);
+}
+
+impl PythonPathCommand for Command {
+    fn set_pythonpath(&mut self, value: OsString) {
+        self.env("PYTHONPATH", value);
+    }
+}
+
+impl PythonPathCommand for tokio::process::Command {
+    fn set_pythonpath(&mut self, value: OsString) {
+        self.env("PYTHONPATH", value);
     }
 }
 
@@ -147,11 +202,13 @@ pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{fs, path::PathBuf};
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -307,5 +364,42 @@ mod tests {
         assert!(msg.contains("python  -> status="));
         assert!(msg.contains("Python 2.7.18"));
         assert!(msg.contains("python3  -> spawn failed"));
+    }
+
+    #[test]
+    fn detects_packaged_python_import_root() {
+        let temp = TempDir::new().expect("tempdir");
+        let resources = temp.path().join("resources");
+        fs::create_dir_all(resources.join("python")).expect("create python");
+        fs::create_dir_all(resources.join("utils")).expect("create utils");
+        fs::write(resources.join("config.py"), "# test").expect("write config");
+        let script_path = resources
+            .join("python")
+            .join("compute_node_bridge.py")
+            .to_string_lossy()
+            .to_string();
+
+        let detected = detect_python_import_root(&script_path).expect("detect import root");
+        assert_eq!(detected, resources);
+    }
+
+    #[test]
+    fn resolved_pythonpath_prepends_detected_import_root() {
+        let temp = TempDir::new().expect("tempdir");
+        let import_root = temp.path().join("bundle");
+        fs::create_dir_all(import_root.join("python")).expect("create python");
+        fs::create_dir_all(import_root.join("utils")).expect("create utils");
+        fs::write(import_root.join("config.py"), "# test").expect("write config");
+        let script_path = import_root
+            .join("python")
+            .join("model_bridge.py")
+            .to_string_lossy()
+            .to_string();
+
+        let existing = env::join_paths([PathBuf::from("/tmp/existing")]).expect("join existing");
+        let resolved = resolved_pythonpath(&script_path, Some(existing)).expect("resolve pythonpath");
+        let parts = env::split_paths(&resolved).collect::<Vec<_>>();
+        assert_eq!(parts.first(), Some(&import_root));
+        assert!(parts.iter().any(|entry| entry == &PathBuf::from("/tmp/existing")));
     }
 }

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -27,7 +27,9 @@
     "resources": [
       "python/compute_node_bridge.py",
       "python/inference_sidecar.py",
-      "python/model_bridge.py"
+      "python/model_bridge.py",
+      "../../config.py",
+      "../../utils"
     ],
     "icon": [
       "icons/32x32.png",

--- a/desktop-tauri/src/operator.e2e.test.tsx
+++ b/desktop-tauri/src/operator.e2e.test.tsx
@@ -1,0 +1,187 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { App } from './App';
+
+const invokeMock = vi.fn();
+const listenMock = vi.fn();
+const eventHandlers = new Map<string, (evt: { payload: Record<string, unknown> }) => void>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn(),
+}));
+
+const relayUrl = process.env.DESKTOP_OPERATOR_E2E_RELAY_URL ?? 'http://127.0.0.1:5010';
+const shouldRun = process.env.RUN_DESKTOP_OPERATOR_E2E === '1';
+const maybeIt = shouldRun ? it : it.skip;
+
+let bridgeChild: ChildProcessWithoutNullStreams | null = null;
+let tempRoot: string | null = null;
+
+function emitComputeNode(payload: Record<string, unknown>) {
+  eventHandlers.get('compute_node_event')?.({ payload });
+}
+
+function bootstrapInvokeDefaults(modelPath: string) {
+  invokeMock.mockImplementation((command: string, args?: any) => {
+    if (command === 'detect_backend') {
+      return Promise.resolve({
+        platform_label: 'linux',
+        preferred_mode: 'cpu',
+        display_label: 'cpu',
+      });
+    }
+    if (command === 'load_config') {
+      return Promise.resolve({
+        model_path: modelPath,
+        relay_base_url: relayUrl,
+        preferred_mode: 'cpu',
+      });
+    }
+    if (command === 'get_compute_node_status') {
+      return Promise.resolve({
+        running: false,
+        registered: false,
+        active_relay_url: '',
+        backend_mode: 'cpu',
+        model_path: modelPath,
+        last_error: null,
+      });
+    }
+    if (command === 'inspect_model_artifact') {
+      return Promise.resolve({
+        canonical_family_url: 'https://example.test/models',
+        filename: path.basename(modelPath),
+        url: 'https://example.test/model.gguf',
+        models_dir: path.dirname(modelPath),
+        resolved_model_path: modelPath,
+        exists: true,
+        size_bytes: 1,
+      });
+    }
+    if (command === 'save_config') {
+      return Promise.resolve(undefined);
+    }
+    if (command === 'start_compute_node') {
+      const request = args?.request;
+      return new Promise<void>((resolve, reject) => {
+        const repoRoot = path.resolve(__dirname, '..', '..');
+        const script = path.resolve(repoRoot, 'desktop-tauri/src-tauri/python/compute_node_bridge.py');
+        const python = process.env.PYTHON_BIN ?? 'python3';
+        bridgeChild = spawn(
+          python,
+          [
+            script,
+            '--model',
+            request.model_path,
+            '--mode',
+            request.mode,
+            '--relay-url',
+            request.relay_base_url,
+          ],
+          {
+            cwd: repoRoot,
+            env: {
+              ...process.env,
+              USE_MOCK_LLM: '1',
+            },
+          }
+        );
+
+        let started = false;
+        bridgeChild.stdout.on('data', (chunk: Buffer) => {
+          for (const line of chunk.toString().split('\n').filter(Boolean)) {
+            try {
+              emitComputeNode(JSON.parse(line));
+            } catch {
+              // ignore malformed bridge output
+            }
+          }
+          if (!started) {
+            started = true;
+            resolve();
+          }
+        });
+
+        bridgeChild.once('error', (error) => reject(error));
+        bridgeChild.stderr.on('data', (chunk: Buffer) => {
+          emitComputeNode({ type: 'error', message: chunk.toString() });
+        });
+        bridgeChild.once('exit', (code) => {
+          if (code !== 0) {
+            emitComputeNode({ type: 'error', message: `bridge exited with ${code}` });
+          }
+        });
+      });
+    }
+    if (command === 'stop_compute_node') {
+      if (bridgeChild && !bridgeChild.killed) {
+        bridgeChild.stdin.write('{"type":"cancel"}\n');
+      }
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve(undefined);
+  });
+}
+
+describe('desktop operator e2e against local relay', () => {
+  beforeEach(() => {
+    cleanup();
+    invokeMock.mockReset();
+    listenMock.mockReset();
+    eventHandlers.clear();
+
+    listenMock.mockImplementation((event: string, handler: unknown) => {
+      eventHandlers.set(event, handler as (evt: { payload: Record<string, unknown> }) => void);
+      return Promise.resolve(() => {});
+    });
+
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'token-place-desktop-e2e-'));
+    const modelPath = path.join(tempRoot, 'model.gguf');
+    writeFileSync(modelPath, 'x');
+    bootstrapInvokeDefaults(modelPath);
+  });
+
+  afterEach(async () => {
+    if (bridgeChild && !bridgeChild.killed) {
+      bridgeChild.stdin.write('{"type":"cancel"}\n');
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      if (!bridgeChild.killed) {
+        bridgeChild.kill('SIGKILL');
+      }
+    }
+    bridgeChild = null;
+    if (tempRoot && existsSync(tempRoot)) {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+    tempRoot = null;
+    cleanup();
+  });
+
+  maybeIt('starts operator from UI and reaches running state', async () => {
+    render(<App />);
+
+    const relayInput = (await screen.findByText('Relay URL')).parentElement?.querySelector('input');
+    expect(relayInput).toBeTruthy();
+    fireEvent.change(relayInput as HTMLInputElement, { target: { value: relayUrl } });
+
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Running:').textContent).toContain('yes');
+    });
+  }, 30000);
+});


### PR DESCRIPTION
### Motivation
- Packaged desktop builds launched the bridge scripts but failed at runtime with `No module named 'utils'` because packaged bundles included only the bridge entry scripts and not the shared repo import root (`utils`, `config.py`), so Python subprocesses could not resolve imports in installed layouts.  
- The goal is the smallest reliable fix that preserves development behavior while making packaged subprocesses import the repo modules, and to add CI e2e coverage that would catch this regression before merge.  

### Description
- Set `PYTHONPATH` for desktop-launched Python subprocesses by detecting a packaging/dev import root and prepending it to `PYTHONPATH` in the Rust launcher; changes live in `desktop-tauri/src-tauri/src/python_runtime.rs`.  
- Bundle the minimal Python resources into the Tauri package by adding `../../config.py` and `../../utils` to `desktop-tauri/src-tauri/tauri.conf.json` `resources` so installed builds include the import tree.  
- Add a UI-driven desktop operator E2E test `desktop-tauri/src/operator.e2e.test.tsx` that starts the real `compute_node_bridge.py` against a local `relay.py` and verifies the app reaches `Running: yes`.  
- Wire a PR CI workflow `.github/workflows/desktop-operator-e2e.yml` to start a local relay and run the new E2E test on pull requests that touch desktop/relay/python resources.  

### Testing
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which failed in this environment due to missing system `glib-2.0` / pkg-config (environment issue), not the changes.  
- Frontend/test steps succeeded: `cd desktop-tauri && npm ci` (succeeded) and `cd desktop-tauri && npm run build` (succeeded).  
- End-to-end test exercised locally in this environment by starting a local relay and running the new test with `python -m pip install -r requirements.txt && python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm &` then `cd desktop-tauri && RUN_DESKTOP_OPERATOR_E2E=1 DESKTOP_OPERATOR_E2E_RELAY_URL=http://127.0.0.1:5010 npm test -- src/operator.e2e.test.tsx`, and the E2E test passed.  
- Notes: `pre-commit run --all-files` was not available in the runner so it was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf5cea65c832f9da6936f698d8d70)