### PR TITLE
Improve desktop Tauri log signal with default stderr filtering

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -29,6 +29,11 @@ and fast local testing:
 - Set `TOKEN_PLACE_SIDECAR=/full/path/to/script.py` to explicitly override the
   sidecar command path (this takes precedence over
   `TOKEN_PLACE_USE_FAKE_SIDECAR`).
+- Desktop subprocess logging is concise by default: noisy llama.cpp startup lines
+  are filtered while warnings/errors are retained, and startup/inference summary
+  lines are emitted for operators.
+- Set `TOKEN_PLACE_DESKTOP_VERBOSE_LOGS=1` to disable filtering and restore raw
+  llama.cpp stderr output for troubleshooting.
 
 ## Run locally
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import queue
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Tuple
 
@@ -51,6 +53,29 @@ def emit(payload: Dict[str, Any]) -> None:
 def emit_error(code: str, message: str) -> int:
     emit({"type": "error", "code": code, "message": message})
     return 1
+
+
+def _desktop_verbose_logs_enabled() -> bool:
+    return os.getenv("TOKEN_PLACE_DESKTOP_VERBOSE_LOGS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _configure_desktop_logging() -> None:
+    if _desktop_verbose_logs_enabled():
+        return
+    logging.getLogger().setLevel(logging.WARNING)
+    logging.getLogger("model_manager").setLevel(logging.WARNING)
+
+
+def _estimate_token_count(text: str) -> int:
+    stripped = (text or "").strip()
+    if not stripped:
+        return 0
+    return len(stripped.split())
 
 
 def cancel_requested() -> bool:
@@ -128,6 +153,7 @@ def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
 
 
 def run(args: argparse.Namespace) -> int:
+    _configure_desktop_logging()
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
 
@@ -144,18 +170,26 @@ def run(args: argparse.Namespace) -> int:
     manager.model_path = args.model
     apply_compute_mode(manager, args.mode)
 
+    init_start = time.perf_counter()
     llm = manager.get_llm_instance()
+    init_elapsed_ms = int((time.perf_counter() - init_start) * 1000)
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
     diagnostics = compute_mode_diagnostics(manager)
+    model_name = Path(args.model).name
+    context_size = manager.config.get("model.context_size", 8192)
     emit(
         {
             "type": "started",
+            "model_path": args.model,
+            "model_name": model_name,
             "requested_mode": diagnostics.get("requested_mode"),
             "effective_mode": diagnostics.get("effective_mode"),
             "backend_used": diagnostics.get("backend_used"),
             "n_gpu_layers": diagnostics.get("n_gpu_layers"),
+            "context_size": context_size,
+            "load_ms": init_elapsed_ms,
             "fallback_reason": diagnostics.get("fallback_reason"),
         }
     )
@@ -171,6 +205,8 @@ def run(args: argparse.Namespace) -> int:
         "top_p": manager.config.get("model.top_p", 0.9),
         "stop": manager.config.get("model.stop_tokens", []),
     }
