### PR TITLE
🐛 fix: prefer explicit desktop Relay URL in compute bridge

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -24,6 +24,7 @@ ensure_runtime_import_paths(__file__)
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+DEFAULT_RELAY_URL = "https://token.place"
 
 
 def _start_stdin_reader() -> None:
@@ -82,13 +83,12 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
             resolve_relay_port,
-            resolve_relay_url,
         )
     except ModuleNotFoundError as exc:
         emit({"type": "error", "message": f"runtime unavailable: {exc}"})
         return 1
 
-    relay_url = resolve_relay_url(args.relay_url)
+    relay_url = str(args.relay_url).strip() or DEFAULT_RELAY_URL
     relay_port = resolve_relay_port(args.relay_port, relay_url)
 
     runtime = ComputeNodeRuntime(
@@ -185,7 +185,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--model", required=True)
     parser.add_argument("--mode", default="auto")
-    parser.add_argument("--relay-url", default="https://token.place")
+    parser.add_argument("--relay-url", default=DEFAULT_RELAY_URL)
     parser.add_argument("--relay-port", type=int, default=None)
     args = parser.parse_args()
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -129,6 +129,17 @@ class IncompatibleRelayRuntime(FakeRuntime):
         self._processed = []
 
 
+class RelayUrlCaptureRuntime(FakeRuntime):
+    last_relay_url = None
+
+    def __init__(self, config):
+        RelayUrlCaptureRuntime.last_relay_url = config.relay_url
+        self.model_manager = FakeModelManager()
+        self.relay_client = SimpleNamespace(relay_url=config.relay_url)
+        self._responses = []
+        self._processed = []
+
+
 def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     from utils.compute_node_runtime import (
         SUPPORTED_COMPUTE_MODES as _SUPPORTED_COMPUTE_MODES,
@@ -344,6 +355,27 @@ def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert events[0]['type'] == 'started'
     assert events[0]['backend_mode'] == 'auto'
+
+
+def test_run_prefers_explicit_relay_url_over_environment_override(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RelayUrlCaptureRuntime)
+    monkeypatch.setenv('TOKENPLACE_RELAY_URL', 'https://token.place')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='http://127.0.0.1:5010',
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert RelayUrlCaptureRuntime.last_relay_url == 'http://127.0.0.1:5010'
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['active_relay_url'] == 'http://127.0.0.1:5010'
 
 
 def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- The desktop Python bridge was re-resolving the relay URL via environment overrides (e.g. `TOKENPLACE_RELAY_URL`), which allowed a stale/default `https://token.place` to be used instead of the single URL shown in the desktop UI.

### Description
- Treat the bridge `--relay-url` value as authoritative by using `str(args.relay_url).strip() or DEFAULT_RELAY_URL` when instantiating the runtime instead of calling `resolve_relay_url`.
- Add `DEFAULT_RELAY_URL` constant and use it as the CLI default to keep behavior explicit and consistent.
- Add a regression unit test `test_run_prefers_explicit_relay_url_over_environment_override` that ensures an explicit desktop relay URL (e.g. `http://127.0.0.1:5010`) is used even when `TOKENPLACE_RELAY_URL` is set.

### Testing
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and all tests passed (`11 passed`).
- Built JS UI with `npm --prefix desktop-tauri run build` which succeeded.
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` failed in this environment due to missing system `glib-2.0` / `pkg-config` dependencies (environment limitation, unrelated to this change).
- `pre-commit run --all-files` surfaced existing repo-wide hook failures unrelated to the focused change.

The new unit test would have failed prior to this change, providing the intended regression coverage for the bug.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8280f250832fa5c9aeeb47162206)