### PR TITLE
Desktop: real compute modes (auto/cpu/gpu/hybrid) and truthful runtime diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -78,6 +78,7 @@ def run(args: argparse.Namespace) -> int:
     try:
         from utils.compute_node_runtime import (
             apply_compute_mode,
+            resolve_compute_mode,
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
@@ -99,7 +100,10 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    resolved_mode = apply_compute_mode(runtime.model_manager, args.mode)
+    requested_mode = apply_compute_mode(runtime.model_manager, args.mode)
+    resolution = resolve_compute_mode(runtime.model_manager, requested_mode)
+    effective_mode = getattr(runtime.model_manager, "effective_compute_mode", "uninitialized")
+    mode_reason = getattr(runtime.model_manager, "last_compute_note", None) or resolution.mode_reason
 
     if not runtime.ensure_model_ready():
         emit(
@@ -107,6 +111,10 @@ def run(args: argparse.Namespace) -> int:
                 "type": "error",
                 "message": "failed to initialize model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
+                "backend_mode_requested": resolution.requested_mode,
+                "backend_mode_effective": effective_mode,
+                "backend_available": resolution.backend_available,
+                "mode_reason": mode_reason,
             }
         )
         return 1
@@ -118,7 +126,10 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": resolved_mode,
+            "backend_mode_requested": resolution.requested_mode,
+            "backend_mode_effective": effective_mode,
+            "backend_available": resolution.backend_available,
+            "mode_reason": mode_reason,
             "model_path": args.model,
             "last_error": None,
         }
@@ -155,7 +166,10 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
-                    "backend_mode": resolved_mode,
+                    "backend_mode_requested": resolution.requested_mode,
+                    "backend_mode_effective": effective_mode,
+                    "backend_available": resolution.backend_available,
+                    "mode_reason": mode_reason,
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -173,7 +187,10 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": resolved_mode,
+            "backend_mode_requested": resolution.requested_mode,
+            "backend_mode_effective": effective_mode,
+            "backend_available": resolution.backend_available,
+            "mode_reason": mode_reason,
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -132,7 +132,7 @@ def run(args: argparse.Namespace) -> int:
         return emit_error("bad_model", "model path not found")
 
     try:
