### PR TITLE
Auto-repair Windows CUDA llama-cpp runtime for desktop sidecars

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -46,13 +46,17 @@ repair when the runtime is CPU-only. They emit:
 - `compute_runtime ...` after `Llama(...)` init (backend actually used, offloaded
   layers, KV cache placement, and fallback reason)
 
+Set `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1` to explicitly disable the
+Windows auto-repair path and keep startup in probe-only mode (useful for
+packaging/troubleshooting while preserving normal CPU fallback diagnostics).
+
 When Windows CUDA repair is needed, desktop uses the same interpreter binary that
 launches the sidecar process (`sys.executable`) and applies the repo
 source-build recipe:
 
 - `CMAKE_ARGS=-DGGML_CUDA=on`
 - `FORCE_CMAKE=1`
-- `pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose`
+- `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose`
 
 After a successful repair, the sidecar automatically re-execs once so the active
 process immediately uses the repaired runtime (no manual restart/environment flag required).
@@ -120,7 +124,9 @@ python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto --model /path
 
 It prints:
 
-- `sys.executable` / `sys.prefix`
-- `llama_cpp.__file__`
-- backend markers and offload support
-- ModelManager diagnostics before/after init
+- Shared runtime probe fields (`backend`, `gpu_offload_supported`,
+  `detected_device`, `interpreter`, `prefix`, `llama_module_path`)
+- `compute_runtime_*` summaries using stable fields
+  (`requested`, `effective`, `backend_available`, `backend_used`,
+  `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
+  `fallback_reason`, `interpreter`, `llama_module_path`)

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -38,20 +38,24 @@ npm ci
 npm run tauri dev
 ```
 
-During normal startup, desktop sidecars run a **probe-only** runtime check in
-`auto`/`gpu`/`hybrid` modes and emit:
+During normal startup, desktop sidecars probe the active sidecar interpreter and, on
+Windows in `auto`/`gpu`/`hybrid` modes, automatically run a one-time CUDA runtime
+repair when the runtime is CPU-only. They emit:
 
 - `desktop.runtime_setup ...` during sidecar start (backend selected + fallback reason)
 - `compute_runtime ...` after `Llama(...)` init (backend actually used, offloaded
   layers, KV cache placement, and fallback reason)
 
-Normal inference requests do **not** mutate Python packages. For local desktop
-development, explicitly run one bootstrap start with
-`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` to allow a one-time
-`llama-cpp-python` install/repair attempt, then restart sidecars/app.
+When Windows CUDA repair is needed, desktop uses the same interpreter binary that
+launches the sidecar process (`sys.executable`) and applies the repo
+source-build recipe:
 
-Packaged builds should rely on pre-provisioned runtime dependencies and keep
-`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` unset.
+- `CMAKE_ARGS=-DGGML_CUDA=on`
+- `FORCE_CMAKE=1`
+- `pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose`
+
+After a successful repair, the sidecar automatically re-execs once so the active
+process immediately uses the repaired runtime (no manual restart/environment flag required).
 
 ### Platform packaging assumptions (documented, not fully automated in MVP)
 
@@ -103,3 +107,20 @@ To restore full raw subprocess output (including verbose llama.cpp logs), run de
 - `TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS=1`
 
 Both flags are equivalent opt-in toggles and intended for troubleshooting.
+
+
+### Manual runtime verification
+
+Use the helper below to print authoritative runtime wiring details from the same
+Python environment used by desktop sidecars:
+
+```bash
+python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto --model /path/to/model.gguf
+```
+
+It prints:
+
+- `sys.executable` / `sys.prefix`
+- `llama_cpp.__file__`
+- backend markers and offload support
+- ModelManager diagnostics before/after init

--- a/desktop-tauri/scripts/verify_desktop_runtime.py
+++ b/desktop-tauri/scripts/verify_desktop_runtime.py
@@ -22,16 +22,16 @@ def main() -> int:
 
     from utils.llm.model_manager import detect_llama_runtime_capabilities
 
-    payload = {
-        'sys.executable': sys.executable,
-        'sys.prefix': sys.prefix,
-    }
-
     runtime = detect_llama_runtime_capabilities()
-    payload['llama_cpp.__file__'] = runtime.get('llama_module_path', 'missing')
-    payload['GGML_USE_CUDA'] = runtime.get('backend') == 'cuda'
-    payload['GGML_USE_METAL'] = runtime.get('backend') == 'metal'
-    payload['llama_supports_gpu_offload'] = runtime.get('gpu_offload_supported', False)
+    payload = {
+        'backend': runtime.get('backend', 'missing'),
+        'gpu_offload_supported': runtime.get('gpu_offload_supported', False),
+        'detected_device': runtime.get('detected_device', 'none'),
+        'interpreter': runtime.get('interpreter', sys.executable),
+        'prefix': runtime.get('prefix', sys.prefix),
+        'llama_module_path': runtime.get('llama_module_path', 'missing'),
+        'error': runtime.get('error'),
+    }
 
     try:
         from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
@@ -41,16 +41,44 @@ def main() -> int:
         if args.model:
             manager.model_path = args.model
         apply_compute_mode(manager, args.mode)
-        payload['compute_plan_pre_init'] = compute_mode_diagnostics(manager)
+        pre_init = compute_mode_diagnostics(manager)
+        payload['compute_runtime_pre_init'] = {
+            'requested': pre_init.get('requested_mode'),
+            'effective': pre_init.get('effective_mode'),
+            'backend_available': pre_init.get('backend_available'),
+            'backend_used': pre_init.get('backend_used'),
+            'device_backend': pre_init.get('backend_used'),
+            'device_name': 'unreported',
+            'offloaded_layers': pre_init.get('n_gpu_layers'),
+            'kv_cache': 'unknown_pre_init',
+            'fallback_reason': pre_init.get('fallback_reason'),
+            'interpreter': payload['interpreter'],
+            'llama_module_path': payload['llama_module_path'],
+        }
 
         if args.model and os.path.exists(args.model):
             manager.get_llm_instance()
-            payload['compute_plan_post_init'] = compute_mode_diagnostics(manager)
+            post_init = compute_mode_diagnostics(manager)
+            payload['compute_runtime_post_init'] = {
+                'requested': post_init.get('requested_mode'),
+                'effective': post_init.get('effective_mode'),
+                'backend_available': post_init.get('backend_available'),
+                'backend_used': post_init.get('backend_used'),
+                'device_backend': post_init.get('device_backend'),
+                'device_name': post_init.get('device_name'),
+                'offloaded_layers': post_init.get('offloaded_layers'),
+                'kv_cache': post_init.get('kv_cache_device'),
+                'fallback_reason': post_init.get('fallback_reason'),
+                'interpreter': payload['interpreter'],
+                'llama_module_path': payload['llama_module_path'],
+            }
         else:
-            payload['compute_plan_post_init'] = 'skipped (provide --model <gguf> to initialize Llama)'
+            payload['compute_runtime_post_init'] = (
+                'skipped (provide --model <gguf> to initialize Llama)'
+            )
     except ModuleNotFoundError as exc:
-        payload['compute_plan_pre_init'] = f'skipped (missing dependency: {exc})'
-        payload['compute_plan_post_init'] = 'skipped'
+        payload['compute_runtime_pre_init'] = f'skipped (missing dependency: {exc})'
+        payload['compute_runtime_post_init'] = 'skipped'
 
     print(json.dumps(payload, indent=2))
     return 0

--- a/desktop-tauri/scripts/verify_desktop_runtime.py
+++ b/desktop-tauri/scripts/verify_desktop_runtime.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Manual desktop runtime verification for llama-cpp backend wiring."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Verify desktop llama runtime wiring')
+    parser.add_argument('--mode', default='auto')
+    parser.add_argument('--model', default='')
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from utils.llm.model_manager import detect_llama_runtime_capabilities
+
+    payload = {
+        'sys.executable': sys.executable,
+        'sys.prefix': sys.prefix,
+    }
+
+    runtime = detect_llama_runtime_capabilities()
+    payload['llama_cpp.__file__'] = runtime.get('llama_module_path', 'missing')
+    payload['GGML_USE_CUDA'] = runtime.get('backend') == 'cuda'
+    payload['GGML_USE_METAL'] = runtime.get('backend') == 'metal'
+    payload['llama_supports_gpu_offload'] = runtime.get('gpu_offload_supported', False)
+
+    try:
+        from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
+        from utils.llm.model_manager import get_model_manager
+
+        manager = get_model_manager()
+        if args.model:
+            manager.model_path = args.model
+        apply_compute_mode(manager, args.mode)
+        payload['compute_plan_pre_init'] = compute_mode_diagnostics(manager)
+
+        if args.model and os.path.exists(args.model):
+            manager.get_llm_instance()
+            payload['compute_plan_post_init'] = compute_mode_diagnostics(manager)
+        else:
+            payload['compute_plan_post_init'] = 'skipped (provide --model <gguf> to initialize Llama)'
+    except ModuleNotFoundError as exc:
+        payload['compute_plan_pre_init'] = f'skipped (missing dependency: {exc})'
+        payload['compute_plan_post_init'] = 'skipped'
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -111,8 +111,8 @@ def run(args: argparse.Namespace) -> int:
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
-        f"python={runtime_setup.get('interpreter', sys.executable)} "
-        f"llama_module={runtime_setup.get('llama_module_path', 'missing')} "
+        f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
+        f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -20,7 +20,7 @@ if __package__ in (None, ""):
 from path_bootstrap import ensure_runtime_import_paths
 
 try:
-    from desktop_runtime_setup import ensure_desktop_llama_runtime
+    from desktop_runtime_setup import ensure_desktop_llama_runtime, maybe_reexec_for_runtime_refresh
 except ModuleNotFoundError:
     def ensure_desktop_llama_runtime(_mode: str) -> Dict[str, str]:
         return {
@@ -29,6 +29,9 @@ except ModuleNotFoundError:
             "runtime_action": "unavailable",
             "fallback_reason": "desktop_runtime_setup module missing",
         }
+
+    def maybe_reexec_for_runtime_refresh(_runtime_setup: Dict[str, str]) -> None:
+        return
 
 ensure_runtime_import_paths(__file__)
 
@@ -101,12 +104,15 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
+        f"python={runtime_setup.get('interpreter', sys.executable)} "
+        f"llama_module={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -33,49 +33,34 @@ GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 PIP_INSTALL_TIMEOUT_SECONDS = 300
 PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
+DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
 
 _PROBE_SNIPPET = """
-import json, sys
-payload = {
-    "backend": "cpu",
-    "gpu_offload_supported": False,
-    "detected_device": "cpu",
-    "interpreter": sys.executable,
-    "prefix": sys.prefix,
-    "llama_module_path": "missing",
-    "error": None,
-}
-try:
-    import llama_cpp
-    payload["llama_module_path"] = getattr(llama_cpp, "__file__", "unknown") or "unknown"
-    backend = "cpu"
-    if bool(getattr(llama_cpp, "GGML_USE_CUDA", False)):
-        backend = "cuda"
-    elif bool(getattr(llama_cpp, "GGML_USE_METAL", False)):
-        backend = "metal"
-    supports_gpu = getattr(llama_cpp, "llama_supports_gpu_offload", None)
-    if callable(supports_gpu):
-        try:
-            payload["gpu_offload_supported"] = bool(supports_gpu())
-        except Exception:
-            payload["gpu_offload_supported"] = False
-    else:
-        payload["gpu_offload_supported"] = backend in {"cuda", "metal"}
-    if payload["gpu_offload_supported"] and backend == "cpu":
-        backend = "metal" if sys.platform == "darwin" else "cuda"
-    payload["backend"] = backend
-    payload["detected_device"] = backend if payload["gpu_offload_supported"] else "cpu"
-except Exception as exc:
-    payload["backend"] = "missing"
-    payload["detected_device"] = "none"
-    payload["error"] = str(exc)
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path.cwd()
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from utils.llm.model_manager import detect_llama_runtime_capabilities
+
+payload = detect_llama_runtime_capabilities()
 print(json.dumps(payload))
 """.strip()
 
 
 def _probe_llama_runtime() -> RuntimeProbe:
+    repo_root = Path(__file__).resolve().parents[3]
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    pythonpath_entries = [str(repo_root)]
+    if existing_pythonpath:
+        pythonpath_entries.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     try:
         result = subprocess.run(
             cmd,
@@ -83,6 +68,8 @@ def _probe_llama_runtime() -> RuntimeProbe:
             capture_output=True,
             text=True,
             timeout=30,
+            cwd=str(repo_root),
+            env=env,
         )
     except Exception as exc:
         return RuntimeProbe(
@@ -279,6 +266,16 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "fallback_reason": (
                 f"GPU runtime unavailable ({before.error or before.backend}); "
                 "desktop auto-repair is currently Windows-focused"
+            ),
+            "runtime_action": "probe_only",
+            **_probe_result_payload(before),
+        }
+
+    if os.getenv(DISABLE_BOOTSTRAP_ENV) == "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
             ),
             "runtime_action": "probe_only",
             **_probe_result_payload(before),

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -10,7 +11,6 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from desktop_gpu_packaging import LlamaCppInstallPlan, llama_cpp_install_plan_fallbacks
-from utils.llm.model_manager import detect_llama_runtime_capabilities
 
 
 @dataclass(frozen=True)
