### PR TITLE
Reduce desktop-tauri stderr noise by default with opt-in raw logs

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -29,6 +29,11 @@ and fast local testing:
 - Set `TOKEN_PLACE_SIDECAR=/full/path/to/script.py` to explicitly override the
   sidecar command path (this takes precedence over
   `TOKEN_PLACE_USE_FAKE_SIDECAR`).
+- Default stderr forwarding now suppresses known low-value llama.cpp spam
+  (metadata dumps, control-token spam, per-layer offload chatter, and repack
+  spam) while still emitting warnings/errors and a concise runtime summary.
+- Set `TOKEN_PLACE_DESKTOP_VERBOSE_RAW_LOGS=1` to restore raw unfiltered
+  sidecar/compute-node stderr output for deep troubleshooting.
 
 ## Run locally
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -41,6 +41,82 @@ pub struct ComputeNodeState {
     pub lifecycle_lock: Arc<Mutex<()>>,
 }
 
+#[derive(Default, Debug)]
+struct ComputeStderrSummary {
+    context_size: Option<String>,
+    offloaded_layers: Option<String>,
+    load_time: Option<String>,
+    prompt_throughput: Option<String>,
+    eval_throughput: Option<String>,
+    fallback_reason: Option<String>,
+    noisy_counts: [usize; 4],
+}
+
+fn raw_compute_logs_enabled() -> bool {
+    matches!(
+        std::env::var("TOKEN_PLACE_DESKTOP_VERBOSE_RAW_LOGS").as_deref(),
+        Ok("1")
+    )
+}
+
+fn looks_like_warning_or_error(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    ["error", "warn", "failed", "exception", "traceback", "fatal"]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+fn noisy_pattern_bucket(line: &str) -> Option<usize> {
+    if line.contains("Dumping metadata keys/values") {
+        return Some(0);
+    }
+    if line.contains("is not marked as EOG") {
+        return Some(1);
+    }
+    if line.contains("load_tensors: layer") || line.contains("load_tensors: offloading layer") {
+        return Some(2);
+    }
+    if line.contains("repack:") {
+        return Some(3);
+    }
+    None
+}
+
+fn parse_summary_line(summary: &mut ComputeStderrSummary, line: &str) {
+    let compact = line.trim().replace('"', "'");
+    if summary.context_size.is_none() && line.contains("n_ctx") {
+        summary.context_size = Some(compact.clone());
+    }
+    if summary.offloaded_layers.is_none()
+        && line.to_ascii_lowercase().contains("offloaded")
+        && line.to_ascii_lowercase().contains("layers")
+    {
+        summary.offloaded_layers = Some(compact.clone());
+    }
+    if summary.load_time.is_none()
+        && (line.to_ascii_lowercase().contains("load time")
+            || line.to_ascii_lowercase().contains("loaded in")
+            || line.to_ascii_lowercase().contains("done in"))
+    {
+        summary.load_time = Some(compact.clone());
+    }
+    if summary.prompt_throughput.is_none()
+        && line.to_ascii_lowercase().contains("tokens per second")
+        && line.to_ascii_lowercase().contains("prompt")
+    {
+        summary.prompt_throughput = Some(compact.clone());
+    }
+    if summary.eval_throughput.is_none()
+        && line.to_ascii_lowercase().contains("tokens per second")
+        && line.to_ascii_lowercase().contains("eval")
+    {
+        summary.eval_throughput = Some(compact.clone());
+    }
+    if summary.fallback_reason.is_none() && line.to_ascii_lowercase().contains("falling back") {
+        summary.fallback_reason = Some(compact);
+    }
+}
+
 fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error> {
     serde_json::from_str::<Value>(line)
 }
@@ -210,12 +286,35 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
 
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ComputeStderrSummary> {
+    let show_raw = raw_compute_logs_enabled();
+    let mut summary = ComputeStderrSummary::default();
     let mut lines = BufReader::new(reader).lines();
     while let Some(line) = lines.next_line().await? {
+        parse_summary_line(&mut summary, &line);
+        if show_raw || looks_like_warning_or_error(&line) {
+            eprintln!("desktop.compute_node.stderr line={line}");
+            continue;
+        }
+        if let Some(bucket) = noisy_pattern_bucket(&line) {
+            summary.noisy_counts[bucket] += 1;
+            continue;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
         eprintln!("desktop.compute_node.stderr line={line}");
     }
-    Ok(())
+    if !show_raw {
+        eprintln!(
+            "desktop.compute_node.stderr_summary metadata_dumps={} eog_spam={} layer_spam={} repack_spam={}",
+            summary.noisy_counts[0],
+            summary.noisy_counts[1],
+            summary.noisy_counts[2],
+            summary.noisy_counts[3],
+        );
+    }
+    Ok(summary)
 }
 
 pub async fn start_compute_node(
@@ -340,10 +439,11 @@ pub async fn start_compute_node(
         };
     }
 
+    let stderr_model_path = request.model_path.clone();
+    let stderr_mode = format!("{:?}", request.mode).to_lowercase();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_compute_node_stderr(stderr).await {
-            eprintln!("desktop.compute_node.stderr_error error={err}");
-        }
+        let summary = drain_compute_node_stderr(stderr).await;
+        (stderr_model_path, stderr_mode, summary)
     });
 
     let mut lines = BufReader::new(stdout).lines();
