### PR TITLE
🧹 Reduce desktop llama.cpp log noise by default

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -70,3 +70,19 @@ You can also run the workflow manually with `workflow_dispatch` and provide
 
 
 The local prompt panel still uses `src-tauri/python/inference_sidecar.py` as a smoke test for local model setup.
+
+
+## Desktop logging defaults
+
+Desktop subprocess logs now default to high-signal output:
+
+- Known low-value llama.cpp noise (metadata dumps, control-token spam, per-layer assignment spam, tensor repack spam) is filtered at the Tauri stderr forwarding boundary.
+- Warnings and errors are always preserved in default mode.
+- The inference sidecar emits concise summary lines for model init and inference throughput.
+
+To restore full raw subprocess output (including verbose llama.cpp logs), run desktop with either:
+
+- `TOKEN_PLACE_VERBOSE_LLM_LOGS=1`
+- `TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS=1`
+
+Both flags are opt-in and intended for troubleshooting.

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -78,11 +78,11 @@ Desktop subprocess logs now default to high-signal output:
 
 - Known low-value llama.cpp noise (metadata dumps, control-token spam, per-layer assignment spam, tensor repack spam) is filtered at the Tauri stderr forwarding boundary.
 - Warnings and errors are always preserved in default mode.
-- The inference sidecar emits concise summary lines for model init and inference throughput.
+- The inference sidecar emits concise stderr summary lines for model init and prompt/eval throughput.
 
 To restore full raw subprocess output (including verbose llama.cpp logs), run desktop with either:
 
 - `TOKEN_PLACE_VERBOSE_LLM_LOGS=1`
 - `TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS=1`
 
-Both flags are opt-in and intended for troubleshooting.
+Both flags are equivalent opt-in toggles and intended for troubleshooting.

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -244,14 +244,20 @@ def run(args: argparse.Namespace) -> int:
                 text = fallback_text
 
     inference_elapsed_s = max(time.perf_counter() - inference_started_at, 1e-6)
-    approx_chars_per_second = int(len(text) / inference_elapsed_s) if text else 0
+    prompt_chars_per_second = int(len(args.prompt) / inference_elapsed_s) if args.prompt else 0
+    eval_chars_per_second = int(len(text) / inference_elapsed_s) if text else 0
+    eval_tokens_per_second = round(token_events / inference_elapsed_s, 2) if token_events else 0
     emit_summary(
         "inference",
         prompt_chars=len(args.prompt),
         output_chars=len(text),
         token_events=token_events,
         eval_seconds=f"{inference_elapsed_s:.3f}",
-        approx_chars_per_second=approx_chars_per_second,
+        throughput_summary=(
+            f"prompt_chars_per_s={prompt_chars_per_second};"
+            f"eval_chars_per_s={eval_chars_per_second};"
+            f"eval_tokens_per_s={eval_tokens_per_second}"
+        ),
     )
 
     emit({"type": "done"})

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -9,6 +9,7 @@ import os
 import queue
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Tuple
 
@@ -53,6 +54,13 @@ def emit_error(code: str, message: str) -> int:
     return 1
 
 
+def emit_summary(label: str, **fields: Any) -> None:
+    summary_fields = " ".join(
+        f"{key}={value}" for key, value in fields.items() if value is not None
+    )
+    print(f"desktop.inference.summary {label} {summary_fields}", file=sys.stderr, flush=True)
+
+
 def cancel_requested() -> bool:
     _start_stdin_reader()
     while True:
@@ -92,13 +100,14 @@ def _fallback_normalize_chunk(chunk: Any) -> Dict[str, Any]:
 def _stream_content(
     completion: Iterable[Any],
     normalize_chunk: Callable[[Any], Dict[str, Any]],
-) -> Tuple[str, bool]:
+) -> Tuple[str, bool, int]:
     full_text = []
     emitted = False
+    token_events = 0
     for raw_chunk in completion:
         if cancel_requested():
             emit({"type": "canceled"})