@@ -18,122 +18,256 @@ class RuntimeProbe:
     backend: str
     gpu_offload_supported: bool
     detected_device: str
+    interpreter: str
+    prefix: str
+    llama_module_path: str
     error: Optional[str] = None
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 PIP_INSTALL_TIMEOUT_SECONDS = 300
-ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
+REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
+
+_PROBE_SNIPPET = """
+import json, sys
+payload = {
+    "backend": "cpu",
+    "gpu_offload_supported": False,
+    "detected_device": "cpu",
+    "interpreter": sys.executable,
+    "prefix": sys.prefix,
+    "llama_module_path": "missing",
+    "error": None,
+}
+try:
+    import llama_cpp
+    payload["llama_module_path"] = getattr(llama_cpp, "__file__", "unknown") or "unknown"
+    backend = "cpu"
+    if bool(getattr(llama_cpp, "GGML_USE_CUDA", False)):
+        backend = "cuda"
+    elif bool(getattr(llama_cpp, "GGML_USE_METAL", False)):
+        backend = "metal"
+    supports_gpu = getattr(llama_cpp, "llama_supports_gpu_offload", None)
+    if callable(supports_gpu):
+        try:
+            payload["gpu_offload_supported"] = bool(supports_gpu())
+        except Exception:
+            payload["gpu_offload_supported"] = False
+    else:
+        payload["gpu_offload_supported"] = backend in {"cuda", "metal"}
+    if payload["gpu_offload_supported"] and backend == "cpu":
+        backend = "metal" if sys.platform == "darwin" else "cuda"
+    payload["backend"] = backend
+    payload["detected_device"] = backend if payload["gpu_offload_supported"] else "cpu"
+except Exception as exc:
+    payload["backend"] = "missing"
+    payload["detected_device"] = "none"
+    payload["error"] = str(exc)
+print(json.dumps(payload))
+""".strip()
 
 
 def _probe_llama_runtime() -> RuntimeProbe:
