### PR TITLE
Harden desktop llama_cpp import resolution to avoid repo-local shim shadowing

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -131,6 +131,15 @@ It prints:
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
   `fallback_reason`, `interpreter`, `llama_module_path`)
 
+The verifier output is authoritative for desktop sidecars. A **bad** shadowed
+path looks like:
+
+- `llama_module_path: C:\\...\\token.place\\llama_cpp.py`
+
+A **good** path points to the installed package code (typically under
+`site-packages`, e.g. `...\\Lib\\site-packages\\llama_cpp\\__init__.py`) for
+the sidecar interpreter.
+
 ### Regression and smoke tests
 
 - Operator startup regression coverage (bridge startup event + surfaced errors):

--- a/desktop-tauri/scripts/verify_desktop_runtime.py
+++ b/desktop-tauri/scripts/verify_desktop_runtime.py
@@ -10,6 +10,15 @@ import sys
 from pathlib import Path
 
 
+def _is_repo_local_llama_module_path(module_path: str, repo_root: Path) -> bool:
+    if not module_path:
+        return False
+    try:
+        return Path(module_path).resolve() == (repo_root / 'llama_cpp.py').resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description='Verify desktop llama runtime wiring')
     parser.add_argument('--mode', default='auto')
@@ -32,6 +41,16 @@ def main() -> int:
         'llama_module_path': runtime.get('llama_module_path', 'missing'),
         'error': runtime.get('error'),
     }
+    if _is_repo_local_llama_module_path(payload['llama_module_path'], repo_root):
+        payload['error'] = (
+            'llama_cpp import resolved to repo-local llama_cpp.py; '
+            'desktop verifier requires installed llama-cpp-python package path '
+            '(site-packages) in the sidecar interpreter'
+        )
+        payload['compute_runtime_pre_init'] = 'skipped'
+        payload['compute_runtime_post_init'] = 'skipped'
+        print(json.dumps(payload, indent=2))
+        return 1
 
     try:
         from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics

--- a/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
+++ b/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
@@ -34,6 +34,15 @@ def _offloaded_layer_count(value: Any) -> int:
     return int(value or 0)
 
 
+def _is_repo_local_llama_module_path(module_path: str, repo_root: Path) -> bool:
+    if not module_path:
+        return False
+    try:
+        return Path(module_path).resolve() == (repo_root / 'llama_cpp.py').resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
 def _load_compute_runtime_diagnostics(model_path: str, mode: str) -> dict[str, Any]:
     from desktop_runtime_setup import ensure_desktop_llama_runtime
     from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
@@ -122,6 +131,11 @@ def main() -> int:
         }
         print(json.dumps(payload, indent=2))
 
+        _require(
+            not _is_repo_local_llama_module_path(payload['llama_module_path'], repo_root),
+            'llama_module_path resolved to repo-local llama_cpp.py instead of installed '
+            'llama-cpp-python package',
+        )
         _require(payload['backend_available'] == 'cuda', 'backend_available is not cuda')
         _require(payload['backend_used'] == 'cuda', 'backend_used is not cuda')
         _require(_offloaded_layer_count(payload.get('offloaded_layers')) > 0, 'offloaded_layers must be > 0')

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -9,7 +9,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
@@ -26,6 +26,7 @@ class RuntimeProbe:
     interpreter: str
     prefix: str
     llama_module_path: str
+    shadowed_by_repo_shim: bool = False
     error: Optional[str] = None
 
 
@@ -79,6 +80,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
             interpreter=sys.executable,
             prefix=sys.prefix,
             llama_module_path="missing",
+            shadowed_by_repo_shim=False,
             error=str(exc),
         )
 
@@ -92,6 +94,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
             interpreter=sys.executable,
             prefix=sys.prefix,
             llama_module_path="missing",
+            shadowed_by_repo_shim=False,
             error=stderr or f"probe subprocess failed with return code {result.returncode}",
         )
 
@@ -115,8 +118,18 @@ def _probe_llama_runtime() -> RuntimeProbe:
         interpreter=str(payload.get("interpreter", sys.executable)),
         prefix=str(payload.get("prefix", sys.prefix)),
         llama_module_path=str(payload.get("llama_module_path", "missing")),
+        shadowed_by_repo_shim=bool(payload.get("shadowed_by_repo_shim", False)),
         error=payload.get("error"),
     )
