### PR TITLE
Fix desktop operator startup early-exit regression and add Windows/NVIDIA smoke test

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -58,8 +58,10 @@ source-build recipe:
 - `FORCE_CMAKE=1`
 - `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose`
 
-After a successful repair, the sidecar automatically re-execs once so the active
-process immediately uses the repaired runtime (no manual restart/environment flag required).
+After a successful repair, the local inference sidecar automatically re-execs once so the
+active process immediately uses the repaired runtime (no manual restart/environment flag
+required). The compute-node bridge keeps startup in-process and surfaces a structured startup
+error if refreshed runtime activation still fails.
 
 ### Platform packaging assumptions (documented, not fully automated in MVP)
 
@@ -130,3 +132,24 @@ It prints:
   (`requested`, `effective`, `backend_available`, `backend_used`,
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
   `fallback_reason`, `interpreter`, `llama_module_path`)
+
+### Regression tests for operator startup
+
+Run the targeted regression checks that cover startup event flow and the desktop UI state
+transition:
+
+```bash
+pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py
+cd desktop-tauri && npm run test -- App.test.tsx
+```
+
+### Local Windows/NVIDIA operator smoke test
+
+On a Windows machine with an NVIDIA GPU and a local GGUF model, run:
+
+```bash
+python desktop-tauri/scripts/windows_nvidia_operator_smoke.py --model C:\\path\\to\\model.gguf
+```
+
+The command passes only when the same desktop operator bridge path can initialize in `auto` mode
+with CUDA (`backend_available=cuda`, `backend_used=cuda`, non-zero offload, and non-CPU KV cache).

--- a/desktop-tauri/scripts/windows_nvidia_operator_smoke.py
+++ b/desktop-tauri/scripts/windows_nvidia_operator_smoke.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Manual Windows/NVIDIA smoke test for desktop operator GPU startup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Verify desktop operator startup uses CUDA on Windows/NVIDIA.'
+    )
+    parser.add_argument('--model', required=True, help='Path to local GGUF model file.')
+    parser.add_argument('--relay-url', default='https://token.place')
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    python_dir = repo_root / 'desktop-tauri' / 'src-tauri' / 'python'
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    if str(python_dir) not in sys.path:
+        sys.path.insert(0, str(python_dir))
+
+    from desktop_runtime_setup import ensure_desktop_llama_runtime
+    from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
+    from utils.llm.model_manager import detect_llama_runtime_capabilities, get_model_manager
+
+    runtime_setup = ensure_desktop_llama_runtime('auto', repo_root=repo_root)
+    runtime_probe = detect_llama_runtime_capabilities()
+
+    _assert(sys.platform.startswith('win'), 'This smoke test is intended for Windows hosts.')
+    _assert(os.path.exists(args.model), f'Model file not found: {args.model}')
+    _assert(
+        runtime_probe.get('llama_module_path') not in (None, '', 'missing'),
+        f"llama_cpp module path missing ({runtime_probe.get('llama_module_path')})",
+    )
+
+    manager = get_model_manager()
+    manager.model_path = args.model
+    apply_compute_mode(manager, 'auto')
+    manager.get_llm_instance()
+    diagnostics = compute_mode_diagnostics(manager)
+
+    _assert(
+        diagnostics.get('backend_available') == 'cuda',
+        f"backend_available must be cuda, got {diagnostics.get('backend_available')}",
+    )
+    _assert(
+        diagnostics.get('backend_used') == 'cuda',
+        f"backend_used must be cuda, got {diagnostics.get('backend_used')}",
+    )
+    offloaded_layers = diagnostics.get('offloaded_layers', diagnostics.get('n_gpu_layers', 0))
+    _assert(
+        isinstance(offloaded_layers, int) and offloaded_layers != 0,
+        f'offloaded_layers must be non-zero, got {offloaded_layers}',
+    )
+    kv_cache_device = str(diagnostics.get('kv_cache_device', '')).lower()
+    _assert(
+        kv_cache_device not in {'cpu', 'host', 'none', ''},
+        f'kv_cache_device must not be CPU-only, got {diagnostics.get("kv_cache_device")}',
+    )
+
+    bridge_cmd = [
+        sys.executable,
+        str(python_dir / 'compute_node_bridge.py'),
+        '--model',
+        args.model,
+        '--mode',
+        'auto',
+        '--relay-url',
+        args.relay_url,
+    ]
+    env = os.environ.copy()
+    env['TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP'] = '1'
+    proc = subprocess.Popen(
+        bridge_cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    proc.stdin.write('{"type":"cancel"}\n')
+    proc.stdin.flush()
+    proc.stdin.close()
+    stdout, stderr = proc.communicate(timeout=45)
+    _assert(proc.returncode == 0, f'compute_node_bridge exited {proc.returncode}: {stderr}')
+
+    started = None
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if payload.get('type') == 'started':
+            started = payload
+            break
+
+    _assert(started is not None, 'compute_node_bridge did not emit a started event')
+    _assert(
+        started.get('backend_available') == 'cuda',
+        f"bridge started.backend_available must be cuda, got {started.get('backend_available')}",
+    )
+    _assert(
+        started.get('backend_used') == 'cuda',
+        f"bridge started.backend_used must be cuda, got {started.get('backend_used')}",
+    )
+    _assert(
+        str(started.get('kv_cache_device', '')).lower() not in {'cpu', 'host', 'none', ''},
+        f"bridge started.kv_cache_device must not be CPU-only, got {started.get('kv_cache_device')}",
+    )
+
+    result = {
+        'runtime_setup': runtime_setup,
+        'runtime_probe': runtime_probe,
+        'compute_mode_diagnostics': diagnostics,
+        'bridge_started_event': started,
+        'interpreter': sys.executable,
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -104,7 +104,17 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
-    maybe_reexec_for_runtime_refresh(runtime_setup)
+    if runtime_setup.get("runtime_action") == "installed_cuda_reexec":
+        runtime_setup = {
+            **runtime_setup,
+            "runtime_action": "installed_cuda_restart_required",
+            "fallback_reason": (
+                runtime_setup.get("fallback_reason")
+                or "CUDA runtime installed; restart operator to activate refreshed interpreter"
+            ),
+        }
+    else:
+        maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
@@ -132,10 +142,15 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     if not runtime.ensure_model_ready():
+        setup_reason = runtime_setup.get("fallback_reason") or "none"
         emit(
             {
                 "type": "error",
-                "message": "failed to initialize model runtime",
+                "message": (
+                    "failed to initialize model runtime "
+                    f"(runtime_action={runtime_setup.get('runtime_action', 'none')}, "
+                    f"reason={setup_reason})"
+                ),
                 "active_relay_url": runtime.relay_client.relay_url,
             }
         )
@@ -155,6 +170,8 @@ def run(args: argparse.Namespace) -> int:
             "backend_selected": diagnostics.get("backend_selected"),
             "backend_used": diagnostics.get("backend_used"),
             "fallback_reason": diagnostics.get("fallback_reason"),
+            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
+            "kv_cache_device": diagnostics.get("kv_cache_device"),
             "model_path": args.model,
             "last_error": None,
         }
@@ -198,6 +215,10 @@ def run(args: argparse.Namespace) -> int:
                     "backend_selected": diagnostics.get("backend_selected"),
                     "backend_used": diagnostics.get("backend_used"),
                     "fallback_reason": diagnostics.get("fallback_reason"),
+                    "offloaded_layers": diagnostics.get(
+                        "offloaded_layers", diagnostics.get("n_gpu_layers")
+                    ),
+                    "kv_cache_device": diagnostics.get("kv_cache_device"),
                     "model_path": args.model,
                     "last_error": last_error,
                 }
