### PR TITLE
Add real desktop compute-mode mapping and GPU runtime diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -99,7 +99,7 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    resolved_mode = apply_compute_mode(runtime.model_manager, args.mode)
+    requested_mode = apply_compute_mode(runtime.model_manager, args.mode)
 
     if not runtime.ensure_model_ready():
         emit(
@@ -111,6 +111,10 @@ def run(args: argparse.Namespace) -> int:
         )
         return 1
 
+    diagnostics = getattr(runtime.model_manager, "last_runtime_compute_status", {})
+    effective_mode = diagnostics.get("effective_mode", "cpu")
+    backend_available = diagnostics.get("backend_available", "unknown")
+    mode_reason = diagnostics.get("mode_reason")
     last_error: Optional[str] = None
     emit(
         {
@@ -118,7 +122,11 @@ def run(args: argparse.Namespace) -> int:
             "running": True,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": resolved_mode,
+            "backend_mode": effective_mode,
+            "requested_mode": requested_mode,
+            "effective_mode": effective_mode,
+            "backend_available": backend_available,
+            "mode_reason": mode_reason,
             "model_path": args.model,
             "last_error": None,
         }
@@ -155,7 +163,11 @@ def run(args: argparse.Namespace) -> int:
                     "running": True,
                     "registered": registered,
                     "active_relay_url": active_relay_url,
-                    "backend_mode": resolved_mode,
+                    "backend_mode": effective_mode,
+                    "requested_mode": requested_mode,
+                    "effective_mode": effective_mode,
+                    "backend_available": backend_available,
+                    "mode_reason": mode_reason,
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -173,7 +185,11 @@ def run(args: argparse.Namespace) -> int:
             "running": False,
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
-            "backend_mode": resolved_mode,
+            "backend_mode": effective_mode,
+            "requested_mode": requested_mode,
+            "effective_mode": effective_mode,
+            "backend_available": backend_available,
+            "mode_reason": mode_reason,
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -148,7 +148,16 @@ def run(args: argparse.Namespace) -> int:
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
-    emit({"type": "started"})
+    diagnostics = getattr(manager, "last_runtime_compute_status", {})
+    emit(
+        {
+            "type": "started",
+            "requested_mode": diagnostics.get("requested_mode", args.mode),
+            "effective_mode": diagnostics.get("effective_mode", "cpu"),
+            "backend_available": diagnostics.get("backend_available", "unknown"),
+            "mode_reason": diagnostics.get("mode_reason"),
+        }
+    )
     if cancel_requested():
         emit({"type": "canceled"})
         return 0

--- a/desktop-tauri/src-tauri/src/backend.rs
+++ b/desktop-tauri/src-tauri/src/backend.rs
@@ -4,15 +4,19 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum ComputeMode {
     Auto,
+    Cpu,
+    Gpu,
+    Hybrid,
     Metal,
     Cuda,
-    Cpu,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BackendInfo {
     pub platform_label: String,
     pub preferred_mode: ComputeMode,
+    pub available_backend: String,
+    pub gpu_backend_available: bool,
     pub display_label: String,
 }
 
@@ -25,23 +29,29 @@ pub fn detect_backend_for(target_os: &str, target_arch: &str) -> BackendInfo {
         };
         return BackendInfo {
             platform_label: format!("macOS {target_arch}"),
-            preferred_mode: ComputeMode::Metal,
-            display_label: display_label.into(),
+            preferred_mode: ComputeMode::Auto,
+            available_backend: "metal".into(),
+            gpu_backend_available: true,
+            display_label: format!("{display_label} available"),
         };
     }
 
     if target_os == "windows" && target_arch == "x86_64" {
         return BackendInfo {
             platform_label: "Windows x64".into(),
-            preferred_mode: ComputeMode::Cuda,
-            display_label: "CUDA / NVIDIA".into(),
+            preferred_mode: ComputeMode::Auto,
+            available_backend: "cuda".into(),
+            gpu_backend_available: true,
+            display_label: "CUDA / NVIDIA available".into(),
         };
     }
 
     BackendInfo {
         platform_label: format!("{} {}", target_os, target_arch),
-        preferred_mode: ComputeMode::Cpu,
-        display_label: "CPU fallback".into(),
+        preferred_mode: ComputeMode::Auto,
+        available_backend: "none".into(),
+        gpu_backend_available: false,
+        display_label: "GPU backend unavailable (CPU only)".into(),
     }
 }
 
