### PR TITLE
🐛 fix: desktop compute-node use single Relay URL (disable configured relay pool)

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -95,6 +95,7 @@ def run(args: argparse.Namespace) -> int:
         ComputeNodeRuntimeConfig(
             relay_url=relay_url,
             relay_port=relay_port,
+            include_configured_relay_pool=False,
         )
     )
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -129,6 +129,14 @@ class IncompatibleRelayRuntime(FakeRuntime):
         self._processed = []
 
 
+class RuntimeConfigCapture(FakeRuntime):
+    last_config = None
+
+    def __init__(self, runtime_config):
+        RuntimeConfigCapture.last_config = runtime_config
+        super().__init__(runtime_config)
+
+
 def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     from utils.compute_node_runtime import (
         SUPPORTED_COMPUTE_MODES as _SUPPORTED_COMPUTE_MODES,
@@ -137,9 +145,10 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     )
 
     module = ModuleType('utils.compute_node_runtime')
-    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port: SimpleNamespace(
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port, **kwargs: SimpleNamespace(
         relay_url=relay_url,
         relay_port=relay_port,
+        include_configured_relay_pool=kwargs.get('include_configured_relay_pool', True),
     )
     module.ComputeNodeRuntime = runtime_cls
     module.is_legacy_relay_payload = (
@@ -186,6 +195,26 @@ def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeyp
     assert event_types[-1] == 'stopped'
     assert any(event.get('registered') is False for event in events if event['type'] == 'status')
     assert any(event.get('registered') is True for event in events if event['type'] == 'status')
+
+
+def test_run_disables_configured_relay_pool_for_desktop(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RuntimeConfigCapture)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='http://127.0.0.1:5010',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert RuntimeConfigCapture.last_config is not None
+    assert RuntimeConfigCapture.last_config.relay_url == 'http://127.0.0.1:5010'
+    assert RuntimeConfigCapture.last_config.include_configured_relay_pool is False
+    assert capsys.readouterr().out
 
 
 def test_run_reports_model_initialization_failures(capsys, monkeypatch):
@@ -448,9 +477,10 @@ def is_legacy_relay_payload(_payload):
 
 
 class ComputeNodeRuntimeConfig:
-    def __init__(self, relay_url, relay_port):
+    def __init__(self, relay_url, relay_port, include_configured_relay_pool=True):
         self.relay_url = relay_url
         self.relay_port = relay_port
+        self.include_configured_relay_pool = include_configured_relay_pool
 
 
 class _RelayClient:

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -97,6 +97,28 @@ def test_compose_relay_url_keeps_explicit_localhost_port():
     assert result == 'http://localhost:5000'
 
 
+def test_init_can_disable_configured_relay_pool(monkeypatch):
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    mock_config.get.side_effect = lambda key, default=None: {
+        'relay.request_timeout': 10,
+        'relay.server_url': 'https://token.place',
+        'relay.additional_servers': ['https://backup-relay.example'],
+    }.get(key, default)
+    monkeypatch.setattr('utils.networking.relay_client.get_config_lazy', lambda: mock_config)
+
+    relay_client = RelayClient(
+        base_url='http://127.0.0.1',
+        port=5010,
+        crypto_manager=MagicMock(public_key_b64='mock_public_key_b64'),
+        model_manager=MagicMock(),
+        include_configured_servers=False,
+    )
+
+    assert relay_client.relay_urls == ('http://127.0.0.1:5010',)
+    assert relay_client.relay_url == 'http://127.0.0.1:5010'
+
+
 class TestRelayClient:
     """Test class for RelayClient."""
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -38,6 +38,7 @@ class ComputeNodeRuntimeConfig:
 
     relay_url: str
     relay_port: Optional[int]
+    include_configured_relay_pool: bool = True
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
@@ -183,6 +184,7 @@ class ComputeNodeRuntime:
         self.relay_client = relay_client or RelayClient(
             base_url=runtime_config.relay_url,
             port=runtime_config.relay_port,
+            include_configured_servers=runtime_config.include_configured_relay_pool,
             crypto_manager=self.crypto_manager,
             model_manager=self.model_manager,
         )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -192,7 +192,15 @@ class RelayClient:
         polling_thread.join(timeout=15)  # Wait for thread to finish
         ```
     """
-    def __init__(self, base_url: str, port: Optional[int], crypto_manager, model_manager):
+    def __init__(
+        self,
+        base_url: str,
+        port: Optional[int],
+        crypto_manager,
+        model_manager,
+        *,
+        include_configured_servers: bool = True,
+    ):
         """
         Initialize the RelayClient.
 
@@ -216,28 +224,29 @@ class RelayClient:
             config = get_config_lazy()
             self._request_timeout = config.get('relay.request_timeout', 10)
 
-            configured_servers = list(config.get('relay.additional_servers', []) or [])
+            if include_configured_servers:
+                configured_servers = list(config.get('relay.additional_servers', []) or [])
 
-            cf_fallbacks = config.get('relay.cloudflare_fallback_urls', []) or []
-            for entry in cf_fallbacks:
-                if entry not in configured_servers:
-                    configured_servers.append(entry)
+                cf_fallbacks = config.get('relay.cloudflare_fallback_urls', []) or []
+                for entry in cf_fallbacks:
+                    if entry not in configured_servers:
+                        configured_servers.append(entry)
 
-            pool_secondary = config.get('relay.server_pool_secondary', []) or []
-            for entry in pool_secondary:
-                if entry not in configured_servers:
-                    configured_servers.append(entry)
+                pool_secondary = config.get('relay.server_pool_secondary', []) or []
+                for entry in pool_secondary:
+                    if entry not in configured_servers:
+                        configured_servers.append(entry)
 
-            primary_config_url = config.get('relay.server_url', '')
-            if primary_config_url and primary_config_url not in configured_servers:
-                configured_servers.insert(0, primary_config_url)
+                primary_config_url = config.get('relay.server_url', '')
+                if primary_config_url and primary_config_url not in configured_servers:
+                    configured_servers.insert(0, primary_config_url)
 
-            cluster_only_value = config.get('relay.cluster_only', False)
-            parsed_cluster_only = _coerce_optional_bool(cluster_only_value)
-            if parsed_cluster_only is not None:
-                self._cluster_only = parsed_cluster_only
-            elif isinstance(cluster_only_value, bool):
-                self._cluster_only = cluster_only_value
+                cluster_only_value = config.get('relay.cluster_only', False)
+                parsed_cluster_only = _coerce_optional_bool(cluster_only_value)
+                if parsed_cluster_only is not None:
+                    self._cluster_only = parsed_cluster_only
+                elif isinstance(cluster_only_value, bool):
+                    self._cluster_only = cluster_only_value
 
             token_value = config.get('relay.server_registration_token', None)
             if not token_value:
@@ -246,42 +255,43 @@ class RelayClient:
 
         except Exception:
             self._request_timeout = 10  # Fallback default
-            cluster_env = _coerce_optional_bool(os.environ.get('TOKEN_PLACE_RELAY_CLUSTER_ONLY'))
-            self._cluster_only = cluster_env if cluster_env is not None else False
+            if include_configured_servers:
+                cluster_env = _coerce_optional_bool(os.environ.get('TOKEN_PLACE_RELAY_CLUSTER_ONLY'))
+                self._cluster_only = cluster_env if cluster_env is not None else False
 
-            upstreams_raw = os.environ.get('TOKEN_PLACE_RELAY_UPSTREAMS', '')
-            if upstreams_raw:
-                normalised = upstreams_raw.replace('\n', ',')
-                configured_servers.extend(
-                    entry.strip()
-                    for entry in normalised.split(',')
-                    if entry and entry.strip()
-                )
-
-            cf_raw = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URLS', '')
-            cf_single = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URL', '')
-            combined = ','.join(part for part in (cf_raw, cf_single) if part)
-            if combined:
-                entries: List[str] = []
-                try:
-                    loaded = json.loads(combined)
-                except json.JSONDecodeError:
-                    normalised_cf = combined.replace('\n', ',')
-                    entries.extend(
-                        segment.strip()
-                        for segment in normalised_cf.split(',')
-                        if segment.strip()
+                upstreams_raw = os.environ.get('TOKEN_PLACE_RELAY_UPSTREAMS', '')
+                if upstreams_raw:
+                    normalised = upstreams_raw.replace('\n', ',')
+                    configured_servers.extend(
+                        entry.strip()
+                        for entry in normalised.split(',')
+                        if entry and entry.strip()
                     )
-                else:
-                    if isinstance(loaded, str):
-                        entries.append(loaded.strip())
-                    elif isinstance(loaded, (list, tuple)):
-                        for item in loaded:
-                            if isinstance(item, str) and item.strip():
-                                entries.append(item.strip())
-                for entry in entries:
-                    if entry and entry not in configured_servers:
-                        configured_servers.append(entry)
+
+                cf_raw = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URLS', '')
+                cf_single = os.environ.get('TOKEN_PLACE_RELAY_CLOUDFLARE_URL', '')
+                combined = ','.join(part for part in (cf_raw, cf_single) if part)
+                if combined:
+                    entries: List[str] = []
+                    try:
+                        loaded = json.loads(combined)
+                    except json.JSONDecodeError:
+                        normalised_cf = combined.replace('\n', ',')
+                        entries.extend(
+                            segment.strip()
+                            for segment in normalised_cf.split(',')
+                            if segment.strip()
+                        )
+                    else:
+                        if isinstance(loaded, str):
+                            entries.append(loaded.strip())
+                        elif isinstance(loaded, (list, tuple)):
+                            for item in loaded:
+                                if isinstance(item, str) and item.strip():
+                                    entries.append(item.strip())
+                    for entry in entries:
+                        if entry and entry not in configured_servers:
+                            configured_servers.append(entry)
 
             self._registration_token = _normalise_registration_token(
                 os.environ.get('TOKEN_PLACE_RELAY_SERVER_TOKEN')


### PR DESCRIPTION
### Motivation
- The desktop compute-node was alternating pings between the UI-provided Relay URL and configured/default relay pool (e.g., `https://token.place`), caused by the runtime/relay client loading additional relay targets in addition to the explicit UI URL. Only the single UI Relay URL should be used for desktop sessions.

### Description
- Add `include_configured_relay_pool: bool` to `ComputeNodeRuntimeConfig` and default it to `True` so server usage remains unchanged. 
- Desktop bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) now constructs the runtime with `include_configured_relay_pool=False` so desktop sessions use only the explicit UI relay URL. 
- `RelayClient` (`utils/networking/relay_client.py`) gains an `include_configured_servers: bool` parameter and skips loading configured/server-pool/env upstreams when the flag is `False`, ensuring a single normalized target list containing only the explicit base URL (and injected port if applicable). 
- Wire `ComputeNodeRuntime` to pass `runtime_config.include_configured_relay_pool` through to `RelayClient`. 
- Add unit tests to cover the new single-target flow: `test_init_can_disable_configured_relay_pool` in `tests/unit/test_relay_client.py` and `test_run_disables_configured_relay_pool_for_desktop` in `tests/unit/test_desktop_compute_node_bridge.py`; tests updated to accept the new `ComputeNodeRuntimeConfig` field in the test harness.

### Testing
- Ran `npm --prefix desktop-tauri run build` which completed successfully to ensure desktop assets build. 
- Attempted `python -m pytest tests/unit/test_desktop_compute_node_bridge.py` and `python -m pytest tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py`, but test execution in this environment failed due to missing test runtime dependencies reported by `tests/conftest.py` (ModuleNotFoundError for `playwright` / `psutil`), so the new tests could not be executed here. 
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle`, but these are blocked in this CI-like environment by missing system `glib-2.0` (pkg-config) required for building native crates. 

Notes: the change is purposely small and scoped to `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `utils/compute_node_runtime.py`, `utils/networking/relay_client.py`, and two unit-test files; it prevents the desktop operator from picking up configured relay pools and provides regression tests that will fail on the old behavior once test deps are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8280f250832fa5c9aeeb47162206)