### PR TITLE
Harden Windows CUDA fallback, add GPU docs and regression tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,18 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Always run `pre-commit run --all-files` before pushing. This executes
   `./run_all_tests.sh` and mirrors CI.
 
+## Hardware acceleration (llama-cpp-python)
+- Keep the desktop and server GPU runtime behavior aligned with the
+  [README hardware acceleration section](README.md#hardware-acceleration).
+- Windows/NVIDIA support depends on installing a CUDA-enabled
+  `llama-cpp-python` build (not CPU-only wheels) with `CMAKE_ARGS=-DGGML_CUDA=on`
+  and `FORCE_CMAKE=1` when source-building is required.
+- macOS Apple Silicon support depends on Metal-enabled `llama-cpp-python`
+  builds as documented in the README.
+- When touching desktop runtime/bootstrap code, preserve explicit diagnostics
+  (`backend_available`, `backend_used`, `llama_module_path`, fallback reason) so
+  GPU fallbacks are auditable in logs and tests.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -6,6 +6,13 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+CUDA_WHEEL_INDEXES = (
+    "https://abetlen.github.io/llama-cpp-python/whl/cu128",
+    "https://abetlen.github.io/llama-cpp-python/whl/cu126",
+    "https://abetlen.github.io/llama-cpp-python/whl/cu125",
+    "https://abetlen.github.io/llama-cpp-python/whl/cu124",
+)
+
 
 @dataclass(frozen=True)
 class LlamaCppInstallPlan:
@@ -75,7 +82,7 @@ def llama_cpp_install_plan(
             package_spec=package_spec,
             cmake_args=None,
             force_cmake=False,
-            index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+            index_url=CUDA_WHEEL_INDEXES[0],
             extra_index_url="https://pypi.org/simple",
             only_binary=True,
         )
@@ -111,23 +118,41 @@ def llama_cpp_install_plan_fallbacks(
     plans = [primary]
 
     if primary.platform.startswith("win"):
+        # Try additional CUDA wheel channels in descending recency order because
+        # wheels for a given Python ABI can land on newer CUDA channels first.
+        for cuda_index in CUDA_WHEEL_INDEXES[1:]:
+            plans.append(
+                LlamaCppInstallPlan(
+                    platform=primary.platform,
+                    backend="cuda",
+                    package_spec=primary.package_spec,
+                    cmake_args=None,
+                    force_cmake=False,
+                    index_url=cuda_index,
+                    extra_index_url="https://pypi.org/simple",
+                    only_binary=True,
+                    no_binary=False,
+                )
+            )
+
         # CUDA wheels may be unavailable for a given Python ABI on Windows.
         # First, fall back to an unpinned CUDA wheel so CI can use the newest
         # available CUDA binary (e.g. when requirements pin is newer than
         # published CUDA wheels on the mirror index).
-        plans.append(
-            LlamaCppInstallPlan(
-                platform=primary.platform,
-                backend="cuda",
-                package_spec="llama-cpp-python",
-                cmake_args=None,
-                force_cmake=False,
-                index_url=primary.index_url,
-                extra_index_url=primary.extra_index_url,
-                only_binary=True,
-                no_binary=False,
+        for cuda_index in CUDA_WHEEL_INDEXES:
+            plans.append(
+                LlamaCppInstallPlan(
+                    platform=primary.platform,
+                    backend="cuda",
+                    package_spec="llama-cpp-python",
+                    cmake_args=None,
+                    force_cmake=False,
+                    index_url=cuda_index,
+                    extra_index_url=None,
+                    only_binary=True,
+                    no_binary=False,
+                )
             )
-        )
 
         # If CUDA wheels are unavailable entirely for this ABI, fall back to
         # an unpinned CPU wheel from PyPI to keep desktop CI/release buildable

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from desktop_gpu_packaging import (
+    CUDA_WHEEL_INDEXES,
     LlamaCppInstallPlan,
     llama_cpp_install_plan_fallbacks,
     llama_cpp_requirement_spec,
@@ -439,18 +440,21 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
 def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
     detected_platform = platform.lower()
     if detected_platform.startswith("win"):
-        return [
+        plans = [
             LlamaCppInstallPlan(
                 platform=detected_platform,
                 backend="cuda",
                 package_spec="llama-cpp-python",
                 cmake_args=None,
                 force_cmake=False,
-                index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
-                extra_index_url="https://pypi.org/simple",
+                index_url=index_url,
+                extra_index_url=None,
                 only_binary=True,
                 no_binary=False,
-            ),
+            )
+            for index_url in CUDA_WHEEL_INDEXES
+        ]
+        plans.append(
             LlamaCppInstallPlan(
                 platform=detected_platform,
                 backend="cpu",
@@ -461,8 +465,9 @@ def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
                 extra_index_url=None,
                 only_binary=True,
                 no_binary=False,
-            ),
-        ]
+            )
+        )
+        return plans
 
     if detected_platform == "darwin":
         return [

--- a/outages/2026-04-18-desktop-tauri-windows-gpu-fallback.json
+++ b/outages/2026-04-18-desktop-tauri-windows-gpu-fallback.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-tauri-windows-gpu-fallback",
+  "summary": "Desktop Tauri Windows GPU startup could silently settle on CPU because CUDA wheel fallback logic only targeted a single wheel channel and unpinned fallback allowed PyPI CPU wheel selection.",
+  "impact": "Windows 11 operators with NVIDIA GPUs could complete startup in CPU mode even when GPU mode was requested, reducing performance and obscuring whether llama-cpp-python CUDA support was actually active.",
+  "fix": "Expanded Windows CUDA wheel fallback coverage across multiple wheel channels, prevented unpinned CUDA recovery from pulling CPU wheels through PyPI extra-index fallback, documented hardware acceleration requirements in AGENTS.md, and added unit/e2e regression tests for fallback ordering and CUDA runtime activation expectations.",
+  "lessons": "GPU-capable packaging paths must prefer deterministic CUDA-only installation candidates, and desktop startup must continuously test/report backend-selection contracts so CPU fallback cannot masquerade as successful GPU enablement."
+}

--- a/outages/2026-04-18-desktop-tauri-windows-gpu-fallback.md
+++ b/outages/2026-04-18-desktop-tauri-windows-gpu-fallback.md
@@ -1,0 +1,37 @@
+# Outage: desktop-tauri Windows GPU mode fell back to CPU during runtime bootstrap
+
+- **Date:** 2026-04-18
+- **Slug:** `desktop-tauri-windows-gpu-fallback`
+- **Affected area:** desktop-tauri Windows 11 + NVIDIA/CUDA runtime bootstrap
+
+## Summary
+On Windows desktop installs, startup could report a successful runtime setup while effectively
+running `llama-cpp-python` in CPU mode.
+
+## Impact
+Operators requesting `auto`, `gpu`, or `hybrid` mode on NVIDIA-capable Windows hosts could still end
+up in CPU execution, with reduced inference performance and ambiguous diagnostics.
+
+## Root cause
+1. Windows CUDA wheel fallback targeted a single CUDA wheel index first, then used an unpinned
+   fallback that included PyPI as an extra index.
+2. That unpinned fallback could resolve to a CPU wheel from PyPI when matching CUDA wheels were not
+   available for the active Python ABI/channel.
+3. The runtime could therefore proceed with CPU runtime availability after CUDA installation attempts
+   without deterministically exhausting CUDA-only channels first.
+
+## Remediation
+- Expanded Windows CUDA fallback plans to walk multiple CUDA wheel channels (`cu128`, `cu126`,
+  `cu125`, `cu124`) before CPU fallback.
+- Updated unpinned CUDA fallback plans to avoid PyPI extra-index fallback for the
+  `llama-cpp-python` package candidate.
+- Mirrored hardware-acceleration requirements in `AGENTS.md` so future work keeps bootstrap logic
+  aligned with README guidance.
+- Added unit and e2e regression tests to validate fallback ordering and successful CUDA activation
+  when a later CUDA channel becomes available.
+
+## Follow-up / prevention
+- Keep Windows CUDA channel coverage updated when upstream wheel publishing patterns change.
+- Preserve structured backend diagnostics (`backend_available`, `backend_used`, fallback reason)
+  through desktop bridge startup events.
+- Treat CPU fallback as a last-resort recovery path, never as a silent substitute for GPU mode.

--- a/tests/e2e/test_windows_cuda_runtime_install_contract.py
+++ b/tests/e2e/test_windows_cuda_runtime_install_contract.py
@@ -1,0 +1,75 @@
+"""E2E-style regression for Windows CUDA runtime install fallback order."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_PYTHON = ROOT / 'desktop-tauri' / 'src-tauri' / 'python'
+if str(DESKTOP_PYTHON) not in sys.path:
+    sys.path.insert(0, str(DESKTOP_PYTHON))
+
+MODULE_PATH = DESKTOP_PYTHON / 'desktop_runtime_setup.py'
+SPEC = importlib.util.spec_from_file_location('desktop_runtime_setup_e2e', MODULE_PATH)
+assert SPEC and SPEC.loader
+runtime_setup = importlib.util.module_from_spec(SPEC)
+sys.modules['desktop_runtime_setup_e2e'] = runtime_setup
+SPEC.loader.exec_module(runtime_setup)
+
+
+class _SysStub:
+    platform = 'win32'
+    executable = sys.executable
+    prefix = sys.prefix
+    argv = ['python']
+
+
+def _probe(*, backend='cpu', gpu=False, device='cpu', error=None):
+    return runtime_setup.RuntimeProbe(
+        backend=backend,
+        gpu_offload_supported=gpu,
+        detected_device=device,
+        interpreter=sys.executable,
+        prefix=sys.prefix,
+        llama_module_path='C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+        error=error,
+    )
+
+
+def test_windows_runtime_install_walks_cuda_channels_before_cpu(monkeypatch):
+    monkeypatch.setattr(runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(runtime_setup, '_should_attempt_source_repair', lambda: (False, 'skip'))
+    monkeypatch.setattr(
+        runtime_setup,
+        'llama_cpp_install_plan_fallbacks',
+        lambda **kwargs: runtime_setup._fallback_unpinned_plans(kwargs['platform']),
+    )
+
+    probes = iter([_probe(), _probe(backend='cuda', gpu=True, device='cuda')])
+    monkeypatch.setattr(runtime_setup, '_probe_llama_runtime', lambda: next(probes))
+
+    attempted_indexes: list[str] = []
+
+    def fake_run(cmd, _env, **_kwargs):
+        package_spec = cmd[-1]
+        if package_spec != 'llama-cpp-python':
+            return False, 'pinned unavailable in packaged layout'
+
+        if '--index-url' in cmd:
+            idx = cmd[cmd.index('--index-url') + 1]
+            attempted_indexes.append(idx)
+            if idx == runtime_setup.CUDA_WHEEL_INDEXES[1]:
+                return True, 'installed cuda wheel from secondary channel'
+
+        return False, 'no matching distribution found'
+
+    monkeypatch.setattr(runtime_setup, '_run_pip_install', fake_run)
+
+    result = runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=ROOT)
+
+    assert result['runtime_action'] == 'installed_cuda_reexec'
+    assert result['selected_backend'] == 'cuda'
+    assert attempted_indexes[:2] == list(runtime_setup.CUDA_WHEEL_INDEXES[:2])

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -9,6 +9,7 @@ if str(DESKTOP_PYTHON) not in sys.path:
     sys.path.insert(0, str(DESKTOP_PYTHON))
 
 from desktop_gpu_packaging import (
+    CUDA_WHEEL_INDEXES,
     LlamaCppInstallPlan,
     llama_cpp_install_plan,
     llama_cpp_install_plan_fallbacks,
@@ -18,25 +19,36 @@ from desktop_gpu_packaging import (
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    assert len(plans) == 3
+    assert len(plans) == 1 + (len(CUDA_WHEEL_INDEXES) - 1) + len(CUDA_WHEEL_INDEXES) + 1
 
     gpu_plan = plans[0]
     assert gpu_plan.backend == "cuda"
     assert gpu_plan.package_spec.startswith("llama-cpp-python==")
-    assert gpu_plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert gpu_plan.index_url == CUDA_WHEEL_INDEXES[0]
     assert gpu_plan.extra_index_url == "https://pypi.org/simple"
     assert gpu_plan.only_binary is True
     assert gpu_plan.pip_env() == {}
 
-    unpinned_cuda_fallback = plans[1]
-    assert unpinned_cuda_fallback.backend == "cuda"
-    assert unpinned_cuda_fallback.package_spec == "llama-cpp-python"
-    assert unpinned_cuda_fallback.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
-    assert unpinned_cuda_fallback.extra_index_url == "https://pypi.org/simple"
-    assert unpinned_cuda_fallback.only_binary is True
-    assert unpinned_cuda_fallback.no_binary is False
+    pinned_cuda_fallbacks = plans[1 : len(CUDA_WHEEL_INDEXES)]
+    assert [plan.package_spec for plan in pinned_cuda_fallbacks] == [gpu_plan.package_spec] * len(
+        pinned_cuda_fallbacks
+    )
+    assert [plan.index_url for plan in pinned_cuda_fallbacks] == list(CUDA_WHEEL_INDEXES[1:])
+    assert all(plan.extra_index_url == "https://pypi.org/simple" for plan in pinned_cuda_fallbacks)
 
-    cpu_fallback = plans[2]
+    unpinned_start = len(CUDA_WHEEL_INDEXES)
+    unpinned_end = unpinned_start + len(CUDA_WHEEL_INDEXES)
+    unpinned_cuda_fallbacks = plans[unpinned_start:unpinned_end]
+    assert [plan.backend for plan in unpinned_cuda_fallbacks] == ["cuda"] * len(CUDA_WHEEL_INDEXES)
+    assert [plan.package_spec for plan in unpinned_cuda_fallbacks] == ["llama-cpp-python"] * len(
+        CUDA_WHEEL_INDEXES
+    )
+    assert [plan.index_url for plan in unpinned_cuda_fallbacks] == list(CUDA_WHEEL_INDEXES)
+    assert all(plan.extra_index_url is None for plan in unpinned_cuda_fallbacks)
+    assert all(plan.only_binary is True for plan in unpinned_cuda_fallbacks)
+    assert all(plan.no_binary is False for plan in unpinned_cuda_fallbacks)
+
+    cpu_fallback = plans[-1]
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.package_spec == "llama-cpp-python"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
@@ -145,7 +157,7 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
 
 def test_windows_cpu_fallback_install_args_are_binary_only():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    cpu_fallback = plans[2]
+    cpu_fallback = plans[-1]
 
     assert cpu_fallback.pip_install_args() == [
         "--upgrade",
@@ -180,6 +192,16 @@ def test_llama_cpp_install_plan_uses_current_platform_for_windows(monkeypatch):
     assert plan.platform == "win32"
     assert plan.backend == "cuda"
     assert plan.only_binary is True
+
+
+def test_windows_unpinned_cuda_fallbacks_do_not_use_extra_index():
+    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    unpinned = [
+        plan for plan in plans if plan.backend == "cuda" and plan.package_spec == "llama-cpp-python"
+    ]
+
+    assert [plan.index_url for plan in unpinned] == list(CUDA_WHEEL_INDEXES)
+    assert all(plan.extra_index_url is None for plan in unpinned)
 
 
 def test_llama_cpp_install_plan_darwin_selects_metal_wheel_index():

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -198,7 +198,13 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     darwin_plans = desktop_runtime_setup._fallback_unpinned_plans('darwin')
     linux_plans = desktop_runtime_setup._fallback_unpinned_plans('linux')
 
-    assert [plan.backend for plan in win_plans] == ['cuda', 'cpu']
+    assert len(win_plans) == len(desktop_runtime_setup.CUDA_WHEEL_INDEXES) + 1
+    assert [plan.backend for plan in win_plans[:-1]] == ['cuda'] * len(
+        desktop_runtime_setup.CUDA_WHEEL_INDEXES
+    )
+    assert [plan.index_url for plan in win_plans[:-1]] == list(desktop_runtime_setup.CUDA_WHEEL_INDEXES)
+    assert all(plan.extra_index_url is None for plan in win_plans[:-1])
+    assert win_plans[-1].backend == 'cpu'
     assert [plan.backend for plan in darwin_plans] == ['metal', 'metal']
     assert [plan.backend for plan in linux_plans] == ['cpu']
 


### PR DESCRIPTION
### Motivation
- The desktop Tauri operator could silently run with a CPU-only `llama-cpp-python` runtime on Windows because the install/fallback plan only targeted a single CUDA wheel channel and an unpinned fallback could pick a PyPI CPU wheel. This change prevents that accidental CPU substitution and documents the hardware-acceleration contract. 
- Make runtime bootstrap deterministic and auditable so GPU-enabled installs are preferred and runtime diagnostics (`backend_available`, `backend_used`, `llama_module_path`, fallback reason) remain testable.

### Description
- Add a hardware-acceleration note to `AGENTS.md` pointing to the README guidance for Windows (CUDA) and macOS (Metal) and reminding authors to preserve runtime diagnostics.
- Introduce `CUDA_WHEEL_INDEXES` and expand Windows install planning in `desktop-tauri/src-tauri/python/desktop_gpu_packaging.py` to try multiple CUDA wheel channels (`cu128`, `cu126`, `cu125`, `cu124`) before falling back to CPU, and to avoid using PyPI extra-index for unpinned CUDA candidates.
- Reuse the shared `CUDA_WHEEL_INDEXES` in the runtime repair/fallback helper in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` so runtime bootstrap and release build flows use the same ordered CUDA-channel-first strategy.
- Add a new outage report describing the root cause and fix at `outages/2026-04-18-desktop-tauri-windows-gpu-fallback.{json,md}`.
- Add and update regression tests: updated `tests/unit/test_desktop_gpu_packaging.py` and `tests/unit/test_desktop_runtime_setup.py` to assert the new fallback ordering/behaviour and a new e2e-style test `tests/e2e/test_windows_cuda_runtime_install_contract.py` that simulates walking CUDA channels and succeeding on a later channel.

### Testing
- Ran the focused regression suite with `pytest -q --confcutdir=tests/unit tests/unit/test_desktop_gpu_packaging.py tests/unit/test_desktop_runtime_setup.py tests/e2e/test_windows_cuda_runtime_install_contract.py` and all tests passed (`46 passed`).
- Ran `pre-commit run --all-files` in the current environment and it failed because full project checks require additional system/Python deps (missing `cryptography` and an environment mismatch for the pinned `numpy==2.3.4`), so full repo-wide checks could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e329de4f08832f8587a4edb6b39fca)