@@ -222,6 +243,8 @@ def run(args: argparse.Namespace) -> int:
             "backend_selected": diagnostics.get("backend_selected"),
             "backend_used": diagnostics.get("backend_used"),
             "fallback_reason": diagnostics.get("fallback_reason"),
+            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
+            "kv_cache_device": diagnostics.get("kv_cache_device"),
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -353,10 +353,12 @@ pub async fn start_compute_node(
     });
 
     let mut lines = BufReader::new(stdout).lines();
+    let mut saw_structured_event = false;
     let mut saw_error_event = false;
     while let Some(line) = lines.next_line().await? {
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
+                saw_structured_event = true;
                 if payload.get("type").and_then(Value::as_str) == Some("error") {
                     saw_error_event = true;
                 }
@@ -391,7 +393,12 @@ pub async fn start_compute_node(
             let mut status = state.status.lock().await;
             status.running = false;
             status.registered = false;
-            if !exit_status.success() && status.last_error.is_none() {
+            if !saw_structured_event && status.last_error.is_none() {
+                status.last_error = Some(format!(
+                    "compute-node bridge exited with status {exit_status} before emitting \
+                     startup events; see desktop.compute_node.stderr logs"
+                ));
+            } else if !exit_status.success() && status.last_error.is_none() {
                 status.last_error = Some(format!(
                     "compute-node bridge exited with status {exit_status}; \
                      see desktop.compute_node.stderr logs"
@@ -400,7 +407,20 @@ pub async fn start_compute_node(
         }
         *state.stdin.lock().await = None;
 
-        if !exit_status.success() && !saw_error_event {
+        if !saw_structured_event && !saw_error_event {
+            app.emit(
+                "compute_node_event",
+                serde_json::json!({
+                    "type": "error",
+                    "running": false,
+                    "registered": false,
+                    "last_error": format!(
+                        "compute-node bridge exited with status {exit_status} before \
+                         emitting startup events; see desktop.compute_node.stderr logs"
+                    ),
+                }),
+            )?;
+        } else if !exit_status.success() && !saw_error_event {
             app.emit(
                 "compute_node_event",
                 serde_json::json!({

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -199,6 +199,79 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+  it('does not silently bounce running state on compute-node early-exit errors', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'start_compute_node') {
+        return Promise.resolve(undefined);
+      }
+      if (command === 'detect_backend') {
+        return Promise.resolve({
+          platform_label: 'windows',
+          preferred_mode: 'auto',
+          available_backend: 'cuda',
+          availability_label: 'CUDA-capable runtime detected',
+        });
+      }
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: false,
+          registered: false,
+          active_relay_url: '',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '',
+          last_error: null,
+        });
+      }
+      return Promise.resolve({
+        canonical_family_url: 'https://example.test/models',
+        filename: 'model.gguf',
+        url: 'https://example.test/model.gguf',
+        models_dir: '/tmp',
+        resolved_model_path: '/tmp/model.gguf',
+        exists: true,
+        size_bytes: 1,
+      });
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect(screen.getByText('Running:').textContent).toContain('yes')
+    );
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        last_error: 'bridge exited before emitting startup events',
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Running:').textContent).toContain('no')
+    );
+    expect(screen.getByText(/Last error:/).textContent).toContain(
+      'bridge exited before emitting startup events'
+    );
+  });
+
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -212,6 +212,45 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
     assert 'failed to initialize model runtime' in payload['message']
+    assert 'runtime_action=' in payload['message']
+
+
+def test_run_suppresses_reexec_paths_and_emits_started_event(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'runtime_action': 'installed_cuda_reexec',
+            'fallback_reason': '',
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'interpreter': sys.executable,
+            'llama_module_path': '/tmp/llama_cpp/__init__.py',
+        },
+    )
+    reexec_called = {'value': False}
+
+    def _fake_reexec(_setup):
+        reexec_called['value'] = True
+
+    monkeypatch.setattr(compute_node_bridge, 'maybe_reexec_for_runtime_refresh', _fake_reexec)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert reexec_called['value'] is False
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+    assert events[0]['running'] is True
 
 
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Recent runtime bootstrap/re-exec interaction could cause the desktop compute-node bridge to exit or re-exec before emitting the first structured `started`/`status` event, producing only stderr lines and making the UI flip from `Running: yes` back to `Running: no` with no actionable error.
- The change ensures the operator startup path always emits structured diagnostics (or a clear structured error) and prevents silent early-exit/re-exec regressions while preserving the Windows/NVIDIA repair behavior.

### Description
- Prevent in-process re-exec during operator startup by treating `installed_cuda_reexec` as a restart-required marker and continuing startup so `started`/`status` events are emitted instead of silently exiting; implemented in `desktop-tauri/src-tauri/python/compute_node_bridge.py`.
- Add richer diagnostics fields (`offloaded_layers`, `kv_cache_device`) to the bridge `started`/`status`/`stopped` events for better failure/smoke-test assertions in `compute_node_bridge.py`.
- Harden Tauri-side handling to detect when the bridge exits before emitting any structured events and emit a clear `compute_node_event` error with an explanatory `last_error`; implemented in `desktop-tauri/src-tauri/src/compute_node.rs`.
- Add regression tests that would have caught the regression: a Python bridge unit test ensuring the re-exec path is suppressed and `started` is emitted, and a desktop UI test that verifies Start operator transitions to running and surfaces early-exit errors; updated `tests/unit/test_desktop_compute_node_bridge.py` and `desktop-tauri/src/App.test.tsx`.
- Add a manual Windows/NVIDIA smoke script that exercises the same bridge/runtime startup path and asserts CUDA is actually used (`desktop-tauri/scripts/windows_nvidia_operator_smoke.py`) and document the new checks in `desktop-tauri/README.md`.

### Testing
- Ran Python syntax checks: `python -m py_compile desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/inference_sidecar.py desktop-tauri/scripts/windows_nvidia_operator_smoke.py` — succeeded.
- Ran targeted unit tests: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py` — all tests passed.
- Ran the updated Python bridge unit suite `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` in this environment and observed failures caused by missing system/test dependencies in the container (missing `requests`/`cryptography`), so results are environment-limited (9 failed, 4 passed here); the new regression test is included in the suite and validates the re-exec suppression logic when dependencies are available.
- Ran desktop JS tests: `cd desktop-tauri && npm run test -- App.test.tsx` — Vitest suite passed (4 tests) including the new UI regression test.
- Attempted Rust `cargo test compute_node` but it could not run in this environment due to missing system library (`glib-2.0`) so that check is noted as environment-limited.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2f7aa284832fb7bcd68059b16353)