### PR TITLE
Enforce single desktop relay target (use UI relay URL only)

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -88,13 +88,14 @@ def run(args: argparse.Namespace) -> int:
         emit({"type": "error", "message": f"runtime unavailable: {exc}"})
         return 1
 
-    relay_url = resolve_relay_url(args.relay_url)
+    relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(
             relay_url=relay_url,
             relay_port=relay_port,
+            use_configured_relay_fallbacks=False,
         )
     )
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -196,6 +196,14 @@ def test_compute_node_runtime_relay_resolution_uses_env_overrides(monkeypatch):
     assert format_relay_target(relay_url, relay_port) == "https://relay.example:4444"
 
 
+def test_compute_node_runtime_relay_resolution_prefers_explicit_cli_value(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELAY_URL", "https://relay.example")
+
+    relay_url = resolve_relay_url("http://127.0.0.1:5010", prefer_cli=True)
+
+    assert relay_url == "http://127.0.0.1:5010"
+
+
 def test_compute_node_runtime_resolve_relay_port_accepts_explicit_zero_port():
     assert resolve_relay_port(None, "https://token.place:0") == 0
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -347,6 +347,64 @@ def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
     assert events[0]['backend_mode'] == 'auto'
 
 
+def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallbacks(monkeypatch):
+    _reset_cancel_queue()
+    captured = {}
+
+    class CapturingRuntime:
+        def __init__(self, config):
+            captured['config'] = config
+            self.model_manager = FakeModelManager()
+            self.relay_client = SimpleNamespace(relay_url=config.relay_url)
+
+        def ensure_model_ready(self):
+            return True
+
+        def register_and_poll_once(self):
+            return {'next_ping_in_x_seconds': 0}
+
+        def process_relay_request(self, _payload):
+            return True
+
+        def stop(self):
+            return None
+
+    module = ModuleType('utils.compute_node_runtime')
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port, **kwargs: SimpleNamespace(
+        relay_url=relay_url,
+        relay_port=relay_port,
+        **kwargs,
+    )
+    module.ComputeNodeRuntime = CapturingRuntime
+    module.is_legacy_relay_payload = lambda _payload: False
+    module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    module.normalize_compute_mode = lambda mode: mode
+    module.apply_compute_mode = lambda _model_manager, mode: mode
+    module.SUPPORTED_COMPUTE_MODES = {'auto', 'cpu', 'cuda', 'metal'}
+
+    def _resolve_relay_url(relay_url, **kwargs):
+        prefer_cli = bool(kwargs.get('prefer_cli', False))
+        env_override = os.environ.get('TOKENPLACE_RELAY_URL')
+        return relay_url if prefer_cli else (env_override or relay_url)
+
+    module.resolve_relay_url = _resolve_relay_url
+    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
+    monkeypatch.setenv('TOKENPLACE_RELAY_URL', 'https://token.place')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='http://127.0.0.1:5010',
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert captured['config'].relay_url == 'http://127.0.0.1:5010'
+    assert captured['config'].use_configured_relay_fallbacks is False
+
+
 def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):
     real_import = __import__
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -530,7 +530,7 @@ class ComputeNodeRuntime:
         return True
 
     def register_and_poll_once(self):
-        return {"next_ping_in_x_seconds": 0}
+        return {"next_ping_in_x_seconds": 1}
 
     def process_relay_request(self, _payload):
         return True

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -436,7 +436,7 @@ def apply_compute_mode(_model_manager, mode):
     return normalize_compute_mode(mode)
 
 
-def resolve_relay_url(relay_url):
+def resolve_relay_url(relay_url, **_kwargs):
     return relay_url
 
 
@@ -449,7 +449,7 @@ def is_legacy_relay_payload(_payload):
 
 
 class ComputeNodeRuntimeConfig:
-    def __init__(self, relay_url, relay_port):
+    def __init__(self, relay_url, relay_port, **_kwargs):
         self.relay_url = relay_url
         self.relay_port = relay_port
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -137,15 +137,16 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     )
 
     module = ModuleType('utils.compute_node_runtime')
-    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port, **kwargs: SimpleNamespace(
         relay_url=relay_url,
         relay_port=relay_port,
+        **kwargs,
     )
     module.ComputeNodeRuntime = runtime_cls
     module.is_legacy_relay_payload = (
         lambda payload: {"client_public_key", "chat_history", "cipherkey", "iv"}.issubset(payload)
     )
