### PR TITLE
🐛 Fix packaged desktop Python bridge import root resolution

### DIFF
--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import os
 from pathlib import Path
 
 
@@ -11,11 +12,14 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     script_path = Path(script_file).resolve()
     script_root = script_path.parent.parent
+    explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
     candidates = [
+        Path(explicit_import_root) if explicit_import_root else None,
         script_root,  # bundled resources root in packaged apps
         script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
         script_root / "Resources",  # macOS-style resources casing
         script_root / "_up_",  # tauri ".." resources are rewritten under _up_
+        script_root / "_up_" / "_up_",  # tauri "../.." resources can nest _up_ segments
         script_path.parent.parent.parent,
     ]
 
@@ -24,6 +28,8 @@ def ensure_runtime_import_paths(script_file: str) -> None:
 
     valid_candidates: list[str] = []
     for candidate in candidates:
+        if candidate is None:
+            continue
         if not candidate.exists():
             continue
         has_runtime_modules = (candidate / "utils").is_dir() or (candidate / "config.py").is_file()

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,5 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::{resolve_python_launcher, PythonLauncher};
+use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -116,29 +116,15 @@ fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> 
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
-    let mut candidates = vec![manifest_dir.to_path_buf()];
-    if let Some(parent) = manifest_dir.parent() {
-        candidates.push(parent.to_path_buf());
-        if let Some(grandparent) = parent.parent() {
-            candidates.push(grandparent.to_path_buf());
-        }
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| {
-            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-        })
-        .map(|candidate| candidate.to_string_lossy().into_owned())
-}
-
-fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path) {
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path, bridge_script: &str) {
+    if let Some(import_root) =
+        resolve_runtime_import_root(Some(Path::new(bridge_script)), manifest_dir)
+    {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 if let Ok(joined) =
-                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
+                    std::env::join_paths([import_root.as_path(), Path::new(&existing)])
                 {
                     command.env("PYTHONPATH", joined);
                 } else {
@@ -262,7 +248,7 @@ pub async fn start_compute_node(
             return Err(err);
         }
     };
-    configure_runtime_pythonpath(&mut bridge_command, manifest_dir);
+    configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
 
     let spawn_result = bridge_command
         .arg("--model")

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -123,9 +123,9 @@ fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path, brid
         command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
-                if let Ok(joined) =
-                    std::env::join_paths([import_root.as_path(), Path::new(&existing)])
-                {
+                let mut components = vec![import_root.clone()];
+                components.extend(std::env::split_paths(&existing));
+                if let Ok(joined) = std::env::join_paths(components) {
                     command.env("PYTHONPATH", joined);
                 } else {
                     command.env("PYTHONPATH", import_root);

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -90,31 +90,17 @@ fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
     })
 }
 
-fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
-    let mut candidates = vec![manifest_dir.to_path_buf()];
-    if let Some(parent) = manifest_dir.parent() {
-        candidates.push(parent.to_path_buf());
-        if let Some(grandparent) = parent.parent() {
-            candidates.push(grandparent.to_path_buf());
-        }
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| {
-            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-        })
-        .map(|candidate| candidate.to_string_lossy().into_owned())
-}
-
-fn configure_runtime_pythonpath(command: &mut std::process::Command) {
+fn configure_runtime_pythonpath(command: &mut std::process::Command, bridge_script: &Path) {
     // NOTE: CARGO_MANIFEST_DIR is compile-time and primarily helps local/dev launches.
     // Packaged end-user launches rely on python/path_bootstrap.py for runtime import roots.
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    if let Some(import_root) =
+        python_runtime::resolve_runtime_import_root(Some(bridge_script), manifest_dir)
+    {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
-                let mut components = vec![PathBuf::from(&import_root)];
+                let mut components = vec![import_root.clone()];
                 components.extend(std::env::split_paths(&existing));
                 if let Ok(joined) = std::env::join_paths(components) {
                     command.env("PYTHONPATH", joined);
@@ -135,7 +121,7 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
     let bridge_script = resolve_model_bridge_script_path()?;
     let mut bridge_command =
         launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
-    configure_runtime_pythonpath(&mut bridge_command);
+    configure_runtime_pythonpath(&mut bridge_command, &bridge_script);
     let output = bridge_command
         .arg(action)
         .output()

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Clone)]
@@ -144,9 +145,51 @@ pub fn resolve_python_launcher(var_name: &str) -> anyhow::Result<PythonLauncher>
     })
 }
 
