### PR TITLE
fix: detect llama.cpp GPU runtime and add clear desktop backend diagnostics

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -44,6 +44,17 @@ npm run tauri dev
 - **Windows 11 + NVIDIA GPU**: run with a CUDA-enabled llama.cpp sidecar build.
 - CPU fallback mode is available in both cases.
 
+### Verifying effective llama.cpp backend selection
+
+To validate that Auto mode actually offloads to GPU (instead of silently staying on CPU), run:
+
+```bash
+python scripts/verify_llama_backend.py --model /path/to/model.gguf --mode auto
+```
+
+The command initializes the shared `ModelManager` runtime and prints JSON diagnostics that include
+`backend_available`, `backend_used`, `n_gpu_layers`, and `fallback_reason`.
+
 ## Privacy defaults
 
 - Prompt/response plaintext stays in-memory by default.

--- a/desktop-tauri/scripts/verify_llama_backend.py
+++ b/desktop-tauri/scripts/verify_llama_backend.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Smoke-test helper to print effective llama.cpp backend/offload diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PYTHON_RUNTIME_DIR = SCRIPT_DIR.parent / "src-tauri" / "python"
+if str(PYTHON_RUNTIME_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_RUNTIME_DIR))
+
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(__file__)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify desktop llama.cpp backend selection")
+    parser.add_argument("--model", required=True, help="Path to GGUF model")
+    parser.add_argument("--mode", default="auto", help="compute mode (auto/cpu/gpu/hybrid)")
+    args = parser.parse_args()
+
+    from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
+    from utils.llm.model_manager import get_model_manager
+
+    manager = get_model_manager()
+    manager.model_path = str(Path(args.model).expanduser())
+    apply_compute_mode(manager, args.mode)
+    llm = manager.get_llm_instance()
+    diagnostics = compute_mode_diagnostics(manager)
+
+    output = {
+        "initialized": llm is not None,
+        "diagnostics": diagnostics,
+    }
+    print(json.dumps(output))
+    return 0 if llm is not None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -154,11 +154,24 @@ def run(args: argparse.Namespace) -> int:
             "type": "started",
             "requested_mode": diagnostics.get("requested_mode"),
             "effective_mode": diagnostics.get("effective_mode"),
+            "backend_available": diagnostics.get("backend_available"),
+            "backend_selected": diagnostics.get("backend_selected"),
             "backend_used": diagnostics.get("backend_used"),
             "n_gpu_layers": diagnostics.get("n_gpu_layers"),
             "fallback_reason": diagnostics.get("fallback_reason"),
         }
     )
+    summary = (
+        "desktop.inference.started "
+        f"requested={diagnostics.get('requested_mode')} "
+        f"effective={diagnostics.get('effective_mode')} "
+        f"backend_available={diagnostics.get('backend_available')} "
+        f"backend_selected={diagnostics.get('backend_selected')} "
+        f"backend_used={diagnostics.get('backend_used')} "
+        f"offload_layers={diagnostics.get('n_gpu_layers')} "
+        f"fallback={diagnostics.get('fallback_reason') or 'none'}"
+    )
+    print(summary, file=sys.stderr)
     if cancel_requested():
         emit({"type": "canceled"})
         return 0

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -140,6 +140,8 @@ def test_run_streams_started_token_done_with_shared_runtime(tmp_path, capsys):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert [event['type'] for event in events] == ['started', 'token', 'token', 'done']
+    assert events[0]['backend_available'] == 'unknown'
+    assert events[0]['backend_selected'] == 'cpu'
     assert manager.default_n_gpu_layers == 0
 
 
@@ -405,7 +407,7 @@ def test_extract_text_from_completion_handles_empty_choices():
 
 def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
     class WithBadDict:
-        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+        def dict(self, _required):  # pragma: no cover - intentionally incompatible signature
             return {'choices': []}
 
     class UnknownShape:

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -856,6 +856,21 @@ class TestModelManager:
 
         assert backend == 'cuda'
 
