### PR TITLE
Fix packaged desktop Python imports and add packaged-bridge e2e CI

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -9,6 +9,7 @@ on:
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'utils/**'
       - 'config.py'
+      - 'encrypt.py'
       - 'relay.py'
       - 'requirements.txt'
   push:
@@ -20,6 +21,7 @@ on:
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'utils/**'
       - 'config.py'
+      - 'encrypt.py'
       - 'relay.py'
       - 'requirements.txt'
 

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -9,6 +9,8 @@ on:
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'utils/**'
       - 'config.py'
+      - 'relay.py'
+      - 'requirements.txt'
   push:
     branches: [ main, master ]
     paths:
@@ -18,10 +20,13 @@ on:
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'utils/**'
       - 'config.py'
+      - 'relay.py'
+      - 'requirements.txt'
 
 jobs:
   packaged-operator-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -1,0 +1,41 @@
+name: Desktop operator packaged bridge e2e
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/desktop-operator-e2e.yml'
+      - 'desktop-tauri/src-tauri/python/**'
+      - 'desktop-tauri/src-tauri/tauri.conf.json'
+      - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'utils/**'
+      - 'config.py'
+  push:
+    branches: [ main, master ]
+    paths:
+      - '.github/workflows/desktop-operator-e2e.yml'
+      - 'desktop-tauri/src-tauri/python/**'
+      - 'desktop-tauri/src-tauri/tauri.conf.json'
+      - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'utils/**'
+      - 'config.py'
+
+jobs:
+  packaged-operator-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run packaged operator bridge e2e
+        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""End-to-end regression for packaged operator Python bridge imports."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.request import urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: float = 20.0) -> None:
+    deadline = time.time() + timeout_seconds
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with urlopen(f"http://127.0.0.1:{port}/livez", timeout=1) as resp:  # noqa: S310
+                if resp.status == 200:
+                    return
+        except Exception as exc:  # pragma: no cover - retry loop
+            last_error = exc
+
+        if relay.poll() is not None:
+            stderr = relay.stderr.read() if relay.stderr else ""
+            stdout = relay.stdout.read() if relay.stdout else ""
+            raise RuntimeError(
+                f"relay exited early with code {relay.returncode}; stdout={stdout}; stderr={stderr}"
+            )
+        time.sleep(0.25)
+
+    raise RuntimeError(f"relay did not become live on port {port}: {last_error}")
+
+
+def create_packaged_layout(tmp_root: Path) -> Path:
+    resources_root = tmp_root / "resources"
+    python_dir = resources_root / "python"
+    python_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename in (
+        "compute_node_bridge.py",
+        "inference_sidecar.py",
+        "model_bridge.py",
+        "path_bootstrap.py",
+    ):
+        shutil.copy2(
+            REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / filename,
+            python_dir / filename,
+        )
+
+    shutil.copy2(REPO_ROOT / "config.py", resources_root / "config.py")
+    shutil.copytree(REPO_ROOT / "utils", resources_root / "utils", dirs_exist_ok=True)
+
+    return python_dir / "compute_node_bridge.py"
+
+
+def main() -> int:
+    relay_port = 5011
+    env = os.environ.copy()
+    env["USE_MOCK_LLM"] = "1"
+
+    with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
+        bridge_script = create_packaged_layout(Path(tmpdir))
+
+        relay = subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                str(REPO_ROOT / "relay.py"),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(relay_port),
+                "--use_mock_llm",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        bridge: subprocess.Popen[str] | None = None
+        try:
+            wait_for_livez(relay, relay_port)
+            bridge = subprocess.Popen(  # noqa: S603
+                [
+                    sys.executable,
+                    str(bridge_script),
+                    "--model",
+                    "mock.gguf",
+                    "--mode",
+                    "cpu",
+                    "--relay-url",
+                    f"http://127.0.0.1:{relay_port}",
+                ],
+                cwd=tmpdir,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+            assert bridge.stdout is not None
+            assert bridge.stdin is not None
+            saw_started = False
+
+            deadline = time.time() + 20
+            while time.time() < deadline:
+                line = bridge.stdout.readline()
+                if not line:
+                    break
+                payload = json.loads(line)
+                if payload.get("type") == "error":
+                    raise RuntimeError(f"bridge emitted error event: {payload}")
+                if payload.get("type") == "started" and payload.get("running") is True:
+                    saw_started = True
+                    bridge.stdin.write('{"type":"cancel"}\n')
+                    bridge.stdin.flush()
+                    break
+
+            if not saw_started:
+                raise RuntimeError("bridge did not emit started/running event")
+
+            bridge.wait(timeout=20)
+            if bridge.returncode != 0:
+                stderr = bridge.stderr.read() if bridge.stderr else ""
+                raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {stderr}")
+
+        finally:
+            if bridge is not None and bridge.poll() is None:
+                bridge.kill()
+            if relay.poll() is None:
+                relay.kill()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import json
 import os
+import selectors
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -15,6 +17,12 @@ from urllib.request import urlopen
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def reserve_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
 
 
 def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: float = 20.0) -> None:
