### PR TITLE
Fix model bridge PYTHONPATH for packaged desktop launches and add path-bootstrap test

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -14,7 +14,13 @@ def ensure_runtime_import_paths(script_file: str) -> None:
     candidates = [
         resources_root,  # bundled resources root in packaged apps
         resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
+        resources_root / "resources",
+        resources_root / "resources" / "_up_",
         script_path.parent.parent.parent,
+        script_path.parent.parent.parent / "resources",
+        script_path.parent.parent.parent / "resources" / "_up_",
+        script_path.parent.parent.parent / "Resources",
+        script_path.parent.parent.parent / "Resources" / "_up_",
     ]
 
     if len(script_path.parents) > 3:

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
@@ -84,6 +85,43 @@ fn model_bridge_script_candidates(exe_path: Option<&Path>, manifest_dir: &Path) 
     candidates
 }
 
+
+fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
+    let mut candidates = vec![manifest_dir.to_path_buf()];
+    if let Some(parent) = manifest_dir.parent() {
+        candidates.push(parent.to_path_buf());
+        if let Some(grandparent) = parent.parent() {
+            candidates.push(grandparent.to_path_buf());
+        }
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| {
+            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
+        })
+        .map(|candidate| candidate.to_string_lossy().into_owned())
+}
+
+fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path) {
+    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+        match std::env::var("PYTHONPATH") {
+            Ok(existing) if !existing.trim().is_empty() => {
+                if let Ok(joined) =
+                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
+                {
+                    command.env("PYTHONPATH", joined);
+                } else {
+                    command.env("PYTHONPATH", import_root);
+                }
+            }
+            _ => {
+                command.env("PYTHONPATH", import_root);
+            }
+        }
+    }
+}
+
 fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
     find_existing_bridge_script_path().ok_or_else(|| {
         "unable to locate model bridge script relative to executable/resources or development source tree".into()
@@ -94,8 +132,11 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path()?;
-    let output = launcher
-        .command_for_script_blocking(bridge_script.to_str().unwrap_or_default())
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut bridge_command =
+        launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
+    configure_runtime_pythonpath(&mut bridge_command, manifest_dir);
+    let output = bridge_command
         .arg(action)
         .output()
         .map_err(|e| format!("unable to run model bridge: {e}"))?;
@@ -329,6 +370,41 @@ fn main() {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn configure_runtime_pythonpath_prefixes_manifest_import_root() {
+        let mut command = std::process::Command::new("python");
+        configure_runtime_pythonpath(&mut command, Path::new(env!("CARGO_MANIFEST_DIR")));
+
+        let configured = command
+            .get_envs()
+            .find_map(|(key, value)| {
+                if key == "PYTHONPATH" {
+                    value.map(|raw| raw.to_string_lossy().into_owned())
+                } else {
+                    None
+                }
+            })
+            .expect("configured PYTHONPATH");
+        let mut configured_paths = std::env::split_paths(&configured).collect::<Vec<_>>();
+
+        if configured_paths.is_empty() {
+            configured_paths.push(PathBuf::from(configured));
+        }
+
+        let expected_root = repo_runtime_import_root(Path::new(env!("CARGO_MANIFEST_DIR")))
+            .expect("repo runtime import root")
+            .to_lowercase();
+
+        assert_eq!(
+            configured_paths
+                .first()
+                .expect("first PYTHONPATH entry")
+                .to_string_lossy()
+                .to_lowercase(),
+            expected_root
+        );
+    }
 
     #[test]
     fn model_bridge_candidates_include_packaged_resources() {

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -1,0 +1,35 @@
+"""Unit tests for desktop Python bridge import path bootstrapping."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'src-tauri'
+    / 'python'
+    / 'path_bootstrap.py'
+)
+SPEC = importlib.util.spec_from_file_location('desktop_path_bootstrap', MODULE_PATH)
+path_bootstrap = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(path_bootstrap)
+
+
+def test_bootstrap_supports_exe_python_with_sibling_resources_up(tmp_path):
+    script_file = tmp_path / 'build' / 'debug' / 'python' / 'model_bridge.py'
+    script_file.parent.mkdir(parents=True)
+    script_file.write_text('# bridge')
+
+    import_root = tmp_path / 'build' / 'debug' / 'resources' / '_up_'
+    (import_root / 'utils').mkdir(parents=True)
+
+    original_sys_path = sys.path.copy()
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script_file))
+        assert str(import_root) in sys.path
+        assert sys.path.index(str(import_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path


### PR DESCRIPTION
### Motivation
- The desktop `model_bridge.py` launch path did not apply the same runtime `PYTHONPATH` setup used by the compute-node/sidecar bridges, causing `ModuleNotFoundError: No module named 'utils'` in real packaged-like launches. 
- `path_bootstrap.ensure_runtime_import_paths` omitted a realistic exe/python + sibling `resources` layout, so bootstrapping could miss the repo import root in some desktop release layouts. 
- CI missed this because existing tests exercised the compute-node/sidecar path but not the exact model-bridge packaged-like layout. 

### Description
- Apply the same runtime import-root detection and PYTHONPATH injection to the model bridge launcher by adding `repo_runtime_import_root` and `configure_runtime_pythonpath` and calling `configure_runtime_pythonpath` before running `model_bridge.py` in `desktop-tauri/src-tauri/src/main.rs`. 
- Expand `desktop-tauri/src-tauri/python/path_bootstrap.py` candidates to include sibling `resources`/`Resources` and `_up_` variants so packaged exe/python + sibling resources topologies are discovered by `ensure_runtime_import_paths`. 
- Add a Python unit test `tests/unit/test_desktop_path_bootstrap.py` that simulates a packaged-like layout (`.../python/model_bridge.py` with shared modules under `.../resources/_up_/utils`) and asserts the correct import root is prepended to `sys.path`. 
- Add a small Rust unit test in `main.rs` that verifies `configure_runtime_pythonpath` prefixes the discovered manifest import root into the spawned process env `PYTHONPATH`. 

### Testing
- Ran the Python unit tests with `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_path_bootstrap.py` and all tests passed (`17 passed`).
- Verified the new standalone path-bootstrapping test with `python -m pytest tests/unit/test_desktop_path_bootstrap.py` and it passed. 
- Verified frontend build with `npm --prefix desktop-tauri run build` which completed successfully. 
- Attempting `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` / `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` in this environment failed due to missing system `glib-2.0`/`pkg-config` host dependencies, so full `cargo`/tauri integration tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f0e5b30832f899cf715f8bda3f4)