### PR TITLE
🐛 Fix bundled desktop bridges failing to import utils in installed releases

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -2,8 +2,23 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+
+def _has_runtime_modules(path: Path) -> bool:
+    return (path / "utils").is_dir() or (path / "config.py").is_file()
+
+
+def _resource_candidates(resource_dir: Path) -> list[Path]:
+    # Tauri rewrites ".." path segments into nested "_up_" directories.
+    candidates = [resource_dir]
+    nested = resource_dir
+    for _ in range(4):
+        nested = nested / "_up_"
+        candidates.append(nested)
+    return candidates
 
 
 def ensure_runtime_import_paths(script_file: str) -> None:
@@ -11,6 +26,8 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     script_root = script_path.parent.parent
+    env_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    env_resource_dir = os.environ.get("TOKEN_PLACE_RESOURCE_DIR", "").strip()
     candidates = [
         script_root,  # bundled resources root in packaged apps
         script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
@@ -18,6 +35,10 @@ def ensure_runtime_import_paths(script_file: str) -> None:
         script_root / "_up_",  # tauri ".." resources are rewritten under _up_
         script_path.parent.parent.parent,
     ]
+    if env_import_root:
+        candidates.insert(0, Path(env_import_root))
+    if env_resource_dir:
+        candidates = _resource_candidates(Path(env_resource_dir)) + candidates
 
     if len(script_path.parents) > 3:
         candidates.append(script_path.parents[3])  # repo root in development tree
@@ -26,7 +47,7 @@ def ensure_runtime_import_paths(script_file: str) -> None:
     for candidate in candidates:
         if not candidate.exists():
             continue
