### PR TITLE
Fix desktop Windows GPU bootstrap and runtime CUDA detection regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ This will replace the llama-cpp-python you installed via `pip install -r require
 ```
 set CMAKE_ARGS=-DGGML_CUDA=on
 set FORCE_CMAKE=1
-pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose
+pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --no-binary llama-cpp-python --verbose
 ```
 
 **if you're using Powershell**
@@ -487,7 +487,7 @@ pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbos
 ```
 $env:CMAKE_ARGS = "-DGGML_CUDA=on"
 $env:FORCE_CMAKE=1
-pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose
+pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --no-binary llama-cpp-python --verbose
 ```
 
 > **Note:** The compilation process can take 5-20 minutes depending on your system. The `--verbose` flag shows build progress, but there may still be periods with no visible output. This is normal - the compiler is working in the background. As long as your system shows CPU activity, the process is still running.

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -56,7 +56,7 @@ source-build recipe:
 
 - `CMAKE_ARGS=-DGGML_CUDA=on`
 - `FORCE_CMAKE=1`
-- `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose`
+- `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --upgrade --no-cache-dir --no-binary llama-cpp-python --verbose`
 
 After a successful repair, the sidecar automatically re-execs once so the active
 process immediately uses the repaired runtime (no manual restart/environment flag required).

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -35,6 +35,7 @@ PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
+WINDOWS_CUDA_WHEEL_SUPPORTED_PYTHON = {(3, 10), (3, 11), (3, 12)}
 
 _PROBE_SNIPPET = """
 import json
@@ -177,8 +178,11 @@ def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
         "pip",
         "install",
         package_spec,
+        "--upgrade",
         "--force-reinstall",
         "--no-cache-dir",
+        "--no-binary",
+        "llama-cpp-python",
         "--verbose",
     ]
     return _run_pip_install(cmd, env, timeout_seconds=PIP_SOURCE_BUILD_TIMEOUT_SECONDS)
@@ -219,6 +223,15 @@ def _is_repo_local_llama_module(module_path: str, repo_root: Path) -> bool:
 
 def _runtime_state_path() -> Path:
     return Path.home() / ".token_place_desktop_runtime_state.json"
+
+
+def _windows_cuda_wheel_supported_python() -> bool:
+    version_info = getattr(sys, "version_info", None)
+    if version_info is None:
+        return True
+    major = int(getattr(version_info, "major", 0))
+    minor = int(getattr(version_info, "minor", 0))
+    return (major, minor) in WINDOWS_CUDA_WHEEL_SUPPORTED_PYTHON
 
 
 def _load_runtime_state() -> dict:
@@ -371,6 +384,20 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     except (FileNotFoundError, ValueError):
         plans = _fallback_unpinned_plans(sys.platform)
 
+    cuda_wheels_supported = _windows_cuda_wheel_supported_python()
+    if sys.platform.startswith("win") and not cuda_wheels_supported:
+        version_info = getattr(sys, "version_info", None)
+        active_major = int(getattr(version_info, "major", 0))
+        active_minor = int(getattr(version_info, "minor", 0))
+        supported_versions = ", ".join(
+            f"{major}.{minor}" for major, minor in sorted(WINDOWS_CUDA_WHEEL_SUPPORTED_PYTHON)
+        )
+        last_error = (
+            f"Windows CUDA wheels are published for Python versions {supported_versions}; "
+            f"active interpreter is {active_major}.{active_minor}"
+        )
+        plans = [plan for plan in plans if plan.backend != "cuda"]
+
     for plan in plans:
         env = os.environ.copy()
         env.update(plan.pip_env())
@@ -390,9 +417,12 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             }
 
         if plan.backend == "cpu":
+            fallback_reason = "GPU runtime unavailable after repair; using CPU runtime"
+            if last_error:
+                fallback_reason = f"{fallback_reason} ({last_error})"
             return {
                 "selected_backend": "cpu",
-                "fallback_reason": "GPU runtime unavailable after repair; using CPU runtime",
+                "fallback_reason": fallback_reason,
                 "runtime_action": "installed_cpu_fallback",
                 **_probe_result_payload(after),
             }

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -356,6 +356,54 @@ def test_run_continues_when_runtime_setup_reports_missing_packaged_requirements(
     assert '[Errno 2]' not in json.dumps(events)
 
 
+def test_run_surfaces_gpu_capable_startup_status_fields(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'runtime_action': 'already_supported',
+            'fallback_reason': '',
+            'interpreter': sys.executable,
+            'llama_module_path': 'C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+        },
+    )
+    runtime_module = sys.modules['utils.compute_node_runtime']
+    runtime_module.compute_mode_diagnostics = lambda _manager: {
+        'requested_mode': 'auto',
+        'effective_mode': 'cuda',
+        'backend_available': 'cuda',
+        'backend_selected': 'cuda',
+        'backend_used': 'cuda',
+        'offloaded_layers': -1,
+        'n_gpu_layers': -1,
+        'kv_cache_device': 'cuda',
+        'fallback_reason': None,
+    }
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    started = events[0]
+    assert started['type'] == 'started'
+    assert started['effective_mode'] == 'cuda'
+    assert started['backend_used'] == 'cuda'
+    assert started['offloaded_layers'] == -1
+    assert started['kv_cache_device'] == 'cuda'
+    assert started['fallback_reason'] is None
+
+
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -23,6 +23,7 @@ class _SysStub:
     executable = sys.executable
     prefix = sys.prefix
     argv = [str(MODULE_PATH)]
+    version_info = sys.version_info
 
 
 def _probe(*, backend='cpu', gpu=False, device='cpu', error=None):
@@ -195,9 +196,65 @@ def test_windows_source_repair_uses_active_interpreter(monkeypatch):
     assert ok is True
     assert captured['cmd'][:3] == [sys.executable, '-m', 'pip']
     assert captured['cmd'][4].startswith('llama-cpp-python==')
+    assert '--upgrade' in captured['cmd']
+    assert '--no-binary' in captured['cmd']
+    assert 'llama-cpp-python' in captured['cmd']
     assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
     assert captured['env']['FORCE_CMAKE'] == '1'
     assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+
+
+def test_runtime_bootstrap_skips_windows_cuda_wheel_attempts_for_unsupported_python(monkeypatch):
+    class _UnsupportedPythonSys:
+        platform = 'win32'
+        executable = sys.executable
+        prefix = sys.prefix
+        argv = [str(MODULE_PATH)]
+        version_info = type('VersionInfo', (), {'major': 3, 'minor': 13})()
+
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _UnsupportedPythonSys)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cuda',
+            package_spec='llama-cpp-python',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://abetlen.github.io/llama-cpp-python/whl/cu124',
+            extra_index_url='https://pypi.org/simple',
+            only_binary=True,
+            no_binary=False,
+        ),
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cpu',
+            package_spec='llama-cpp-python',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://pypi.org/simple',
+            extra_index_url=None,
+            only_binary=True,
+            no_binary=False,
+        ),
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    installs = []
+
+    def _fake_install(cmd, _env, *, timeout_seconds=desktop_runtime_setup.PIP_INSTALL_TIMEOUT_SECONDS):
+        installs.append(cmd)
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _fake_install)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert result['runtime_action'] == 'installed_cpu_fallback'
+    assert 'Python versions 3.10, 3.11, 3.12' in result['fallback_reason']
+    assert 'active interpreter is 3.13' in result['fallback_reason']
+    assert len(installs) == 1
+    assert installs[0][-1] == 'llama-cpp-python'
 
 
 def test_windows_source_repair_returns_actionable_message_when_requirements_missing(tmp_path):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -842,6 +842,22 @@ class TestModelManager:
 
         assert backend == 'metal'
 
+    def test_platform_gpu_backend_detects_cuda_marker_from_nested_llama_cpp_module(self):
+        """Backend probe should honor GGML markers exposed on llama_cpp.llama_cpp."""
+        nested = SimpleNamespace(GGML_USE_CUDA=True, GGML_USE_METAL=False)
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            llama_cpp=nested,
+            __file__=str(Path(__file__).resolve()),
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            payload = ModelManager._platform_gpu_backend()
+
+        assert payload == 'cuda'
+
     def test_platform_gpu_backend_linux_uses_gpu_offload_probe(self):
         """Linux backend detection should map positive runtime probes to CUDA."""
         fake_llama = SimpleNamespace(
@@ -939,6 +955,45 @@ class TestModelManager:
         assert payload['gpu_offload_supported'] is False
         assert payload['detected_device'] == 'none'
         assert "No module named 'llama_cpp'" in payload['error']
+
+    def test_detect_runtime_capabilities_uses_nested_gpu_probe_when_top_level_missing(self):
+        from utils.llm import model_manager as mm
+
+        nested = SimpleNamespace(llama_supports_gpu_offload=lambda: True)
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            llama_cpp=nested,
+            __file__=str(Path(__file__).resolve()),
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            payload = mm.detect_llama_runtime_capabilities()
+
+        assert payload['backend'] == 'cuda'
+        assert payload['gpu_offload_supported'] is True
+
+    def test_detect_runtime_capabilities_uses_packaged_ggml_cuda_library_hint(self, tmp_path):
+        from utils.llm import model_manager as mm
+
+        pkg_dir = tmp_path / 'llama_cpp'
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / '__init__.py').write_text('', encoding='utf-8')
+        (pkg_dir / 'ggml-cuda.dll').write_text('binary-placeholder', encoding='utf-8')
+        fake_llama = SimpleNamespace(
+            GGML_USE_CUDA=False,
+            GGML_USE_METAL=False,
+            llama_supports_gpu_offload=None,
+            __file__=str(pkg_dir / '__init__.py'),
+        )
+
+        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+            payload = mm.detect_llama_runtime_capabilities()
+
+        assert payload['backend'] == 'cuda'
+        assert payload['gpu_offload_supported'] is True
+        assert payload['detected_device'] == 'cuda'
 
     def test_compute_runtime_log_includes_backend_device_offload_and_fallback(self, model_manager):
         class FakeLlama:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -30,13 +30,48 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
             'error': str(exc),
         }
 
+    def _backend_marker(module: Any, attr: str) -> bool:
+        return bool(getattr(module, attr, False))
+
+    def _first_backend_marker() -> Optional[str]:
+        candidates: list[Any] = [llama_cpp]
+        nested = getattr(llama_cpp, 'llama_cpp', None)
+        if nested is not None:
+            candidates.append(nested)
+
+        for module in candidates:
+            if _backend_marker(module, 'GGML_USE_CUDA'):
+                return 'cuda'
+            if _backend_marker(module, 'GGML_USE_METAL'):
+                return 'metal'
+        return None
+
+    def _package_file_backend_hint() -> Optional[str]:
+        module_path = Path(str(getattr(llama_cpp, '__file__', '') or ''))
+        if not module_path:
+            return None
+        package_dir = module_path.parent
+        if not package_dir.is_dir():
+            return None
+        for candidate in package_dir.rglob('*'):
+            if not candidate.is_file():
+                continue
+            name = candidate.name.lower()
+            if 'ggml-cuda' in name:
+                return 'cuda'
+            if 'ggml-metal' in name:
+                return 'metal'
+        return None
+
     backend = 'cpu'
-    if bool(getattr(llama_cpp, 'GGML_USE_CUDA', False)):
-        backend = 'cuda'
-    elif bool(getattr(llama_cpp, 'GGML_USE_METAL', False)):
-        backend = 'metal'
+    marker_backend = _first_backend_marker()
+    if marker_backend:
+        backend = marker_backend
 
     supports_gpu = getattr(llama_cpp, 'llama_supports_gpu_offload', None)
+    if not callable(supports_gpu):
+        nested = getattr(llama_cpp, 'llama_cpp', None)
+        supports_gpu = getattr(nested, 'llama_supports_gpu_offload', None)
     gpu_offload_supported = False
     if callable(supports_gpu):
         try:
@@ -45,6 +80,12 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
             gpu_offload_supported = False
     else:
         gpu_offload_supported = backend in {'cuda', 'metal'}
+
+    if backend == 'cpu':
+        file_backend_hint = _package_file_backend_hint()
+        if file_backend_hint in {'cuda', 'metal'}:
+            backend = file_backend_hint
+            gpu_offload_supported = True
 
     # Some llama_cpp builds can report runtime GPU offload support via probe
     # without exposing GGML_USE_* backend markers. Preserve prior Linux behavior


### PR DESCRIPTION
### Motivation
- Users reported desktop Tauri on Windows falling back to CPU even when CUDA was intended; investigation showed the desktop bootstrap and probe logic were not reliably detecting or installing a GPU-capable `llama-cpp-python` runtime.
- Root causes: pip could reinstall CPU wheels during the Windows "source repair" step (no `--no-binary`), CUDA wheel attempts were attempted for unsupported Python ABIs, and runtime probing missed GPU indicators exposed on nested bindings or packaged backend artifacts.

### Description
- Force source builds for the Windows CUDA repair path by adding `--no-binary llama-cpp-python` and `--upgrade` to the pip command in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` so pip will not silently install CPU wheels during repair.  (`_windows_cuda_source_repair`)
- Add Python ABI gating for Windows CUDA wheels via `WINDOWS_CUDA_WHEEL_SUPPORTED_PYTHON` and skip CUDA wheel plans (with an actionable fallback message) when the active interpreter version is unsupported. (`desktop_runtime_setup`) 
- Improve fallback diagnostics so `installed_cpu_fallback` includes contextual ABI/last-error information when wheel/source attempts fail. (`desktop_runtime_setup`)
- Harden runtime capability detection in `utils/llm/model_manager.py` to detect GPU support when: top-level `llama_cpp` markers are on a nested `llama_cpp.llama_cpp` module, `llama_supports_gpu_offload` is exposed on either level, or packaged backend library names (`ggml-cuda` / `ggml-metal`) are present next to the installed module.
- Add targeted unit tests: `tests/unit/test_desktop_runtime_setup.py` (source-repair command contract and unsupported-Python gating), `tests/unit/test_desktop_compute_node_bridge.py` (startup status surfaces GPU-capable fields), and `tests/unit/test_model_manager.py` (nested probe and packaged-ggml hints). 
- Update docs to match the repaired runtime behavior by adding `--no-binary llama-cpp-python` to the Windows CUDA instructions in `README.md` and `desktop-tauri/README.md`.

### Testing
- Ran unit test suite: `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_model_manager.py -q` which passed: `88 passed` (all added and existing unit tests succeeded).
- Built desktop Rust tests: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` was attempted but the environment lacked system `glib-2.0` pkg-config metadata so the compile job failed in this environment (system dependency issue, unrelated to the Python changes).
- Ran repository checks: `pre-commit run --all-files` was executed; it completed but surfaced unrelated, pre-existing repo warnings/hooks (codespell on `desktop-tauri/package-lock.json` and a vulture unused-variable warning in `tests/unit/test_desktop_inference_sidecar.py`) which are outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d86aadec832f86409f9271c9a37e)