+    def test_platform_gpu_backend_windows_returns_none_for_cpu_runtime(self):
+        """Windows should not report CUDA when llama_cpp runtime lacks GPU markers."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            GGML_USE_VULKAN=False,
+            llama_supports_gpu_offload=lambda: False,
+        )
+
+        with patch('utils.llm.model_manager.sys.platform', 'win32'), \
+             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend is None
+
     def test_platform_gpu_backend_linux_returns_none_when_probe_raises(self):
         """Linux backend detection should fail closed when probe raises."""
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -73,48 +73,97 @@ class ModelManager:
         }
 
     @staticmethod
-    def _platform_gpu_backend() -> Optional[str]:
-        if sys.platform == 'darwin':
-            return 'metal'
-        if sys.platform.startswith('win'):
-            return 'cuda'
-        if sys.platform.startswith('linux'):
-            try:
-                import llama_cpp
-            except Exception:
+    def _detect_primary_gpu_device(backend: str) -> Optional[str]:
+        if backend != 'cuda':
+            return None
+        try:
+            import pynvml
+        except Exception:
+            return None
+
+        try:
+            pynvml.nvmlInit()
+        except Exception:
+            return None
+
+        try:
+            count = int(pynvml.nvmlDeviceGetCount())
+            if count <= 0:
                 return None
-            if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
-                return 'cuda'
-            if bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
-                return 'metal'
-            supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
-            if callable(supports_gpu):
-                try:
-                    if bool(supports_gpu()):
-                        # Linux builds that expose GPU offload are expected to be CUDA.
-                        return 'cuda'
-                except Exception:
-                    return None
-        return None
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            raw_name = pynvml.nvmlDeviceGetName(handle)
+            if isinstance(raw_name, bytes):
+                return raw_name.decode('utf-8', errors='replace')
+            return str(raw_name)
+        except Exception:
+            return None
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception:
+                pass
 
     @staticmethod
-    def _llama_gpu_offload_available() -> bool:
+    def _llama_runtime_capabilities() -> Dict[str, Any]:
+        capability_snapshot: Dict[str, Any] = {
+            'cuda': False,
+            'metal': False,
+            'vulkan': False,
+            'gpu_offload': False,
+            'system_info': '',
+        }
+
         try:
             import llama_cpp
         except Exception:
-            return False
+            return capability_snapshot
+
+        capability_snapshot['cuda'] = bool(getattr(llama_cpp, 'GGML_USE_CUDA', False))
+        capability_snapshot['metal'] = bool(getattr(llama_cpp, 'GGML_USE_METAL', False))
+        capability_snapshot['vulkan'] = bool(getattr(llama_cpp, 'GGML_USE_VULKAN', False))
 
         supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
         if callable(supports_gpu):
             try:
-                return bool(supports_gpu())
+                capability_snapshot['gpu_offload'] = bool(supports_gpu())
             except Exception:
-                return False
+                capability_snapshot['gpu_offload'] = False
+        else:
+            capability_snapshot['gpu_offload'] = bool(
+                capability_snapshot['cuda']
+                or capability_snapshot['metal']
+                or capability_snapshot['vulkan']
+            )
 
-        for marker in ('GGML_USE_CUDA', 'GGML_USE_METAL'):
-            if bool(getattr(llama_cpp, marker, False)):
-                return True
-        return False
+        system_info = getattr(llama_cpp, 'llama_print_system_info', None)
+        if callable(system_info):
+            try:
+                info = system_info()
+                capability_snapshot['system_info'] = str(info or '').strip()
+            except Exception:
+                capability_snapshot['system_info'] = ''
+
+        return capability_snapshot
+
+    @staticmethod
+    def _platform_gpu_backend() -> Optional[str]:
+        capabilities = ModelManager._llama_runtime_capabilities()
+        if capabilities.get('cuda'):
+            return 'cuda'
+        if capabilities.get('metal'):
+            return 'metal'
+        if capabilities.get('vulkan'):
+            return 'vulkan'
+        if capabilities.get('gpu_offload'):
+            if sys.platform == 'darwin':
+                return 'metal'
+            if sys.platform.startswith(('win', 'linux')):
+                return 'cuda'
+        return None
+
+    @staticmethod
+    def _llama_gpu_offload_available() -> bool:
+        return bool(ModelManager._llama_runtime_capabilities().get('gpu_offload'))
 
     def _resolve_compute_plan(self) -> Dict[str, Any]:
         requested = str(getattr(self, 'requested_compute_mode', 'auto')).lower()
@@ -132,7 +181,7 @@ class ModelManager:
             ):
                 n_gpu_layers = 0
                 fallback_reason = (
-                    'no CUDA/Metal backend is supported on this platform'
+                    'no supported llama.cpp GPU backend is available in this runtime'
                     if backend_available == 'cpu'
                     else (
                         f'llama-cpp-python runtime does not expose {backend_available} '
@@ -161,7 +210,7 @@ class ModelManager:
             }
 
         if backend_available == 'cpu':
-            fallback_reason = 'no CUDA/Metal backend is supported on this platform'
+            fallback_reason = 'no supported llama.cpp GPU backend is available in this runtime'
         elif not gpu_runtime_supported:
             fallback_reason = (
                 f'llama-cpp-python runtime does not expose {backend_available} GPU offload support'
@@ -405,6 +454,35 @@ class ModelManager:
                                 chat_format=self.config.get('model.chat_format', 'llama-3')
                             )
                             compute_plan['n_gpu_layers'] = n_gpu_layers
+                            gpu_device = self._detect_primary_gpu_device(
+                                str(compute_plan.get('backend_used', 'cpu'))
+                            )
+                            runtime_capabilities = self._llama_runtime_capabilities()
+                            kv_cache_target = (
+                                compute_plan.get('backend_used')
+                                if n_gpu_layers != 0 and compute_plan.get('backend_used') != 'cpu'
+                                else 'cpu'
+                            )
+                            summary_parts = [
+                                f"requested={compute_plan.get('requested_mode')}",
+                                f"effective={compute_plan.get('effective_mode')}",
+                                f"backend={compute_plan.get('backend_used')}",
+                                f"backend_available={compute_plan.get('backend_available')}",
+                                f"offload_layers={n_gpu_layers}",
+                                f"kv_cache={kv_cache_target}",
+                                f"gpu_offload_supported={runtime_capabilities.get('gpu_offload')}",
+                            ]
+                            if gpu_device:
+                                summary_parts.append(f"device={gpu_device}")
+                            if runtime_capabilities.get('system_info'):
+                                summary_parts.append(
+                                    f"llama_system_info={runtime_capabilities.get('system_info')}"
+                                )
+                            if compute_plan.get('fallback_reason'):
+                                summary_parts.append(
+                                    f"fallback_reason={compute_plan.get('fallback_reason')}"
+                                )
+                            self.log_info("Llama backend summary: " + " ".join(summary_parts))
                             self.last_compute_diagnostics = compute_plan
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:


### PR DESCRIPTION
### Motivation
- The desktop Tauri inference path relied on platform assumptions and ambiguous logs, so an Auto-mode desktop could appear GPU-capable while running a CPU-only `llama-cpp-python` runtime. This makes diagnosing GPU fallbacks and verifying offload impossible.
- The shared compute runtime used by `server.py` already contains the intended behavior; desktop must share the same runtime truth and provide high-signal logs so users can verify real GPU offload at runtime.

### Description
- Replace platform-only probing with runtime capability inspection in `ModelManager`: add `_llama_runtime_capabilities()` to read `llama_cpp` markers (`GGML_USE_*`, `llama_supports_gpu_offload`, `llama_print_system_info`) and drive `_platform_gpu_backend()` and `_llama_gpu_offload_available()` from that snapshot. (`utils/llm/model_manager.py`)
- Add `_detect_primary_gpu_device()` (uses `pynvml` when available) and emit a concise one-line backend summary on model init including requested/effective mode, backend available/used, offload layers, KV cache target, GPU device (when detected), `llama` system info and fallback reason. (`utils/llm/model_manager.py`)
- Extend the desktop inference sidecar `started` event to include `backend_available` and `backend_selected` and print a single high-signal stderr summary line for immediate runtime verification. (`desktop-tauri/src-tauri/python/inference_sidecar.py`)
- Add a smoke-test helper script `desktop-tauri/scripts/verify_llama_backend.py` which boots the shared `ModelManager` and prints JSON diagnostics (useful for manual verification on a GPU host). (`desktop-tauri/scripts/verify_llama_backend.py`)
- Document the verification command in `desktop-tauri/README.md` and add/update small unit tests to assert the new detection/logging behavior and a Windows CPU-runtime case.

### Testing
- Ran unit tests: `pytest -q tests/unit/test_model_manager.py tests/unit/test_desktop_inference_sidecar.py` — all tests passed (61 passed).
- Verified helper script usage: `python desktop-tauri/scripts/verify_llama_backend.py --help` — prints usage successfully.
- Ran `pre-commit run --all-files` to mirror CI; the pre-commit environment initialization ran, but the repo-wide pre-commit hooks flagged unrelated repository-level checks (e.g. `codespell` on `desktop-tauri/package-lock.json` and the larger `run-checks` suite) that are outside the scope of this targeted change.

Files changed (key):
- `utils/llm/model_manager.py` (runtime capability probing, device detection, backend summary logging)
- `desktop-tauri/src-tauri/python/inference_sidecar.py` (expanded `started` payload + stderr summary)
- `desktop-tauri/scripts/verify_llama_backend.py` (new smoke-test CLI)
- `desktop-tauri/README.md` (verification instructions)
- `tests/unit/*` (added/updated tests for detection & sidecar payload)

Notes: full end-to-end GPU offload verification requires running the packaged desktop or sidecar on a supported Windows/macOS host with a GPU-capable `llama-cpp-python` build; the added logs and `verify_llama_backend.py` make that verification straightforward and explicit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf7f1791c832fa3d925a69618764f)