### PR TITLE
🐛 Fix packaged desktop Python import root and add packaged runtime e2e

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -1,36 +1,59 @@
-name: Desktop operator packaged bridge e2e
+name: Desktop operator packaged runtime e2e
 
 on:
   pull_request:
     paths:
       - '.github/workflows/desktop-operator-e2e.yml'
       - 'desktop-tauri/src-tauri/python/**'
+      - 'desktop-tauri/src-tauri/src/**'
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'desktop-tauri/src/**'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
       - 'relay.py'
       - 'requirements.txt'
+      - 'desktop-tauri/package.json'
+      - 'desktop-tauri/package-lock.json'
   push:
     branches: [ main, master ]
     paths:
       - '.github/workflows/desktop-operator-e2e.yml'
       - 'desktop-tauri/src-tauri/python/**'
+      - 'desktop-tauri/src-tauri/src/**'
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'desktop-tauri/src/**'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
       - 'relay.py'
       - 'requirements.txt'
+      - 'desktop-tauri/package.json'
+      - 'desktop-tauri/package-lock.json'
 
 jobs:
-  packaged-operator-e2e:
+  packaged-operator-runtime-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: desktop-tauri/package-lock.json
+
+      - name: Install desktop dependencies
+        run: npm ci
+        working-directory: desktop-tauri
+
+      - name: Build desktop frontend
+        run: npm run build
+        working-directory: desktop-tauri
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -44,5 +67,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run packaged operator bridge e2e
+      - name: Run packaged operator runtime e2e
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""End-to-end regression for packaged operator Python bridge imports."""
+"""End-to-end regression for packaged desktop Python runtime journey."""
 
 from __future__ import annotations
 
@@ -47,10 +47,12 @@ def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: flo
     raise RuntimeError(f"relay did not become live on port {port}: {last_error}")
 
 
-def create_packaged_layout(tmp_root: Path) -> Path:
+def create_packaged_layout(tmp_root: Path) -> tuple[Path, Path]:
     resources_root = tmp_root / "resources"
     python_dir = resources_root / "python"
+    up_root = resources_root / "_up_" / "_up_"
     python_dir.mkdir(parents=True, exist_ok=True)
+    up_root.mkdir(parents=True, exist_ok=True)
 
     for filename in (
         "compute_node_bridge.py",
@@ -63,11 +65,63 @@ def create_packaged_layout(tmp_root: Path) -> Path:
             python_dir / filename,
         )
 
-    shutil.copy2(REPO_ROOT / "config.py", resources_root / "config.py")
-    shutil.copy2(REPO_ROOT / "encrypt.py", resources_root / "encrypt.py")
-    shutil.copytree(REPO_ROOT / "utils", resources_root / "utils", dirs_exist_ok=True)
+    shutil.copy2(REPO_ROOT / "config.py", up_root / "config.py")
+    shutil.copy2(REPO_ROOT / "encrypt.py", up_root / "encrypt.py")
+    shutil.copytree(REPO_ROOT / "utils", up_root / "utils", dirs_exist_ok=True)
 
-    return python_dir / "compute_node_bridge.py"
+    model_path = up_root / "mock.gguf"
+    model_path.write_text("mock model artifact for packaged e2e\n", encoding="utf-8")
+
+    return python_dir / "compute_node_bridge.py", python_dir / "inference_sidecar.py"
+
+
+def read_ndjson_until(
+    process: subprocess.Popen[str],
+    *,
+    timeout_seconds: float,
+    predicate,
+) -> tuple[list[dict[str, object]], str]:
+    assert process.stdout is not None
+
+    os.set_blocking(process.stdout.fileno(), False)
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    events: list[dict[str, object]] = []
+    raw_output = ""
+    buffered = ""
+    deadline = time.time() + timeout_seconds
+
+    try:
+        while time.time() < deadline:
+            timeout = max(0.0, min(0.25, deadline - time.time()))
+            ready = selector.select(timeout=timeout)
+            if not ready and process.poll() is not None:
+                break
+
+            for key, _ in ready:
+                chunk = os.read(key.fileobj.fileno(), 4096)
+                if not chunk:
+                    continue
+                text = chunk.decode("utf-8", errors="replace")
+                raw_output += text
+                buffered += text
+
+                while "\n" in buffered:
+                    line, buffered = buffered.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    events.append(payload)
+                    if predicate(payload):
+                        return events, raw_output
+
+        raise RuntimeError(f"timed out waiting for expected event; output={raw_output[-2000:]}")
+    finally:
+        selector.close()
 
 
 def main() -> int:
@@ -76,8 +130,7 @@ def main() -> int:
     env["USE_MOCK_LLM"] = "1"
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
-        bridge_script = create_packaged_layout(Path(tmpdir))
-
+        compute_bridge, inference_sidecar = create_packaged_layout(Path(tmpdir))
         relay = subprocess.Popen(  # noqa: S603
             [
                 sys.executable,
@@ -95,17 +148,17 @@ def main() -> int:
             text=True,
         )
 
-        bridge: subprocess.Popen[bytes] | None = None
-        bridge_output = ""
-        selector: selectors.BaseSelector | None = None
+        compute_proc: subprocess.Popen[str] | None = None
+        inference_proc: subprocess.Popen[str] | None = None
         try:
             wait_for_livez(relay, relay_port)
-            bridge = subprocess.Popen(  # noqa: S603
+
+            compute_proc = subprocess.Popen(  # noqa: S603
                 [
                     sys.executable,
-                    str(bridge_script),
+                    str(compute_bridge),
                     "--model",
-                    "mock.gguf",
+                    str(Path(tmpdir) / "resources" / "_up_" / "_up_" / "mock.gguf"),
                     "--mode",
                     "cpu",
                     "--relay-url",
@@ -116,69 +169,73 @@ def main() -> int:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                text=False,
+                text=True,
+            )
+            assert compute_proc.stdin is not None
+
+            compute_events, compute_output = read_ndjson_until(
+                compute_proc,
+                timeout_seconds=25,
+                predicate=lambda payload: bool(payload.get("running"))
+                and bool(payload.get("registered")),
             )
 
-            assert bridge.stdout is not None
-            assert bridge.stdin is not None
+            if any(event.get("type") == "error" for event in compute_events):
+                raise RuntimeError(f"compute bridge error event(s): {compute_events}")
+            if "No module named 'utils'" in compute_output:
+                raise RuntimeError(f"missing utils import in packaged runtime: {compute_output}")
 
-            os.set_blocking(bridge.stdout.fileno(), False)
-            selector = selectors.DefaultSelector()
-            selector.register(bridge.stdout, selectors.EVENT_READ)
+            inference_proc = subprocess.Popen(  # noqa: S603
+                [
+                    sys.executable,
+                    str(inference_sidecar),
+                    "--model",
+                    str(Path(tmpdir) / "resources" / "_up_" / "_up_" / "mock.gguf"),
+                    "--mode",
+                    "cpu",
+                    "--prompt",
+                    "Say hello from the packaged desktop e2e test.",
+                ],
+                cwd=tmpdir,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
 
-            saw_started = False
-            buffered = ""
-            deadline = time.time() + 20
+            inference_events, inference_output = read_ndjson_until(
+                inference_proc,
+                timeout_seconds=25,
+                predicate=lambda payload: payload.get("type") == "done",
+            )
 
-            while time.time() < deadline:
-                timeout = max(0.0, min(0.25, deadline - time.time()))
-                events = selector.select(timeout=timeout)
-                if not events and bridge.poll() is not None:
-                    break
-
-                for key, _ in events:
-                    chunk = os.read(key.fileobj.fileno(), 4096)
-                    if not chunk:
-                        continue
-                    text = chunk.decode("utf-8", errors="replace")
-                    bridge_output += text
-                    buffered += text
-
-                    while "\n" in buffered:
-                        line, buffered = buffered.split("\n", 1)
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            payload = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if payload.get("type") == "error":
-                            raise RuntimeError(f"bridge emitted error event: {payload}")
-                        if payload.get("type") == "started" and payload.get("running") is True:
-                            saw_started = True
-                            bridge.stdin.write(b'{"type":"cancel"}\n')
-                            bridge.stdin.flush()
-                            break
-
-                if saw_started:
-                    break
-
-            if not saw_started:
+            tokens = [
+                str(event.get("text", ""))
+                for event in inference_events
+                if event.get("type") == "token" and event.get("text")
+            ]
+            if not "".join(tokens).strip():
                 raise RuntimeError(
-                    "bridge did not emit started/running event; output="
-                    f"{bridge_output[-2000:]}"
+                    "expected non-empty inference token output; "
+                    f"events={inference_events}; output={inference_output}"
                 )
 
-            bridge.wait(timeout=20)
-            if bridge.returncode != 0:
-                raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
+            compute_proc.stdin.write('{"type":"cancel"}\n')
+            compute_proc.stdin.flush()
+            compute_proc.wait(timeout=20)
+            if compute_proc.returncode != 0:
+                raise RuntimeError(f"compute bridge exited non-zero: {compute_output}")
+
+            inference_proc.wait(timeout=20)
+            if inference_proc.returncode != 0:
+                raise RuntimeError(f"inference sidecar exited non-zero: {inference_output}")
 
         finally:
-            if selector is not None:
-                selector.close()
-            if bridge is not None and bridge.poll() is None:
-                bridge.kill()
+            if compute_proc is not None and compute_proc.poll() is None:
+                compute_proc.kill()
+            if inference_proc is not None and inference_proc.poll() is None:
+                inference_proc.kill()
             if relay.poll() is None:
                 relay.kill()
 

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -11,11 +11,14 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     resources_root = script_path.parent.parent
-    candidates = [
-        resources_root,  # bundled resources root in packaged apps
-        resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
-        script_path.parent.parent.parent,
-    ]
+    candidates = [resources_root, script_path.parent.parent.parent]
+
+    # In packaged apps Tauri rewrites ".." path segments in bundled resources as
+    # nested "_up_" directories (e.g. ../../utils -> _up_/_up_/utils).
+    up_cursor = resources_root
+    for _ in range(3):
+        up_cursor = up_cursor / "_up_"
+        candidates.append(up_cursor)
 
     if len(script_path.parents) > 3:
         candidates.append(script_path.parents[3])  # repo root in development tree


### PR DESCRIPTION
### Motivation
- Packaged Tauri apps can rewrite `../../` resource paths into nested `_up_` directories which left the bridge bootstrap unable to find `utils` and caused `No module named 'utils'` at runtime.
- The existing CI smoke check did not exercise the full packaged runtime journey (relay registration + inference token output), allowing the regression to slip through.

### Description
- Update `desktop-tauri/src-tauri/python/path_bootstrap.py` to search nested `_up_` directories (walks multiple `_up_` levels) while preserving development import behavior so packaged bridges can locate `utils` and `config.py`.
- Expand `desktop-tauri/scripts/test_packaged_operator_e2e.py` to create a packaged-style layout (resources under `_up_/_up_`), start a local mock relay, launch the packaged `compute_node_bridge.py` and wait for `running` + `registered`, then run `inference_sidecar.py` and require non-empty token output and `done` events, failing explicitly on `No module named 'utils'` or other bridge errors.
- Update `.github/workflows/desktop-operator-e2e.yml` to build the desktop frontend (`npm ci` / `npm run build`) before running the packaged runtime e2e and to trigger on the broader desktop/runtime paths so the PR gate covers real desktop resource changes.
- Changes touch only the import-bootstrap, the packaged runtime e2e script, and the desktop e2e workflow to keep the diff minimal and focused on the regression class.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` which failed in this environment due to missing system `glib-2.0` / pkg-config system libs and is noted as an environment limitation rather than a code regression.
- Ran `cd desktop-tauri && npm ci` and `cd desktop-tauri && npm run build` which both succeeded locally, confirming frontend build steps added to the workflow complete.
- Executed `python desktop-tauri/scripts/test_packaged_operator_e2e.py` locally and reproduced dependency failures in the ephemeral environment (initial run failed for missing Flask, then additional runtime packages were installed manually); the script still exposes missing Python runtime packages in this constrained environment (e.g. `jsonschema`) so local execution required installing the full `requirements.txt`/`config/requirements_relay.txt` set; the workflow will install those dependencies and run the scripted e2e in CI where the packaged runtime journey is fully validated.

Files changed: `desktop-tauri/src-tauri/python/path_bootstrap.py`, `desktop-tauri/scripts/test_packaged_operator_e2e.py`, and `.github/workflows/desktop-operator-e2e.yml`.

Verification commands (run locally where appropriate): `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, `cd desktop-tauri && npm ci`, `cd desktop-tauri && npm run build`, `python desktop-tauri/scripts/test_packaged_operator_e2e.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db300d39b8832fb47ac6660cd0537a)