-        from utils.compute_node_runtime import apply_compute_mode
+        from utils.compute_node_runtime import apply_compute_mode, resolve_compute_mode
         from utils.llm.model_manager import ModelManager, get_model_manager
     except ModuleNotFoundError as exc:
         return emit_error(
@@ -142,13 +142,24 @@ def run(args: argparse.Namespace) -> int:
 
     manager = get_model_manager()
     manager.model_path = args.model
-    apply_compute_mode(manager, args.mode)
+    requested = apply_compute_mode(manager, args.mode)
+    resolution = resolve_compute_mode(manager, requested)
+    effective_mode = getattr(manager, "effective_compute_mode", "uninitialized")
+    mode_reason = getattr(manager, "last_compute_note", None) or resolution.mode_reason
 
     llm = manager.get_llm_instance()
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
-    emit({"type": "started"})
+    emit(
+        {
+            "type": "started",
+            "backend_mode_requested": resolution.requested_mode,
+            "backend_mode_effective": effective_mode,
+            "backend_available": resolution.backend_available,
+            "mode_reason": mode_reason,
+        }
+    )
     if cancel_requested():
         emit({"type": "canceled"})
         return 0

--- a/desktop-tauri/src-tauri/src/backend.rs
+++ b/desktop-tauri/src-tauri/src/backend.rs
@@ -4,28 +4,31 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum ComputeMode {
     Auto,
-    Metal,
-    Cuda,
     Cpu,
+    #[serde(alias = "metal", alias = "cuda")]
+    Gpu,
+    Hybrid,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BackendInfo {
     pub platform_label: String,
-    pub preferred_mode: ComputeMode,
+    pub available_backend: String,
+    pub gpu_available: bool,
     pub display_label: String,
 }
 
 pub fn detect_backend_for(target_os: &str, target_arch: &str) -> BackendInfo {
     if target_os == "macos" {
         let display_label = if target_arch == "aarch64" {
-            "Metal / Apple Silicon"
+            "Metal available (Apple Silicon)"
         } else {
-            "Metal / Apple"
+            "Metal available (macOS)"
         };
         return BackendInfo {
             platform_label: format!("macOS {target_arch}"),
-            preferred_mode: ComputeMode::Metal,
+            available_backend: "metal".into(),
+            gpu_available: true,
             display_label: display_label.into(),
         };
     }
@@ -33,15 +36,17 @@ pub fn detect_backend_for(target_os: &str, target_arch: &str) -> BackendInfo {
     if target_os == "windows" && target_arch == "x86_64" {
         return BackendInfo {
             platform_label: "Windows x64".into(),
-            preferred_mode: ComputeMode::Cuda,
-            display_label: "CUDA / NVIDIA".into(),
+            available_backend: "cuda".into(),
+            gpu_available: true,
+            display_label: "CUDA potentially available (NVIDIA)".into(),
         };
     }
 
     BackendInfo {
         platform_label: format!("{} {}", target_os, target_arch),
-        preferred_mode: ComputeMode::Cpu,
-        display_label: "CPU fallback".into(),
+        available_backend: "cpu".into(),
+        gpu_available: false,
+        display_label: "CPU-only host".into(),
     }
 }
 
@@ -52,28 +57,32 @@ mod tests {
     #[test]
     fn selects_metal_for_apple_silicon() {
         let info = detect_backend_for("macos", "aarch64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple Silicon");
+        assert!(info.gpu_available);
+        assert_eq!(info.available_backend, "metal");
+        assert_eq!(info.display_label, "Metal available (Apple Silicon)");
     }
 
     #[test]
     fn selects_metal_for_macos_intel() {
         let info = detect_backend_for("macos", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple");
+        assert!(info.gpu_available);
+        assert_eq!(info.available_backend, "metal");
+        assert_eq!(info.display_label, "Metal available (macOS)");
     }
 
     #[test]
     fn selects_cuda_for_windows_x64() {
         let info = detect_backend_for("windows", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cuda);
-        assert_eq!(info.display_label, "CUDA / NVIDIA");
+        assert!(info.gpu_available);
+        assert_eq!(info.available_backend, "cuda");
+        assert_eq!(info.display_label, "CUDA potentially available (NVIDIA)");
     }
 
     #[test]
     fn falls_back_to_cpu() {
         let info = detect_backend_for("linux", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cpu);
-        assert_eq!(info.display_label, "CPU fallback");
+        assert!(!info.gpu_available);
+        assert_eq!(info.available_backend, "cpu");
+        assert_eq!(info.display_label, "CPU-only host");
     }
 }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -23,7 +23,10 @@ pub struct ComputeNodeStatus {
     pub running: bool,
     pub registered: bool,
     pub active_relay_url: String,
-    pub backend_mode: String,
+    pub backend_mode_requested: String,
+    pub backend_mode_effective: String,
+    pub backend_available: String,
+    pub mode_reason: Option<String>,
     pub model_path: String,
     pub last_error: Option<String>,
 }
@@ -143,7 +146,10 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         running: false,
         registered: false,
         active_relay_url: request.relay_base_url.clone(),
-        backend_mode: format!("{:?}", request.mode).to_lowercase(),
+        backend_mode_requested: format!("{:?}", request.mode).to_lowercase(),
+        backend_mode_effective: "unknown".into(),
+        backend_available: "unknown".into(),
+        mode_reason: None,
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
     }
@@ -159,8 +165,26 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     if let Some(active_relay_url) = payload.get("active_relay_url").and_then(Value::as_str) {
         status.active_relay_url = active_relay_url.into();
     }
-    if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
-        status.backend_mode = backend_mode.into();
+    if let Some(backend_mode_requested) = payload
+        .get("backend_mode_requested")
+        .and_then(Value::as_str)
+    {
+        status.backend_mode_requested = backend_mode_requested.into();
+    }
+    if let Some(backend_mode_effective) = payload
+        .get("backend_mode_effective")
+        .and_then(Value::as_str)
+    {
+        status.backend_mode_effective = backend_mode_effective.into();
+    }
+    if let Some(backend_available) = payload.get("backend_available").and_then(Value::as_str) {
+        status.backend_available = backend_available.into();
+    }
+    if payload.get("mode_reason").is_some() {
+        status.mode_reason = payload
+            .get("mode_reason")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
     }
     if let Some(model_path) = payload.get("model_path").and_then(Value::as_str) {
         status.model_path = model_path.into();
@@ -301,7 +325,10 @@ pub async fn start_compute_node(
             running: true,
             registered: false,
             active_relay_url: request.relay_base_url.clone(),
-            backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            backend_mode_requested: format!("{:?}", request.mode).to_lowercase(),
+            backend_mode_effective: "initializing".into(),
+            backend_available: "unknown".into(),
+            mode_reason: None,
             model_path: request.model_path.clone(),
             last_error: None,
         };

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -4,25 +4,29 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 type UiState = 'idle' | 'starting' | 'streaming' | 'canceled' | 'completed' | 'failed';
-type BackendMode = 'auto' | 'metal' | 'cuda' | 'cpu';
+type ComputeMode = 'auto' | 'cpu' | 'gpu' | 'hybrid';
 
 interface BackendInfo {
   platform_label: string;
-  preferred_mode: BackendMode;
+  available_backend: string;
+  gpu_available: boolean;
   display_label: string;
 }
 
 interface DesktopConfig {
   model_path: string;
   relay_base_url: string;
-  preferred_mode: BackendMode;
+  preferred_mode: ComputeMode;
 }
 
 interface ComputeNodeStatus {
   running: boolean;
   registered: boolean;
   active_relay_url: string;
-  backend_mode: string;
+  backend_mode_requested: string;
+  backend_mode_effective: string;
+  backend_available: string;
+  mode_reason: string | null;
   model_path: string;
   last_error: string | null;
 }
@@ -49,7 +53,10 @@ const defaultComputeStatus: ComputeNodeStatus = {
   running: false,
   registered: false,
   active_relay_url: '',
-  backend_mode: 'auto',
+  backend_mode_requested: 'auto',
+  backend_mode_effective: 'unknown',
+  backend_available: 'unknown',
+  mode_reason: null,
   model_path: '',
   last_error: null,
 };
@@ -160,8 +167,24 @@ export function App() {
           typeof payload.active_relay_url === 'string'
             ? payload.active_relay_url
             : prev.active_relay_url,
-        backend_mode:
-          typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
+        backend_mode_requested:
+          typeof payload.backend_mode_requested === 'string'
+            ? payload.backend_mode_requested
+            : prev.backend_mode_requested,
+        backend_mode_effective:
+          typeof payload.backend_mode_effective === 'string'
+            ? payload.backend_mode_effective
+            : prev.backend_mode_effective,
+        backend_available:
+          typeof payload.backend_available === 'string'
+            ? payload.backend_available
+            : prev.backend_available,
+        mode_reason:
+          payload.mode_reason === null
+            ? null
+            : typeof payload.mode_reason === 'string'
+              ? payload.mode_reason
+              : prev.mode_reason,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         last_error:
           payload.last_error === null
@@ -200,15 +223,6 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running,
     [config.model_path, computeStatus.running]
   );
-  const platformLabel = (backend?.platform_label ?? '').toLowerCase();
-  const backendDisplayLabel = (backend?.display_label ?? '').toLowerCase();
-  const metalSupported = platformLabel.includes('apple') || platformLabel.includes('mac');
-  const cudaSupported =
-    backend?.preferred_mode === 'cuda' ||
-    backendDisplayLabel.includes('cuda') ||
-    platformLabel.includes('nvidia') ||
-    platformLabel.includes('cuda');
-
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {
       window.clearTimeout(saveTimerRef.current);
@@ -293,7 +307,10 @@ export function App() {
         running: true,
         registered: false,
         active_relay_url: config.relay_base_url,
-        backend_mode: config.preferred_mode,
+        backend_mode_requested: config.preferred_mode,
+        backend_mode_effective: 'initializing',
+        backend_available: backend?.available_backend ?? 'unknown',
+        mode_reason: null,
         model_path: config.model_path,
         last_error: null,
       }));
@@ -342,7 +359,7 @@ export function App() {
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
       <h1>token.place desktop compute node</h1>
-      <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
+      <p>Detected capability: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
         <input
@@ -382,17 +399,15 @@ export function App() {
       <label style={{ display: 'block', marginTop: 12 }}>Compute mode</label>
       <select
         value={config.preferred_mode}
-        onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
+        onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as ComputeMode })}
       >
-        <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
-        <option value="metal" disabled={!metalSupported}>Metal GPU (macOS Apple Silicon)</option>
-        <option value="cuda" disabled={!cudaSupported}>CUDA GPU (Windows/NVIDIA)</option>
-        <option value="cpu">CPU fallback</option>
+        <option value="auto">Auto (platform-aware)</option>
+        <option value="cpu">CPU only</option>
+        <option value="gpu">GPU only</option>
+        <option value="hybrid">Hybrid (partial GPU offload)</option>
       </select>
       <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
-        Operator note: <code>cuda</code> is for Windows/NVIDIA workstations, <code>metal</code> is
-        for macOS/Apple Silicon, and <code>cpu</code> is fallback. Raspberry Pi remains a later
-        low-power workstation target and is not part of the current sugarkube relay rollout.
+        Runtime note: requested mode and effective runtime are tracked separately.
       </p>
 
       <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
@@ -411,7 +426,16 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>
+          Requested mode: <code>{computeStatus.backend_mode_requested || config.preferred_mode}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Effective mode: <code>{computeStatus.backend_mode_effective || 'unknown'}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Available backend: <code>{computeStatus.backend_available || backend?.available_backend || 'unknown'}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>Mode reason: <code>{computeStatus.mode_reason || 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -219,21 +219,26 @@ def test_compute_node_runtime_format_relay_target_preserves_explicit_url_port():
 
 
 def test_normalize_compute_mode_is_case_insensitive_and_falls_back_to_auto():
-    assert normalize_compute_mode("CUDA") == "cuda"
-    assert normalize_compute_mode("  metal ") == "metal"
+    assert normalize_compute_mode("CUDA") == "gpu"
+    assert normalize_compute_mode("  metal ") == "gpu"
+    assert normalize_compute_mode("hybrid") == "hybrid"
     assert normalize_compute_mode("unknown") == "auto"
     assert normalize_compute_mode("") == "auto"
     assert normalize_compute_mode(None) == "auto"
 
 
-def test_apply_compute_mode_sets_expected_gpu_layer_defaults():
+def test_apply_compute_mode_sets_expected_gpu_layer_defaults(monkeypatch):
     manager = MagicMock()
+    monkeypatch.setenv("TOKEN_PLACE_PLATFORM", "win32")
 
     assert apply_compute_mode(manager, "cpu") == "cpu"
     assert manager.default_n_gpu_layers == 0
 
     assert apply_compute_mode(manager, "auto") == "auto"
     assert manager.default_n_gpu_layers == -1
+
+    assert apply_compute_mode(manager, "hybrid") == "hybrid"
+    assert manager.default_n_gpu_layers > 0
 
 
 def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -134,6 +134,7 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
         SUPPORTED_COMPUTE_MODES as _SUPPORTED_COMPUTE_MODES,
         apply_compute_mode as _apply_compute_mode,
         normalize_compute_mode as _normalize_compute_mode,
+        resolve_compute_mode as _resolve_compute_mode,
     )
 
     module = ModuleType('utils.compute_node_runtime')
@@ -150,6 +151,7 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     module.SUPPORTED_COMPUTE_MODES = _SUPPORTED_COMPUTE_MODES
     module.normalize_compute_mode = _normalize_compute_mode
     module.apply_compute_mode = _apply_compute_mode
+    module.resolve_compute_mode = _resolve_compute_mode
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
 
@@ -310,18 +312,19 @@ def test_run_reports_error_when_legacy_relay_request_processing_fails(capsys, mo
     assert status_events[0]['last_error'] == 'failed to process relay request'
 
 
-def test_apply_compute_mode_supports_gpu_and_cpu_modes():
+def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
     manager = FakeModelManager()
     from utils.compute_node_runtime import apply_compute_mode
 
+    monkeypatch.setenv('TOKEN_PLACE_PLATFORM', 'win32')
     assert apply_compute_mode(manager, 'auto') == 'auto'
     assert manager.default_n_gpu_layers == -1
 
-    assert apply_compute_mode(manager, 'metal') == 'metal'
+    assert apply_compute_mode(manager, 'gpu') == 'gpu'
     assert manager.default_n_gpu_layers == -1
 
-    assert apply_compute_mode(manager, 'cuda') == 'cuda'
-    assert manager.default_n_gpu_layers == -1
+    assert apply_compute_mode(manager, 'hybrid') == 'hybrid'
+    assert manager.default_n_gpu_layers > 0
 
     assert apply_compute_mode(manager, 'cpu') == 'cpu'
     assert manager.default_n_gpu_layers == 0
@@ -343,7 +346,7 @@ def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert events[0]['type'] == 'started'
-    assert events[0]['backend_mode'] == 'auto'
+    assert events[0]['backend_mode_requested'] == 'auto'
 
 
 def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):
@@ -391,7 +394,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,
@@ -423,7 +426,7 @@ def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_pat
     (utils_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
-SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "cuda", "metal"}
+SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid"}
 
 
 def normalize_compute_mode(mode):
@@ -433,6 +436,17 @@ def normalize_compute_mode(mode):
 
 def apply_compute_mode(_model_manager, mode):
     return normalize_compute_mode(mode)
+
+
+def resolve_compute_mode(_model_manager, mode):
+    resolved = normalize_compute_mode(mode)
+    return type("Resolution", (), {
+        "requested_mode": resolved,
+        "backend_available": "cpu",
+        "effective_mode": "cpu",
+        "mode_reason": "test",
+        "n_gpu_layers": 0,
+    })()
 
 
 def resolve_relay_url(relay_url):

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -179,9 +179,10 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
 
 @pytest.mark.parametrize(
     ('mode', 'expected'),
-    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+    [('cpu', 0), ('gpu', -1), ('hybrid', 16), ('auto', -1)],
 )
-def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
+def test_run_applies_compute_mode_to_manager(tmp_path, capsys, monkeypatch, mode, expected):
+    monkeypatch.setenv('TOKEN_PLACE_PLATFORM', 'win32')
     _reset_cancel_queue()
     model_path = tmp_path / 'model.gguf'
     model_path.write_text('fake-model')
@@ -214,7 +215,8 @@ def test_run_handles_dict_completion_payload(tmp_path, capsys):
     assert events[1]['text'] == 'dict response'
 
 
-def test_run_normalizes_unknown_mode_to_auto_gpu_default(tmp_path, capsys):
+def test_run_normalizes_unknown_mode_to_auto_gpu_default(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_PLATFORM', 'win32')
     _reset_cancel_queue()
     model_path = tmp_path / 'model.gguf'
     model_path.write_text('fake-model')
@@ -374,7 +376,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = inference_sidecar.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,
@@ -405,7 +407,7 @@ def test_extract_text_from_completion_handles_empty_choices():
 
 def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
     class WithBadDict:
-        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+        def dict(self, _required):  # pragma: no cover - signature intentionally incompatible
             return {'choices': []}
 
     class UnknownShape:

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Protocol, Sequence
@@ -134,29 +135,101 @@ def format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
     return f"{relay_url}:{relay_port}"
 
 
-SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "metal", "cuda"})
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "gpu", "hybrid", "metal", "cuda"})
+HYBRID_GPU_LAYERS = 16
+
+
+@dataclass(frozen=True)
+class ComputeModeResolution:
+    requested_mode: str
+    backend_available: str
+    effective_mode: str
+    mode_reason: Optional[str]
+    n_gpu_layers: int
 
 
 def normalize_compute_mode(mode: Optional[str]) -> str:
     """Normalize operator-provided compute mode values."""
 
     selected = (mode or "auto").strip().lower()
