### PR TITLE
Fix Windows desktop GPU bootstrap: add CUDA source fallback and harden runtime probe

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -129,6 +129,22 @@ def llama_cpp_install_plan_fallbacks(
             )
         )
 
+        # If CUDA wheels are unavailable for this ABI, attempt an unpinned
+        # source build with CUDA explicitly enabled before settling on CPU.
+        plans.append(
+            LlamaCppInstallPlan(
+                platform=primary.platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args="-DGGML_CUDA=on",
+                force_cmake=True,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+                no_binary=True,
+            )
+        )
+
         # If CUDA wheels are unavailable entirely for this ABI, fall back to
         # an unpinned CPU wheel from PyPI to keep desktop CI/release buildable
         # without requiring local native compilation toolchains.

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -422,6 +422,17 @@ def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
             ),
             LlamaCppInstallPlan(
                 platform=detected_platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args="-DGGML_CUDA=on",
+                force_cmake=True,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+                no_binary=True,
+            ),
+            LlamaCppInstallPlan(
+                platform=detected_platform,
                 backend="cpu",
                 package_spec="llama-cpp-python",
                 cmake_args=None,

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -289,6 +289,56 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     assert 'failed to initialize model runtime' in payload['message']
 
 
+def test_run_surfaces_gpu_capable_runtime_status_payload(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'runtime_action': 'already_supported',
+            'interpreter': sys.executable,
+            'llama_module_path': 'C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+            'fallback_reason': '',
+        },
+    )
+
+    module = sys.modules['utils.compute_node_runtime']
+    module.compute_mode_diagnostics = lambda _manager: {
+        'requested_mode': 'auto',
+        'effective_mode': 'cuda',
+        'backend_available': 'cuda',
+        'backend_selected': 'cuda',
+        'backend_used': 'cuda',
+        'n_gpu_layers': -1,
+        'offloaded_layers': -1,
+        'kv_cache_device': 'cuda',
+        'fallback_reason': None,
+    }
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    started = events[0]
+    assert started['type'] == 'started'
+    assert started['effective_mode'] == 'cuda'
+    assert started['backend_available'] == 'cuda'
+    assert started['backend_used'] == 'cuda'
+    assert started['offloaded_layers'] == -1
+    assert started['fallback_reason'] is None
+    assert started['llama_module_path'].endswith('llama_cpp/__init__.py')
+
+
 def test_run_disables_runtime_reexec_to_avoid_pre_startup_exit(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -18,7 +18,7 @@ from desktop_gpu_packaging import (
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    assert len(plans) == 3
+    assert len(plans) == 4
 
     gpu_plan = plans[0]
     assert gpu_plan.backend == "cuda"
@@ -36,7 +36,18 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert unpinned_cuda_fallback.only_binary is True
     assert unpinned_cuda_fallback.no_binary is False
 
-    cpu_fallback = plans[2]
+    source_cuda_fallback = plans[2]
+    assert source_cuda_fallback.backend == "cuda"
+    assert source_cuda_fallback.package_spec == "llama-cpp-python"
+    assert source_cuda_fallback.index_url == "https://pypi.org/simple"
+    assert source_cuda_fallback.only_binary is False
+    assert source_cuda_fallback.no_binary is True
+    assert source_cuda_fallback.pip_env() == {
+        "CMAKE_ARGS": "-DGGML_CUDA=on",
+        "FORCE_CMAKE": "1",
+    }
+
+    cpu_fallback = plans[3]
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.package_spec == "llama-cpp-python"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
@@ -145,7 +156,7 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
 
 def test_windows_cpu_fallback_install_args_are_binary_only():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    cpu_fallback = plans[2]
+    cpu_fallback = plans[3]
 
     assert cpu_fallback.pip_install_args() == [
         "--upgrade",
@@ -153,6 +164,21 @@ def test_windows_cpu_fallback_install_args_are_binary_only():
         "--index-url",
         "https://pypi.org/simple",
         "--only-binary",
+        "llama-cpp-python",
+        "--prefer-binary",
+    ]
+
+
+def test_windows_source_fallback_install_args_force_source_build():
+    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    source_fallback = plans[2]
+
+    assert source_fallback.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--index-url",
+        "https://pypi.org/simple",
+        "--no-binary",
         "llama-cpp-python",
         "--prefer-binary",
     ]

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -174,7 +174,7 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     darwin_plans = desktop_runtime_setup._fallback_unpinned_plans('darwin')
     linux_plans = desktop_runtime_setup._fallback_unpinned_plans('linux')
 
-    assert [plan.backend for plan in win_plans] == ['cuda', 'cpu']
+    assert [plan.backend for plan in win_plans] == ['cuda', 'cuda', 'cpu']
     assert [plan.backend for plan in darwin_plans] == ['metal', 'metal']
     assert [plan.backend for plan in linux_plans] == ['cpu']
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # Import the module to test
-from utils.llm.model_manager import ModelManager
+from utils.llm.model_manager import ModelManager, detect_llama_runtime_capabilities
 
 
 class _ToDictOnly:
@@ -841,6 +841,50 @@ class TestModelManager:
             backend = ModelManager._platform_gpu_backend()
 
         assert backend == 'metal'
+
+    def test_platform_gpu_backend_uses_nested_cuda_marker_aliases(self):
+        """Backend detection should support nested marker aliases from newer bindings."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            llama_cpp=SimpleNamespace(GGML_CUDA=True),
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend == 'cuda'
+
+    def test_platform_gpu_backend_uses_low_level_cuda_symbols_when_markers_missing(self):
+        """Backend detection should use low-level CUDA symbols when markers are absent."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            llama_cpp=SimpleNamespace(ggml_backend_cuda_init=lambda: None),
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend == 'cuda'
+
+    def test_detect_runtime_capabilities_reports_cuda_without_gpu_offload_callable(self):
+        """Runtime capability probe should still mark CUDA as available without callable probe."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            llama_cpp=SimpleNamespace(ggml_backend_cuda_init=lambda: None),
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            payload = detect_llama_runtime_capabilities()
+
+        assert payload['backend'] == 'cuda'
+        assert payload['gpu_offload_supported'] is True
+        assert payload['detected_device'] == 'cuda'
 
     def test_platform_gpu_backend_linux_uses_gpu_offload_probe(self):
         """Linux backend detection should map positive runtime probes to CUDA."""

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -18,6 +18,30 @@ from utils.system import resource_monitor
 logger = logging.getLogger('model_manager')
 
 
+def _llama_backend_marker_enabled(llama_cpp_module: Any, names: Iterable[str]) -> bool:
+    """Return True when any backend marker name is present and truthy."""
+    for name in names:
+        if bool(getattr(llama_cpp_module, name, False)):
+            return True
+    nested = getattr(llama_cpp_module, "llama_cpp", None)
+    if nested is not None:
+        for name in names:
+            if bool(getattr(nested, name, False)):
+                return True
+    return False
+
+
+def _llama_backend_symbol_present(llama_cpp_module: Any, prefixes: Iterable[str]) -> bool:
+    """Best-effort probe for backend-specific low-level symbols."""
+    nested = getattr(llama_cpp_module, "llama_cpp", None)
+    symbol_holders = [holder for holder in (llama_cpp_module, nested) if holder is not None]
+    for holder in symbol_holders:
+        for prefix in prefixes:
+            if any(name.startswith(prefix) for name in dir(holder)):
+                return True
+    return False
+
+
 def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     """Return backend/offload capability details from the installed llama_cpp runtime."""
     try:
@@ -31,9 +55,11 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         }
 
     backend = 'cpu'
-    if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
+    if _llama_backend_marker_enabled(llama_cpp, ('GGML_USE_CUDA', 'GGML_CUDA', 'LLAMA_CUDA')):
         backend = 'cuda'
-    elif bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
+    elif _llama_backend_marker_enabled(
+        llama_cpp, ('GGML_USE_METAL', 'GGML_METAL', 'LLAMA_METAL')
+    ):
         backend = 'metal'
 
     supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
@@ -45,6 +71,20 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
             gpu_offload_supported = False
     else:
         gpu_offload_supported = backend in {'cuda', 'metal'}
+
+    # Some llama_cpp builds expose CUDA/Metal only via low-level symbols under
+    # llama_cpp.llama_cpp while omitting top-level GGML_* markers.
+    if backend == 'cpu' and _llama_backend_symbol_present(
+        llama_cpp, ('ggml_backend_cuda', 'llama_backend_cuda')
+    ):
+        backend = 'cuda'
+    elif backend == 'cpu' and _llama_backend_symbol_present(
+        llama_cpp, ('ggml_backend_metal', 'llama_backend_metal')
+    ):
+        backend = 'metal'
+
+    if backend in {'cuda', 'metal'}:
+        gpu_offload_supported = True if callable(supports_gpu) is False else gpu_offload_supported
 
     # Some llama_cpp builds can report runtime GPU offload support via probe
     # without exposing GGML_USE_* backend markers. Preserve prior Linux behavior


### PR DESCRIPTION
### Motivation
- Root cause: the Windows desktop bootstrap could prematurely settle on a CPU wheel because the install fallback order lacked an unpinned CUDA source-build attempt (`GGML_CUDA` + `FORCE_CMAKE`) before falling back to CPU wheels.
- Secondary cause: `detect_llama_runtime_capabilities()` relied on a narrow set of top-level GGML markers and a callable probe, causing some valid CUDA/Metal builds (nested symbol aliases or low-level symbols) to be misclassified as CPU-only.
- The goal is to preserve robust CPU fallback while ensuring Windows systems that can build/use CUDA do not get incorrectly downgraded to CPU.

### Description
- Added an unpinned CUDA source-build fallback plan (sets `CMAKE_ARGS=-DGGML_CUDA=on` and `FORCE_CMAKE=1`) before the CPU fallback in `llama_cpp_install_plan_fallbacks()` and `_fallback_unpinned_plans()` so the bootstrap will attempt a source build when wheels are unavailable for the Python ABI (`desktop-tauri/src-tauri/python/desktop_gpu_packaging.py`, `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`).
- Hardened runtime detection in `detect_llama_runtime_capabilities()` by introducing helper probes that: (1) check multiple marker aliases (e.g., `GGML_CUDA`, `LLAMA_CUDA`) and nested `llama_cpp` aliases, and (2) scan for low-level backend symbols (e.g., `ggml_backend_cuda*` / `llama_backend_cuda*`) so builds exposing capabilities in non-top-level places are recognized (`utils/llm/model_manager.py`).
- Kept existing behavior and guardrails: CPU fallback remains the final option, opt-out via `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP` preserved, and repo-local `llama_cpp.py` shim detection unchanged.
- Added/updated unit tests to cover the new source-build plan ordering, pip env flags, expanded probe behavior, and a high-value desktop startup path that asserts GPU-capable status is surfaced by the compute-node bridge (`tests/unit/test_desktop_gpu_packaging.py`, `tests/unit/test_desktop_runtime_setup.py`, `tests/unit/test_model_manager.py`, `tests/unit/test_desktop_compute_node_bridge.py`).

### Testing
- Ran the focused Python unit test suite with `pytest` covering the modified modules: `tests/unit/test_desktop_runtime_setup.py`, `tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_desktop_gpu_packaging.py`, and `tests/unit/test_model_manager.py`, and all tests passed (`103 passed`).
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` which exercised Rust bridge code but failed in this environment due to missing system library `glib-2.0` / `pkg-config` (environment limitation), not due to the changes.
- Ran `pre-commit run --all-files` which started hooks; unrelated repo-level hooks (e.g. `codespell` and `vulture`) surfaced existing issues and long-running checks, but they are orthogonal to this change and did not block the targeted unit-test verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d86aadec832f86409f9271c9a37e)