@@ -62,7 +70,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
 
 
 def main() -> int:
-    relay_port = 5011
+    relay_port = reserve_free_port()
     env = os.environ.copy()
     env["USE_MOCK_LLM"] = "1"
 
@@ -86,7 +94,9 @@ def main() -> int:
             text=True,
         )
 
-        bridge: subprocess.Popen[str] | None = None
+        bridge: subprocess.Popen[bytes] | None = None
+        bridge_output = ""
+        selector: selectors.BaseSelector | None = None
         try:
             wait_for_livez(relay, relay_port)
             bridge = subprocess.Popen(  # noqa: S603
@@ -104,37 +114,68 @@ def main() -> int:
                 env=env,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
+                stderr=subprocess.STDOUT,
+                text=False,
             )
 
             assert bridge.stdout is not None
             assert bridge.stdin is not None
-            saw_started = False
 
+            os.set_blocking(bridge.stdout.fileno(), False)
+            selector = selectors.DefaultSelector()
+            selector.register(bridge.stdout, selectors.EVENT_READ)
+
+            saw_started = False
+            buffered = ""
             deadline = time.time() + 20
+
             while time.time() < deadline:
-                line = bridge.stdout.readline()
-                if not line:
+                timeout = max(0.0, min(0.25, deadline - time.time()))
+                events = selector.select(timeout=timeout)
+                if not events and bridge.poll() is not None:
                     break
-                payload = json.loads(line)
-                if payload.get("type") == "error":
-                    raise RuntimeError(f"bridge emitted error event: {payload}")
-                if payload.get("type") == "started" and payload.get("running") is True:
-                    saw_started = True
-                    bridge.stdin.write('{"type":"cancel"}\n')
-                    bridge.stdin.flush()
+
+                for key, _ in events:
+                    chunk = os.read(key.fileobj.fileno(), 4096)
+                    if not chunk:
+                        continue
+                    text = chunk.decode("utf-8", errors="replace")
+                    bridge_output += text
+                    buffered += text
+
+                    while "\n" in buffered:
+                        line, buffered = buffered.split("\n", 1)
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            payload = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if payload.get("type") == "error":
+                            raise RuntimeError(f"bridge emitted error event: {payload}")
+                        if payload.get("type") == "started" and payload.get("running") is True:
+                            saw_started = True
+                            bridge.stdin.write(b'{"type":"cancel"}\n')
+                            bridge.stdin.flush()
+                            break
+
+                if saw_started:
                     break
 
             if not saw_started:
-                raise RuntimeError("bridge did not emit started/running event")
+                raise RuntimeError(
+                    "bridge did not emit started/running event; output="
+                    f"{bridge_output[-2000:]}"
+                )
 
             bridge.wait(timeout=20)
             if bridge.returncode != 0:
