### PR TITLE
🐛 Fix packaged desktop import root and add real Tauri operator E2E gate

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -1,12 +1,17 @@
-name: Desktop operator packaged bridge e2e
+name: Desktop operator real app e2e
 
 on:
   pull_request:
     paths:
       - '.github/workflows/desktop-operator-e2e.yml'
+      - 'desktop-tauri/src-tauri/src/**'
       - 'desktop-tauri/src-tauri/python/**'
       - 'desktop-tauri/src-tauri/tauri.conf.json'
+      - 'desktop-tauri/src/**'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'desktop-tauri/scripts/test_desktop_operator_tauri_e2e.py'
+      - 'desktop-tauri/package.json'
+      - 'desktop-tauri/package-lock.json'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -16,9 +21,14 @@ on:
     branches: [ main, master ]
     paths:
       - '.github/workflows/desktop-operator-e2e.yml'
+      - 'desktop-tauri/src-tauri/src/**'
       - 'desktop-tauri/src-tauri/python/**'
       - 'desktop-tauri/src-tauri/tauri.conf.json'
+      - 'desktop-tauri/src/**'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'desktop-tauri/scripts/test_desktop_operator_tauri_e2e.py'
+      - 'desktop-tauri/package.json'
+      - 'desktop-tauri/package-lock.json'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -26,11 +36,31 @@ on:
       - 'requirements.txt'
 
 jobs:
-  packaged-operator-e2e:
+  desktop-operator-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            webkit2gtk-driver
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: desktop-tauri/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -43,6 +73,23 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install selenium
 
-      - name: Run packaged operator bridge e2e
+      - name: Install desktop dependencies
+        working-directory: desktop-tauri
+        run: npm ci
+
+      - name: Build desktop app (no bundle)
+        working-directory: desktop-tauri
+        run: npm run tauri build -- --no-bundle
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Run packaged bridge import regression
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+      - name: Run real desktop app e2e
+        env:
+          TOKEN_PLACE_SIDECAR_PYTHON: python
+        run: python desktop-tauri/scripts/test_desktop_operator_tauri_e2e.py

