### PR TITLE
🧹 Reduce desktop llama.cpp log noise by default

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -29,6 +29,10 @@ and fast local testing:
 - Set `TOKEN_PLACE_SIDECAR=/full/path/to/script.py` to explicitly override the
   sidecar command path (this takes precedence over
   `TOKEN_PLACE_USE_FAKE_SIDECAR`).
+- Set `TOKEN_PLACE_VERBOSE_LLAMA_LOGS=1` to disable desktop stderr filtering
+  and stream full raw llama.cpp output for troubleshooting. By default, desktop
+  suppresses known low-signal llama.cpp init spam while still showing
+  warnings/errors and concise runtime summaries.
 
 ## Run locally
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -9,6 +9,7 @@ import os
 import queue
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Tuple
 
@@ -144,7 +145,9 @@ def run(args: argparse.Namespace) -> int:
     manager.model_path = args.model
     apply_compute_mode(manager, args.mode)
 
+    model_load_started_at = time.perf_counter()
     llm = manager.get_llm_instance()
+    model_load_ms = (time.perf_counter() - model_load_started_at) * 1000.0
     if llm is None:
         return emit_error("bad_model", "unable to initialize model runtime")
 
@@ -152,10 +155,14 @@ def run(args: argparse.Namespace) -> int:
     emit(
         {
             "type": "started",
+            "model_path": args.model,
+            "model_name": Path(args.model).name,
             "requested_mode": diagnostics.get("requested_mode"),
             "effective_mode": diagnostics.get("effective_mode"),
             "backend_used": diagnostics.get("backend_used"),
             "n_gpu_layers": diagnostics.get("n_gpu_layers"),
+            "context_size": manager.config.get("model.context_size", 8192),
+            "load_ms": model_load_ms,
             "fallback_reason": diagnostics.get("fallback_reason"),
         }
     )
@@ -172,6 +179,7 @@ def run(args: argparse.Namespace) -> int:
         "stop": manager.config.get("model.stop_tokens", []),
     }
     try:
