### PR TITLE
🛠️ fix: auto-repair desktop CUDA runtime on Windows

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -38,20 +38,38 @@ npm ci
 npm run tauri dev
 ```
 
-During normal startup, desktop sidecars run a **probe-only** runtime check in
+During normal startup, desktop sidecars run a runtime check in
 `auto`/`gpu`/`hybrid` modes and emit:
 
 - `desktop.runtime_setup ...` during sidecar start (backend selected + fallback reason)
 - `compute_runtime ...` after `Llama(...)` init (backend actually used, offloaded
   layers, KV cache placement, and fallback reason)
 
-Normal inference requests do **not** mutate Python packages. For local desktop
-development, explicitly run one bootstrap start with
-`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` to allow a one-time
-`llama-cpp-python` install/repair attempt, then restart sidecars/app.
+On Windows desktop builds, `auto`/`gpu`/`hybrid` now attempt a one-time
+`llama-cpp-python` CUDA repair automatically in the same interpreter used by
+the sidecar (`sys.executable`) when the active runtime is CPU-only. The repair
+uses the canonical README recipe:
 
-Packaged builds should rely on pre-provisioned runtime dependencies and keep
-`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` unset.
+```powershell
+$env:CMAKE_ARGS = "-DGGML_CUDA=on"
+$env:FORCE_CMAKE=1
+pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose
+```
+
+The sidecar then re-execs itself once so the repaired runtime is immediately
+active for the same launch.
+
+Set `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1` to force probe-only
+behavior.
+
+For manual runtime verification, run:
+
+```bash
+python desktop-tauri/src-tauri/python/verify_llama_runtime.py auto
+```
+
+This prints `sys.executable`, `llama_cpp.__file__`, backend markers,
+`llama_supports_gpu_offload`, and `ModelManager` compute diagnostics.
 
 ### Platform packaging assumptions (documented, not fully automated in MVP)
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import queue
 import sys
 import threading
@@ -35,6 +36,7 @@ ensure_runtime_import_paths(__file__)
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+RUNTIME_REEXEC_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 
 
 def _start_stdin_reader() -> None:
@@ -101,13 +103,21 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    if (
+        str(runtime_setup.get("runtime_action", "")).endswith("_restart_required")
+        and os.environ.get(RUNTIME_REEXEC_ENV) != "1"
+    ):
+        restart_env = os.environ.copy()
+        restart_env[RUNTIME_REEXEC_ENV] = "1"
+        os.execve(sys.executable, [sys.executable, __file__, *sys.argv[1:]], restart_env)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
-        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
+        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'} "
+        f"python={runtime_setup.get('python_executable') or sys.executable}",
         file=sys.stderr,
     )
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -24,6 +25,8 @@ class RuntimeProbe:
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 PIP_INSTALL_TIMEOUT_SECONDS = 300
 ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
+DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
+VERBOSE_BOOTSTRAP_ENV = "TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS"
 
 
 def _probe_llama_runtime() -> RuntimeProbe:
@@ -37,15 +40,98 @@ def _probe_llama_runtime() -> RuntimeProbe:
     )
 
 
+def _probe_llama_runtime_from_subprocess(executable: str) -> RuntimeProbe:
+    cmd = [
+        executable,
+        "-c",
+        (
+            "import json; "
+            "from utils.llm.model_manager import detect_llama_runtime_capabilities; "
+            "print(json.dumps(detect_llama_runtime_capabilities()))"
+        ),
+    ]
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as exc:
+        return RuntimeProbe(
+            backend="cpu",
+            gpu_offload_supported=False,
+            detected_device="cpu",
+            error=f"subprocess runtime probe failed: {exc}",
+        )
+
+    if completed.returncode != 0:
+        error_output = (completed.stderr or completed.stdout or "").strip()
+        return RuntimeProbe(
+            backend="cpu",
+            gpu_offload_supported=False,
+            detected_device="cpu",
+            error=f"subprocess runtime probe nonzero exit: {error_output or completed.returncode}",
+        )
+
+    try:
+        payload = json.loads((completed.stdout or "{}").strip())
+    except json.JSONDecodeError:
+        return RuntimeProbe(
+            backend="cpu",
+            gpu_offload_supported=False,
+            detected_device="cpu",
+            error="subprocess runtime probe returned invalid JSON",
+        )
+
+    return RuntimeProbe(
+        backend=str(payload.get("backend", "cpu")),
+        gpu_offload_supported=bool(payload.get("gpu_offload_supported", False)),
+        detected_device=str(payload.get("detected_device", "cpu")),
+        error=payload.get("error"),
+    )
+
+
+def _preferred_install_plans(platform: str, requirements_path: Path) -> list[LlamaCppInstallPlan]:
+    detected_platform = platform.lower()
+    if detected_platform.startswith("win"):
+        return [
+            # Canonical Windows recipe from README hardware acceleration section.
+            LlamaCppInstallPlan(
+                platform=detected_platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args="-DGGML_CUDA=on",
+                force_cmake=True,
+                index_url=None,
+                extra_index_url=None,
+                only_binary=False,
+                no_binary=False,
+            ),
+            *llama_cpp_install_plan_fallbacks(
+                platform=platform,
+                requirements_path=requirements_path,
+            ),
+        ]
+
+    return llama_cpp_install_plan_fallbacks(
+        platform=platform,
+        requirements_path=requirements_path,
+    )
+
+
 def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
-    """Probe runtime by default; install/repair only when explicit bootstrap env is enabled."""
+    """Ensure desktop sidecar runtime has GPU support when GPU-preferring modes are requested."""
 
     selected_mode = (mode or "auto").strip().lower()
+    interpreter_path = sys.executable
     if selected_mode not in GPU_MODES:
         return {
             "selected_backend": "cpu",
             "fallback_reason": "cpu mode explicitly selected",
             "runtime_action": "skipped",
+            "python_executable": interpreter_path,
         }
 
     before = _probe_llama_runtime()
@@ -55,24 +141,29 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "fallback_reason": "",
             "runtime_action": "already_supported",
             "detected_device": before.detected_device,
+            "python_executable": interpreter_path,
         }
 
-    if os.environ.get(ENABLE_BOOTSTRAP_ENV) != "1":
+    bootstrap_enabled = os.environ.get(ENABLE_BOOTSTRAP_ENV) == "1" or (
+        sys.platform.startswith("win") and os.environ.get(DISABLE_BOOTSTRAP_ENV) != "1"
+    )
+    if not bootstrap_enabled:
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
                 f"GPU runtime unavailable ({before.error or before.backend}); "
-                f"set {ENABLE_BOOTSTRAP_ENV}=1 for one-time bootstrap"
+                f"set {ENABLE_BOOTSTRAP_ENV}=1 to force bootstrap"
             ),
             "runtime_action": "probe_only",
             "detected_device": before.detected_device or "cpu",
+            "python_executable": interpreter_path,
         }
 
     target_root = repo_root or Path(__file__).resolve().parents[3]
     requirements_path = target_root / "requirements.txt"
 
     try:
-        plans = llama_cpp_install_plan_fallbacks(
+        plans = _preferred_install_plans(
             platform=sys.platform,
             requirements_path=requirements_path,
         )
@@ -87,7 +178,16 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     for plan in plans:
         env = os.environ.copy()
         env.update(plan.pip_env())
-        cmd = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
+        cmd = [
+            interpreter_path,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "--verbose",
+            *plan.pip_install_args(),
+            plan.package_spec,
+        ]
         try:
             install = subprocess.run(
                 cmd,
@@ -102,16 +202,21 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
                 f"pip install timed out after {PIP_INSTALL_TIMEOUT_SECONDS}s for backend={plan.backend}"
             )
             continue
+
         if install.returncode != 0:
             last_install_error = (install.stderr or install.stdout or "").strip()
             continue
 
-        if plan.backend in {"cuda", "metal"}:
+        post_install = _probe_llama_runtime_from_subprocess(interpreter_path)
+        if post_install.gpu_offload_supported and post_install.backend in {"cuda", "metal"}:
             return {
-                "selected_backend": plan.backend,
-                "fallback_reason": "bootstrap install complete; restart sidecar to activate runtime",
-                "runtime_action": f"installed_{plan.backend}_restart_required",
-                "detected_device": "cpu",
+                "selected_backend": post_install.backend,
+                "fallback_reason": (
+                    "runtime repaired in active interpreter; sidecar restart required to reload module"
+                ),
+                "runtime_action": f"installed_{post_install.backend}_restart_required",
+                "detected_device": post_install.detected_device or "cpu",
+                "python_executable": interpreter_path,
             }
 
         if plan.backend == "cpu":
@@ -122,9 +227,12 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
                 ),
                 "runtime_action": "installed_cpu_fallback",
                 "detected_device": "cpu",
+                "python_executable": interpreter_path,
             }
 
-    return {
+        last_install_error = post_install.error or "installed package still reports cpu-only runtime"
+
+    summary = {
         "selected_backend": "cpu",
         "fallback_reason": (
             before.error
@@ -134,7 +242,11 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         ),
         "runtime_action": "failed",
         "detected_device": "cpu",
+        "python_executable": interpreter_path,
     }
+    if os.environ.get(VERBOSE_BOOTSTRAP_ENV) == "1":
+        summary["debug_probe_error"] = before.error or ""
+    return summary
 
 
 def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -26,6 +26,7 @@ ensure_runtime_import_paths(__file__)
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+RUNTIME_REEXEC_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 
 
 def _start_stdin_reader() -> None:
@@ -166,13 +167,21 @@ def run(args: argparse.Namespace) -> int:
         )
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    if (
+        str(runtime_setup.get("runtime_action", "")).endswith("_restart_required")
+        and os.environ.get(RUNTIME_REEXEC_ENV) != "1"
+    ):
+        restart_env = os.environ.copy()
+        restart_env[RUNTIME_REEXEC_ENV] = "1"
+        os.execve(sys.executable, [sys.executable, __file__, *sys.argv[1:]], restart_env)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
-        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
+        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'} "
+        f"python={runtime_setup.get('python_executable') or sys.executable}",
         file=sys.stderr,
     )
 

--- a/desktop-tauri/src-tauri/python/verify_llama_runtime.py
+++ b/desktop-tauri/src-tauri/python/verify_llama_runtime.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Manual desktop helper: print authoritative llama-cpp runtime details."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    script_dir = str(Path(__file__).resolve().parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(__file__)
+
+from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
+from utils.llm.model_manager import detect_llama_runtime_capabilities, get_model_manager
+
+
+def main() -> int:
+    mode = "auto"
+    if len(sys.argv) > 1:
+        mode = sys.argv[1]
+
+    payload = detect_llama_runtime_capabilities()
+    print(f"sys.executable={sys.executable}")
+    print(f"sys.prefix={sys.prefix}")
+    print(f"llama_cpp.__file__={payload.get('llama_cpp_module_path') or 'missing'}")
+    print(f"GGML backend marker={payload.get('backend')}")
+    print(f"llama_supports_gpu_offload={payload.get('gpu_offload_supported')}")
+
+    manager = get_model_manager()
+    apply_compute_mode(manager, mode)
+    manager.last_compute_diagnostics = manager._resolve_compute_plan()  # noqa: SLF001
+    print(f"model_manager.compute_mode={json.dumps(compute_mode_diagnostics(manager), sort_keys=True)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -616,3 +616,46 @@ def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch
     setup = module.ensure_desktop_llama_runtime('auto')
     assert setup['runtime_action'] == 'unavailable'
     assert 'module missing' in setup['fallback_reason']
+
+def test_run_reexecs_after_runtime_repair(monkeypatch, tmp_path):
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+    _install_fake_runtime_module(monkeypatch)
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'runtime_action': 'installed_cuda_restart_required',
+            'selected_backend': 'cuda',
+            'python_executable': sys.executable,
+        },
+    )
+
+    called = {}
+
+    def fake_execve(executable, argv, env):
+        called['executable'] = executable
+        called['argv'] = argv
+        called['env'] = env
+        raise SystemExit(0)
+
+    monkeypatch.delenv(compute_node_bridge.RUNTIME_REEXEC_ENV, raising=False)
+    monkeypatch.setattr(compute_node_bridge.os, 'execve', fake_execve)
+
+    args = SimpleNamespace(
+        model=str(model_path),
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    try:
+        compute_node_bridge.run(args)
+        assert False, 'expected SystemExit from fake_execve'
+    except SystemExit:
+        pass
+
+    assert called['executable'] == sys.executable
+    assert called['argv'][0] == sys.executable
+    assert called['env'][compute_node_bridge.RUNTIME_REEXEC_ENV] == '1'

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -405,7 +405,7 @@ def test_extract_text_from_completion_handles_empty_choices():
 
 def test_normalize_chunk_fallback_handles_typeerror_and_unknown_shape():
     class WithBadDict:
-        def dict(self, required):  # pragma: no cover - signature intentionally incompatible
+        def dict(self, _required):  # pragma: no cover - signature intentionally incompatible
             return {'choices': []}
 
     class UnknownShape:
@@ -491,3 +491,40 @@ def test_run_done_without_token_when_stream_and_fallback_are_empty(tmp_path, cap
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert [event['type'] for event in events] == ['started', 'done']
+
+def test_run_reexecs_after_runtime_repair(tmp_path, monkeypatch):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+
+    monkeypatch.setattr(
+        inference_sidecar,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'runtime_action': 'installed_cuda_restart_required',
+            'selected_backend': 'cuda',
+            'python_executable': sys.executable,
+        },
+    )
+
+    called = {}
+
+    def fake_execve(executable, argv, env):
+        called['executable'] = executable
+        called['argv'] = argv
+        called['env'] = env
+        raise SystemExit(0)
+
+    monkeypatch.delenv(inference_sidecar.RUNTIME_REEXEC_ENV, raising=False)
+    monkeypatch.setattr(inference_sidecar.os, 'execve', fake_execve)
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')
+    with pytest.raises(SystemExit):
+        inference_sidecar.run(args)
+
+    assert called['executable'] == sys.executable
+    assert called['argv'][0] == sys.executable
+    assert called['env'][inference_sidecar.RUNTIME_REEXEC_ENV] == '1'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -30,64 +30,40 @@ def test_skip_runtime_bootstrap_for_cpu_mode():
     assert result['selected_backend'] == 'cpu'
 
 
-def test_probe_only_runtime_path_does_not_install_without_explicit_flag(monkeypatch):
-    probe = desktop_runtime_setup.RuntimeProbe(
-        backend='cpu',
-        gpu_offload_supported=False,
-        detected_device='cpu',
-        error=None,
-    )
-    pip_calls = []
-
-    def fake_run(*_args, **_kwargs):
-        pip_calls.append(True)
-        return _Result(returncode=0)
-
-    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
-    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
-
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
-    assert result['runtime_action'] == 'probe_only'
-    assert result['selected_backend'] == 'cpu'
-    assert desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV in result['fallback_reason']
-    assert pip_calls == []
-
-
-def test_runtime_bootstrap_explicitly_enabled_installs_and_requires_restart(monkeypatch):
-    state = {'pip_calls': []}
+def test_windows_auto_mode_repairs_cpu_runtime_without_opt_in_flag(monkeypatch):
     probe = desktop_runtime_setup.RuntimeProbe(
         backend='cpu',
         gpu_offload_supported=False,
         detected_device='cpu',
         error='cpu-only runtime',
     )
-    plan = desktop_runtime_setup.LlamaCppInstallPlan(
-        platform='win32',
-        backend='cuda',
-        package_spec='llama-cpp-python',
-        cmake_args=None,
-        force_cmake=False,
-        index_url='https://example.invalid/cuda',
-        extra_index_url=None,
-        only_binary=True,
-        no_binary=False,
-    )
+    pip_calls = []
 
     def fake_run(cmd, **_kwargs):
-        state['pip_calls'].append(cmd)
-        return _Result(returncode=0)
+        pip_calls.append(cmd)
+        return _Result(returncode=0, stdout='ok')
 
-    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(desktop_runtime_setup.sys, 'platform', 'win32')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime_from_subprocess',
+        lambda _exe: desktop_runtime_setup.RuntimeProbe(
+            backend='cuda', gpu_offload_supported=True, detected_device='nvidia', error=None
+        ),
+    )
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
     assert result['runtime_action'] == 'installed_cuda_restart_required'
     assert result['selected_backend'] == 'cuda'
-    assert 'restart sidecar' in result['fallback_reason']
-    assert len(state['pip_calls']) == 1
+    assert len(pip_calls) == 1
+    joined = ' '.join(pip_calls[0])
+    assert '--force-reinstall' in joined
+    assert '--verbose' in joined
 
 
 def test_runtime_bootstrap_returns_already_supported_when_gpu_runtime_is_present(monkeypatch):
@@ -106,33 +82,28 @@ def test_runtime_bootstrap_returns_already_supported_when_gpu_runtime_is_present
     assert result['detected_device'] == 'nvidia'
 
 
-def test_runtime_bootstrap_uses_unpinned_fallback_plans_when_requirements_missing(monkeypatch):
+def test_runtime_bootstrap_respects_disable_flag(monkeypatch):
     probe = desktop_runtime_setup.RuntimeProbe(
         backend='cpu',
         gpu_offload_supported=False,
         detected_device='cpu',
-        error='probe says cpu',
+        error='missing CUDA',
     )
-    calls = []
+    pip_calls = []
 
-    def fake_plan_fallbacks(**_kwargs):
-        raise FileNotFoundError('requirements.txt missing')
-
-    def fake_run(cmd, **_kwargs):
-        calls.append(cmd)
+    def fake_run(*_args, **_kwargs):
+        pip_calls.append(True)
         return _Result(returncode=0)
 
-    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(desktop_runtime_setup.sys, 'platform', 'win32')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', fake_plan_fallbacks)
-    monkeypatch.setattr(desktop_runtime_setup, 'sys', type('S', (), {'platform': 'linux', 'executable': sys.executable}))
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
 
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
-
-    assert result['runtime_action'] == 'installed_cpu_fallback'
-    assert result['selected_backend'] == 'cpu'
-    assert calls
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+    assert result['runtime_action'] == 'probe_only'
+    assert pip_calls == []
 
 
 def test_runtime_bootstrap_reports_timeout_and_install_errors(monkeypatch):
@@ -147,11 +118,11 @@ def test_runtime_bootstrap_reports_timeout_and_install_errors(monkeypatch):
             platform='win32',
             backend='cuda',
             package_spec='llama-cpp-python',
-            cmake_args=None,
-            force_cmake=False,
-            index_url='https://example.invalid/cuda',
+            cmake_args='-DGGML_CUDA=on',
+            force_cmake=True,
+            index_url=None,
             extra_index_url=None,
-            only_binary=True,
+            only_binary=False,
             no_binary=False,
         ),
         desktop_runtime_setup.LlamaCppInstallPlan(
@@ -176,7 +147,7 @@ def test_runtime_bootstrap_reports_timeout_and_install_errors(monkeypatch):
 
     monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    monkeypatch.setattr(desktop_runtime_setup, '_preferred_install_plans', lambda **_kwargs: plans)
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
@@ -184,6 +155,49 @@ def test_runtime_bootstrap_reports_timeout_and_install_errors(monkeypatch):
     assert result['runtime_action'] == 'failed'
     assert result['selected_backend'] == 'cpu'
     assert result['fallback_reason'] == 'wheel not found'
+
+
+def test_runtime_bootstrap_uses_same_interpreter_for_pip(monkeypatch):
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cpu',
+        gpu_offload_supported=False,
+        detected_device='cpu',
+        error='cpu runtime',
+    )
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='win32',
+        backend='cuda',
+        package_spec='llama-cpp-python',
+        cmake_args='-DGGML_CUDA=on',
+        force_cmake=True,
+        index_url=None,
+        extra_index_url=None,
+        only_binary=False,
+        no_binary=False,
+    )
+    call_cmds = []
+
+    def fake_run(cmd, **_kwargs):
+        call_cmds.append(cmd)
+        return _Result(returncode=0)
+
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
+    monkeypatch.setattr(desktop_runtime_setup, '_preferred_install_plans', lambda **_kwargs: [plan])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime_from_subprocess',
+        lambda _exe: desktop_runtime_setup.RuntimeProbe(
+            backend='cuda', gpu_offload_supported=True, detected_device='nvidia', error=None
+        ),
+    )
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert result['runtime_action'] == 'installed_cuda_restart_required'
+    assert call_cmds
+    assert call_cmds[0][0] == desktop_runtime_setup.sys.executable
 
 
 def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -28,6 +28,9 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
             'gpu_offload_supported': False,
             'detected_device': 'none',
             'error': str(exc),
+            'python_executable': sys.executable,
+            'python_prefix': sys.prefix,
+            'llama_cpp_module_path': '',
         }
 
     backend = 'cpu'
@@ -57,6 +60,9 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'gpu_offload_supported': gpu_offload_supported,
         'detected_device': backend if gpu_offload_supported else 'cpu',
         'error': None,
+        'python_executable': sys.executable,
+        'python_prefix': sys.prefix,
+        'llama_cpp_module_path': str(getattr(llama_cpp, '__file__', '')),
     }
 
 
@@ -442,6 +448,7 @@ class ModelManager:
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "
                                 f"effective={compute_plan['effective_mode']} "
+                                f"backend_available={compute_plan['backend_available']} "
                                 f"backend={compute_plan['backend_used']} "
                                 f"device_backend={compute_plan['device_backend']} "
                                 f"device_name={compute_plan['device_name']} "
@@ -449,6 +456,14 @@ class ModelManager:
                                 f"kv_cache={compute_plan['kv_cache_device']} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
+                            if llama_cpp_verbose_logging_enabled():
+                                runtime = detect_llama_runtime_capabilities()
+                                self.log_info(
+                                    "compute_runtime_paths "
+                                    f"python={runtime.get('python_executable') or sys.executable} "
+                                    f"prefix={runtime.get('python_prefix') or sys.prefix} "
+                                    f"llama_cpp={runtime.get('llama_cpp_module_path') or 'unknown'}"
+                                )
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)


### PR DESCRIPTION
### Motivation
- Desktop Auto mode often stayed CPU-only on Windows because the sidecar runtime path used a probe-only default instead of repairing the runtime in the interpreter the sidecars actually run with. 
- The goal is to ensure GPU-capable `llama-cpp-python` is repaired/installed in the same `sys.executable` interpreter when CUDA prerequisites exist so Auto/GPU modes use CUDA by default and fall back cleanly when they cannot.

### Description
- Make Windows GPU-preferring launches attempt a one-time in-place repair using the canonical README recipe by running `sys.executable -m pip install --force-reinstall --verbose` with `CMAKE_ARGS=-DGGML_CUDA=on` and `FORCE_CMAKE=1` as the primary repair plan, while preserving existing fallback plans; changes live in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`.
- Probe the real sidecar interpreter before and after install via a subprocess probe (`_probe_llama_runtime_from_subprocess`) to verify `backend_available`/`gpu_offload_supported` in the exact interpreter used by sidecars and only return a restart-required action when CUDA is truly active.
- Re-exec the sidecar/bridge process automatically after a successful repair so the newly installed runtime is immediately used (implemented in `inference_sidecar.py` and `compute_node_bridge.py`), and add concise `python=<executable>` observability to `desktop.runtime_setup` logs.
- Improve runtime diagnostics visibility by reporting interpreter/prefix/module-path info from `detect_llama_runtime_capabilities()` and adding a manual helper `desktop-tauri/src-tauri/python/verify_llama_runtime.py` plus targeted unit tests under `tests/unit/` to cover repair decisioning, same-interpreter pip usage, disable opt-out behavior, failure fallback, and re-exec behavior.

### Testing
- Ran static/compile checks with `python -m py_compile <files>` on modified Python modules and the new verify helper, which succeeded. 
- Ran the focused unit test suites with `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_compute_node_bridge.py -q` and all tests passed (`44 passed`).
- Executed the manual verification helper with `python desktop-tauri/src-tauri/python/verify_llama_runtime.py auto` to emit authoritative runtime diagnostics (printed `sys.executable`, `llama_cpp.__file__`, backend markers, offload support, and ModelManager compute diagnostics). 
- Ran `pre-commit run --all-files` which executed repository checks and reported unrelated existing repo issues (e.g., `codespell` noise in `desktop-tauri/package-lock.json` and other environment/dependency work items), so pre-commit hooks flagged unrelated failures independent of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2234e2b8832fa7a3a6202b66813c)