### PR TITLE
Fix desktop Windows GPU bootstrap to avoid premature CPU fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,10 @@ The next steps need to be executed in the same virtual environment you set up ab
 
 This will replace the llama-cpp-python you installed via `pip install -r requirements.txt` and will instruct it to use [cuBLAS](https://docs.nvidia.com/cuda/cublas/index.html).
 
+For the desktop Tauri compute-node path, runtime bootstrap follows the same contract:
+it first tries a CUDA wheel, then an unpinned CUDA wheel, then a CUDA source build
+with `CMAKE_ARGS=-DGGML_CUDA=on` and `FORCE_CMAKE=1`, and only then falls back to CPU.
+
 **if you're using Command Prompt**
 
 ```

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -129,6 +129,22 @@ def llama_cpp_install_plan_fallbacks(
             )
         )
 
+        # If no compatible CUDA wheels exist (common with new Python ABIs),
+        # try a source build with CUDA explicitly enabled before giving up.
+        plans.append(
+            LlamaCppInstallPlan(
+                platform=primary.platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args="-DGGML_CUDA=on",
+                force_cmake=True,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+                no_binary=True,
+            )
+        )
+
         # If CUDA wheels are unavailable entirely for this ABI, fall back to
         # an unpinned CPU wheel from PyPI to keep desktop CI/release buildable
         # without requiring local native compilation toolchains.

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -422,6 +422,17 @@ def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
             ),
             LlamaCppInstallPlan(
                 platform=detected_platform,
+                backend="cuda",
+                package_spec="llama-cpp-python",
+                cmake_args="-DGGML_CUDA=on",
+                force_cmake=True,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=False,
+                no_binary=True,
+            ),
+            LlamaCppInstallPlan(
+                platform=detected_platform,
                 backend="cpu",
                 package_spec="llama-cpp-python",
                 cmake_args=None,

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -356,6 +356,73 @@ def test_run_continues_when_runtime_setup_reports_missing_packaged_requirements(
     assert '[Errno 2]' not in json.dumps(events)
 
 
+def test_run_emits_gpu_capable_status_when_runtime_and_model_diagnostics_report_cuda(
+    capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'runtime_action': 'already_supported',
+            'fallback_reason': '',
+            'interpreter': sys.executable,
+            'llama_module_path': 'C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+        },
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        'utils.compute_node_runtime',
+        ModuleType('utils.compute_node_runtime'),
+    )
+    runtime_module = sys.modules['utils.compute_node_runtime']
+    runtime_module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port, **kwargs: SimpleNamespace(
+        relay_url=relay_url, relay_port=relay_port, **kwargs
+    )
+    runtime_module.ComputeNodeRuntime = FakeRuntime
+    runtime_module.is_legacy_relay_payload = (
+        lambda payload: {"client_public_key", "chat_history", "cipherkey", "iv"}.issubset(payload)
+    )
+    runtime_module.resolve_relay_url = lambda relay_url, **_kwargs: relay_url
+    runtime_module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    runtime_module.SUPPORTED_COMPUTE_MODES = {'auto', 'cpu', 'gpu', 'hybrid'}
+    runtime_module.normalize_compute_mode = lambda mode: mode
+    runtime_module.apply_compute_mode = lambda manager, mode: setattr(
+        manager, 'requested_compute_mode', mode
+    ) or mode
+    runtime_module.compute_mode_diagnostics = lambda _manager: {
+        'requested_mode': 'auto',
+        'effective_mode': 'cuda',
+        'backend_available': 'cuda',
+        'backend_selected': 'cuda',
+        'backend_used': 'cuda',
+        'offloaded_layers': -1,
+        'kv_cache_device': 'cuda',
+        'fallback_reason': None,
+    }
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    started = events[0]
+    assert started['type'] == 'started'
+    assert started['effective_mode'] == 'cuda'
+    assert started['backend_available'] == 'cuda'
+    assert started['backend_used'] == 'cuda'
+    assert started['llama_module_path'].endswith('llama_cpp/__init__.py')
+
+
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -18,7 +18,7 @@ from desktop_gpu_packaging import (
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    assert len(plans) == 3
+    assert len(plans) == 4
 
     gpu_plan = plans[0]
     assert gpu_plan.backend == "cuda"
@@ -36,7 +36,16 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert unpinned_cuda_fallback.only_binary is True
     assert unpinned_cuda_fallback.no_binary is False
 
-    cpu_fallback = plans[2]
+    source_cuda_fallback = plans[2]
+    assert source_cuda_fallback.backend == "cuda"
+    assert source_cuda_fallback.package_spec == "llama-cpp-python"
+    assert source_cuda_fallback.index_url == "https://pypi.org/simple"
+    assert source_cuda_fallback.only_binary is False
+    assert source_cuda_fallback.no_binary is True
+    assert source_cuda_fallback.force_cmake is True
+    assert source_cuda_fallback.cmake_args == "-DGGML_CUDA=on"
+
+    cpu_fallback = plans[3]
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.package_spec == "llama-cpp-python"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
@@ -145,7 +154,7 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
 
 def test_windows_cpu_fallback_install_args_are_binary_only():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    cpu_fallback = plans[2]
+    cpu_fallback = plans[3]
 
     assert cpu_fallback.pip_install_args() == [
         "--upgrade",
@@ -156,6 +165,25 @@ def test_windows_cpu_fallback_install_args_are_binary_only():
         "llama-cpp-python",
         "--prefer-binary",
     ]
+
+
+def test_windows_cuda_source_fallback_forces_source_build_with_cuda_flags():
+    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    source_cuda_fallback = plans[2]
+
+    assert source_cuda_fallback.pip_install_args() == [
+        "--upgrade",
+        "--no-cache-dir",
+        "--index-url",
+        "https://pypi.org/simple",
+        "--no-binary",
+        "llama-cpp-python",
+        "--prefer-binary",
+    ]
+    assert source_cuda_fallback.pip_env() == {
+        "CMAKE_ARGS": "-DGGML_CUDA=on",
+        "FORCE_CMAKE": "1",
+    }
 
 
 def test_macos_source_fallback_install_args_force_source_build():

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -174,9 +174,55 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     darwin_plans = desktop_runtime_setup._fallback_unpinned_plans('darwin')
     linux_plans = desktop_runtime_setup._fallback_unpinned_plans('linux')
 
-    assert [plan.backend for plan in win_plans] == ['cuda', 'cpu']
+    assert [plan.backend for plan in win_plans] == ['cuda', 'cuda', 'cpu']
+    assert win_plans[1].force_cmake is True
+    assert win_plans[1].cmake_args == '-DGGML_CUDA=on'
     assert [plan.backend for plan in darwin_plans] == ['metal', 'metal']
     assert [plan.backend for plan in linux_plans] == ['cpu']
+
+
+def test_windows_runtime_bootstrap_uses_cuda_source_fallback_when_wheels_unavailable(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    repo_root = Path.cwd()
+    assert (repo_root / 'requirements.txt').exists()
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
+    probes = iter([_probe(), _probe(backend='cuda', gpu=True, device='cuda')])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: next(probes))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cuda',
+            package_spec='llama-cpp-python',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://abetlen.github.io/llama-cpp-python/whl/cu124',
+            extra_index_url='https://pypi.org/simple',
+            only_binary=True,
+            no_binary=False,
+        ),
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cuda',
+            package_spec='llama-cpp-python',
+            cmake_args='-DGGML_CUDA=on',
+            force_cmake=True,
+            index_url='https://pypi.org/simple',
+            extra_index_url=None,
+            only_binary=False,
+            no_binary=True,
+        ),
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
+    pip_results = iter([(False, 'wheel missing for cp313'), (True, 'built from source with cuda')])
+    monkeypatch.setattr(
+        desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: next(pip_results)
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=repo_root)
+
+    assert result['runtime_action'] == 'installed_cuda_reexec'
+    assert result['selected_backend'] == 'cuda'
 
 
 def test_windows_source_repair_uses_active_interpreter(monkeypatch):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -799,6 +799,24 @@ class TestModelManager:
 
         assert backend == 'cuda'
 
+    def test_platform_gpu_backend_detects_nested_cuda_marker_variants(self):
+        """Backend detection should accept CUDA markers on nested llama_cpp module."""
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_cpp=SimpleNamespace(
+                GGML_CUDA=True,
+                GGML_USE_CUBLAS=False,
+            ),
+            llama_supports_gpu_offload=lambda: False,
+        )
+
+        with patch('utils.llm.model_manager.sys.platform', 'win32'), \
+             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            backend = ModelManager._platform_gpu_backend()
+
+        assert backend == 'cuda'
+
     def test_llama_gpu_offload_available_returns_false_on_runtime_error(self):
         """GPU support probe should fail closed if llama_cpp probe raises."""
 
@@ -884,6 +902,24 @@ class TestModelManager:
 
         with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
             assert ModelManager._llama_gpu_offload_available() is True
+
+    def test_detect_runtime_capabilities_accepts_top_level_ggml_cuda_marker(self):
+        from utils.llm import model_manager as mm
+
+        fake_llama = SimpleNamespace(
+            GGML_CUDA=True,
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            __file__='C:/Python/site-packages/llama_cpp/__init__.py',
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            payload = mm.detect_llama_runtime_capabilities()
+
+        assert payload['backend'] == 'cuda'
+        assert payload['gpu_offload_supported'] is True
+        assert payload['detected_device'] == 'cuda'
 
     def test_resolve_compute_plan_gpu_and_hybrid_success_paths(self, model_manager):
         """Explicit gpu/hybrid requests should emit expected diagnostics."""

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -30,10 +30,30 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
             'error': str(exc),
         }
 
+    def _marker_enabled(module: Any, markers: Iterable[str]) -> bool:
+        for marker in markers:
+            try:
+                if bool(getattr(module, marker, False)):
+                    return True
+            except Exception:
+                continue
+        return False
+
+    # Newer llama-cpp-python builds can expose backend markers either on the
+    # top-level module or the nested extension module. Keep this probe tolerant
+    # to naming drift across releases.
+    nested_module = getattr(llama_cpp, 'llama_cpp', None)
     backend = 'cpu'
-    if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
+    if _marker_enabled(llama_cpp, ('GGML_USE_CUDA', 'GGML_CUDA', 'GGML_USE_CUBLAS')) or (
+        nested_module
+        and _marker_enabled(
+            nested_module, ('GGML_USE_CUDA', 'GGML_CUDA', 'GGML_USE_CUBLAS')
+        )
+    ):
         backend = 'cuda'
-    elif bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
+    elif _marker_enabled(llama_cpp, ('GGML_USE_METAL', 'GGML_METAL')) or (
+        nested_module and _marker_enabled(nested_module, ('GGML_USE_METAL', 'GGML_METAL'))
+    ):
         backend = 'metal'
 
     supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)


### PR DESCRIPTION
### Motivation
- Root cause 1: the Windows desktop install fallback chain skipped a CUDA source-build attempt and could drop straight to CPU when CUDA wheels were unavailable for the active Python ABI. 
- Root cause 2: runtime probe was too narrow and missed newer/alternate `llama-cpp-python` backend markers (or nested extension module markers), causing false CPU-only conclusions. 
- The observed symptom was the desktop operator/sidecar logging `installed_cpu_fallback` / `cpu_fallback` even when CUDA could be available per README guidance. 

### Description
- Added a Windows CUDA source-build fallback plan (CMAKE_ARGS `-DGGML_CUDA=on`, `FORCE_CMAKE=1`, `--no-binary llama-cpp-python`) to the packaging planner and the runtime unpinned fallback list so desktop bootstrap will try a source build before falling back to CPU. 
- Hardened `detect_llama_runtime_capabilities()` to accept multiple marker name variants and to probe both top-level and nested `llama_cpp` modules (markers checked include `GGML_USE_CUDA`, `GGML_CUDA`, `GGML_USE_CUBLAS`, `GGML_USE_METAL`, `GGML_METAL`). 
- Added unit tests covering the new Windows fallback ordering and source-build success path, packaging plan expectations (pip args/env), marker-variant runtime detection, and a higher-level desktop bridge test that asserts GPU-capable status is emitted when runtime + compute diagnostics report CUDA. 
- Documented the desktop/Tauri bootstrap fallback chain in `README.md` so the runtime behavior matches the Windows GPU guidance (CUDA wheel -> unpinned CUDA wheel -> CUDA source build -> CPU fallback). 

### Testing
- Ran targeted unit tests: `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_gpu_packaging.py tests/unit/test_model_manager.py`, all unit tests passed (103 passed locally in the CI-like environment). 
- Confirmed the new unit that simulates wheel-unavailable then source-build success exercises the new path and asserts `installed_cuda_reexec` is returned. 
- Tried `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node`, which failed in this environment due to missing system `glib-2.0`/pkg-config system libs (environmental/system dependency, unrelated to the changes). 
- Ran `pre-commit run --all-files`; it executed but exposed existing repository-level hooks (codespell and vulture findings) unrelated to this change (pre-existing failures), so pre-commit did not fully pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d86aadec832f86409f9271c9a37e)