-    payload = detect_llama_runtime_capabilities()
+    cmd = [sys.executable, "-c", _PROBE_SNIPPET]
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as exc:
+        return RuntimeProbe(
+            backend="missing",
+            gpu_offload_supported=False,
+            detected_device="none",
+            interpreter=sys.executable,
+            prefix=sys.prefix,
+            llama_module_path="missing",
+            error=str(exc),
+        )
+
+    stdout = (result.stdout or "").strip()
+    try:
+        payload = json.loads(stdout) if stdout else {}
+    except json.JSONDecodeError:
+        payload = {
+            "backend": "missing",
+            "gpu_offload_supported": False,
+            "detected_device": "none",
+            "interpreter": sys.executable,
+            "prefix": sys.prefix,
+            "llama_module_path": "missing",
+            "error": (result.stderr or "").strip() or "probe parse failure",
+        }
 
     return RuntimeProbe(
         backend=str(payload.get("backend", "cpu")),
         gpu_offload_supported=bool(payload.get("gpu_offload_supported", False)),
         detected_device=str(payload.get("detected_device", "cpu")),
+        interpreter=str(payload.get("interpreter", sys.executable)),
+        prefix=str(payload.get("prefix", sys.prefix)),
+        llama_module_path=str(payload.get("llama_module_path", "missing")),
         error=payload.get("error"),
     )
 
 
+def _run_pip_install(cmd: list[str], env: dict[str, str]) -> tuple[bool, str]:
+    try:
+        install = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=PIP_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"pip install timed out after {PIP_INSTALL_TIMEOUT_SECONDS}s"
+
+    if install.returncode == 0:
+        return True, (install.stdout or "").strip()
+
+    return False, (install.stderr or install.stdout or "").strip()
+
+
+def _windows_cuda_source_repair() -> tuple[bool, str]:
+    env = os.environ.copy()
+    env["CMAKE_ARGS"] = "-DGGML_CUDA=on"
+    env["FORCE_CMAKE"] = "1"
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "llama-cpp-python",
+        "--force-reinstall",
+        "--upgrade",
+        "--no-cache-dir",
+        "--verbose",
+    ]
+    return _run_pip_install(cmd, env)
+
+
+def _summarize_install_error(raw: str) -> str:
+    text = (raw or "").strip()
+    if not text:
+        return "install failed"
+    return text.splitlines()[-1][:240]
+
+
+def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
+    return {
+        "detected_device": probe.detected_device or "cpu",
+        "interpreter": probe.interpreter,
+        "interpreter_prefix": probe.prefix,
+        "llama_module_path": probe.llama_module_path,
+    }
+
+
+def maybe_reexec_for_runtime_refresh(runtime_setup: Dict[str, str]) -> None:
+    if runtime_setup.get("runtime_action") != "installed_cuda_reexec":
+        return
+    if os.environ.get(REEXEC_GUARD_ENV) == "1":
+        return
+    env = os.environ.copy()
+    env[REEXEC_GUARD_ENV] = "1"
+    os.execve(sys.executable, [sys.executable, *sys.argv], env)
+
+
 def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