+    legacy_aliases = {"metal": "gpu", "cuda": "gpu"}
+    selected = legacy_aliases.get(selected, selected)
     if selected in SUPPORTED_COMPUTE_MODES:
+        if selected in ("metal", "cuda"):
+            return "gpu"
         return selected
     return "auto"
+
+
+def detect_backend_for_host() -> str:
+    """Return platform-default accelerator backend."""
+
+    platform = (os.environ.get("TOKEN_PLACE_PLATFORM") or sys.platform).lower()
+    if platform.startswith("win"):
+        return "cuda"
+    if platform == "darwin":
+        return "metal"
+    return "cpu"
+
+
+def resolve_compute_mode(manager: Any, mode: Optional[str]) -> ComputeModeResolution:
+    """Resolve user mode to backend intent and GPU layer policy."""
+
+    selected = normalize_compute_mode(mode)
+    backend_available = detect_backend_for_host()
+
+    if selected == "cpu":
+        return ComputeModeResolution(
+            requested_mode=selected,
+            backend_available=backend_available,
+            effective_mode="cpu",
+            mode_reason="operator selected CPU-only mode",
+            n_gpu_layers=0,
+        )
+
+    if backend_available == "cpu":
+        return ComputeModeResolution(
+            requested_mode=selected,
+            backend_available=backend_available,
+            effective_mode="cpu",
+            mode_reason="no supported GPU backend available on this host",
+            n_gpu_layers=0,
+        )
+
+    if selected == "hybrid":
+        return ComputeModeResolution(
+            requested_mode=selected,
+            backend_available=backend_available,
+            effective_mode=f"{backend_available}-hybrid",
+            mode_reason=f"partial {backend_available} offload requested",
+            n_gpu_layers=HYBRID_GPU_LAYERS,
+        )
+
+    # GPU and auto both prefer full offload on GPU-capable hosts.
+    mode_label = f"{backend_available}-gpu" if selected == "gpu" else f"{backend_available}-auto"
+    reason = (
+        f"full {backend_available} offload requested"
+        if selected == "gpu"
+        else f"auto selected {backend_available} backend"
+    )
+    return ComputeModeResolution(
+        requested_mode=selected,
+        backend_available=backend_available,
+        effective_mode=mode_label,
+        mode_reason=reason,
+        n_gpu_layers=-1,
+    )
 
 
 def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
     """Apply normalized compute mode to model-manager GPU settings."""
 