@@ -369,8 +469,28 @@ pub async fn start_compute_node(
         }
     }
 
-    if let Err(err) = stderr_task.await {
-        eprintln!("desktop.compute_node.stderr_task_join_error error={err}");
+    match stderr_task.await {
+        Ok((model_path, mode, Ok(summary))) => {
+            if !raw_compute_logs_enabled() {
+                eprintln!(
+                    "desktop.compute_node.runtime_summary model_path={} mode={} context={} offload={} load_time={} prompt_tps={} eval_tps={} fallback_reason={}",
+                    model_path,
+                    mode,
+                    summary.context_size.as_deref().unwrap_or("n/a"),
+                    summary.offloaded_layers.as_deref().unwrap_or("n/a"),
+                    summary.load_time.as_deref().unwrap_or("n/a"),
+                    summary.prompt_throughput.as_deref().unwrap_or("n/a"),
+                    summary.eval_throughput.as_deref().unwrap_or("n/a"),
+                    summary.fallback_reason.as_deref().unwrap_or("n/a"),
+                );
+            }
+        }
+        Ok((_, _, Err(err))) => {
+            eprintln!("desktop.compute_node.stderr_error error={err}");
+        }
+        Err(err) => {
+            eprintln!("desktop.compute_node.stderr_task_join_error error={err}");
+        }
     }
 
     let running_child = {

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -46,6 +46,98 @@ pub struct SidecarState {
     pub stdin: Arc<Mutex<Option<ChildStdin>>>,
 }
 
+#[derive(Default, Debug)]
+struct StderrSummary {
+    backend: Option<String>,
+    device: Option<String>,
+    context_size: Option<String>,
+    offloaded_layers: Option<String>,
+    load_time: Option<String>,
+    prompt_throughput: Option<String>,
+    eval_throughput: Option<String>,
+    fallback_reason: Option<String>,
+    noisy_counts: [usize; 4],
+}
+
+fn raw_sidecar_logs_enabled() -> bool {
+    matches!(
+        std::env::var("TOKEN_PLACE_DESKTOP_VERBOSE_RAW_LOGS").as_deref(),
+        Ok("1")
+    )
+}
+
+fn looks_like_warning_or_error(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    ["error", "warn", "failed", "exception", "traceback", "fatal"]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+fn noisy_pattern_bucket(line: &str) -> Option<usize> {
+    if line.contains("Dumping metadata keys/values") {
+        return Some(0);
+    }
+    if line.contains("is not marked as EOG") {
+        return Some(1);
+    }
+    if line.contains("load_tensors: layer") || line.contains("load_tensors: offloading layer") {
+        return Some(2);
+    }
+    if line.contains("repack:") {
+        return Some(3);
+    }
+    None
+}
+
+fn parse_summary_line(summary: &mut StderrSummary, line: &str) {
+    let compact = line.trim().replace('"', "'");
+    if summary.context_size.is_none() && line.contains("n_ctx") {
+        summary.context_size = Some(compact.clone());
+    }
+    if summary.offloaded_layers.is_none()
+        && line.to_ascii_lowercase().contains("offloaded")
+        && line.to_ascii_lowercase().contains("layers")
+    {
+        summary.offloaded_layers = Some(compact.clone());
+    }
+    if summary.load_time.is_none()
+        && (line.to_ascii_lowercase().contains("load time")
+            || line.to_ascii_lowercase().contains("loaded in")
+            || line.to_ascii_lowercase().contains("done in"))
+    {
+        summary.load_time = Some(compact.clone());
+    }
+    if summary.prompt_throughput.is_none()
+        && line.to_ascii_lowercase().contains("tokens per second")
+        && line.to_ascii_lowercase().contains("prompt")
+    {
+        summary.prompt_throughput = Some(compact.clone());
+    }
+    if summary.eval_throughput.is_none()
+        && line.to_ascii_lowercase().contains("tokens per second")
+        && line.to_ascii_lowercase().contains("eval")
+    {
+        summary.eval_throughput = Some(compact.clone());
+    }
+    if summary.backend.is_none()
+        && (line.contains("CUDA")
+            || line.contains("Metal")
+            || line.contains("CPU")
+            || line.to_ascii_lowercase().contains("backend"))
+    {
+        summary.backend = Some(compact.clone());
+    }
+    if summary.device.is_none()
+        && (line.to_ascii_lowercase().contains("using device")
+            || line.to_ascii_lowercase().contains("device"))
+    {
+        summary.device = Some(compact.clone());
+    }
+    if summary.fallback_reason.is_none() && line.to_ascii_lowercase().contains("falling back") {
+        summary.fallback_reason = Some(compact);
+    }
+}
+
 pub fn parse_event_line(line: &str) -> Result<SidecarEvent, serde_json::Error> {
     serde_json::from_str::<SidecarEvent>(line)
 }
@@ -67,12 +159,36 @@ pub async fn collect_events_from_stdout<R: tokio::io::AsyncRead + Unpin>(
 async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     request_id: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<StderrSummary> {
+    let show_raw = raw_sidecar_logs_enabled();
+    let mut summary = StderrSummary::default();
     let mut lines = BufReader::new(reader).lines();
     while let Some(line) = lines.next_line().await? {
+        parse_summary_line(&mut summary, &line);
+        if show_raw || looks_like_warning_or_error(&line) {
+            eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
+            continue;
+        }
+        if let Some(bucket) = noisy_pattern_bucket(&line) {
+            summary.noisy_counts[bucket] += 1;
+            continue;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
         eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
     }
-    Ok(())
+    if !show_raw {
+        eprintln!(
+            "desktop.sidecar.stderr_summary request_id={} metadata_dumps={} eog_spam={} layer_spam={} repack_spam={}",
+            request_id,
+            summary.noisy_counts[0],
+            summary.noisy_counts[1],
+            summary.noisy_counts[2],
+            summary.noisy_counts[3],
+        );
+    }
+    Ok(summary)
 }
 
 fn build_sidecar_command(
@@ -280,13 +396,11 @@ pub async fn start_sidecar(
 
     let request_id = request.request_id;
     let stderr_request_id = request_id.clone();
+    let stderr_model_path = request.model_path.clone();
+    let stderr_mode = format!("{:?}", request.mode).to_lowercase();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_sidecar_stderr(stderr, &stderr_request_id).await {
-            eprintln!(
-                "desktop.sidecar.stderr_error request_id={} error={}",
-                stderr_request_id, err
-            );
-        }
+        let summary = drain_sidecar_stderr(stderr, &stderr_request_id).await;
+        (stderr_request_id, stderr_model_path, stderr_mode, summary)
     });
 
     let mut reader = BufReader::new(stdout).lines();
@@ -314,11 +428,37 @@ pub async fn start_sidecar(
         }
     }
 
-    if let Err(err) = stderr_task.await {
-        eprintln!(
-            "desktop.sidecar.stderr_task_join_error request_id={} error={}",
-            request_id, err
-        );
+    match stderr_task.await {
+        Ok((stderr_request_id, model_path, mode, Ok(summary))) => {
+            if !raw_sidecar_logs_enabled() {
+                eprintln!(
+                    "desktop.sidecar.runtime_summary request_id={} model_path={} mode={} backend={} device={} context={} offload={} load_time={} prompt_tps={} eval_tps={} fallback_reason={}",
+                    stderr_request_id,
+                    model_path,
+                    mode,
+                    summary.backend.as_deref().unwrap_or("n/a"),
+                    summary.device.as_deref().unwrap_or("n/a"),
+                    summary.context_size.as_deref().unwrap_or("n/a"),
+                    summary.offloaded_layers.as_deref().unwrap_or("n/a"),
+                    summary.load_time.as_deref().unwrap_or("n/a"),
+                    summary.prompt_throughput.as_deref().unwrap_or("n/a"),
+                    summary.eval_throughput.as_deref().unwrap_or("n/a"),
+                    summary.fallback_reason.as_deref().unwrap_or("n/a"),
+                );
+            }
+        }
+        Ok((stderr_request_id, _, _, Err(err))) => {
+            eprintln!(
+                "desktop.sidecar.stderr_error request_id={} error={}",
+                stderr_request_id, err
+            );
+        }
+        Err(err) => {
+            eprintln!(
+                "desktop.sidecar.stderr_task_join_error request_id={} error={}",
+                request_id, err
+            );
+        }
     }
 
     let running_child = {


### PR DESCRIPTION
### Motivation
- The Tauri desktop app was forwarding raw subprocess stderr lines verbatim, which let low-value llama.cpp chatter (metadata dumps, control-token lines, per-layer offload noise, tensor repack spam) overwhelm operator-visible logs.
- Improve operator signal-to-noise by collapsing/suppressing known noisy patterns while keeping warnings/errors and useful runtime diagnostics.
- Preserve full debuggability via an explicit opt-in raw-logs toggle so deep troubleshooting remains possible.

### Description
- Add line-level filtering and lightweight summary aggregation at the Tauri Rust boundary for both inference sidecar stderr and compute-node bridge stderr, suppressing known noisy patterns (`Dumping metadata keys/values`, `is not marked as EOG`, `load_tensors: layer`/offload lines, `repack:`) by default and counting suppressed occurrences (`desktop.*.stderr_summary`).
- Emit concise runtime summary lines after the stderr drain containing operator-relevant fields (model path/mode, parsed backend/device/context/offloaded layers/load time/prompt+eval throughput/fallback snippet) as `desktop.sidecar.runtime_summary` and `desktop.compute_node.runtime_summary`.
- Preserve and always forward warnings/errors (lines containing `error`, `warn`, `failed`, `exception`, `traceback`, `fatal`) and non-empty non-noisy lines so actionable diagnostics remain visible.
- Add an explicit verbose/raw toggle `TOKEN_PLACE_DESKTOP_VERBOSE_RAW_LOGS=1` that restores full unfiltered stderr passthrough for deep debugging.
- Files changed: `desktop-tauri/src-tauri/src/sidecar.rs`, `desktop-tauri/src-tauri/src/compute_node.rs`, and documentation update in `desktop-tauri/README.md`.

### Testing
- Ran `cargo fmt` in `desktop-tauri/src-tauri` and it completed successfully.
- Attempted `cargo test` for the new stderr-drain tests (`drain_sidecar_stderr_reads_all_lines` and `drain_compute_node_stderr_reads_all_lines`), but tests could not finish in this environment due to missing system dependency `glib-2.0` / pkg-config required by Tauri Rust crates (build failed), so the unit tests could not be fully executed here.
- `pre-commit run --all-files` was not available in this environment because the `pre-commit` command is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf7f9d464832fa3fa7618c5318479)