### PR TITLE
Fix desktop sidecar llama_cpp import shadowing on Windows GPU path

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -131,6 +131,15 @@ It prints:
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
   `fallback_reason`, `interpreter`, `llama_module_path`)
 
+Path sanity check for `llama_module_path`:
+
+- **Bad (shadowed shim):** `<repo-root>/llama_cpp.py`
+  (example: `C:\\Users\\<you>\\token.place\\llama_cpp.py`)
+- **Good (installed package):** interpreter `site-packages` path
+  (example: `...\\Lib\\site-packages\\llama_cpp\\__init__.py`)
+
+The verifier exits non-zero when `llama_module_path` points at the repo-local shim.
+
 ### Regression and smoke tests
 
 - Operator startup regression coverage (bridge startup event + surfaced errors):

--- a/desktop-tauri/scripts/verify_desktop_runtime.py
+++ b/desktop-tauri/scripts/verify_desktop_runtime.py
@@ -10,6 +10,13 @@ import sys
 from pathlib import Path
 
 
+def _is_repo_local_llama_shim(module_path: str, repo_root: Path) -> bool:
+    try:
+        return Path(module_path).resolve() == (repo_root / 'llama_cpp.py').resolve()
+    except Exception:
+        return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description='Verify desktop llama runtime wiring')
     parser.add_argument('--mode', default='auto')
@@ -17,20 +24,31 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[2]
-    if str(repo_root) not in sys.path:
-        sys.path.insert(0, str(repo_root))
+    python_root = repo_root / 'desktop-tauri' / 'src-tauri' / 'python'
+    if str(python_root) not in sys.path:
+        sys.path.insert(0, str(python_root))
+    from path_bootstrap import ensure_runtime_import_paths
 
+    ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
+
+    from desktop_runtime_setup import ensure_desktop_llama_runtime
     from utils.llm.model_manager import detect_llama_runtime_capabilities
 
+    runtime_setup = ensure_desktop_llama_runtime(args.mode, repo_root=repo_root)
     runtime = detect_llama_runtime_capabilities()
     payload = {
-        'backend': runtime.get('backend', 'missing'),
+        'backend': runtime_setup.get('selected_backend', runtime.get('backend', 'missing')),
         'gpu_offload_supported': runtime.get('gpu_offload_supported', False),
-        'detected_device': runtime.get('detected_device', 'none'),
-        'interpreter': runtime.get('interpreter', sys.executable),
-        'prefix': runtime.get('prefix', sys.prefix),
-        'llama_module_path': runtime.get('llama_module_path', 'missing'),
-        'error': runtime.get('error'),
+        'detected_device': runtime_setup.get('detected_device', runtime.get('detected_device', 'none')),
+        'interpreter': runtime_setup.get('interpreter', runtime.get('interpreter', sys.executable)),
+        'prefix': runtime_setup.get('prefix', runtime.get('prefix', sys.prefix)),
+        'llama_module_path': runtime_setup.get(
+            'llama_module_path',
+            runtime.get('llama_module_path', 'missing'),
+        ),
+        'runtime_action': runtime_setup.get('runtime_action', 'unknown'),
+        'fallback_reason': runtime_setup.get('fallback_reason', ''),
+        'error': runtime_setup.get('fallback_reason') or runtime.get('error'),
     }
 
     try:
@@ -80,8 +98,17 @@ def main() -> int:
         payload['compute_runtime_pre_init'] = f'skipped (missing dependency: {exc})'
         payload['compute_runtime_post_init'] = 'skipped'
 
+    if _is_repo_local_llama_shim(payload['llama_module_path'], repo_root):
+        payload['error'] = (
+            'llama_cpp import shadowed by repo-local shim; expected installed '
+            'llama-cpp-python package path under site-packages'
+        )
+        payload['shadowing_detected'] = True
+    else:
+        payload['shadowing_detected'] = False
+
     print(json.dumps(payload, indent=2))
-    return 0
+    return 1 if payload['shadowing_detected'] else 0
 
 
 if __name__ == '__main__':

--- a/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
+++ b/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
@@ -34,6 +34,13 @@ def _offloaded_layer_count(value: Any) -> int:
     return int(value or 0)
 
 
+def _is_repo_local_llama_shim(module_path: str, repo_root: Path) -> bool:
+    try:
+        return Path(module_path).resolve() == (repo_root / 'llama_cpp.py').resolve()
+    except Exception:
+        return False
+
+
 def _load_compute_runtime_diagnostics(model_path: str, mode: str) -> dict[str, Any]:
     from desktop_runtime_setup import ensure_desktop_llama_runtime
     from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
@@ -104,9 +111,11 @@ def main() -> int:
 
     repo_root = _repo_root()
     python_root = repo_root / 'desktop-tauri' / 'src-tauri' / 'python'
