### PR TITLE
Implement real desktop GPU compute modes with truthful runtime diagnostics

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -96,16 +96,27 @@ jobs:
           from desktop_gpu_packaging import llama_cpp_install_plan
 
           plan = llama_cpp_install_plan(platform=sys.platform, requirements_path=repo_root / "requirements.txt")
-          command = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
+          install_args = plan.pip_install_args()
+          command = [sys.executable, "-m", "pip", "install", *install_args, plan.package_spec]
           env = os.environ.copy()
           env.update(plan.pip_env())
 
           print(f"Installing {plan.package_spec} for backend={plan.backend} on platform={sys.platform}")
+          if plan.index_url:
+              print(f"Using primary wheel index: {plan.index_url}")
           if plan.extra_index_url:
-              print(f"Using wheel index: {plan.extra_index_url}")
+              print(f"Using extra package index: {plan.extra_index_url}")
           if plan.pip_env():
               print(f"Using build env: {plan.pip_env()}")
-          subprocess.check_call(command, env=env)
+
+          for attempt in range(1, 4):
+              try:
+                  subprocess.check_call(command, env=env)
+                  break
+              except subprocess.CalledProcessError:
+                  if attempt >= 3:
+                      raise
+                  print(f"Install attempt {attempt} failed, retrying...")
           PY
 
       - name: Build frontend assets

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -97,6 +97,10 @@ jobs:
 
           plans = llama_cpp_install_plan_fallbacks(platform=sys.platform, requirements_path=repo_root / "requirements.txt")
 
+          def _is_bad_zip_error(output: str) -> bool:
+              lower = output.lower()
+              return "bad crc-32" in lower or "badzipfile" in lower
+
           for plan_index, plan in enumerate(plans, start=1):
               install_args = plan.pip_install_args()
               command = [sys.executable, "-m", "pip", "install", *install_args, plan.package_spec]
@@ -112,17 +116,35 @@ jobs:
               if plan.pip_env():
                   print(f"Using build env: {plan.pip_env()}")
 
-              for attempt in range(1, 4):
-                  try:
-                      subprocess.check_call(command, env=env)
+              max_attempts = 3
+              for attempt in range(1, max_attempts + 1):
+                  result = subprocess.run(
+                      command,
+                      env=env,
+                      check=False,
+                      capture_output=True,
+                      text=True,
+                  )
+                  if result.returncode == 0:
                       raise SystemExit(0)
-                  except subprocess.CalledProcessError:
-                      if attempt >= 3:
-                          print(f"Install attempt {attempt} failed for plan {plan_index}.")
-                      else:
-                          print(f"Install attempt {attempt} failed, retrying...")
+
+                  combined_output = f"{result.stdout}\n{result.stderr}"
+                  print(combined_output)
+
+                  if _is_bad_zip_error(combined_output):
+                      print("Detected corrupted wheel archive (BadZip/CRC); switching to next fallback plan.")
+                      break
+
+                  if attempt >= max_attempts:
+                      print(f"Install attempt {attempt} failed for plan {plan_index}.")
+                  else:
+                      print(f"Install attempt {attempt} failed, retrying...")
 
               print(f"Falling back from plan {plan_index} to next candidate...")
+              subprocess.run(
+                  [sys.executable, "-m", "pip", "uninstall", "-y", "llama-cpp-python"],
+                  check=False,
+              )
 
           raise RuntimeError("Failed to install llama-cpp-python for all configured plans")
           PY

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -96,11 +96,13 @@ jobs:
           from desktop_gpu_packaging import llama_cpp_install_plan
 
           plan = llama_cpp_install_plan(platform=sys.platform, requirements_path=repo_root / "requirements.txt")
-          command = [sys.executable, "-m", "pip", "install", "--upgrade", "--no-cache-dir", plan.package_spec]
+          command = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
           env = os.environ.copy()
           env.update(plan.pip_env())
 
           print(f"Installing {plan.package_spec} for backend={plan.backend} on platform={sys.platform}")
+          if plan.extra_index_url:
+              print(f"Using wheel index: {plan.extra_index_url}")
           if plan.pip_env():
               print(f"Using build env: {plan.pip_env()}")
           subprocess.check_call(command, env=env)

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -93,30 +93,38 @@ jobs:
           desktop_python_root = repo_root / "desktop-tauri" / "src-tauri" / "python"
           sys.path.insert(0, str(desktop_python_root))
 
-          from desktop_gpu_packaging import llama_cpp_install_plan
+          from desktop_gpu_packaging import llama_cpp_install_plan_fallbacks
 
-          plan = llama_cpp_install_plan(platform=sys.platform, requirements_path=repo_root / "requirements.txt")
-          install_args = plan.pip_install_args()
-          command = [sys.executable, "-m", "pip", "install", *install_args, plan.package_spec]
-          env = os.environ.copy()
-          env.update(plan.pip_env())
+          plans = llama_cpp_install_plan_fallbacks(platform=sys.platform, requirements_path=repo_root / "requirements.txt")
 
-          print(f"Installing {plan.package_spec} for backend={plan.backend} on platform={sys.platform}")
-          if plan.index_url:
-              print(f"Using primary wheel index: {plan.index_url}")
-          if plan.extra_index_url:
-              print(f"Using extra package index: {plan.extra_index_url}")
-          if plan.pip_env():
-              print(f"Using build env: {plan.pip_env()}")
+          for plan_index, plan in enumerate(plans, start=1):
+              install_args = plan.pip_install_args()
+              command = [sys.executable, "-m", "pip", "install", *install_args, plan.package_spec]
+              env = os.environ.copy()
+              env.update(plan.pip_env())
 
