### PR TITLE
🐛 fix: desktop packaged python import root contract

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 import sys
+import os
 from pathlib import Path
+
+
+def _candidate_import_roots_from_resource_dir(resource_dir: Path) -> list[Path]:
+    candidates: list[Path] = [resource_dir]
+    current = resource_dir
+    for _ in range(4):
+        current = current / "_up_"
+        candidates.append(current)
+    return candidates
 
 
 def ensure_runtime_import_paths(script_file: str) -> None:
@@ -11,11 +21,25 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     script_root = script_path.parent.parent
+    env_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    env_resource_dir = os.environ.get("TOKEN_PLACE_RESOURCE_DIR", "").strip()
+
+    env_candidates: list[Path] = []
+    if env_import_root:
+        env_candidates.append(Path(env_import_root).expanduser())
+    if env_resource_dir:
+        env_candidates.extend(
+            _candidate_import_roots_from_resource_dir(Path(env_resource_dir).expanduser())
+        )
+
     candidates = [
+        *env_candidates,
         script_root,  # bundled resources root in packaged apps
         script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
         script_root / "Resources",  # macOS-style resources casing
         script_root / "_up_",  # tauri ".." resources are rewritten under _up_
+        script_root / "_up_" / "_up_",
+        script_root / "_up_" / "_up_" / "_up_",
         script_path.parent.parent.parent,
     ]
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -116,29 +116,28 @@ fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> 
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
-    let mut candidates = vec![manifest_dir.to_path_buf()];
-    if let Some(parent) = manifest_dir.parent() {
-        candidates.push(parent.to_path_buf());
-        if let Some(grandparent) = parent.parent() {
-            candidates.push(grandparent.to_path_buf());
-        }
+fn configure_runtime_python_env(
+    command: &mut Command,
+    manifest_dir: &Path,
+    resource_dir: Option<&Path>,
+) {
+    if let Some(resource_dir) = resource_dir {
+        command.env(
+            crate::python_runtime::RESOURCE_DIR_ENV,
+            resource_dir.to_string_lossy().as_ref(),
+        );
     }
-
-    candidates
-        .into_iter()
-        .find(|candidate| {
-            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-        })
-        .map(|candidate| candidate.to_string_lossy().into_owned())
-}
-
-fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path) {
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    if let Some(import_root) =
+        crate::python_runtime::resolve_runtime_import_root(resource_dir, manifest_dir)
+    {
+        command.env(
+            crate::python_runtime::PYTHON_IMPORT_ROOT_ENV,
+            import_root.to_string_lossy().as_ref(),
+        );
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 if let Ok(joined) =
-                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
+                    std::env::join_paths([import_root.as_path(), Path::new(&existing)])
                 {
                     command.env("PYTHONPATH", joined);
                 } else {
@@ -262,7 +261,8 @@ pub async fn start_compute_node(
             return Err(err);
         }
     };
-    configure_runtime_pythonpath(&mut bridge_command, manifest_dir);
+    let resource_dir = app.path().resource_dir().ok();
+    configure_runtime_python_env(&mut bridge_command, manifest_dir, resource_dir.as_deref());
 
     let spawn_result = bridge_command
         .arg("--model")

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
-use tauri::{Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::Mutex;
 
 #[derive(Default)]
@@ -90,31 +90,25 @@ fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
     })
 }
 
-fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
-    let mut candidates = vec![manifest_dir.to_path_buf()];
-    if let Some(parent) = manifest_dir.parent() {
-        candidates.push(parent.to_path_buf());
-        if let Some(grandparent) = parent.parent() {
-            candidates.push(grandparent.to_path_buf());
-        }
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| {
-            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-        })
-        .map(|candidate| candidate.to_string_lossy().into_owned())
-}
-
-fn configure_runtime_pythonpath(command: &mut std::process::Command) {
-    // NOTE: CARGO_MANIFEST_DIR is compile-time and primarily helps local/dev launches.
-    // Packaged end-user launches rely on python/path_bootstrap.py for runtime import roots.
+fn configure_runtime_python_env(command: &mut std::process::Command, app: Option<&AppHandle>) {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    let resource_dir = app.and_then(|handle| handle.path().resource_dir().ok());
+    if let Some(resource_dir) = resource_dir.as_ref() {
+        command.env(
+            python_runtime::RESOURCE_DIR_ENV,
+            resource_dir.to_string_lossy().as_ref(),
+        );
+    }
+    if let Some(import_root) =
+        python_runtime::resolve_runtime_import_root(resource_dir.as_deref(), manifest_dir)
+    {
+        command.env(
+            python_runtime::PYTHON_IMPORT_ROOT_ENV,
+            import_root.to_string_lossy().as_ref(),
+        );
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
-                let mut components = vec![PathBuf::from(&import_root)];
+                let mut components = vec![import_root.clone()];
                 components.extend(std::env::split_paths(&existing));
                 if let Ok(joined) = std::env::join_paths(components) {
                     command.env("PYTHONPATH", joined);
@@ -129,13 +123,13 @@ fn configure_runtime_pythonpath(command: &mut std::process::Command) {
     }
 }
 
-fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
+fn run_model_bridge(action: &str, app: Option<&AppHandle>) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path()?;
     let mut bridge_command =
         launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
-    configure_runtime_pythonpath(&mut bridge_command);
+    configure_runtime_python_env(&mut bridge_command, app);
     let output = bridge_command
         .arg(action)
         .output()
@@ -329,13 +323,13 @@ async fn get_compute_node_status(
 }
 
 #[tauri::command]
-fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
-    run_model_bridge("inspect")
+fn inspect_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    run_model_bridge("inspect", Some(&app))
 }
 
 #[tauri::command]
-async fn download_model_artifact() -> Result<ModelArtifactInfo, String> {
-    tokio::task::spawn_blocking(|| run_model_bridge("download"))
+async fn download_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    tokio::task::spawn_blocking(move || run_model_bridge("download", Some(&app)))
         .await
         .map_err(|e| format!("download bridge task failed: {e}"))?
 }

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,9 +1,56 @@
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct PythonLauncher {
     pub program: String,
     pub args: Vec<String>,
+}
+
+pub const PYTHON_IMPORT_ROOT_ENV: &str = "TOKEN_PLACE_PYTHON_IMPORT_ROOT";
+pub const RESOURCE_DIR_ENV: &str = "TOKEN_PLACE_RESOURCE_DIR";
+
+fn has_runtime_modules(candidate: &Path) -> bool {
+    candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
+}
+
+fn runtime_import_candidates_from_resource_dir(resource_dir: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let mut current = resource_dir.to_path_buf();
+    candidates.push(current.clone());
+
+    for _ in 0..4 {
+        current = current.join("_up_");
+        candidates.push(current.clone());
+    }
+
+    candidates
+}
+
+pub fn resolve_runtime_import_root(
+    resource_dir: Option<&Path>,
+    manifest_dir: &Path,
+) -> Option<PathBuf> {
+    if let Some(resource_dir) = resource_dir {
+        if let Some(import_root) = runtime_import_candidates_from_resource_dir(resource_dir)
+            .into_iter()
+            .find(|candidate| has_runtime_modules(candidate))
+        {
+            return Some(import_root);
+        }
+    }
+
+    let mut repo_candidates = vec![manifest_dir.to_path_buf()];
+    if let Some(parent) = manifest_dir.parent() {
+        repo_candidates.push(parent.to_path_buf());
+        if let Some(grandparent) = parent.parent() {
+            repo_candidates.push(grandparent.to_path_buf());
+        }
+    }
+
+    repo_candidates
+        .into_iter()
+        .find(|candidate| has_runtime_modules(candidate))
 }
 
 impl PythonLauncher {
@@ -152,6 +199,7 @@ mod tests {
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -307,5 +355,24 @@ mod tests {
         assert!(msg.contains("python  -> status="));
         assert!(msg.contains("Python 2.7.18"));
         assert!(msg.contains("python3  -> spawn failed"));
+    }
+
+    #[test]
+    fn runtime_import_root_prefers_packaged_up_path_when_present() {
+        let temp = TempDir::new().expect("tempdir");
+        let resource_dir = temp.path().join("resources");
+        let import_root = resource_dir.join("_up_").join("_up_");
+        std::fs::create_dir_all(import_root.join("utils")).expect("create utils");
+
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        std::fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+
+        let resolved =
+            resolve_runtime_import_root(Some(&resource_dir), &manifest_dir).expect("import root");
+        assert_eq!(resolved, import_root);
     }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -185,30 +185,25 @@ fn should_force_fake_sidecar() -> bool {
     )
 }
 
-fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
-    let mut candidates = vec![manifest_dir.to_path_buf()];
-    if let Some(parent) = manifest_dir.parent() {
-        candidates.push(parent.to_path_buf());
-        if let Some(grandparent) = parent.parent() {
-            candidates.push(grandparent.to_path_buf());
-        }
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| {
-            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-        })
-        .map(|candidate| candidate.to_string_lossy().into_owned())
-}
-
-fn configure_runtime_pythonpath(command: &mut Command) {
+fn configure_runtime_python_env(command: &mut Command, resource_dir: Option<&Path>) {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    if let Some(resource_dir) = resource_dir {
+        command.env(
+            crate::python_runtime::RESOURCE_DIR_ENV,
+            resource_dir.to_string_lossy().as_ref(),
+        );
+    }
+    if let Some(import_root) =
+        crate::python_runtime::resolve_runtime_import_root(resource_dir, manifest_dir)
+    {
+        command.env(
+            crate::python_runtime::PYTHON_IMPORT_ROOT_ENV,
+            import_root.to_string_lossy().as_ref(),
+        );
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 if let Ok(joined) =
-                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
+                    std::env::join_paths([import_root.as_path(), Path::new(&existing)])
                 {
                     command.env("PYTHONPATH", joined);
                 } else {
@@ -258,7 +253,8 @@ pub async fn start_sidecar(
     };
 
     let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
-    configure_runtime_pythonpath(&mut sidecar_command);
+    let resource_dir = app.path().resource_dir().ok();
+    configure_runtime_python_env(&mut sidecar_command, resource_dir.as_deref());
 
     let mut child = sidecar_command
         .arg("--model")

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -54,3 +54,21 @@ def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path, path_bootstrap):
         assert str(repo_root) in sys.path
     finally:
         sys.path[:] = original_sys_path
+
+
+def test_bootstrap_prefers_explicit_import_root_env(tmp_path, path_bootstrap, monkeypatch):
+    script = tmp_path / 'bin' / 'resources' / 'python' / 'model_bridge.py'
+    import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
+    (import_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(import_root))
+    monkeypatch.delenv('TOKEN_PLACE_RESOURCE_DIR', raising=False)
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(import_root) in sys.path
+        assert sys.path.index(str(import_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path


### PR DESCRIPTION
### Motivation
- Installed/bundled desktop builds could not find the shared Python runtime modules (e.g. `utils`) because packaged layouts can rebase resources under nested `_up_` directories and the bridges relied on heuristics alone.
- Bridges exercised in CI used a `--no-bundle` debug layout so the regression slipped into releases while local/dev tests passed.

### Description
- Introduced an explicit runtime contract and resolver: new env vars `TOKEN_PLACE_RESOURCE_DIR` and `TOKEN_PLACE_PYTHON_IMPORT_ROOT`, and a centralized `resolve_runtime_import_root(...)` helper that searches packaged `_up_` rebased candidates before falling back to repo-layout roots (implemented in `desktop-tauri/src-tauri/src/python_runtime.rs`).
- Pass the resolved resource/import roots from Rust to Python subprocesses: updated model bridge launcher to accept an `AppHandle` and set the envs, and applied the same env injection for compute-node and sidecar launches (`desktop-tauri/src-tauri/src/main.rs`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/src/sidecar.rs`).
- Updated `desktop-tauri/src-tauri/python/path_bootstrap.py` to prefer env-provided import roots and to include deeper `_up_` traversal candidates so packaged layouts are found reliably.
- Added a targeted regression test that verifies env-driven packaged `_up_/_up_` import-root resolution and extended an existing path-bootstrap unit test to validate the explicit-import-root behavior (`tests/unit/test_desktop_path_bootstrap.py`).

### Testing
- Ran Python unit tests: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_path_bootstrap.py` and all tests passed (20 passed).
- Ran the targeted bootstrap test: `python -m pytest tests/unit/test_desktop_path_bootstrap.py::test_bootstrap_prefers_explicit_import_root_env` and it passed.
- Built the frontend bundle: `npm --prefix desktop-tauri run build` succeeded.
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` but these failed in this environment due to missing system `glib-2.0` / pkg-config libraries (external to this change).
- Could not run `pre-commit run --all-files` in this environment because `pre-commit` is not installed; no repository secrets scanner script was present at the referenced path.

Files changed (focused):
- desktop-tauri/src-tauri/src/python_runtime.rs
- desktop-tauri/src-tauri/src/main.rs
- desktop-tauri/src-tauri/src/compute_node.rs
- desktop-tauri/src-tauri/src/sidecar.rs
- desktop-tauri/src-tauri/python/path_bootstrap.py
- tests/unit/test_desktop_path_bootstrap.py

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc761c0698832fb93156c175840249)