### PR TITLE
🛠️ fix: harden desktop llama_cpp import resolution

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -131,6 +131,13 @@ It prints:
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
   `fallback_reason`, `interpreter`, `llama_module_path`)
 
+Runtime verification now fails fast when `llama_module_path` resolves to the
+repo-local shim (`.../token.place/llama_cpp.py`), because that shadowed import
+cannot expose CUDA/Metal offload support. Expected good paths resolve to the
+installed `llama-cpp-python` package under the active interpreter's
+`site-packages` directory (for example
+`.../.venv/Lib/site-packages/llama_cpp/__init__.py` on Windows).
+
 ### Regression and smoke tests
 
 - Operator startup regression coverage (bridge startup event + surfaced errors):

--- a/desktop-tauri/scripts/verify_desktop_runtime.py
+++ b/desktop-tauri/scripts/verify_desktop_runtime.py
@@ -17,9 +17,14 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[2]
+    python_root = repo_root / 'desktop-tauri' / 'src-tauri' / 'python'
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
+    if str(python_root) not in sys.path:
+        sys.path.insert(0, str(python_root))
+    os.environ.setdefault('TOKEN_PLACE_STRICT_LLAMA_IMPORT', '1')
 
+    from desktop_runtime_setup import llama_cpp_path_is_repo_shim, llama_cpp_shadowing_error
     from utils.llm.model_manager import detect_llama_runtime_capabilities
 
     runtime = detect_llama_runtime_capabilities()
@@ -32,6 +37,11 @@ def main() -> int:
         'llama_module_path': runtime.get('llama_module_path', 'missing'),
         'error': runtime.get('error'),
     }
+    if llama_cpp_path_is_repo_shim(payload['llama_module_path'], repo_root=repo_root):
+        payload['error'] = llama_cpp_shadowing_error(payload['llama_module_path'], repo_root=repo_root)
+        payload['status'] = 'failed'
+        print(json.dumps(payload, indent=2))
+        return 2
 
     try:
         from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics

--- a/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
+++ b/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
@@ -36,10 +36,15 @@ def _offloaded_layer_count(value: Any) -> int:
 
 def _load_compute_runtime_diagnostics(model_path: str, mode: str) -> dict[str, Any]:
     from desktop_runtime_setup import ensure_desktop_llama_runtime
+    from desktop_runtime_setup import llama_cpp_path_is_repo_shim, llama_cpp_shadowing_error
     from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
     from utils.llm.model_manager import get_model_manager
 
     runtime_setup = ensure_desktop_llama_runtime(mode)
+    repo_root = _repo_root()
+    llama_module_path = runtime_setup.get('llama_module_path', 'missing')
+    if llama_cpp_path_is_repo_shim(llama_module_path, repo_root=repo_root):
+        raise RuntimeError(llama_cpp_shadowing_error(llama_module_path, repo_root=repo_root))
 
     manager = get_model_manager()
     manager.model_path = model_path
@@ -104,6 +109,7 @@ def main() -> int:
 
     repo_root = _repo_root()
     python_root = repo_root / 'desktop-tauri' / 'src-tauri' / 'python'
+    os.environ.setdefault('TOKEN_PLACE_STRICT_LLAMA_IMPORT', '1')
     for entry in (str(repo_root), str(python_root)):
         if entry not in sys.path:
             sys.path.insert(0, entry)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import queue
 import sys
 import threading
@@ -36,6 +37,7 @@ except ModuleNotFoundError:
         return
 
 ensure_runtime_import_paths(__file__)
+os.environ.setdefault("TOKEN_PLACE_STRICT_LLAMA_IMPORT", "1")
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -34,6 +34,7 @@ PIP_INSTALL_TIMEOUT_SECONDS = 300
 PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