-          for attempt in range(1, 4):
-              try:
-                  subprocess.check_call(command, env=env)
-                  break
-              except subprocess.CalledProcessError:
-                  if attempt >= 3:
-                      raise
-                  print(f"Install attempt {attempt} failed, retrying...")
+              print(f"Installing {plan.package_spec} for backend={plan.backend} on platform={sys.platform}")
+              print(f"Install plan {plan_index}/{len(plans)}")
+              if plan.index_url:
+                  print(f"Using primary wheel index: {plan.index_url}")
+              if plan.extra_index_url:
+                  print(f"Using extra package index: {plan.extra_index_url}")
+              if plan.pip_env():
+                  print(f"Using build env: {plan.pip_env()}")
+
+              for attempt in range(1, 4):
+                  try:
+                      subprocess.check_call(command, env=env)
+                      raise SystemExit(0)
+                  except subprocess.CalledProcessError:
+                      if attempt >= 3:
+                          print(f"Install attempt {attempt} failed for plan {plan_index}.")
+                      else:
+                          print(f"Install attempt {attempt} failed, retrying...")
+
+              print(f"Falling back from plan {plan_index} to next candidate...")
+
+          raise RuntimeError("Failed to install llama-cpp-python for all configured plans")
           PY
 
       - name: Build frontend assets

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -55,6 +55,13 @@ jobs:
           cache: npm
           cache-dependency-path: desktop-tauri/package-lock.json
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
@@ -71,6 +78,33 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci
+
+      - name: Install desktop llama-cpp runtime with platform GPU backend
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+          import sys
+
+          repo_root = pathlib.Path.cwd().parent
+          desktop_python_root = repo_root / "desktop-tauri" / "src-tauri" / "python"
+          sys.path.insert(0, str(desktop_python_root))
+
+          from desktop_gpu_packaging import llama_cpp_install_plan
+
+          plan = llama_cpp_install_plan(platform=sys.platform, requirements_path=repo_root / "requirements.txt")
+          command = [sys.executable, "-m", "pip", "install", "--upgrade", "--no-cache-dir", plan.package_spec]
+          env = os.environ.copy()
+          env.update(plan.pip_env())
+
+          print(f"Installing {plan.package_spec} for backend={plan.backend} on platform={sys.platform}")
+          if plan.pip_env():
+              print(f"Using build env: {plan.pip_env()}")
+          subprocess.check_call(command, env=env)
+          PY
 
       - name: Build frontend assets
         # Keep this explicit pre-build. Some CI failures reported frontendDist validation

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -78,6 +78,7 @@ def run(args: argparse.Namespace) -> int:
     try:
         from utils.compute_node_runtime import (
             apply_compute_mode,
+            compute_mode_diagnostics,
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_legacy_relay_payload,
@@ -99,7 +100,7 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    resolved_mode = apply_compute_mode(runtime.model_manager, args.mode)
+    apply_compute_mode(runtime.model_manager, args.mode)
 
     if not runtime.ensure_model_ready():
         emit(
@@ -111,6 +112,7 @@ def run(args: argparse.Namespace) -> int:
         )
         return 1
 
+    diagnostics = compute_mode_diagnostics(runtime.model_manager)
     last_error: Optional[str] = None
     emit(
         {
@@ -118,7 +120,12 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": resolved_mode,
+            "requested_mode": diagnostics.get("requested_mode"),
+            "effective_mode": diagnostics.get("effective_mode"),
+            "backend_available": diagnostics.get("backend_available"),
+            "backend_selected": diagnostics.get("backend_selected"),
+            "backend_used": diagnostics.get("backend_used"),
+            "fallback_reason": diagnostics.get("fallback_reason"),
             "model_path": args.model,
             "last_error": None,
         }
@@ -155,7 +162,12 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
-                    "backend_mode": resolved_mode,
+                    "requested_mode": diagnostics.get("requested_mode"),
+                    "effective_mode": diagnostics.get("effective_mode"),
+                    "backend_available": diagnostics.get("backend_available"),
+                    "backend_selected": diagnostics.get("backend_selected"),
+                    "backend_used": diagnostics.get("backend_used"),
+                    "fallback_reason": diagnostics.get("fallback_reason"),
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -173,7 +185,12 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": resolved_mode,
+            "requested_mode": diagnostics.get("requested_mode"),
+            "effective_mode": diagnostics.get("effective_mode"),
+            "backend_available": diagnostics.get("backend_available"),
+            "backend_selected": diagnostics.get("backend_selected"),
+            "backend_used": diagnostics.get("backend_used"),
+            "fallback_reason": diagnostics.get("fallback_reason"),
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -156,6 +156,7 @@ def run(args: argparse.Namespace) -> int:
             else:
                 last_error = None
 
+            diagnostics = compute_mode_diagnostics(runtime.model_manager)
             emit(
                 {
                     "type": "status",
@@ -179,6 +180,7 @@ def run(args: argparse.Namespace) -> int:
     finally:
         runtime.stop()
 
+    diagnostics = compute_mode_diagnostics(runtime.model_manager)
     emit(
         {
             "type": "stopped",

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -16,12 +16,19 @@ class LlamaCppInstallPlan:
     package_spec: str
     cmake_args: str | None
     force_cmake: bool
+    index_url: str | None = None
     extra_index_url: str | None = None
+    only_binary: bool = False
 
     def pip_install_args(self) -> list[str]:
         args = ["--upgrade", "--no-cache-dir"]
+        if self.index_url:
+            args.extend(["--index-url", self.index_url])
         if self.extra_index_url:
             args.extend(["--extra-index-url", self.extra_index_url])
+        if self.only_binary:
+            args.extend(["--only-binary", "llama-cpp-python"])
+        if self.index_url or self.extra_index_url:
             args.append("--prefer-binary")
         return args
 
@@ -65,7 +72,9 @@ def llama_cpp_install_plan(
             package_spec=package_spec,
             cmake_args=None,
             force_cmake=False,
-            extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+            index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+            extra_index_url="https://pypi.org/simple",
+            only_binary=True,
         )
 
     if detected_platform == "darwin":
@@ -75,7 +84,9 @@ def llama_cpp_install_plan(
             package_spec=package_spec,
             cmake_args=None,
             force_cmake=False,
-            extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/metal",
+            index_url="https://abetlen.github.io/llama-cpp-python/whl/metal",
+            extra_index_url="https://pypi.org/simple",
+            only_binary=True,
         )
 
     return LlamaCppInstallPlan(

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -111,9 +111,9 @@ def llama_cpp_install_plan_fallbacks(
     plans = [primary]
 
     if primary.platform.startswith("win"):
-        # 0.3.16 CUDA indexes publish Linux wheels only; keep desktop CI/release
-        # buildable by falling back to a deterministic source build when CUDA
-        # wheels are unavailable for the current Python ABI.
+        # CUDA wheels may be unavailable for a given Python ABI on Windows.
+        # Fall back to PyPI's prebuilt CPU wheel to keep desktop CI/release
+        # buildable without requiring local native compilation toolchains.
         plans.append(
             LlamaCppInstallPlan(
                 platform=primary.platform,
@@ -123,8 +123,8 @@ def llama_cpp_install_plan_fallbacks(
                 force_cmake=False,
                 index_url="https://pypi.org/simple",
                 extra_index_url=None,
-                only_binary=False,
-                no_binary=True,
+                only_binary=True,
+                no_binary=False,
             )
         )
 

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -16,6 +16,14 @@ class LlamaCppInstallPlan:
     package_spec: str
     cmake_args: str | None
     force_cmake: bool
+    extra_index_url: str | None = None
+
+    def pip_install_args(self) -> list[str]:
+        args = ["--upgrade", "--no-cache-dir"]
+        if self.extra_index_url:
+            args.extend(["--extra-index-url", self.extra_index_url])
+            args.append("--prefer-binary")
+        return args
 
     def pip_env(self) -> dict[str, str]:
         env: dict[str, str] = {}
@@ -55,8 +63,9 @@ def llama_cpp_install_plan(
             platform=detected_platform,
             backend="cuda",
             package_spec=package_spec,
-            cmake_args="-DGGML_CUDA=on",
-            force_cmake=True,
+            cmake_args=None,
+            force_cmake=False,
+            extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
         )
 
     if detected_platform == "darwin":
@@ -64,8 +73,9 @@ def llama_cpp_install_plan(
             platform=detected_platform,
             backend="metal",
             package_spec=package_spec,
-            cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
-            force_cmake=True,
+            cmake_args=None,
+            force_cmake=False,
+            extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/metal",
         )
 
     return LlamaCppInstallPlan(

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -64,7 +64,7 @@ def llama_cpp_install_plan(
             platform=detected_platform,
             backend="metal",
             package_spec=package_spec,
-            cmake_args="-DGGML_METAL=on",
+            cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
             force_cmake=True,
         )
 

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -112,13 +112,31 @@ def llama_cpp_install_plan_fallbacks(
 
     if primary.platform.startswith("win"):
         # CUDA wheels may be unavailable for a given Python ABI on Windows.
-        # Fall back to PyPI's prebuilt CPU wheel to keep desktop CI/release
-        # buildable without requiring local native compilation toolchains.
+        # First, fall back to an unpinned CUDA wheel so CI can use the newest
+        # available CUDA binary (e.g. when requirements pin is newer than
+        # published CUDA wheels on the mirror index).
+        plans.append(
+            LlamaCppInstallPlan(
+                platform=primary.platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args=None,
+                force_cmake=False,
+                index_url=primary.index_url,
+                extra_index_url=primary.extra_index_url,
+                only_binary=True,
+                no_binary=False,
+            )
+        )
+
+        # If CUDA wheels are unavailable entirely for this ABI, fall back to
+        # an unpinned CPU wheel from PyPI to keep desktop CI/release buildable
+        # without requiring local native compilation toolchains.
         plans.append(
             LlamaCppInstallPlan(
                 platform=primary.platform,
                 backend="cpu",
-                package_spec=primary.package_spec,
+                package_spec="llama-cpp-python",
                 cmake_args=None,
                 force_cmake=False,
                 index_url="https://pypi.org/simple",

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -19,6 +19,7 @@ class LlamaCppInstallPlan:
     index_url: str | None = None
     extra_index_url: str | None = None
     only_binary: bool = False
+    no_binary: bool = False
 
     def pip_install_args(self) -> list[str]:
         args = ["--upgrade", "--no-cache-dir"]
@@ -28,6 +29,8 @@ class LlamaCppInstallPlan:
             args.extend(["--extra-index-url", self.extra_index_url])
         if self.only_binary:
             args.extend(["--only-binary", "llama-cpp-python"])
+        if self.no_binary:
+            args.extend(["--no-binary", "llama-cpp-python"])
         if self.index_url or self.extra_index_url:
             args.append("--prefer-binary")
         return args
@@ -120,7 +123,7 @@ def llama_cpp_install_plan_fallbacks(
                 force_cmake=False,
                 index_url="https://pypi.org/simple",
                 extra_index_url=None,
-                only_binary=False,
+                only_binary=True,
             )
         )
 
@@ -138,6 +141,7 @@ def llama_cpp_install_plan_fallbacks(
                 index_url="https://pypi.org/simple",
                 extra_index_url=None,
                 only_binary=False,
+                no_binary=True,
             )
         )
 

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -96,3 +96,49 @@ def llama_cpp_install_plan(
         cmake_args=None,
         force_cmake=False,
     )
+
+
+def llama_cpp_install_plan_fallbacks(
+    platform: str | None = None,
+    requirements_path: str | Path = "requirements.txt",
+) -> list[LlamaCppInstallPlan]:
+    """Return ordered install plans with conservative fallbacks per platform."""
+
+    primary = llama_cpp_install_plan(platform=platform, requirements_path=requirements_path)
+    plans = [primary]
+
+    if primary.platform.startswith("win"):
+        # 0.3.16 CUDA indexes publish Linux wheels only; keep desktop CI/release
+        # buildable by falling back to the pinned PyPI package when CUDA wheels
+        # are unavailable for the current Python ABI.
+        plans.append(
+            LlamaCppInstallPlan(
+                platform=primary.platform,
+                backend="cpu",
+                package_spec=primary.package_spec,
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+            )
+        )
+
+    if primary.platform == "darwin":
+        # The Metal wheel can intermittently fail integrity checks in CI.
+        # Fall back to a deterministic source build with Metal enabled and
+        # GGML native tuning disabled to avoid arm64 i8mm compile issues.
+        plans.append(
+            LlamaCppInstallPlan(
+                platform=primary.platform,
+                backend="metal",
+                package_spec=primary.package_spec,
+                cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
+                force_cmake=True,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+            )
+        )
+
+    return plans

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -1,0 +1,77 @@
+"""Helpers for desktop llama-cpp-python GPU packaging/install contract."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LlamaCppInstallPlan:
+    """Deterministic install plan for platform-specific llama-cpp-python builds."""
+
+    platform: str
+    backend: str
+    package_spec: str
+    cmake_args: str | None
+    force_cmake: bool
+
+    def pip_env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        if self.cmake_args:
+            env["CMAKE_ARGS"] = self.cmake_args
+        if self.force_cmake:
+            env["FORCE_CMAKE"] = "1"
+        return env
+
+
+def llama_cpp_requirement_spec(requirements_path: str | Path = "requirements.txt") -> str:
+    """Return pinned llama-cpp-python requirement from requirements.txt."""
+
+    path = Path(requirements_path)
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        normalized = line.replace("-", "_").lower()
+        if normalized.startswith("llama_cpp_python=="):
+            version = line.split("==", 1)[1].strip()
+            return f"llama-cpp-python=={version}"
+    raise ValueError(f"llama_cpp_python pin not found in {path}")
+
+
+def llama_cpp_install_plan(
+    platform: str | None = None,
+    requirements_path: str | Path = "requirements.txt",
+) -> LlamaCppInstallPlan:
+    """Return explicit, conservative desktop install plan for llama-cpp-python."""
+
+    detected_platform = (platform or sys.platform).lower()
+    package_spec = llama_cpp_requirement_spec(requirements_path)
+
+    if detected_platform.startswith("win"):
+        return LlamaCppInstallPlan(
+            platform=detected_platform,
+            backend="cuda",
+            package_spec=package_spec,
+            cmake_args="-DGGML_CUDA=on",
+            force_cmake=True,
+        )
+
+    if detected_platform == "darwin":
+        return LlamaCppInstallPlan(
+            platform=detected_platform,
+            backend="metal",
+            package_spec=package_spec,
+            cmake_args="-DGGML_METAL=on",
+            force_cmake=True,
+        )
+
+    return LlamaCppInstallPlan(
+        platform=detected_platform,
+        backend="cpu",
+        package_spec=package_spec,
+        cmake_args=None,
+        force_cmake=False,
+    )

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -112,8 +112,8 @@ def llama_cpp_install_plan_fallbacks(
 
     if primary.platform.startswith("win"):
         # 0.3.16 CUDA indexes publish Linux wheels only; keep desktop CI/release
-        # buildable by falling back to the pinned PyPI package when CUDA wheels
-        # are unavailable for the current Python ABI.
+        # buildable by falling back to a deterministic source build when CUDA
+        # wheels are unavailable for the current Python ABI.
         plans.append(
             LlamaCppInstallPlan(
                 platform=primary.platform,
@@ -123,7 +123,8 @@ def llama_cpp_install_plan_fallbacks(
                 force_cmake=False,
                 index_url="https://pypi.org/simple",
                 extra_index_url=None,
-                only_binary=True,
+                only_binary=False,
+                no_binary=True,
             )
         )
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -132,7 +132,7 @@ def run(args: argparse.Namespace) -> int:
         return emit_error("bad_model", "model path not found")
 
     try:
-        from utils.compute_node_runtime import apply_compute_mode
+        from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
         from utils.llm.model_manager import ModelManager, get_model_manager
     except ModuleNotFoundError as exc:
         return emit_error(
@@ -148,7 +148,17 @@ def run(args: argparse.Namespace) -> int:
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
-    emit({"type": "started"})
+    diagnostics = compute_mode_diagnostics(manager)
+    emit(
+        {
+            "type": "started",
+            "requested_mode": diagnostics.get("requested_mode"),
+            "effective_mode": diagnostics.get("effective_mode"),
+            "backend_used": diagnostics.get("backend_used"),
+            "n_gpu_layers": diagnostics.get("n_gpu_layers"),
+            "fallback_reason": diagnostics.get("fallback_reason"),
+        }
+    )
     if cancel_requested():
         emit({"type": "canceled"})
         return 0

--- a/desktop-tauri/src-tauri/src/backend.rs
+++ b/desktop-tauri/src-tauri/src/backend.rs
@@ -4,44 +4,49 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum ComputeMode {
     Auto,
-    Metal,
-    Cuda,
     Cpu,
+    #[serde(alias = "cuda", alias = "metal")]
+    Gpu,
+    Hybrid,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BackendInfo {
     pub platform_label: String,
     pub preferred_mode: ComputeMode,
-    pub display_label: String,
+    pub available_backend: String,
+    pub availability_label: String,
 }
 
 pub fn detect_backend_for(target_os: &str, target_arch: &str) -> BackendInfo {
     if target_os == "macos" {
-        let display_label = if target_arch == "aarch64" {
-            "Metal / Apple Silicon"
+        let availability_label = if target_arch == "aarch64" {
+            "Metal-capable platform (Apple Silicon)"
         } else {
-            "Metal / Apple"
+            "Metal-capable platform (macOS)"
         };
         return BackendInfo {
             platform_label: format!("macOS {target_arch}"),
-            preferred_mode: ComputeMode::Metal,
-            display_label: display_label.into(),
+            preferred_mode: ComputeMode::Auto,
+            available_backend: "metal".into(),
+            availability_label: availability_label.into(),
         };
     }
 
     if target_os == "windows" && target_arch == "x86_64" {
         return BackendInfo {
             platform_label: "Windows x64".into(),
-            preferred_mode: ComputeMode::Cuda,
-            display_label: "CUDA / NVIDIA".into(),
+            preferred_mode: ComputeMode::Auto,
+            available_backend: "cuda".into(),
+            availability_label: "CUDA-capable platform (Windows x64)".into(),
         };
     }
 
     BackendInfo {
         platform_label: format!("{} {}", target_os, target_arch),
-        preferred_mode: ComputeMode::Cpu,
-        display_label: "CPU fallback".into(),
+        preferred_mode: ComputeMode::Auto,
+        available_backend: "cpu".into(),
+        availability_label: "GPU backend not supported on this platform".into(),
     }
 }
 
@@ -50,30 +55,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn selects_metal_for_apple_silicon() {
+    fn selects_metal_availability_for_apple_silicon() {
         let info = detect_backend_for("macos", "aarch64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple Silicon");
+        assert_eq!(info.available_backend, "metal");
+        assert_eq!(
+            info.availability_label,
+            "Metal-capable platform (Apple Silicon)"
+        );
     }
 
     #[test]
-    fn selects_metal_for_macos_intel() {
+    fn selects_metal_availability_for_macos_intel() {
         let info = detect_backend_for("macos", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple");
+        assert_eq!(info.available_backend, "metal");
+        assert_eq!(info.availability_label, "Metal-capable platform (macOS)");
     }
 
     #[test]
-    fn selects_cuda_for_windows_x64() {
+    fn selects_cuda_availability_for_windows_x64() {
         let info = detect_backend_for("windows", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cuda);
-        assert_eq!(info.display_label, "CUDA / NVIDIA");
+        assert_eq!(info.available_backend, "cuda");
+        assert_eq!(
+            info.availability_label,
+            "CUDA-capable platform (Windows x64)"
+        );
     }
 
     #[test]
     fn falls_back_to_cpu() {
         let info = detect_backend_for("linux", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cpu);
-        assert_eq!(info.display_label, "CPU fallback");
+        assert_eq!(info.available_backend, "cpu");
+        assert_eq!(
+            info.availability_label,
+            "GPU backend not supported on this platform"
+        );
     }
 }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -23,7 +23,12 @@ pub struct ComputeNodeStatus {
     pub running: bool,
     pub registered: bool,
     pub active_relay_url: String,
-    pub backend_mode: String,
+    pub requested_mode: String,
+    pub effective_mode: String,
+    pub backend_available: String,
+    pub backend_selected: String,
+    pub backend_used: String,
+    pub fallback_reason: Option<String>,
     pub model_path: String,
     pub last_error: Option<String>,
 }
@@ -143,7 +148,12 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         running: false,
         registered: false,
         active_relay_url: request.relay_base_url.clone(),
-        backend_mode: format!("{:?}", request.mode).to_lowercase(),
+        requested_mode: format!("{:?}", request.mode).to_lowercase(),
+        effective_mode: "cpu".into(),
+        backend_available: "unknown".into(),
+        backend_selected: "cpu".into(),
+        backend_used: "cpu".into(),
+        fallback_reason: None,
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
     }
@@ -159,8 +169,26 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     if let Some(active_relay_url) = payload.get("active_relay_url").and_then(Value::as_str) {
         status.active_relay_url = active_relay_url.into();
     }
-    if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
-        status.backend_mode = backend_mode.into();
+    if let Some(requested_mode) = payload.get("requested_mode").and_then(Value::as_str) {
+        status.requested_mode = requested_mode.into();
+    }
+    if let Some(effective_mode) = payload.get("effective_mode").and_then(Value::as_str) {
+        status.effective_mode = effective_mode.into();
+    }
+    if let Some(backend_available) = payload.get("backend_available").and_then(Value::as_str) {
+        status.backend_available = backend_available.into();
+    }
+    if let Some(backend_selected) = payload.get("backend_selected").and_then(Value::as_str) {
+        status.backend_selected = backend_selected.into();
+    }
+    if let Some(backend_used) = payload.get("backend_used").and_then(Value::as_str) {
+        status.backend_used = backend_used.into();
+    }
+    if payload.get("fallback_reason").is_some() {
+        status.fallback_reason = payload
+            .get("fallback_reason")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
     }
     if let Some(model_path) = payload.get("model_path").and_then(Value::as_str) {
         status.model_path = model_path.into();
@@ -301,7 +329,12 @@ pub async fn start_compute_node(
             running: true,
             registered: false,
             active_relay_url: request.relay_base_url.clone(),
-            backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            requested_mode: format!("{:?}", request.mode).to_lowercase(),
+            effective_mode: "cpu".into(),
+            backend_available: "unknown".into(),
+            backend_selected: "cpu".into(),
+            backend_used: "cpu".into(),
+            fallback_reason: None,
             model_path: request.model_path.clone(),
             last_error: None,
         };

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -37,7 +37,8 @@ describe('desktop app start failure handling', () => {
         return Promise.resolve({
           platform_label: 'macos',
           preferred_mode: 'auto',
-          display_label: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
         });
       }
       if (command === 'load_config') {
@@ -52,7 +53,12 @@ describe('desktop app start failure handling', () => {
           running: false,
           registered: false,
           active_relay_url: '',
-          backend_mode: 'auto',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
           model_path: '',
           last_error: null,
         });
@@ -88,14 +94,20 @@ describe('desktop app start failure handling', () => {
             ? {
                 platform_label: 'macos',
                 preferred_mode: 'auto',
-                display_label: 'auto',
+                available_backend: 'metal',
+                availability_label: 'Metal-capable platform (Apple Silicon)',
               }
             : command === 'get_compute_node_status'
               ? {
                   running: false,
                   registered: false,
                   active_relay_url: '',
-                  backend_mode: 'auto',
+                  requested_mode: 'auto',
+                  effective_mode: 'cpu',
+                  backend_available: 'unknown',
+                  backend_selected: 'cpu',
+                  backend_used: 'cpu',
+                  fallback_reason: null,
                   model_path: '',
                   last_error: null,
                 }
@@ -139,7 +151,8 @@ describe('desktop app start failure handling', () => {
         return Promise.resolve({
           platform_label: 'macos',
           preferred_mode: 'auto',
-          display_label: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
         });
       }
       if (command === 'load_config') {
@@ -154,7 +167,12 @@ describe('desktop app start failure handling', () => {
           running: false,
           registered: false,
           active_relay_url: '',
-          backend_mode: 'auto',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
           model_path: '',
           last_error: null,
         });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -23,11 +23,11 @@ interface ComputeNodeStatus {
   running: boolean;
   registered: boolean;
   active_relay_url: string;
-  requested_mode: string;
-  effective_mode: string;
-  backend_available: string;
-  backend_selected: string;
-  backend_used: string;
+  requested_mode: string | null;
+  effective_mode: string | null;
+  backend_available: string | null;
+  backend_selected: string | null;
+  backend_used: string | null;
   fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
@@ -56,10 +56,10 @@ const defaultComputeStatus: ComputeNodeStatus = {
   registered: false,
   active_relay_url: '',
   requested_mode: 'auto',
-  effective_mode: 'cpu',
-  backend_available: 'unknown',
-  backend_selected: 'cpu',
-  backend_used: 'cpu',
+  effective_mode: null,
+  backend_available: null,
+  backend_selected: null,
+  backend_used: null,
   fallback_reason: null,
   model_path: '',
   last_error: null,
@@ -317,6 +317,11 @@ export function App() {
         registered: false,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,
+        effective_mode: null,
+        backend_available: null,
+        backend_selected: null,
+        backend_used: null,
+        fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
       }));
@@ -434,10 +439,10 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
-        <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend available: <code>{computeStatus.backend_available}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend selected: <code>{computeStatus.backend_selected}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend used: <code>{computeStatus.backend_used}</code></p>
+        <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode ?? 'pending'}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend available: <code>{computeStatus.backend_available ?? 'pending'}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend selected: <code>{computeStatus.backend_selected ?? 'pending'}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend used: <code>{computeStatus.backend_used ?? 'pending'}</code></p>
         <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -4,12 +4,13 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 type UiState = 'idle' | 'starting' | 'streaming' | 'canceled' | 'completed' | 'failed';
-type BackendMode = 'auto' | 'metal' | 'cuda' | 'cpu';
+type BackendMode = 'auto' | 'cpu' | 'gpu' | 'hybrid';
 
 interface BackendInfo {
   platform_label: string;
   preferred_mode: BackendMode;
-  display_label: string;
+  available_backend: 'cpu' | 'cuda' | 'metal';
+  availability_label: string;
 }
 
 interface DesktopConfig {
@@ -22,7 +23,12 @@ interface ComputeNodeStatus {
   running: boolean;
   registered: boolean;
   active_relay_url: string;
-  backend_mode: string;
+  requested_mode: string;
+  effective_mode: string;
+  backend_available: string;
+  backend_selected: string;
+  backend_used: string;
+  fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
 }
@@ -49,7 +55,12 @@ const defaultComputeStatus: ComputeNodeStatus = {
   running: false,
   registered: false,
   active_relay_url: '',
-  backend_mode: 'auto',
+  requested_mode: 'auto',
+  effective_mode: 'cpu',
+  backend_available: 'unknown',
+  backend_selected: 'cpu',
+  backend_used: 'cpu',
+  fallback_reason: null,
   model_path: '',
   last_error: null,
 };
@@ -160,8 +171,26 @@ export function App() {
           typeof payload.active_relay_url === 'string'
             ? payload.active_relay_url
             : prev.active_relay_url,
-        backend_mode:
-          typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
+        requested_mode:
+          typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
+        effective_mode:
+          typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
+        backend_available:
+          typeof payload.backend_available === 'string'
+            ? payload.backend_available
+            : prev.backend_available,
+        backend_selected:
+          typeof payload.backend_selected === 'string'
+            ? payload.backend_selected
+            : prev.backend_selected,
+        backend_used:
+          typeof payload.backend_used === 'string' ? payload.backend_used : prev.backend_used,
+        fallback_reason:
+          payload.fallback_reason === null
+            ? null
+            : typeof payload.fallback_reason === 'string'
+              ? payload.fallback_reason
+              : prev.fallback_reason,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         last_error:
           payload.last_error === null
@@ -200,14 +229,8 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running,
     [config.model_path, computeStatus.running]
   );
-  const platformLabel = (backend?.platform_label ?? '').toLowerCase();
-  const backendDisplayLabel = (backend?.display_label ?? '').toLowerCase();
-  const metalSupported = platformLabel.includes('apple') || platformLabel.includes('mac');
-  const cudaSupported =
-    backend?.preferred_mode === 'cuda' ||
-    backendDisplayLabel.includes('cuda') ||
-    platformLabel.includes('nvidia') ||
-    platformLabel.includes('cuda');
+  const availableBackend = backend?.available_backend ?? 'cpu';
+  const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
 
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {
@@ -293,7 +316,7 @@ export function App() {
         running: true,
         registered: false,
         active_relay_url: config.relay_base_url,
-        backend_mode: config.preferred_mode,
+        requested_mode: config.preferred_mode,
         model_path: config.model_path,
         last_error: null,
       }));
@@ -342,7 +365,7 @@ export function App() {
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
       <h1>token.place desktop compute node</h1>
-      <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
+      <p>Platform GPU availability: <strong>{backend?.availability_label ?? 'loading...'}</strong></p>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
         <input
@@ -384,15 +407,14 @@ export function App() {
         value={config.preferred_mode}
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
-        <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
-        <option value="metal" disabled={!metalSupported}>Metal GPU (macOS Apple Silicon)</option>
-        <option value="cuda" disabled={!cudaSupported}>CUDA GPU (Windows/NVIDIA)</option>
-        <option value="cpu">CPU fallback</option>
+        <option value="auto">Auto</option>
+        <option value="cpu">CPU only</option>
+        <option value="gpu" disabled={!gpuCapable}>GPU only</option>
+        <option value="hybrid" disabled={!gpuCapable}>Hybrid (partial GPU offload)</option>
       </select>
       <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
-        Operator note: <code>cuda</code> is for Windows/NVIDIA workstations, <code>metal</code> is
-        for macOS/Apple Silicon, and <code>cpu</code> is fallback. Raspberry Pi remains a later
-        low-power workstation target and is not part of the current sugarkube relay rollout.
+        Operator note: GPU mode requests full offload when CUDA/Metal is available; Hybrid requests
+        partial offload. Unsupported platforms fall back to CPU with diagnostics.
       </p>
 
       <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
@@ -411,7 +433,12 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend available: <code>{computeStatus.backend_available}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend selected: <code>{computeStatus.backend_selected}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend used: <code>{computeStatus.backend_used}</code></p>
+        <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -219,8 +219,10 @@ def test_compute_node_runtime_format_relay_target_preserves_explicit_url_port():
 
 
 def test_normalize_compute_mode_is_case_insensitive_and_falls_back_to_auto():
-    assert normalize_compute_mode("CUDA") == "cuda"
-    assert normalize_compute_mode("  metal ") == "metal"
+    assert normalize_compute_mode("GPU") == "gpu"
+    assert normalize_compute_mode("  hybrid ") == "hybrid"
+    assert normalize_compute_mode("CUDA") == "gpu"
+    assert normalize_compute_mode("metal") == "gpu"
     assert normalize_compute_mode("unknown") == "auto"
     assert normalize_compute_mode("") == "auto"
     assert normalize_compute_mode(None) == "auto"
@@ -234,6 +236,10 @@ def test_apply_compute_mode_sets_expected_gpu_layer_defaults():
 
     assert apply_compute_mode(manager, "auto") == "auto"
     assert manager.default_n_gpu_layers == -1
+
+    manager.hybrid_n_gpu_layers = 12
+    assert apply_compute_mode(manager, "hybrid") == "hybrid"
+    assert manager.default_n_gpu_layers == 12
 
 
 def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -133,6 +133,7 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     from utils.compute_node_runtime import (
         SUPPORTED_COMPUTE_MODES as _SUPPORTED_COMPUTE_MODES,
         apply_compute_mode as _apply_compute_mode,
+        compute_mode_diagnostics as _compute_mode_diagnostics,
         normalize_compute_mode as _normalize_compute_mode,
     )
 
@@ -150,6 +151,7 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     module.SUPPORTED_COMPUTE_MODES = _SUPPORTED_COMPUTE_MODES
     module.normalize_compute_mode = _normalize_compute_mode
     module.apply_compute_mode = _apply_compute_mode
+    module.compute_mode_diagnostics = _compute_mode_diagnostics
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
 
 
@@ -317,14 +319,15 @@ def test_apply_compute_mode_supports_gpu_and_cpu_modes():
     assert apply_compute_mode(manager, 'auto') == 'auto'
     assert manager.default_n_gpu_layers == -1
 
-    assert apply_compute_mode(manager, 'metal') == 'metal'
-    assert manager.default_n_gpu_layers == -1
-
-    assert apply_compute_mode(manager, 'cuda') == 'cuda'
+    assert apply_compute_mode(manager, 'gpu') == 'gpu'
     assert manager.default_n_gpu_layers == -1
 
     assert apply_compute_mode(manager, 'cpu') == 'cpu'
     assert manager.default_n_gpu_layers == 0
+
+    manager.hybrid_n_gpu_layers = 9
+    assert apply_compute_mode(manager, 'hybrid') == 'hybrid'
+    assert manager.default_n_gpu_layers == 9
 
 
 def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
@@ -343,7 +346,7 @@ def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert events[0]['type'] == 'started'
-    assert events[0]['backend_mode'] == 'auto'
+    assert events[0]['requested_mode'] == 'auto'
 
 
 def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):
@@ -391,7 +394,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,
@@ -423,16 +426,29 @@ def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_pat
     (utils_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
-SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "cuda", "metal"}
+SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid"}
 
 
 def normalize_compute_mode(mode):
     mode = str(mode).lower()
+    mode = {"cuda": "gpu", "metal": "gpu"}.get(mode, mode)
     return mode if mode in SUPPORTED_COMPUTE_MODES else "auto"
 
 
 def apply_compute_mode(_model_manager, mode):
     return normalize_compute_mode(mode)
+
+
+def compute_mode_diagnostics(_model_manager):
+    return {
+        "requested_mode": "auto",
+        "effective_mode": "pending",
+        "backend_available": "unknown",
+        "backend_selected": "unknown",
+        "backend_used": "unknown",
+        "n_gpu_layers": -1,
+        "fallback_reason": None,
+    }
 
 
 def resolve_relay_url(relay_url):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -391,6 +391,7 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
         return relay_url if prefer_cli else (env_override or relay_url)
 
     module.resolve_relay_url = _resolve_relay_url
+    module.compute_mode_diagnostics = lambda _model_manager: {}
     monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
     monkeypatch.setenv('TOKENPLACE_RELAY_URL', 'https://token.place')
     monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -27,8 +27,8 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
     assert cpu_fallback.extra_index_url is None
-    assert cpu_fallback.only_binary is False
-    assert cpu_fallback.no_binary is True
+    assert cpu_fallback.only_binary is True
+    assert cpu_fallback.no_binary is False
 
 
 def test_macos_install_plan_requests_metal_then_source_fallback():

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -8,7 +8,12 @@ DESKTOP_PYTHON = ROOT / "desktop-tauri" / "src-tauri" / "python"
 if str(DESKTOP_PYTHON) not in sys.path:
     sys.path.insert(0, str(DESKTOP_PYTHON))
 
-from desktop_gpu_packaging import llama_cpp_install_plan_fallbacks
+from desktop_gpu_packaging import (
+    LlamaCppInstallPlan,
+    llama_cpp_install_plan,
+    llama_cpp_install_plan_fallbacks,
+    llama_cpp_requirement_spec,
+)
 
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
@@ -61,3 +66,69 @@ def test_linux_install_plan_remains_cpu_default():
     assert plan.backend == "cpu"
     assert plan.pip_env() == {}
     assert plan.pip_install_args() == ["--upgrade", "--no-cache-dir"]
+
+
+def test_requirement_spec_parses_comments_and_blank_lines(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        "# comment\n\n"
+        "numpy==2.0.0\n"
+        "llama-cpp-python==0.3.16\n",
+        encoding="utf-8",
+    )
+
+    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.16"
+
+
+def test_requirement_spec_accepts_underscore_package_name(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("llama_cpp_python==0.2.90\n", encoding="utf-8")
+
+    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.2.90"
+
+
+def test_requirement_spec_raises_when_pin_missing(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("numpy==2.0.0\n", encoding="utf-8")
+
+    try:
+        llama_cpp_requirement_spec(requirements)
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "llama_cpp_python pin not found" in str(exc)
+
+
+def test_pip_install_args_include_index_and_binary_flags():
+    plan = LlamaCppInstallPlan(
+        platform="darwin",
+        backend="metal",
+        package_spec="llama-cpp-python==0.3.16",
+        cmake_args=None,
+        force_cmake=False,
+        index_url="https://example.invalid/simple",
+        extra_index_url="https://pypi.org/simple",
+        only_binary=True,
+        no_binary=True,
+    )
+
+    assert plan.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--index-url",
+        "https://example.invalid/simple",
+        "--extra-index-url",
+        "https://pypi.org/simple",
+        "--only-binary",
+        "llama-cpp-python",
+        "--no-binary",
+        "llama-cpp-python",
+        "--prefer-binary",
+    ]
+
+
+def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
+    monkeypatch.setattr("desktop_gpu_packaging.sys.platform", "linux")
+    plan = llama_cpp_install_plan(requirements_path=ROOT / "requirements.txt")
+
+    assert plan.platform == "linux"
+    assert plan.backend == "cpu"

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -28,7 +28,7 @@ def test_macos_install_plan_requests_metal_build_flags():
     assert plan.backend == "metal"
     assert plan.package_spec.startswith("llama-cpp-python==")
     assert plan.pip_env() == {
-        "CMAKE_ARGS": "-DGGML_METAL=on",
+        "CMAKE_ARGS": "-DGGML_METAL=on -DGGML_NATIVE=off",
         "FORCE_CMAKE": "1",
     }
 

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -1,0 +1,40 @@
+"""Unit tests for desktop llama-cpp-python packaging contract helpers."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_PYTHON = ROOT / "desktop-tauri" / "src-tauri" / "python"
+if str(DESKTOP_PYTHON) not in sys.path:
+    sys.path.insert(0, str(DESKTOP_PYTHON))
+
+from desktop_gpu_packaging import llama_cpp_install_plan
+
+
+def test_windows_install_plan_requests_cuda_build_flags():
+    plan = llama_cpp_install_plan(platform="win32", requirements_path=ROOT / "requirements.txt")
+
+    assert plan.backend == "cuda"
+    assert plan.package_spec.startswith("llama-cpp-python==")
+    assert plan.pip_env() == {
+        "CMAKE_ARGS": "-DGGML_CUDA=on",
+        "FORCE_CMAKE": "1",
+    }
+
+
+def test_macos_install_plan_requests_metal_build_flags():
+    plan = llama_cpp_install_plan(platform="darwin", requirements_path=ROOT / "requirements.txt")
+
+    assert plan.backend == "metal"
+    assert plan.package_spec.startswith("llama-cpp-python==")
+    assert plan.pip_env() == {
+        "CMAKE_ARGS": "-DGGML_METAL=on",
+        "FORCE_CMAKE": "1",
+    }
+
+
+def test_linux_install_plan_remains_cpu_default():
+    plan = llama_cpp_install_plan(platform="linux", requirements_path=ROOT / "requirements.txt")
+
+    assert plan.backend == "cpu"
+    assert plan.pip_env() == {}

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -8,56 +8,54 @@ DESKTOP_PYTHON = ROOT / "desktop-tauri" / "src-tauri" / "python"
 if str(DESKTOP_PYTHON) not in sys.path:
     sys.path.insert(0, str(DESKTOP_PYTHON))
 
-from desktop_gpu_packaging import llama_cpp_install_plan
+from desktop_gpu_packaging import llama_cpp_install_plan_fallbacks
 
 
-def test_windows_install_plan_requests_cuda_build_flags():
-    plan = llama_cpp_install_plan(platform="win32", requirements_path=ROOT / "requirements.txt")
+def test_windows_install_plan_requests_cuda_then_cpu_fallback():
+    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    assert len(plans) == 2
 
-    assert plan.backend == "cuda"
-    assert plan.package_spec.startswith("llama-cpp-python==")
-    assert plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
-    assert plan.extra_index_url == "https://pypi.org/simple"
-    assert plan.only_binary is True
-    assert plan.pip_env() == {}
-    assert plan.pip_install_args() == [
-        "--upgrade",
-        "--no-cache-dir",
-        "--index-url",
-        "https://abetlen.github.io/llama-cpp-python/whl/cu124",
-        "--extra-index-url",
-        "https://pypi.org/simple",
-        "--only-binary",
-        "llama-cpp-python",
-        "--prefer-binary",
-    ]
+    gpu_plan = plans[0]
+    assert gpu_plan.backend == "cuda"
+    assert gpu_plan.package_spec.startswith("llama-cpp-python==")
+    assert gpu_plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert gpu_plan.extra_index_url == "https://pypi.org/simple"
+    assert gpu_plan.only_binary is True
+    assert gpu_plan.pip_env() == {}
+
+    cpu_fallback = plans[1]
+    assert cpu_fallback.backend == "cpu"
+    assert cpu_fallback.index_url == "https://pypi.org/simple"
+    assert cpu_fallback.extra_index_url is None
+    assert cpu_fallback.only_binary is False
 
 
-def test_macos_install_plan_requests_metal_build_flags():
-    plan = llama_cpp_install_plan(platform="darwin", requirements_path=ROOT / "requirements.txt")
+def test_macos_install_plan_requests_metal_then_source_fallback():
+    plans = llama_cpp_install_plan_fallbacks(platform="darwin", requirements_path=ROOT / "requirements.txt")
+    assert len(plans) == 2
 
-    assert plan.backend == "metal"
-    assert plan.package_spec.startswith("llama-cpp-python==")
-    assert plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/metal"
-    assert plan.extra_index_url == "https://pypi.org/simple"
-    assert plan.only_binary is True
-    assert plan.pip_env() == {}
-    assert plan.pip_install_args() == [
-        "--upgrade",
-        "--no-cache-dir",
-        "--index-url",
-        "https://abetlen.github.io/llama-cpp-python/whl/metal",
-        "--extra-index-url",
-        "https://pypi.org/simple",
-        "--only-binary",
-        "llama-cpp-python",
-        "--prefer-binary",
-    ]
+    wheel_plan = plans[0]
+    assert wheel_plan.backend == "metal"
+    assert wheel_plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/metal"
+    assert wheel_plan.extra_index_url == "https://pypi.org/simple"
+    assert wheel_plan.only_binary is True
+
+    source_fallback = plans[1]
+    assert source_fallback.backend == "metal"
+    assert source_fallback.index_url == "https://pypi.org/simple"
+    assert source_fallback.only_binary is False
+    assert source_fallback.force_cmake is True
+    assert source_fallback.pip_env() == {
+        "CMAKE_ARGS": "-DGGML_METAL=on -DGGML_NATIVE=off",
+        "FORCE_CMAKE": "1",
+    }
 
 
 def test_linux_install_plan_remains_cpu_default():
-    plan = llama_cpp_install_plan(platform="linux", requirements_path=ROOT / "requirements.txt")
+    plans = llama_cpp_install_plan_fallbacks(platform="linux", requirements_path=ROOT / "requirements.txt")
+    assert len(plans) == 1
 
+    plan = plans[0]
     assert plan.backend == "cpu"
     assert plan.pip_env() == {}
     assert plan.pip_install_args() == ["--upgrade", "--no-cache-dir"]

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -27,7 +27,7 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
     assert cpu_fallback.extra_index_url is None
-    assert cpu_fallback.only_binary is False
+    assert cpu_fallback.only_binary is True
 
 
 def test_macos_install_plan_requests_metal_then_source_fallback():
@@ -45,6 +45,7 @@ def test_macos_install_plan_requests_metal_then_source_fallback():
     assert source_fallback.index_url == "https://pypi.org/simple"
     assert source_fallback.only_binary is False
     assert source_fallback.force_cmake is True
+    assert source_fallback.no_binary is True
     assert source_fallback.pip_env() == {
         "CMAKE_ARGS": "-DGGML_METAL=on -DGGML_NATIVE=off",
         "FORCE_CMAKE": "1",

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -141,3 +141,42 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
 
     assert plan.platform == "linux"
     assert plan.backend == "cpu"
+
+
+def test_windows_cpu_fallback_install_args_are_binary_only():
+    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    cpu_fallback = plans[2]
+
+    assert cpu_fallback.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--index-url",
+        "https://pypi.org/simple",
+        "--only-binary",
+        "llama-cpp-python",
+        "--prefer-binary",
+    ]
+
+
+def test_macos_source_fallback_install_args_force_source_build():
+    plans = llama_cpp_install_plan_fallbacks(platform="darwin", requirements_path=ROOT / "requirements.txt")
+    source_fallback = plans[1]
+
+    assert source_fallback.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--index-url",
+        "https://pypi.org/simple",
+        "--no-binary",
+        "llama-cpp-python",
+        "--prefer-binary",
+    ]
+
+
+def test_llama_cpp_install_plan_uses_current_platform_for_windows(monkeypatch):
+    monkeypatch.setattr("desktop_gpu_packaging.sys.platform", "win32")
+    plan = llama_cpp_install_plan(requirements_path=ROOT / "requirements.txt")
+
+    assert plan.platform == "win32"
+    assert plan.backend == "cuda"
+    assert plan.only_binary is True

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -16,10 +16,15 @@ def test_windows_install_plan_requests_cuda_build_flags():
 
     assert plan.backend == "cuda"
     assert plan.package_spec.startswith("llama-cpp-python==")
-    assert plan.pip_env() == {
-        "CMAKE_ARGS": "-DGGML_CUDA=on",
-        "FORCE_CMAKE": "1",
-    }
+    assert plan.extra_index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert plan.pip_env() == {}
+    assert plan.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--extra-index-url",
+        "https://abetlen.github.io/llama-cpp-python/whl/cu124",
+        "--prefer-binary",
+    ]
 
 
 def test_macos_install_plan_requests_metal_build_flags():
@@ -27,10 +32,15 @@ def test_macos_install_plan_requests_metal_build_flags():
 
     assert plan.backend == "metal"
     assert plan.package_spec.startswith("llama-cpp-python==")
-    assert plan.pip_env() == {
-        "CMAKE_ARGS": "-DGGML_METAL=on -DGGML_NATIVE=off",
-        "FORCE_CMAKE": "1",
-    }
+    assert plan.extra_index_url == "https://abetlen.github.io/llama-cpp-python/whl/metal"
+    assert plan.pip_env() == {}
+    assert plan.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--extra-index-url",
+        "https://abetlen.github.io/llama-cpp-python/whl/metal",
+        "--prefer-binary",
+    ]
 
 
 def test_linux_install_plan_remains_cpu_default():
@@ -38,3 +48,4 @@ def test_linux_install_plan_remains_cpu_default():
 
     assert plan.backend == "cpu"
     assert plan.pip_env() == {}
+    assert plan.pip_install_args() == ["--upgrade", "--no-cache-dir"]

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -16,13 +16,19 @@ def test_windows_install_plan_requests_cuda_build_flags():
 
     assert plan.backend == "cuda"
     assert plan.package_spec.startswith("llama-cpp-python==")
-    assert plan.extra_index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert plan.extra_index_url == "https://pypi.org/simple"
+    assert plan.only_binary is True
     assert plan.pip_env() == {}
     assert plan.pip_install_args() == [
         "--upgrade",
         "--no-cache-dir",
-        "--extra-index-url",
+        "--index-url",
         "https://abetlen.github.io/llama-cpp-python/whl/cu124",
+        "--extra-index-url",
+        "https://pypi.org/simple",
+        "--only-binary",
+        "llama-cpp-python",
         "--prefer-binary",
     ]
 
@@ -32,13 +38,19 @@ def test_macos_install_plan_requests_metal_build_flags():
 
     assert plan.backend == "metal"
     assert plan.package_spec.startswith("llama-cpp-python==")
-    assert plan.extra_index_url == "https://abetlen.github.io/llama-cpp-python/whl/metal"
+    assert plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/metal"
+    assert plan.extra_index_url == "https://pypi.org/simple"
+    assert plan.only_binary is True
     assert plan.pip_env() == {}
     assert plan.pip_install_args() == [
         "--upgrade",
         "--no-cache-dir",
-        "--extra-index-url",
+        "--index-url",
         "https://abetlen.github.io/llama-cpp-python/whl/metal",
+        "--extra-index-url",
+        "https://pypi.org/simple",
+        "--only-binary",
+        "llama-cpp-python",
         "--prefer-binary",
     ]
 

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -18,7 +18,7 @@ from desktop_gpu_packaging import (
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    assert len(plans) == 2
+    assert len(plans) == 3
 
     gpu_plan = plans[0]
     assert gpu_plan.backend == "cuda"
@@ -28,8 +28,17 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert gpu_plan.only_binary is True
     assert gpu_plan.pip_env() == {}
 
-    cpu_fallback = plans[1]
+    unpinned_cuda_fallback = plans[1]
+    assert unpinned_cuda_fallback.backend == "cuda"
+    assert unpinned_cuda_fallback.package_spec == "llama-cpp-python"
+    assert unpinned_cuda_fallback.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert unpinned_cuda_fallback.extra_index_url == "https://pypi.org/simple"
+    assert unpinned_cuda_fallback.only_binary is True
+    assert unpinned_cuda_fallback.no_binary is False
+
+    cpu_fallback = plans[2]
     assert cpu_fallback.backend == "cpu"
+    assert cpu_fallback.package_spec == "llama-cpp-python"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
     assert cpu_fallback.extra_index_url is None
     assert cpu_fallback.only_binary is True

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -180,3 +180,41 @@ def test_llama_cpp_install_plan_uses_current_platform_for_windows(monkeypatch):
     assert plan.platform == "win32"
     assert plan.backend == "cuda"
     assert plan.only_binary is True
+
+
+def test_llama_cpp_install_plan_darwin_selects_metal_wheel_index():
+    plan = llama_cpp_install_plan(platform="darwin", requirements_path=ROOT / "requirements.txt")
+
+    assert plan.backend == "metal"
+    assert plan.package_spec.startswith("llama-cpp-python==")
+    assert plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/metal"
+    assert plan.extra_index_url == "https://pypi.org/simple"
+    assert plan.only_binary is True
+    assert plan.no_binary is False
+
+
+def test_non_desktop_platform_fallbacks_return_only_primary_plan():
+    plans = llama_cpp_install_plan_fallbacks(platform="freebsd13", requirements_path=ROOT / "requirements.txt")
+
+    assert len(plans) == 1
+    assert plans[0].platform == "freebsd13"
+    assert plans[0].backend == "cpu"
+
+
+def test_pip_env_omits_force_cmake_when_disabled():
+    plan = LlamaCppInstallPlan(
+        platform="darwin",
+        backend="metal",
+        package_spec="llama-cpp-python==0.3.16",
+        cmake_args="-DGGML_METAL=on",
+        force_cmake=False,
+    )
+
+    assert plan.pip_env() == {"CMAKE_ARGS": "-DGGML_METAL=on"}
+
+
+def test_requirement_spec_strips_spaces_around_version_pin(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("llama-cpp-python== 0.3.16 \n", encoding="utf-8")
+
+    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.16"

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -27,7 +27,8 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
     assert cpu_fallback.extra_index_url is None
-    assert cpu_fallback.only_binary is True
+    assert cpu_fallback.only_binary is False
+    assert cpu_fallback.no_binary is True
 
 
 def test_macos_install_plan_requests_metal_then_source_fallback():

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -179,7 +179,7 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
 
 @pytest.mark.parametrize(
     ('mode', 'expected'),
-    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+    [('cpu', 0), ('gpu', -1), ('hybrid', 24), ('auto', -1)],
 )
 def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
     _reset_cancel_queue()
@@ -374,7 +374,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = inference_sidecar.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -270,7 +270,9 @@ class TestModelManager:
         instance = MagicMock()
         mock_llama.return_value = instance
 
-        result = model_manager.get_llm_instance()
+        with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
+            result = model_manager.get_llm_instance()
 
         assert result is instance
         mock_llama.assert_called_once()
@@ -295,7 +297,9 @@ class TestModelManager:
         instance = MagicMock()
         mock_llama.return_value = instance
 
-        result = model_manager.get_llm_instance()
+        with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
+            result = model_manager.get_llm_instance()
 
         assert result is instance
         kwargs = mock_llama.call_args.kwargs
@@ -310,7 +314,9 @@ class TestModelManager:
         with patch('llama_cpp.Llama', return_value=instance, create=True) as mock_llama, \
              patch('utils.llm.model_manager.resource_monitor.can_allocate_gpu_memory') as mock_can_allocate, \
              patch('utils.llm.model_manager.os.path.exists', return_value=True), \
-             patch('utils.llm.model_manager.os.path.getsize', side_effect=OSError('stat failed')):
+             patch('utils.llm.model_manager.os.path.getsize', side_effect=OSError('stat failed')), \
+             patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
 
             result = model_manager.get_llm_instance()
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -9,6 +9,7 @@ import json
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 # Add the project root to the path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -752,3 +753,77 @@ class TestModelManager:
         stream_call, non_stream_call = mock_llm.create_chat_completion.call_args_list
         assert stream_call.kwargs['stream'] is True
         assert non_stream_call.kwargs['stream'] is False
+
+    def test_resolve_compute_plan_auto_falls_back_when_runtime_lacks_gpu(self, model_manager):
+        """Auto mode should downshift GPU layers when runtime support is missing."""
+        model_manager.requested_compute_mode = 'auto'
+        model_manager.default_n_gpu_layers = -1
+
+        with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=False):
+            plan = model_manager._resolve_compute_plan()
+
+        assert plan['requested_mode'] == 'auto'
+        assert plan['effective_mode'] == 'cpu_fallback'
+        assert plan['backend_selected'] == 'cuda'
+        assert plan['backend_used'] == 'cpu'
+        assert plan['n_gpu_layers'] == 0
+        assert 'does not expose cuda GPU offload support' in plan['fallback_reason']
+
+    def test_resolve_compute_plan_auto_cpu_request_keeps_cpu(self, model_manager):
+        """Auto mode should stay on CPU when default GPU layers request CPU-only."""
+        model_manager.requested_compute_mode = 'auto'
+        model_manager.default_n_gpu_layers = 0
+
+        with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
+            plan = model_manager._resolve_compute_plan()
+
+        assert plan['effective_mode'] == 'cpu'
+        assert plan['backend_selected'] == 'cpu'
+        assert plan['backend_used'] == 'cpu'
+        assert plan['n_gpu_layers'] == 0
+        assert plan['fallback_reason'] is None
+
+    def test_platform_gpu_backend_linux_detects_cuda_marker(self):
+        """Linux backend detection should use llama_cpp capability markers."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=True,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=lambda: False,
+        )
+
+        with patch('utils.llm.model_manager.sys.platform', 'linux'), \
+             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend == 'cuda'
+
+    def test_llama_gpu_offload_available_returns_false_on_runtime_error(self):
+        """GPU support probe should fail closed if llama_cpp probe raises."""
+
+        def _raise_runtime_error():
+            raise RuntimeError("probe failed")
+
+        fake_llama = SimpleNamespace(llama_supports_gpu_offload=_raise_runtime_error)
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            assert ModelManager._llama_gpu_offload_available() is False
+
+    def test_get_llm_instance_mock_mode_refreshes_compute_diagnostics(self, model_manager):
+        """Mock mode should persist diagnostics from resolved compute plan."""
+        model_manager.use_mock_llm = True
+        expected_plan = {
+            'requested_mode': 'hybrid',
+            'effective_mode': 'hybrid_cuda',
+            'backend_available': 'cuda',
+            'backend_selected': 'cuda',
+            'backend_used': 'cuda',
+            'n_gpu_layers': 24,
+            'fallback_reason': None,
+        }
+
+        with patch.object(model_manager, '_resolve_compute_plan', return_value=expected_plan):
+            llm = model_manager.get_llm_instance()
+
+        assert isinstance(llm, MagicMock)
+        assert model_manager.last_compute_diagnostics == expected_plan

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -827,3 +827,83 @@ class TestModelManager:
 
         assert isinstance(llm, MagicMock)
         assert model_manager.last_compute_diagnostics == expected_plan
+
+    def test_platform_gpu_backend_linux_detects_metal_marker(self):
+        """Linux backend detection should return Metal when CUDA is unavailable."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=True,
+            llama_supports_gpu_offload=lambda: False,
+        )
+
+        with patch('utils.llm.model_manager.sys.platform', 'linux'), \
+             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend == 'metal'
+
+    def test_platform_gpu_backend_linux_uses_gpu_offload_probe(self):
+        """Linux backend detection should map positive runtime probes to CUDA."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=lambda: True,
+        )
+
+        with patch('utils.llm.model_manager.sys.platform', 'linux'), \
+             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend == 'cuda'
+
+    def test_platform_gpu_backend_linux_returns_none_when_probe_raises(self):
+        """Linux backend detection should fail closed when probe raises."""
+
+        def _raise_runtime_error():
+            raise RuntimeError("probe failed")
+
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=_raise_runtime_error,
+        )
+
+        with patch('utils.llm.model_manager.sys.platform', 'linux'), \
+             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend is None
+
+    def test_llama_gpu_offload_available_uses_marker_fallback(self):
+        """GPU support probe should fall back to GGML capability markers."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=True,
+            llama_supports_gpu_offload=None,
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            assert ModelManager._llama_gpu_offload_available() is True
+
+    def test_resolve_compute_plan_gpu_and_hybrid_success_paths(self, model_manager):
+        """Explicit gpu/hybrid requests should emit expected diagnostics."""
+        model_manager.requested_compute_mode = 'gpu'
+        with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
+            gpu_plan = model_manager._resolve_compute_plan()
+
+        assert gpu_plan['effective_mode'] == 'cuda'
+        assert gpu_plan['backend_used'] == 'cuda'
+        assert gpu_plan['n_gpu_layers'] == -1
+        assert gpu_plan['fallback_reason'] is None
+
+        model_manager.requested_compute_mode = 'hybrid'
+        model_manager.hybrid_n_gpu_layers = -5
+        with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
+             patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
+            hybrid_plan = model_manager._resolve_compute_plan()
+
+        assert hybrid_plan['effective_mode'] == 'hybrid_cuda'
+        assert hybrid_plan['backend_used'] == 'cuda'
+        assert hybrid_plan['n_gpu_layers'] == 1
+        assert hybrid_plan['fallback_reason'] is None

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -160,17 +160,26 @@ def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
     else:
         # ``auto`` and explicit ``gpu`` request full offload when a compatible backend exists.
         manager.default_n_gpu_layers = -1
+    manager.last_compute_diagnostics = {
+        "requested_mode": selected,
+        "effective_mode": "cpu" if selected == "cpu" else "pending",
+        "backend_available": "unknown",
+        "backend_selected": "cpu" if selected == "cpu" else "unknown",
+        "backend_used": "cpu" if selected == "cpu" else "unknown",
+        "n_gpu_layers": manager.default_n_gpu_layers,
+        "fallback_reason": None,
+    }
     return selected
 
 
 def compute_mode_diagnostics(manager: Any) -> Dict[str, Any]:
     """Return compute-mode diagnostics from manager state for bridge/UI status payloads."""
 
+    requested = normalize_compute_mode(getattr(manager, "requested_compute_mode", "auto"))
     runtime = getattr(manager, "last_compute_diagnostics", None)
-    if isinstance(runtime, dict):
+    if isinstance(runtime, dict) and runtime.get("requested_mode") == requested:
         return dict(runtime)
 
-    requested = normalize_compute_mode(getattr(manager, "requested_compute_mode", "auto"))
     if requested == "cpu":
         return {
             "requested_mode": requested,

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -134,13 +134,15 @@ def format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
     return f"{relay_url}:{relay_port}"
 
 
-SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "metal", "cuda"})
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "gpu", "hybrid"})
+LEGACY_COMPUTE_MODE_ALIASES = {"cuda": "gpu", "metal": "gpu"}
 
 
 def normalize_compute_mode(mode: Optional[str]) -> str:
     """Normalize operator-provided compute mode values."""
 
     selected = (mode or "auto").strip().lower()
+    selected = LEGACY_COMPUTE_MODE_ALIASES.get(selected, selected)
     if selected in SUPPORTED_COMPUTE_MODES:
         return selected
     return "auto"
@@ -150,13 +152,44 @@ def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
     """Apply normalized compute mode to model-manager GPU settings."""
 
     selected = normalize_compute_mode(mode)
+    manager.requested_compute_mode = selected
     if selected == "cpu":
         manager.default_n_gpu_layers = 0
+    elif selected == "hybrid":
+        manager.default_n_gpu_layers = getattr(manager, "hybrid_n_gpu_layers", 24)
     else:
-        # ``auto`` follows runtime autodetection and maps to GPU-preferred layers where available.
-        # ``metal`` and ``cuda`` also request GPU-backed inference on supported hosts.
+        # ``auto`` and explicit ``gpu`` request full offload when a compatible backend exists.
         manager.default_n_gpu_layers = -1
     return selected
+
+
+def compute_mode_diagnostics(manager: Any) -> Dict[str, Any]:
+    """Return compute-mode diagnostics from manager state for bridge/UI status payloads."""
+
+    runtime = getattr(manager, "last_compute_diagnostics", None)
+    if isinstance(runtime, dict):
+        return dict(runtime)
+
+    requested = normalize_compute_mode(getattr(manager, "requested_compute_mode", "auto"))
+    if requested == "cpu":
+        return {
+            "requested_mode": requested,
+            "effective_mode": "cpu",
+            "backend_available": "unknown",
+            "backend_selected": "cpu",
+            "backend_used": "cpu",
+            "n_gpu_layers": 0,
+            "fallback_reason": None,
+        }
+    return {
+        "requested_mode": requested,
+        "effective_mode": "pending",
+        "backend_available": "unknown",
+        "backend_selected": "unknown",
+        "backend_used": "unknown",
+        "n_gpu_layers": getattr(manager, "default_n_gpu_layers", -1),
+        "fallback_reason": None,
+    }
 
 
 class ComputeNodeRuntime:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -78,6 +78,23 @@ class ModelManager:
             return 'metal'
         if sys.platform.startswith('win'):
             return 'cuda'
+        if sys.platform.startswith('linux'):
+            try:
+                import llama_cpp
+            except Exception:
+                return None
+            if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
+                return 'cuda'
+            if bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
+                return 'metal'
+            supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
+            if callable(supports_gpu):
+                try:
+                    if bool(supports_gpu()):
+                        # Linux builds that expose GPU offload are expected to be CUDA.
+                        return 'cuda'
+                except Exception:
+                    return None
         return None
 
     @staticmethod
@@ -106,17 +123,30 @@ class ModelManager:
         fallback_reason = None
 
         if requested == 'auto':
-            n_gpu_layers = int(self.default_n_gpu_layers)
+            requested_layers = int(self.default_n_gpu_layers)
+            n_gpu_layers = requested_layers
             gpu_requested = n_gpu_layers != 0
             backend_selected = backend_available if gpu_requested else 'cpu'
+            if gpu_requested and (
+                backend_available == 'cpu' or not gpu_runtime_supported
+            ):
+                n_gpu_layers = 0
+                fallback_reason = (
+                    'no CUDA/Metal backend is supported on this platform'
+                    if backend_available == 'cpu'
+                    else (
+                        f'llama-cpp-python runtime does not expose {backend_available} '
+                        'GPU offload support'
+                    )
+                )
             return {
                 'requested_mode': requested,
-                'effective_mode': backend_selected if gpu_requested else 'cpu',
+                'effective_mode': 'cpu_fallback' if fallback_reason else backend_selected,
                 'backend_available': backend_available,
                 'backend_selected': backend_selected,
-                'backend_used': backend_selected if gpu_requested else 'cpu',
+                'backend_used': 'cpu' if fallback_reason else backend_selected,
                 'n_gpu_layers': n_gpu_layers,
-                'fallback_reason': None,
+                'fallback_reason': fallback_reason,
             }
 
         if requested == 'cpu':
@@ -314,6 +344,7 @@ class ModelManager:
         # Check if mocking is enabled via configuration
         if self.use_mock_llm:
             self.log_info("Using Mock LLM instance based on USE_MOCK_LLM configuration.")
+            self.last_compute_diagnostics = self._resolve_compute_plan()
             mock_llama_instance = MagicMock()
             mock_response = {
                 'choices': [

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -58,8 +58,118 @@ class ModelManager:
         # Check if mock mode is enabled
         self.use_mock_llm = config.get('model.use_mock', False) or os.getenv('USE_MOCK_LLM') == '1'
         self.default_n_gpu_layers = config.get('model.n_gpu_layers', -1)
+        self.hybrid_n_gpu_layers = config.get('model.hybrid_n_gpu_layers', 24)
         self.gpu_headroom_percent = config.get('model.gpu_memory_headroom_percent', 0.1)
         self.enforce_gpu_headroom = config.get('model.enforce_gpu_memory_headroom', True)
+        self.requested_compute_mode = 'auto'
+        self.last_compute_diagnostics = {
+            'requested_mode': 'auto',
+            'effective_mode': 'pending',
+            'backend_available': 'unknown',
+            'backend_selected': 'unknown',
+            'backend_used': 'unknown',
+            'n_gpu_layers': self.default_n_gpu_layers,
+            'fallback_reason': None,
+        }
+
+    @staticmethod
+    def _platform_gpu_backend() -> Optional[str]:
+        if sys.platform == 'darwin':
+            return 'metal'
+        if sys.platform.startswith('win'):
+            return 'cuda'
+        return None
+
+    @staticmethod
+    def _llama_gpu_offload_available() -> bool:
+        try:
+            import llama_cpp
+        except Exception:
+            return False
+
+        supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
+        if callable(supports_gpu):
+            try:
+                return bool(supports_gpu())
+            except Exception:
+                return False
+
+        for marker in ('GGML_USE_CUDA', 'GGML_USE_METAL'):
+            if bool(getattr(llama_cpp, marker, False)):
+                return True
+        return False
+
+    def _resolve_compute_plan(self) -> Dict[str, Any]:
+        requested = str(getattr(self, 'requested_compute_mode', 'auto')).lower()
+        backend_available = self._platform_gpu_backend() or 'cpu'
+        gpu_runtime_supported = self._llama_gpu_offload_available()
+        fallback_reason = None
+
+        if requested == 'auto':
+            n_gpu_layers = int(self.default_n_gpu_layers)
+            gpu_requested = n_gpu_layers != 0
+            backend_selected = backend_available if gpu_requested else 'cpu'
+            return {
+                'requested_mode': requested,
+                'effective_mode': backend_selected if gpu_requested else 'cpu',
+                'backend_available': backend_available,
+                'backend_selected': backend_selected,
+                'backend_used': backend_selected if gpu_requested else 'cpu',
+                'n_gpu_layers': n_gpu_layers,
+                'fallback_reason': None,
+            }
+
+        if requested == 'cpu':
+            return {
+                'requested_mode': requested,
+                'effective_mode': 'cpu',
+                'backend_available': backend_available,
+                'backend_selected': 'cpu',
+                'backend_used': 'cpu',
+                'n_gpu_layers': 0,
+                'fallback_reason': None,
+            }
+
+        if backend_available == 'cpu':
+            fallback_reason = 'no CUDA/Metal backend is supported on this platform'
+        elif not gpu_runtime_supported:
+            fallback_reason = (
+                f'llama-cpp-python runtime does not expose {backend_available} GPU offload support'
+            )
+
+        if fallback_reason:
+            return {
+                'requested_mode': requested,
+                'effective_mode': 'cpu_fallback',
+                'backend_available': backend_available,
+                'backend_selected': backend_available,
+                'backend_used': 'cpu',
+                'n_gpu_layers': 0,
+                'fallback_reason': fallback_reason,
+            }
+
+        if requested == 'hybrid':
+            n_gpu_layers = max(1, int(self.hybrid_n_gpu_layers))
+            return {
+                'requested_mode': requested,
+                'effective_mode': f'hybrid_{backend_available}',
+                'backend_available': backend_available,
+                'backend_selected': backend_available,
+                'backend_used': backend_available,
+                'n_gpu_layers': n_gpu_layers,
+                'fallback_reason': None,
+            }
+
+        # Explicit ``gpu`` uses full offload when backend support is available.
+        return {
+            'requested_mode': requested,
+            'effective_mode': backend_available,
+            'backend_available': backend_available,
+            'backend_selected': backend_available,
+            'backend_used': backend_available,
+            'n_gpu_layers': -1,
+            'fallback_reason': None,
+        }
 
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
         """Return runtime model metadata used by server and desktop bridges."""
@@ -233,7 +343,8 @@ class ModelManager:
                             # Dynamically import Llama only when needed
                             from llama_cpp import Llama
 
-                            n_gpu_layers = self.default_n_gpu_layers
+                            compute_plan = self._resolve_compute_plan()
+                            n_gpu_layers = int(compute_plan['n_gpu_layers'])
                             if self.enforce_gpu_headroom and n_gpu_layers != 0:
                                 try:
                                     model_size = os.path.getsize(self.model_path)
@@ -249,6 +360,11 @@ class ModelManager:
                                             "to CPU inference for this model."
                                         )
                                         n_gpu_layers = 0
+                                        compute_plan['effective_mode'] = 'cpu_fallback'
+                                        compute_plan['backend_used'] = 'cpu'
+                                        compute_plan['fallback_reason'] = (
+                                            'insufficient GPU memory headroom for safe offload'
+                                        )
 
                             self.log_info(f"Initializing Llama model from {self.model_path}...")
                             self.llm = Llama(
@@ -257,6 +373,8 @@ class ModelManager:
                                 n_ctx=self.config.get('model.context_size', 8192),
                                 chat_format=self.config.get('model.chat_format', 'llama-3')
                             )
+                            compute_plan['n_gpu_layers'] = n_gpu_layers
+                            self.last_compute_diagnostics = compute_plan
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)


### PR DESCRIPTION
### Motivation
- The desktop UI previously exposed vendor labels (CUDA/Metal) but did not ensure the selected mode reached the runtime and changed llama.cpp behavior, causing misleading GPU claims.
- We need explicit user-facing compute modes (auto, cpu, gpu, hybrid) wired end-to-end so `n_gpu_layers` and runtime behavior match the operator intent.

### Description
- Introduce explicit compute modes `auto`, `cpu`, `gpu`, and `hybrid` across frontend, Rust bridge, and Python runtime, while mapping legacy `cuda`/`metal` aliases to `gpu` (files changed: `desktop-tauri/src/App.tsx`, `desktop-tauri/src-tauri/src/backend.rs`, `utils/compute_node_runtime.py`).
- Replace optimistic platform display labels with availability diagnostics and add structured runtime diagnostics that separate requested vs effective mode and report `backend_available`, `backend_selected`, `backend_used`, `n_gpu_layers`, and `fallback_reason` (files changed: Rust compute-node state and backend plumbing in `desktop-tauri/src-tauri/src/compute_node.rs` and `desktop-tauri/src-tauri/src/backend.rs`).
- Wire mode selection through the Rust -> Python bridge so `start_compute_node` / inference sidecars call `apply_compute_mode` and the shared runtime emits diagnostics, and the bridge forwards those diagnostics in NDJSON events (`desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/src-tauri/python/inference_sidecar.py`).
- Update `ModelManager` to resolve a compute plan (`_resolve_compute_plan`) that is platform- and runtime-aware, choose `n_gpu_layers` accordingly (CPU=0, GPU=-1 for full offload, Hybrid=positive partial offload using `hybrid_n_gpu_layers`), apply GPU headroom fallback, and persist `last_compute_diagnostics` for bridge consumption (`utils/llm/model_manager.py`).
- Add `compute_mode_diagnostics` helper in the shared runtime so bridges and UI can get a deterministic diagnostics payload when starting the sidecar/compute-node (`utils/compute_node_runtime.py`).
- Update desktop UI and tests to present requested/effective modes and backend diagnostics instead of a single backend label (`desktop-tauri/src/App.tsx`, tests & test fixtures). Tests were also updated to use `gpu`/`hybrid` names and to validate the mapping to `n_gpu_layers` and bridge propagation.

### Testing
- Ran the Python unit test suites: `python -m pytest tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_model_manager.py`, all tests passed (79 passed).
- Ran focused bridge tests: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py`, passed (10 passed).
- Ran frontend unit tests: `npm --prefix desktop-tauri run test -- --run`, passed (Vitest tests passed).
- Built frontend assets: `npm --prefix desktop-tauri run build`, succeeded.
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` failed in this environment due to missing system dependency `glib-2.0` / pkg-config (environment limitation), not due to code changes.
- `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` also failed in this environment for the same missing system dependency.

Note: `pre-commit run --all-files` was not available in the container (`pre-commit` missing), and an internal repo secrets-scan script referenced by CI was not present in the execution environment; these do not block the change but were noted in the verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc82426148832f9498cb317a7f19ee)