-            return "", True
+            return "", True, token_events
 
         chunk = normalize_chunk(raw_chunk)
         choices = chunk.get("choices") or []
@@ -113,11 +122,12 @@ def _stream_content(
             full_text.append(text)
             emitted = True
             emit({"type": "token", "text": text})
+            token_events += 1
 
         if (choices[0] or {}).get("finish_reason"):
             break
 
-    return "".join(full_text) if emitted else "", False
+    return "".join(full_text) if emitted else "", False, token_events
 
 
 def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
@@ -144,11 +154,25 @@ def run(args: argparse.Namespace) -> int:
     manager.model_path = args.model
     apply_compute_mode(manager, args.mode)
 
+    model_load_started_at = time.perf_counter()
     llm = manager.get_llm_instance()
+    model_load_elapsed_ms = int((time.perf_counter() - model_load_started_at) * 1000)
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
     diagnostics = compute_mode_diagnostics(manager)
+    model_name = Path(args.model).name
+    emit_summary(
+        "model_init",
+        model=model_name,
+        model_path=args.model,
+        backend=diagnostics.get("backend_used"),
+        device=diagnostics.get("effective_mode"),
+        context_size=manager.config.get("model.context_size", 8192),
+        offloaded_layers=diagnostics.get("n_gpu_layers"),
+        load_time_ms=model_load_elapsed_ms,
+        fallback_reason=diagnostics.get("fallback_reason"),
+    )
     emit(
         {
             "type": "started",
@@ -171,6 +195,7 @@ def run(args: argparse.Namespace) -> int:
         "top_p": manager.config.get("model.top_p", 0.9),
         "stop": manager.config.get("model.stop_tokens", []),
     }
+    inference_started_at = time.perf_counter()
     try:
         completion = llm.create_chat_completion(
             **request_kwargs,
@@ -181,12 +206,15 @@ def run(args: argparse.Namespace) -> int:
 
     normalize_chunk = getattr(ModelManager, "_normalize_stream_chunk", _fallback_normalize_chunk)
 
+    token_events = 0
+    text = ""
     if isinstance(completion, dict):
         text = _extract_text_from_completion(completion)
         if text:
             emit({"type": "token", "text": text})
+            token_events += 1
     else:
-        text, canceled = _stream_content(completion, normalize_chunk)
+        text, canceled, token_events = _stream_content(completion, normalize_chunk)
         if canceled:
             return 0
 
@@ -202,6 +230,19 @@ def run(args: argparse.Namespace) -> int:
             fallback_text = _extract_text_from_completion(fallback)
             if fallback_text:
                 emit({"type": "token", "text": fallback_text})
+                token_events = max(token_events, 1)
+                text = fallback_text
+
+    inference_elapsed_s = max(time.perf_counter() - inference_started_at, 1e-6)
+    approx_chars_per_second = int(len(text) / inference_elapsed_s) if text else 0
+    emit_summary(
+        "inference",
+        prompt_chars=len(args.prompt),
+        output_chars=len(text),
+        token_events=token_events,
+        eval_seconds=f"{inference_elapsed_s:.3f}",
+        approx_chars_per_second=approx_chars_per_second,
+    )
 
     emit({"type": "done"})
     return 0

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -109,14 +109,17 @@ def _fallback_normalize_chunk(chunk: Any) -> Dict[str, Any]:
 def _stream_content(
     completion: Iterable[Any],
     normalize_chunk: Callable[[Any], Dict[str, Any]],
-) -> Tuple[str, bool, int]:
+    token_counter: list[int] | None = None,
+) -> Tuple[str, bool]:
     full_text = []
     emitted = False
     token_events = 0
     for raw_chunk in completion:
         if cancel_requested():
             emit({"type": "canceled"})
-            return "", True, token_events
+            if token_counter is not None:
+                token_counter.append(token_events)
+            return "", True
 
         chunk = normalize_chunk(raw_chunk)
         choices = chunk.get("choices") or []
@@ -136,7 +139,9 @@ def _stream_content(
         if (choices[0] or {}).get("finish_reason"):
             break
 
-    return "".join(full_text) if emitted else "", False, token_events
+    if token_counter is not None:
+        token_counter.append(token_events)
+    return "".join(full_text) if emitted else "", False
 
 
 def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
@@ -224,7 +229,9 @@ def run(args: argparse.Namespace) -> int:
             emit({"type": "token", "text": text})
             token_events += 1
     else:
-        text, canceled, token_events = _stream_content(completion, normalize_chunk)
+        token_counts: list[int] = []
+        text, canceled = _stream_content(completion, normalize_chunk, token_counts)
+        token_events = token_counts[0] if token_counts else 0
         if canceled:
             return 0
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -55,10 +55,19 @@ def emit_error(code: str, message: str) -> int:
 
 
 def emit_summary(label: str, **fields: Any) -> None:
-    summary_fields = " ".join(
-        f"{key}={value}" for key, value in fields.items() if value is not None
+    summary_payload = {"label": label}
+    summary_payload.update({key: value for key, value in fields.items() if value is not None})
+    print(
+        f"desktop.inference.summary {json.dumps(summary_payload, separators=(',', ':'))}",
+        file=sys.stderr,
+        flush=True,
     )
-    print(f"desktop.inference.summary {label} {summary_fields}", file=sys.stderr, flush=True)
+
+
+def verbose_subprocess_logging_enabled() -> bool:
+    return os.getenv("TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS") == "1" or os.getenv(
+        "TOKEN_PLACE_VERBOSE_LLM_LOGS"
+    ) == "1"
 
 
 def cancel_requested() -> bool:
@@ -162,10 +171,11 @@ def run(args: argparse.Namespace) -> int:
 
     diagnostics = compute_mode_diagnostics(manager)
     model_name = Path(args.model).name
+    model_path_for_summary = args.model if verbose_subprocess_logging_enabled() else model_name
     emit_summary(
         "model_init",
         model=model_name,
-        model_path=args.model,
+        model_path=model_path_for_summary,
         backend=diagnostics.get("backend_used"),
         device=diagnostics.get("effective_mode"),
         context_size=manager.config.get("model.context_size", 8192),

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,6 @@
 use crate::backend::ComputeMode;
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -210,11 +211,16 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
 
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
+    policy: SubprocessLogPolicy,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
+    let mut filter = SubprocessLogFilter::new("compute_node", policy);
     while let Some(line) = lines.next_line().await? {
-        eprintln!("desktop.compute_node.stderr line={line}");
+        if filter.should_emit(&line) {
+            eprintln!("desktop.compute_node.stderr line={line}");
+        }
     }
+    filter.flush_summary();
     Ok(())
 }
 
@@ -340,8 +346,9 @@ pub async fn start_compute_node(
         };
     }
 
+    let log_policy = SubprocessLogPolicy::from_env();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_compute_node_stderr(stderr).await {
+        if let Err(err) = drain_compute_node_stderr(stderr, log_policy).await {
             eprintln!("desktop.compute_node.stderr_error error={err}");
         }
     });
@@ -509,7 +516,7 @@ mod tests {
             .expect("spawn stderr script");
 
         let stderr = child.stderr.take().expect("stderr");
-        drain_compute_node_stderr(stderr)
+        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true })
             .await
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -220,7 +220,6 @@ async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
             eprintln!("desktop.compute_node.stderr line={line}");
         }
     }