+STRICT_LLAMA_IMPORT_ENV = "TOKEN_PLACE_STRICT_LLAMA_IMPORT"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
 
 _PROBE_SNIPPET = """
@@ -61,6 +62,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env[STRICT_LLAMA_IMPORT_ENV] = "1"
     try:
         result = subprocess.run(
             cmd,
@@ -116,6 +118,35 @@ def _probe_llama_runtime() -> RuntimeProbe:
         prefix=str(payload.get("prefix", sys.prefix)),
         llama_module_path=str(payload.get("llama_module_path", "missing")),
         error=payload.get("error"),
+    )
+
+
+def _repo_local_llama_cpp_shim_path(*, repo_root: Optional[Path] = None) -> Path:
+    root = repo_root or Path(__file__).resolve().parents[3]
+    return root / "llama_cpp.py"
+
+
+def llama_cpp_path_is_repo_shim(
+    llama_module_path: str, *, repo_root: Optional[Path] = None
+) -> bool:
+    if not llama_module_path or llama_module_path == "missing":
+        return False
+    try:
+        return Path(llama_module_path).resolve() == _repo_local_llama_cpp_shim_path(
+            repo_root=repo_root
+        ).resolve()
+    except OSError:
+        return False
+
+
+def llama_cpp_shadowing_error(
+    llama_module_path: str, *, repo_root: Optional[Path] = None
+) -> str:
+    shim_path = _repo_local_llama_cpp_shim_path(repo_root=repo_root)
+    return (
+        "desktop runtime resolved llama_cpp to repo-local shim "
+        f"({llama_module_path}); expected installed llama-cpp-python package "
+        f"under site-packages. Remove shim shadowing from import path ({shim_path})."
     )
 
 
@@ -247,6 +278,17 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
 
     selected_mode = (mode or "auto").strip().lower()
     before = _probe_llama_runtime()
+    target_root = repo_root or Path(__file__).resolve().parents[3]
+
+    if llama_cpp_path_is_repo_shim(before.llama_module_path, repo_root=target_root):
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": llama_cpp_shadowing_error(
+                before.llama_module_path, repo_root=target_root
+            ),
+            "runtime_action": "failed_shadowed_llama_cpp",
+            **_probe_result_payload(before),
+        }
 
     if selected_mode not in GPU_MODES:
         return {
@@ -285,7 +327,6 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    target_root = repo_root or Path(__file__).resolve().parents[3]
     requirements_path = target_root / "requirements.txt"
     last_error = ""
 
@@ -295,6 +336,15 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         if source_ok:
             _clear_source_repair_failure()
             after = _probe_llama_runtime()
+            if llama_cpp_path_is_repo_shim(after.llama_module_path, repo_root=target_root):
+                return {
+                    "selected_backend": "cpu",
+                    "fallback_reason": llama_cpp_shadowing_error(
+                        after.llama_module_path, repo_root=target_root
+                    ),
+                    "runtime_action": "failed_shadowed_llama_cpp",
+                    **_probe_result_payload(after),
+                }
             if after.gpu_offload_supported and after.backend == "cuda":
                 return {
                     "selected_backend": "cuda",
@@ -331,6 +381,15 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             continue
 
         after = _probe_llama_runtime()
+        if llama_cpp_path_is_repo_shim(after.llama_module_path, repo_root=target_root):
+            return {
+                "selected_backend": "cpu",
+                "fallback_reason": llama_cpp_shadowing_error(
+                    after.llama_module_path, repo_root=target_root
+                ),
+                "runtime_action": "failed_shadowed_llama_cpp",
+                **_probe_result_payload(after),
+            }
         if after.gpu_offload_supported and after.backend in {"cuda", "metal"}:
             return {
                 "selected_backend": after.backend,

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -22,6 +22,7 @@ from path_bootstrap import ensure_runtime_import_paths
 from desktop_runtime_setup import ensure_desktop_llama_runtime, maybe_reexec_for_runtime_refresh
 
 ensure_runtime_import_paths(__file__)
+os.environ.setdefault("TOKEN_PLACE_STRICT_LLAMA_IMPORT", "1")
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -215,6 +215,24 @@ def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):
     assert probe.error == 'probe failed'
 
 
+def test_probe_sets_strict_llama_import_env(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    captured = {}
+
+    class _Result:
+        returncode = 0
+        stdout = '{}'
+        stderr = ''
+
+    def fake_run(*_args, **kwargs):
+        captured['env'] = kwargs.get('env', {})
+        return _Result()
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+    _ = desktop_runtime_setup._probe_llama_runtime()
+    assert captured['env'][desktop_runtime_setup.STRICT_LLAMA_IMPORT_ENV] == '1'
+
+
 def test_maybe_reexec_for_runtime_refresh_skips_when_guard_set(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     called = {'execve': False}
@@ -261,6 +279,31 @@ def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
 
     assert result['runtime_action'] == 'failed'
     assert result['fallback_reason'] == 'build failed'
+
+
+def test_runtime_bootstrap_fails_fast_when_llama_cpp_is_repo_shim(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    repo_root = Path('/tmp/token.place')
+    shim_path = str(repo_root / 'llama_cpp.py')
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda: desktop_runtime_setup.RuntimeProbe(
+            backend='cpu',
+            gpu_offload_supported=False,
+            detected_device='cpu',
+            interpreter=sys.executable,
+            prefix=sys.prefix,
+            llama_module_path=shim_path,
+            error=None,
+        ),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=repo_root)
+
+    assert result['runtime_action'] == 'failed_shadowed_llama_cpp'
+    assert 'repo-local shim' in result['fallback_reason']
+    assert 'site-packages' in result['fallback_reason']
 
 
 def test_probe_marks_error_when_subprocess_raises(monkeypatch):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -973,3 +973,15 @@ class TestModelManager:
         assert 'interpreter=' in summary
         assert 'llama_module_path=' in summary
         assert 'fallback_reason=runtime missing cuda support' in summary
+
+    def test_detect_runtime_capabilities_strict_mode_rejects_repo_shim(self, monkeypatch):
+        from utils.llm import model_manager as mm
+
+        shim_module = SimpleNamespace(__file__=str(Path.cwd() / 'llama_cpp.py'))
+        monkeypatch.setenv(mm.STRICT_LLAMA_IMPORT_ENV, '1')
+        monkeypatch.setattr(mm.importlib, 'import_module', lambda _name: shim_module)
+
+        payload = mm.detect_llama_runtime_capabilities()
+
+        assert payload['backend'] == 'missing'
+        assert 'repo-local llama_cpp shim' in payload['error']

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -7,6 +7,7 @@ import logging
 import requests
 import json
 import sys
+import importlib
 from pathlib import Path
 from threading import Lock
 from unittest.mock import MagicMock
@@ -16,12 +17,73 @@ from utils.system import resource_monitor
 
 # Configure logging
 logger = logging.getLogger('model_manager')
+STRICT_LLAMA_IMPORT_ENV = 'TOKEN_PLACE_STRICT_LLAMA_IMPORT'
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _repo_llama_shim_path() -> Path:
+    return _repo_root() / 'llama_cpp.py'
+
+
+def _llama_cpp_module_is_repo_shim(module: Any) -> bool:
+    module_path = getattr(module, '__file__', '')
+    if not module_path:
+        return False
+    try:
+        return Path(module_path).resolve() == _repo_llama_shim_path().resolve()
+    except OSError:
+        return False
+
+
+def _path_entry_points_to_repo_shim(entry: str) -> bool:
+    try:
+        if not entry:
+            return False
+        candidate = (Path(entry).resolve() / 'llama_cpp.py').resolve()
+        return candidate == _repo_llama_shim_path().resolve()
+    except OSError:
+        return False
+
+
+def _import_llama_cpp_runtime() -> Any:
+    strict = os.getenv(STRICT_LLAMA_IMPORT_ENV) == '1'
+    if not strict:
+        return importlib.import_module('llama_cpp')
+
+    original_sys_path = list(sys.path)
+    filtered_sys_path = [
+        path_entry
+        for path_entry in original_sys_path
+        if not _path_entry_points_to_repo_shim(path_entry)
+    ]
+    if not filtered_sys_path:
+        filtered_sys_path = original_sys_path
+
+    existing = sys.modules.get('llama_cpp')
+    if existing is not None and _llama_cpp_module_is_repo_shim(existing):
+        sys.modules.pop('llama_cpp', None)
+
+    try:
+        sys.path[:] = filtered_sys_path
+        module = importlib.import_module('llama_cpp')
+    finally:
+        sys.path[:] = original_sys_path
+
+    if _llama_cpp_module_is_repo_shim(module):
+        raise RuntimeError(
+            f"resolved repo-local llama_cpp shim at {_repo_llama_shim_path()} "
+            f"while {STRICT_LLAMA_IMPORT_ENV}=1; expected installed llama-cpp-python package"
+        )
+    return module
 
 
 def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     """Return backend/offload capability details from the installed llama_cpp runtime."""
     try:
-        import llama_cpp
+        llama_cpp = _import_llama_cpp_runtime()
     except Exception as exc:
         return {
             'backend': 'missing',


### PR DESCRIPTION
### Motivation
- Desktop runtime probes were resolving `import llama_cpp` to the repo-local `llama_cpp.py` shim (repo root) due to import-path precedence, causing the authoritative Windows GPU path to report CPU-only and never enable CUDA offload.

### Description
- Add a strict import mode controlled by `TOKEN_PLACE_STRICT_LLAMA_IMPORT=1` and enable it for the runtime probe, sidecar, and bridge by setting the env in probe subprocesses and at module startup (changes to `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`, `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/src-tauri/python/inference_sidecar.py`).
- Implement strict import resolution in `detect_llama_runtime_capabilities()` by filtering `sys.path` entries that would point at the repo-local shim and raising an actionable error when the repo-local `llama_cpp.py` is detected (changes to `utils/llm/model_manager.py`).
- Add helper detection and a fast-fail guard in the desktop probe/bootstrap that returns a clear `failed_shadowed_llama_cpp` runtime action and descriptive `fallback_reason` if the authoritative `llama_module_path` points at the repo-local shim (changes to `desktop_runtime_setup.py`).
- Make verifier and smoke-test fail explicitly on shim-shadowing by enabling strict-mode and checking for repo-shim paths (changes to `desktop-tauri/scripts/verify_desktop_runtime.py` and `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py`).
- Add focused regression tests that assert (1) the probe sets the strict env, (2) the bootstrap fails fast on repo-shim resolution, and (3) strict-mode detection rejects the repo shim (changes to `tests/unit/test_desktop_runtime_setup.py` and `tests/unit/test_model_manager.py`).
- Minimal docs update in `desktop-tauri/README.md` explaining bad vs expected `llama_module_path` shapes.

### Testing
- Ran `python -m py_compile` on the modified entrypoints (`desktop_runtime_setup.py`, `path_bootstrap.py`, `compute_node_bridge.py`, `inference_sidecar.py`, `verify_desktop_runtime.py`, `windows_nvidia_gpu_smoke_test.py`, `utils/llm/model_manager.py`), which succeeded. 
- `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py` passed (20 tests passed). 
- `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` passed (13 tests passed). 
- `pytest -q --noconftest tests/unit/test_desktop_inference_sidecar.py` exercised the changed paths but failed in this container due to missing runtime deps (many failures referencing missing `cryptography` / `requests`); these failures are environmental and not regressions introduced by this change. 
- Targeted strict-mode test for `utils.llm.model_manager` was added but collection in this container hit missing `requests` during import (environmental). 
- `npm --prefix desktop-tauri run test -- src/App.test.tsx` passed. 

Notes: `pre-commit` and a local `./scripts/scan-secrets.py` were not available in this execution environment; full CI (which installs test deps) should validate the inference-sidecar and model-manager tests end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3dd2ea14832fabe4609acaaa0136)