### PR TITLE
Guard packaged Windows runtime requirements lookup

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -159,7 +159,18 @@ def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
     env = os.environ.copy()
     env["CMAKE_ARGS"] = "-DGGML_CUDA=on"
     env["FORCE_CMAKE"] = "1"
-    package_spec = llama_cpp_requirement_spec(requirements_path)
+    try:
+        package_spec = llama_cpp_requirement_spec(requirements_path)
+    except FileNotFoundError:
+        return (
+            False,
+            f"requirements file not found at {requirements_path}; skipping pinned CUDA source reinstall",
+        )
+    except (OSError, ValueError) as exc:
+        return (
+            False,
+            f"unable to resolve pinned llama-cpp-python requirement from {requirements_path}: {exc}",
+        )
     cmd = [
         sys.executable,
         "-m",

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -332,7 +332,8 @@ def test_run_continues_when_runtime_setup_reports_missing_packaged_requirements(
             'runtime_action': 'failed',
             'fallback_reason': (
                 'requirements file not found at '
-                'C:/Users/danie/AppData/requirements.txt; skipping pinned CUDA source reinstall'
+                'C:/Users/testuser/AppData/Local/token.place/requirements.txt; '
+                'skipping pinned CUDA source reinstall'
             ),
             'interpreter': sys.executable,
             'llama_module_path': 'missing',

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -320,6 +320,41 @@ def test_run_disables_runtime_reexec_to_avoid_pre_startup_exit(capsys, monkeypat
     assert events[-1]['type'] == 'stopped'
 
 
+def test_run_continues_when_runtime_setup_reports_missing_packaged_requirements(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cpu',
+            'runtime_action': 'failed',
+            'fallback_reason': (
+                'requirements file not found at '
+                'C:/Users/danie/AppData/requirements.txt; skipping pinned CUDA source reinstall'
+            ),
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+    assert events[-1]['type'] == 'stopped'
+    assert '[Errno 2]' not in json.dumps(events)
+
+
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -209,6 +209,38 @@ def test_windows_source_repair_returns_actionable_message_when_requirements_miss
     assert str(missing_requirements) in reason
 
 
+def test_windows_source_repair_returns_actionable_message_when_requirement_is_unreadable(monkeypatch, tmp_path):
+    unreadable_requirements = tmp_path / 'AppData' / 'requirements.txt'
+
+    def _raise_unreadable(_requirements_path):
+        raise OSError('permission denied')
+
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_requirement_spec', _raise_unreadable)
+
+    ok, reason = desktop_runtime_setup._windows_cuda_source_repair(unreadable_requirements)
+
+    assert ok is False
+    assert 'unable to resolve pinned llama-cpp-python requirement' in reason
+    assert str(unreadable_requirements) in reason
+    assert 'permission denied' in reason
+
+
+def test_windows_source_repair_returns_actionable_message_when_requirement_is_invalid(monkeypatch, tmp_path):
+    invalid_requirements = tmp_path / 'AppData' / 'requirements.txt'
+
+    def _raise_invalid(_requirements_path):
+        raise ValueError('missing pinned llama-cpp-python requirement')
+
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_requirement_spec', _raise_invalid)
+
+    ok, reason = desktop_runtime_setup._windows_cuda_source_repair(invalid_requirements)
+
+    assert ok is False
+    assert 'unable to resolve pinned llama-cpp-python requirement' in reason
+    assert str(invalid_requirements) in reason
+    assert 'missing pinned llama-cpp-python requirement' in reason
+
+
 def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -200,6 +200,15 @@ def test_windows_source_repair_uses_active_interpreter(monkeypatch):
     assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
 
 
+def test_windows_source_repair_returns_actionable_message_when_requirements_missing(tmp_path):
+    missing_requirements = tmp_path / 'AppData' / 'requirements.txt'
+    ok, reason = desktop_runtime_setup._windows_cuda_source_repair(missing_requirements)
+
+    assert ok is False
+    assert 'requirements file not found' in reason
+    assert str(missing_requirements) in reason
+
+
 def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
 
@@ -434,6 +443,24 @@ def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp
     can_retry, reason = desktop_runtime_setup._should_attempt_source_repair()
     assert can_retry is True
     assert reason == ''
+
+
+def test_windows_packaged_layout_without_requirements_falls_back_without_exception(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [])
+
+    packaged_root = tmp_path / 'Users' / 'danie' / 'AppData' / 'Local' / 'token.place'
+    packaged_root.mkdir(parents=True)
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=packaged_root)
+
+    assert result['runtime_action'] == 'failed'
+    assert result['selected_backend'] == 'cpu'
+    assert '[Errno 2]' not in result['fallback_reason']
+    assert 'requirements file not found' in result['fallback_reason']
 
 
 def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):


### PR DESCRIPTION
### Motivation
- Fix a packaged-runtime bootstrap crash on Windows where `_windows_cuda_source_repair` directly attempted to read a repo-root `requirements.txt` (often absent in `%AppData%` packaged layouts) which raised and caused the compute-node bridge to exit before emitting startup events.
- Preserve the existing pinned `llama-cpp-python` install behavior when a real `requirements.txt` is present while ensuring packaged layouts without repo metadata degrade safely to fallback plans.

### Description
- Add a guarded lookup around `llama_cpp_requirement_spec(requirements_path)` in `_windows_cuda_source_repair(requirements_path)` so `FileNotFoundError`, `OSError`, and `ValueError` produce deterministic failure messages instead of raising.
- Keep the existing pip-install path and pinned-package behavior intact when the requirements file is readable, only short-circuiting when the file is missing or unreadable.
- Add regression tests covering the new fallback behavior: `test_windows_source_repair_returns_actionable_message_when_requirements_missing` and `test_windows_packaged_layout_without_requirements_falls_back_without_exception` in `tests/unit/test_desktop_runtime_setup.py`, and `test_run_continues_when_runtime_setup_reports_missing_packaged_requirements` in `tests/unit/test_desktop_compute_node_bridge.py` to assert startup events still emit.
- Change is narrowly scoped to runtime bootstrap path handling and does not refactor other compute-node logic.

### Testing
- Ran `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and observed all unit tests pass (`39 passed`).
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` but it could not complete in this environment due to missing system `glib-2.0` development libraries, so Rust tests were not executed here.
- `pre-commit run --all-files` was not executed in this container because `pre-commit` is not installed, but unit tests exercise the changed behavior and cover the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cf3da634832f89ca4ad00b09df44)