### PR TITLE
🐛 fix: honor single desktop Relay URL

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -95,7 +95,8 @@ def run(args: argparse.Namespace) -> int:
         ComputeNodeRuntimeConfig(
             relay_url=relay_url,
             relay_port=relay_port,
-        )
+        ),
+        include_configured_relays=False,
     )
 
     runtime.model_manager.model_path = args.model

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -45,7 +45,7 @@ class FakeRelayClientRouting(FakeRelayClient):
 
 
 class FakeRuntime:
-    def __init__(self, _config):
+    def __init__(self, _config, **_kwargs):
         self.model_manager = FakeModelManager()
         self.relay_client = FakeRelayClient()
         self._responses = [
@@ -79,7 +79,7 @@ class FakeRuntime:
 class StreamingRuntime(FakeRuntime):
     last_instance = None
 
-    def __init__(self, _config):
+    def __init__(self, _config, **_kwargs):
         StreamingRuntime.last_instance = self
         self.model_manager = FakeModelManager()
         self.relay_client = FakeRelayClientRouting()
@@ -102,7 +102,7 @@ class StreamingRuntime(FakeRuntime):
 
 
 class ProcessingFailureRuntime(FakeRuntime):
-    def __init__(self, _config):
+    def __init__(self, _config, **_kwargs):
         self.model_manager = FakeModelManager()
         self.relay_client = FakeRelayClient()
         self._responses = [
@@ -122,7 +122,7 @@ class ProcessingFailureRuntime(FakeRuntime):
 
 
 class IncompatibleRelayRuntime(FakeRuntime):
-    def __init__(self, _config):
+    def __init__(self, _config, **_kwargs):
         self.model_manager = FakeModelManager()
         self.relay_client = FakeRelayClient()
         self._responses = [{'relay_version': 'outdated'}]
@@ -209,6 +209,30 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
     assert 'failed to initialize model runtime' in payload['message']
+
+
+def test_run_disables_configured_relay_fallbacks(monkeypatch):
+    _reset_cancel_queue()
+    captured = {}
+
+    class CapturingRuntime(FakeRuntime):
+        def __init__(self, _config, **kwargs):
+            captured.update(kwargs)
+            super().__init__(_config, **kwargs)
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=CapturingRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='http://127.0.0.1:5010',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert captured == {'include_configured_relays': False}
 
 
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
@@ -463,7 +487,7 @@ class _ModelManager:
 
 
 class ComputeNodeRuntime:
-    def __init__(self, config):
+    def __init__(self, config, **_kwargs):
         self.relay_client = _RelayClient(config.relay_url)
         self.model_manager = _ModelManager()
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -97,6 +97,28 @@ def test_compose_relay_url_keeps_explicit_localhost_port():
     assert result == 'http://localhost:5000'
 
 
+def test_init_can_disable_configured_relay_fallbacks():
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    config_values = {
+        'relay.request_timeout': 10,
+        'relay.server_url': 'https://token.place',
+        'relay.additional_servers': ['https://backup.token.place'],
+    }
+    mock_config.get.side_effect = lambda key, default: config_values.get(key, default)
+
+    with patch('utils.networking.relay_client.get_config_lazy', return_value=mock_config):
+        client = RelayClient(
+            base_url='http://127.0.0.1:5010',
+            port=None,
+            crypto_manager=MagicMock(public_key_b64='key'),
+            model_manager=MagicMock(),
+            include_configured_relays=False,
+        )
+
+    assert client.relay_urls == ('http://127.0.0.1:5010',)
+
+
 class TestRelayClient:
     """Test class for RelayClient."""
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -166,6 +166,7 @@ class ComputeNodeRuntime:
         self,
         runtime_config: ComputeNodeRuntimeConfig,
         *,
+        include_configured_relays: bool = True,
         relay_client: Optional["RelayClient"] = None,
         crypto_manager=None,
         model_manager=None,
@@ -183,6 +184,7 @@ class ComputeNodeRuntime:
         self.relay_client = relay_client or RelayClient(
             base_url=runtime_config.relay_url,
             port=runtime_config.relay_port,
+            include_configured_relays=include_configured_relays,
             crypto_manager=self.crypto_manager,
             model_manager=self.model_manager,
         )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -192,7 +192,15 @@ class RelayClient:
         polling_thread.join(timeout=15)  # Wait for thread to finish
         ```
     """
-    def __init__(self, base_url: str, port: Optional[int], crypto_manager, model_manager):
+    def __init__(
+        self,
+        base_url: str,
+        port: Optional[int],
+        crypto_manager,
+        model_manager,
+        *,
+        include_configured_relays: bool = True,
+    ):
         """
         Initialize the RelayClient.
 
@@ -216,21 +224,22 @@ class RelayClient:
             config = get_config_lazy()
             self._request_timeout = config.get('relay.request_timeout', 10)
 
-            configured_servers = list(config.get('relay.additional_servers', []) or [])
+            if include_configured_relays:
+                configured_servers = list(config.get('relay.additional_servers', []) or [])
 
-            cf_fallbacks = config.get('relay.cloudflare_fallback_urls', []) or []
-            for entry in cf_fallbacks:
-                if entry not in configured_servers:
-                    configured_servers.append(entry)
+                cf_fallbacks = config.get('relay.cloudflare_fallback_urls', []) or []
+                for entry in cf_fallbacks:
+                    if entry not in configured_servers:
+                        configured_servers.append(entry)
 
-            pool_secondary = config.get('relay.server_pool_secondary', []) or []
-            for entry in pool_secondary:
-                if entry not in configured_servers:
-                    configured_servers.append(entry)
+                pool_secondary = config.get('relay.server_pool_secondary', []) or []
+                for entry in pool_secondary:
+                    if entry not in configured_servers:
+                        configured_servers.append(entry)
 
-            primary_config_url = config.get('relay.server_url', '')
-            if primary_config_url and primary_config_url not in configured_servers:
-                configured_servers.insert(0, primary_config_url)
+                primary_config_url = config.get('relay.server_url', '')
+                if primary_config_url and primary_config_url not in configured_servers:
+                    configured_servers.insert(0, primary_config_url)
 
             cluster_only_value = config.get('relay.cluster_only', False)
             parsed_cluster_only = _coerce_optional_bool(cluster_only_value)


### PR DESCRIPTION
### Motivation
- The desktop compute-node operator was alternately pinging the UI-configured Relay URL and fallback/stale configured relay endpoints (e.g. `https://token.place`), causing mixed traffic; the runtime must use only the single Relay URL shown in the desktop UI.

### Description
- Add an explicit `include_configured_relays` flag to `RelayClient` to control whether config-provided fallback/secondary relay targets are loaded from `get_config()` (file: `utils/networking/relay_client.py`).
- Thread the `include_configured_relays` flag through `ComputeNodeRuntime` so callers can opt out of loading configured relays (file: `utils/compute_node_runtime.py`).
- Disable configured-relays for the desktop bridge by creating the runtime with `include_configured_relays=False` so the compute-node bridge only uses the UI-provided URL (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`).
- Add regression unit tests that verify the desktop bridge forwards `include_configured_relays=False` and that the `RelayClient` exposes only the explicit target when configured relays are disabled (files: `tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_relay_client.py`).

### Testing
- Ran the focused Python unit tests: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_relay_client.py`, both passed (these would have caught the regression).
- Built the desktop frontend: `npm --prefix desktop-tauri run build` succeeded.
- Attempted Rust integration: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` failed in this environment due to missing system `glib-2.0` pkg-config/dev libs (environment limitation, not related to the change).
- Ran repo CI driver `npm run test:ci`; it reported unrelated repo-wide failures (missing optional test deps like `flask`, `Pillow`, `openai`, and `bandit`) in this execution environment, but the targeted unit tests introduced by this PR passed as noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8280f250832fa5c9aeeb47162206)