### PR TITLE
Fix packaged desktop bridge imports by passing explicit runtime import root

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import os
 from pathlib import Path
 
 
@@ -11,13 +12,28 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     script_root = script_path.parent.parent
-    candidates = [
+    env_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    env_resource_dir = os.environ.get("TOKEN_PLACE_RESOURCE_DIR", "").strip()
+
+    candidates = []
+    if env_import_root:
+        candidates.append(Path(env_import_root))
+    if env_resource_dir:
+        resource_dir = Path(env_resource_dir)
+        candidates.extend(
+            [
+                resource_dir,
+                resource_dir / "_up_",
+            ]
+        )
+
+    candidates.extend([
         script_root,  # bundled resources root in packaged apps
         script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
         script_root / "Resources",  # macOS-style resources casing
         script_root / "_up_",  # tauri ".." resources are rewritten under _up_
         script_path.parent.parent.parent,
-    ]
+    ])
 
     if len(script_path.parents) > 3:
         candidates.append(script_path.parents[3])  # repo root in development tree

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -152,6 +152,40 @@ fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path) {
     }
 }
 
+fn resolve_runtime_import_root(
+    bridge_path: &Path,
+    manifest_dir: &Path,
+) -> Option<std::path::PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(script_dir) = bridge_path.parent() {
+        if let Some(parent) = script_dir.parent() {
+            candidates.push(parent.to_path_buf());
+            candidates.push(parent.join("_up_"));
+        }
+        if let Some(grandparent) = script_dir.parent().and_then(|p| p.parent()) {
+            candidates.push(grandparent.to_path_buf());
+            candidates.push(grandparent.join("_up_"));
+        }
+    }
+    if let Some(repo_root) = repo_runtime_import_root(manifest_dir) {
+        candidates.push(std::path::PathBuf::from(repo_root));
+    }
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+}
+
+fn configure_runtime_import_contract(command: &mut Command, bridge_path: &Path, manifest_dir: &Path) {
+    if let Some(script_dir) = bridge_path.parent() {
+        if let Some(resource_dir) = script_dir.parent() {
+            command.env("TOKEN_PLACE_RESOURCE_DIR", resource_dir);
+        }
+    }
+    if let Some(import_root) = resolve_runtime_import_root(bridge_path, manifest_dir) {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root);
+    }
+}
+
 fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
     ComputeNodeStatus {
         running: false,
@@ -263,6 +297,7 @@ pub async fn start_compute_node(
         }
     };
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir);
+    configure_runtime_import_contract(&mut bridge_command, Path::new(&bridge_script), manifest_dir);
 
     let spawn_result = bridge_command
         .arg("--model")
@@ -579,5 +614,25 @@ mod tests {
         let resolved = first_existing_script(candidates).expect("resolved bridge path");
 
         assert_eq!(Path::new(&resolved), resources_bridge);
+    }
+
+    #[test]
+    fn runtime_import_root_prefers_packaged_resources_up_layout() {
+        let temp = TempDir::new().expect("tempdir");
+        let script = temp
+            .path()
+            .join("bin")
+            .join("resources")
+            .join("python")
+            .join("compute_node_bridge.py");
+        let import_root = temp.path().join("bin").join("resources").join("_up_");
+        std::fs::create_dir_all(import_root.join("utils")).expect("create import root");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create script parent");
+        std::fs::write(&script, "print('ok')\n").expect("write bridge script");
+
+        let resolved =
+            resolve_runtime_import_root(&script, temp.path()).expect("resolve import root");
+        assert_eq!(resolved, import_root);
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -129,6 +129,40 @@ fn configure_runtime_pythonpath(command: &mut std::process::Command) {
     }
 }
 