+pub fn resolve_runtime_import_root(
+    script_path: Option<&Path>,
+    manifest_dir: &Path,
+) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Ok(explicit) = std::env::var("TOKEN_PLACE_PYTHON_IMPORT_ROOT") {
+        let explicit = PathBuf::from(explicit);
+        if !explicit.as_os_str().is_empty() {
+            candidates.push(explicit);
+        }
+    }
+
+    if let Some(script_path) = script_path {
+        let script_dir = script_path.parent()?;
+        if let Some(script_root) = script_dir.parent() {
+            candidates.push(script_root.to_path_buf());
+            let mut up = script_root.to_path_buf();
+            for _ in 0..4 {
+                up = up.join("_up_");
+                candidates.push(up.clone());
+            }
+            if let Some(root_parent) = script_root.parent() {
+                candidates.push(root_parent.to_path_buf());
+            }
+        }
+    }
+
+    candidates.push(manifest_dir.to_path_buf());
+    if let Some(parent) = manifest_dir.parent() {
+        candidates.push(parent.to_path_buf());
+        if let Some(grandparent) = parent.parent() {
+            candidates.push(grandparent.to_path_buf());
+        }
+    }
+
+    candidates.into_iter().find(|candidate| {
+        candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
@@ -307,5 +350,18 @@ mod tests {
         assert!(msg.contains("python  -> status="));
         assert!(msg.contains("Python 2.7.18"));
         assert!(msg.contains("python3  -> spawn failed"));
+    }
+
+    #[test]
+    fn resolve_runtime_import_root_detects_nested_up_layout() {
+        let temp = TempDir::new().expect("tempdir");
+        let script = temp.path().join("resources").join("python").join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script dir");
+        std::fs::write(&script, "#!/usr/bin/env python3\n").expect("write script");
+        let import_root = temp.path().join("resources").join("_up_").join("_up_");
+        std::fs::create_dir_all(import_root.join("utils")).expect("create utils dir");
+
+        let resolved = resolve_runtime_import_root(Some(&script), Path::new("/missing"));
+        assert_eq!(resolved.as_deref(), Some(import_root.as_path()));
     }
 }

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -152,23 +152,24 @@ pub fn resolve_runtime_import_root(
     let mut candidates = Vec::new();
 
     if let Ok(explicit) = std::env::var("TOKEN_PLACE_PYTHON_IMPORT_ROOT") {
-        let explicit = PathBuf::from(explicit);
-        if !explicit.as_os_str().is_empty() {
-            candidates.push(explicit);
+        let explicit = explicit.trim();
+        if !explicit.is_empty() {
+            candidates.push(PathBuf::from(explicit));
         }
     }
 
     if let Some(script_path) = script_path {
-        let script_dir = script_path.parent()?;
-        if let Some(script_root) = script_dir.parent() {
-            candidates.push(script_root.to_path_buf());
-            let mut up = script_root.to_path_buf();
-            for _ in 0..4 {
-                up = up.join("_up_");
-                candidates.push(up.clone());
-            }
-            if let Some(root_parent) = script_root.parent() {
-                candidates.push(root_parent.to_path_buf());
+        if let Some(script_dir) = script_path.parent() {
+            if let Some(script_root) = script_dir.parent() {
+                candidates.push(script_root.to_path_buf());
+                let mut up = script_root.to_path_buf();
+                for _ in 0..2 {
+                    up = up.join("_up_");
+                    candidates.push(up.clone());
+                }
+                if let Some(root_parent) = script_root.parent() {
+                    candidates.push(root_parent.to_path_buf());
+                }
             }
         }
     }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -193,9 +193,9 @@ fn configure_runtime_pythonpath(command: &mut Command, sidecar_path: &str) {
         command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
-                if let Ok(joined) =
-                    std::env::join_paths([import_root.as_path(), Path::new(&existing)])
-                {
+                let mut components = vec![import_root.clone()];
+                components.extend(std::env::split_paths(&existing));
+                if let Ok(joined) = std::env::join_paths(components) {
                     command.env("PYTHONPATH", joined);
                 } else {
                     command.env("PYTHONPATH", import_root);

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,5 +1,5 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::{resolve_python_launcher, PythonLauncher};
+use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -185,30 +185,16 @@ fn should_force_fake_sidecar() -> bool {
     )
 }
 
-fn repo_runtime_import_root(manifest_dir: &Path) -> Option<String> {
-    let mut candidates = vec![manifest_dir.to_path_buf()];
-    if let Some(parent) = manifest_dir.parent() {
-        candidates.push(parent.to_path_buf());
-        if let Some(grandparent) = parent.parent() {
-            candidates.push(grandparent.to_path_buf());
-        }
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| {
-            candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-        })
-        .map(|candidate| candidate.to_string_lossy().into_owned())
-}
-
-fn configure_runtime_pythonpath(command: &mut Command) {
+fn configure_runtime_pythonpath(command: &mut Command, sidecar_path: &str) {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) = repo_runtime_import_root(manifest_dir) {
+    if let Some(import_root) =
+        resolve_runtime_import_root(Some(Path::new(sidecar_path)), manifest_dir)
+    {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
         match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.trim().is_empty() => {
                 if let Ok(joined) =
-                    std::env::join_paths([Path::new(&import_root), Path::new(&existing)])
+                    std::env::join_paths([import_root.as_path(), Path::new(&existing)])
                 {
                     command.env("PYTHONPATH", joined);
                 } else {
@@ -258,7 +244,7 @@ pub async fn start_sidecar(
     };
 
     let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
-    configure_runtime_pythonpath(&mut sidecar_command);
+    configure_runtime_pythonpath(&mut sidecar_command, &sidecar_script);
 
     let mut child = sidecar_command
         .arg("--model")

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2,7 +2,9 @@
 
 import importlib.util
 import json
+import os
 import queue
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -400,3 +402,118 @@ def test_main_normalizes_mode_before_run(monkeypatch):
     status = compute_node_bridge.main()
     assert status == 0
     assert captured['mode'] == 'auto'
+
+
+def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):
+    python_dir = tmp_path / 'bin' / 'resources' / 'python'
+    import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
+    utils_dir = import_root / 'utils'
+    python_dir.mkdir(parents=True)
+    utils_dir.mkdir(parents=True)
+
+    (python_dir / 'compute_node_bridge.py').write_text(
+        MODULE_PATH.read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    path_bootstrap_path = MODULE_PATH.parent / 'path_bootstrap.py'
+    (python_dir / 'path_bootstrap.py').write_text(
+        path_bootstrap_path.read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_dir / 'compute_node_runtime.py').write_text(
+        """
+SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "cuda", "metal"}
+
+
+def normalize_compute_mode(mode):
+    mode = str(mode).lower()
+    return mode if mode in SUPPORTED_COMPUTE_MODES else "auto"
+
+
+def apply_compute_mode(_model_manager, mode):
+    return normalize_compute_mode(mode)
+
+
+def resolve_relay_url(relay_url):
+    return relay_url
+
+
+def resolve_relay_port(relay_port, _relay_url):
+    return relay_port
+
+
+def is_legacy_relay_payload(_payload):
+    return False
+
+
+class ComputeNodeRuntimeConfig:
+    def __init__(self, relay_url, relay_port):
+        self.relay_url = relay_url
+        self.relay_port = relay_port
+
+
+class _RelayClient:
+    def __init__(self, relay_url):
+        self.relay_url = relay_url
+
+
+class _ModelManager:
+    model_path = ""
+
+
+class ComputeNodeRuntime:
+    def __init__(self, config):
+        self.relay_client = _RelayClient(config.relay_url)
+        self.model_manager = _ModelManager()
+
+    def ensure_model_ready(self):
+        return True
+
+    def register_and_poll_once(self):
+        return {"next_ping_in_x_seconds": 0}
+
+    def process_relay_request(self, _payload):
+        return True
+
+    def stop(self):
+        return None
+""".strip()
+        + "\n",
+        encoding='utf-8',
+    )
+
+    env = os.environ.copy()
+    env.pop('PYTHONPATH', None)
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(python_dir / 'compute_node_bridge.py'),
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'auto',
+            '--relay-url',
+            'https://token.place',
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    proc.stdin.write('{"type":"cancel"}\n')
+    proc.stdin.flush()
+    proc.stdin.close()
+    proc.wait(timeout=10)
+    stdout = proc.stdout.read()
+    stderr = proc.stderr.read()
+
+    assert proc.returncode == 0, stderr
+    events = [json.loads(line) for line in stdout.splitlines() if line.strip()]
+    assert any(event.get('type') == 'started' for event in events)
+    assert any(event.get('type') == 'stopped' for event in events)
+    assert "No module named 'utils'" not in stdout

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -115,17 +115,18 @@ def test_main_dispatches_download_action():
 
 
 def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):
-    """Regression: pre-fix exe/python + resources layout failed with No module named 'utils'."""
-    python_dir = tmp_path / 'bin' / 'python'
+    """Regression: packaged resources with ../../utils failed with No module named 'utils'."""
+    python_dir = tmp_path / 'bin' / 'resources' / 'python'
     resources_dir = tmp_path / 'bin' / 'resources'
-    utils_llm_dir = resources_dir / 'utils' / 'llm'
+    import_root = resources_dir / '_up_' / '_up_'
+    utils_llm_dir = import_root / 'utils' / 'llm'
     python_dir.mkdir(parents=True)
     utils_llm_dir.mkdir(parents=True)
 
     (python_dir / 'model_bridge.py').write_text(MODULE_PATH.read_text(encoding='utf-8'), encoding='utf-8')
     path_bootstrap_path = MODULE_PATH.parent / 'path_bootstrap.py'
     (python_dir / 'path_bootstrap.py').write_text(path_bootstrap_path.read_text(encoding='utf-8'), encoding='utf-8')
-    (resources_dir / 'utils' / '__init__.py').write_text('', encoding='utf-8')
+    (import_root / 'utils' / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / 'model_manager.py').write_text(
         """

--- a/tests/unit/test_desktop_packaged_layout.py
+++ b/tests/unit/test_desktop_packaged_layout.py
@@ -1,0 +1,61 @@
+"""Validate Linux no-bundle desktop staging layout contains Python runtime resources."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LINUX_STAGING_ROOT = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug"
+
+
+def _staging_root() -> Path:
+    override = os.environ.get("TOKEN_PLACE_DESKTOP_STAGING_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return DEFAULT_LINUX_STAGING_ROOT
+
+
+def _assert_any_exists(staging_root: Path, candidates: tuple[str, ...], label: str) -> None:
+    resolved = [staging_root / candidate for candidate in candidates]
+    if not any(path.exists() for path in resolved):
+        joined = ", ".join(str(path) for path in resolved)
+        raise AssertionError(f"missing packaged runtime {label}; looked for: {joined}")
+
+
+def test_linux_no_bundle_layout_contains_python_runtime_resources() -> None:
+    """CI proxy check: verify `tauri build -- --debug --no-bundle` staged runtime files."""
+
+    staging_root = _staging_root()
+    if not staging_root.exists():
+        pytest.skip(
+            "desktop staging root missing; run `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` "
+            "before this validation"
+        )
+
+    # Linux CI no-bundle builds stage files under `desktop-tauri/src-tauri/target/debug`.
+    # We accept both known script placements because Tauri layout can differ by host packaging mode.
+    _assert_any_exists(
+        staging_root,
+        ("python/model_bridge.py", "resources/python/model_bridge.py"),
+        "python/model_bridge.py",
+    )
+    _assert_any_exists(
+        staging_root,
+        ("python/compute_node_bridge.py", "resources/python/compute_node_bridge.py"),
+        "python/compute_node_bridge.py",
+    )
+    _assert_any_exists(
+        staging_root,
+        ("python/path_bootstrap.py", "resources/python/path_bootstrap.py"),
+        "python/path_bootstrap.py",
+    )
+    _assert_any_exists(staging_root, ("utils", "resources/utils"), "utils/")
+    _assert_any_exists(staging_root, ("config.py", "resources/config.py"), "config.py")
+
+
+if __name__ == "__main__":
+    test_linux_no_bundle_layout_contains_python_runtime_resources()

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -54,3 +54,38 @@ def test_bootstrap_adds_repo_root_for_dev_layout(tmp_path, path_bootstrap):
         assert str(repo_root) in sys.path
     finally:
         sys.path[:] = original_sys_path
+
+
+def test_bootstrap_supports_nested_up_packaged_layout(tmp_path, path_bootstrap):
+    script = tmp_path / 'bin' / 'resources' / 'python' / 'model_bridge.py'
+    import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
+    (import_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(import_root) in sys.path
+        assert sys.path.index(str(import_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def test_bootstrap_prefers_explicit_env_import_root(tmp_path, path_bootstrap, monkeypatch):
+    script = tmp_path / 'bin' / 'resources' / 'python' / 'model_bridge.py'
+    fallback_root = tmp_path / 'bin' / 'resources' / '_up_'
+    explicit_root = tmp_path / 'explicit-import-root'
+    (fallback_root / 'utils').mkdir(parents=True)
+    (explicit_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(explicit_root))
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(explicit_root) in sys.path
+        assert sys.path.index(str(explicit_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path


### PR DESCRIPTION
### Motivation
- Packaged desktop releases could still fail with `No module named 'utils'` because bundled `../../utils` resources can be rewritten into nested `_up_` paths that the bridges didn’t reliably resolve at runtime.
- The bridges already call the Python bootstrap but relied on heuristics or compile-time manifest-only paths rather than a single runtime contract passed from Rust to Python.

### Description
- Add `resolve_runtime_import_root` in Rust to discover the actual import root from the launched bridge script location and from an explicit env var if present (`TOKEN_PLACE_PYTHON_IMPORT_ROOT`).
- Pass `TOKEN_PLACE_PYTHON_IMPORT_ROOT` from Rust when launching Python subprocesses and derive/merge `PYTHONPATH` from the same resolved root for model bridge, compute-node bridge, and sidecar launches.
- Teach Python `path_bootstrap.py` to prefer the explicit `TOKEN_PLACE_PYTHON_IMPORT_ROOT` first and to consider nested `_up_/_up_` packaged candidates so `utils` is found in deeper rewritten layouts.
- Add targeted regression tests that simulate packaged layouts (nested `_up_/_up_`), exercise the model and compute-node bridges as subprocesses, and verify no `No module named 'utils'` failures.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_desktop_path_bootstrap.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (`22 passed`).
- Built frontend: `npm --prefix desktop-tauri run build` succeeded.
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` but both were blocked by missing system `glib-2.0`/pkg-config in the environment (so Rust-native integration builds were not exercised here).
- `pre-commit run --all-files` was not executed in this environment because `pre-commit` is not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc761c0698832fb93156c175840249)