### PR TITLE
Add AGENTS guidance for llama_cpp_python hardware-acceleration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Always run `pre-commit run --all-files` before pushing. This executes
   `./run_all_tests.sh` and mirrors CI.
 
+## Crucial `llama_cpp_python` guidance
+- For any `llama_cpp_python` / `llama-cpp-python` development work, treat
+  [`README.md#hardware-acceleration`](README.md#hardware-acceleration) as the
+  canonical setup and troubleshooting reference.
+- GPU acceleration is platform-specific (Windows CUDA/cuBLAS, macOS Metal,
+  Linux OpenBLAS) and requires the documented `CMAKE_ARGS` + `FORCE_CMAKE=1`
+  force-reinstall flow; do **not** replace this with generic `pip install`
+  advice.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.


### PR DESCRIPTION
### Motivation
- Ensure future LLM-driven work involving `llama_cpp_python` / `llama-cpp-python` uses the repo's canonical hardware-acceleration instructions and does not regress to generic `pip install` advice.

### Description
- Modified `AGENTS.md` to add a concise, high-signal section that treats `README.md#hardware-acceleration` as the canonical reference and explicitly calls out the platform-specific GPU reinstall flow using `CMAKE_ARGS` + `FORCE_CMAKE=1` (Windows CUDA/cuBLAS, macOS Metal, Linux OpenBLAS).

### Testing
- Ran `pnpm install` which completed successfully; `npm run type-check` printed the configured placeholder and returned success; and `npm run build` printed the configured placeholder and returned success. 
- `npm test` failed in this environment due to Python test dependencies (`ModuleNotFoundError: No module named 'requests'`).
- `node scripts/link-check.mjs` failed because `scripts/link-check.mjs` is not present in this checkout.
- `pre-commit run --all-files` could not run here because `pre-commit` is not installed in the environment.

Files changed: `AGENTS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fd036db8832fb698d6931fbe1f09)