-    for entry in (str(repo_root), str(python_root)):
-        if entry not in sys.path:
-            sys.path.insert(0, entry)
+    if str(python_root) not in sys.path:
+        sys.path.insert(0, str(python_root))
+    from path_bootstrap import ensure_runtime_import_paths
+
+    ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
     try:
         diagnostics = _load_compute_runtime_diagnostics(args.model, args.mode)
@@ -121,6 +130,10 @@ def main() -> int:
             'fallback_reason': diagnostics.get('fallback_reason'),
         }
         print(json.dumps(payload, indent=2))
+        _require(
+            not _is_repo_local_llama_shim(payload.get('llama_module_path', ''), repo_root),
+            'llama_module_path points to repo-local llama_cpp.py shim; expected installed package',
+        )
 
         _require(payload['backend_available'] == 'cuda', 'backend_available is not cuda')
         _require(payload['backend_used'] == 'cuda', 'backend_used is not cuda')

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError:
     ) -> None:
         return
 
-ensure_runtime_import_paths(__file__)
+ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -42,8 +42,15 @@ import sys
 from pathlib import Path
 
 repo_root = Path.cwd()
-if str(repo_root) not in sys.path:
-    sys.path.insert(0, str(repo_root))
+repo_root_str = str(repo_root)
+sanitized_sys_path = []
+for entry in sys.path:
+    candidate = Path(entry or ".").resolve()
+    if candidate == repo_root:
+        continue
+    sanitized_sys_path.append(entry)
+sys.path[:] = sanitized_sys_path
+sys.path.append(repo_root_str)
 
 from utils.llm.model_manager import detect_llama_runtime_capabilities
 