-    module.resolve_relay_url = lambda relay_url: relay_url
+    module.resolve_relay_url = lambda relay_url, **_kwargs: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
     module.SUPPORTED_COMPUTE_MODES = _SUPPORTED_COMPUTE_MODES
     module.normalize_compute_mode = _normalize_compute_mode

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -97,6 +97,27 @@ def test_compose_relay_url_keeps_explicit_localhost_port():
     assert result == 'http://localhost:5000'
 
 
+def test_init_can_disable_configured_server_fallbacks():
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    mock_config.get.side_effect = lambda key, default: {
+        'relay.request_timeout': 10,
+        'relay.server_url': 'https://token.place',
+        'relay.additional_servers': ['https://relay-backup.example'],
+    }.get(key, default)
+
+    with patch('utils.networking.relay_client.get_config_lazy', return_value=mock_config):
+        client = RelayClient(
+            base_url='http://127.0.0.1:5010',
+            port=None,
+            crypto_manager=object(),
+            model_manager=object(),
+            include_configured_servers=False,
+        )
+
+    assert client.relay_urls == ('http://127.0.0.1:5010',)
+
+
 class TestRelayClient:
     """Test class for RelayClient."""
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -119,6 +119,40 @@ def test_init_can_disable_configured_server_fallbacks():
     assert client.relay_urls == ('http://127.0.0.1:5010',)
 
 
+def test_init_excludes_config_and_env_fallback_relays_when_configured_servers_disabled(monkeypatch):
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    mock_config.get.side_effect = lambda key, default: {
+        'relay.request_timeout': 10,
+        'relay.cluster_only': True,
+        'relay.server_url': 'https://token.place',
+        'relay.additional_servers': ['https://relay-backup.example'],
+        'relay.cloudflare_fallback_urls': ['https://cloudflare-a.example'],
+    }.get(key, default)
+
+    monkeypatch.setenv(
+        'TOKEN_PLACE_RELAY_UPSTREAMS',
+        'https://token.place,https://env-upstream.example',
+    )
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_CLOUDFLARE_URL', 'https://token.place')
+    monkeypatch.setenv(
+        'TOKEN_PLACE_RELAY_CLOUDFLARE_URLS',
+        '["https://token.place","https://env-cloudflare.example"]',
+    )
+
+    with patch('utils.networking.relay_client.get_config_lazy', return_value=mock_config):
+        client = RelayClient(
+            base_url='http://127.0.0.1:5010',
+            port=None,
+            crypto_manager=object(),
+            model_manager=object(),
+            include_configured_servers=False,
+        )
+
+    assert client.relay_urls == ('http://127.0.0.1:5010',)
+    assert 'https://token.place' not in client.relay_urls
+
+
 class TestRelayClient:
     """Test class for RelayClient."""
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -102,6 +102,7 @@ def test_init_can_disable_configured_server_fallbacks():
     mock_config.is_production = False
     mock_config.get.side_effect = lambda key, default: {
         'relay.request_timeout': 10,
+        'relay.cluster_only': True,
         'relay.server_url': 'https://token.place',
         'relay.additional_servers': ['https://relay-backup.example'],
     }.get(key, default)

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -38,6 +38,7 @@ class ComputeNodeRuntimeConfig:
 
     relay_url: str
     relay_port: Optional[int]
+    use_configured_relay_fallbacks: bool = True
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
@@ -86,8 +87,11 @@ def first_env(keys: List[str]) -> Optional[str]:
     return None
 
 
-def resolve_relay_url(cli_default: str) -> str:
+def resolve_relay_url(cli_default: str, *, prefer_cli: bool = False) -> str:
     """Resolve the relay base URL from CLI or env."""
