### PR TITLE
Fix desktop model-bridge PYTHONPATH bootstrap for exe/python launches

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -10,10 +10,12 @@ def ensure_runtime_import_paths(script_file: str) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
     script_path = Path(script_file).resolve()
-    resources_root = script_path.parent.parent
+    script_root = script_path.parent.parent
     candidates = [
-        resources_root,  # bundled resources root in packaged apps
-        resources_root / "_up_",  # tauri ".." resources are rewritten under _up_
+        script_root,  # bundled resources root in packaged apps
+        script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
+        script_root / "Resources",  # macOS-style resources casing
+        script_root / "_up_",  # tauri ".." resources are rewritten under _up_
         script_path.parent.parent.parent,
     ]
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -108,13 +108,15 @@ fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
 }
 
 fn configure_runtime_pythonpath(command: &mut std::process::Command) {
+    // NOTE: CARGO_MANIFEST_DIR is compile-time and primarily helps local/dev launches.
+    // Packaged end-user launches rely on python/path_bootstrap.py for runtime import roots.
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
-                if let Ok(joined) =
-                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
-                {
+                let mut components = vec![PathBuf::from(&import_root)];
+                components.extend(std::env::split_paths(&existing));
+                if let Ok(joined) = std::env::join_paths(components) {
                     command.env("PYTHONPATH", joined);
                 } else {
                     command.env("PYTHONPATH", import_root);

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -90,12 +90,51 @@ fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
     })
 }
 
+fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
+    let mut candidates = vec![manifest_dir.to_path_buf()];
+    if let Some(parent) = manifest_dir.parent() {
+        candidates.push(parent.to_path_buf());
+        if let Some(grandparent) = parent.parent() {
+            candidates.push(grandparent.to_path_buf());
+        }
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| {
+            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
+        })
+        .map(|candidate| candidate.to_string_lossy().into_owned())
+}
+
+fn configure_runtime_pythonpath(command: &mut std::process::Command) {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+        match std::env::var("PYTHONPATH") {
+            Ok(existing) if !existing.trim().is_empty() => {
+                if let Ok(joined) =
+                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
+                {
+                    command.env("PYTHONPATH", joined);
+                } else {
+                    command.env("PYTHONPATH", import_root);
+                }
+            }
+            _ => {
+                command.env("PYTHONPATH", import_root);
+            }
+        }
+    }
+}
+
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path()?;
-    let output = launcher
-        .command_for_script_blocking(bridge_script.to_str().unwrap_or_default())
+    let mut bridge_command =
+        launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
+    configure_runtime_pythonpath(&mut bridge_command);
+    let output = bridge_command
         .arg(action)
         .output()
         .map_err(|e| format!("unable to run model bridge: {e}"))?;

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -2,6 +2,9 @@
 
 import importlib.util
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -109,3 +112,47 @@ def test_main_dispatches_download_action():
             assert model_bridge.main() == 0
 
     download_model.assert_called_once_with()
+
+
+def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):
+    """Regression: pre-fix exe/python + resources layout failed with No module named 'utils'."""
+    python_dir = tmp_path / 'bin' / 'python'
+    resources_dir = tmp_path / 'bin' / 'resources'
+    utils_llm_dir = resources_dir / 'utils' / 'llm'
+    python_dir.mkdir(parents=True)
+    utils_llm_dir.mkdir(parents=True)
+
+    (python_dir / 'model_bridge.py').write_text(MODULE_PATH.read_text(encoding='utf-8'), encoding='utf-8')
+    path_bootstrap_path = MODULE_PATH.parent / 'path_bootstrap.py'
+    (python_dir / 'path_bootstrap.py').write_text(path_bootstrap_path.read_text(encoding='utf-8'), encoding='utf-8')
+    (resources_dir / 'utils' / '__init__.py').write_text('', encoding='utf-8')
+    (utils_llm_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_llm_dir / 'model_manager.py').write_text(
+        """
+class _Manager:
+    def get_model_artifact_metadata(self):
+        return {"filename": "mock.gguf", "exists": False}
+
+
+def get_model_manager():
+    return _Manager()
+""".strip()
+        + "\n",
+        encoding='utf-8',
+    )
+
+    env = os.environ.copy()
+    env.pop('PYTHONPATH', None)
+    result = subprocess.run(
+        [sys.executable, str(python_dir / 'model_bridge.py'), 'inspect'],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip())
+    assert payload['ok'] is True
+    assert payload['payload']['filename'] == 'mock.gguf'
+    assert "Missing Python dependency for model downloads" not in result.stdout

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[2]
@@ -12,13 +14,18 @@ MODULE_PATH = (
     / 'python'
     / 'path_bootstrap.py'
 )