+        inference_started_at = time.perf_counter()
         completion = llm.create_chat_completion(
             **request_kwargs,
             stream=True,
@@ -202,8 +210,25 @@ def run(args: argparse.Namespace) -> int:
             fallback_text = _extract_text_from_completion(fallback)
             if fallback_text:
                 emit({"type": "token", "text": fallback_text})
+                text = fallback_text
 
-    emit({"type": "done"})
+    inference_ms = (time.perf_counter() - inference_started_at) * 1000.0
+    prompt_tokens_estimate = len(args.prompt.split())
+    output_tokens_estimate = len(text.split()) if text else 0
+    throughput_tps = (
+        (output_tokens_estimate / (inference_ms / 1000.0))
+        if output_tokens_estimate > 0 and inference_ms > 0
+        else None
+    )
+    emit(
+        {
+            "type": "done",
+            "prompt_tokens_estimate": prompt_tokens_estimate,
+            "output_tokens_estimate": output_tokens_estimate,
+            "tokens_per_second_estimate": throughput_tps,
+            "inference_ms": inference_ms,
+        }
+    )
     return 0
 
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::logging::SubprocessLogFilter;
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -211,9 +212,26 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
 ) -> anyhow::Result<()> {
+    let mut filter = SubprocessLogFilter::default();
     let mut lines = BufReader::new(reader).lines();
     while let Some(line) = lines.next_line().await? {
-        eprintln!("desktop.compute_node.stderr line={line}");
+        if let Some(filtered) = filter.classify_and_filter(&line) {
+            eprintln!("desktop.compute_node.stderr line={filtered}");
+        }
+    }
+    let verbose = filter.is_verbose();
+    let summary = filter.finish();
+    if !summary.suppressed_by_kind.is_empty() && !verbose {
+        let categories = summary
+            .suppressed_by_kind
+            .iter()
+            .map(|(kind, count)| format!("{kind}={count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!(
+            "desktop.compute_node.stderr_summary shown={} suppressed={} categories={}",
+            summary.shown_lines, summary.suppressed_lines, categories
+        );
     }
     Ok(())
 }

--- a/desktop-tauri/src-tauri/src/logging.rs
+++ b/desktop-tauri/src-tauri/src/logging.rs
@@ -1,4 +1,129 @@
 use serde::Serialize;
+use std::collections::BTreeMap;
+
+const DEFAULT_VERBOSE_LLAMA_ENV: &str = "TOKEN_PLACE_VERBOSE_LLAMA_LOGS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum NoiseKind {
+    MetadataDump,
+    ControlTokenSpam,
+    LayerAssignmentSpam,
+    RepackSpam,
+    InitChatter,
+}
+
+impl NoiseKind {
+    fn label(self) -> &'static str {
+        match self {
+            NoiseKind::MetadataDump => "metadata_dump",
+            NoiseKind::ControlTokenSpam => "control_token_spam",
+            NoiseKind::LayerAssignmentSpam => "layer_assignment_spam",
+            NoiseKind::RepackSpam => "tensor_repack_spam",
+            NoiseKind::InitChatter => "llama_init_chatter",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SubprocessLogFilterSummary {
+    pub shown_lines: usize,
+    pub suppressed_lines: usize,
+    pub suppressed_by_kind: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubprocessLogFilter {
+    verbose: bool,
+    summary: SubprocessLogFilterSummary,
+}
+
+impl Default for SubprocessLogFilter {
+    fn default() -> Self {
+        Self::new_from_env(DEFAULT_VERBOSE_LLAMA_ENV)
+    }
+}
+
+impl SubprocessLogFilter {
+    pub fn new_from_env(verbose_env_key: &str) -> Self {
+        Self {
+            verbose: std::env::var(verbose_env_key).is_ok_and(|v| v.trim() == "1"),
+            summary: SubprocessLogFilterSummary::default(),
+        }
+    }
+
+    pub fn is_verbose(&self) -> bool {
+        self.verbose
+    }
+
+    pub fn classify_and_filter<'a>(&mut self, raw_line: &'a str) -> Option<&'a str> {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            return None;
+        }
+        if self.verbose || is_important_runtime_line(line) {
+            self.summary.shown_lines += 1;
+            return Some(line);
+        }
+        if let Some(kind) = classify_noise_line(line) {
+            self.summary.suppressed_lines += 1;
+            *self
+                .summary
+                .suppressed_by_kind
+                .entry(kind.label().to_string())
+                .or_insert(0) += 1;
+            return None;
+        }
+
+        self.summary.shown_lines += 1;
+        Some(line)
+    }
+
+    pub fn finish(self) -> SubprocessLogFilterSummary {
+        self.summary
+    }
+}
+
+fn is_important_runtime_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    [
+        "error",
+        "warning",
+        "warn:",
+        "failed",
+        "exception",
+        "traceback",
+        "fatal",
+        "panic",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn classify_noise_line(line: &str) -> Option<NoiseKind> {
+    if line.contains("llama_model_loader: Dumping metadata keys/values") {
+        return Some(NoiseKind::MetadataDump);
+    }
+    if line.contains("is not marked as EOG") {
+        return Some(NoiseKind::ControlTokenSpam);
+    }
+    if line.contains("load_tensors: layer")
+        || line.contains("offloading layer")
+        || line.contains("offloaded")
+    {
+        return Some(NoiseKind::LayerAssignmentSpam);
+    }
+    if line.contains("repack:") {
+        return Some(NoiseKind::RepackSpam);
+    }
+    if line.starts_with("llama_kv_cache")
+        || line.starts_with("llama_context:")
+        || line.starts_with("llama_model_loader:")
+        || line.starts_with("llama_new_context_with_model")
+    {
+        return Some(NoiseKind::InitChatter);
+    }
+    None
+}
 
 #[derive(Debug, Serialize)]
 pub struct RedactedInferenceLog {
@@ -35,5 +160,31 @@ mod tests {
         assert!(!json.contains(prompt));
         assert!(!json.contains(output));
         assert!(json.contains("prompt_bytes"));
+    }
+
+    #[test]
+    fn subprocess_filter_hides_expected_llama_noise_by_default() {
+        let mut filter = SubprocessLogFilter::new_from_env("TOKEN_PLACE_VERBOSE_LLAMA_LOGS_TEST");
+        assert!(
+            filter
+                .classify_and_filter(
+                    "llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output."
+                )
+                .is_none()
+        );
+        assert!(filter
+            .classify_and_filter(
+                "llama_model_loader: control token: 128009 '<|eot_id|>' is not marked as EOG"
+            )
+            .is_none());
+        assert!(filter
+            .classify_and_filter("llama_model_load_tensors: layer 12 assigned to CPU")
+            .is_none());
+        assert!(filter
+            .classify_and_filter("llama_log_callback: warning: using fallback implementation")
+            .is_some());
+        let summary = filter.finish();
+        assert_eq!(summary.shown_lines, 1);
+        assert_eq!(summary.suppressed_lines, 3);
     }
 }

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::logging::SubprocessLogFilter;
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -22,15 +23,99 @@ pub struct InferenceRequest {
 #[serde(tag = "type")]
 pub enum SidecarEvent {
     #[serde(rename = "started")]
-    Started,
+    Started {
+        #[serde(default)]
+        model_path: Option<String>,
+        #[serde(default)]
+        model_name: Option<String>,
+        #[serde(default)]
+        backend_used: Option<String>,
+        #[serde(default)]
+        effective_mode: Option<String>,
+        #[serde(default)]
+        n_gpu_layers: Option<i64>,
+        #[serde(default)]
+        context_size: Option<i64>,
+        #[serde(default)]
+        load_ms: Option<f64>,
+        #[serde(default)]
+        fallback_reason: Option<String>,
+    },
     #[serde(rename = "token")]
     Token { text: String },
     #[serde(rename = "done")]
-    Done,
+    Done {
+        #[serde(default)]
+        prompt_tokens_estimate: Option<usize>,
+        #[serde(default)]
+        output_tokens_estimate: Option<usize>,
+        #[serde(default)]
+        tokens_per_second_estimate: Option<f64>,
+        #[serde(default)]
+        inference_ms: Option<f64>,
+    },
     #[serde(rename = "canceled")]
     Canceled,
     #[serde(rename = "error")]
     Error { code: String, message: String },
+}
+
+fn log_sidecar_started_summary(request_id: &str, event: &SidecarEvent) {
+    if let SidecarEvent::Started {
+        model_path,
+        model_name,
+        backend_used,
+        effective_mode,
+        n_gpu_layers,
+        context_size,
+        load_ms,
+        fallback_reason,
+    } = event
+    {
+        eprintln!(
+            "desktop.sidecar.summary request_id={} phase=model_init model={} path={} backend={} mode={} ctx={} offloaded_layers={} load_ms={} fallback_reason={}",
+            request_id,
+            model_name.as_deref().unwrap_or("unknown"),
+            model_path.as_deref().unwrap_or("unknown"),
+            backend_used.as_deref().unwrap_or("unknown"),
+            effective_mode.as_deref().unwrap_or("unknown"),
+            context_size.map(|v| v.to_string()).unwrap_or_else(|| "unknown".into()),
+            n_gpu_layers
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "unknown".into()),
+            load_ms
+                .map(|v| format!("{v:.2}"))
+                .unwrap_or_else(|| "unknown".into()),
+            fallback_reason.as_deref().unwrap_or("none"),
+        );
+    }
+}
+
+fn log_sidecar_done_summary(request_id: &str, event: &SidecarEvent) {
+    if let SidecarEvent::Done {
+        prompt_tokens_estimate,
+        output_tokens_estimate,
+        tokens_per_second_estimate,
+        inference_ms,
+    } = event
+    {
+        eprintln!(
+            "desktop.sidecar.summary request_id={} phase=inference prompt_tokens_est={} output_tokens_est={} throughput_tps_est={} inference_ms={}",
+            request_id,
+            prompt_tokens_estimate
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "unknown".into()),
+            output_tokens_estimate
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "unknown".into()),
+            tokens_per_second_estimate
+                .map(|v| format!("{v:.2}"))
+                .unwrap_or_else(|| "unknown".into()),
+            inference_ms
+                .map(|v| format!("{v:.2}"))
+                .unwrap_or_else(|| "unknown".into()),
+        );
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -68,9 +153,36 @@ async fn drain_sidecar_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     request_id: &str,
 ) -> anyhow::Result<()> {
+    let mut filter = SubprocessLogFilter::default();
+    let mut timing_lines: Vec<String> = Vec::new();
     let mut lines = BufReader::new(reader).lines();
     while let Some(line) = lines.next_line().await? {
-        eprintln!("desktop.sidecar.stderr request_id={request_id} line={line}");
+        if line.contains("llama_print_timings:") {
+            timing_lines.push(line.trim().to_string());
+        }
+        if let Some(filtered) = filter.classify_and_filter(&line) {
+            eprintln!("desktop.sidecar.stderr request_id={request_id} line={filtered}");
+        }
+    }
+    let verbose = filter.is_verbose();
+    let summary = filter.finish();
+    if !summary.suppressed_by_kind.is_empty() && !verbose {
+        let categories = summary
+            .suppressed_by_kind
+            .iter()
+            .map(|(kind, count)| format!("{kind}={count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!(
+            "desktop.sidecar.stderr_summary request_id={request_id} shown={} suppressed={} categories={}",
+            summary.shown_lines, summary.suppressed_lines, categories
+        );
+    }
+    if !timing_lines.is_empty() {
+        eprintln!(
+            "desktop.sidecar.llama_timing_summary request_id={request_id} {}",
+            timing_lines.join(" | ")
+        );
     }
     Ok(())
 }
@@ -297,6 +409,11 @@ pub async fn start_sidecar(
                 if matches!(event, SidecarEvent::Error { .. }) {
                     saw_error_event = true;
                 }
+                if matches!(event, SidecarEvent::Started { .. }) {
+                    log_sidecar_started_summary(&request_id, &event);
+                } else if matches!(event, SidecarEvent::Done { .. }) {
+                    log_sidecar_done_summary(&request_id, &event);
+                }
                 app.emit(
                     "inference_event",
                     UiInferenceEvent {
@@ -418,8 +535,12 @@ mod tests {
         let events = collect_events_from_stdout(stdout)
             .await
             .expect("collect events");
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Started { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Done { .. })));
     }
 
     #[tokio::test]
@@ -447,11 +568,15 @@ mod tests {
         let events = collect_events_from_stdout(stdout)
             .await
             .expect("collect events");
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Started { .. })));
         assert!(events
             .iter()
             .any(|e| matches!(e, SidecarEvent::Token { .. })));
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SidecarEvent::Done { .. })));
     }
 
     #[tokio::test]