-    selected = normalize_compute_mode(mode)
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    else:
-        # ``auto`` follows runtime autodetection and maps to GPU-preferred layers where available.
-        # ``metal`` and ``cuda`` also request GPU-backed inference on supported hosts.
-        manager.default_n_gpu_layers = -1
-    return selected
+    resolution = resolve_compute_mode(manager, mode)
+    manager.default_n_gpu_layers = resolution.n_gpu_layers
+    manager.requested_compute_mode = resolution.requested_mode
+    manager.available_compute_backend = resolution.backend_available
+    manager.requested_mode_reason = resolution.mode_reason
+    return resolution.requested_mode
 
 
 class ComputeNodeRuntime:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -60,6 +60,12 @@ class ModelManager:
         self.default_n_gpu_layers = config.get('model.n_gpu_layers', -1)
         self.gpu_headroom_percent = config.get('model.gpu_memory_headroom_percent', 0.1)
         self.enforce_gpu_headroom = config.get('model.enforce_gpu_memory_headroom', True)
+        self.requested_compute_mode = 'auto'
+        self.available_compute_backend = 'unknown'
+        self.requested_mode_reason = None
+        self.effective_compute_mode = 'uninitialized'
+        self.effective_n_gpu_layers = None
+        self.last_compute_note = None
 
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
         """Return runtime model metadata used by server and desktop bridges."""
