### PR TITLE
Fix packaged Windows runtime bootstrap when requirements.txt is missing

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -159,7 +159,13 @@ def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
     env = os.environ.copy()
     env["CMAKE_ARGS"] = "-DGGML_CUDA=on"
     env["FORCE_CMAKE"] = "1"
-    package_spec = llama_cpp_requirement_spec(requirements_path)
+    package_spec = "llama-cpp-python"
+    try:
+        package_spec = llama_cpp_requirement_spec(requirements_path)
+    except (FileNotFoundError, OSError, ValueError):
+        # Packaged desktop layouts may not ship a repo-root requirements.txt.
+        # Degrade gracefully to an unpinned source reinstall in that case.
+        package_spec = "llama-cpp-python"
     cmd = [
         sys.executable,
         "-m",

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -200,6 +200,27 @@ def test_windows_source_repair_uses_active_interpreter(monkeypatch):
     assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
 
 
+def test_windows_source_repair_falls_back_to_unpinned_when_requirements_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    captured = {}
+
+    def fake_run(cmd, env, timeout_seconds):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        captured['timeout_seconds'] = timeout_seconds
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', fake_run)
+    ok, _ = desktop_runtime_setup._windows_cuda_source_repair(tmp_path / 'requirements.txt')
+
+    assert ok is True
+    assert captured['cmd'][:3] == [sys.executable, '-m', 'pip']
+    assert captured['cmd'][4] == 'llama-cpp-python'
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
+    assert captured['env']['FORCE_CMAKE'] == '1'
+    assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+
+
 def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
 
@@ -444,3 +465,28 @@ def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
 
     module_path = str(shim.resolve()).upper()
     assert desktop_runtime_setup._is_repo_local_llama_module(module_path, repo_root) is True
+
+
+def test_windows_packaged_layout_without_requirements_uses_safe_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+
+    pip_calls = []
+
+    def fake_run(cmd, env, timeout_seconds=desktop_runtime_setup.PIP_INSTALL_TIMEOUT_SECONDS):
+        pip_calls.append(cmd)
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', fake_run)
+    packaged_root = tmp_path / 'AppData' / 'token.place'
+    packaged_root.mkdir(parents=True)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=packaged_root)
+
+    assert result['runtime_action'] == 'installed_cpu_fallback'
+    assert result['selected_backend'] == 'cpu'
+    assert 'No such file or directory' not in result['fallback_reason']
+    assert any(cmd[4] == 'llama-cpp-python' for cmd in pip_calls)


### PR DESCRIPTION
### Motivation
- Packaged Windows runtimes can set the runtime root to an extracted AppData/resources path that does not contain the repository `requirements.txt`, causing `_windows_cuda_source_repair()` to call `llama_cpp_requirement_spec(requirements_path)` and raise `FileNotFoundError`, which aborts startup early. 
- The goal is to make packaged desktop startup tolerate missing repo metadata while preserving pinned install semantics during development. 

### Description
- Guard `_windows_cuda_source_repair()` so it attempts to read a pinned spec from `requirements.txt` but falls back deterministically to the unpinned `"llama-cpp-python"` package when the file is missing, unreadable, or does not contain a pin. (change in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`).
- Preserve existing pinned behavior when `requirements.txt` exists and contains a pin by still using `llama_cpp_requirement_spec(...)` when it succeeds. 
- Add unit tests covering both the direct source-repair fallback and a Windows-style packaged-layout bootstrap without `requirements.txt` so future regressions fail in CI (`tests/unit/test_desktop_runtime_setup.py`).

### Testing
- Ran unit tests with `pytest --confcutdir=tests/unit tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py`, and all unit tests passed (`38 passed`).
- Attempted Rust tests with `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node`, which failed in this environment due to a missing system dependency (`glib-2.0` / pkg-config), not related to the Python change.
- Ran repository checks with `pre-commit run --all-files`, which reported existing repo-wide hook issues (codespell/vulture) unrelated to this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cf3da634832f89ca4ad00b09df44)