### PR TITLE
Desktop: bootstrap GPU-capable llama.cpp runtime in Auto mode and add runtime observability

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -38,17 +38,28 @@ npm ci
 npm run tauri dev
 ```
 
-During startup, desktop sidecars now run a lightweight llama runtime bootstrap
-that prefers a GPU-capable `llama-cpp-python` build in `auto`/`gpu`/`hybrid`
-modes and logs the selected backend + fallback reason to stderr. Set
-`TOKEN_PLACE_DESKTOP_SKIP_RUNTIME_BOOTSTRAP=1` to disable this behavior for
-manual debugging.
+During normal startup, desktop sidecars run a **probe-only** runtime check in
+`auto`/`gpu`/`hybrid` modes and emit:
+
+- `desktop.runtime_setup ...` during sidecar start (backend selected + fallback reason)
+- `compute_runtime ...` after `Llama(...)` init (backend actually used, offloaded
+  layers, KV cache placement, and fallback reason)
+
+Normal inference requests do **not** mutate Python packages. For local desktop
+development, explicitly run one bootstrap start with
+`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` to allow a one-time
+`llama-cpp-python` install/repair attempt, then restart sidecars/app.
+
+Packaged builds should rely on pre-provisioned runtime dependencies and keep
+`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` unset.
 
 ### Platform packaging assumptions (documented, not fully automated in MVP)
 
 - **macOS Apple Silicon**: run with a Metal-enabled llama.cpp sidecar build.
 - **Windows 11 + NVIDIA GPU**: run with a CUDA-enabled llama.cpp sidecar build.
-- CPU fallback mode is available in both cases.
+- CPU fallback mode is available in both cases, with explicit fallback details
+  surfaced in `desktop.runtime_setup ... fallback_reason=...` and
+  `compute_runtime ... fallback_reason=...`.
 
 ## Privacy defaults
 

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -38,6 +38,12 @@ npm ci
 npm run tauri dev
 ```
 
+During startup, desktop sidecars now run a lightweight llama runtime bootstrap
+that prefers a GPU-capable `llama-cpp-python` build in `auto`/`gpu`/`hybrid`
+modes and logs the selected backend + fallback reason to stderr. Set
+`TOKEN_PLACE_DESKTOP_SKIP_RUNTIME_BOOTSTRAP=1` to disable this behavior for
+manual debugging.
+
 ### Platform packaging assumptions (documented, not fully automated in MVP)
 
 - **macOS Apple Silicon**: run with a Metal-enabled llama.cpp sidecar build.

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -18,6 +18,7 @@ if __package__ in (None, ""):
         sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
+from desktop_runtime_setup import ensure_desktop_llama_runtime
 
 ensure_runtime_import_paths(__file__)
 
@@ -88,6 +89,17 @@ def run(args: argparse.Namespace) -> int:
     except ModuleNotFoundError as exc:
         emit({"type": "error", "message": f"runtime unavailable: {exc}"})
         return 1
+
+    runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    print(
+        "desktop.runtime_setup "
+        f"mode={args.mode} "
+        f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
+        f"device={runtime_setup.get('detected_device', 'cpu')} "
+        f"action={runtime_setup.get('runtime_action', 'none')} "
+        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
+        file=sys.stderr,
+    )
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -18,7 +18,17 @@ if __package__ in (None, ""):
         sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
-from desktop_runtime_setup import ensure_desktop_llama_runtime
+
+try:
+    from desktop_runtime_setup import ensure_desktop_llama_runtime
+except ModuleNotFoundError:
+    def ensure_desktop_llama_runtime(_mode: str) -> Dict[str, str]:
+        return {
+            "selected_backend": "cpu",
+            "detected_device": "cpu",
+            "runtime_action": "unavailable",
+            "fallback_reason": "desktop_runtime_setup module missing",
+        }
 
 ensure_runtime_import_paths(__file__)
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from desktop_gpu_packaging import LlamaCppInstallPlan, llama_cpp_install_plan_fallbacks
+from utils.llm.model_manager import detect_llama_runtime_capabilities
 
 
 @dataclass(frozen=True)
@@ -23,70 +23,11 @@ class RuntimeProbe:
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 PIP_INSTALL_TIMEOUT_SECONDS = 300
+ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
 
 
 def _probe_llama_runtime() -> RuntimeProbe:
