### PR TITLE
Fix packaged Python imports for desktop bridges and add desktop operator e2e CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,36 @@ on:
     branches: [ main, master ]
 
 jobs:
+  desktop-operator-e2e:
+    name: Desktop operator e2e (packaged bridge layout)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: desktop-tauri/package-lock.json
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install desktop dependencies
+        working-directory: desktop-tauri
+        run: npm ci
+      - name: Run desktop operator e2e
+        working-directory: desktop-tauri
+        env:
+          RUN_DESKTOP_OPERATOR_E2E: '1'
+        run: npm test
+
   test:
     name: Run tests and collect coverage
     runs-on: ubuntu-latest

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -12,9 +12,31 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+
+def _configure_import_root() -> None:
+    script_path = Path(__file__).resolve()
+    candidates = []
+
+    for parent in script_path.parents:
+        if (parent / "utils").is_dir() and (parent / "config.py").is_file():
+            candidates.append(parent)
+            break
+
+    candidates.append(script_path.parents[3])
+    candidates.append(Path.cwd())
+
+    seen = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        candidate_str = str(resolved)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+
+
+_configure_import_root()
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -12,9 +12,31 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Tuple
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+
+def _configure_import_root() -> None:
+    script_path = Path(__file__).resolve()
+    candidates = []
+
+    for parent in script_path.parents:
+        if (parent / "utils").is_dir() and (parent / "config.py").is_file():
+            candidates.append(parent)
+            break
+
+    candidates.append(script_path.parents[3])
+    candidates.append(Path.cwd())
+
+    seen = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        candidate_str = str(resolved)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+
+
+_configure_import_root()
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -10,9 +10,30 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+def _configure_import_root() -> None:
+    script_path = Path(__file__).resolve()
+    candidates = []
+
+    for parent in script_path.parents:
+        if (parent / "utils").is_dir() and (parent / "config.py").is_file():
+            candidates.append(parent)
+            break
+
+    candidates.append(script_path.parents[3])
+    candidates.append(Path.cwd())
+
+    seen = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        candidate_str = str(resolved)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+
+
+_configure_import_root()
 
 
 def _response(ok: bool, *, payload: Dict[str, Any] | None = None, error: str = "") -> int:

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -27,7 +27,9 @@
     "resources": [
       "python/compute_node_bridge.py",
       "python/inference_sidecar.py",
-      "python/model_bridge.py"
+      "python/model_bridge.py",
+      "../../config.py",
+      "../../utils/**/*.py"
     ],
     "icon": [
       "icons/32x32.png",

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1,10 +1,16 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 
 const invokeMock = vi.fn();
 const listenMock = vi.fn();
 const eventHandlers = new Map<string, (evt: { payload: Record<string, unknown> }) => void>();
+const testDir = path.dirname(fileURLToPath(import.meta.url));
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
@@ -181,7 +187,9 @@ describe('desktop app start failure handling', () => {
     );
   });
 
-  it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
+  it(
+    'marks local inference as failed on emitted error events after start invoke resolves',
+    async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))
       .parentElement?.querySelector('textarea');
@@ -225,5 +233,137 @@ describe('desktop app start failure handling', () => {
       expect(screen.getByText('Status:').textContent).toContain('failed')
     );
     expect(screen.getByText(/Error:/).textContent).toContain('event failure path');
-  });
+    },
+  );
+
+  it(
+    'starts operator end-to-end against a local relay using packaged bridge layout',
+    async () => {
+      if (process.env.RUN_DESKTOP_OPERATOR_E2E !== '1') {
+        return;
+      }
+
+      const pythonCommand = process.env.PYTHON ?? process.env.PYTHON3 ?? 'python3';
+      const relayPort = 19567;
+      const relayUrl = `http://127.0.0.1:${relayPort}`;
+      const relayProcess = spawn(
+        pythonCommand,
+        [path.resolve(testDir, '../../relay.py'), '--port', String(relayPort), '--use_mock_llm'],
+        { env: { ...process.env, TOKEN_PLACE_ENV: 'testing', USE_MOCK_LLM: '1' } },
+      );
+
+      const waitForRelay = async () => {
+        const startedAt = Date.now();
+        while (Date.now() - startedAt < 20_000) {
+          try {
+            const response = await fetch(`${relayUrl}/`);
+            if (response.ok) {
+              return;
+            }
+          } catch {
+            // Relay is still booting.
+          }
+          await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        throw new Error('relay failed to start in test timeout');
+      };
+
+      let bridgeProcess: ChildProcessWithoutNullStreams | null = null;
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'token-place-packaged-'));
+      const resourcesRoot = path.join(tempRoot, 'resources');
+      const bridgePath = path.join(resourcesRoot, 'python', 'compute_node_bridge.py');
+
+      await fs.mkdir(path.dirname(bridgePath), { recursive: true });
+      await fs.cp(path.resolve(testDir, '../src-tauri/python/compute_node_bridge.py'), bridgePath);
+      await fs.cp(path.resolve(testDir, '../../utils'), path.join(resourcesRoot, 'utils'), {
+        recursive: true,
+      });
+      await fs.copyFile(
+        path.resolve(testDir, '../../config.py'),
+        path.join(resourcesRoot, 'config.py'),
+      );
+
+      const stopBridge = async () => {
+        if (!bridgeProcess) {
+          return;
+        }
+        bridgeProcess.stdin.write('{"type":"cancel"}\n');
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        bridgeProcess.kill('SIGTERM');
+      };
+
+      try {
+        await waitForRelay();
+        const defaultInvoke = invokeMock.getMockImplementation();
+
+        invokeMock.mockImplementation((command: string, args?: Record<string, unknown>) => {
+          if (command === 'start_compute_node') {
+            const request = (args?.request as Record<string, string>) ?? {};
+            const handler = eventHandlers.get('compute_node_event');
+            bridgeProcess = spawn(
+              pythonCommand,
+              [
+                bridgePath,
+                '--model',
+                request.model_path,
+                '--mode',
+                request.mode,
+                '--relay-url',
+                request.relay_base_url,
+              ],
+              {
+                cwd: resourcesRoot,
+                env: {
+                  ...process.env,
+                  TOKEN_PLACE_ENV: 'testing',
+                  USE_MOCK_LLM: '1',
+                },
+              },
+            );
+            bridgeProcess.stdout.on('data', (chunk) => {
+              const lines = String(chunk)
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean);
+              for (const line of lines) {
+                try {
+                  handler?.({ payload: JSON.parse(line) });
+                } catch {
+                  // Ignore malformed NDJSON test output.
+                }
+              }
+            });
+            return Promise.resolve(undefined);
+          }
+          if (command === 'stop_compute_node') {
+            return stopBridge();
+          }
+          return defaultInvoke
+            ? (defaultInvoke(command, args) as Promise<unknown>)
+            : Promise.resolve(undefined);
+        });
+
+        render(<App />);
+        const relayInput = (await screen.findByText('Relay URL'))
+          .parentElement?.querySelector('input') as HTMLInputElement;
+        fireEvent.change(relayInput, { target: { value: relayUrl } });
+
+        const startOperatorButton =
+          (await screen.findByText('Start operator')) as HTMLButtonElement;
+        await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+        fireEvent.click(startOperatorButton);
+
+        await waitFor(
+          () => expect(screen.getByText(/Registered:/).textContent).toContain('yes'),
+          { timeout: 25_000 },
+        );
+        expect(screen.getByText(/Last error:/).textContent).not.toContain('No module named');
+      } finally {
+        await stopBridge();
+        relayProcess.kill('SIGTERM');
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+    40_000,
+  );
 });