@@ -487,9 +612,23 @@ mod tests {
         assert_eq!(
             events,
             vec![
-                SidecarEvent::Started,
+                SidecarEvent::Started {
+                    model_path: None,
+                    model_name: None,
+                    backend_used: None,
+                    effective_mode: None,
+                    n_gpu_layers: None,
+                    context_size: None,
+                    load_ms: None,
+                    fallback_reason: None,
+                },
                 SidecarEvent::Token { text: "ok".into() },
-                SidecarEvent::Done
+                SidecarEvent::Done {
+                    prompt_tokens_estimate: None,
+                    output_tokens_estimate: None,
+                    tokens_per_second_estimate: None,
+                    inference_ms: None,
+                }
             ]
         );
     }


### PR DESCRIPTION
### Motivation
- The desktop Tauri app forwarded raw subprocess stderr line-by-line, which caused llama.cpp init/inference spam (metadata dumps, control-token chatter, per-layer assignment and repack lines) to overwhelm operator logs. The goal is higher signal-by-default while keeping full debug output opt-in.

### Description
- Add a Rust-side `SubprocessLogFilter` (`desktop-tauri/src-tauri/src/logging.rs`) that classifies and suppresses known low-signal llama.cpp patterns while always allowing warnings/errors and preserving a verbosity opt-in via `TOKEN_PLACE_VERBOSE_LLAMA_LOGS=1`.
- Wire the filter into the subprocess stderr drains so filtering happens at the forwarding boundary in `sidecar.rs` and `compute_node.rs`, and emit concise suppression summaries as `desktop.sidecar.stderr_summary` / `desktop.compute_node.stderr_summary` for auditability.
- Add concise runtime summaries for model init and inference (model path/name, backend, effective mode, context size, offloaded layers, load time, token/throughput estimates, inference ms) by extending the sidecar `started`/`done` events and logging one-line summaries; compute this data in `desktop-tauri/src-tauri/python/inference_sidecar.py` and log from `sidecar.rs`.
- Document the new opt-in verbose toggle in `desktop-tauri/README.md` and update tests/matchers to account for optional summary fields added to sidecar events.

### Testing
- Ran `python3 -m py_compile desktop-tauri/src-tauri/python/inference_sidecar.py` and it succeeded.
- Attempted `cd desktop-tauri/src-tauri && cargo fmt --all && cargo test` but the Rust test run failed in this container due to missing system `glib-2.0` dev libs required by the Tauri/native toolchain (failure is environmental, not caused by the change).
- `pre-commit run --all-files` was not available in the container (`pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf7f9d464832fa3fa7618c5318479)