@@ -52,28 +62,32 @@ mod tests {
     #[test]
     fn selects_metal_for_apple_silicon() {
         let info = detect_backend_for("macos", "aarch64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple Silicon");
+        assert_eq!(info.preferred_mode, ComputeMode::Auto);
+        assert_eq!(info.available_backend, "metal");
+        assert_eq!(info.display_label, "Metal / Apple Silicon available");
     }
 
     #[test]
     fn selects_metal_for_macos_intel() {
         let info = detect_backend_for("macos", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple");
+        assert_eq!(info.preferred_mode, ComputeMode::Auto);
+        assert_eq!(info.available_backend, "metal");
+        assert_eq!(info.display_label, "Metal / Apple available");
     }
 
     #[test]
     fn selects_cuda_for_windows_x64() {
         let info = detect_backend_for("windows", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cuda);
-        assert_eq!(info.display_label, "CUDA / NVIDIA");
+        assert_eq!(info.preferred_mode, ComputeMode::Auto);
+        assert_eq!(info.available_backend, "cuda");
+        assert_eq!(info.display_label, "CUDA / NVIDIA available");
     }
 
     #[test]
     fn falls_back_to_cpu() {
         let info = detect_backend_for("linux", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cpu);
-        assert_eq!(info.display_label, "CPU fallback");
+        assert_eq!(info.preferred_mode, ComputeMode::Auto);
+        assert_eq!(info.available_backend, "none");
+        assert_eq!(info.display_label, "GPU backend unavailable (CPU only)");
     }
 }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -24,6 +24,10 @@ pub struct ComputeNodeStatus {
     pub registered: bool,
     pub active_relay_url: String,
     pub backend_mode: String,
+    pub requested_mode: String,
+    pub effective_mode: String,
+    pub backend_available: String,
+    pub mode_reason: Option<String>,
     pub model_path: String,
     pub last_error: Option<String>,
 }
@@ -144,6 +148,10 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         registered: false,
         active_relay_url: request.relay_base_url.clone(),
         backend_mode: format!("{:?}", request.mode).to_lowercase(),
+        requested_mode: format!("{:?}", request.mode).to_lowercase(),
+        effective_mode: "cpu".into(),
+        backend_available: "unknown".into(),
+        mode_reason: None,
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
     }
@@ -161,6 +169,21 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     }
     if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
         status.backend_mode = backend_mode.into();