-        has_runtime_modules = (candidate / "utils").is_dir() or (candidate / "config.py").is_file()
+        has_runtime_modules = _has_runtime_modules(candidate)
         if has_runtime_modules:
             candidate_str = str(candidate)
             if candidate_str not in valid_candidates:

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -133,8 +133,38 @@ fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path) {
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+fn resolve_runtime_import_root(
+    bridge_script: &Path,
+    manifest_dir: &Path,
+) -> (Option<std::path::PathBuf>, Option<String>) {
+    let resource_dir = bridge_script.parent().and_then(|parent| parent.parent());
+    let mut candidates = Vec::new();
+    if let Some(resource_dir) = resource_dir {
+        candidates.push(resource_dir.to_path_buf());
+        let mut nested = resource_dir.to_path_buf();
+        for _ in 0..4 {
+            nested = nested.join("_up_");
+            candidates.push(nested.clone());
+        }
+    }
+    if let Some(repo_root) = repo_runtime_import_root(manifest_dir) {
+        candidates.push(std::path::PathBuf::from(repo_root));
+    }
+    let import_root = candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned());
+    (resource_dir.map(Path::to_path_buf), import_root)
+}
+
+fn configure_runtime_pythonpath(command: &mut Command, bridge_path: &str, manifest_dir: &Path) {
+    let bridge_script = Path::new(bridge_path);
+    let (resource_dir, import_root) = resolve_runtime_import_root(bridge_script, manifest_dir);
+    if let Some(resource_dir) = resource_dir {
+        command.env("TOKEN_PLACE_RESOURCE_DIR", resource_dir);
+    }
+    if let Some(import_root) = import_root {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 if let Ok(joined) =
@@ -262,7 +292,7 @@ pub async fn start_compute_node(
             return Err(err);
         }
     };
-    configure_runtime_pythonpath(&mut bridge_command, manifest_dir);
+    configure_runtime_pythonpath(&mut bridge_command, &bridge_script, manifest_dir);
 
     let spawn_result = bridge_command
         .arg("--model")

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -107,11 +107,43 @@ fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn configure_runtime_pythonpath(command: &mut std::process::Command) {
+fn resolve_runtime_import_root(
+    bridge_script: &Path,
+    manifest_dir: &Path,
+) -> (Option<PathBuf>, Option<String>) {
+    let resource_dir = bridge_script.parent().and_then(|parent| parent.parent());
+    let mut candidates = Vec::new();
+    if let Some(resource_dir) = resource_dir {
+        candidates.push(resource_dir.to_path_buf());
+        let mut nested = resource_dir.to_path_buf();
+        for _ in 0..4 {
+            nested = nested.join("_up_");
+            candidates.push(nested.clone());
+        }
+    }
+    if let Some(repo_root) = repo_runtime_import_root(manifest_dir) {
+        candidates.push(PathBuf::from(repo_root));
+    }
+    let import_root = candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned());
+    (resource_dir.map(Path::to_path_buf), import_root)
+}
+
+fn configure_runtime_pythonpath(
+    command: &mut std::process::Command,
+    bridge_script: &Path,
+    manifest_dir: &Path,
+) {
+    let (resource_dir, import_root) = resolve_runtime_import_root(bridge_script, manifest_dir);
+    if let Some(resource_dir) = resource_dir {
+        command.env("TOKEN_PLACE_RESOURCE_DIR", resource_dir);
+    }
     // NOTE: CARGO_MANIFEST_DIR is compile-time and primarily helps local/dev launches.
     // Packaged end-user launches rely on python/path_bootstrap.py for runtime import roots.
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    if let Some(import_root) = import_root {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 let mut components = vec![PathBuf::from(&import_root)];
@@ -130,12 +162,13 @@ fn configure_runtime_pythonpath(command: &mut std::process::Command) {
 }
 
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path()?;
     let mut bridge_command =
         launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
-    configure_runtime_pythonpath(&mut bridge_command);
+    configure_runtime_pythonpath(&mut bridge_command, &bridge_script, manifest_dir);
     let output = bridge_command
         .arg(action)
         .output()

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -202,9 +202,39 @@ fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn configure_runtime_pythonpath(command: &mut Command) {
+fn resolve_runtime_import_root(
+    sidecar_script: &Path,
+    manifest_dir: &Path,
+) -> (Option<std::path::PathBuf>, Option<String>) {
+    let resource_dir = sidecar_script.parent().and_then(|parent| parent.parent());
+    let mut candidates = Vec::new();
+    if let Some(resource_dir) = resource_dir {
+        candidates.push(resource_dir.to_path_buf());
+        let mut nested = resource_dir.to_path_buf();
+        for _ in 0..4 {
+            nested = nested.join("_up_");
+            candidates.push(nested.clone());
+        }
+    }
+    if let Some(repo_root) = repo_runtime_import_root(manifest_dir) {
+        candidates.push(std::path::PathBuf::from(repo_root));
+    }
+    let import_root = candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned());
+    (resource_dir.map(Path::to_path_buf), import_root)
+}
+
+fn configure_runtime_pythonpath(command: &mut Command, sidecar_script: &str) {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    let sidecar_path = Path::new(sidecar_script);
+    let (resource_dir, import_root) = resolve_runtime_import_root(sidecar_path, manifest_dir);
+    if let Some(resource_dir) = resource_dir {
+        command.env("TOKEN_PLACE_RESOURCE_DIR", resource_dir);
+    }
+    if let Some(import_root) = import_root {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 if let Ok(joined) =
@@ -258,7 +288,7 @@ pub async fn start_sidecar(
     };
 
     let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
-    configure_runtime_pythonpath(&mut sidecar_command);
+    configure_runtime_pythonpath(&mut sidecar_command, &sidecar_script);
 
     let mut child = sidecar_command
         .arg("--model")

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2,7 +2,9 @@
 
 import importlib.util
 import json
+import os
 import queue
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -400,3 +402,104 @@ def test_main_normalizes_mode_before_run(monkeypatch):
     status = compute_node_bridge.main()
     assert status == 0
     assert captured['mode'] == 'auto'
+
+
+def test_compute_node_subprocess_resolves_nested_up_packaged_layout(tmp_path):
+    python_dir = tmp_path / 'installed' / 'resources' / 'python'
+    runtime_root = tmp_path / 'installed' / 'resources' / '_up_' / '_up_'
+    utils_dir = runtime_root / 'utils'
+    python_dir.mkdir(parents=True)
+    utils_dir.mkdir(parents=True)
+
+    (python_dir / 'compute_node_bridge.py').write_text(
+        MODULE_PATH.read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    bridge_bootstrap = MODULE_PATH.parent / 'path_bootstrap.py'
+    (python_dir / 'path_bootstrap.py').write_text(
+        bridge_bootstrap.read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_dir / 'compute_node_runtime.py').write_text(
+        """
+def normalize_compute_mode(mode):
+    return mode.lower()
+
+
+def apply_compute_mode(_manager, mode):
+    return mode
+
+
+def resolve_relay_url(relay_url):
+    return relay_url
+
+
+def resolve_relay_port(relay_port, _relay_url):
+    return relay_port
+
+
+def is_legacy_relay_payload(payload):
+    return False
+
+
+class _RelayClient:
+    relay_url = "https://token.place"
+
+
+class _ModelManager:
+    model_path = ""
+
+
+class ComputeNodeRuntimeConfig:
+    def __init__(self, relay_url, relay_port):
+        self.relay_url = relay_url
+        self.relay_port = relay_port
+
+
+class ComputeNodeRuntime:
+    def __init__(self, _config):
+        self.model_manager = _ModelManager()
+        self.relay_client = _RelayClient()
+
+    def ensure_model_ready(self):
+        return True
+
+    def register_and_poll_once(self):
+        return {"next_ping_in_x_seconds": 0}
+
+    def process_relay_request(self, _payload):
+        return True
+
+    def stop(self):
+        return None
+""".strip()
+        + "\n",
+        encoding='utf-8',
+    )
+
+    env = os.environ.copy()
+    env.pop('PYTHONPATH', None)
+    env['TOKEN_PLACE_RESOURCE_DIR'] = str(tmp_path / 'installed' / 'resources')
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(python_dir / 'compute_node_bridge.py'),
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'cpu',
+            '--relay-url',
+            'https://token.place',
+        ],
+        input='{"type":"cancel"}\n',
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    events = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    assert events[0]['type'] == 'started'
+    assert events[-1]['type'] == 'stopped'

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -1,6 +1,7 @@
 """Unit tests for desktop Python path bootstrap behavior."""
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -53,4 +54,46 @@ def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path, path_bootstrap):
         path_bootstrap.ensure_runtime_import_paths(str(script))
         assert str(repo_root) in sys.path
     finally:
+        sys.path[:] = original_sys_path
+
+
+def test_bootstrap_prefers_explicit_import_root_env(tmp_path, path_bootstrap):
+    script = tmp_path / 'bin' / 'python' / 'model_bridge.py'
+    explicit_root = tmp_path / 'bundle' / 'runtime-root'
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    (explicit_root / 'utils').mkdir(parents=True)
+
+    original_sys_path = list(sys.path)
+    previous_import_root = os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT')
+    try:
+        os.environ['TOKEN_PLACE_PYTHON_IMPORT_ROOT'] = str(explicit_root)
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert sys.path[0] == str(explicit_root)
+    finally:
+        if previous_import_root is None:
+            os.environ.pop('TOKEN_PLACE_PYTHON_IMPORT_ROOT', None)
+        else:
+            os.environ['TOKEN_PLACE_PYTHON_IMPORT_ROOT'] = previous_import_root
+        sys.path[:] = original_sys_path
+
+
+def test_bootstrap_resolves_nested_up_resource_layout(tmp_path, path_bootstrap):
+    script = tmp_path / 'installed' / 'resources' / 'python' / 'model_bridge.py'
+    nested_up_root = tmp_path / 'installed' / 'resources' / '_up_' / '_up_'
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    (nested_up_root / 'utils').mkdir(parents=True)
+
+    original_sys_path = list(sys.path)
+    previous_resource_dir = os.environ.get('TOKEN_PLACE_RESOURCE_DIR')
+    try:
+        os.environ['TOKEN_PLACE_RESOURCE_DIR'] = str(tmp_path / 'installed' / 'resources')
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert sys.path[0] == str(nested_up_root)
+    finally:
+        if previous_resource_dir is None:
+            os.environ.pop('TOKEN_PLACE_RESOURCE_DIR', None)
+        else:
+            os.environ['TOKEN_PLACE_RESOURCE_DIR'] = previous_resource_dir
         sys.path[:] = original_sys_path


### PR DESCRIPTION
### Motivation
- Packaged/installed desktop builds could still raise `No module named 'utils'` because bundled `../../utils` may be rewritten into nested `_up_` paths by Tauri and previously-used heuristics missed those layouts.
- Both Python bridges already call `ensure_runtime_import_paths(__file__)`, so the remaining issue was that the runtime import root was not being explicitly conveyed for packaged launches.
- Provide a small, explicit runtime contract from Rust to Python so the packaged layout is resolved deterministically at launch.

### Description
- Resolve the effective bundled resource root from the resolved bridge script path in Rust and export explicit env vars used by Python: `TOKEN_PLACE_RESOURCE_DIR` and `TOKEN_PLACE_PYTHON_IMPORT_ROOT`, and set `PYTHONPATH` when an import root is found; applied for model bridge, compute-node bridge and sidecar launcher (`main.rs`, `compute_node.rs`, `sidecar.rs`).
- Extend the Python bootstrap `ensure_runtime_import_paths` to prefer the explicit env vars first and then fall back to heuristic discovery, and add support for multi-level `_up_` candidates that Tauri uses when rewriting `..` segments (`desktop-tauri/src-tauri/python/path_bootstrap.py`).
- Add focused regression unit tests that simulate packaged layouts:
  - explicit-import-root precedence and nested `_up_` resolution in `tests/unit/test_desktop_path_bootstrap.py`, and
  - a compute-node subprocess regression that runs the bridge from a packaged-like nested `_up_/_up_` layout without `PYTHONPATH` in `tests/unit/test_desktop_compute_node_bridge.py`.
- Changes limited to the desktop runtime/bridge files and tests as requested.

### Testing
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_path_bootstrap.py` and observed all unit tests pass: `22 passed`.
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py` and observed `10 passed` for the compute-node suite.
- Built the frontend with `npm --prefix desktop-tauri run build` which succeeded.
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` in this container but they fail due to missing system-level dependency `glib-2.0`/pkg-config in the execution environment (these failures are environmental and not related to the change).
- `pre-commit run --all-files` was not available in the container environment and was not run here.

Commands used during verification: `python -m pytest ...`, `npm --prefix desktop-tauri run build`, `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle`, and `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` (env-dependent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc761c0698832fb93156c175840249)