-    filter.flush_summary();
     Ok(())
 }
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod keygen;
 mod logging;
 mod python_runtime;
 mod sidecar;
+mod subprocess_logging;
 
 use backend::{detect_backend_for, BackendInfo};
 use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -71,13 +71,12 @@ async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     policy: SubprocessLogPolicy,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
-    let mut filter = SubprocessLogFilter::new("sidecar", policy);
+    let mut filter = SubprocessLogFilter::new("sidecar", policy).with_request_id(request_id);
     while let Some(line) = lines.next_line().await? {
         if filter.should_emit(&line) {
             eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
         }
     }
-    filter.flush_summary();
     Ok(())
 }
 

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,5 +1,6 @@
 use crate::backend::ComputeMode;
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -67,11 +68,16 @@ pub async fn collect_events_from_stdout<R: tokio::io::AsyncRead + Unpin>(
 async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     request_id: &str,
+    policy: SubprocessLogPolicy,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
+    let mut filter = SubprocessLogFilter::new("sidecar", policy);
     while let Some(line) = lines.next_line().await? {
-        eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
+        if filter.should_emit(&line) {
+            eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
+        }
     }
+    filter.flush_summary();
     Ok(())
 }
 
@@ -280,8 +286,9 @@ pub async fn start_sidecar(
 
     let request_id = request.request_id;
     let stderr_request_id = request_id.clone();
+    let log_policy = SubprocessLogPolicy::from_env();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_sidecar_stderr(stderr, &stderr_request_id).await {
+        if let Err(err) = drain_sidecar_stderr(stderr, &stderr_request_id, log_policy).await {
             eprintln!(
                 "desktop.sidecar.stderr_error request_id={} error={}",
                 stderr_request_id, err
@@ -470,7 +477,7 @@ mod tests {
             .expect("spawn stderr script");
 
         let stderr = child.stderr.take().expect("stderr");
-        drain_sidecar_stderr(stderr, "test")
+        drain_sidecar_stderr(stderr, "test", SubprocessLogPolicy { verbose_raw: true })
             .await
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");

--- a/desktop-tauri/src-tauri/src/subprocess_logging.rs
+++ b/desktop-tauri/src-tauri/src/subprocess_logging.rs
@@ -1,0 +1,140 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy)]
+pub struct SubprocessLogPolicy {
+    pub verbose_raw: bool,
+}
+
+impl SubprocessLogPolicy {
+    pub fn from_env() -> Self {
+        Self {
+            verbose_raw: matches!(
+                std::env::var("TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS").as_deref(),
+                Ok("1")
+            ) || matches!(
+                std::env::var("TOKEN_PLACE_VERBOSE_LLM_LOGS").as_deref(),
+                Ok("1")
+            ),
+        }
+    }
+}
+
+pub struct SubprocessLogFilter {
+    source: &'static str,
+    policy: SubprocessLogPolicy,
+    suppressed_counts: BTreeMap<&'static str, usize>,
+    suppressed_total: usize,
+}
+
+impl SubprocessLogFilter {
+    pub fn new(source: &'static str, policy: SubprocessLogPolicy) -> Self {
+        Self {
+            source,
+            policy,
+            suppressed_counts: BTreeMap::new(),
+            suppressed_total: 0,
+        }
+    }
+
+    pub fn should_emit(&mut self, line: &str) -> bool {
+        if self.policy.verbose_raw {
+            return true;
+        }
+
+        if looks_actionable(line) {
+            return true;
+        }
+
+        if let Some(pattern) = noisy_pattern(line) {
+            self.suppressed_total += 1;
+            *self.suppressed_counts.entry(pattern).or_default() += 1;
+            return false;
+        }
+
+        true
+    }
+
+    pub fn flush_summary(&self) {
+        if self.suppressed_total == 0 {
+            return;
+        }
+        let breakdown = self
+            .suppressed_counts
+            .iter()
+            .map(|(pattern, count)| format!("{pattern}:{count}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        eprintln!(
+            "desktop.subprocess.stderr_summary source={} suppressed_total={} patterns={}",
+            self.source, self.suppressed_total, breakdown
+        );
+    }
+}
+
+fn looks_actionable(line: &str) -> bool {
+    let normalized = line.to_ascii_lowercase();
+    [
+        "error",
+        "warning",
+        "warn",
+        "traceback",
+        "exception",
+        "failed",
+        "failure",
+        "fallback",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn noisy_pattern(line: &str) -> Option<&'static str> {
+    if line.contains("llama_model_loader: Dumping metadata keys/values") {
+        return Some("metadata_dump");
+    }
+    if line.contains("is not marked as EOG") {
+        return Some("control_tokens");
+    }
+    if line.contains("load_tensors: layer") {
+        return Some("layer_assignment");
+    }
+    if line.contains("repack:") {
+        return Some("tensor_repack");
+    }
+    if line.contains("llama_model_loader:")
+        && (line.contains("- kv") || line.contains("- type") || line.contains("- name"))
+    {
+        return Some("metadata_kv");
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suppresses_known_noisy_patterns_in_default_mode() {
+        let policy = SubprocessLogPolicy { verbose_raw: false };
+        let mut filter = SubprocessLogFilter::new("test", policy);
+        assert!(!filter.should_emit("llama_model_loader: Dumping metadata keys/values"));
+        assert!(!filter.should_emit("token '</s>' is not marked as EOG"));
+        assert!(!filter.should_emit("load_tensors: layer 1 assigned to CPU"));
+        assert!(!filter.should_emit("repack: f16 -> q8_0"));
+        assert_eq!(filter.suppressed_total, 4);
+    }
+
+    #[test]
+    fn keeps_actionable_lines_even_if_noisy_substrings_exist() {
+        let policy = SubprocessLogPolicy { verbose_raw: false };
+        let mut filter = SubprocessLogFilter::new("test", policy);
+        assert!(filter.should_emit("WARNING llama_model_loader: Dumping metadata keys/values"));
+        assert!(filter.should_emit("fallback reason: gpu init failed"));
+    }
+
+    #[test]
+    fn allows_all_lines_when_verbose_is_enabled() {
+        let policy = SubprocessLogPolicy { verbose_raw: true };
+        let mut filter = SubprocessLogFilter::new("test", policy);
+        assert!(filter.should_emit("llama_model_loader: Dumping metadata keys/values"));
+    }
+}

--- a/desktop-tauri/src-tauri/src/subprocess_logging.rs
+++ b/desktop-tauri/src-tauri/src/subprocess_logging.rs
@@ -123,6 +123,27 @@ fn noisy_pattern(line: &str) -> Option<&'static str> {
     {
         return Some("metadata_kv");
     }
+    if line.contains("llama_context:") {
+        return Some("llama_context_init");
+    }
+    if line.contains("llama_kv_cache_unified:") {
+        return Some("kv_cache_init");
+    }
+    if line.contains("graph_reserve:") {
+        return Some("graph_reserve");
+    }
+    if line.contains("backend_ptrs.size") {
+        return Some("backend_enumeration");
+    }
+    if line.contains("CPU compute buffer size")
+        || line.contains("output buffer size")
+        || line.contains("KV buffer size")
+    {
+        return Some("buffer_sizes");
+    }
+    if line.contains("special tokens cache size") || line.contains("token to piece cache size") {
+        return Some("token_cache_sizes");
+    }
     None
 }
 
@@ -138,7 +159,16 @@ mod tests {
         assert!(!filter.should_emit("token '</s>' is not marked as EOG"));
         assert!(!filter.should_emit("load_tensors: layer 1 assigned to CPU"));
         assert!(!filter.should_emit("repack: f16 -> q8_0"));
-        assert_eq!(filter.suppressed_total, 4);
+        assert!(!filter.should_emit("llama_context: n_ctx = 8192"));
+        assert!(!filter.should_emit("llama_kv_cache_unified: creating unified KV cache"));
+        assert!(!filter.should_emit("graph_reserve: reserving graph for decoder"));
+        assert!(!filter.should_emit("backend_ptrs.size() = 2"));
+        assert!(!filter.should_emit("CPU compute buffer size = 1024.00 MiB"));
+        assert!(!filter.should_emit("output buffer size = 16.00 MiB"));
+        assert!(!filter.should_emit("KV buffer size = 512.00 MiB"));
+        assert!(!filter.should_emit("special tokens cache size = 256"));
+        assert!(!filter.should_emit("token to piece cache size = 32000"));
+        assert_eq!(filter.suppressed_total, 13);
     }
 
     #[test]
@@ -147,6 +177,8 @@ mod tests {
         let mut filter = SubprocessLogFilter::new("test", policy);
         assert!(filter.should_emit("WARNING llama_model_loader: Dumping metadata keys/values"));
         assert!(filter.should_emit("fallback reason: gpu init failed"));
+        assert!(filter.should_emit("error: llama_context: failed to initialize"));
+        assert!(filter.should_emit("warning: KV buffer size estimate may be inaccurate"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/subprocess_logging.rs
+++ b/desktop-tauri/src-tauri/src/subprocess_logging.rs
@@ -21,6 +21,7 @@ impl SubprocessLogPolicy {
 
 pub struct SubprocessLogFilter {
     source: &'static str,
+    request_id: Option<String>,
     policy: SubprocessLogPolicy,
     suppressed_counts: BTreeMap<&'static str, usize>,
     suppressed_total: usize,
@@ -30,10 +31,16 @@ impl SubprocessLogFilter {
     pub fn new(source: &'static str, policy: SubprocessLogPolicy) -> Self {
         Self {
             source,
+            request_id: None,
             policy,
             suppressed_counts: BTreeMap::new(),
             suppressed_total: 0,
         }
+    }
+
+    pub fn with_request_id(mut self, request_id: impl Into<String>) -> Self {
+        self.request_id = Some(request_id.into());
+        self
     }
 
     pub fn should_emit(&mut self, line: &str) -> bool {
@@ -41,11 +48,10 @@ impl SubprocessLogFilter {
             return true;
         }
 
-        if looks_actionable(line) {
-            return true;
-        }
-
         if let Some(pattern) = noisy_pattern(line) {
+            if looks_actionable(line) {
+                return true;
+            }
             self.suppressed_total += 1;
             *self.suppressed_counts.entry(pattern).or_default() += 1;
             return false;
@@ -64,10 +70,22 @@ impl SubprocessLogFilter {
             .map(|(pattern, count)| format!("{pattern}:{count}"))
             .collect::<Vec<_>>()
             .join(",");
-        eprintln!(
-            "desktop.subprocess.stderr_summary source={} suppressed_total={} patterns={}",
-            self.source, self.suppressed_total, breakdown
-        );
+        match &self.request_id {
+            Some(request_id) => eprintln!(
+                "desktop.subprocess.stderr_summary source={} request_id={} suppressed_total={} patterns={}",
+                self.source, request_id, self.suppressed_total, breakdown
+            ),
+            None => eprintln!(
+                "desktop.subprocess.stderr_summary source={} suppressed_total={} patterns={}",
+                self.source, self.suppressed_total, breakdown
+            ),
+        }
+    }
+}
+
+impl Drop for SubprocessLogFilter {
+    fn drop(&mut self) {
+        self.flush_summary();
     }
 }
 

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -435,6 +435,42 @@ def test_stream_content_ignores_invalid_chunks_and_stops_on_finish_reason(capsys
     assert events == [{'type': 'token', 'text': 'ok'}]
 
 
+def test_stream_content_records_token_count_when_requested(capsys):
+    inference_sidecar._stdin_lines = queue.Queue()
+    inference_sidecar._stdin_reader_started = True
+
+    chunks = iter(
+        [
+            {'choices': [{'delta': {'content': 'one'}, 'finish_reason': None}]},
+            {'choices': [{'delta': {'content': ' two'}, 'finish_reason': 'stop'}]},
+        ]
+    )
+    token_counts = []
+    text, canceled = inference_sidecar._stream_content(chunks, lambda chunk: chunk, token_counts)
+
+    assert canceled is False
+    assert text == 'one two'
+    assert token_counts == [2]
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events == [{'type': 'token', 'text': 'one'}, {'type': 'token', 'text': ' two'}]
+
+
+def test_stream_content_records_token_count_on_cancel(capsys):
+    inference_sidecar._stdin_lines = queue.Queue()
+    inference_sidecar._stdin_reader_started = True
+    inference_sidecar._stdin_lines.put('{"type":"cancel"}')
+
+    chunks = iter([{'choices': [{'delta': {'content': 'ignored'}, 'finish_reason': None}]}])
+    token_counts = []
+    text, canceled = inference_sidecar._stream_content(chunks, lambda chunk: chunk, token_counts)
+
+    assert canceled is True
+    assert text == ''
+    assert token_counts == [0]
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events == [{'type': 'canceled'}]
+
+
 def test_run_done_without_token_when_stream_and_fallback_are_empty(tmp_path, capsys):
     class EmptyLlm:
         def create_chat_completion(self, **kwargs):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -17,6 +17,16 @@ from utils.system import resource_monitor
 # Configure logging
 logger = logging.getLogger('model_manager')
 
+
+def llama_cpp_verbose_logging_enabled() -> bool:
+    """Return whether raw llama.cpp verbose logging should be enabled."""
+
+    return (
+        os.getenv('TOKEN_PLACE_VERBOSE_LLM_LOGS') == '1'
+        or os.getenv('TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS') == '1'
+    )
+
+
 class ModelManager:
     """
     Manages LLM model downloading, initialization, and inference.
@@ -402,7 +412,8 @@ class ModelManager:
                                 model_path=self.model_path,
                                 n_gpu_layers=n_gpu_layers,
                                 n_ctx=self.config.get('model.context_size', 8192),
-                                chat_format=self.config.get('model.chat_format', 'llama-3')
+                                chat_format=self.config.get('model.chat_format', 'llama-3'),
+                                verbose=llama_cpp_verbose_logging_enabled(),
                             )
                             compute_plan['n_gpu_layers'] = n_gpu_layers
                             self.last_compute_diagnostics = compute_plan


### PR DESCRIPTION
### Motivation

- Desktop Tauri was forwarding raw subprocess stderr (sidecar / compute-node bridge) line-by-line, which exposed high-volume, low-signal llama.cpp chatter (metadata dumps, control-token lines, per-layer assignment, tensor repacks) and hid actionable status and warnings.
- The goal is to make the default desktop console useful to operators by collapsing/suppressing known noise while preserving warnings/errors and providing an opt-in way to restore raw output for debugging.

### Description

- Add a small shared Rust filter module `desktop-tauri/src-tauri/src/subprocess_logging.rs` that implements `SubprocessLogPolicy` (env-driven verbose toggle) and `SubprocessLogFilter` (allowlist/actionable detection + denylist of known noisy patterns and suppression counters), plus tests for the filter.
- Wire the filter into Tauri subprocess drains by updating `sidecar.rs` and `compute_node.rs` to call the filter when reading child `stderr`, and emit a compact suppression summary line when filtering occurs; register the new module in `main.rs`.
- Emit concise, operator-focused summary lines from the Python inference sidecar (`desktop-tauri/src-tauri/python/inference_sidecar.py`) for `model_init` and `inference` (model name/path, backend/device/context/offloaded layers/load time, token/event counts, elapsed time, throughput) while preserving the existing NDJSON stdout event stream.
- Add an opt-in verbose toggle via environment variables `TOKEN_PLACE_VERBOSE_LLM_LOGS=1` and alias `TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS=1`, and thread that into `utils/llm/model_manager.py` so `Llama(..., verbose=...)` is enabled when requested; update `desktop-tauri/README.md` to document default vs verbose behavior.

### Testing

- Python syntax checks: `python -m py_compile desktop-tauri/src-tauri/python/inference_sidecar.py utils/llm/model_manager.py` completed successfully.
- Rust unit tests: targeted `cargo test` runs were attempted for the modified Rust tests, but `cargo test` failed in this environment due to missing host system dependency (`glib-2.0`), so Rust tests were not executed to completion here.
- Tooling hooks: `pre-commit run --all-files` could not be executed because `pre-commit` is not installed in this environment, and the repository's `./scripts/scan-secrets.py` was not available for the secret-scan step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf7f9d464832fa3fa7618c5318479)