+    inference_start = time.perf_counter()
+    generated_text = ""
     try:
         completion = llm.create_chat_completion(
             **request_kwargs,
@@ -183,10 +219,12 @@ def run(args: argparse.Namespace) -> int:
 
     if isinstance(completion, dict):
         text = _extract_text_from_completion(completion)
+        generated_text = text
         if text:
             emit({"type": "token", "text": text})
     else:
         text, canceled = _stream_content(completion, normalize_chunk)
+        generated_text = text
         if canceled:
             return 0
 
@@ -200,10 +238,25 @@ def run(args: argparse.Namespace) -> int:
                 return emit_error("inference_failed", f"non-streaming completion failed: {exc}")
 
             fallback_text = _extract_text_from_completion(fallback)
+            generated_text = fallback_text
             if fallback_text:
                 emit({"type": "token", "text": fallback_text})
 
-    emit({"type": "done"})
+    inference_elapsed = max(time.perf_counter() - inference_start, 0.000001)
+    prompt_tokens_estimate = _estimate_token_count(args.prompt)
+    eval_tokens_estimate = _estimate_token_count(generated_text)
+    emit(
+        {
+            "type": "done",
+            "prompt_chars": len(args.prompt),
+            "output_chars": len(generated_text),
+            "prompt_tokens_estimate": prompt_tokens_estimate,
+            "eval_tokens_estimate": eval_tokens_estimate,
+            "prompt_tokens_per_second": round(prompt_tokens_estimate / inference_elapsed, 2),
+            "eval_tokens_per_second": round(eval_tokens_estimate / inference_elapsed, 2),
+            "inference_ms": int(inference_elapsed * 1000),
+        }
+    )
     return 0
 
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,6 @@
 use crate::backend::ComputeMode;
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::subprocess_log::{verbose_stderr_enabled, StderrDecision, StderrFilter};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
@@ -211,9 +212,23 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
 ) -> anyhow::Result<()> {
+    if verbose_stderr_enabled() {
+        let mut lines = BufReader::new(reader).lines();
+        while let Some(line) = lines.next_line().await? {
+            eprintln!("desktop.compute_node.stderr line={line}");
+        }
+        return Ok(());
+    }
+
+    let mut filter = StderrFilter::new("compute_node", "component=bridge");
     let mut lines = BufReader::new(reader).lines();
     while let Some(line) = lines.next_line().await? {
-        eprintln!("desktop.compute_node.stderr line={line}");
+        if let StderrDecision::Emit(message) = filter.classify(&line) {
+            eprintln!("{message}");
+        }
+    }
+    if let Some(summary) = filter.flush_summary() {
+        eprintln!("{summary}");
     }
     Ok(())
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod keygen;
 mod logging;
 mod python_runtime;
 mod sidecar;
+mod subprocess_log;
 
 use backend::{detect_backend_for, BackendInfo};
 use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,5 +1,6 @@
 use crate::backend::ComputeMode;
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::subprocess_log::{verbose_stderr_enabled, StderrDecision, StderrFilter};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
@@ -22,11 +23,45 @@ pub struct InferenceRequest {
 #[serde(tag = "type")]
 pub enum SidecarEvent {
     #[serde(rename = "started")]
-    Started,
+    Started {
+        #[serde(default)]
+        model_path: Option<String>,
+        #[serde(default)]
+        model_name: Option<String>,
+        #[serde(default)]
+        requested_mode: Option<String>,
+        #[serde(default)]
+        effective_mode: Option<String>,
+        #[serde(default)]
+        backend_used: Option<String>,
+        #[serde(default)]
+        n_gpu_layers: Option<i64>,
+        #[serde(default)]
+        context_size: Option<i64>,
+        #[serde(default)]
+        fallback_reason: Option<String>,
+        #[serde(default)]
+        load_ms: Option<u64>,
+    },
     #[serde(rename = "token")]
     Token { text: String },
     #[serde(rename = "done")]
-    Done,
+    Done {
+        #[serde(default)]
+        output_chars: Option<usize>,
+        #[serde(default)]
+        prompt_chars: Option<usize>,
+        #[serde(default)]
+        eval_tokens_estimate: Option<usize>,
+        #[serde(default)]
+        prompt_tokens_estimate: Option<usize>,
+        #[serde(default)]
+        eval_tokens_per_second: Option<f64>,
+        #[serde(default)]
+        prompt_tokens_per_second: Option<f64>,
+        #[serde(default)]
+        inference_ms: Option<u64>,
+    },
     #[serde(rename = "canceled")]
     Canceled,
     #[serde(rename = "error")]
@@ -68,9 +103,23 @@ async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     request_id: &str,
 ) -> anyhow::Result<()> {
+    if verbose_stderr_enabled() {
+        let mut lines = BufReader::new(reader).lines();
+        while let Some(line) = lines.next_line().await? {
+            eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
+        }
+        return Ok(());
+    }
+
+    let mut filter = StderrFilter::new("sidecar", format!("request_id={request_id}"));
     let mut lines = BufReader::new(reader).lines();
     while let Some(line) = lines.next_line().await? {
-        eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
+        if let StderrDecision::Emit(message) = filter.classify(&line) {
+            eprintln!("{message}");
+        }
+    }
+    if let Some(summary) = filter.flush_summary() {
+        eprintln!("{summary}");
     }
     Ok(())
 }
@@ -297,6 +346,59 @@ pub async fn start_sidecar(
                 if matches!(event, SidecarEvent::Error { .. }) {
                     saw_error_event = true;
                 }
+                match &event {
+                    SidecarEvent::Started {
+                        model_path,
+                        model_name,
+                        requested_mode,
+                        effective_mode,
+                        backend_used,
+                        n_gpu_layers,
+                        context_size,
+                        fallback_reason,
+                        load_ms,
+                    } => {
+                        let fallback = fallback_reason.as_deref().unwrap_or("none");
+                        eprintln!(
+                            "desktop.sidecar.summary request_id={} model_name={} model_path={} requested_mode={} effective_mode={} backend={} n_gpu_layers={} context_size={} load_ms={} fallback_reason={}",
+                            request_id,
+                            model_name.as_deref().unwrap_or("unknown"),
+                            model_path.as_deref().unwrap_or("unknown"),
+                            requested_mode.as_deref().unwrap_or("unknown"),
+                            effective_mode.as_deref().unwrap_or("unknown"),
+                            backend_used.as_deref().unwrap_or("unknown"),
+                            n_gpu_layers.map_or("unknown".into(), |value| value.to_string()),
+                            context_size.map_or("unknown".into(), |value| value.to_string()),
+                            load_ms.map_or("unknown".into(), |value| value.to_string()),
+                            fallback,
+                        );
+                    }
+                    SidecarEvent::Done {
+                        output_chars,
+                        prompt_chars,
+                        eval_tokens_estimate,
+                        prompt_tokens_estimate,
+                        eval_tokens_per_second,
+                        prompt_tokens_per_second,
+                        inference_ms,
+                    } => {
+                        let fmt = |value: Option<f64>| -> String {
+                            value.map_or_else(|| "unknown".into(), |v| format!("{v:.2}"))
+                        };
+                        eprintln!(
+                            "desktop.sidecar.summary request_id={} prompt_chars={} output_chars={} prompt_tokens_est={} eval_tokens_est={} prompt_tps={} eval_tps={} inference_ms={}",
+                            request_id,
+                            prompt_chars.map_or("unknown".into(), |value| value.to_string()),
+                            output_chars.map_or("unknown".into(), |value| value.to_string()),
+                            prompt_tokens_estimate.map_or("unknown".into(), |value| value.to_string()),
+                            eval_tokens_estimate.map_or("unknown".into(), |value| value.to_string()),
+                            fmt(*prompt_tokens_per_second),
+                            fmt(*eval_tokens_per_second),
+                            inference_ms.map_or("unknown".into(), |value| value.to_string()),
+                        );
+                    }
+                    _ => {}
+                }
                 app.emit(
                     "inference_event",
                     UiInferenceEvent {
@@ -418,8 +520,12 @@ mod tests {
         let events = collect_events_from_stdout(stdout)
             .await
             .expect("collect events");
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Started { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Done { .. })));
     }
 
     #[tokio::test]
@@ -447,11 +553,15 @@ mod tests {
         let events = collect_events_from_stdout(stdout)
             .await
             .expect("collect events");
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Started { .. })));
         assert!(events
             .iter()
             .any(|e| matches!(e, SidecarEvent::Token { .. })));
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Done { .. })));
     }
 
     #[tokio::test]
