### PR TITLE
Add AGENTS guidance for llama-cpp-python hardware-acceleration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Always run `pre-commit run --all-files` before pushing. This executes
   `./run_all_tests.sh` and mirrors CI.
 
+## Critical build guidance (`llama_cpp_python` / `llama-cpp-python`)
+- For any development or troubleshooting involving `llama_cpp_python` /
+  `llama-cpp-python`, treat `README.md#hardware-acceleration` as the canonical
+  instructions.
+- GPU-capable installs are platform-specific (Windows CUDA/cuBLAS, macOS Metal,
+  Linux OpenBLAS) and require the documented `CMAKE_ARGS` + `FORCE_CMAKE=1`
+  force-reinstall flow; do **not** substitute generic `pip install` guidance.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.


### PR DESCRIPTION
### Motivation
- Prevent future LLM-driven or contributor edits from giving generic `pip install` advice for `llama_cpp_python` by pointing to the repository's canonical, platform-specific reinstall instructions.

### Description
- Add a small "Critical build guidance (`llama_cpp_python` / `llama-cpp-python`)" section to `AGENTS.md` that directs contributors to `README.md#hardware-acceleration` and emphasizes that GPU-capable installs are platform-specific and must use the documented `CMAKE_ARGS` + `FORCE_CMAKE=1` force-reinstall flow; no other behavioral changes were made.

### Testing
- Ran verification commands: `pnpm install` (succeeded), `npm run type-check` (succeeded — repository `type-check` is a no-op), `npm run build` (succeeded — repository `build` is a no-op), `npm test` (failed: `ModuleNotFoundError: No module named 'requests'` from Python test setup), `node scripts/link-check.mjs` (failed: script not present in this checkout), and `pre-commit run --all-files` (failed in this environment because `pre-commit` is not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fd036db8832fb698d6931fbe1f09)