+
+
+def _is_repo_local_llama_module_path(module_path: str, *, repo_root: Path) -> bool:
+    if not module_path:
+        return False
+    try:
+        return Path(module_path).resolve() == (repo_root / "llama_cpp.py").resolve()
+    except (OSError, RuntimeError):
+        return False
 
 
 def _run_pip_install(
@@ -168,13 +181,14 @@ def _summarize_install_error(raw: str) -> str:
     return text.splitlines()[-1][:240]
 
 
-def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
+def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, Any]:
     return {
         "detected_device": probe.detected_device or "cpu",
         "interpreter": probe.interpreter,
         "prefix": probe.prefix,
         "interpreter_prefix": probe.prefix,
         "llama_module_path": probe.llama_module_path,
+        "shadowed_by_repo_shim": probe.shadowed_by_repo_shim,
     }
 
 
@@ -246,13 +260,30 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
+    target_root = repo_root or Path(__file__).resolve().parents[3]
     before = _probe_llama_runtime()
+    shadowed_by_repo_shim = before.shadowed_by_repo_shim or _is_repo_local_llama_module_path(
+        before.llama_module_path,
+        repo_root=target_root,
+    )
 
     if selected_mode not in GPU_MODES:
         return {
             "selected_backend": "cpu",
             "fallback_reason": "cpu mode explicitly selected",
             "runtime_action": "skipped",
+            **_probe_result_payload(before),
+        }
+
+    if shadowed_by_repo_shim:
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                "llama_cpp import shadowed by repo-local llama_cpp.py; "
+                "use the sidecar interpreter where installed llama-cpp-python "
+                "is importable from site-packages"
+            ),
+            "runtime_action": "failed",
             **_probe_result_payload(before),
         }
 
@@ -285,7 +316,6 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    target_root = repo_root or Path(__file__).resolve().parents[3]
     requirements_path = target_root / "requirements.txt"
     last_error = ""
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -307,6 +307,79 @@ def test_probe_falls_back_when_payload_is_not_json(monkeypatch):
     assert probe.llama_module_path == 'missing'
 
 
+def test_probe_reads_shadow_flag_from_payload(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                'backend': 'missing',
+                'gpu_offload_supported': False,
+                'detected_device': 'none',
+                'interpreter': 'python',
+                'prefix': 'prefix',
+                'llama_module_path': str(REPO_ROOT / 'llama_cpp.py'),
+                'shadowed_by_repo_shim': True,
+                'error': 'shadowed import',
+            }
+        )
+        stderr = ''
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _Result())
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+    assert probe.shadowed_by_repo_shim is True
+    assert probe.llama_module_path.endswith('llama_cpp.py')
+
+
+def test_probe_subprocess_sets_pythonpath_and_repo_cwd(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    captured = {}
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps({'backend': 'cpu'})
+        stderr = ''
+
+    def _fake_run(cmd, check, capture_output, text, timeout, cwd, env):
+        captured['cmd'] = cmd
+        captured['cwd'] = cwd
+        captured['pythonpath'] = env.get('PYTHONPATH', '')
+        return _Result()
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _fake_run)
+
+    desktop_runtime_setup._probe_llama_runtime()
+
+    assert captured['cmd'][:2] == [sys.executable, '-c']
+    assert captured['cwd'] == str(REPO_ROOT)
+    assert str(REPO_ROOT) in captured['pythonpath'].split(desktop_runtime_setup.os.pathsep)
+
+
+def test_runtime_bootstrap_fails_fast_when_llama_import_is_shadowed(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda: desktop_runtime_setup.RuntimeProbe(
+            backend='cpu',
+            gpu_offload_supported=False,
+            detected_device='cpu',
+            interpreter=sys.executable,
+            prefix=sys.prefix,
+            llama_module_path=str(REPO_ROOT / 'llama_cpp.py'),
+            shadowed_by_repo_shim=True,
+            error='shadowed import',
+        ),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'failed'
+    assert 'shadowed by repo-local llama_cpp.py' in result['fallback_reason']
+
+
 def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     class _OkResult:
         returncode = 0

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -7,6 +7,7 @@ import logging
 import requests
 import json
 import sys
+import importlib
 from pathlib import Path
 from threading import Lock
 from unittest.mock import MagicMock
@@ -18,16 +19,80 @@ from utils.system import resource_monitor
 logger = logging.getLogger('model_manager')
 
 
+def _repo_local_llama_shim_path() -> Path:
+    return Path(__file__).resolve().parents[2] / 'llama_cpp.py'
+
+
+def _is_repo_local_llama_module_path(module_path: str) -> bool:
+    if not module_path:
+        return False
+    try:
+        return Path(module_path).resolve() == _repo_local_llama_shim_path().resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
+def _import_llama_cpp_prefer_installed_package() -> Any:
+    """Import llama_cpp while preventing repo-local shim shadowing."""
+    repo_root = _repo_local_llama_shim_path().parent.resolve()
+    original_sys_path = list(sys.path)
+    filtered_sys_path: list[str] = []
+    for entry in original_sys_path:
+        if entry == '':
+            resolved = Path.cwd().resolve()
+        else:
+            try:
+                resolved = Path(entry).resolve()
+            except (OSError, RuntimeError):
+                resolved = None
+        if resolved == repo_root:
+            continue
+        filtered_sys_path.append(entry)
+
+    existing_module = sys.modules.get('llama_cpp')
+    existing_module_path = str(getattr(existing_module, '__file__', '') or '')
+    if _is_repo_local_llama_module_path(existing_module_path):
+        sys.modules.pop('llama_cpp', None)
+
+    try:
+        sys.path[:] = filtered_sys_path
+        importlib.invalidate_caches()
+        import llama_cpp  # type: ignore
+    finally:
+        sys.path[:] = original_sys_path
+
+    return llama_cpp
+
+
 def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     """Return backend/offload capability details from the installed llama_cpp runtime."""
     try:
-        import llama_cpp
+        llama_cpp = _import_llama_cpp_prefer_installed_package()
     except Exception as exc:
         return {
             'backend': 'missing',
             'gpu_offload_supported': False,
             'detected_device': 'none',
+            'llama_module_path': 'missing',
             'error': str(exc),
+            'shadowed_by_repo_shim': False,
+        }
+
+    llama_module_path = str(getattr(llama_cpp, '__file__', 'unknown') or 'unknown')
+    if _is_repo_local_llama_module_path(llama_module_path):
+        return {
+            'backend': 'missing',
+            'gpu_offload_supported': False,
+            'detected_device': 'none',
+            'interpreter': sys.executable,
+            'prefix': sys.prefix,
+            'llama_module_path': llama_module_path,
+            'error': (
+                'llama_cpp import resolved to repo-local llama_cpp.py shim; '
+                'desktop runtime requires installed llama-cpp-python package '
+                '(site-packages) in the sidecar interpreter'
+            ),
+            'shadowed_by_repo_shim': True,
         }
 
     backend = 'cpu'
@@ -58,8 +123,9 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'detected_device': backend if gpu_offload_supported else 'cpu',
         'interpreter': sys.executable,
         'prefix': sys.prefix,
-        'llama_module_path': getattr(llama_cpp, '__file__', 'unknown'),
+        'llama_module_path': llama_module_path,
         'error': None,
+        'shadowed_by_repo_shim': False,
     }
 
 