+    }
+    if let Some(requested_mode) = payload.get("requested_mode").and_then(Value::as_str) {
+        status.requested_mode = requested_mode.into();
+    }
+    if let Some(effective_mode) = payload.get("effective_mode").and_then(Value::as_str) {
+        status.effective_mode = effective_mode.into();
+    }
+    if let Some(backend_available) = payload.get("backend_available").and_then(Value::as_str) {
+        status.backend_available = backend_available.into();
+    }
+    if payload.get("mode_reason").is_some() {
+        status.mode_reason = payload
+            .get("mode_reason")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
     }
     if let Some(model_path) = payload.get("model_path").and_then(Value::as_str) {
         status.model_path = model_path.into();
@@ -302,6 +325,10 @@ pub async fn start_compute_node(
             registered: false,
             active_relay_url: request.relay_base_url.clone(),
             backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            requested_mode: format!("{:?}", request.mode).to_lowercase(),
+            effective_mode: "pending".into(),
+            backend_available: "unknown".into(),
+            mode_reason: None,
             model_path: request.model_path.clone(),
             last_error: None,
         };

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -37,6 +37,8 @@ describe('desktop app start failure handling', () => {
         return Promise.resolve({
           platform_label: 'macos',
           preferred_mode: 'auto',
+          available_backend: 'none',
+          gpu_backend_available: false,
           display_label: 'auto',
         });
       }
@@ -53,6 +55,10 @@ describe('desktop app start failure handling', () => {
           registered: false,
           active_relay_url: '',
           backend_mode: 'auto',
+          requested_mode: 'auto',
+          effective_mode: 'pending',
+          backend_available: 'unknown',
+          mode_reason: null,
           model_path: '',
           last_error: null,
         });
@@ -88,6 +94,8 @@ describe('desktop app start failure handling', () => {
             ? {
                 platform_label: 'macos',
                 preferred_mode: 'auto',
+                available_backend: 'none',
+                gpu_backend_available: false,
                 display_label: 'auto',
               }
             : command === 'get_compute_node_status'
@@ -96,6 +104,10 @@ describe('desktop app start failure handling', () => {
                   registered: false,
                   active_relay_url: '',
                   backend_mode: 'auto',
+                  requested_mode: 'auto',
+                  effective_mode: 'pending',
+                  backend_available: 'unknown',
+                  mode_reason: null,
                   model_path: '',
                   last_error: null,
                 }
@@ -139,6 +151,8 @@ describe('desktop app start failure handling', () => {
         return Promise.resolve({
           platform_label: 'macos',
           preferred_mode: 'auto',
+          available_backend: 'none',
+          gpu_backend_available: false,
           display_label: 'auto',
         });
       }
@@ -155,6 +169,10 @@ describe('desktop app start failure handling', () => {
           registered: false,
           active_relay_url: '',
           backend_mode: 'auto',
+          requested_mode: 'auto',
+          effective_mode: 'pending',
+          backend_available: 'unknown',
+          mode_reason: null,
           model_path: '',
           last_error: null,
         });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -4,11 +4,13 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 type UiState = 'idle' | 'starting' | 'streaming' | 'canceled' | 'completed' | 'failed';
-type BackendMode = 'auto' | 'metal' | 'cuda' | 'cpu';
+type BackendMode = 'auto' | 'cpu' | 'gpu' | 'hybrid' | 'metal' | 'cuda';
 
 interface BackendInfo {
   platform_label: string;
   preferred_mode: BackendMode;
+  available_backend: 'cuda' | 'metal' | 'none' | string;
+  gpu_backend_available: boolean;
   display_label: string;
 }
 
@@ -23,6 +25,10 @@ interface ComputeNodeStatus {
   registered: boolean;
   active_relay_url: string;
   backend_mode: string;
+  requested_mode: string;
+  effective_mode: string;
+  backend_available: string;
+  mode_reason: string | null;
   model_path: string;
   last_error: string | null;
 }
@@ -50,6 +56,10 @@ const defaultComputeStatus: ComputeNodeStatus = {
   registered: false,
   active_relay_url: '',
   backend_mode: 'auto',
+  requested_mode: 'auto',
+  effective_mode: 'pending',
+  backend_available: 'unknown',
+  mode_reason: null,
   model_path: '',
   last_error: null,
 };
@@ -162,6 +172,20 @@ export function App() {
             : prev.active_relay_url,
         backend_mode:
           typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
+        requested_mode:
+          typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
+        effective_mode:
+          typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
+        backend_available:
+          typeof payload.backend_available === 'string'
+            ? payload.backend_available
+            : prev.backend_available,
+        mode_reason:
+          payload.mode_reason === null
+            ? null
+            : typeof payload.mode_reason === 'string'
+              ? payload.mode_reason
+              : prev.mode_reason,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         last_error:
           payload.last_error === null
@@ -200,14 +224,8 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running,
     [config.model_path, computeStatus.running]
   );
-  const platformLabel = (backend?.platform_label ?? '').toLowerCase();
-  const backendDisplayLabel = (backend?.display_label ?? '').toLowerCase();
-  const metalSupported = platformLabel.includes('apple') || platformLabel.includes('mac');
-  const cudaSupported =
-    backend?.preferred_mode === 'cuda' ||
-    backendDisplayLabel.includes('cuda') ||
-    platformLabel.includes('nvidia') ||
-    platformLabel.includes('cuda');
+  const gpuBackend = backend?.available_backend ?? 'none';
+  const gpuSupported = backend?.gpu_backend_available ?? false;
 
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {
@@ -342,7 +360,7 @@ export function App() {
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
       <h1>token.place desktop compute node</h1>
-      <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
+      <p>Detected platform/backend capability: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
         <input
@@ -384,15 +402,15 @@ export function App() {
         value={config.preferred_mode}
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
-        <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
-        <option value="metal" disabled={!metalSupported}>Metal GPU (macOS Apple Silicon)</option>
-        <option value="cuda" disabled={!cudaSupported}>CUDA GPU (Windows/NVIDIA)</option>
-        <option value="cpu">CPU fallback</option>
+        <option value="auto">Auto ({gpuSupported ? `${gpuBackend} available` : 'CPU fallback'})</option>
+        <option value="cpu">CPU only</option>
+        <option value="gpu" disabled={!gpuSupported}>GPU only</option>
+        <option value="hybrid" disabled={!gpuSupported}>Hybrid (partial GPU offload)</option>
       </select>
       <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
-        Operator note: <code>cuda</code> is for Windows/NVIDIA workstations, <code>metal</code> is
-        for macOS/Apple Silicon, and <code>cpu</code> is fallback. Raspberry Pi remains a later
-        low-power workstation target and is not part of the current sugarkube relay rollout.
+        Runtime note: mode selection requests execution intent (<code>cpu</code>, <code>gpu</code>,
+        <code>hybrid</code>, <code>auto</code>). Actual backend use appears below after runtime
+        initialization.
       </p>
 
       <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
@@ -411,7 +429,10 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode || computeStatus.backend_mode || 'pending'}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend available: <code>{computeStatus.backend_available || backend?.available_backend || 'unknown'}</code></p>
+        <p style={{ marginBottom: 0 }}>Mode reason: <code>{computeStatus.mode_reason || 'n/a'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -219,21 +219,24 @@ def test_compute_node_runtime_format_relay_target_preserves_explicit_url_port():
 
 
 def test_normalize_compute_mode_is_case_insensitive_and_falls_back_to_auto():
+    assert normalize_compute_mode("GPU") == "gpu"
+    assert normalize_compute_mode("  hybrid ") == "hybrid"
     assert normalize_compute_mode("CUDA") == "cuda"
-    assert normalize_compute_mode("  metal ") == "metal"
     assert normalize_compute_mode("unknown") == "auto"
     assert normalize_compute_mode("") == "auto"
     assert normalize_compute_mode(None) == "auto"
 
 
-def test_apply_compute_mode_sets_expected_gpu_layer_defaults():
+def test_apply_compute_mode_sets_expected_gpu_layer_defaults(monkeypatch):
     manager = MagicMock()
+    manager.config.get.return_value = 20
+    monkeypatch.setattr("utils.compute_node_runtime.platform.system", lambda: "Windows")
 
     assert apply_compute_mode(manager, "cpu") == "cpu"
     assert manager.default_n_gpu_layers == 0
 
-    assert apply_compute_mode(manager, "auto") == "auto"
-    assert manager.default_n_gpu_layers == -1
+    assert apply_compute_mode(manager, "hybrid") == "hybrid"
+    assert manager.default_n_gpu_layers > 0
 
 
 def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -310,18 +310,19 @@ def test_run_reports_error_when_legacy_relay_request_processing_fails(capsys, mo
     assert status_events[0]['last_error'] == 'failed to process relay request'
 
 
-def test_apply_compute_mode_supports_gpu_and_cpu_modes():
+def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
     manager = FakeModelManager()
     from utils.compute_node_runtime import apply_compute_mode
+    monkeypatch.setattr('utils.compute_node_runtime.platform.system', lambda: 'Windows')
 
     assert apply_compute_mode(manager, 'auto') == 'auto'
+    assert manager.default_n_gpu_layers in {0, -1}
+
+    assert apply_compute_mode(manager, 'gpu') == 'gpu'
     assert manager.default_n_gpu_layers == -1
 
-    assert apply_compute_mode(manager, 'metal') == 'metal'
-    assert manager.default_n_gpu_layers == -1
-
-    assert apply_compute_mode(manager, 'cuda') == 'cuda'
-    assert manager.default_n_gpu_layers == -1
+    assert apply_compute_mode(manager, 'hybrid') == 'hybrid'
+    assert manager.default_n_gpu_layers > 0
 
     assert apply_compute_mode(manager, 'cpu') == 'cpu'
     assert manager.default_n_gpu_layers == 0
@@ -343,7 +344,7 @@ def test_run_normalizes_unknown_mode_to_auto_in_status(capsys, monkeypatch):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert events[0]['type'] == 'started'
-    assert events[0]['backend_mode'] == 'auto'
+    assert events[0]['requested_mode'] == 'auto'
 
 
 def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):
@@ -386,12 +387,12 @@ def test_main_normalizes_mode_before_run(monkeypatch):
     monkeypatch.setattr(
         sys,
         'argv',
-        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'CUDA'],
+        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'GPU'],
     )
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,
@@ -423,7 +424,7 @@ def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_pat
     (utils_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
-SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "cuda", "metal"}
+SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid", "cuda", "metal"}
 
 
 def normalize_compute_mode(mode):

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -179,7 +179,7 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
 
 @pytest.mark.parametrize(
     ('mode', 'expected'),
-    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+    [('cpu', 0), ('gpu', -1), ('hybrid', 20), ('auto', -1)],
 )
 def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
     _reset_cancel_queue()
@@ -188,6 +188,8 @@ def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
 
     manager = FakeManager()
     _install_fake_manager_module(manager)
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr('utils.compute_node_runtime.platform.system', lambda: 'Windows')
 
     args = SimpleNamespace(model=str(model_path), mode=mode, prompt='Mode test')
     status = inference_sidecar.run(args)
@@ -195,6 +197,7 @@ def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
     assert status == 0
     _ = capsys.readouterr()
     assert manager.default_n_gpu_layers == expected
+    monkeypatch.undo()
 
 
 def test_run_handles_dict_completion_payload(tmp_path, capsys):
@@ -221,6 +224,8 @@ def test_run_normalizes_unknown_mode_to_auto_gpu_default(tmp_path, capsys):
 
     manager = FakeManager()
     _install_fake_manager_module(manager)
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr('utils.compute_node_runtime.platform.system', lambda: 'Windows')
 
     args = SimpleNamespace(model=str(model_path), mode='UNSUPPORTED', prompt='hello')
     status = inference_sidecar.run(args)
@@ -228,6 +233,7 @@ def test_run_normalizes_unknown_mode_to_auto_gpu_default(tmp_path, capsys):
     assert status == 0
     _ = capsys.readouterr()
     assert manager.default_n_gpu_layers == -1
+    monkeypatch.undo()
 
 
 def test_normalize_chunk_fallback_handles_object_shapes():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import platform
 import os
 import threading
 from dataclasses import dataclass
@@ -134,7 +135,7 @@ def format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
     return f"{relay_url}:{relay_port}"
 
 
-SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "metal", "cuda"})
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "gpu", "hybrid", "metal", "cuda"})
 
 
 def normalize_compute_mode(mode: Optional[str]) -> str:
@@ -146,17 +147,88 @@ def normalize_compute_mode(mode: Optional[str]) -> str:
     return "auto"
 
 
+def _detect_available_gpu_backend() -> str:
+    system = platform.system().lower()
+    if system == "windows":
+        return "cuda"
+    if system == "darwin":
+        return "metal"
+    return "none"
+
+
+def _hybrid_gpu_layers(manager: Any) -> int:
+    configured = 20
+    config = getattr(manager, "config", None)
+    if config is not None and hasattr(config, "get"):
+        configured = config.get("model.hybrid_n_gpu_layers", 20)
+    try:
+        value = int(configured)
+    except (TypeError, ValueError):
+        value = 20
+    return max(1, value)
+
+
 def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
     """Apply normalized compute mode to model-manager GPU settings."""
 
     selected = normalize_compute_mode(mode)
+    available_backend = _detect_available_gpu_backend()
+    requested_mode = selected
+    effective_mode = "cpu"
+    mode_reason: Optional[str] = None
+
     if selected == "cpu":
         manager.default_n_gpu_layers = 0
+        mode_reason = "Operator selected CPU-only mode."
+    elif selected in {"cuda", "metal"}:
+        requested_mode = "gpu"
+        if selected == available_backend:
+            manager.default_n_gpu_layers = -1
+            effective_mode = f"{available_backend}_gpu"
+            mode_reason = f"Explicit {available_backend} request."
+        else:
+            manager.default_n_gpu_layers = 0
+            mode_reason = (
+                f"Requested {selected} backend is not available on this host; using CPU fallback."
+            )
+    elif selected == "gpu":
+        if available_backend == "none":
+            manager.default_n_gpu_layers = 0
+            mode_reason = "No supported GPU backend available on this host; using CPU fallback."
+        else:
+            manager.default_n_gpu_layers = -1
+            effective_mode = f"{available_backend}_gpu"
+            mode_reason = f"Operator selected GPU-only mode ({available_backend})."
+    elif selected == "hybrid":
+        if available_backend == "none":
+            manager.default_n_gpu_layers = 0
+            mode_reason = "Hybrid mode requested but no GPU backend is available; using CPU fallback."
+        else:
+            manager.default_n_gpu_layers = _hybrid_gpu_layers(manager)
+            effective_mode = f"hybrid_{available_backend}"
+            mode_reason = (
+                f"Operator selected hybrid mode with n_gpu_layers={manager.default_n_gpu_layers}."
+            )
     else:
-        # ``auto`` follows runtime autodetection and maps to GPU-preferred layers where available.
-        # ``metal`` and ``cuda`` also request GPU-backed inference on supported hosts.
-        manager.default_n_gpu_layers = -1
-    return selected
+        if available_backend == "none":
+            manager.default_n_gpu_layers = 0
+            mode_reason = "Auto selected; no supported GPU backend detected, using CPU."
+        else:
+            manager.default_n_gpu_layers = -1
+            effective_mode = f"{available_backend}_gpu"
+            mode_reason = f"Auto selected; requesting full {available_backend} GPU offload."
+
+    manager.requested_compute_mode = requested_mode
+    manager.available_gpu_backend = available_backend
+    manager.mode_reason = mode_reason
+    manager.last_runtime_compute_status = {
+        "requested_mode": requested_mode,
+        "effective_mode": effective_mode if manager.default_n_gpu_layers != 0 else "cpu",
+        "backend_available": available_backend,
+        "mode_reason": mode_reason,
+        "n_gpu_layers": manager.default_n_gpu_layers,
+    }
+    return requested_mode
 
 
 class ComputeNodeRuntime:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -60,6 +60,16 @@ class ModelManager:
         self.default_n_gpu_layers = config.get('model.n_gpu_layers', -1)
         self.gpu_headroom_percent = config.get('model.gpu_memory_headroom_percent', 0.1)
         self.enforce_gpu_headroom = config.get('model.enforce_gpu_memory_headroom', True)
+        self.requested_compute_mode = 'auto'
+        self.available_gpu_backend = 'unknown'
+        self.mode_reason = None
+        self.last_runtime_compute_status = {
+            'requested_mode': 'auto',
+            'effective_mode': 'unknown',
+            'backend_available': 'unknown',
+            'mode_reason': None,
+            'n_gpu_layers': self.default_n_gpu_layers,
+        }
 
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
         """Return runtime model metadata used by server and desktop bridges."""
@@ -234,6 +244,7 @@ class ModelManager:
                             from llama_cpp import Llama
 
                             n_gpu_layers = self.default_n_gpu_layers
+                            mode_reason = self.mode_reason
                             if self.enforce_gpu_headroom and n_gpu_layers != 0:
                                 try:
                                     model_size = os.path.getsize(self.model_path)
@@ -249,6 +260,10 @@ class ModelManager:
                                             "to CPU inference for this model."
                                         )
                                         n_gpu_layers = 0
+                                        mode_reason = (
+                                            "GPU mode requested but insufficient GPU memory "
+                                            "headroom was detected; using CPU fallback."
+                                        )
 
                             self.log_info(f"Initializing Llama model from {self.model_path}...")
                             self.llm = Llama(
@@ -258,8 +273,27 @@ class ModelManager:
                                 chat_format=self.config.get('model.chat_format', 'llama-3')
                             )
                             self.log_info("Llama model initialized successfully.")
+                            effective_mode = 'cpu'
+                            if n_gpu_layers == -1 and self.available_gpu_backend not in {'none', 'unknown'}:
+                                effective_mode = f'{self.available_gpu_backend}_gpu'
+                            elif n_gpu_layers > 0 and self.available_gpu_backend not in {'none', 'unknown'}:
+                                effective_mode = f'hybrid_{self.available_gpu_backend}'
+                            self.last_runtime_compute_status = {
+                                'requested_mode': self.requested_compute_mode,
+                                'effective_mode': effective_mode,
+                                'backend_available': self.available_gpu_backend,
+                                'mode_reason': mode_reason,
+                                'n_gpu_layers': n_gpu_layers,
+                            }
                         except Exception as e:
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)
+                            self.last_runtime_compute_status = {
+                                'requested_mode': self.requested_compute_mode,
+                                'effective_mode': 'cpu',
+                                'backend_available': self.available_gpu_backend,
+                                'mode_reason': f'model initialization failed: {e}',
+                                'n_gpu_layers': 0,
+                            }
                             return None
 
         return self.llm


### PR DESCRIPTION
### Motivation
- The desktop UI could claim a GPU backend (CUDA/Metal) while the runtime still initialized `llama-cpp-python` on CPU because `n_gpu_layers` and related runtime knobs were not being wired through correctly.  
- Provide four operator-intent modes (`auto`, `cpu`, `gpu`, `hybrid`) that map to deterministic `llama-cpp-python` behavior rather than vendor-only labels.  
- Surface truthful runtime diagnostics so the UI reports requested vs effective mode and why a CPU fallback occurred.  

### Description
- Add intent-level compute modes and backend capability metadata by extending `ComputeMode` and `BackendInfo` in `desktop-tauri/src-tauri/src/backend.rs` and making detection report `available_backend` and `gpu_backend_available`.  
- Propagate requested/effective/mode-reason fields through the compute-node plumbing by extending `ComputeNodeStatus` and status update handling in `desktop-tauri/src-tauri/src/compute_node.rs`.  
- Update the desktop UI in `desktop-tauri/src/App.tsx` to offer `auto | cpu | gpu | hybrid` operator choices and display `requested_mode`, `effective_mode`, `backend_available`, and `mode_reason` instead of implying GPU use.  
- Wire mode intent into the Python bridge and sidecar by returning the normalized/requested mode from `utils.compute_node_runtime.apply_compute_mode`, and emitting diagnostics from `desktop-tauri/src-tauri/python/compute_node_bridge.py` and `desktop-tauri/src-tauri/python/inference_sidecar.py`.  
- Implement concrete runtime mapping in `utils/compute_node_runtime.py` so modes set `manager.default_n_gpu_layers` as follows: CPU → `0`, GPU → `-1` (full offload) when supported, Hybrid → positive `n_gpu_layers` (conservative default / configurable), Auto → backend-aware request or CPU fallback; include detection helper `_detect_available_gpu_backend`.  
- Record and publish final runtime diagnostics from `utils/llm/model_manager.py` after headroom checks / `Llama(...)` initialization so the bridge can truthfully report effective mode (CPU/GPU/hybrid) and the reason for any fallback.  
- Add/adjust focused unit tests that validate `normalize_compute_mode`, `apply_compute_mode` mapping, hybrid nonzero layer behavior, and correct propagation of requested/effective diagnostics through the compute-node bridge (`tests/unit/test_compute_node_runtime.py`, `tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_desktop_inference_sidecar.py`).  

### Testing
- Ran targeted Python unit tests: `python -m pytest tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py -q`, which passed locally (50 passed).  
- Ran the desktop JS unit tests with `npm --prefix desktop-tauri run test -- --run`, which succeeded (Vitest: `src/App.test.tsx` passing).  
- Built the web frontend with `npm --prefix desktop-tauri run build`, which succeeded.  
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` but those require system `glib-2.0` / pkg-config development libs in the container and therefore failed in this environment; the Rust changes are small and unit tests in the Rust module remain straightforward, but a CI runner with system deps will be required to validate the full Rust/Tauri build.  
- Notes: `pre-commit run --all-files` was not executed because `pre-commit` is not installed in this environment; no secrets were added in the diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc82426148832f9498cb317a7f19ee)