-    """Probe runtime by default; install/repair only when explicit bootstrap env is enabled."""
+    """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
+    before = _probe_llama_runtime()
+
     if selected_mode not in GPU_MODES:
         return {
             "selected_backend": "cpu",
             "fallback_reason": "cpu mode explicitly selected",
             "runtime_action": "skipped",
+            **_probe_result_payload(before),
         }
 
-    before = _probe_llama_runtime()
     if before.gpu_offload_supported and before.backend in {"cuda", "metal"}:
         return {
             "selected_backend": before.backend,
             "fallback_reason": "",
             "runtime_action": "already_supported",
-            "detected_device": before.detected_device,
+            **_probe_result_payload(before),
         }
 
-    if os.environ.get(ENABLE_BOOTSTRAP_ENV) != "1":
+    if not sys.platform.startswith("win"):
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
                 f"GPU runtime unavailable ({before.error or before.backend}); "
-                f"set {ENABLE_BOOTSTRAP_ENV}=1 for one-time bootstrap"
+                "desktop auto-repair is currently Windows-focused"
             ),
             "runtime_action": "probe_only",
-            "detected_device": before.detected_device or "cpu",
+            **_probe_result_payload(before),
         }
+
+    last_error = ""
+    source_ok, source_log = _windows_cuda_source_repair()
+    if source_ok:
+        after = _probe_llama_runtime()
+        if after.gpu_offload_supported and after.backend == "cuda":
+            return {
+                "selected_backend": "cuda",
+                "fallback_reason": "installed CUDA runtime; re-executing sidecar",
+                "runtime_action": "installed_cuda_reexec",
+                **_probe_result_payload(after),
+            }
+        last_error = (
+            "CUDA source reinstall completed but runtime still CPU-only; "
+            "check CUDA toolkit/build tools"
+        )
+    else:
+        last_error = _summarize_install_error(source_log)
 
     target_root = repo_root or Path(__file__).resolve().parents[3]
     requirements_path = target_root / "requirements.txt"
-
     try:
         plans = llama_cpp_install_plan_fallbacks(
             platform=sys.platform,
             requirements_path=requirements_path,
         )
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, ValueError):
         plans = _fallback_unpinned_plans(sys.platform)
-        fallback_setup_error = str(exc)
-    else:
-        fallback_setup_error = ""
-
-    last_install_error = ""
 
     for plan in plans:
         env = os.environ.copy()
         env.update(plan.pip_env())
         cmd = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
-        try:
-            install = subprocess.run(
-                cmd,
-                check=False,
-                capture_output=True,
-                text=True,
-                env=env,
-                timeout=PIP_INSTALL_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            last_install_error = (
-                f"pip install timed out after {PIP_INSTALL_TIMEOUT_SECONDS}s for backend={plan.backend}"
-            )
-            continue
-        if install.returncode != 0:
-            last_install_error = (install.stderr or install.stdout or "").strip()
+        ok, log_output = _run_pip_install(cmd, env)
+        if not ok:
+            last_error = _summarize_install_error(log_output)
             continue
 
-        if plan.backend in {"cuda", "metal"}:
+        after = _probe_llama_runtime()
+        if after.gpu_offload_supported and after.backend in {"cuda", "metal"}:
             return {
-                "selected_backend": plan.backend,
-                "fallback_reason": "bootstrap install complete; restart sidecar to activate runtime",
-                "runtime_action": f"installed_{plan.backend}_restart_required",
-                "detected_device": "cpu",
+                "selected_backend": after.backend,
+                "fallback_reason": "installed GPU runtime; re-executing sidecar",
+                "runtime_action": "installed_cuda_reexec",
+                **_probe_result_payload(after),
             }
 
         if plan.backend == "cpu":
             return {
                 "selected_backend": "cpu",
-                "fallback_reason": (
-                    "GPU runtime unavailable after install attempts; using CPU wheel fallback"
-                ),
+                "fallback_reason": "GPU runtime unavailable after repair; using CPU runtime",
                 "runtime_action": "installed_cpu_fallback",
-                "detected_device": "cpu",
+                **_probe_result_payload(after),
             }
 
     return {
         "selected_backend": "cpu",
-        "fallback_reason": (
-            before.error
-            or fallback_setup_error
-            or last_install_error
-            or "unable to install a GPU-capable llama-cpp runtime"
-        ),
+        "fallback_reason": before.error or last_error or "unable to install a GPU-capable runtime",
         "runtime_action": "failed",
-        "detected_device": "cpu",
+        **_probe_result_payload(before),
     }
 
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -6,11 +6,16 @@ import json
 import os
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 
-from desktop_gpu_packaging import LlamaCppInstallPlan, llama_cpp_install_plan_fallbacks
+from desktop_gpu_packaging import (
+    LlamaCppInstallPlan,
+    llama_cpp_install_plan_fallbacks,
+    llama_cpp_requirement_spec,
+)
 
 
 @dataclass(frozen=True)
@@ -26,7 +31,9 @@ class RuntimeProbe:
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 PIP_INSTALL_TIMEOUT_SECONDS = 300
+PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
+SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
 
 _PROBE_SNIPPET = """
 import json, sys
@@ -89,8 +96,20 @@ def _probe_llama_runtime() -> RuntimeProbe:
         )
 
     stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0 or not stdout:
+        return RuntimeProbe(
+            backend="missing",
+            gpu_offload_supported=False,
+            detected_device="none",
+            interpreter=sys.executable,
+            prefix=sys.prefix,
+            llama_module_path="missing",
+            error=stderr or f"probe subprocess failed with return code {result.returncode}",
+        )
+
     try:
-        payload = json.loads(stdout) if stdout else {}
+        payload = json.loads(stdout)
     except json.JSONDecodeError:
         payload = {
             "backend": "missing",
@@ -99,7 +118,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
             "interpreter": sys.executable,
             "prefix": sys.prefix,
             "llama_module_path": "missing",
-            "error": (result.stderr or "").strip() or "probe parse failure",
+            "error": stderr or "probe parse failure",
         }
 
     return RuntimeProbe(
@@ -113,7 +132,12 @@ def _probe_llama_runtime() -> RuntimeProbe:
     )
 
 