### PR DESCRIPTION
### Motivation
- Desktop runtime probes could accidentally import the repo-local `llama_cpp.py` shim (repo root) instead of the installed `llama-cpp-python` package, causing silent CPU-only fallbacks on Windows GPU paths. This change prevents that shadowing and surfaces an actionable error when it occurs.

### Description
- Prefer the installed package when importing `llama_cpp` by temporarily filtering repo-root entries from `sys.path`, clearing a previously-loaded `llama_cpp` from `sys.modules`, and importing with caches invalidated. (modified `utils/llm/model_manager.py`)
- Extend the probe payload with `shadowed_by_repo_shim` and add a runtime guard that fails fast with an actionable `fallback_reason` when the repo-local shim is detected. (modified `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`)
- Make the manual verifier and Windows NVIDIA smoke test explicitly detect and fail when `llama_module_path` points at the repo-local `llama_cpp.py` shim. (modified `desktop-tauri/scripts/verify_desktop_runtime.py`, `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py`)
- Add focused regression tests that assert probe subprocess wiring, probe payload shadow flag parsing, and fail-fast behavior when shim shadowing is present. (modified `tests/unit/test_desktop_runtime_setup.py`)
- Document the authoritative verifier and show an example of a bad vs good `llama_module_path` in `desktop-tauri/README.md`.

Files changed: `utils/llm/model_manager.py`, `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`, `desktop-tauri/scripts/verify_desktop_runtime.py`, `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py`, `tests/unit/test_desktop_runtime_setup.py`, `desktop-tauri/README.md`.

### Testing
- Compiled desktop runtime and helpers with `python -m py_compile ...` and the command completed successfully. (pass)
- Unit tests: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py` passed (21 tests). (pass)
- Unit tests: `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` passed (13 tests). (pass)
- Unit tests: `pytest -q --noconftest tests/unit/test_desktop_inference_sidecar.py` failed in this environment due to missing external Python deps (`cryptography` / `requests`) that cause import-time `runtime_unavailable` errors; failures are environment-bound and not caused by the shim fix. (environment limitation)
- Frontend tests: `npm --prefix desktop-tauri run test -- src/App.test.tsx` passed. (pass)
- `pre-commit run --all-files` was not available in the environment (`pre-commit: command not found`). (environment limitation)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3dd2ea14832fabe4609acaaa0136)