### PR TITLE
🐛 Fix desktop operator startup silent-exit regression and add Windows/NVIDIA smoke test

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -130,3 +130,33 @@ It prints:
   (`requested`, `effective`, `backend_available`, `backend_used`,
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
   `fallback_reason`, `interpreter`, `llama_module_path`)
+
+### Operator startup regression checks
+
+Run focused regression coverage for the desktop operator startup flow:
+
+```bash
+pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py
+npm --prefix desktop-tauri run test -- src/App.test.tsx
+```
+
+The UI/operator regression coverage asserts both paths:
+
+- successful `started`/`status` events keep Running as `yes`
+- startup/bridge failure emits actionable `last_error` text instead of a silent bounce
+
+### Windows/NVIDIA local smoke test
+
+Run this manually on a Windows machine with an NVIDIA GPU to validate the same
+runtime/bootstrap path used by desktop sidecars:
+
+```bash
+python desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py --mode auto --model C:\\path\\to\\model.gguf
+```
+
+This smoke test fails when desktop's GPU path would fail too. A pass requires:
+
+- authoritative interpreter and `llama_cpp` module path are present
+- `backend_available=cuda` and `backend_used=cuda` after initialization
+- nonzero GPU offload layers
+- KV cache placement is not CPU-only

--- a/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
+++ b/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Manual Windows/NVIDIA smoke test for desktop sidecar GPU runtime path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _fail(message: str, payload: dict) -> int:
+    payload["result"] = "fail"
+    payload["failure_reason"] = message
+    print(json.dumps(payload, indent=2))
+    return 1
+
+
+def _assert_truthy(payload: dict, key: str, value: object) -> str | None:
+    if value:
+        return None
+    return f"missing/empty required field: {key}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Windows/NVIDIA desktop sidecar runtime bootstrap + GPU diagnostics"
+    )
+    parser.add_argument("--model", required=True, help="Path to a local GGUF model")
+    parser.add_argument("--mode", default="auto", choices=["auto", "gpu", "hybrid"])
+    args = parser.parse_args()
+
+    model_path = Path(args.model).expanduser()
+    if not model_path.is_file():
+        print(
+            json.dumps(
+                {"result": "fail", "failure_reason": f"model path not found: {model_path}"},
+                indent=2,
+            )
+        )
+        return 1
+
+    repo_root = Path(__file__).resolve().parents[2]
+    python_dir = repo_root / "desktop-tauri" / "src-tauri" / "python"
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    if str(python_dir) not in sys.path:
+        sys.path.insert(0, str(python_dir))
+
+    from desktop_runtime_setup import ensure_desktop_llama_runtime, maybe_reexec_for_runtime_refresh
+    from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
+    from utils.llm.model_manager import get_model_manager
+
+    runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    maybe_reexec_for_runtime_refresh(runtime_setup)
+
+    manager = get_model_manager()
+    manager.model_path = str(model_path)
+    apply_compute_mode(manager, args.mode)
+    pre = compute_mode_diagnostics(manager)
+
+    llm = manager.get_llm_instance()
+    if llm is None:
+        payload = {
+            "result": "fail",
+            "failure_reason": "unable to initialize llama runtime",
+            "runtime_setup": runtime_setup,
+            "pre_init": pre,
+        }
+        print(json.dumps(payload, indent=2))
+        return 1
+
+    post = compute_mode_diagnostics(manager)
+
+    payload = {
+        "result": "pass",
+        "mode": args.mode,
+        "authoritative_interpreter": runtime_setup.get("interpreter", sys.executable),
+        "authoritative_llama_module_path": runtime_setup.get("llama_module_path", "missing"),
+        "runtime_setup": runtime_setup,
+        "pre_init": pre,
+        "post_init": post,
+    }
+
+    for key in ("authoritative_interpreter", "authoritative_llama_module_path"):
+        error = _assert_truthy(payload, key, payload.get(key))
+        if error:
+            return _fail(error, payload)
+
+    if post.get("backend_available") != "cuda":
+        return _fail(
+            f"expected backend_available=cuda, got {post.get('backend_available')}",
+            payload,
+        )
+    if post.get("backend_used") != "cuda":
+        return _fail(
+            f"expected backend_used=cuda, got {post.get('backend_used')}",
+            payload,
+        )
+
+    offloaded_layers = post.get("offloaded_layers")
+    if offloaded_layers is None:
+        offloaded_layers = post.get("n_gpu_layers")
+    if not isinstance(offloaded_layers, int) or offloaded_layers <= 0:
+        return _fail(f"expected offloaded_layers > 0, got {offloaded_layers!r}", payload)
+
+    kv_cache = str(post.get("kv_cache_device") or post.get("kv_cache") or "").lower()
+    if "cpu" in kv_cache and "cuda" not in kv_cache and "gpu" not in kv_cache:
+        return _fail(f"expected non-CPU KV cache placement, got {kv_cache!r}", payload)
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -104,7 +104,16 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
-    maybe_reexec_for_runtime_refresh(runtime_setup)
+    if runtime_setup.get("runtime_action") == "installed_cuda_reexec":
+        fallback_reason = runtime_setup.get("fallback_reason") or ""
+        runtime_setup["runtime_action"] = "installed_cuda_restart_required"
+        runtime_setup["fallback_reason"] = (
+            f"{fallback_reason}; restart operator to enable refreshed runtime"
+            if fallback_reason
+            else "restart operator to enable refreshed runtime"
+        )
+    else:
+        maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -354,11 +354,18 @@ pub async fn start_compute_node(
 
     let mut lines = BufReader::new(stdout).lines();
     let mut saw_error_event = false;
+    let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
-                if payload.get("type").and_then(Value::as_str) == Some("error") {
-                    saw_error_event = true;
+                match payload.get("type").and_then(Value::as_str) {
+                    Some("error") => {
+                        saw_error_event = true;
+                    }
+                    Some("started") | Some("status") => {
+                        saw_startup_event = true;
+                    }
+                    _ => {}
                 }
                 {
                     let mut status = state.status.lock().await;
@@ -391,28 +398,39 @@ pub async fn start_compute_node(
             let mut status = state.status.lock().await;
             status.running = false;
             status.registered = false;
-            if !exit_status.success() && status.last_error.is_none() {
-                status.last_error = Some(format!(
-                    "compute-node bridge exited with status {exit_status}; \
-                     see desktop.compute_node.stderr logs"
-                ));
+            if status.last_error.is_none() {
+                if !saw_startup_event {
+                    status.last_error = Some(format!(
+                        "compute-node bridge exited before emitting startup events \
+                         (started/status). Exit status: {exit_status}. \
+                         See desktop.compute_node.stderr logs."
+                    ));
+                } else if !exit_status.success() {
+                    status.last_error = Some(format!(
+                        "compute-node bridge exited with status {exit_status}; \
+                         see desktop.compute_node.stderr logs"
+                    ));
+                }
             }
         }
         *state.stdin.lock().await = None;
 
-        if !exit_status.success() && !saw_error_event {
-            app.emit(
-                "compute_node_event",
-                serde_json::json!({
-                    "type": "error",
-                    "running": false,
-                    "registered": false,
-                    "last_error": format!(
-                        "compute-node bridge exited with status {exit_status}; \
-                         see desktop.compute_node.stderr logs"
-                    ),
-                }),
-            )?;
+        if !saw_error_event {
+            let last_error = {
+                let status = state.status.lock().await;
+                status.last_error.clone()
+            };
+            if let Some(last_error) = last_error {
+                app.emit(
+                    "compute_node_event",
+                    serde_json::json!({
+                        "type": "error",
+                        "running": false,
+                        "registered": false,
+                        "last_error": last_error,
+                    }),
+                )?;
+            }
         }
     } else {
         let mut status = state.status.lock().await;

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -199,6 +199,52 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+  it('keeps operator running after started event and surfaces actionable startup-exit errors', async () => {
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        active_relay_url: 'https://token.place',
+        requested_mode: 'auto',
+        effective_mode: 'cpu',
+        backend_available: 'cuda',
+        backend_selected: 'cuda',
+        backend_used: 'cuda',
+        model_path: '/tmp/model.gguf',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain('yes')
+    );
+
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        message:
+          'compute-node bridge exited before emitting startup events (started/status)',
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain('no')
+    );
+    expect(screen.getByText(/Last error:/).textContent).toContain(
+      'before emitting startup events'
+    );
+  });
+
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -313,6 +313,55 @@ def test_run_reports_error_when_legacy_relay_request_processing_fails(capsys, mo
     assert status_events[0]['last_error'] == 'failed to process relay request'
 
 
+def test_run_avoids_reexec_in_operator_mode_and_emits_startup_events(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    reexec_calls = {'count': 0}
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'runtime_action': 'installed_cuda_reexec',
+            'fallback_reason': 'installed CUDA runtime; re-executing sidecar',
+            'interpreter': sys.executable,
+            'llama_module_path': 'C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'maybe_reexec_for_runtime_refresh',
+        lambda _runtime_setup: reexec_calls.update(count=reexec_calls['count'] + 1),
+    )
+
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert reexec_calls['count'] == 0
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.out.splitlines()]
+    assert events[0]['type'] == 'started'
+    assert any(event['type'] == 'status' for event in events)
+    stderr_output = captured.err
+    assert 'action=installed_cuda_restart_required' in stderr_output
+
+
 def test_apply_compute_mode_supports_gpu_and_cpu_modes():
     manager = FakeModelManager()
     from utils.compute_node_runtime import apply_compute_mode


### PR DESCRIPTION
### Motivation
- A regression caused the desktop compute-node bridge to sometimes exit (or re-exec) before emitting the first structured `started`/`status` events, producing only stderr config lines and causing the UI to flip from `Running: yes` to `Running: no` with no actionable error.
- The desktop runtime auto-reexec flow for Windows/CUDA needed to remain available but must not silently cause early exit paths the UI cannot interpret.
- Add regression coverage and a manual Windows/NVIDIA smoke test that exercise the same bootstrap/runtime path used by desktop sidecars.

### Description
- Prevent re-exec from silently happening in operator mode by converting `installed_cuda_reexec` into a restart-required action in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and still emitting the runtime diagnostics line.
- Harden the Tauri supervisor so it tracks whether any startup event (`started`/`status`) was seen and, if the bridge exits without those, sets an actionable `last_error` and emits a structured `compute_node_event` error instead of a silent bounce in `desktop-tauri/src-tauri/src/compute_node.rs`.
- Add a Python unit regression `test_run_avoids_reexec_in_operator_mode_and_emits_startup_events` to `tests/unit/test_desktop_compute_node_bridge.py` to catch the re-exec / no-startup-event regression at the bridge level.
- Add a UI-level test to `desktop-tauri/src/App.test.tsx` asserting that a `started` event keeps `Running: yes` and that a subsequent startup-exit produces a visible `last_error` rather than a silent toggle.
- Add a manual Windows/NVIDIA smoke-test script `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py` that runs the same bootstrap/runtime probe and verifies `backend_available=CUDA`, `backend_used=CUDA`, nonzero offloaded layers, and non-CPU KV cache placement.
- Update `desktop-tauri/README.md` with the focused regression commands and the smoke-test invocation and expected pass criteria.
- Files changed: `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/src-tauri/src/compute_node.rs`, `tests/unit/test_desktop_compute_node_bridge.py`, `desktop-tauri/src/App.test.tsx`, `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py`, `desktop-tauri/README.md`.

### Testing
- Ran `python -m py_compile desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/inference_sidecar.py desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py` which compiled with no syntax errors.
- Ran `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py`, `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py`, and `pytest -q --noconftest tests/unit/test_desktop_inference_sidecar.py`, and all Python unit tests passed after installing test-deps; the new regression test(s) pass.
- Ran `npm --prefix desktop-tauri run test -- src/App.test.tsx` and the added UI test passed under `vitest`.
- Attempting `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node -- --nocapture` in this container failed due to missing system `glib-2.0` development packages required by Tauri/Rust native deps and is environment-specific rather than code-related.
- Notes: `pre-commit run --all-files` was not available in this environment and an optional `./scripts/scan-secrets.py` hook is not present here; these are environment/tooling issues and not regressions in the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2f7aa284832fb7bcd68059b16353)