@@ -250,13 +256,37 @@ class ModelManager:
                                         )
                                         n_gpu_layers = 0
 
+                            llama_kwargs = {
+                                'model_path': self.model_path,
+                                'n_gpu_layers': n_gpu_layers,
+                                'n_ctx': self.config.get('model.context_size', 8192),
+                                'chat_format': self.config.get('model.chat_format', 'llama-3'),
+                            }
                             self.log_info(f"Initializing Llama model from {self.model_path}...")
-                            self.llm = Llama(
-                                model_path=self.model_path,
-                                n_gpu_layers=n_gpu_layers,
-                                n_ctx=self.config.get('model.context_size', 8192),
-                                chat_format=self.config.get('model.chat_format', 'llama-3')
-                            )
+                            try:
+                                self.llm = Llama(**llama_kwargs)
+                                self.effective_n_gpu_layers = n_gpu_layers
+                                self.effective_compute_mode = (
+                                    f"{self.available_compute_backend}-gpu"
+                                    if n_gpu_layers != 0
+                                    else "cpu"
+                                )
+                                self.last_compute_note = self.requested_mode_reason
+                            except Exception as gpu_exc:
+                                if n_gpu_layers == 0:
+                                    raise
+
+                                self.log_warning(
+                                    "GPU initialization failed; retrying with CPU-only "
+                                    f"inference: {gpu_exc}"
+                                )
+                                self.last_compute_note = (
+                                    f"GPU initialization failed ({gpu_exc}); fell back to CPU"
+                                )
+                                self.effective_compute_mode = "cpu-fallback"
+                                llama_kwargs['n_gpu_layers'] = 0
+                                self.llm = Llama(**llama_kwargs)
+                                self.effective_n_gpu_layers = 0
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)


