### PR TITLE
Fix packaged desktop runtime fallback when requirements.txt is absent

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -159,7 +159,7 @@ def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
     env = os.environ.copy()
     env["CMAKE_ARGS"] = "-DGGML_CUDA=on"
     env["FORCE_CMAKE"] = "1"
-    package_spec = llama_cpp_requirement_spec(requirements_path)
+    package_spec = _llama_cpp_package_spec(requirements_path)
     cmd = [
         sys.executable,
         "-m",
@@ -171,6 +171,13 @@ def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
         "--verbose",
     ]
     return _run_pip_install(cmd, env, timeout_seconds=PIP_SOURCE_BUILD_TIMEOUT_SECONDS)
+
+
+def _llama_cpp_package_spec(requirements_path: Path) -> str:
+    try:
+        return llama_cpp_requirement_spec(requirements_path)
+    except (FileNotFoundError, OSError, ValueError):
+        return "llama-cpp-python"
 
 
 def _summarize_install_error(raw: str) -> str:
@@ -326,6 +333,7 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         }
 
     requirements_path = target_root / "requirements.txt"
+    requirements_available = requirements_path.is_file()
     last_error = ""
 
     should_repair, repair_skip_reason = _should_attempt_source_repair()
@@ -353,11 +361,15 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         last_error = repair_skip_reason
 
     try:
-        plans = llama_cpp_install_plan_fallbacks(
-            platform=sys.platform,
-            requirements_path=requirements_path,
+        plans = (
+            llama_cpp_install_plan_fallbacks(
+                platform=sys.platform,
+                requirements_path=requirements_path,
+            )
+            if requirements_available
+            else _fallback_unpinned_plans(sys.platform)
         )
-    except (FileNotFoundError, ValueError):
+    except (FileNotFoundError, OSError, ValueError):
         plans = _fallback_unpinned_plans(sys.platform)
 
     for plan in plans:

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -200,6 +200,21 @@ def test_windows_source_repair_uses_active_interpreter(monkeypatch):
     assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
 
 
+def test_llama_cpp_package_spec_prefers_pinned_requirement_when_present(tmp_path):
+    requirements_path = tmp_path / 'requirements.txt'
+    requirements_path.write_text('llama-cpp-python==0.3.7\n', encoding='utf-8')
+
+    assert (
+        desktop_runtime_setup._llama_cpp_package_spec(requirements_path)
+        == 'llama-cpp-python==0.3.7'
+    )
+
+
+def test_llama_cpp_package_spec_falls_back_when_requirements_missing(tmp_path):
+    missing_requirements = tmp_path / 'requirements.txt'
+    assert desktop_runtime_setup._llama_cpp_package_spec(missing_requirements) == 'llama-cpp-python'
+
+
 def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
 
@@ -261,6 +276,49 @@ def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
 
     assert result['runtime_action'] == 'failed'
     assert result['fallback_reason'] == 'build failed'
+
+
+def test_windows_packaged_layout_without_requirements_uses_safe_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    repo_root = tmp_path / 'AppData' / 'token-place-runtime'
+    repo_root.mkdir(parents=True)
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_windows_cuda_source_repair',
+        lambda _requirements_path: (False, 'compile failed'),
+    )
+
+    fallback_plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cpu',
+            package_spec='llama-cpp-python',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://pypi.org/simple',
+            extra_index_url=None,
+            only_binary=True,
+            no_binary=False,
+        )
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: fallback_plans)
+
+    called = {'fallback_from_requirements': False}
+
+    def _unexpected_fallbacks(**_kwargs):
+        called['fallback_from_requirements'] = True
+        return []
+
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', _unexpected_fallbacks)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=repo_root)
+
+    assert result['runtime_action'] == 'installed_cpu_fallback'
+    assert called['fallback_from_requirements'] is False
 
 
 def test_probe_marks_error_when_subprocess_raises(monkeypatch):


### PR DESCRIPTION
### Motivation

- Packaged Windows desktop runtimes could crash startup with `FileNotFoundError` when `ensure_desktop_llama_runtime()` attempted to read a repo-root `requirements.txt` under a runtime-extracted `%AppData%` layout, causing the compute-node bridge to exit before emitting startup events.
- The source-repair path called `llama_cpp_requirement_spec()` unguarded which raised early when the file was missing; the goal is to make packaged layouts degrade to a safe, deterministic install plan while preserving pinned installs for normal dev/repo-root flows.

### Description

- Add `_llama_cpp_package_spec(requirements_path)` which returns the pinned `llama-cpp-python==...` when present and falls back to the unpinned string `llama-cpp-python` when the requirements file is missing, unreadable, or unpinned.
- Use `_llama_cpp_package_spec()` from `_windows_cuda_source_repair()` so source-repair no longer raises on missing `requirements.txt` in packaged layouts.
- Detect `requirements.txt` availability and, when absent, skip invoking `llama_cpp_install_plan_fallbacks(...)` and instead use `_fallback_unpinned_plans(...)`, and broaden the fallback exception handling to include `OSError`.
- Add unit tests covering the pinned-vs-fallback package-spec helper and a Windows-packaged-layout regression test asserting that missing `requirements.txt` no longer causes startup crashes and proceeds to a CPU fallback plan.

### Testing

- Ran `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (`39 passed`).
- Ran the desktop Rust tests with `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node`, which failed in this container due to a missing system `glib-2.0` / `pkg-config` dependency (environment issue), not the Python change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cf3da634832f89ca4ad00b09df44)