-def _run_pip_install(cmd: list[str], env: dict[str, str]) -> tuple[bool, str]:
+def _run_pip_install(
+    cmd: list[str],
+    env: dict[str, str],
+    *,
+    timeout_seconds: int = PIP_INSTALL_TIMEOUT_SECONDS,
+) -> tuple[bool, str]:
     try:
         install = subprocess.run(
             cmd,
@@ -121,10 +145,10 @@ def _run_pip_install(cmd: list[str], env: dict[str, str]) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             env=env,
-            timeout=PIP_INSTALL_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
-        return False, f"pip install timed out after {PIP_INSTALL_TIMEOUT_SECONDS}s"
+        return False, f"pip install timed out after {timeout_seconds}s"
 
     if install.returncode == 0:
         return True, (install.stdout or "").strip()
@@ -132,22 +156,22 @@ def _run_pip_install(cmd: list[str], env: dict[str, str]) -> tuple[bool, str]:
     return False, (install.stderr or install.stdout or "").strip()
 
 
-def _windows_cuda_source_repair() -> tuple[bool, str]:
+def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
     env = os.environ.copy()
     env["CMAKE_ARGS"] = "-DGGML_CUDA=on"
     env["FORCE_CMAKE"] = "1"
+    package_spec = llama_cpp_requirement_spec(requirements_path)
     cmd = [
         sys.executable,
         "-m",
         "pip",
         "install",
-        "llama-cpp-python",
+        package_spec,
         "--force-reinstall",
-        "--upgrade",
         "--no-cache-dir",
         "--verbose",
     ]
-    return _run_pip_install(cmd, env)
+    return _run_pip_install(cmd, env, timeout_seconds=PIP_SOURCE_BUILD_TIMEOUT_SECONDS)
 
 
 def _summarize_install_error(raw: str) -> str:
@@ -161,9 +185,57 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
     return {
         "detected_device": probe.detected_device or "cpu",
         "interpreter": probe.interpreter,
+        "prefix": probe.prefix,
         "interpreter_prefix": probe.prefix,
         "llama_module_path": probe.llama_module_path,
     }
+
+
+def _runtime_state_path() -> Path:
+    return Path.home() / ".token_place_desktop_runtime_state.json"
+
+
+def _load_runtime_state() -> dict:
+    path = _runtime_state_path()
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_runtime_state(state: dict) -> None:
+    path = _runtime_state_path()
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def _should_attempt_source_repair() -> tuple[bool, str]:
+    state = _load_runtime_state()
+    failures = state.get("source_repair_failures", {})
+    entry = failures.get(sys.executable, {})
+    last_failed_at = float(entry.get("last_failed_at", 0))
+    now = time.time()
+    if now - last_failed_at >= SOURCE_REPAIR_COOLDOWN_SECONDS:
+        return True, ""
+    retry_in_seconds = int(SOURCE_REPAIR_COOLDOWN_SECONDS - (now - last_failed_at))
+    return False, entry.get("reason") or f"source repair cooldown active ({retry_in_seconds}s remaining)"
+
+
+def _record_source_repair_failure(reason: str) -> None:
+    state = _load_runtime_state()
+    failures = state.setdefault("source_repair_failures", {})
+    failures[sys.executable] = {
+        "last_failed_at": time.time(),
+        "reason": reason,
+    }
+    _save_runtime_state(state)
+
+
+def _clear_source_repair_failure() -> None:
+    state = _load_runtime_state()
+    failures = state.get("source_repair_failures", {})
+    if sys.executable in failures:
+        failures.pop(sys.executable, None)
+        _save_runtime_state(state)
 
 
 def maybe_reexec_for_runtime_refresh(runtime_setup: Dict[str, str]) -> None:
@@ -173,7 +245,10 @@ def maybe_reexec_for_runtime_refresh(runtime_setup: Dict[str, str]) -> None:
         return
     env = os.environ.copy()
     env[REEXEC_GUARD_ENV] = "1"
-    os.execve(sys.executable, [sys.executable, *sys.argv], env)
+    try:
+        os.execve(sys.executable, [sys.executable, *sys.argv], env)
+    except OSError:
+        return
 
 
 def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
@@ -209,26 +284,34 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    last_error = ""
-    source_ok, source_log = _windows_cuda_source_repair()
-    if source_ok:
-        after = _probe_llama_runtime()
-        if after.gpu_offload_supported and after.backend == "cuda":
-            return {
-                "selected_backend": "cuda",
-                "fallback_reason": "installed CUDA runtime; re-executing sidecar",
-                "runtime_action": "installed_cuda_reexec",
-                **_probe_result_payload(after),
-            }
-        last_error = (
-            "CUDA source reinstall completed but runtime still CPU-only; "
-            "check CUDA toolkit/build tools"
-        )
-    else:
-        last_error = _summarize_install_error(source_log)
-
     target_root = repo_root or Path(__file__).resolve().parents[3]
     requirements_path = target_root / "requirements.txt"
+    last_error = ""
+
+    should_repair, repair_skip_reason = _should_attempt_source_repair()
+    if should_repair:
+        source_ok, source_log = _windows_cuda_source_repair(requirements_path)
+        if source_ok:
+            _clear_source_repair_failure()
+            after = _probe_llama_runtime()
+            if after.gpu_offload_supported and after.backend == "cuda":
+                return {
+                    "selected_backend": "cuda",
+                    "fallback_reason": "installed CUDA runtime; re-executing sidecar",
+                    "runtime_action": "installed_cuda_reexec",
+                    **_probe_result_payload(after),
+                }
+            last_error = (
+                "CUDA source reinstall completed but runtime still CPU-only; "
+                "check CUDA toolkit/build tools"
+            )
+            _record_source_repair_failure(last_error)
+        else:
+            last_error = _summarize_install_error(source_log)
+            _record_source_repair_failure(last_error)
+    else:
+        last_error = repair_skip_reason
+
     try:
         plans = llama_cpp_install_plan_fallbacks(
             platform=sys.platform,

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -173,8 +173,8 @@ def run(args: argparse.Namespace) -> int:
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
-        f"python={runtime_setup.get('interpreter', sys.executable)} "
-        f"llama_module={runtime_setup.get('llama_module_path', 'missing')} "
+        f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
+        f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -19,7 +19,7 @@ if __package__ in (None, ""):
         sys.path.insert(0, script_dir)
 
 from path_bootstrap import ensure_runtime_import_paths
-from desktop_runtime_setup import ensure_desktop_llama_runtime
+from desktop_runtime_setup import ensure_desktop_llama_runtime, maybe_reexec_for_runtime_refresh
 
 ensure_runtime_import_paths(__file__)
 
@@ -166,12 +166,15 @@ def run(args: argparse.Namespace) -> int:
         )
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
+        f"python={runtime_setup.get('interpreter', sys.executable)} "
+        f"llama_module={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -124,6 +124,51 @@ def test_maybe_reexec_for_runtime_refresh_reexecs_once(monkeypatch):
     assert called['guard'] == '1'
 
 
+def test_windows_runtime_bootstrap_respects_opt_out_env(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
+    invoked = {'source_repair': False}
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_windows_cuda_source_repair',
+        lambda _requirements_path: (invoked.update(source_repair=True), '') and (False, 'unexpected call'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+
+    assert result['runtime_action'] == 'probe_only'
+    assert desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert invoked['source_repair'] is False
+
+
+def test_windows_runtime_bootstrap_success_reexec_is_guarded_to_one_attempt(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    probes = iter([_probe(), _probe(backend='cuda', gpu=True, device='cuda')])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: next(probes))
+    monkeypatch.setattr(
+        desktop_runtime_setup, '_windows_cuda_source_repair', lambda _requirements_path: (True, 'ok')
+    )
+    exec_calls = {'count': 0}
+    monkeypatch.setattr(
+        desktop_runtime_setup.os,
+        'execve',
+        lambda *_args: exec_calls.update(count=exec_calls['count'] + 1),
+    )
+    monkeypatch.delenv(desktop_runtime_setup.REEXEC_GUARD_ENV, raising=False)
+
+    runtime_setup = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+    desktop_runtime_setup.maybe_reexec_for_runtime_refresh(runtime_setup)
+    monkeypatch.setenv(desktop_runtime_setup.REEXEC_GUARD_ENV, '1')
+    desktop_runtime_setup.maybe_reexec_for_runtime_refresh(runtime_setup)
+
+    assert runtime_setup['runtime_action'] == 'installed_cuda_reexec'
+    assert exec_calls['count'] == 1
+
+
 def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     win_plans = desktop_runtime_setup._fallback_unpinned_plans('win32')
     darwin_plans = desktop_runtime_setup._fallback_unpinned_plans('darwin')

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -261,3 +261,102 @@ def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
 
     assert result['runtime_action'] == 'failed'
     assert result['fallback_reason'] == 'build failed'
+
+
+def test_probe_marks_error_when_subprocess_raises(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError('subprocess unavailable')
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _raise)
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+    assert probe.backend == 'missing'
+    assert probe.error == 'subprocess unavailable'
+
+
+def test_probe_uses_return_code_when_stderr_is_empty(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+
+    class _Result:
+        returncode = 9
+        stdout = ''
+        stderr = ''
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _Result())
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+    assert probe.backend == 'missing'
+    assert probe.error == 'probe subprocess failed with return code 9'
+
+
+def test_probe_falls_back_when_payload_is_not_json(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+
+    class _Result:
+        returncode = 0
+        stdout = 'not-json'
+        stderr = 'json parse failed'
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _Result())
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+    assert probe.backend == 'missing'
+    assert probe.error == 'json parse failed'
+    assert probe.llama_module_path == 'missing'
+
+
+def test_run_pip_install_success_failure_and_timeout(monkeypatch):
+    class _OkResult:
+        returncode = 0
+        stdout = 'ok output'
+        stderr = ''
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _OkResult())
+    ok, output = desktop_runtime_setup._run_pip_install(['python'], {})
+    assert ok is True
+    assert output == 'ok output'
+
+    class _FailResult:
+        returncode = 1
+        stdout = 'fallback stdout'
+        stderr = 'real stderr'
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _FailResult())
+    ok, output = desktop_runtime_setup._run_pip_install(['python'], {})
+    assert ok is False
+    assert output == 'real stderr'
+
+    def _timeout(*_args, **_kwargs):
+        raise desktop_runtime_setup.subprocess.TimeoutExpired(cmd='pip', timeout=12)
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _timeout)
+    ok, output = desktop_runtime_setup._run_pip_install(['python'], {}, timeout_seconds=12)
+    assert ok is False
+    assert output == 'pip install timed out after 12s'
+
+
+def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    state_path = tmp_path / 'runtime_state.json'
+    monkeypatch.setattr(desktop_runtime_setup, '_runtime_state_path', lambda: state_path)
+    now = 2_000.0
+    monkeypatch.setattr(desktop_runtime_setup.time, 'time', lambda: now)
+
+    desktop_runtime_setup._record_source_repair_failure('build failed badly')
+    can_retry, reason = desktop_runtime_setup._should_attempt_source_repair()
+    assert can_retry is False
+    assert reason == 'build failed badly'
+
+    desktop_runtime_setup._clear_source_repair_failure()
+    state = json.loads(state_path.read_text(encoding='utf-8'))
+    assert sys.executable not in state.get('source_repair_failures', {})
+    monkeypatch.setattr(
+        desktop_runtime_setup.time,
+        'time',
+        lambda: now + desktop_runtime_setup.SOURCE_REPAIR_COOLDOWN_SECONDS + 1,
+    )
+    can_retry, reason = desktop_runtime_setup._should_attempt_source_repair()
+    assert can_retry is True
+    assert reason == ''

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -46,9 +47,14 @@ def test_skip_runtime_bootstrap_for_cpu_mode(monkeypatch):
 
 def test_windows_runtime_bootstrap_auto_repairs_and_requests_reexec(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
     probes = iter([_probe(), _probe(backend='cuda', gpu=True, device='cuda')])
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: next(probes))
-    monkeypatch.setattr(desktop_runtime_setup, '_windows_cuda_source_repair', lambda: (True, 'ok'))
+    monkeypatch.setattr(
+        desktop_runtime_setup, '_windows_cuda_source_repair', lambda _requirements_path: (True, 'ok')
+    )
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
 