+fn resolve_runtime_import_root(script_path: &Path) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(script_dir) = script_path.parent() {
+        if let Some(parent) = script_dir.parent() {
+            candidates.push(parent.to_path_buf());
+            candidates.push(parent.join("_up_"));
+        }
+        if let Some(grandparent) = script_dir.parent().and_then(|p| p.parent()) {
+            candidates.push(grandparent.to_path_buf());
+            candidates.push(grandparent.join("_up_"));
+        }
+    }
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if let Some(repo_root) = repo_runtime_import_root(manifest_dir) {
+        candidates.push(PathBuf::from(repo_root));
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+}
+
+fn configure_runtime_import_contract(command: &mut std::process::Command, script_path: &Path) {
+    if let Some(script_dir) = script_path.parent() {
+        if let Some(resource_dir) = script_dir.parent() {
+            command.env("TOKEN_PLACE_RESOURCE_DIR", resource_dir);
+        }
+    }
+    if let Some(import_root) = resolve_runtime_import_root(script_path) {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root);
+    }
+}
+
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
@@ -136,6 +170,7 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
     let mut bridge_command =
         launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
     configure_runtime_pythonpath(&mut bridge_command);
+    configure_runtime_import_contract(&mut bridge_command, &bridge_script);
     let output = bridge_command
         .arg(action)
         .output()
@@ -472,5 +507,18 @@ mod tests {
                 "missing bundled python resource: {script}"
             );
         }
+    }
+
+    #[test]
+    fn runtime_import_root_prefers_packaged_resources_up_layout() {
+        let temp = TempDir::new().expect("tempdir");
+        let script = temp.path().join("bin").join("resources").join("python").join("model_bridge.py");
+        let import_root = temp.path().join("bin").join("resources").join("_up_");
+        std::fs::create_dir_all(import_root.join("utils")).expect("create import root");
+        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script parent");
+        std::fs::write(&script, "print('ok')\n").expect("write bridge script");
+
+        let resolved = resolve_runtime_import_root(&script).expect("resolve import root");
+        assert_eq!(resolved, import_root);
     }
 }

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -54,3 +54,20 @@ def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path, path_bootstrap):
         assert str(repo_root) in sys.path
     finally:
         sys.path[:] = original_sys_path
+
+
+def test_bootstrap_prefers_explicit_runtime_import_root_env(tmp_path, path_bootstrap, monkeypatch):
+    script = tmp_path / 'unrelated' / 'python' / 'model_bridge.py'
+    explicit_root = tmp_path / 'packaged' / 'resources' / '_up_'
+    (explicit_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(explicit_root))
+    monkeypatch.delenv('TOKEN_PLACE_RESOURCE_DIR', raising=False)
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert sys.path[0] == str(explicit_root)
+    finally:
+        sys.path[:] = original_sys_path


### PR DESCRIPTION
### Motivation
- Packaged/installed desktop releases could still raise `No module named 'utils'` because the Python bridge relied only on heuristic discovery of the repo/resource layout at runtime. 
- A small, explicit runtime contract from the Rust launcher to Python bridges is more robust for bundled layouts (especially Tauri's rewritten `_up_` paths). 

### Description
- Rust now resolves a probable runtime import root from the resolved bridge-script location and exports two env vars for bridge subprocesses: `TOKEN_PLACE_PYTHON_IMPORT_ROOT` and `TOKEN_PLACE_RESOURCE_DIR`. 
- `desktop-tauri/src-tauri/python/path_bootstrap.py` was updated to prefer `TOKEN_PLACE_PYTHON_IMPORT_ROOT` first, then `TOKEN_PLACE_RESOURCE_DIR` (and its `_up_` variant), before falling back to the previous heuristics. 
- The same import-contract wiring was added to both model bridge launch path and compute-node bridge launch path so both entrypoints behave identically. 
- Added targeted regression coverage: a Python unit test to verify the explicit env override, and Rust unit tests that assert `_up_` packaged-resource import roots are preferred for model and compute-node bridge resolution. 

### Testing
- Ran Python unit tests with `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_path_bootstrap.py` and the targeted suite passed (20 passed). 
- Verified the new env-var-specific test with `python -m pytest tests/unit/test_desktop_path_bootstrap.py::test_bootstrap_prefers_explicit_runtime_import_root_env` which passed. 
- Built the frontend with `npm --prefix desktop-tauri run build` which succeeded. 
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` were attempted but failed in this environment due to missing system `glib-2.0` (`glib-sys`) required by the platform toolchain, not due to the patch. 
- `pre-commit run --all-files` was exercised but full project hooks failed in this environment (hook tooling and some unrelated checks installed/ran and produced non-targeted findings), which is orthogonal to the runtime-path fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc761c0698832fb93156c175840249)