### PR TITLE
Implement desktop Auto/CPU/GPU/Hybrid compute modes and truthful GPU diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -80,6 +80,7 @@ def run(args: argparse.Namespace) -> int:
             apply_compute_mode,
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
+            describe_compute_mode,
             is_legacy_relay_payload,
             resolve_relay_port,
             resolve_relay_url,
@@ -99,7 +100,12 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
-    resolved_mode = apply_compute_mode(runtime.model_manager, args.mode)
+    resolved_mode = apply_compute_mode(
+        runtime.model_manager,
+        args.mode,
+        getattr(args, "backend", "unknown"),
+    )
+    mode_details = describe_compute_mode(runtime.model_manager)
 
     if not runtime.ensure_model_ready():
         emit(
@@ -119,6 +125,7 @@ def run(args: argparse.Namespace) -> int:
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
             "backend_mode": resolved_mode,
+            **mode_details,
             "model_path": args.model,
             "last_error": None,
         }
@@ -149,6 +156,7 @@ def run(args: argparse.Namespace) -> int:
             else:
                 last_error = None
 
+            mode_details = describe_compute_mode(runtime.model_manager)
             emit(
                 {
                     "type": "status",
@@ -156,6 +164,7 @@ def run(args: argparse.Namespace) -> int:
                     "registered": registered,
                     "active_relay_url": active_relay_url,
                     "backend_mode": resolved_mode,
+                    **mode_details,
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -167,6 +176,7 @@ def run(args: argparse.Namespace) -> int:
     finally:
         runtime.stop()
 
+    mode_details = describe_compute_mode(runtime.model_manager)
     emit(
         {
             "type": "stopped",
@@ -174,6 +184,7 @@ def run(args: argparse.Namespace) -> int:
             "registered": False,
             "active_relay_url": runtime.relay_client.relay_url,
             "backend_mode": resolved_mode,
+            **mode_details,
             "model_path": args.model,
             "last_error": None,
         }
@@ -185,6 +196,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--model", required=True)
     parser.add_argument("--mode", default="auto")
+    parser.add_argument("--backend", default="unknown")
     parser.add_argument("--relay-url", default="https://token.place")
     parser.add_argument("--relay-port", type=int, default=None)
     args = parser.parse_args()

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -132,7 +132,7 @@ def run(args: argparse.Namespace) -> int:
         return emit_error("bad_model", "model path not found")
 
     try:
-        from utils.compute_node_runtime import apply_compute_mode
+        from utils.compute_node_runtime import apply_compute_mode, describe_compute_mode
         from utils.llm.model_manager import ModelManager, get_model_manager
     except ModuleNotFoundError as exc:
         return emit_error(
@@ -142,13 +142,13 @@ def run(args: argparse.Namespace) -> int:
 
     manager = get_model_manager()
     manager.model_path = args.model
-    apply_compute_mode(manager, args.mode)
+    apply_compute_mode(manager, args.mode, getattr(args, "backend", "unknown"))
 
     llm = manager.get_llm_instance()
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
-    emit({"type": "started"})
+    emit({"type": "started", **describe_compute_mode(manager)})
     if cancel_requested():
         emit({"type": "canceled"})
         return 0
@@ -201,6 +201,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop inference sidecar")
     parser.add_argument("--model", required=True)
     parser.add_argument("--mode", default="auto")
+    parser.add_argument("--backend", default="unknown")
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
     try:

--- a/desktop-tauri/src-tauri/src/backend.rs
+++ b/desktop-tauri/src-tauri/src/backend.rs
@@ -4,44 +4,53 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum ComputeMode {
     Auto,
+    Cpu,
+    #[serde(alias = "metal", alias = "cuda")]
+    Gpu,
+    Hybrid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BackendKind {
+    Cpu,
     Metal,
     Cuda,
-    Cpu,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BackendInfo {
     pub platform_label: String,
-    pub preferred_mode: ComputeMode,
-    pub display_label: String,
+    pub available_backend: BackendKind,
+    pub availability_label: String,
 }
 
 pub fn detect_backend_for(target_os: &str, target_arch: &str) -> BackendInfo {
     if target_os == "macos" {
-        let display_label = if target_arch == "aarch64" {
-            "Metal / Apple Silicon"
+        let availability_label = if target_arch == "aarch64" {
+            "Metal backend available"
         } else {
-            "Metal / Apple"
+            "Metal backend available (Intel macOS may perform worse)"
         };
         return BackendInfo {
             platform_label: format!("macOS {target_arch}"),
-            preferred_mode: ComputeMode::Metal,
-            display_label: display_label.into(),
+            available_backend: BackendKind::Metal,
+            availability_label: availability_label.into(),
         };
     }
 
     if target_os == "windows" && target_arch == "x86_64" {
         return BackendInfo {
             platform_label: "Windows x64".into(),
-            preferred_mode: ComputeMode::Cuda,
-            display_label: "CUDA / NVIDIA".into(),
+            available_backend: BackendKind::Cuda,
+            availability_label: "CUDA backend available".into(),
         };
     }
 
     BackendInfo {
         platform_label: format!("{} {}", target_os, target_arch),
-        preferred_mode: ComputeMode::Cpu,
-        display_label: "CPU fallback".into(),
+        available_backend: BackendKind::Cpu,
+        availability_label: "No GPU backend detected (CPU only)".into(),
     }
 }
 
@@ -52,28 +61,31 @@ mod tests {
     #[test]
     fn selects_metal_for_apple_silicon() {
         let info = detect_backend_for("macos", "aarch64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple Silicon");
+        assert_eq!(info.available_backend, BackendKind::Metal);
+        assert_eq!(info.availability_label, "Metal backend available");
     }
 
     #[test]
     fn selects_metal_for_macos_intel() {
         let info = detect_backend_for("macos", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Metal);
-        assert_eq!(info.display_label, "Metal / Apple");
+        assert_eq!(info.available_backend, BackendKind::Metal);
+        assert_eq!(
+            info.availability_label,
+            "Metal backend available (Intel macOS may perform worse)"
+        );
     }
 
     #[test]
     fn selects_cuda_for_windows_x64() {
         let info = detect_backend_for("windows", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cuda);
-        assert_eq!(info.display_label, "CUDA / NVIDIA");
+        assert_eq!(info.available_backend, BackendKind::Cuda);
+        assert_eq!(info.availability_label, "CUDA backend available");
     }
 
     #[test]
     fn falls_back_to_cpu() {
         let info = detect_backend_for("linux", "x86_64");
-        assert_eq!(info.preferred_mode, ComputeMode::Cpu);
-        assert_eq!(info.display_label, "CPU fallback");
+        assert_eq!(info.available_backend, BackendKind::Cpu);
+        assert_eq!(info.availability_label, "No GPU backend detected (CPU only)");
     }
 }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,4 @@
-use crate::backend::ComputeMode;
+use crate::backend::{detect_backend_for, ComputeMode};
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -24,6 +24,12 @@ pub struct ComputeNodeStatus {
     pub registered: bool,
     pub active_relay_url: String,
     pub backend_mode: String,
+    pub requested_mode: String,
+    pub backend_available: String,
+    pub effective_mode: String,
+    pub backend_used: String,
+    pub n_gpu_layers: i32,
+    pub fallback_reason: Option<String>,
     pub model_path: String,
     pub last_error: Option<String>,
 }
@@ -139,11 +145,22 @@ fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path, brid
 }
 
 fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
+    let backend_available = format!(
+        "{:?}",
+        detect_backend_for(std::env::consts::OS, std::env::consts::ARCH).available_backend
+    )
+    .to_lowercase();
     ComputeNodeStatus {
         running: false,
         registered: false,
         active_relay_url: request.relay_base_url.clone(),
         backend_mode: format!("{:?}", request.mode).to_lowercase(),
+        requested_mode: format!("{:?}", request.mode).to_lowercase(),
+        backend_available,
+        effective_mode: "unknown".into(),
+        backend_used: "unknown".into(),
+        n_gpu_layers: 0,
+        fallback_reason: None,
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
     }
@@ -161,6 +178,27 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     }
     if let Some(backend_mode) = payload.get("backend_mode").and_then(Value::as_str) {
         status.backend_mode = backend_mode.into();
+    }
+    if let Some(requested_mode) = payload.get("requested_mode").and_then(Value::as_str) {
+        status.requested_mode = requested_mode.into();
+    }
+    if let Some(backend_available) = payload.get("backend_available").and_then(Value::as_str) {
+        status.backend_available = backend_available.into();
+    }
+    if let Some(effective_mode) = payload.get("effective_mode").and_then(Value::as_str) {
+        status.effective_mode = effective_mode.into();
+    }
+    if let Some(backend_used) = payload.get("backend_used").and_then(Value::as_str) {
+        status.backend_used = backend_used.into();
+    }
+    if let Some(n_gpu_layers) = payload.get("n_gpu_layers").and_then(Value::as_i64) {
+        status.n_gpu_layers = n_gpu_layers as i32;
+    }
+    if payload.get("fallback_reason").is_some() {
+        status.fallback_reason = payload
+            .get("fallback_reason")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
     }
     if let Some(model_path) = payload.get("model_path").and_then(Value::as_str) {
         status.model_path = model_path.into();
@@ -255,6 +293,12 @@ pub async fn start_compute_node(
         .arg(&request.model_path)
         .arg("--mode")
         .arg(format!("{:?}", request.mode).to_lowercase())
+        .arg("--backend")
+        .arg(format!(
+            "{:?}",
+            detect_backend_for(std::env::consts::OS, std::env::consts::ARCH).available_backend
+        )
+        .to_lowercase())
         .arg("--relay-url")
         .arg(&request.relay_base_url)
         .stdin(Stdio::piped())
@@ -302,6 +346,16 @@ pub async fn start_compute_node(
             registered: false,
             active_relay_url: request.relay_base_url.clone(),
             backend_mode: format!("{:?}", request.mode).to_lowercase(),
+            requested_mode: format!("{:?}", request.mode).to_lowercase(),
+            backend_available: format!(
+                "{:?}",
+                detect_backend_for(std::env::consts::OS, std::env::consts::ARCH).available_backend
+            )
+            .to_lowercase(),
+            effective_mode: "unknown".into(),
+            backend_used: "unknown".into(),
+            n_gpu_layers: 0,
+            fallback_reason: None,
             model_path: request.model_path.clone(),
             last_error: None,
         };

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,4 @@
-use crate::backend::ComputeMode;
+use crate::backend::{detect_backend_for, ComputeMode};
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -251,6 +251,12 @@ pub async fn start_sidecar(
         .arg(&request.model_path)
         .arg("--mode")
         .arg(format!("{:?}", request.mode).to_lowercase())
+        .arg("--backend")
+        .arg(format!(
+            "{:?}",
+            detect_backend_for(std::env::consts::OS, std::env::consts::ARCH).available_backend
+        )
+        .to_lowercase())
         .arg("--prompt")
         .arg(&request.prompt)
         .stdin(Stdio::piped())

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -36,8 +36,8 @@ describe('desktop app start failure handling', () => {
       if (command === 'detect_backend') {
         return Promise.resolve({
           platform_label: 'macos',
-          preferred_mode: 'auto',
-          display_label: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal backend available',
         });
       }
       if (command === 'load_config') {
@@ -53,6 +53,12 @@ describe('desktop app start failure handling', () => {
           registered: false,
           active_relay_url: '',
           backend_mode: 'auto',
+          requested_mode: 'auto',
+          backend_available: 'metal',
+          effective_mode: 'unknown',
+          backend_used: 'unknown',
+          n_gpu_layers: 0,
+          fallback_reason: null,
           model_path: '',
           last_error: null,
         });
@@ -87,8 +93,8 @@ describe('desktop app start failure handling', () => {
           : command === 'detect_backend'
             ? {
                 platform_label: 'macos',
-                preferred_mode: 'auto',
-                display_label: 'auto',
+                available_backend: 'metal',
+                availability_label: 'Metal backend available',
               }
             : command === 'get_compute_node_status'
               ? {
@@ -96,6 +102,12 @@ describe('desktop app start failure handling', () => {
                   registered: false,
                   active_relay_url: '',
                   backend_mode: 'auto',
+                  requested_mode: 'auto',
+                  backend_available: 'metal',
+                  effective_mode: 'unknown',
+                  backend_used: 'unknown',
+                  n_gpu_layers: 0,
+                  fallback_reason: null,
                   model_path: '',
                   last_error: null,
                 }
@@ -138,8 +150,8 @@ describe('desktop app start failure handling', () => {
       if (command === 'detect_backend') {
         return Promise.resolve({
           platform_label: 'macos',
-          preferred_mode: 'auto',
-          display_label: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal backend available',
         });
       }
       if (command === 'load_config') {
@@ -155,6 +167,12 @@ describe('desktop app start failure handling', () => {
           registered: false,
           active_relay_url: '',
           backend_mode: 'auto',
+          requested_mode: 'auto',
+          backend_available: 'metal',
+          effective_mode: 'unknown',
+          backend_used: 'unknown',
+          n_gpu_layers: 0,
+          fallback_reason: null,
           model_path: '',
           last_error: null,
         });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -4,12 +4,13 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 type UiState = 'idle' | 'starting' | 'streaming' | 'canceled' | 'completed' | 'failed';
-type BackendMode = 'auto' | 'metal' | 'cuda' | 'cpu';
+type BackendMode = 'auto' | 'cpu' | 'gpu' | 'hybrid';
+type BackendKind = 'cpu' | 'cuda' | 'metal';
 
 interface BackendInfo {
   platform_label: string;
-  preferred_mode: BackendMode;
-  display_label: string;
+  available_backend: BackendKind;
+  availability_label: string;
 }
 
 interface DesktopConfig {
@@ -23,6 +24,12 @@ interface ComputeNodeStatus {
   registered: boolean;
   active_relay_url: string;
   backend_mode: string;
+  requested_mode: string;
+  backend_available: string;
+  effective_mode: string;
+  backend_used: string;
+  n_gpu_layers: number;
+  fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
 }
@@ -50,6 +57,12 @@ const defaultComputeStatus: ComputeNodeStatus = {
   registered: false,
   active_relay_url: '',
   backend_mode: 'auto',
+  requested_mode: 'auto',
+  backend_available: 'unknown',
+  effective_mode: 'unknown',
+  backend_used: 'unknown',
+  n_gpu_layers: 0,
+  fallback_reason: null,
   model_path: '',
   last_error: null,
 };
@@ -162,6 +175,26 @@ export function App() {
             : prev.active_relay_url,
         backend_mode:
           typeof payload.backend_mode === 'string' ? payload.backend_mode : prev.backend_mode,
+        requested_mode:
+          typeof payload.requested_mode === 'string'
+            ? payload.requested_mode
+            : prev.requested_mode,
+        backend_available:
+          typeof payload.backend_available === 'string'
+            ? payload.backend_available
+            : prev.backend_available,
+        effective_mode:
+          typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
+        backend_used:
+          typeof payload.backend_used === 'string' ? payload.backend_used : prev.backend_used,
+        n_gpu_layers:
+          typeof payload.n_gpu_layers === 'number' ? payload.n_gpu_layers : prev.n_gpu_layers,
+        fallback_reason:
+          payload.fallback_reason === null
+            ? null
+            : typeof payload.fallback_reason === 'string'
+              ? payload.fallback_reason
+              : prev.fallback_reason,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         last_error:
           payload.last_error === null
@@ -200,14 +233,7 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running,
     [config.model_path, computeStatus.running]
   );
-  const platformLabel = (backend?.platform_label ?? '').toLowerCase();
-  const backendDisplayLabel = (backend?.display_label ?? '').toLowerCase();
-  const metalSupported = platformLabel.includes('apple') || platformLabel.includes('mac');
-  const cudaSupported =
-    backend?.preferred_mode === 'cuda' ||
-    backendDisplayLabel.includes('cuda') ||
-    platformLabel.includes('nvidia') ||
-    platformLabel.includes('cuda');
+  const gpuCapable = backend?.available_backend === 'cuda' || backend?.available_backend === 'metal';
 
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {
@@ -294,6 +320,12 @@ export function App() {
         registered: false,
         active_relay_url: config.relay_base_url,
         backend_mode: config.preferred_mode,
+        requested_mode: config.preferred_mode,
+        backend_available: backend?.available_backend ?? 'unknown',
+        effective_mode: 'starting',
+        backend_used: 'unknown',
+        n_gpu_layers: 0,
+        fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
       }));
@@ -342,7 +374,7 @@ export function App() {
   return (
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
       <h1>token.place desktop compute node</h1>
-      <p>Detected backend: <strong>{backend?.display_label ?? 'loading...'}</strong></p>
+      <p>Backend availability: <strong>{backend?.availability_label ?? 'loading...'}</strong></p>
       <label>Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
         <input
@@ -384,15 +416,14 @@ export function App() {
         value={config.preferred_mode}
         onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
       >
-        <option value="auto">Auto ({backend?.display_label ?? '...'})</option>
-        <option value="metal" disabled={!metalSupported}>Metal GPU (macOS Apple Silicon)</option>
-        <option value="cuda" disabled={!cudaSupported}>CUDA GPU (Windows/NVIDIA)</option>
-        <option value="cpu">CPU fallback</option>
+        <option value="auto">Auto</option>
+        <option value="cpu">CPU only</option>
+        <option value="gpu" disabled={!gpuCapable}>GPU only</option>
+        <option value="hybrid" disabled={!gpuCapable}>Hybrid (partial offload)</option>
       </select>
       <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
-        Operator note: <code>cuda</code> is for Windows/NVIDIA workstations, <code>metal</code> is
-        for macOS/Apple Silicon, and <code>cpu</code> is fallback. Raspberry Pi remains a later
-        low-power workstation target and is not part of the current sugarkube relay rollout.
+        Request intent is explicit: Auto / CPU only / GPU only / Hybrid. Runtime status below shows
+        requested mode and effective mode so CPU fallback is visible when GPU offload is unavailable.
       </p>
 
       <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
@@ -411,7 +442,13 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend available: <code>{computeStatus.backend_available}</code></p>
+        <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode}</code></p>
+        <p style={{ marginBottom: 0 }}>Backend used: <code>{computeStatus.backend_used}</code></p>
+        <p style={{ marginBottom: 0 }}>n_gpu_layers: <code>{computeStatus.n_gpu_layers}</code></p>
+        <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
+        <p style={{ marginBottom: 0 }}>Bridge mode: <code>{computeStatus.backend_mode || config.preferred_mode}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -219,8 +219,9 @@ def test_compute_node_runtime_format_relay_target_preserves_explicit_url_port():
 
 
 def test_normalize_compute_mode_is_case_insensitive_and_falls_back_to_auto():
-    assert normalize_compute_mode("CUDA") == "cuda"
-    assert normalize_compute_mode("  metal ") == "metal"
+    assert normalize_compute_mode("CUDA") == "gpu"
+    assert normalize_compute_mode("  metal ") == "gpu"
+    assert normalize_compute_mode("hybrid") == "hybrid"
     assert normalize_compute_mode("unknown") == "auto"
     assert normalize_compute_mode("") == "auto"
     assert normalize_compute_mode(None) == "auto"
@@ -234,6 +235,10 @@ def test_apply_compute_mode_sets_expected_gpu_layer_defaults():
 
     assert apply_compute_mode(manager, "auto") == "auto"
     assert manager.default_n_gpu_layers == -1
+    assert apply_compute_mode(manager, "gpu", "cpu") == "gpu"
+    assert manager.default_n_gpu_layers == 0
+    assert apply_compute_mode(manager, "hybrid", "cuda") == "hybrid"
+    assert manager.default_n_gpu_layers == 20
 
 
 def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -186,6 +186,8 @@ def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeyp
     assert event_types[-1] == 'stopped'
     assert any(event.get('registered') is False for event in events if event['type'] == 'status')
     assert any(event.get('registered') is True for event in events if event['type'] == 'status')
+    assert events[0]['requested_mode'] == 'cpu'
+    assert events[0]['n_gpu_layers'] == 0
 
 
 def test_run_reports_model_initialization_failures(capsys, monkeypatch):
@@ -317,11 +319,11 @@ def test_apply_compute_mode_supports_gpu_and_cpu_modes():
     assert apply_compute_mode(manager, 'auto') == 'auto'
     assert manager.default_n_gpu_layers == -1
 
-    assert apply_compute_mode(manager, 'metal') == 'metal'
+    assert apply_compute_mode(manager, 'gpu') == 'gpu'
     assert manager.default_n_gpu_layers == -1
 
-    assert apply_compute_mode(manager, 'cuda') == 'cuda'
-    assert manager.default_n_gpu_layers == -1
+    assert apply_compute_mode(manager, 'hybrid') == 'hybrid'
+    assert manager.default_n_gpu_layers == 20
 
     assert apply_compute_mode(manager, 'cpu') == 'cpu'
     assert manager.default_n_gpu_layers == 0
@@ -391,7 +393,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,
@@ -423,7 +425,7 @@ def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_pat
     (utils_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
-SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "cuda", "metal"}
+SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid"}
 
 
 def normalize_compute_mode(mode):

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -179,7 +179,7 @@ def test_run_falls_back_to_non_streaming_when_stream_is_empty(tmp_path, capsys):
 
 @pytest.mark.parametrize(
     ('mode', 'expected'),
-    [('cpu', 0), ('metal', -1), ('cuda', -1), ('auto', -1)],
+    [('cpu', 0), ('gpu', -1), ('hybrid', 20), ('auto', -1)],
 )
 def test_run_applies_compute_mode_to_manager(tmp_path, capsys, mode, expected):
     _reset_cancel_queue()
@@ -374,7 +374,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = inference_sidecar.main()
     assert status == 0
-    assert captured['mode'] == 'cuda'
+    assert captured['mode'] == 'gpu'
 
     monkeypatch.setattr(
         sys,

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -134,29 +134,86 @@ def format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
     return f"{relay_url}:{relay_port}"
 
 
-SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "metal", "cuda"})
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "gpu", "hybrid", "metal", "cuda"})
+SUPPORTED_BACKEND_HINTS = frozenset({"cpu", "cuda", "metal", "unknown"})
 
 
 def normalize_compute_mode(mode: Optional[str]) -> str:
     """Normalize operator-provided compute mode values."""
 
     selected = (mode or "auto").strip().lower()
+    if selected in {"metal", "cuda"}:
+        return "gpu"
     if selected in SUPPORTED_COMPUTE_MODES:
         return selected
     return "auto"
 
 
-def apply_compute_mode(manager: Any, mode: Optional[str]) -> str:
+def normalize_backend_hint(backend_hint: Optional[str]) -> str:
+    """Normalize host backend hints provided by desktop launchers."""
+
+    selected = (backend_hint or "unknown").strip().lower()
+    if selected in SUPPORTED_BACKEND_HINTS:
+        return selected
+    return "unknown"
+
+
+def _resolve_gpu_layers(mode: str, backend_hint: str) -> tuple[int, str, Optional[str]]:
+    """Resolve n_gpu_layers and effective mode for requested mode + backend hint."""
+
+    if mode == "cpu":
+        return 0, "cpu", None
+    if mode == "hybrid":
+        if backend_hint in {"cuda", "metal"}:
+            return 20, f"{backend_hint}-hybrid", None
+        if backend_hint == "cpu":
+            return 0, "cpu", "hybrid requested but no GPU backend is available on this host"
+        return 20, "hybrid", None
+    if mode == "gpu":
+        if backend_hint in {"cuda", "metal"}:
+            return -1, f"{backend_hint}-gpu", None
+        if backend_hint == "cpu":
+            return 0, "cpu", "gpu requested but no GPU backend is available on this host"
+        return -1, "gpu", None
+
+    # auto
+    if backend_hint in {"cuda", "metal"}:
+        return -1, f"{backend_hint}-gpu(auto)", None
+    if backend_hint == "cpu":
+        return 0, "cpu", "auto selected CPU because this host has no supported GPU backend"
+    return -1, "auto", None
+
+
+def apply_compute_mode(manager: Any, mode: Optional[str], backend_hint: Optional[str] = None) -> str:
     """Apply normalized compute mode to model-manager GPU settings."""
 
     selected = normalize_compute_mode(mode)
-    if selected == "cpu":
-        manager.default_n_gpu_layers = 0
-    else:
-        # ``auto`` follows runtime autodetection and maps to GPU-preferred layers where available.
-        # ``metal`` and ``cuda`` also request GPU-backed inference on supported hosts.
-        manager.default_n_gpu_layers = -1
+    resolved_backend = normalize_backend_hint(backend_hint)
+    n_gpu_layers, effective_mode, fallback_reason = _resolve_gpu_layers(selected, resolved_backend)
+    manager.default_n_gpu_layers = n_gpu_layers
+    manager.requested_compute_mode = selected
+    manager.requested_backend_hint = resolved_backend
+    manager.effective_compute_mode = effective_mode
+    manager.compute_fallback_reason = fallback_reason
     return selected
+
+
+def describe_compute_mode(manager: Any) -> Dict[str, Any]:
+    """Return request/effective compute mode diagnostics for desktop status surfaces."""
+
+    n_gpu_layers = getattr(manager, "last_runtime_n_gpu_layers", manager.default_n_gpu_layers)
+    return {
+        "requested_mode": getattr(manager, "requested_compute_mode", "auto"),
+        "backend_available": getattr(manager, "requested_backend_hint", "unknown"),
+        "effective_mode": getattr(
+            manager,
+            "effective_compute_mode",
+            "cpu" if n_gpu_layers == 0 else "gpu",
+        ),
+        "backend_used": getattr(manager, "effective_backend_used", "cpu" if n_gpu_layers == 0 else "gpu"),
+        "n_gpu_layers": n_gpu_layers,
+        "fallback_reason": getattr(manager, "compute_fallback_reason", None),
+    }
 
 
 class ComputeNodeRuntime:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -60,6 +60,12 @@ class ModelManager:
         self.default_n_gpu_layers = config.get('model.n_gpu_layers', -1)
         self.gpu_headroom_percent = config.get('model.gpu_memory_headroom_percent', 0.1)
         self.enforce_gpu_headroom = config.get('model.enforce_gpu_memory_headroom', True)
+        self.requested_compute_mode = 'auto'
+        self.requested_backend_hint = 'unknown'
+        self.effective_compute_mode = 'auto'
+        self.effective_backend_used = 'unknown'
+        self.compute_fallback_reason = None
+        self.last_runtime_n_gpu_layers = self.default_n_gpu_layers
 
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
         """Return runtime model metadata used by server and desktop bridges."""
@@ -231,9 +237,11 @@ class ModelManager:
                     else:
                         try:
                             # Dynamically import Llama only when needed
+                            import llama_cpp
                             from llama_cpp import Llama
 
                             n_gpu_layers = self.default_n_gpu_layers
+                            fallback_reason = self.compute_fallback_reason
                             if self.enforce_gpu_headroom and n_gpu_layers != 0:
                                 try:
                                     model_size = os.path.getsize(self.model_path)
@@ -249,6 +257,25 @@ class ModelManager:
                                             "to CPU inference for this model."
                                         )
                                         n_gpu_layers = 0
+                                        fallback_reason = (
+                                            "insufficient GPU memory headroom; running on CPU"
+                                        )
+                            if n_gpu_layers != 0:
+                                gpu_support_fn = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
+                                if callable(gpu_support_fn):
+                                    try:
+                                        if not bool(gpu_support_fn()):
+                                            self.log_warning(
+                                                "llama.cpp runtime reports no GPU offload support; "
+                                                "forcing CPU mode."
+                                            )
+                                            n_gpu_layers = 0
+                                            fallback_reason = (
+                                                "llama_cpp build has no GPU offload support; running on CPU"
+                                            )
+                                    except Exception:
+                                        # Capability probing is best-effort only.
+                                        pass
 
                             self.log_info(f"Initializing Llama model from {self.model_path}...")
                             self.llm = Llama(
@@ -257,6 +284,19 @@ class ModelManager:
                                 n_ctx=self.config.get('model.context_size', 8192),
                                 chat_format=self.config.get('model.chat_format', 'llama-3')
                             )
+                            self.last_runtime_n_gpu_layers = n_gpu_layers
+                            if n_gpu_layers == 0:
+                                self.effective_backend_used = 'cpu'
+                                self.effective_compute_mode = 'cpu'
+                            elif n_gpu_layers < 0:
+                                self.effective_backend_used = self.requested_backend_hint
+                                self.effective_compute_mode = f'{self.requested_backend_hint}-gpu'
+                            else:
+                                self.effective_backend_used = self.requested_backend_hint
+                                self.effective_compute_mode = (
+                                    f'{self.requested_backend_hint}-hybrid({n_gpu_layers})'
+                                )
+                            self.compute_fallback_reason = fallback_reason
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)


### PR DESCRIPTION
### Motivation
- The desktop app could claim GPU backends (CUDA/Metal) while the Python runtime still initialized CPU-only inference, which is misleading and unsafe for operator intent. 
- The goal is to wire operator-selected compute intent end-to-end (Rust -> Python -> shared runtime) and map that intent to concrete `llama-cpp-python` behavior (`n_gpu_layers`) rather than only UI labels. 
- Make runtime behavior and diagnostics truthful and platform-aware so unsupported hosts fall back to CPU with an explicit reason.

### Description
- Replace vendor-labelled desktop modes with intent-based modes (`auto`, `cpu`, `gpu`, `hybrid`) and add a `BackendKind`/availability signal so detection reports availability not usage by adding `BackendKind` and renaming display fields in `desktop-tauri/src-tauri/src/backend.rs` and related code. 
- Wire platform backend hints from Tauri into Python sidecars and bridge by passing a `--backend` arg in `compute_node.rs` and `sidecar.rs`, and accept/preserve that in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and `desktop-tauri/src-tauri/python/inference_sidecar.py`. 
- Implement concrete mode -> `llama-cpp-python` mapping in the shared runtime: added `normalize_backend_hint`, `_resolve_gpu_layers`, `apply_compute_mode` (now sets `manager.default_n_gpu_layers` plus diagnostic fields) and `describe_compute_mode` in `utils/compute_node_runtime.py`. 
- Add runtime truthfulness checks in `utils/llm/model_manager.py` to probe `llama_cpp.llama_supports_gpu_offload` (best-effort), preserve existing GPU headroom fallback, and record `effective_compute_mode`, `effective_backend_used`, `last_runtime_n_gpu_layers`, and `compute_fallback_reason` after initialization. 
- Surface requested vs effective state in the desktop UI by extending `App.tsx` to show `requested_mode`, `backend_available`, `effective_mode`, `backend_used`, `n_gpu_layers`, and `fallback_reason`, and update tests and test fixtures to align with the new payload shape. 
- Update and add small unit test expectations to validate normalization, `n_gpu_layers` mapping, and that the bridge emits diagnostic fields so regressions where UI shows GPU but runtime uses CPU are caught.

### Testing
- Ran `npm --prefix desktop-tauri run build` which completed successfully. 
- Ran `npm --prefix desktop-tauri run test -- App.test.tsx` (Vitest) and the mocked UI tests passed (`3` tests passed). 
- Attempted `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_compute_node_runtime.py` but the run failed in this environment due to missing test environment dependencies (`playwright` imported by repo `tests/conftest.py`), and an earlier run showed `requests` was missing then installed; full Python test run could not be completed here. 
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `npm --prefix desktop-tauri run tauri build -- --debug --no-bundle` but both failed in this environment due to missing system `glib-2.0` / `pkg-config` metadata required to build native crates; these are environment prerequisites rather than regressions. 
- `pre-commit run --all-files` was not available in this environment so it was not executed here.

If you want, I can split further minimal PRs (UI-only, runtime-only) or add a small CI job to run the Python unit tests in a container with `playwright` and system `glib` installed so the full test matrix can be validated automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc82426148832f9498cb317a7f19ee)