### PR DESCRIPTION
### Motivation
- Packaged desktop subprocesses launched the bridge scripts but could not import repo modules (error: `No module named 'utils'`) because the packaged runtime lacked a correct Python import root and the Tauri bundle omitted the minimal Python module tree.
- The goal is a minimal, reliable runtime fix so packaged operator start succeeds and to add e2e CI coverage that would catch regressions of this class before merge.

### Description
- Added an import-root discovery helper `_configure_import_root()` to the three bridge entrypoints to prepend a sensible repo root to `sys.path` when running from a packaged layout (`desktop-tauri/src-tauri/python/compute_node_bridge.py`, `inference_sidecar.py`, `model_bridge.py`).
- Bundled the minimal Python resources in Tauri by adding `../../config.py` and `../../utils/**/*.py` to `desktop-tauri/src-tauri/tauri.conf.json` so packaged builds include the modules the bridges import.
- Added a desktop operator end-to-end test that simulates a packaged bridge layout, starts a real local `relay.py`, launches the bridge script from a temporary resources directory, and exercises the UI `Start operator` flow to assert successful registration; the test lives in `desktop-tauri/src/App.test.tsx` and runs conditionally under `RUN_DESKTOP_OPERATOR_E2E=1`.
- Wired a CI job `desktop-operator-e2e` in `.github/workflows/ci.yml` that installs Python deps from `requirements.txt`, installs desktop npm deps, and runs the desktop test suite with the e2e toggle enabled.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` which failed in this environment due to missing system `glib-2.0` / pkg-config for the Tauri Rust build (this is an environmental constraint, not the change itself).
- Ran `cd desktop-tauri && npm ci` which completed successfully and `cd desktop-tauri && npm run build` which produced a successful Vite build.
- Ran `cd desktop-tauri && npm test` and the desktop test suite passed (the new e2e test is gated behind `RUN_DESKTOP_OPERATOR_E2E=1` and thus did not run in the quick local run).
- Attempted `cd desktop-tauri && RUN_DESKTOP_OPERATOR_E2E=1 npm test` locally and observed the e2e path fails in this sandbox due to missing Python runtime dependencies for `relay.py` (e.g. Flask); the CI job installs `requirements.txt` before running the e2e job so it will exercise the end-to-end flow in CI.

Verification commands used
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` (environmental failure: missing glib)
- `cd desktop-tauri && npm ci`
- `cd desktop-tauri && npm run build`
- `cd desktop-tauri && npm test`
- CI job will run: install Python deps (`pip install -r requirements.txt`) then `cd desktop-tauri && npm ci && npm test` with `RUN_DESKTOP_OPERATOR_E2E=1` enabled

Files changed
- desktop-tauri/src-tauri/python/compute_node_bridge.py (added import-root helper)
- desktop-tauri/src-tauri/python/inference_sidecar.py (added import-root helper)
- desktop-tauri/src-tauri/python/model_bridge.py (added import-root helper)
- desktop-tauri/src-tauri/tauri.conf.json (bundle resources: `config.py` + `utils/**/*.py`)
- desktop-tauri/src/App.test.tsx (added packaged-layout desktop operator e2e test)
- .github/workflows/ci.yml (added `desktop-operator-e2e` CI job)

What changed to fix the bug
- Confirmed root cause: packaged bridge scripts were launched without a Python import root containing repo modules (`utils`, `config.py`), and the Tauri bundle did not include those minimal Python files; the change adds a small runtime import-root discovery and bundles the minimal Python module tree so packaged subprocesses can import dependencies.
- Minimal additional resources added: `config.py` and the `utils/**/*.py` tree are included as Tauri bundle resources and the bridge scripts add the discovered repo root to `sys.path` at startup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf5cea65c832f9da6936f698d8d70)