@@ -52,14 +59,31 @@ print(json.dumps(payload))
 """.strip()
 
 
+def _is_repo_local_llama_shim(module_path: str, repo_root: Path) -> bool:
+    try:
+        resolved_module_path = Path(module_path).resolve()
+    except Exception:
+        return False
+    return resolved_module_path == (repo_root / "llama_cpp.py").resolve()
+
+
 def _probe_llama_runtime() -> RuntimeProbe:
     repo_root = Path(__file__).resolve().parents[3]
+    python_module_dir = Path(__file__).resolve().parent
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
     env = os.environ.copy()
-    existing_pythonpath = env.get("PYTHONPATH", "")
-    pythonpath_entries = [str(repo_root)]
-    if existing_pythonpath:
-        pythonpath_entries.append(existing_pythonpath)
+    existing_pythonpath = env.get("PYTHONPATH", "").split(os.pathsep) if env.get("PYTHONPATH") else []
+    pythonpath_entries = [str(python_module_dir)]
+    for entry in existing_pythonpath:
+        if not entry:
+            continue
+        try:
+            if Path(entry).resolve() == repo_root:
+                continue
+        except Exception:
+            pass
+        if entry not in pythonpath_entries:
+            pythonpath_entries.append(entry)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     try:
         result = subprocess.run(
@@ -68,7 +92,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
             capture_output=True,
             text=True,
             timeout=30,
-            cwd=str(repo_root),
+            cwd=str(python_module_dir),
             env=env,
         )
     except Exception as exc:
@@ -108,7 +132,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
             "error": stderr or "probe parse failure",
         }
 
-    return RuntimeProbe(
+    probe = RuntimeProbe(
         backend=str(payload.get("backend", "cpu")),
         gpu_offload_supported=bool(payload.get("gpu_offload_supported", False)),
         detected_device=str(payload.get("detected_device", "cpu")),
@@ -117,6 +141,21 @@ def _probe_llama_runtime() -> RuntimeProbe:
         llama_module_path=str(payload.get("llama_module_path", "missing")),
         error=payload.get("error"),
     )
+    if _is_repo_local_llama_shim(probe.llama_module_path, repo_root):
+        return RuntimeProbe(
+            backend="missing",
+            gpu_offload_supported=False,
+            detected_device="none",
+            interpreter=probe.interpreter,
+            prefix=probe.prefix,
+            llama_module_path=probe.llama_module_path,
+            error=(
+                "llama_cpp import shadowed by repo-local shim "
+                f"({probe.llama_module_path}); remove repo root from import precedence "
+                "and use the installed llama-cpp-python package from the sidecar interpreter"
+            ),
+        )
+    return probe
 
 
 def _run_pip_install(
@@ -246,7 +285,15 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
+    target_root = repo_root or Path(__file__).resolve().parents[3]
     before = _probe_llama_runtime()
+    if _is_repo_local_llama_shim(before.llama_module_path, target_root):
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": before.error or "llama_cpp import shadowed by repo-local shim",
+            "runtime_action": "shadowed_import",
+            **_probe_result_payload(before),
+        }
 
     if selected_mode not in GPU_MODES:
         return {
@@ -285,7 +332,6 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    target_root = repo_root or Path(__file__).resolve().parents[3]
     requirements_path = target_root / "requirements.txt"
     last_error = ""
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -21,7 +21,7 @@ if __package__ in (None, ""):
 from path_bootstrap import ensure_runtime_import_paths
 from desktop_runtime_setup import ensure_desktop_llama_runtime, maybe_reexec_for_runtime_refresh
 
-ensure_runtime_import_paths(__file__)
+ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 
-def ensure_runtime_import_paths(script_file: str) -> None:
+def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: bool = False) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
     script_path = Path(script_file).resolve()
@@ -38,7 +38,28 @@ def ensure_runtime_import_paths(script_file: str) -> None:
             if candidate_str not in valid_candidates:
                 valid_candidates.append(candidate_str)
 
-    # Preserve candidate priority: first valid candidate should be first on sys.path.
-    for candidate_str in reversed(valid_candidates):
+    if not avoid_llama_cpp_shadowing:
+        # Preserve candidate priority: first valid candidate should be first on sys.path.
+        for candidate_str in reversed(valid_candidates):
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+        return
+
+    safe_candidates: list[str] = []
+    shim_candidates: list[str] = []
+    for candidate_str in valid_candidates:
+        if (Path(candidate_str) / "llama_cpp.py").is_file():
+            shim_candidates.append(candidate_str)
+        else:
+            safe_candidates.append(candidate_str)
+
+    # Keep non-shim runtime modules importable with highest priority.
+    for candidate_str in reversed(safe_candidates):
         if candidate_str not in sys.path:
             sys.path.insert(0, candidate_str)
+
+    # Keep shim-containing roots importable, but behind installed site-packages.
+    for candidate_str in shim_candidates:
+        while candidate_str in sys.path:
+            sys.path.remove(candidate_str)
+        sys.path.append(candidate_str)

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -89,3 +89,20 @@ def test_bootstrap_prefers_explicit_env_import_root(tmp_path, path_bootstrap, mo
         assert sys.path.index(str(explicit_root)) == 0
     finally:
         sys.path[:] = original_sys_path
+
+
+def test_bootstrap_avoids_llama_cpp_shadowing_when_requested(tmp_path, path_bootstrap):
+    script = tmp_path / 'repo' / 'desktop-tauri' / 'src-tauri' / 'python' / 'model_bridge.py'
+    repo_root = tmp_path / 'repo'
+    (repo_root / 'utils').mkdir(parents=True)
+    (repo_root / 'llama_cpp.py').write_text('# local shim\n', encoding='utf-8')
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    original_sys_path = list(sys.path)
+    try:
+        sys.path.insert(0, str(repo_root))
+        path_bootstrap.ensure_runtime_import_paths(str(script), avoid_llama_cpp_shadowing=True)
+        assert sys.path[-1] == str(repo_root)
+    finally:
+        sys.path[:] = original_sys_path

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -305,6 +306,89 @@ def test_probe_falls_back_when_payload_is_not_json(monkeypatch):
     assert probe.backend == 'missing'
     assert probe.error == 'json parse failed'
     assert probe.llama_module_path == 'missing'
+
+
+def test_probe_detects_repo_local_llama_cpp_shadowing(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    repo_root = Path(__file__).resolve().parents[2]
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                'backend': 'cpu',
+                'gpu_offload_supported': False,
+                'detected_device': 'cpu',
+                'interpreter': sys.executable,
+                'prefix': sys.prefix,
+                'llama_module_path': str(repo_root / 'llama_cpp.py'),
+                'error': None,
+            }
+        )
+        stderr = ''
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _Result())
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+    assert probe.backend == 'missing'
+    assert 'shadowed by repo-local shim' in (probe.error or '')
+
+
+def test_probe_sanitizes_pythonpath_for_subprocess(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    captured = {}
+    repo_root = Path(__file__).resolve().parents[2]
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                'backend': 'cuda',
+                'gpu_offload_supported': True,
+                'detected_device': 'cuda',
+                'interpreter': sys.executable,
+                'prefix': sys.prefix,
+                'llama_module_path': 'C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+                'error': None,
+            }
+        )
+        stderr = ''
+
+    def _fake_run(*args, **kwargs):
+        captured['cwd'] = kwargs.get('cwd')
+        captured['env'] = kwargs.get('env', {})
+        return _Result()
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _fake_run)
+    monkeypatch.setenv('PYTHONPATH', os.pathsep.join([str(repo_root), '/tmp/other-path']))
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+
+    assert probe.backend == 'cuda'
+    assert captured['cwd'].endswith('desktop-tauri/src-tauri/python')
+    pythonpath_entries = captured['env']['PYTHONPATH'].split(os.pathsep)
+    assert str(repo_root) not in pythonpath_entries
+    assert '/tmp/other-path' in pythonpath_entries
+
+
+def test_runtime_bootstrap_fails_fast_when_repo_local_shim_is_detected(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    repo_root = Path(__file__).resolve().parents[2]
+    shadowed_probe = desktop_runtime_setup.RuntimeProbe(
+        backend='missing',
+        gpu_offload_supported=False,
+        detected_device='none',
+        interpreter=sys.executable,
+        prefix=sys.prefix,
+        llama_module_path=str(repo_root / 'llama_cpp.py'),
+        error='llama_cpp import shadowed by repo-local shim',
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: shadowed_probe)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=repo_root)
+
+    assert result['runtime_action'] == 'shadowed_import'
+    assert 'shadowed by repo-local shim' in result['fallback_reason']
 
 
 def test_run_pip_install_success_failure_and_timeout(monkeypatch):


### PR DESCRIPTION
### Motivation
- Runtime probes and desktop-side entrypoints were inserting the repo root ahead of the interpreter’s site-packages, causing `import llama_cpp` to resolve to the repo-local `llama_cpp.py` shim and forcing a silent CPU-only fallback on Windows GPU setups.
- Need a minimal, robust fix that preserves repo imports (e.g. `utils.*`) while ensuring the authoritative sidecar probe/verification uses the installed `llama-cpp-python` package or fails fast with an actionable message.

### Description
- Demote repo roots that contain a local `llama_cpp.py` shim so they do not appear ahead of site-packages when shadow-avoidance is requested by the desktop bootstrap. (`desktop-tauri/src-tauri/python/path_bootstrap.py`) 
- Enable shadow-avoidance for desktop sidecar entrypoints so bridge/sidecar code uses the shadow-safe import layout. (`compute_node_bridge.py`, `inference_sidecar.py`) 
- Harden the probe subprocess in `desktop_runtime_setup.py` by sanitizing `sys.path`/`PYTHONPATH`, running the probe with `cwd` set to the desktop python module dir, and recording authoritative interpreter/prefix/llama module path. Add a guard that detects repo-local `llama_cpp.py` and returns an actionable `shadowed_import` result (fail-fast). (`desktop-tauri/src-tauri/python/desktop_runtime_setup.py`) 
- Make the manual verifier and Windows smoke test use the shadow-safe bootstrap and explicitly fail (non-zero exit) when `llama_module_path` points at the repo-local shim, with clear error text. (`desktop-tauri/scripts/verify_desktop_runtime.py`, `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py`) 
- Add focused regression tests for path bootstrap shadow-avoidance and probe behavior, and a README note documenting bad vs good `llama_module_path` shapes. (tests in `tests/unit/test_desktop_path_bootstrap.py` and `tests/unit/test_desktop_runtime_setup.py`; `desktop-tauri/README.md` updated)

Files changed (key):
- desktop-tauri/src-tauri/python/path_bootstrap.py
- desktop-tauri/src-tauri/python/desktop_runtime_setup.py
- desktop-tauri/src-tauri/python/compute_node_bridge.py
- desktop-tauri/src-tauri/python/inference_sidecar.py
- desktop-tauri/scripts/verify_desktop_runtime.py
- desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
- tests/unit/test_desktop_path_bootstrap.py
- tests/unit/test_desktop_runtime_setup.py
- desktop-tauri/README.md

### Testing
- Ran `python -m py_compile` on updated Python modules; compilation succeeded. (success)
- Ran targeted unit tests: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py` and `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py`; both passed. (success)
- Ran new/updated path-bootstrap tests: `pytest -q --noconftest tests/unit/test_desktop_path_bootstrap.py`; passed. (success)
- Ran desktop inference sidecar unit suite: `pytest -q --noconftest tests/unit/test_desktop_inference_sidecar.py`; failures are environment-related due to missing optional runtime deps (`cryptography` / `requests`) and are unrelated to the shadowing fix. (environment failure — unrelated)
- Ran frontend tests: `npm --prefix desktop-tauri run test -- src/App.test.tsx`; passed. (success)

Before/After authoritative `llama_module_path` behavior:
- Before: probe often reported `llama_module_path = <repo-root>/llama_cpp.py` and `backend_available = cpu`, `backend_used = cpu`, `offloaded_layers = 0` due to import shadowing.
- After: probe will either report the installed package path under the interpreter’s site-packages (e.g. `.../Lib/site-packages/llama_cpp/__init__.py`) or fail fast with a clear `shadowed_import` fallback reason and actionable error (verifier/smoke tests exit non-zero when shim is detected).

Notes: the change is intentionally minimal and additive — normal repo imports remain available, shim-containing repo roots are kept on sys.path but moved behind installed package resolution when shadow-avoidance is requested by desktop entrypoints and probes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3dd2ea14832fabe4609acaaa0136)