### PR TITLE
Fix model bridge imports for nested Tauri `_up_` resource layouts

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -11,11 +11,13 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     resources_root = script_path.parent.parent
-    candidates = [
-        resources_root,  # bundled resources root in packaged apps
-        resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
-        script_path.parent.parent.parent,
-    ]
+    tauri_up_roots = [resources_root]  # bundled resources root in packaged apps
+    current = resources_root
+    for _ in range(4):
+        current = current / "_up_"
+        tauri_up_roots.append(current)
+
+    candidates = [*tauri_up_roots, script_path.parent.parent.parent]
 
     if len(script_path.parents) > 3:
         candidates.append(script_path.parents[3])  # repo root in development tree

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -2,6 +2,10 @@
 
 import importlib.util
 import json
+import os
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -109,3 +113,58 @@ def test_main_dispatches_download_action():
             assert model_bridge.main() == 0
 
     download_model.assert_called_once_with()
+
+
+def test_packaged_layout_with_nested_up_resources_can_import_utils():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_root = Path(tmpdir)
+        resources_python = temp_root / 'resources' / 'python'
+        resources_python.mkdir(parents=True)
+
+        bridge_path = resources_python / 'model_bridge.py'
+        bridge_path.write_text(MODULE_PATH.read_text(encoding='utf-8'), encoding='utf-8')
+        bootstrap_path = resources_python / 'path_bootstrap.py'
+        bootstrap_path.write_text(
+            (
+                Path(__file__).resolve().parents[2]
+                / 'desktop-tauri'
+                / 'src-tauri'
+                / 'python'
+                / 'path_bootstrap.py'
+            ).read_text(encoding='utf-8'),
+            encoding='utf-8',
+        )
+
+        packaged_root = temp_root / 'resources' / '_up_' / '_up_'
+        utils_llm = packaged_root / 'utils' / 'llm'
+        utils_llm.mkdir(parents=True)
+        (packaged_root / 'utils' / '__init__.py').write_text('', encoding='utf-8')
+        (utils_llm / '__init__.py').write_text('', encoding='utf-8')
+        (utils_llm / 'model_manager.py').write_text(
+            """
+def get_model_manager():
+    class _Manager:
+        def get_model_artifact_metadata(self):
+            return {"resolved_model_path": "packaged/model.gguf", "exists": False}
+    return _Manager()
+""".strip()
+            + '\n',
+            encoding='utf-8',
+        )
+        (packaged_root / 'config.py').write_text('MODEL_PATH = "dummy"\n', encoding='utf-8')
+
+        env = os.environ.copy()
+        env.pop('PYTHONPATH', None)
+        result = subprocess.run(
+            [sys.executable, str(bridge_path), 'inspect'],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(temp_root),
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip())
+    assert payload['ok'] is True
+    assert payload['payload']['resolved_model_path'] == 'packaged/model.gguf'


### PR DESCRIPTION
### Motivation
- The desktop model bridge could fail at runtime with `No module named 'utils'` when launched from the packaged Tauri resources because `path_bootstrap.ensure_runtime_import_paths` only checked a single `resources/_up_` level and missed deeper rewrites like `resources/_up_/_up_/utils` produced by bundling `../../utils`.
- CI did not exercise the exact packaged/nested `_up_` layout, so the failure surfaced only in real desktop launches despite green compute-node e2e.

### Description
- Extend `ensure_runtime_import_paths` to generate and test multiple nested Tauri `_up_` candidates (scan up to several `_up_` layers) so packaged resources rewritten into `_up_/_up_/...` are discovered and inserted on `sys.path` in priority order. (`desktop-tauri/src-tauri/python/path_bootstrap.py`)
- Add a focused regression test that materializes a `resources/python` packaged-like tree with nested `_up_/_up_/utils` and runs `model_bridge.py` in a subprocess with `PYTHONPATH` unset to assert imports succeed; this test reproduces the failing packaged launch path and would have failed before the bootstrap fix. (`tests/unit/test_desktop_model_bridge.py`)
- Change is minimal and targeted to the bootstrap/import discovery used by the model bridge and other desktop Python bridge scripts; no unrelated refactors or behavior changes to compute-node/sidecar logic were made.

### Testing
- Packaged-layout subprocess smoke check: executed a small Python subprocess that copies `model_bridge.py` + `path_bootstrap.py` into `resources/python`, creates `resources/_up_/_up_/utils/llm/model_manager.py`, runs `python resources/python/model_bridge.py inspect` with `PYTHONPATH` unset, and asserted the returned payload; this check passed.
- `python -m pytest tests/unit/test_desktop_model_bridge.py -q` (container run) failed to start the full pytest run due to an external test `conftest.py` import requiring `requests` which is not present in the container; the new regression test itself executes as a subprocess and validates the fix.
- `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` (container run) also could not run due to missing `requests` in test environment.
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not complete in this environment due to missing system `glib-2.0` dev libraries; Rust unit tests were not modified by this change.
- `npm --prefix desktop-tauri run build` completed successfully and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` failed in this environment for the same missing system libs (unrelated to the Python logic).

This change closes the runtime import gap for packaged desktop launches and adds a regression that will catch this issue in future CI runs that can execute the packaged-layout check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f0e5b30832f899cf715f8bda3f4)