### PR DESCRIPTION
### Motivation
- Fix misleading desktop UX that reported GPU-capable backends while the runtime still initialized CPU-only layers by wiring operator compute mode through to the actual llama.cpp initialization.
- Provide a small, auditable mapping from user-facing modes to concrete `llama-cpp-python` behavior (`n_gpu_layers = 0`, `-1`, or a conservative hybrid value) so desktop parity with `server.py` is achievable.
- Make backend detection conservative and distinguish three states: available backend, requested mode, and effective runtime mode so the app never implies GPU use unless the runtime actually uses GPU.

### Description
- Add explicit user-facing compute modes `auto`, `cpu`, `gpu`, and `hybrid` and normalize legacy `metal`/`cuda` aliases to `gpu` in `desktop-tauri/src-tauri/src/backend.rs` and TypeScript UI types in `desktop-tauri/src/App.tsx`.
- Extend Rust compute-node status to carry `backend_mode_requested`, `backend_mode_effective`, `backend_available`, and `mode_reason`, and propagate those fields through the compute-node lifecycle in `compute_node.rs` and the Tauri UI.
- Introduce platform-aware compute-mode resolution in `utils/compute_node_runtime.py` with `resolve_compute_mode` and map resolutions to `n_gpu_layers` (`0`, `-1`, or `HYBRID_GPU_LAYERS`), and update `apply_compute_mode` to set the model-manager defaults.
- Wire the resolution and diagnostics through the Python bridges so `compute_node_bridge.py` and `inference_sidecar.py` emit requested/effective/available/mode-reason fields at `started`/`status`/`stopped` events.
- Harden `utils/llm/model_manager.py` to attempt GPU init when requested, record effective settings, and fall back to CPU (retrying `Llama(..., n_gpu_layers=0)`) with a recorded note instead of reporting GPU active when it failed.
- Update focused unit tests to assert the new normalization, mapping to `n_gpu_layers` for `cpu/gpu/hybrid/auto`, and that the desktop bridges propagate the selected mode into the runtime.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_compute_node_runtime.py -q` and `python -m pytest tests/unit/test_model_manager.py -q`, all relevant unit tests passed in this environment.
- Built the front-end with `npm --prefix desktop-tauri run build`, which succeeded; `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` failed in this environment due to missing system `glib-2.0` pkg-config/dev libs (external to this change).
- `pre-commit run --all-files` reported repository-wide checks and environment-dependent hooks (codespell/vulture/bandit) that are unrelated to the logic in this PR and required additional environment setup; the code changes themselves conform to the updated unit tests added/modified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc82426148832f9498cb317a7f19ee)