-SPEC = importlib.util.spec_from_file_location('desktop_path_bootstrap', MODULE_PATH)
-path_bootstrap = importlib.util.module_from_spec(SPEC)
-assert SPEC and SPEC.loader
-SPEC.loader.exec_module(path_bootstrap)
 
 
-def test_bootstrap_adds_resources_import_root_for_exe_python_layout(tmp_path):
+@pytest.fixture(scope='session')
+def path_bootstrap():
+    spec = importlib.util.spec_from_file_location('desktop_path_bootstrap', MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bootstrap_adds_resources_import_root_for_exe_python_layout(tmp_path, path_bootstrap):
     script = tmp_path / 'bin' / 'python' / 'model_bridge.py'
     resources_root = tmp_path / 'bin' / 'resources'
     (resources_root / 'utils').mkdir(parents=True)
@@ -34,7 +41,7 @@ def test_bootstrap_adds_resources_import_root_for_exe_python_layout(tmp_path):
         sys.path[:] = original_sys_path
 
 
-def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path):
+def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path, path_bootstrap):
     script = tmp_path / 'repo' / 'desktop-tauri' / 'src-tauri' / 'python' / 'model_bridge.py'
     repo_root = tmp_path / 'repo'
     (repo_root / 'utils').mkdir(parents=True)

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -1,0 +1,49 @@
+"""Unit tests for desktop Python path bootstrap behavior."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'src-tauri'
+    / 'python'
+    / 'path_bootstrap.py'
+)
+SPEC = importlib.util.spec_from_file_location('desktop_path_bootstrap', MODULE_PATH)
+path_bootstrap = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(path_bootstrap)
+
+
+def test_bootstrap_adds_resources_import_root_for_exe_python_layout(tmp_path):
+    script = tmp_path / 'bin' / 'python' / 'model_bridge.py'
+    resources_root = tmp_path / 'bin' / 'resources'
+    (resources_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(resources_root) in sys.path
+        assert sys.path.index(str(resources_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path):
+    script = tmp_path / 'repo' / 'desktop-tauri' / 'src-tauri' / 'python' / 'model_bridge.py'
+    repo_root = tmp_path / 'repo'
+    (repo_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(repo_root) in sys.path
+    finally:
+        sys.path[:] = original_sys_path


### PR DESCRIPTION
### Motivation

- The desktop `model_bridge.py` could be launched from an `exe/python` layout where shared modules live under a neighboring `resources` (or `Resources`) directory, causing `ModuleNotFoundError: No module named 'utils'` at runtime. 
- CI remained green because existing compute-node/sidecar launch paths already configured `PYTHONPATH`, while the model-bridge path did not exercise the same runtime import-root wiring.
- The intent is a minimal, targeted fix that reuses the repo-root import-root discovery and ensures the real desktop launch layout is covered by tests.

### Description

- Extend `desktop-tauri/src-tauri/python/path_bootstrap.py` to consider additional import-root candidates for `exe/python` launches by adding `resources`, `Resources`, and preserving bundled/script roots when resolving runtime import paths. 
- Add `repo_runtime_import_root` and `configure_runtime_pythonpath` helper logic to `desktop-tauri/src-tauri/src/main.rs` and apply it when constructing the command used to run the model bridge so the spawned Python process receives a correct `PYTHONPATH`. 
- Add a focused unit test `tests/unit/test_desktop_path_bootstrap.py` that simulates the `bin/python/model_bridge.py` + `bin/resources/utils` layout and an existing dev-tree layout to prevent regressions for the real desktop launch path. 

### Testing

- Ran `python -m pytest tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_path_bootstrap.py` and the targeted unit tests passed. 
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py` and existing compute-node bridge unit tests passed. 
- Ran `npm --prefix desktop-tauri run build` which succeeded; `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` was attempted but failed in this environment due to missing system `glib-2.0` pkg-config/dev libs. 
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` which could not complete in this environment for the same missing system dependency (`glib-2.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2f0e5b30832f899cf715f8bda3f4)