### PR TITLE
Fix model bridge imports for packaged desktop layout

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -13,9 +13,15 @@ def ensure_runtime_import_paths(script_file: str) -> None:
     resources_root = script_path.parent.parent
     candidates = [
         resources_root,  # bundled resources root in packaged apps
-        resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
         script_path.parent.parent.parent,
     ]
+
+    # Tauri rewrites out-of-tree bundle resources into nested `_up_` directories.
+    # For paths like ../../utils, the runtime location becomes resources/_up_/_up_/utils.
+    up_dir = resources_root
+    for _ in range(4):
+        up_dir = up_dir / "_up_"
+        candidates.append(up_dir)
 
     if len(script_path.parents) > 3:
         candidates.append(script_path.parents[3])  # repo root in development tree

--- a/tests/unit/test_desktop_model_bridge_packaged_layout.py
+++ b/tests/unit/test_desktop_model_bridge_packaged_layout.py
@@ -1,0 +1,73 @@
+"""Regression test for desktop model bridge imports in packaged-like layouts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+PYTHON_DIR = Path(__file__).resolve().parents[2] / "desktop-tauri" / "src-tauri" / "python"
+
+
+def _write_model_manager_stub(package_root: Path) -> None:
+    llm_dir = package_root / "utils" / "llm"
+    llm_dir.mkdir(parents=True, exist_ok=True)
+    (package_root / "utils" / "__init__.py").write_text("", encoding="utf-8")
+    (llm_dir / "__init__.py").write_text("", encoding="utf-8")
+    (llm_dir / "model_manager.py").write_text(
+        "\n".join(
+            [
+                "class _Manager:",
+                "    def get_model_artifact_metadata(self):",
+                "        return {",
+                "            'canonical_family_url': 'https://example.invalid/family',",
+                "            'filename': 'model.gguf',",
+                "            'url': 'https://example.invalid/model.gguf',",
+                "            'models_dir': '/tmp/models',",
+                "            'resolved_model_path': '/tmp/models/model.gguf',",
+                "            'exists': False,",
+                "            'size_bytes': None,",
+                "        }",
+                "",
+                "    def download_model_if_needed(self):",
+                "        return True",
+                "",
+                "",
+                "def get_model_manager():",
+                "    return _Manager()",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_model_bridge_inspect_resolves_utils_from_nested_up_dir(tmp_path):
+    resources_python = tmp_path / "resources" / "python"
+    resources_python.mkdir(parents=True, exist_ok=True)
+    (resources_python / "model_bridge.py").write_text(
+        (PYTHON_DIR / "model_bridge.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (resources_python / "path_bootstrap.py").write_text(
+        (PYTHON_DIR / "path_bootstrap.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    # Simulate tauri path rewrite for ../../utils in bundle resources.
+    rewritten_resource_root = tmp_path / "resources" / "_up_" / "_up_"
+    _write_model_manager_stub(rewritten_resource_root)
+
+    result = subprocess.run(
+        [sys.executable, str(resources_python / "model_bridge.py"), "inspect"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path / "resources",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    assert payload["payload"]["filename"] == "model.gguf"


### PR DESCRIPTION
### Motivation
- The desktop app could fail at runtime with `No module named 'utils'` because bundled resources rewritten by Tauri into nested `_up_` directories were not being considered when bootstrapping `PYTHONPATH` for the Python bridge. 
- The change targets the real launch layout (packaged/no-ambient-cwd) so the model bridge can import shared runtime modules when executed from app resources.

### Description
- Extend `path_bootstrap.ensure_runtime_import_paths` to append multiple nested `resources/_up_` candidate roots (up to 4 levels) so `../../utils` rewritten under nested `_up_` directories is discovered and added to `sys.path`.
- Remove the single explicit `_up_` entry and replace it with a loop that builds deeper `_up_` candidate paths while preserving existing candidate priority logic.
- Add a focused regression test `tests/unit/test_desktop_model_bridge_packaged_layout.py` that simulates a packaged-like `resources/_up_/_up_/utils` layout and runs `model_bridge.py inspect` in a subprocess to verify the bridge can resolve `utils` and return a successful JSON payload.

### Testing
- Ran `python -m pytest tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_model_bridge_packaged_layout.py` and all tests passed (8 passed total including the new packaged-layout test). 
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (9 passed).
- Ran `npm --prefix desktop-tauri run build` successfully to ensure frontend build remains intact.
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` but these failed in the execution environment due to missing system `glib-2.0` / pkg-config dev dependency (environment limitation, not regression from this change).
- Note: `pre-commit run --all-files` surfaced unrelated existing repo-wide checks (codespell / vulture) outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f0e5b30832f899cf715f8bda3f4)