-    probe_code = """
-import json
-
-try:
-    import llama_cpp
-except Exception as exc:
-    print(json.dumps({
-        "backend": "missing",
-        "gpu_offload_supported": False,
-        "detected_device": "none",
-        "error": str(exc),
-    }))
-    raise SystemExit(0)
-
-backend = "cpu"
-if bool(getattr(llama_cpp, "GGML_USE_CUDA", False)):
-    backend = "cuda"
-elif bool(getattr(llama_cpp, "GGML_USE_METAL", False)):
-    backend = "metal"
-
-supports = getattr(llama_cpp, "llama_supports_gpu_offload", None)
-gpu = False
-if callable(supports):
-    try:
-        gpu = bool(supports())
-    except Exception:
-        gpu = False
-else:
-    gpu = backend in {"cuda", "metal"}
-
-print(json.dumps({
-    "backend": backend,
-    "gpu_offload_supported": gpu,
-    "detected_device": backend if gpu else "cpu",
-    "error": None,
-}))
-""".strip()
-
-    result = subprocess.run(
-        [sys.executable, "-c", probe_code],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return RuntimeProbe(
-            backend="missing",
-            gpu_offload_supported=False,
-            detected_device="none",
-            error=(result.stderr or result.stdout or "probe failed").strip(),
-        )
-
-    try:
-        payload = json.loads(result.stdout.strip() or "{}")
-    except json.JSONDecodeError:
-        return RuntimeProbe(
-            backend="missing",
-            gpu_offload_supported=False,
-            detected_device="none",
-            error=(result.stdout or "invalid probe response").strip(),
-        )
+    payload = detect_llama_runtime_capabilities()
 
     return RuntimeProbe(
         backend=str(payload.get("backend", "cpu")),
@@ -97,7 +38,7 @@ print(json.dumps({
 
 
 def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
-    """Ensure desktop runs a GPU-capable llama-cpp runtime for GPU-preferring modes."""
+    """Probe runtime by default; install/repair only when explicit bootstrap env is enabled."""
 
     selected_mode = (mode or "auto").strip().lower()
     if selected_mode not in GPU_MODES:
@@ -107,16 +48,6 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "runtime_action": "skipped",
         }
 
-    if os.environ.get("TOKEN_PLACE_DESKTOP_SKIP_RUNTIME_BOOTSTRAP") == "1":
-        return {
-            "selected_backend": "cpu",
-            "fallback_reason": "runtime bootstrap disabled by env",
-            "runtime_action": "skipped",
-        }
-
-    target_root = repo_root or Path(__file__).resolve().parents[3]
-    requirements_path = target_root / "requirements.txt"
-
     before = _probe_llama_runtime()
     if before.gpu_offload_supported and before.backend in {"cuda", "metal"}:
         return {
@@ -125,6 +56,20 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "runtime_action": "already_supported",
             "detected_device": before.detected_device,
         }
+
+    if os.environ.get(ENABLE_BOOTSTRAP_ENV) != "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                f"GPU runtime unavailable ({before.error or before.backend}); "
+                f"set {ENABLE_BOOTSTRAP_ENV}=1 for one-time bootstrap"
+            ),
+            "runtime_action": "probe_only",
+            "detected_device": before.detected_device or "cpu",
+        }
+
+    target_root = repo_root or Path(__file__).resolve().parents[3]
+    requirements_path = target_root / "requirements.txt"
 
     try:
         plans = llama_cpp_install_plan_fallbacks(
@@ -161,13 +106,12 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             last_install_error = (install.stderr or install.stdout or "").strip()
             continue
 
-        after = _probe_llama_runtime()
-        if after.gpu_offload_supported and after.backend in {"cuda", "metal"}:
+        if plan.backend in {"cuda", "metal"}:
             return {
-                "selected_backend": after.backend,
-                "fallback_reason": "",
-                "runtime_action": f"installed_{plan.backend}",
-                "detected_device": after.detected_device,
+                "selected_backend": plan.backend,
+                "fallback_reason": "bootstrap install complete; restart sidecar to activate runtime",
+                "runtime_action": f"installed_{plan.backend}_restart_required",
+                "detected_device": "cpu",
             }
 
         if plan.backend == "cpu":

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -1,0 +1,165 @@
+"""Desktop runtime bootstrap for llama-cpp backend availability."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from desktop_gpu_packaging import llama_cpp_install_plan_fallbacks
+
+
+@dataclass(frozen=True)
+class RuntimeProbe:
+    backend: str
+    gpu_offload_supported: bool
+    detected_device: str
+    error: Optional[str] = None
+
+
+GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
+
+
+def _probe_llama_runtime() -> RuntimeProbe:
+    probe_code = """
+import json
+
+try:
+    import llama_cpp
+except Exception as exc:
+    print(json.dumps({
+        "backend": "missing",
+        "gpu_offload_supported": False,
+        "detected_device": "none",
+        "error": str(exc),
+    }))
+    raise SystemExit(0)
+
+backend = "cpu"
+if bool(getattr(llama_cpp, "GGML_USE_CUDA", False)):
+    backend = "cuda"
+elif bool(getattr(llama_cpp, "GGML_USE_METAL", False)):
+    backend = "metal"
+
+supports = getattr(llama_cpp, "llama_supports_gpu_offload", None)
+gpu = False
+if callable(supports):
+    try:
+        gpu = bool(supports())
+    except Exception:
+        gpu = False
+else:
+    gpu = backend in {"cuda", "metal"}
+
+print(json.dumps({
+    "backend": backend,
+    "gpu_offload_supported": gpu,
+    "detected_device": backend if gpu else "cpu",
+    "error": None,
+}))
+""".strip()
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe_code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return RuntimeProbe(
+            backend="missing",
+            gpu_offload_supported=False,
+            detected_device="none",
+            error=(result.stderr or result.stdout or "probe failed").strip(),
+        )
+
+    try:
+        payload = json.loads(result.stdout.strip() or "{}")
+    except json.JSONDecodeError:
+        return RuntimeProbe(
+            backend="missing",
+            gpu_offload_supported=False,
+            detected_device="none",
+            error=(result.stdout or "invalid probe response").strip(),
+        )
+
+    return RuntimeProbe(
+        backend=str(payload.get("backend", "cpu")),
+        gpu_offload_supported=bool(payload.get("gpu_offload_supported", False)),
+        detected_device=str(payload.get("detected_device", "cpu")),
+        error=payload.get("error"),
+    )
+
+
+def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
+    """Ensure desktop runs a GPU-capable llama-cpp runtime for GPU-preferring modes."""
+
+    selected_mode = (mode or "auto").strip().lower()
+    if selected_mode not in GPU_MODES:
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": "cpu mode explicitly selected",
+            "runtime_action": "skipped",
+        }
+
+    if os.environ.get("TOKEN_PLACE_DESKTOP_SKIP_RUNTIME_BOOTSTRAP") == "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": "runtime bootstrap disabled by env",
+            "runtime_action": "skipped",
+        }
+
+    target_root = repo_root or Path(__file__).resolve().parents[3]
+    requirements_path = target_root / "requirements.txt"
+
+    before = _probe_llama_runtime()
+    if before.gpu_offload_supported and before.backend in {"cuda", "metal"}:
+        return {
+            "selected_backend": before.backend,
+            "fallback_reason": "",
+            "runtime_action": "already_supported",
+            "detected_device": before.detected_device,
+        }
+
+    plans = llama_cpp_install_plan_fallbacks(
+        platform=sys.platform,
+        requirements_path=requirements_path,
+    )
+
+    for plan in plans:
+        env = os.environ.copy()
+        env.update(plan.pip_env())
+        cmd = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
+        install = subprocess.run(cmd, check=False, capture_output=True, text=True, env=env)
+        if install.returncode != 0:
+            continue
+
+        after = _probe_llama_runtime()
+        if after.gpu_offload_supported and after.backend in {"cuda", "metal"}:
+            return {
+                "selected_backend": after.backend,
+                "fallback_reason": "",
+                "runtime_action": f"installed_{plan.backend}",
+                "detected_device": after.detected_device,
+            }
+
+        if plan.backend == "cpu":
+            return {
+                "selected_backend": "cpu",
+                "fallback_reason": (
+                    "GPU runtime unavailable after install attempts; using CPU wheel fallback"
+                ),
+                "runtime_action": "installed_cpu_fallback",
+                "detected_device": "cpu",
+            }
+
+    return {
+        "selected_backend": "cpu",
+        "fallback_reason": before.error or "unable to install a GPU-capable llama-cpp runtime",
+        "runtime_action": "failed",
+        "detected_device": "cpu",
+    }

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 
-from desktop_gpu_packaging import llama_cpp_install_plan_fallbacks
+from desktop_gpu_packaging import LlamaCppInstallPlan, llama_cpp_install_plan_fallbacks
 
 
 @dataclass(frozen=True)
@@ -22,6 +22,7 @@ class RuntimeProbe:
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
+PIP_INSTALL_TIMEOUT_SECONDS = 300
 
 
 def _probe_llama_runtime() -> RuntimeProbe:
@@ -125,17 +126,39 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "detected_device": before.detected_device,
         }
 
-    plans = llama_cpp_install_plan_fallbacks(
-        platform=sys.platform,
-        requirements_path=requirements_path,
-    )
+    try:
+        plans = llama_cpp_install_plan_fallbacks(
+            platform=sys.platform,
+            requirements_path=requirements_path,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        plans = _fallback_unpinned_plans(sys.platform)
+        fallback_setup_error = str(exc)
+    else:
+        fallback_setup_error = ""
+
+    last_install_error = ""
 
     for plan in plans:
         env = os.environ.copy()
         env.update(plan.pip_env())
         cmd = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
-        install = subprocess.run(cmd, check=False, capture_output=True, text=True, env=env)
+        try:
+            install = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=PIP_INSTALL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            last_install_error = (
+                f"pip install timed out after {PIP_INSTALL_TIMEOUT_SECONDS}s for backend={plan.backend}"
+            )
+            continue
         if install.returncode != 0:
+            last_install_error = (install.stderr or install.stdout or "").strip()
             continue
 
         after = _probe_llama_runtime()
@@ -159,7 +182,81 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
 
     return {
         "selected_backend": "cpu",
-        "fallback_reason": before.error or "unable to install a GPU-capable llama-cpp runtime",
+        "fallback_reason": (
+            before.error
+            or fallback_setup_error
+            or last_install_error
+            or "unable to install a GPU-capable llama-cpp runtime"
+        ),
         "runtime_action": "failed",
         "detected_device": "cpu",
     }
+
+
+def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
+    detected_platform = platform.lower()
+    if detected_platform.startswith("win"):
+        return [
+            LlamaCppInstallPlan(
+                platform=detected_platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+                extra_index_url="https://pypi.org/simple",
+                only_binary=True,
+                no_binary=False,
+            ),
+            LlamaCppInstallPlan(
+                platform=detected_platform,
+                backend="cpu",
+                package_spec="llama-cpp-python",
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=True,
+                no_binary=False,
+            ),
+        ]
+
+    if detected_platform == "darwin":
+        return [
+            LlamaCppInstallPlan(
+                platform=detected_platform,
+                backend="metal",
+                package_spec="llama-cpp-python",
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://abetlen.github.io/llama-cpp-python/whl/metal",
+                extra_index_url="https://pypi.org/simple",
+                only_binary=True,
+                no_binary=False,
+            ),
+            LlamaCppInstallPlan(
+                platform=detected_platform,
+                backend="metal",
+                package_spec="llama-cpp-python",
+                cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
+                force_cmake=True,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+                no_binary=True,
+            ),
+        ]
+
+    return [
+        LlamaCppInstallPlan(
+            platform=detected_platform,
+            backend="cpu",
+            package_spec="llama-cpp-python",
+            cmake_args=None,
+            force_cmake=False,
+            index_url=None,
+            extra_index_url=None,
+            only_binary=False,
+            no_binary=False,
+        )
+    ]

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -18,6 +18,7 @@ if __package__ in (None, ""):
         sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
+from desktop_runtime_setup import ensure_desktop_llama_runtime
 
 ensure_runtime_import_paths(__file__)
 
@@ -139,6 +140,17 @@ def run(args: argparse.Namespace) -> int:
             "runtime_unavailable",
             f"Missing Python dependency for local inference ({exc}).",
         )
+
+    runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    print(
+        "desktop.runtime_setup "
+        f"mode={args.mode} "
+        f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
+        f"device={runtime_setup.get('detected_device', 'cpu')} "
+        f"action={runtime_setup.get('runtime_action', 'none')} "
+        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
+        file=sys.stderr,
+    )
 
     manager = get_model_manager()
     manager.model_path = args.model

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -25,6 +25,8 @@
     "active": true,
     "targets": "all",
     "resources": [
+      "python/desktop_gpu_packaging.py",
+      "python/desktop_runtime_setup.py",
       "python/compute_node_bridge.py",
       "python/inference_sidecar.py",
       "python/model_bridge.py",

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -593,3 +593,26 @@ class ComputeNodeRuntime:
     assert any(event.get('type') == 'started' for event in events)
     assert any(event.get('type') == 'stopped' for event in events)
     assert "No module named 'utils'" not in stdout
+
+
+def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch, tmp_path):
+    module_path = tmp_path / 'compute_node_bridge.py'
+    module_path.write_text(MODULE_PATH.read_text(encoding='utf-8'), encoding='utf-8')
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'desktop_runtime_setup':
+            raise ModuleNotFoundError("No module named 'desktop_runtime_setup'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+
+    spec = importlib.util.spec_from_file_location('compute_node_bridge_no_runtime_setup', module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+
+    setup = module.ensure_desktop_llama_runtime('auto')
+    assert setup['runtime_action'] == 'unavailable'
+    assert 'module missing' in setup['fallback_reason']

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -88,3 +88,109 @@ def test_runtime_bootstrap_explicitly_enabled_installs_and_requires_restart(monk
     assert result['selected_backend'] == 'cuda'
     assert 'restart sidecar' in result['fallback_reason']
     assert len(state['pip_calls']) == 1
+
+
+def test_runtime_bootstrap_returns_already_supported_when_gpu_runtime_is_present(monkeypatch):
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cuda',
+        gpu_offload_supported=True,
+        detected_device='nvidia',
+        error=None,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu')
+
+    assert result['runtime_action'] == 'already_supported'
+    assert result['selected_backend'] == 'cuda'
+    assert result['detected_device'] == 'nvidia'
+
+
+def test_runtime_bootstrap_uses_unpinned_fallback_plans_when_requirements_missing(monkeypatch):
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cpu',
+        gpu_offload_supported=False,
+        detected_device='cpu',
+        error='probe says cpu',
+    )
+    calls = []
+
+    def fake_plan_fallbacks(**_kwargs):
+        raise FileNotFoundError('requirements.txt missing')
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return _Result(returncode=0)
+
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', fake_plan_fallbacks)
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', type('S', (), {'platform': 'linux', 'executable': sys.executable}))
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert result['runtime_action'] == 'installed_cpu_fallback'
+    assert result['selected_backend'] == 'cpu'
+    assert calls
+
+
+def test_runtime_bootstrap_reports_timeout_and_install_errors(monkeypatch):
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cpu',
+        gpu_offload_supported=False,
+        detected_device='cpu',
+        error=None,
+    )
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cuda',
+            package_spec='llama-cpp-python',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://example.invalid/cuda',
+            extra_index_url=None,
+            only_binary=True,
+            no_binary=False,
+        ),
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cpu',
+            package_spec='llama-cpp-python',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://example.invalid/cpu',
+            extra_index_url=None,
+            only_binary=True,
+            no_binary=False,
+        ),
+    ]
+    state = {'calls': 0}
+
+    def fake_run(_cmd, **_kwargs):
+        state['calls'] += 1
+        if state['calls'] == 1:
+            raise desktop_runtime_setup.subprocess.TimeoutExpired(cmd='pip', timeout=1)
+        return _Result(returncode=1, stderr='wheel not found')
+
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert result['runtime_action'] == 'failed'
+    assert result['selected_backend'] == 'cpu'
+    assert result['fallback_reason'] == 'wheel not found'
+
+
+def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
+    win_plans = desktop_runtime_setup._fallback_unpinned_plans('win32')
+    darwin_plans = desktop_runtime_setup._fallback_unpinned_plans('darwin')
+    linux_plans = desktop_runtime_setup._fallback_unpinned_plans('linux')
+
+    assert [plan.backend for plan in win_plans] == ['cuda', 'cpu']
+    assert [plan.backend for plan in darwin_plans] == ['metal', 'metal']
+    assert [plan.backend for plan in linux_plans] == ['cpu']

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -5,12 +5,15 @@ from pathlib import Path
 
 PYTHON_MODULE_DIR = Path(__file__).resolve().parents[2] / 'desktop-tauri' / 'src-tauri' / 'python'
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(PYTHON_MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_MODULE_DIR))
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 MODULE_PATH = PYTHON_MODULE_DIR / 'desktop_runtime_setup.py'
 SPEC = importlib.util.spec_from_file_location('desktop_runtime_setup', MODULE_PATH)
 desktop_runtime_setup = importlib.util.module_from_spec(SPEC)
 assert SPEC and SPEC.loader
+sys.modules['desktop_runtime_setup'] = desktop_runtime_setup
 SPEC.loader.exec_module(desktop_runtime_setup)
 
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,13 +1,16 @@
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
+PYTHON_MODULE_DIR = (
+    Path(__file__).resolve().parents[2] / 'desktop-tauri' / 'src-tauri' / 'python'
+)
+if str(PYTHON_MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_MODULE_DIR))
+
 MODULE_PATH = (
-    Path(__file__).resolve().parents[2]
-    / 'desktop-tauri'
-    / 'src-tauri'
-    / 'python'
-    / 'desktop_runtime_setup.py'
+    PYTHON_MODULE_DIR / 'desktop_runtime_setup.py'
 )
 SPEC = importlib.util.spec_from_file_location('desktop_runtime_setup', MODULE_PATH)
 desktop_runtime_setup = importlib.util.module_from_spec(SPEC)
@@ -32,8 +35,6 @@ def test_runtime_bootstrap_uses_existing_gpu_runtime(monkeypatch):
     probe = {'count': 0}
 
     def fake_run(cmd, **kwargs):
-        if cmd[:3] == ['python', '-c', cmd[2]]:
-            raise AssertionError('unexpected probe executable')
         if cmd[1:3] == ['-c', cmd[2]]:
             probe['count'] += 1
             return _Result(
@@ -58,9 +59,9 @@ def test_runtime_bootstrap_uses_existing_gpu_runtime(monkeypatch):
 
 def test_runtime_bootstrap_falls_back_to_cpu_after_gpu_attempt(monkeypatch):
     state = {'probe_calls': 0, 'pip_calls': []}
+    Plan = desktop_runtime_setup.LlamaCppInstallPlan
 
     def fake_plans(**_kwargs):
-        Plan = desktop_runtime_setup.llama_cpp_install_plan_fallbacks()[0].__class__
         return [
             Plan(
                 platform='win32',
@@ -89,20 +90,12 @@ def test_runtime_bootstrap_falls_back_to_cpu_after_gpu_attempt(monkeypatch):
     def fake_run(cmd, **kwargs):
         if cmd[1] == '-c':
             state['probe_calls'] += 1
-            if state['probe_calls'] <= 2:
-                payload = {
-                    'backend': 'cpu',
-                    'gpu_offload_supported': False,
-                    'detected_device': 'cpu',
-                    'error': None,
-                }
-            else:
-                payload = {
-                    'backend': 'cpu',
-                    'gpu_offload_supported': False,
-                    'detected_device': 'cpu',
-                    'error': None,
-                }
+            payload = {
+                'backend': 'cpu',
+                'gpu_offload_supported': False,
+                'detected_device': 'cpu',
+                'error': None,
+            }
             return _Result(stdout=json.dumps(payload))
 
         state['pip_calls'].append(cmd)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,17 +1,13 @@
 import importlib.util
-import json
 import sys
 from pathlib import Path
 
-PYTHON_MODULE_DIR = (
-    Path(__file__).resolve().parents[2] / 'desktop-tauri' / 'src-tauri' / 'python'
-)
-if str(PYTHON_MODULE_DIR) not in sys.path:
-    sys.path.insert(0, str(PYTHON_MODULE_DIR))
 
-MODULE_PATH = (
-    PYTHON_MODULE_DIR / 'desktop_runtime_setup.py'
-)
+PYTHON_MODULE_DIR = Path(__file__).resolve().parents[2] / 'desktop-tauri' / 'src-tauri' / 'python'
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+MODULE_PATH = PYTHON_MODULE_DIR / 'desktop_runtime_setup.py'
 SPEC = importlib.util.spec_from_file_location('desktop_runtime_setup', MODULE_PATH)
 desktop_runtime_setup = importlib.util.module_from_spec(SPEC)
 assert SPEC and SPEC.loader
@@ -31,81 +27,61 @@ def test_skip_runtime_bootstrap_for_cpu_mode():
     assert result['selected_backend'] == 'cpu'
 
 
-def test_runtime_bootstrap_uses_existing_gpu_runtime(monkeypatch):
-    probe = {'count': 0}
+def test_probe_only_runtime_path_does_not_install_without_explicit_flag(monkeypatch):
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cpu',
+        gpu_offload_supported=False,
+        detected_device='cpu',
+        error=None,
+    )
+    pip_calls = []
 
-    def fake_run(cmd, **kwargs):
-        if cmd[1:3] == ['-c', cmd[2]]:
-            probe['count'] += 1
-            return _Result(
-                stdout=json.dumps(
-                    {
-                        'backend': 'cuda',
-                        'gpu_offload_supported': True,
-                        'detected_device': 'cuda',
-                        'error': None,
-                    }
-                )
-            )
-        raise AssertionError(f'unexpected command: {cmd}')
+    def fake_run(*_args, **_kwargs):
+        pip_calls.append(True)
+        return _Result(returncode=0)
 
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
-    assert result['runtime_action'] == 'already_supported'
-    assert result['selected_backend'] == 'cuda'
-    assert probe['count'] == 1
+    assert result['runtime_action'] == 'probe_only'
+    assert result['selected_backend'] == 'cpu'
+    assert desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert pip_calls == []
 
 
-def test_runtime_bootstrap_falls_back_to_cpu_after_gpu_attempt(monkeypatch):
-    state = {'probe_calls': 0, 'pip_calls': []}
-    Plan = desktop_runtime_setup.LlamaCppInstallPlan
+def test_runtime_bootstrap_explicitly_enabled_installs_and_requires_restart(monkeypatch):
+    state = {'pip_calls': []}
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cpu',
+        gpu_offload_supported=False,
+        detected_device='cpu',
+        error='cpu-only runtime',
+    )
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='win32',
+        backend='cuda',
+        package_spec='llama-cpp-python',
+        cmake_args=None,
+        force_cmake=False,
+        index_url='https://example.invalid/cuda',
+        extra_index_url=None,
+        only_binary=True,
+        no_binary=False,
+    )
 
-    def fake_plans(**_kwargs):
-        return [
-            Plan(
-                platform='win32',
-                backend='cuda',
-                package_spec='llama-cpp-python',
-                cmake_args=None,
-                force_cmake=False,
-                index_url='https://example.invalid/cuda',
-                extra_index_url=None,
-                only_binary=True,
-                no_binary=False,
-            ),
-            Plan(
-                platform='win32',
-                backend='cpu',
-                package_spec='llama-cpp-python',
-                cmake_args=None,
-                force_cmake=False,
-                index_url='https://pypi.org/simple',
-                extra_index_url=None,
-                only_binary=True,
-                no_binary=False,
-            ),
-        ]
-
-    def fake_run(cmd, **kwargs):
-        if cmd[1] == '-c':
-            state['probe_calls'] += 1
-            payload = {
-                'backend': 'cpu',
-                'gpu_offload_supported': False,
-                'detected_device': 'cpu',
-                'error': None,
-            }
-            return _Result(stdout=json.dumps(payload))
-
+    def fake_run(cmd, **_kwargs):
         state['pip_calls'].append(cmd)
         return _Result(returncode=0)
 
-    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', fake_plans)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
-    assert result['selected_backend'] == 'cpu'
-    assert result['runtime_action'] == 'installed_cpu_fallback'
-    assert 'GPU runtime unavailable' in result['fallback_reason']
-    assert len(state['pip_calls']) == 2
+    assert result['runtime_action'] == 'installed_cuda_restart_required'
+    assert result['selected_backend'] == 'cuda'
+    assert 'restart sidecar' in result['fallback_reason']
+    assert len(state['pip_calls']) == 1

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,0 +1,118 @@
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'src-tauri'
+    / 'python'
+    / 'desktop_runtime_setup.py'
+)
+SPEC = importlib.util.spec_from_file_location('desktop_runtime_setup', MODULE_PATH)
+desktop_runtime_setup = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(desktop_runtime_setup)
+
+
+class _Result:
+    def __init__(self, returncode=0, stdout='', stderr=''):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_skip_runtime_bootstrap_for_cpu_mode():
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('cpu')
+    assert result['runtime_action'] == 'skipped'
+    assert result['selected_backend'] == 'cpu'
+
+
+def test_runtime_bootstrap_uses_existing_gpu_runtime(monkeypatch):
+    probe = {'count': 0}
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ['python', '-c', cmd[2]]:
+            raise AssertionError('unexpected probe executable')
+        if cmd[1:3] == ['-c', cmd[2]]:
+            probe['count'] += 1
+            return _Result(
+                stdout=json.dumps(
+                    {
+                        'backend': 'cuda',
+                        'gpu_offload_supported': True,
+                        'detected_device': 'cuda',
+                        'error': None,
+                    }
+                )
+            )
+        raise AssertionError(f'unexpected command: {cmd}')
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+    assert result['runtime_action'] == 'already_supported'
+    assert result['selected_backend'] == 'cuda'
+    assert probe['count'] == 1
+
+
+def test_runtime_bootstrap_falls_back_to_cpu_after_gpu_attempt(monkeypatch):
+    state = {'probe_calls': 0, 'pip_calls': []}
+
+    def fake_plans(**_kwargs):
+        Plan = desktop_runtime_setup.llama_cpp_install_plan_fallbacks()[0].__class__
+        return [
+            Plan(
+                platform='win32',
+                backend='cuda',
+                package_spec='llama-cpp-python',
+                cmake_args=None,
+                force_cmake=False,
+                index_url='https://example.invalid/cuda',
+                extra_index_url=None,
+                only_binary=True,
+                no_binary=False,
+            ),
+            Plan(
+                platform='win32',
+                backend='cpu',
+                package_spec='llama-cpp-python',
+                cmake_args=None,
+                force_cmake=False,
+                index_url='https://pypi.org/simple',
+                extra_index_url=None,
+                only_binary=True,
+                no_binary=False,
+            ),
+        ]
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == '-c':
+            state['probe_calls'] += 1
+            if state['probe_calls'] <= 2:
+                payload = {
+                    'backend': 'cpu',
+                    'gpu_offload_supported': False,
+                    'detected_device': 'cpu',
+                    'error': None,
+                }
+            else:
+                payload = {
+                    'backend': 'cpu',
+                    'gpu_offload_supported': False,
+                    'detected_device': 'cpu',
+                    'error': None,
+                }
+            return _Result(stdout=json.dumps(payload))
+
+        state['pip_calls'].append(cmd)
+        return _Result(returncode=0)
+
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', fake_plans)
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+    assert result['selected_backend'] == 'cpu'
+    assert result['runtime_action'] == 'installed_cpu_fallback'
+    assert 'GPU runtime unavailable' in result['fallback_reason']
+    assert len(state['pip_calls']) == 2

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -907,3 +907,47 @@ class TestModelManager:
         assert hybrid_plan['backend_used'] == 'cuda'
         assert hybrid_plan['n_gpu_layers'] == 1
         assert hybrid_plan['fallback_reason'] is None
+
+    def test_shared_runtime_probe_drives_platform_and_offload_detection(self):
+        with patch(
+            'utils.llm.model_manager.detect_llama_runtime_capabilities',
+            return_value={
+                'backend': 'metal',
+                'gpu_offload_supported': True,
+                'detected_device': 'metal',
+                'error': None,
+            },
+        ):
+            assert ModelManager._platform_gpu_backend() == 'metal'
+            assert ModelManager._llama_gpu_offload_available() is True
+
+    def test_compute_runtime_log_includes_backend_device_offload_and_fallback(self, model_manager):
+        class FakeLlama:
+            def __init__(self, **_kwargs):
+                pass
+
+        log_lines = []
+        model_manager.requested_compute_mode = 'gpu'
+        model_manager.log_info = lambda message: log_lines.append(message)
+
+        with patch('llama_cpp.Llama', FakeLlama), \
+             patch.object(model_manager, '_resolve_compute_plan', return_value={
+                 'requested_mode': 'gpu',
+                 'effective_mode': 'cpu_fallback',
+                 'backend_available': 'cuda',
+                 'backend_selected': 'cuda',
+                 'backend_used': 'cpu',
+                 'n_gpu_layers': 0,
+                 'fallback_reason': 'runtime missing cuda support',
+             }):
+            llm = model_manager.get_llm_instance()
+
+        assert llm is not None
+        compute_logs = [line for line in log_lines if line.startswith('compute_runtime ')]
+        assert compute_logs
+        summary = compute_logs[-1]
+        assert 'backend=cpu' in summary
+        assert 'device_backend=cpu' in summary
+        assert 'offloaded_layers=0' in summary
+        assert 'kv_cache=cpu' in summary
+        assert 'fallback_reason=runtime missing cuda support' in summary

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -921,6 +921,25 @@ class TestModelManager:
             assert ModelManager._platform_gpu_backend() == 'metal'
             assert ModelManager._llama_gpu_offload_available() is True
 
+    def test_detect_runtime_capabilities_reports_missing_module_error(self):
+        import builtins
+        from utils.llm import model_manager as mm
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == 'llama_cpp':
+                raise ModuleNotFoundError("No module named 'llama_cpp'")
+            return real_import(name, *args, **kwargs)
+
+        with patch('builtins.__import__', side_effect=fake_import):
+            payload = mm.detect_llama_runtime_capabilities()
+
+        assert payload['backend'] == 'missing'
+        assert payload['gpu_offload_supported'] is False
+        assert payload['detected_device'] == 'none'
+        assert "No module named 'llama_cpp'" in payload['error']
+
     def test_compute_runtime_log_includes_backend_device_offload_and_fallback(self, model_manager):
         class FakeLlama:
             def __init__(self, **_kwargs):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -406,19 +406,23 @@ class ModelManager:
                             )
                             compute_plan['n_gpu_layers'] = n_gpu_layers
                             compute_plan['kv_cache_device'] = (
-                                compute_plan['backend_used'] if n_gpu_layers != 0 else 'cpu'
+                                compute_plan['backend_used']
+                                if n_gpu_layers < 0
+                                else ('cpu' if n_gpu_layers == 0 else 'partial')
                             )
                             compute_plan['offloaded_layers'] = (
                                 n_gpu_layers if n_gpu_layers >= 0 else 'all_supported_layers'
                             )
-                            compute_plan['device_name'] = compute_plan['backend_used']
+                            compute_plan['device_backend'] = compute_plan['backend_used']
+                            compute_plan['device_name'] = 'unreported'
                             self.last_compute_diagnostics = compute_plan
                             self.log_info(
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "
                                 f"effective={compute_plan['effective_mode']} "
                                 f"backend={compute_plan['backend_used']} "
-                                f"device={compute_plan['device_name']} "
+                                f"device_backend={compute_plan['device_backend']} "
+                                f"device_name={compute_plan['device_name']} "
                                 f"offloaded_layers={compute_plan['offloaded_layers']} "
                                 f"kv_cache={compute_plan['kv_cache_device']} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -17,6 +17,43 @@ from utils.system import resource_monitor
 # Configure logging
 logger = logging.getLogger('model_manager')
 
+
+def detect_llama_runtime_capabilities() -> Dict[str, Any]:
+    """Return backend/offload capability details from the installed llama_cpp runtime."""
+    try:
+        import llama_cpp
+    except Exception as exc:
+        return {
+            'backend': 'missing',
+            'gpu_offload_supported': False,
+            'detected_device': 'none',
+            'error': str(exc),
+        }
+
+    backend = 'cpu'
+    if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
+        backend = 'cuda'
+    elif bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
+        backend = 'metal'
+
+    supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
+    gpu_offload_supported = False
+    if callable(supports_gpu):
+        try:
+            gpu_offload_supported = bool(supports_gpu())
+        except Exception:
+            gpu_offload_supported = False
+    else:
+        gpu_offload_supported = backend in {'cuda', 'metal'}
+
+    return {
+        'backend': backend,
+        'gpu_offload_supported': gpu_offload_supported,
+        'detected_device': backend if gpu_offload_supported else 'cpu',
+        'error': None,
+    }
+
+
 class ModelManager:
     """
     Manages LLM model downloading, initialization, and inference.
@@ -74,47 +111,16 @@ class ModelManager:
 
     @staticmethod
     def _platform_gpu_backend() -> Optional[str]:
-        if sys.platform == 'darwin':
-            return 'metal'
-        if sys.platform.startswith('win'):
-            return 'cuda'
-        if sys.platform.startswith('linux'):
-            try:
-                import llama_cpp
-            except Exception:
-                return None
-            if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
-                return 'cuda'
-            if bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
-                return 'metal'
-            supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
-            if callable(supports_gpu):
-                try:
-                    if bool(supports_gpu()):
-                        # Linux builds that expose GPU offload are expected to be CUDA.
-                        return 'cuda'
-                except Exception:
-                    return None
+        runtime = detect_llama_runtime_capabilities()
+        backend = str(runtime.get('backend') or 'cpu')
+        if backend in {'cuda', 'metal'}:
+            return backend
         return None
 
     @staticmethod
     def _llama_gpu_offload_available() -> bool:
-        try:
-            import llama_cpp
-        except Exception:
-            return False
-
-        supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
-        if callable(supports_gpu):
-            try:
-                return bool(supports_gpu())
-            except Exception:
-                return False
-
-        for marker in ('GGML_USE_CUDA', 'GGML_USE_METAL'):
-            if bool(getattr(llama_cpp, marker, False)):
-                return True
-        return False
+        runtime = detect_llama_runtime_capabilities()
+        return bool(runtime.get('gpu_offload_supported', False))
 
     def _resolve_compute_plan(self) -> Dict[str, Any]:
         requested = str(getattr(self, 'requested_compute_mode', 'auto')).lower()

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -405,7 +405,24 @@ class ModelManager:
                                 chat_format=self.config.get('model.chat_format', 'llama-3')
                             )
                             compute_plan['n_gpu_layers'] = n_gpu_layers
+                            compute_plan['kv_cache_device'] = (
+                                compute_plan['backend_used'] if n_gpu_layers != 0 else 'cpu'
+                            )
+                            compute_plan['offloaded_layers'] = (
+                                n_gpu_layers if n_gpu_layers >= 0 else 'all_supported_layers'
+                            )
+                            compute_plan['device_name'] = compute_plan['backend_used']
                             self.last_compute_diagnostics = compute_plan
+                            self.log_info(
+                                "compute_runtime "
+                                f"requested={compute_plan['requested_mode']} "
+                                f"effective={compute_plan['effective_mode']} "
+                                f"backend={compute_plan['backend_used']} "
+                                f"device={compute_plan['device_name']} "
+                                f"offloaded_layers={compute_plan['offloaded_layers']} "
+                                f"kv_cache={compute_plan['kv_cache_device']} "
+                                f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
+                            )
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -46,6 +46,12 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     else:
         gpu_offload_supported = backend in {'cuda', 'metal'}
 
+    # Some llama_cpp builds can report runtime GPU offload support via probe
+    # without exposing GGML_USE_* backend markers. Preserve prior Linux behavior
+    # by inferring CUDA when offload is available and backend markers are absent.
+    if gpu_offload_supported and backend == 'cpu':
+        backend = 'metal' if sys.platform == 'darwin' else 'cuda'
+
     return {
         'backend': backend,
         'gpu_offload_supported': gpu_offload_supported,


### PR DESCRIPTION
### Motivation
- Auto compute mode could report `gpu` but still run with a CPU-only `llama-cpp-python` runtime, so `n_gpu_layers=-1` did not guarantee real GPU offload at runtime.
- Desktop sidecars (compute-node + inference) needed the same backend-selection behavior as `server.py` plus clear, high-signal logs proving the actual runtime/backend used.
- The goal is to prefer a GPU-capable runtime when available, fall back cleanly to CPU, and make that decision observable in startup logs.

### Description
- Added a lightweight desktop bootstrap helper `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` that probes the installed `llama-cpp-python` runtime and, for `auto|gpu|hybrid`, attempts platform-appropriate installs using existing `desktop_gpu_packaging` install plans until a GPU-capable runtime is available or a CPU fallback is chosen.
- Wired the bootstrap into both sidecars by importing and running `ensure_desktop_llama_runtime()` at startup in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and `desktop-tauri/src-tauri/python/inference_sidecar.py`, and emit a concise stderr startup line like `desktop.runtime_setup mode=... selected_backend=... device=... action=... fallback_reason=...`.
- Improved runtime observability in the shared manager by adding `compute_runtime` one-line init logging and richer `last_compute_diagnostics` fields (`kv_cache_device`, `offloaded_layers`, `device_name`) in `utils/llm/model_manager.py` so the model init reports requested/effective mode, backend/device, offloaded layers, KV cache placement, and fallback reason.
- Updated packaging resources so the bootstrap helper is bundled (`desktop-tauri/src-tauri/tauri.conf.json`), documented the behavior and opt-out env var `TOKEN_PLACE_DESKTOP_SKIP_RUNTIME_BOOTSTRAP` in `desktop-tauri/README.md`, and added unit tests for bootstrap paths in `tests/unit/test_desktop_runtime_setup.py`.

### Testing
- Ran Python compilation for modified modules via `python -m compileall ...` which succeeded for `desktop_runtime_setup.py`, both sidecar scripts, `utils/llm/model_manager.py`, and the new unit test file.
- Executed the new unit tests with `pytest` but the repo-level test harness is blocked in this environment due to missing runtime deps (`playwright`, `cryptography`), so `tests/unit/test_desktop_runtime_setup.py` could not be run end-to-end here (tests themselves are present and exercise probe/install logic with monkeypatching).
- Ran `pre-commit run --all-files`; the hook runner executed but several upstream project hooks and environment gaps caused failures (missing dev deps and some codespell/vulture findings unrelated to the new bootstrap logic), so CI-style pre-commit checks will need the normal project test environment to pass.

Notes: full, deterministic verification of actual GPU offload requires running the desktop app on a target Windows/macOS machine with the appropriate GPU and Python wheel availability (the runtime bootstrap will log `desktop.runtime_setup ...` on startup and `compute_runtime ...` on Llama init to prove backend/device/offload selection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf7f1791c832fa3d925a69618764f)