@@ -487,9 +597,27 @@ mod tests {
         assert_eq!(
             events,
             vec![
-                SidecarEvent::Started,
+                SidecarEvent::Started {
+                    model_path: None,
+                    model_name: None,
+                    requested_mode: None,
+                    effective_mode: None,
+                    backend_used: None,
+                    n_gpu_layers: None,
+                    context_size: None,
+                    fallback_reason: None,
+                    load_ms: None,
+                },
                 SidecarEvent::Token { text: "ok".into() },
-                SidecarEvent::Done
+                SidecarEvent::Done {
+                    output_chars: None,
+                    prompt_chars: None,
+                    eval_tokens_estimate: None,
+                    prompt_tokens_estimate: None,
+                    eval_tokens_per_second: None,
+                    prompt_tokens_per_second: None,
+                    inference_ms: None,
+                }
             ]
         );
     }

--- a/desktop-tauri/src-tauri/src/subprocess_log.rs
+++ b/desktop-tauri/src-tauri/src/subprocess_log.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub enum StderrDecision {
+    Emit(String),
+    Suppressed,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct StderrFilter {
+    label: &'static str,
+    context: String,
+    suppressed_total: usize,
+    suppressed_by_pattern: BTreeMap<&'static str, usize>,
+}
+
+impl StderrFilter {
+    pub fn new(label: &'static str, context: impl Into<String>) -> Self {
+        Self {
+            label,
+            context: context.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn classify(&mut self, line: &str) -> StderrDecision {
+        if is_high_priority(line) {
+            return StderrDecision::Emit(format!(
+                "desktop.{}.stderr.important {} line={}",
+                self.label, self.context, line
+            ));
+        }
+
+        if let Some(pattern_name) = noisy_pattern_name(line) {
+            self.suppressed_total += 1;
+            *self.suppressed_by_pattern.entry(pattern_name).or_insert(0) += 1;
+            return StderrDecision::Suppressed;
+        }
+
+        if is_useful_summary_line(line) {
+            return StderrDecision::Emit(format!(
+                "desktop.{}.stderr {} line={}",
+                self.label, self.context, line
+            ));
+        }
+
+        self.suppressed_total += 1;
+        *self
+            .suppressed_by_pattern
+            .entry("other_low_level")
+            .or_insert(0) += 1;
+        StderrDecision::Suppressed
+    }
+
+    pub fn flush_summary(&self) -> Option<String> {
+        if self.suppressed_total == 0 {
+            return None;
+        }
+
+        let mut fragments = Vec::new();
+        for (pattern, count) in &self.suppressed_by_pattern {
+            fragments.push(format!("{}={}", pattern, count));
+        }
+
+        Some(format!(
+            "desktop.{}.stderr.filtered {} total={} details={} hint=Set TOKEN_PLACE_DESKTOP_VERBOSE_LOGS=1 for raw llama.cpp stderr",
+            self.label,
+            self.context,
+            self.suppressed_total,
+            fragments.join(",")
+        ))
+    }
+}
+
+pub fn verbose_stderr_enabled() -> bool {
+    matches!(
+        std::env::var("TOKEN_PLACE_DESKTOP_VERBOSE_LOGS").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("on")
+    )
+}
+
+fn noisy_pattern_name(line: &str) -> Option<&'static str> {
+    let normalized = line.trim();
+    if normalized.contains("llama_model_loader: Dumping metadata keys/values") {
+        return Some("metadata_dump");
+    }
+    if normalized.contains("is not marked as EOG") {
+        return Some("control_token_spam");
+    }
+    if normalized.contains("load_tensors: layer") {
+        return Some("layer_assignment");
+    }
+    if normalized.contains("repack:") {
+        return Some("tensor_repack");
+    }
+    if normalized.contains("llm_load_print_meta:")
+        || normalized.contains("llama_context:")
+        || normalized.contains("llama_new_context_with_model:")
+        || normalized.contains("llama_kv_cache_unified:")
+        || normalized.contains("llama_init_from_model:")
+    {
+        return Some("init_chatter");
+    }
+    None
+}
+
+fn is_high_priority(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("error")
+        || lower.contains("warn")
+        || lower.contains("traceback")
+        || lower.contains("exception")
+        || lower.contains("failed")
+}
+
+fn is_useful_summary_line(line: &str) -> bool {
+    line.contains("llama_perf_context_print")
+        || line.contains("prompt eval time")
+        || line.contains("eval time")
+        || line.contains("load time")
+        || line.contains("sample time")
+}

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -398,11 +398,16 @@ class ModelManager:
                                         )
 
                             self.log_info(f"Initializing Llama model from {self.model_path}...")
+                            verbose_llama_logs = os.getenv(
+                                'TOKEN_PLACE_DESKTOP_VERBOSE_LOGS',
+                                '',
+                            ).strip().lower() in ('1', 'true', 'yes', 'on')
                             self.llm = Llama(
                                 model_path=self.model_path,
                                 n_gpu_layers=n_gpu_layers,
                                 n_ctx=self.config.get('model.context_size', 8192),
-                                chat_format=self.config.get('model.chat_format', 'llama-3')
+                                chat_format=self.config.get('model.chat_format', 'llama-3'),
+                                verbose=verbose_llama_logs,
                             )
                             compute_plan['n_gpu_layers'] = n_gpu_layers
                             self.last_compute_diagnostics = compute_plan


### PR DESCRIPTION
### Motivation
- Desktop Tauri startup and model-init logs were dominated by low-value llama.cpp stderr chatter which hid actionable warnings and summaries.
- The intent is to present high-signal, operator-friendly logs by default while preserving an explicit opt-in for raw verbose debugging.

### Description
- Add a centralized subprocess stderr filter in `desktop-tauri/src-tauri/src/subprocess_log.rs` and wire it into the Tauri bridges so sidecar and compute-node stderr are filtered at the forwarding boundary.  The filter suppresses known noisy patterns (metadata dumps, control-token EOG spam, per-layer assignment, tensor repack, and generic init chatter) while allowing warnings/errors and timing/summary-like lines to pass through.
- Emit concise one-line operator summaries from the sidecar stream: enhanced `started` event (model path/name, backend, device/layers, context size, load time, fallback reason) and enhanced `done` event (prompt/output char counts, token estimates, throughput, inference time), with Rust-side searchable summary lines written to stderr.
- Preserve debuggability via an explicit opt-in environment toggle `TOKEN_PLACE_DESKTOP_VERBOSE_LOGS=1` that disables filtering and restores raw llama.cpp stderr; also pass the same toggle into `Llama(...)` via `verbose=` so underlying runtime verbosity is respected when requested.
- Minor docs note added to `desktop-tauri/README.md` that documents the default concise behavior and the `TOKEN_PLACE_DESKTOP_VERBOSE_LOGS` opt-in.

### Testing
- Ran `cargo fmt` in `desktop-tauri/src-tauri` successfully to normalize Rust formatting.
- Verified Python syntax via `python -m py_compile desktop-tauri/src-tauri/python/inference_sidecar.py utils/llm/model_manager.py` which succeeded.
- Attempted repository checks: `pre-commit run --all-files` could not run in this environment because `pre-commit` is not installed (warning reported).
- Unit test runs were attempted but could not complete in this environment: `pytest` was blocked by a missing Python test dependency (`requests`) and `cargo test sidecar` failed due to missing system `glib-2.0` pkg-config/system dependency; these prevented full automated test runs here (errors and hints are recorded in the rollout transcript).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf7f9d464832fa3fa7618c5318479)