### PR TITLE
docs: add canonical llama-cpp-python hardware-acceleration guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,15 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
   components and hooks.
 - Use **Tailwind CSS** for styling and keep custom CSS minimal.
 
+## Critical build guidance (`llama_cpp_python` / `llama-cpp-python`)
+- For any development or troubleshooting involving `llama_cpp_python`, treat
+  [`README.md#hardware-acceleration`](README.md#hardware-acceleration) as the
+  canonical source of truth.
+- GPU acceleration setup is platform-specific (Windows CUDA/cuBLAS, macOS
+  Metal, Linux OpenBLAS) and requires the documented force-reinstall flow with
+  the correct `CMAKE_ARGS` + `FORCE_CMAKE` values; do **not** provide generic
+  `pip install llama-cpp-python` guidance.
+
 ## Agents
 
 ### Code Linter Agent


### PR DESCRIPTION
### Motivation
- Provide a short, durable AGENTS-level rule that forces future contributors/agents to follow the repo's canonical `README.md#hardware-acceleration` instructions for any `llama_cpp_python` / `llama-cpp-python` work so platform-specific GPU reinstall flows are not guessed or mis-advised.

### Description
- Add a `Critical build guidance (\`llama_cpp_python\` / \`llama-cpp-python\`)` section to `AGENTS.md` that points to `README.md#hardware-acceleration` as the canonical source and explicitly warns that GPU acceleration requires platform-specific force-reinstall flows using the correct `CMAKE_ARGS` + `FORCE_CMAKE` values rather than generic `pip install` guidance (file changed: `AGENTS.md`).

### Testing
- Ran `pnpm install` (succeeded with package-manager warnings), `npm run type-check` (succeeds: prints "No type-check configured"), `npm run build` (succeeds: prints "No build configured"), `npm test` (failed during pytest bootstrap with `ModuleNotFoundError: No module named 'requests'`), and `node scripts/link-check.mjs` (failed because the script is not present), confirming the documentation change is minimal and does not alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fd036db8832fb698d6931fbe1f09)