--- a/desktop-tauri/scripts/test_desktop_operator_tauri_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_tauri_e2e.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""WebDriver e2e for the real Tauri desktop operator journey."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.request import urlopen
+
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as ec
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_ROOT = REPO_ROOT / "desktop-tauri"
+APP_BINARY = DESKTOP_ROOT / "src-tauri" / "target" / "release" / "token-place-desktop-tauri"
+
+
+def reserve_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: float = 30.0) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            with urlopen(f"http://127.0.0.1:{port}/livez", timeout=1) as resp:  # noqa: S310
+                if resp.status == 200:
+                    return
+        except Exception:
+            pass
+
+        if relay.poll() is not None:
+            raise RuntimeError(f"relay exited early with code {relay.returncode}")
+        time.sleep(0.25)
+
+    raise RuntimeError(f"relay did not become live on port {port}")
+
+
+def wait_for_text(driver: webdriver.Remote, text: str, timeout: float = 30.0) -> None:
+    WebDriverWait(driver, timeout).until(
+        ec.text_to_be_present_in_element((By.TAG_NAME, "body"), text)
+    )
+
+
+def fill_input_for_label(driver: webdriver.Remote, label_text: str, value: str) -> None:
+    label = driver.find_element(By.XPATH, f"//label[normalize-space()='{label_text}']")
+    field = label.find_element(By.XPATH, "following-sibling::input[1]")
+    field.send_keys(Keys.CONTROL, "a")
+    field.send_keys(Keys.DELETE)
+    field.send_keys(value)
+
+
+def main() -> int:
+    if not APP_BINARY.is_file():
+        raise FileNotFoundError(f"built app binary not found at {APP_BINARY}")
+
+    relay_port = reserve_free_port()
+    env = os.environ.copy()
+    env["USE_MOCK_LLM"] = "1"
+
+    relay = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            str(REPO_ROOT / "relay.py"),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(relay_port),
+            "--use_mock_llm",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    tauri_driver = subprocess.Popen(  # noqa: S603
+        [str(Path.home() / ".cargo" / "bin" / "tauri-driver")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    driver: webdriver.Remote | None = None
+    try:
+        wait_for_livez(relay, relay_port)
+        time.sleep(1)
+
+        options = webdriver.ChromeOptions()
+        options.set_capability("browserName", "wry")
+        options.set_capability("tauri:options", {"application": str(APP_BINARY)})
+        driver = webdriver.Remote(command_executor="http://127.0.0.1:4444", options=options)
+
+        wait_for_text(driver, "token.place desktop compute node")
+        fill_input_for_label(driver, "Model GGUF path", "mock.gguf")
+        fill_input_for_label(driver, "Relay URL", f"http://127.0.0.1:{relay_port}")
+
+        driver.find_element(By.XPATH, "//button[normalize-space()='Start operator']").click()
+        wait_for_text(driver, "Running: yes", timeout=45)
+        wait_for_text(driver, "Registered: yes", timeout=45)
+
+        prompt = driver.find_element(By.XPATH, "//label[normalize-space()='Prompt']/following-sibling::textarea[1]")
+        prompt.send_keys("Say hello from desktop e2e")
+
+        driver.find_element(By.XPATH, "//button[normalize-space()='Start local inference']").click()
+
+        WebDriverWait(driver, 60).until(
+            lambda d: len(d.find_element(By.XPATH, "//main/pre").text.strip()) > 0
+        )
+
+        body_text = driver.find_element(By.TAG_NAME, "body").text
+        if "Last error: bridge failure" in body_text or "No module named 'utils'" in body_text:
+            raise AssertionError(f"desktop app reported bridge error:\n{body_text}")
+
+    except TimeoutException as exc:
+        raise RuntimeError("desktop e2e timed out waiting for UI state") from exc
+    finally:
+        if driver is not None:
+            driver.quit()
+
+        if tauri_driver.poll() is None:
+            tauri_driver.kill()
+
+        if relay.poll() is None:
+            relay.kill()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -48,9 +48,12 @@ def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: flo
 
 
 def create_packaged_layout(tmp_root: Path) -> Path:
-    resources_root = tmp_root / "resources"
+    executable_root = tmp_root / "bin"
+    resources_root = executable_root / "resources"
+    resources_up = resources_root / "_up_"
     python_dir = resources_root / "python"
     python_dir.mkdir(parents=True, exist_ok=True)
+    resources_up.mkdir(parents=True, exist_ok=True)
 
     for filename in (
         "compute_node_bridge.py",
@@ -63,11 +66,24 @@ def create_packaged_layout(tmp_root: Path) -> Path:
             python_dir / filename,
         )
 
-    shutil.copy2(REPO_ROOT / "config.py", resources_root / "config.py")
-    shutil.copy2(REPO_ROOT / "encrypt.py", resources_root / "encrypt.py")
-    shutil.copytree(REPO_ROOT / "utils", resources_root / "utils", dirs_exist_ok=True)
+    shutil.copy2(REPO_ROOT / "config.py", resources_up / "config.py")
+    shutil.copy2(REPO_ROOT / "encrypt.py", resources_up / "encrypt.py")
+    shutil.copytree(REPO_ROOT / "utils", resources_up / "utils", dirs_exist_ok=True)
 
-    return python_dir / "compute_node_bridge.py"
+    executable_python_dir = executable_root / "python"
+    executable_python_dir.mkdir(parents=True, exist_ok=True)
+    for filename in (
+        "compute_node_bridge.py",
+        "inference_sidecar.py",
+        "model_bridge.py",
+        "path_bootstrap.py",
+    ):
+        shutil.copy2(
+            REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / filename,
+            executable_python_dir / filename,
+        )
+
+    return executable_python_dir / "compute_node_bridge.py"
 
 
 def main() -> int:

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -11,9 +11,13 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     resources_root = script_path.parent.parent
+    sibling_resources_root = script_path.parent.parent / "resources"
+    sibling_resources_up = sibling_resources_root / "_up_"
     candidates = [
         resources_root,  # bundled resources root in packaged apps
         resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
+        sibling_resources_root,  # packaged apps can place python beside executable
+        sibling_resources_up,
         script_path.parent.parent.parent,
     ]
 


### PR DESCRIPTION
### Motivation
- The packaged desktop app still raised `No module named 'utils'` because the Python bootstrap did not probe the executable-adjacent `resources/` layout that Tauri produces, so the runtime import root was missed. 
- Existing CI only exercised a direct bridge subprocess and did not exercise the real Tauri-launched app + UI journey, allowing this regression to slip through.

### Description
- Added sibling `resources` and `resources/_up_` candidates to `desktop-tauri/src-tauri/python/path_bootstrap.py` so packaged bridge entrypoints launched from an executable-adjacent `python/` directory can find `utils` and `config.py`.
- Hardened the packaged-layout regression script in `desktop-tauri/scripts/test_packaged_operator_e2e.py` to mirror the real installed shape (`bin/python` + `bin/resources/_up_`) so the import-root mismatch is reproducible in CI.
- Added a real-app WebDriver-based E2E script `desktop-tauri/scripts/test_desktop_operator_tauri_e2e.py` that starts the local relay (mock LLM), launches the built Tauri binary via `tauri-driver`, clicks through the UI to start the operator and run a prompt, and fails on bridge/import errors visible in the UI.
- Added a PR-time workflow `.github/workflows/desktop-operator-e2e.yml` that installs native deps, builds the app (`tauri build -- --no-bundle`), runs the packaged bridge regression, installs `tauri-driver`, and runs the real desktop-app e2e; this closes the gap where CI previously only ran bridge-level checks.

### Testing
- Ran `cd desktop-tauri && npm ci` and `cd desktop-tauri && npm run build`, both succeeded locally (frontend build OK). 
- Ran `python -m py_compile` on the new/modified Python scripts and `path_bootstrap.py`, which succeeded (syntax OK).
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, which failed in this environment due to missing system library `glib-2.0` required by Tauri native crates (expected on CI runners with proper deps). 
- Executed `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, which exercised the packaged-layout path but failed here because runtime Python dependencies (e.g., `flask`) were not installed in this ephemeral environment; the script is included in the new workflow which installs `requirements.txt` so it will run on CI.
- New workflow will run the full sequence on PRs: build desktop app, run `test_packaged_operator_e2e.py`, install `tauri-driver`, and run `test_desktop_operator_tauri_e2e.py`, and will fail the PR if any of the required UI steps (Start operator → Running: yes → Registered: yes → prompt + inference + non-empty mock-LLM output) do not succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db300d39b8832fb47ac6660cd0537a)