+
+    if prefer_cli and cli_default.strip():
+        return cli_default.strip()
 
     env_override = first_env(
         [
@@ -185,6 +189,7 @@ class ComputeNodeRuntime:
             port=runtime_config.relay_port,
             crypto_manager=self.crypto_manager,
             model_manager=self.model_manager,
+            include_configured_servers=runtime_config.use_configured_relay_fallbacks,
         )
         if request_adapters is None:
             self.request_adapters = [LegacyRelayRequestAdapter(self.relay_client)]

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -210,6 +210,8 @@ class RelayClient:
             port: Optional relay port injected only for non-HTTPS URLs without an explicit port
             crypto_manager: Instance of CryptoManager for encryption/decryption
             model_manager: Instance of ModelManager for LLM interaction
+            include_configured_servers: When True, include configured/env relay fallbacks
+                and relay cluster-only mode. When False, use only the explicit base relay.
         """
         self.base_url = base_url
         self.port = port
@@ -241,12 +243,13 @@ class RelayClient:
                 if primary_config_url and primary_config_url not in configured_servers:
                     configured_servers.insert(0, primary_config_url)
 
-            cluster_only_value = config.get('relay.cluster_only', False)
-            parsed_cluster_only = _coerce_optional_bool(cluster_only_value)
-            if parsed_cluster_only is not None:
-                self._cluster_only = parsed_cluster_only
-            elif isinstance(cluster_only_value, bool):
-                self._cluster_only = cluster_only_value
+            if include_configured_servers:
+                cluster_only_value = config.get('relay.cluster_only', False)
+                parsed_cluster_only = _coerce_optional_bool(cluster_only_value)
+                if parsed_cluster_only is not None:
+                    self._cluster_only = parsed_cluster_only
+                elif isinstance(cluster_only_value, bool):
+                    self._cluster_only = cluster_only_value
 
             token_value = config.get('relay.server_registration_token', None)
             if not token_value:
@@ -255,8 +258,9 @@ class RelayClient:
 
         except Exception:
             self._request_timeout = 10  # Fallback default
-            cluster_env = _coerce_optional_bool(os.environ.get('TOKEN_PLACE_RELAY_CLUSTER_ONLY'))
-            self._cluster_only = cluster_env if cluster_env is not None else False
+            if include_configured_servers:
+                cluster_env = _coerce_optional_bool(os.environ.get('TOKEN_PLACE_RELAY_CLUSTER_ONLY'))
+                self._cluster_only = cluster_env if cluster_env is not None else False
 
             if include_configured_servers:
                 upstreams_raw = os.environ.get('TOKEN_PLACE_RELAY_UPSTREAMS', '')

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -192,7 +192,15 @@ class RelayClient:
         polling_thread.join(timeout=15)  # Wait for thread to finish
         ```
     """
-    def __init__(self, base_url: str, port: Optional[int], crypto_manager, model_manager):
+    def __init__(
+        self,
+        base_url: str,
+        port: Optional[int],
+        crypto_manager,
+        model_manager,
+        *,
+        include_configured_servers: bool = True,
+    ):
         """
         Initialize the RelayClient.
 
@@ -216,21 +224,22 @@ class RelayClient:
             config = get_config_lazy()
             self._request_timeout = config.get('relay.request_timeout', 10)
 
-            configured_servers = list(config.get('relay.additional_servers', []) or [])
+            if include_configured_servers:
+                configured_servers = list(config.get('relay.additional_servers', []) or [])
 
-            cf_fallbacks = config.get('relay.cloudflare_fallback_urls', []) or []
-            for entry in cf_fallbacks:
-                if entry not in configured_servers:
-                    configured_servers.append(entry)
+                cf_fallbacks = config.get('relay.cloudflare_fallback_urls', []) or []
+                for entry in cf_fallbacks:
+                    if entry not in configured_servers:
+                        configured_servers.append(entry)
 
-            pool_secondary = config.get('relay.server_pool_secondary', []) or []
-            for entry in pool_secondary:
-                if entry not in configured_servers:
-                    configured_servers.append(entry)
+                pool_secondary = config.get('relay.server_pool_secondary', []) or []
+                for entry in pool_secondary:
+                    if entry not in configured_servers:
+                        configured_servers.append(entry)
 
-            primary_config_url = config.get('relay.server_url', '')
-            if primary_config_url and primary_config_url not in configured_servers:
-                configured_servers.insert(0, primary_config_url)
+                primary_config_url = config.get('relay.server_url', '')
+                if primary_config_url and primary_config_url not in configured_servers:
+                    configured_servers.insert(0, primary_config_url)
 
             cluster_only_value = config.get('relay.cluster_only', False)
             parsed_cluster_only = _coerce_optional_bool(cluster_only_value)
@@ -249,39 +258,40 @@ class RelayClient:
             cluster_env = _coerce_optional_bool(os.environ.get('TOKEN_PLACE_RELAY_CLUSTER_ONLY'))
             self._cluster_only = cluster_env if cluster_env is not None else False
 
-            upstreams_raw = os.environ.get('TOKEN_PLACE_RELAY_UPSTREAMS', '')
-            if upstreams_raw:
-                normalised = upstreams_raw.replace('\n', ',')
-                configured_servers.extend(
-                    entry.strip()
-                    for entry in normalised.split(',')
-                    if entry and entry.strip()
-                )
-
-            cf_raw = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URLS', '')
-            cf_single = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URL', '')
-            combined = ','.join(part for part in (cf_raw, cf_single) if part)
-            if combined:
-                entries: List[str] = []
-                try:
-                    loaded = json.loads(combined)
-                except json.JSONDecodeError:
-                    normalised_cf = combined.replace('\n', ',')
-                    entries.extend(
-                        segment.strip()
-                        for segment in normalised_cf.split(',')
-                        if segment.strip()
+            if include_configured_servers:
+                upstreams_raw = os.environ.get('TOKEN_PLACE_RELAY_UPSTREAMS', '')
+                if upstreams_raw:
+                    normalised = upstreams_raw.replace('\n', ',')
+                    configured_servers.extend(
+                        entry.strip()
+                        for entry in normalised.split(',')
+                        if entry and entry.strip()
                     )
-                else:
-                    if isinstance(loaded, str):
-                        entries.append(loaded.strip())
-                    elif isinstance(loaded, (list, tuple)):
-                        for item in loaded:
-                            if isinstance(item, str) and item.strip():
-                                entries.append(item.strip())
-                for entry in entries:
-                    if entry and entry not in configured_servers:
-                        configured_servers.append(entry)
+
+                cf_raw = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URLS', '')
+                cf_single = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URL', '')
+                combined = ','.join(part for part in (cf_raw, cf_single) if part)
+                if combined:
+                    entries: List[str] = []
+                    try:
+                        loaded = json.loads(combined)
+                    except json.JSONDecodeError:
+                        normalised_cf = combined.replace('\n', ',')
+                        entries.extend(
+                            segment.strip()
+                            for segment in normalised_cf.split(',')
+                            if segment.strip()
+                        )
+                    else:
+                        if isinstance(loaded, str):
+                            entries.append(loaded.strip())
+                        elif isinstance(loaded, (list, tuple)):
+                            for item in loaded:
+                                if isinstance(item, str) and item.strip():
+                                    entries.append(item.strip())
+                    for entry in entries:
+                        if entry and entry not in configured_servers:
+                            configured_servers.append(entry)
 
             self._registration_token = _normalise_registration_token(
                 os.environ.get('TOKEN_PLACE_RELAY_SERVER_TOKEN')


### PR DESCRIPTION
### Motivation
- The desktop compute-node was alternately pinging the UI-configured relay and a stale/default relay (e.g. `https://token.place`) because the runtime/relay client still injected configured/global fallback servers; the UI-provided Relay URL must be authoritative for desktop runs. 
- Keep the change scoped: make explicit desktop runs opt out of config/env fallback pools rather than globally changing server behavior.

### Description
- Treat CLI/UI relay URL as authoritative for the desktop bridge by calling `resolve_relay_url(..., prefer_cli=True)` and constructing `ComputeNodeRuntimeConfig(..., use_configured_relay_fallbacks=False)` in `desktop-tauri/src-tauri/python/compute_node_bridge.py`.
- Add `use_configured_relay_fallbacks: bool` to `ComputeNodeRuntimeConfig` and thread it into `RelayClient` initialization so callers can opt out of configured/env fallback pools in `utils/compute_node_runtime.py`.
- Add `include_configured_servers: bool` parameter to `RelayClient.__init__` and conditionally disable reading/injecting `relay.server_url`, `relay.additional_servers`, cloudflare/upstream envs, and related fallback logic when it is `False` in `utils/networking/relay_client.py`.
- Update tests and test helpers to reflect the new signatures and behaviours: add a `prefer_cli` relay-resolution unit test and a `RelayClient` test that verifies disabling configured server fallbacks, and adjust the desktop bridge test helper to accept the new config and resolver signatures (`tests/unit/test_compute_node_runtime.py`, `tests/unit/test_relay_client.py`, `tests/unit/test_desktop_compute_node_bridge.py`).

### Testing
- Ran `python -m py_compile` against the modified Python modules and tests which succeeded and verified syntax for `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `utils/compute_node_runtime.py`, `utils/networking/relay_client.py`, and updated tests.
- Added unit tests: a `resolve_relay_url(..., prefer_cli=True)` precedence test and a `RelayClient` initialization test that asserts `relay_urls` contains only the explicit desktop target when `include_configured_servers=False` (these are included under `tests/unit/`).
- Attempted `python -m pytest ...` which fails in this execution environment due to a missing test dependency (`ModuleNotFoundError: No module named 'requests'` from `tests/conftest.py`) so full test run could not complete here.
- Built frontend with `npm --prefix desktop-tauri run build` which succeeded, and attempted `cargo test` / `tauri build` which failed in this environment due to missing system `glib-2.0` dev libraries required by the Rust build.  
- Pre-commit check could not run here because `pre-commit` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8280f250832fa5c9aeeb47162206)