-                stderr = bridge.stderr.read() if bridge.stderr else ""
-                raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {stderr}")
+                raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
 
         finally:
+            if selector is not None:
+                selector.close()
             if bridge is not None and bridge.poll() is None:
                 bridge.kill()
             if relay.poll() is None:

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -64,6 +64,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
         )
 
     shutil.copy2(REPO_ROOT / "config.py", resources_root / "config.py")
+    shutil.copy2(REPO_ROOT / "encrypt.py", resources_root / "encrypt.py")
     shutil.copytree(REPO_ROOT / "utils", resources_root / "utils", dirs_exist_ok=True)
 
     return python_dir / "compute_node_bridge.py"

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 if __package__ in (None, ""):
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    script_dir = str(Path(__file__).resolve().parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -12,9 +12,12 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(__file__)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -12,9 +12,12 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Tuple
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(__file__)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Tuple
 
 if __package__ in (None, ""):
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    script_dir = str(Path(__file__).resolve().parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
 

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -11,7 +11,9 @@ from typing import Any, Dict
 
 
 if __package__ in (None, ""):
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    script_dir = str(Path(__file__).resolve().parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
 

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -10,9 +10,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(__file__)
 
 
 def _response(ok: bool, *, payload: Dict[str, Any] | None = None, error: str = "") -> int:

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -1,0 +1,28 @@
+"""Runtime sys.path bootstrap for desktop Python bridge entrypoints."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_runtime_import_paths(script_file: str) -> None:
+    """Add likely import roots for development and packaged desktop layouts."""
+
+    script_path = Path(script_file).resolve()
+    candidates = [
+        script_path.parent.parent,  # bundled resources root in packaged apps
+        script_path.parent.parent.parent,
+    ]
+
+    if len(script_path.parents) > 3:
+        candidates.append(script_path.parents[3])  # repo root in development tree
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        has_runtime_modules = (candidate / "utils").is_dir() or (candidate / "config.py").is_file()
+        if has_runtime_modules:
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -10,19 +10,27 @@ def ensure_runtime_import_paths(script_file: str) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
     script_path = Path(script_file).resolve()
+    resources_root = script_path.parent.parent
     candidates = [
-        script_path.parent.parent,  # bundled resources root in packaged apps
+        resources_root,  # bundled resources root in packaged apps
+        resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
         script_path.parent.parent.parent,
     ]
 
     if len(script_path.parents) > 3:
         candidates.append(script_path.parents[3])  # repo root in development tree
 
+    valid_candidates: list[str] = []
     for candidate in candidates:
         if not candidate.exists():
             continue
         has_runtime_modules = (candidate / "utils").is_dir() or (candidate / "config.py").is_file()
         if has_runtime_modules:
             candidate_str = str(candidate)
-            if candidate_str not in sys.path:
-                sys.path.insert(0, candidate_str)
+            if candidate_str not in valid_candidates:
+                valid_candidates.append(candidate_str)
+
+    # Preserve candidate priority: first valid candidate should be first on sys.path.
+    for candidate_str in reversed(valid_candidates):
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -391,6 +391,7 @@ mod tests {
             "python/path_bootstrap.py",
             "../../utils",
             "../../config.py",
+            "../../encrypt.py",
         ];
 
         // Intentional strict count: this guards against accidental bundle bloat.

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -393,6 +393,7 @@ mod tests {
             "../../config.py",
         ];
 
+        // Intentional strict count: this guards against accidental bundle bloat.
         assert_eq!(
             resources.len(),
             required.len(),

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -388,12 +388,15 @@ mod tests {
             "python/compute_node_bridge.py",
             "python/inference_sidecar.py",
             "python/model_bridge.py",
+            "python/path_bootstrap.py",
+            "../../utils",
+            "../../config.py",
         ];
 
         assert_eq!(
             resources.len(),
             required.len(),
-            "bundle.resources should only include required python bridge scripts"
+            "bundle.resources should only include required Python bridge/runtime resources"
         );
 
         for script in required {

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -27,7 +27,10 @@
     "resources": [
       "python/compute_node_bridge.py",
       "python/inference_sidecar.py",
-      "python/model_bridge.py"
+      "python/model_bridge.py",
+      "python/path_bootstrap.py",
+      "../../utils",
+      "../../config.py"
     ],
     "icon": [
       "icons/32x32.png",

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -30,7 +30,8 @@
       "python/model_bridge.py",
       "python/path_bootstrap.py",
       "../../utils",
-      "../../config.py"
+      "../../config.py",
+      "../../encrypt.py"
     ],
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
### Motivation
- Packaged desktop Python bridge scripts failed to import repo modules (e.g. `utils`) because packaged layouts run the script without the development repo root on `sys.path`, causing `ModuleNotFoundError: No module named 'utils'` when clicking “Start operator”.
- Provide the smallest, reliable runtime fix so packaged subprocesses resolve the minimal runtime modules they need while keeping development behavior unchanged, and add E2E CI to catch regressions.

### Description
- Add a small runtime bootstrap `desktop-tauri/src-tauri/python/path_bootstrap.py` that inserts likely import roots (packaged resources root first, then dev repo root fallback) into `sys.path` at process startup. 
- Apply the bootstrap to all desktop Python bridge entrypoints by updating `compute_node_bridge.py`, `inference_sidecar.py`, and `model_bridge.py` to import and call `ensure_runtime_import_paths(__file__)` before other repo imports. 
- Include only the minimal runtime resources in Tauri bundle config by updating `desktop-tauri/src-tauri/tauri.conf.json` to bundle `python/path_bootstrap.py`, `../../utils`, and `../../config.py` alongside the existing bridge scripts. 
- Extend the Rust resource-contract test in `desktop-tauri/src-tauri/src/main.rs` to assert the new bundled runtime resources are present. 
- Add a focused, runnable packaged-bridge regression script `desktop-tauri/scripts/test_packaged_operator_e2e.py` plus a small GitHub Actions workflow `.github/workflows/desktop-operator-e2e.yml` that installs Python deps, starts a local `relay.py`, creates a simulated packaged layout (resources/python + utils + config), launches the packaged `compute_node_bridge.py`, and fails on emitted bridge error events.
- Files changed: `desktop-tauri/src-tauri/python/path_bootstrap.py`, `desktop-tauri/src-tauri/python/{compute_node_bridge.py,inference_sidecar.py,model_bridge.py}`, `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/src-tauri/src/main.rs`, `desktop-tauri/scripts/test_packaged_operator_e2e.py`, and `.github/workflows/desktop-operator-e2e.yml`.

### Testing
- Ran Node build steps: `cd desktop-tauri && npm ci` and `cd desktop-tauri && npm run build`, both succeeded locally. 
- Ran the new packaged-bridge e2e script locally: `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, which exercises the exact packaged import layout and launching of `compute_node_bridge.py`, and observed failures in the local environment until relay runtime dependencies were installed; the script is intended to run in CI where `pip install -r requirements.txt` on Python 3.11 is performed. 
- Attempted Rust tests: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` was executed but the environment lacked system `glib-2.0` dev libs so the full cargo test run failed in this execution environment (this is an environment limitation rather than a code regression). 
- Exact verification commands used during development: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` (env-limited), `cd desktop-tauri && npm ci`, `cd desktop-tauri && npm run build`, and `python desktop-tauri/scripts/test_packaged_operator_e2e.py` (CI will run: set up Python 3.11 + `pip install -r requirements.txt` then run the script via the workflow `.github/workflows/desktop-operator-e2e.yml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf5cea65c832f9da6936f698d8d70)