### PR TITLE
🛠️ fix: add root Prettier dep and llama-cpp-python guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Always run `pre-commit run --all-files` before pushing. This executes
   `./run_all_tests.sh` and mirrors CI.
 
+## Crucial repo guidance: `llama_cpp_python` / `llama-cpp-python`
+- For any development or troubleshooting involving `llama_cpp_python` /
+  `llama-cpp-python`, treat `README.md#hardware-acceleration` as the canonical
+  source of truth.
+- GPU acceleration setup is platform-specific (Windows CUDA/cuBLAS, macOS
+  Metal, Linux OpenBLAS) and requires the documented reinstall flow using the
+  correct `CMAKE_ARGS` + `FORCE_CMAKE=1` values (force-reinstall), not generic
+  `pip install` guidance.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^9.13.0",
         "globals": "^15.14.0",
         "playwright": "^1.56.1",
+        "prettier": "^3.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       },
@@ -2311,6 +2312,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "^8.46.2",
     "eslint": "^9.13.0",
     "globals": "^15.14.0",
+    "prettier": "^3.0.0",
     "playwright": "^1.56.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"


### PR DESCRIPTION
### Motivation
- Ensure root-side scripts and plugins can resolve `prettier` from the repository root and capture durable, repo-level guidance for building `llama_cpp_python` / `llama-cpp-python` with GPU acceleration.

### Description
- Add `prettier` to root `devDependencies` in `package.json` and update `package-lock.json` so root-level Node tooling can consistently resolve Prettier from the repo root (`package.json`, `package-lock.json`).
- Add a concise, high-signal section to `AGENTS.md` directing future agent-driven work to `README.md#hardware-acceleration` and noting that GPU-capable installs are platform-specific and require the documented `CMAKE_ARGS` + `FORCE_CMAKE=1` force-reinstall flow rather than generic `pip install` advice (`AGENTS.md`).
- No functional product code was changed and no unrelated refactors were performed.

### Testing
- Ran `pnpm install`, which completed successfully and populated `node_modules` (Prettier installed); status: success.
- Ran `npm run type-check` (project prints `No type-check configured`); status: success.
- Ran `npm run build` (project prints `No build configured`); status: success.
- Ran `npm test`; this failed in the environment due to a missing Python runtime dependency (`ModuleNotFoundError: No module named 'requests'`), so JS-side pretest resolution of Prettier is verified but Python-based test run is blocked by environment packages.
- Ran `node scripts/link-check.mjs`; this failed because the script is not present in this checkout (`Cannot find module '.../scripts/link-check.mjs'`).

Note: I could not apply the requested Vitest typing edit to `tests/runRemoteCompletionistAwardIIIResolver.test.ts` because that file was not present in this repository snapshot, so the TS typing fix remains to be applied where that test file exists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fd036db8832fb698d6931fbe1f09)