@@ -72,8 +78,12 @@ def test_runtime_bootstrap_noop_when_gpu_runtime_is_already_present(monkeypatch)
 
 def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
-    monkeypatch.setattr(desktop_runtime_setup, '_windows_cuda_source_repair', lambda: (False, 'compile failed'))
+    monkeypatch.setattr(
+        desktop_runtime_setup, '_windows_cuda_source_repair', lambda _requirements_path: (False, 'compile failed')
+    )
     plans = [
         desktop_runtime_setup.LlamaCppInstallPlan(
             platform='win32',
@@ -128,15 +138,81 @@ def test_windows_source_repair_uses_active_interpreter(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     captured = {}
 
-    def fake_run(cmd, env):
+    def fake_run(cmd, env, timeout_seconds):
         captured['cmd'] = cmd
         captured['env'] = env
+        captured['timeout_seconds'] = timeout_seconds
         return True, 'ok'
 
     monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', fake_run)
-    ok, _ = desktop_runtime_setup._windows_cuda_source_repair()
+    ok, _ = desktop_runtime_setup._windows_cuda_source_repair(Path.cwd() / 'requirements.txt')
 
     assert ok is True
     assert captured['cmd'][:3] == [sys.executable, '-m', 'pip']
+    assert captured['cmd'][4].startswith('llama-cpp-python==')
     assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
     assert captured['env']['FORCE_CMAKE'] == '1'
+    assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+
+
+def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+
+    class _Result:
+        returncode = 1
+        stdout = ''
+        stderr = 'probe failed'
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _Result())
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+    assert probe.backend == 'missing'
+    assert probe.error == 'probe failed'
+
+
+def test_maybe_reexec_for_runtime_refresh_skips_when_guard_set(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    called = {'execve': False}
+    monkeypatch.setattr(desktop_runtime_setup.os, 'execve', lambda *_args: called.update(execve=True))
+    monkeypatch.setenv(desktop_runtime_setup.REEXEC_GUARD_ENV, '1')
+
+    desktop_runtime_setup.maybe_reexec_for_runtime_refresh({'runtime_action': 'installed_cuda_reexec'})
+
+    assert called['execve'] is False
+
+
+def test_maybe_reexec_for_runtime_refresh_handles_execve_oserror(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+
+    def _raise(*_args):
+        raise OSError('denied')
+
+    monkeypatch.setattr(desktop_runtime_setup.os, 'execve', _raise)
+    monkeypatch.delenv(desktop_runtime_setup.REEXEC_GUARD_ENV, raising=False)
+
+    desktop_runtime_setup.maybe_reexec_for_runtime_refresh({'runtime_action': 'installed_cuda_reexec'})
+
+
+def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    state_path = tmp_path / 'runtime_state.json'
+    monkeypatch.setattr(desktop_runtime_setup, '_runtime_state_path', lambda: state_path)
+    now = 1_000.0
+    monkeypatch.setattr(desktop_runtime_setup.time, 'time', lambda: now)
+    state_path.write_text(
+        json.dumps(
+            {
+                'source_repair_failures': {
+                    sys.executable: {'last_failed_at': now - 30, 'reason': 'build failed'}
+                }
+            }
+        ),
+        encoding='utf-8',
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [])
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert result['runtime_action'] == 'failed'
+    assert result['fallback_reason'] == 'build failed'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -17,173 +17,101 @@ sys.modules['desktop_runtime_setup'] = desktop_runtime_setup
 SPEC.loader.exec_module(desktop_runtime_setup)
 
 
-class _Result:
-    def __init__(self, returncode=0, stdout='', stderr=''):
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
+class _SysStub:
+    platform = 'win32'
+    executable = sys.executable
+    prefix = sys.prefix
+    argv = [str(MODULE_PATH)]
 
 
-def test_skip_runtime_bootstrap_for_cpu_mode():
+def _probe(*, backend='cpu', gpu=False, device='cpu', error=None):
+    return desktop_runtime_setup.RuntimeProbe(
+        backend=backend,
+        gpu_offload_supported=gpu,
+        detected_device=device,
+        interpreter=sys.executable,
+        prefix=sys.prefix,
+        llama_module_path='C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+        error=error,
+    )
+
+
+def test_skip_runtime_bootstrap_for_cpu_mode(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('cpu')
     assert result['runtime_action'] == 'skipped'
     assert result['selected_backend'] == 'cpu'
 
 
-def test_probe_only_runtime_path_does_not_install_without_explicit_flag(monkeypatch):
-    probe = desktop_runtime_setup.RuntimeProbe(
-        backend='cpu',
-        gpu_offload_supported=False,
-        detected_device='cpu',
-        error=None,
-    )
-    pip_calls = []
-
-    def fake_run(*_args, **_kwargs):
-        pip_calls.append(True)
-        return _Result(returncode=0)
-
-    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
-    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+def test_windows_runtime_bootstrap_auto_repairs_and_requests_reexec(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    probes = iter([_probe(), _probe(backend='cuda', gpu=True, device='cuda')])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: next(probes))
+    monkeypatch.setattr(desktop_runtime_setup, '_windows_cuda_source_repair', lambda: (True, 'ok'))
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
-    assert result['runtime_action'] == 'probe_only'
-    assert result['selected_backend'] == 'cpu'
-    assert desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV in result['fallback_reason']
-    assert pip_calls == []
 
-
-def test_runtime_bootstrap_explicitly_enabled_installs_and_requires_restart(monkeypatch):
-    state = {'pip_calls': []}
-    probe = desktop_runtime_setup.RuntimeProbe(
-        backend='cpu',
-        gpu_offload_supported=False,
-        detected_device='cpu',
-        error='cpu-only runtime',
-    )
-    plan = desktop_runtime_setup.LlamaCppInstallPlan(
-        platform='win32',
-        backend='cuda',
-        package_spec='llama-cpp-python',
-        cmake_args=None,
-        force_cmake=False,
-        index_url='https://example.invalid/cuda',
-        extra_index_url=None,
-        only_binary=True,
-        no_binary=False,
-    )
-
-    def fake_run(cmd, **_kwargs):
-        state['pip_calls'].append(cmd)
-        return _Result(returncode=0)
-
-    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
-    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
-    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
-
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
-    assert result['runtime_action'] == 'installed_cuda_restart_required'
+    assert result['runtime_action'] == 'installed_cuda_reexec'
     assert result['selected_backend'] == 'cuda'
-    assert 'restart sidecar' in result['fallback_reason']
-    assert len(state['pip_calls']) == 1
 
 
-def test_runtime_bootstrap_returns_already_supported_when_gpu_runtime_is_present(monkeypatch):
-    probe = desktop_runtime_setup.RuntimeProbe(
-        backend='cuda',
-        gpu_offload_supported=True,
-        detected_device='nvidia',
-        error=None,
+def test_runtime_bootstrap_noop_when_gpu_runtime_is_already_present(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda: _probe(backend='cuda', gpu=True, device='nvidia'),
     )
-    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu')
 
     assert result['runtime_action'] == 'already_supported'
     assert result['selected_backend'] == 'cuda'
-    assert result['detected_device'] == 'nvidia'
 
 
-def test_runtime_bootstrap_uses_unpinned_fallback_plans_when_requirements_missing(monkeypatch):
-    probe = desktop_runtime_setup.RuntimeProbe(
-        backend='cpu',
-        gpu_offload_supported=False,
-        detected_device='cpu',
-        error='probe says cpu',
-    )
-    calls = []
-
-    def fake_plan_fallbacks(**_kwargs):
-        raise FileNotFoundError('requirements.txt missing')
-
-    def fake_run(cmd, **_kwargs):
-        calls.append(cmd)
-        return _Result(returncode=0)
-
-    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
-    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
-    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', fake_plan_fallbacks)
-    monkeypatch.setattr(desktop_runtime_setup, 'sys', type('S', (), {'platform': 'linux', 'executable': sys.executable}))
-    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
-
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
-
-    assert result['runtime_action'] == 'installed_cpu_fallback'
-    assert result['selected_backend'] == 'cpu'
-    assert calls
-
-
-def test_runtime_bootstrap_reports_timeout_and_install_errors(monkeypatch):
-    probe = desktop_runtime_setup.RuntimeProbe(
-        backend='cpu',
-        gpu_offload_supported=False,
-        detected_device='cpu',
-        error=None,
-    )
+def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_windows_cuda_source_repair', lambda: (False, 'compile failed'))
     plans = [
-        desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='win32',
-            backend='cuda',
-            package_spec='llama-cpp-python',
-            cmake_args=None,
-            force_cmake=False,
-            index_url='https://example.invalid/cuda',
-            extra_index_url=None,
-            only_binary=True,
-            no_binary=False,
-        ),
         desktop_runtime_setup.LlamaCppInstallPlan(
             platform='win32',
             backend='cpu',
             package_spec='llama-cpp-python',
             cmake_args=None,
             force_cmake=False,
-            index_url='https://example.invalid/cpu',
+            index_url='https://pypi.org/simple',
             extra_index_url=None,
             only_binary=True,
             no_binary=False,
-        ),
+        )
     ]
-    state = {'calls': 0}
-
-    def fake_run(_cmd, **_kwargs):
-        state['calls'] += 1
-        if state['calls'] == 1:
-            raise desktop_runtime_setup.subprocess.TimeoutExpired(cmd='pip', timeout=1)
-        return _Result(returncode=1, stderr='wheel not found')
-
-    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
-    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: probe)
     monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
-    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
 
-    assert result['runtime_action'] == 'failed'
+    assert result['runtime_action'] == 'installed_cpu_fallback'
     assert result['selected_backend'] == 'cpu'
-    assert result['fallback_reason'] == 'wheel not found'
+
+
+def test_maybe_reexec_for_runtime_refresh_reexecs_once(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    called = {}
+
+    def fake_execve(prog, argv, env):
+        called['prog'] = prog
+        called['argv'] = argv
+        called['guard'] = env.get(desktop_runtime_setup.REEXEC_GUARD_ENV)
+
+    monkeypatch.setattr(desktop_runtime_setup.os, 'execve', fake_execve)
+    monkeypatch.delenv(desktop_runtime_setup.REEXEC_GUARD_ENV, raising=False)
+
+    desktop_runtime_setup.maybe_reexec_for_runtime_refresh({'runtime_action': 'installed_cuda_reexec'})
+
+    assert called['prog'] == sys.executable
+    assert called['guard'] == '1'
 
 
 def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
@@ -194,3 +122,21 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     assert [plan.backend for plan in win_plans] == ['cuda', 'cpu']
     assert [plan.backend for plan in darwin_plans] == ['metal', 'metal']
     assert [plan.backend for plan in linux_plans] == ['cpu']
+
+
+def test_windows_source_repair_uses_active_interpreter(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    captured = {}
+
+    def fake_run(cmd, env):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', fake_run)
+    ok, _ = desktop_runtime_setup._windows_cuda_source_repair()
+
+    assert ok is True
+    assert captured['cmd'][:3] == [sys.executable, '-m', 'pip']
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
+    assert captured['env']['FORCE_CMAKE'] == '1'

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -970,6 +970,6 @@ class TestModelManager:
         assert 'device_backend=cpu' in summary
         assert 'offloaded_layers=0' in summary
         assert 'kv_cache=cpu' in summary
-        assert 'python=' in summary
-        assert 'llama_module=' in summary
+        assert 'interpreter=' in summary
+        assert 'llama_module_path=' in summary
         assert 'fallback_reason=runtime missing cuda support' in summary

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -965,8 +965,11 @@ class TestModelManager:
         compute_logs = [line for line in log_lines if line.startswith('compute_runtime ')]
         assert compute_logs
         summary = compute_logs[-1]
-        assert 'backend=cpu' in summary
+        assert 'backend_available=cuda' in summary
+        assert 'backend_used=cpu' in summary
         assert 'device_backend=cpu' in summary
         assert 'offloaded_layers=0' in summary
         assert 'kv_cache=cpu' in summary
+        assert 'python=' in summary
+        assert 'llama_module=' in summary
         assert 'fallback_reason=runtime missing cuda support' in summary

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -452,8 +452,8 @@ class ModelManager:
                                 f"device_name={compute_plan['device_name']} "
                                 f"offloaded_layers={compute_plan['offloaded_layers']} "
                                 f"kv_cache={compute_plan['kv_cache_device']} "
-                                f"python={runtime_identity.get('interpreter', sys.executable)} "
-                                f"llama_module={runtime_identity.get('llama_module_path', 'unknown')} "
+                                f"interpreter={runtime_identity.get('interpreter', sys.executable)} "
+                                f"llama_module_path={runtime_identity.get('llama_module_path', 'unknown')} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
                             self.log_info("Llama model initialized successfully.")

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -56,6 +56,9 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'backend': backend,
         'gpu_offload_supported': gpu_offload_supported,
         'detected_device': backend if gpu_offload_supported else 'cpu',
+        'interpreter': sys.executable,
+        'prefix': sys.prefix,
+        'llama_module_path': getattr(llama_cpp, '__file__', 'unknown'),
         'error': None,
     }
 
@@ -438,15 +441,19 @@ class ModelManager:
                             compute_plan['device_backend'] = compute_plan['backend_used']
                             compute_plan['device_name'] = 'unreported'
                             self.last_compute_diagnostics = compute_plan
+                            runtime_identity = detect_llama_runtime_capabilities()
                             self.log_info(
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "
                                 f"effective={compute_plan['effective_mode']} "
-                                f"backend={compute_plan['backend_used']} "
+                                f"backend_available={compute_plan['backend_available']} "
+                                f"backend_used={compute_plan['backend_used']} "
                                 f"device_backend={compute_plan['device_backend']} "
                                 f"device_name={compute_plan['device_name']} "
                                 f"offloaded_layers={compute_plan['offloaded_layers']} "
                                 f"kv_cache={compute_plan['kv_cache_device']} "
+                                f"python={runtime_identity.get('interpreter', sys.executable)} "
+                                f"llama_module={runtime_identity.get('llama_module_path', 'unknown')} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
                             self.log_info("Llama model initialized successfully.")


### PR DESCRIPTION
### Motivation
- Desktop sidecars were probe-only on Windows by default so the active sidecar interpreter kept using a CPU-only `llama-cpp-python` runtime instead of repairing the interpreter in-place. 
- The goal is to ensure the sidecar uses the same Python interpreter it is launched with and to default to GPU when CUDA prerequisites are present, while preserving safe CPU fallback.

### Description
- Probe the authoritative interpreter by running a subprocess probe under `sys.executable` and include interpreter identity (`interpreter`, `prefix`, `llama_module_path`) in the probe payload and logs. (`desktop-tauri/src-tauri/python/desktop_runtime_setup.py`)
- On Windows and GPU-preferring modes, automatically attempt the README-canonical CUDA source reinstall recipe by default (`CMAKE_ARGS=-DGGML_CUDA=on`, `FORCE_CMAKE=1`, `pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose`) against the exact sidecar interpreter, and re-probe the interpreter after install. (`desktop-tauri/src-tauri/python/desktop_runtime_setup.py`)
- If install succeeds and enables CUDA, re-exec the running sidecar once so the current process immediately uses the repaired runtime; guard repeated re-exec with `TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED`. (`maybe_reexec_for_runtime_refresh`) (`desktop-tauri/src-tauri/python/inference_sidecar.py`, `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Improve authoritative runtime logs: `desktop.runtime_setup` now includes `python=...` and `llama_module=...`, and `compute_runtime` summary includes `backend_available`, `backend_used`, offload/KV details and interpreter/module identity for high-signal verification. (`utils/llm/model_manager.py`, sidecar/bridge files)
- Add targeted unit tests covering Windows auto-repair decision, no-op when CUDA present, CPU fallback when repair fails, re-exec guard behavior, and verifying the source-repair invocation uses the active `sys.executable`. (`tests/unit/test_desktop_runtime_setup.py`, `tests/unit/test_model_manager.py`) 
- Add a manual verification helper script `desktop-tauri/scripts/verify_desktop_runtime.py` and small README update describing the automatic Windows repair and the verification command.

### Testing
- Ran focused unit tests (no-conftest) and targeted suites: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py` — all 7 tests passed.
- Ran `pytest -q --noconftest tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_compute_node_bridge.py` — all collected tests passed (35 passed).
- Ran the targeted model-manager assertion: `pytest -q --noconftest tests/unit/test_model_manager.py::TestModelManager::test_compute_runtime_log_includes_backend_device_offload_and_fallback` — passed.
- Verified syntactic validity via `python -m py_compile` on modified Python modules — succeeded.
- Executed the manual verifier: `python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto` to show authoritative wiring (printed `sys.executable`, `llama_cpp.__file__`, backend markers and pre/post init diagnostics); the helper executes against the active interpreter and surfaced expected diagnostics in this environment.
- Note: a full test run with repository `conftest.py` requires additional test environment deps (Playwright, dotenv, etc.); those global runs failed in this container due to missing environment packages, so focused `--noconftest` runs were used to validate all targeted behavior and new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2234e2b8832fa7a3a6202b66813c)