### PR TITLE
Enable operator re-exec after CUDA repair; document GPU acceleration and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,19 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Always run `pre-commit run --all-files` before pushing. This executes
   `./run_all_tests.sh` and mirrors CI.
 
+## Desktop GPU acceleration (llama_cpp_python)
+- For desktop-tauri GPU modes (`auto`, `gpu`, `hybrid`), treat GPU-capable
+  `llama-cpp-python` builds as a release requirement, not an optimization.
+- Follow the hardware acceleration section in `README.md` when (re)building
+  local runtimes:
+  - **Windows + NVIDIA/CUDA:** ensure CUDA-enabled builds (`CMAKE_ARGS=-DGGML_CUDA=on`,
+    `FORCE_CMAKE=1`) and verify runtime reports CUDA usage.
+  - **macOS Apple Silicon:** ensure Metal-enabled builds
+    (`CMAKE_ARGS=-DGGML_METAL=on`) and verify runtime reports Metal usage.
+- For desktop changes that touch Python runtime bootstrapping, packaging, or
+  sidecar launch, include regression coverage that asserts GPU mode does not
+  silently fall back to CPU when GPU runtime support is expected.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -65,6 +65,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
 
     shutil.copy2(REPO_ROOT / "config.py", resources_root / "config.py")
     shutil.copy2(REPO_ROOT / "encrypt.py", resources_root / "encrypt.py")
+    shutil.copy2(REPO_ROOT / "requirements.txt", resources_root / "requirements.txt")
     shutil.copytree(REPO_ROOT / "utils", resources_root / "utils", dirs_exist_ok=True)
 
     return python_dir / "compute_node_bridge.py"

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -93,7 +93,7 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 def run(args: argparse.Namespace) -> int:
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
-    maybe_reexec_for_runtime_refresh(runtime_setup, allow_reexec=False)
+    maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -309,6 +309,18 @@ def maybe_reexec_for_runtime_refresh(
         return
 
 
+
+
+def _resolve_requirements_path(target_root: Path) -> Path:
+    candidates = [
+        target_root / "requirements.txt",
+        target_root / "resources" / "requirements.txt",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
 def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
@@ -364,7 +376,7 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    requirements_path = target_root / "requirements.txt"
+    requirements_path = _resolve_requirements_path(target_root)
     last_error = ""
 
     should_repair, repair_skip_reason = _should_attempt_source_repair()
@@ -405,7 +417,15 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     for plan in plans:
         env = os.environ.copy()
         env.update(plan.pip_env())
-        cmd = [sys.executable, "-m", "pip", "install", *plan.pip_install_args(), plan.package_spec]
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            *plan.pip_install_args(),
+            plan.package_spec,
+        ]
         ok, log_output = _run_pip_install(cmd, env)
         if not ok:
             last_error = _summarize_install_error(log_output)

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -33,7 +33,8 @@
       "python/path_bootstrap.py",
       "../../utils",
       "../../config.py",
-      "../../encrypt.py"
+      "../../encrypt.py",
+      "../../requirements.txt"
     ],
     "icon": [
       "icons/32x32.png",

--- a/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-reexec-skipped.json
+++ b/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-reexec-skipped.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-tauri-windows-gpu-runtime-reexec-skipped",
+  "summary": "Desktop-tauri operator mode on Windows could keep using a CPU-only llama-cpp runtime even after successful CUDA runtime repair because compute_node_bridge.py explicitly disabled the required post-install re-exec step.",
+  "impact": "Windows 11 + NVIDIA operators could observe persistent CPU fallback in desktop operator mode, resulting in reduced throughput/latency and confusing diagnostics after runtime repair attempts.",
+  "fix": "Updated compute_node_bridge.py to honor maybe_reexec_for_runtime_refresh(...) with re-exec enabled, aligned bridge behavior with inference_sidecar.py and desktop runtime documentation, and added regression/e2e contract tests that assert CUDA-backed startup expectations for the Windows smoke-test path.",
+  "lessons": "When runtime repair mutates native Python dependencies in-process, all sidecar entrypoints must share the same re-exec contract; diverging behavior between smoke-test and operator paths creates hidden CPU fallback regressions."
+}

--- a/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-reexec-skipped.md
+++ b/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-reexec-skipped.md
@@ -1,0 +1,50 @@
+# Outage: desktop-tauri Windows GPU runtime repair re-exec was skipped in operator mode
+
+- **Date:** 2026-04-18
+- **Slug:** `desktop-tauri-windows-gpu-runtime-reexec-skipped`
+- **Affected area:** desktop-tauri operator path (`compute_node_bridge.py`) on Windows 11 + NVIDIA
+
+## Summary
+Desktop operator mode (`compute_node_bridge.py`) could still run CPU-only inference on Windows even
+after a successful CUDA runtime repair flow. The bridge disabled the runtime refresh re-exec path,
+so it did not guarantee the updated GPU-capable `llama-cpp-python` build was active for the running
+process.
+
+## Symptoms
+- `desktop.runtime_setup` logs indicated repair activity but operator startup often still reported
+  CPU backend usage.
+- Desktop operator `started` events could show `backend_used=cpu` and `offloaded_layers=0` after
+  repair attempts.
+- Windows + NVIDIA operator throughput/latency remained CPU-bound.
+
+## Impact
+Windows 11 operators with NVIDIA GPUs could not reliably benefit from GPU offload in desktop
+operator mode, even though local runtime repair logic existed. This reduced performance and made
+GPU readiness difficult to validate with confidence.
+
+## Root cause
+`compute_node_bridge.py` called:
+
+- `maybe_reexec_for_runtime_refresh(runtime_setup, allow_reexec=False)`
+
+This diverged from `inference_sidecar.py`, which keeps re-exec enabled after runtime installation.
+When runtime setup returned `runtime_action=installed_cuda_reexec`, the operator path suppressed
+the process refresh required to reliably use the repaired GPU runtime.
+
+## Fix
+- Enabled runtime refresh re-exec in `compute_node_bridge.py` by removing the explicit
+  `allow_reexec=False` override.
+- Added regression test coverage to lock the bridge contract: runtime re-exec must remain enabled
+  when CUDA runtime repair is reported.
+- Added e2e-style contract tests for
+  `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py` that verify:
+  - success path accepts `installed_cuda_reexec` runtime setup with CUDA-backed bridge startup
+  - failure path rejects CPU fallback in bridge `started` diagnostics
+- Documented the incident in structured outage JSON + this Markdown report.
+
+## Follow-up / prevention
+- Keep operator and smoke-test sidecars on a single runtime bootstrap contract.
+- Preserve assertions that Windows GPU smoke validation fails closed if bridge startup reports
+  CPU fallback.
+- Continue surfacing `llama_module_path`, backend, offloaded layers, and KV cache diagnostics in
+  startup events so regressions are detectable without manual debugger inspection.

--- a/tests/e2e/test_windows_nvidia_gpu_smoke_contract.py
+++ b/tests/e2e/test_windows_nvidia_gpu_smoke_contract.py
@@ -14,17 +14,30 @@ MODULE_PATH = (
     / 'windows_nvidia_gpu_smoke_test.py'
 )
 SPEC = importlib.util.spec_from_file_location('windows_nvidia_gpu_smoke_test', MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None, (
+    f'Could not load {MODULE_PATH} — ensure desktop-tauri/scripts/ is present in the repo'
+)
 windows_gpu_smoke = importlib.util.module_from_spec(SPEC)
-assert SPEC and SPEC.loader
 SPEC.loader.exec_module(windows_gpu_smoke)
+
+
+def _make_repo_root_with_bootstrap(tmp_path: Path) -> Path:
+    repo_root = tmp_path / 'repo'
+    python_root = repo_root / 'desktop-tauri' / 'src-tauri' / 'python'
+    python_root.mkdir(parents=True)
+    (python_root / 'path_bootstrap.py').write_text(
+        'def ensure_runtime_import_paths(*_args, **_kwargs):\n'
+        '    return None\n',
+        encoding='utf-8',
+    )
+    (repo_root / 'llama_cpp.py').write_text('# shim\n', encoding='utf-8')
+    return repo_root
 
 
 def test_main_accepts_runtime_reexec_and_cuda_bridge_started(monkeypatch, tmp_path):
     model_path = tmp_path / 'model.gguf'
     model_path.write_text('stub', encoding='utf-8')
-    repo_root = tmp_path / 'repo'
-    repo_root.mkdir()
-    (repo_root / 'llama_cpp.py').write_text('# shim\n', encoding='utf-8')
+    repo_root = _make_repo_root_with_bootstrap(tmp_path)
 
     monkeypatch.setattr(windows_gpu_smoke.sys, 'platform', 'win32')
     monkeypatch.setattr(windows_gpu_smoke, '_repo_root', lambda: repo_root)
@@ -67,8 +80,7 @@ def test_main_accepts_runtime_reexec_and_cuda_bridge_started(monkeypatch, tmp_pa
 def test_main_fails_when_bridge_reports_cpu_fallback(monkeypatch, tmp_path):
     model_path = tmp_path / 'model.gguf'
     model_path.write_text('stub', encoding='utf-8')
-    repo_root = tmp_path / 'repo'
-    repo_root.mkdir()
+    repo_root = _make_repo_root_with_bootstrap(tmp_path)
 
     monkeypatch.setattr(windows_gpu_smoke.sys, 'platform', 'win32')
     monkeypatch.setattr(windows_gpu_smoke, '_repo_root', lambda: repo_root)

--- a/tests/e2e/test_windows_nvidia_gpu_smoke_contract.py
+++ b/tests/e2e/test_windows_nvidia_gpu_smoke_contract.py
@@ -1,0 +1,108 @@
+"""Contract tests for the Windows NVIDIA desktop smoke-test helper."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'desktop-tauri'
+    / 'scripts'
+    / 'windows_nvidia_gpu_smoke_test.py'
+)
+SPEC = importlib.util.spec_from_file_location('windows_nvidia_gpu_smoke_test', MODULE_PATH)
+windows_gpu_smoke = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(windows_gpu_smoke)
+
+
+def test_main_accepts_runtime_reexec_and_cuda_bridge_started(monkeypatch, tmp_path):
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('stub', encoding='utf-8')
+    repo_root = tmp_path / 'repo'
+    repo_root.mkdir()
+    (repo_root / 'llama_cpp.py').write_text('# shim\n', encoding='utf-8')
+
+    monkeypatch.setattr(windows_gpu_smoke.sys, 'platform', 'win32')
+    monkeypatch.setattr(windows_gpu_smoke, '_repo_root', lambda: repo_root)
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        'parse_args',
+        lambda _self: argparse.Namespace(model=str(model_path), mode='auto'),
+    )
+    monkeypatch.setattr(windows_gpu_smoke.os.path, 'exists', lambda _path: True)
+    monkeypatch.setattr(windows_gpu_smoke, '_load_compute_runtime_diagnostics', lambda *_args: {
+        'backend_available': 'cuda',
+        'backend_used': 'cuda',
+        'offloaded_layers': 40,
+        'kv_cache_device': 'cuda',
+        'fallback_reason': '',
+        'runtime_setup': {
+            'runtime_action': 'installed_cuda_reexec',
+            'interpreter': 'C:/Python312/python.exe',
+            'llama_module_path': 'C:/Python312/Lib/site-packages/llama_cpp/__init__.py',
+        },
+    })
+    monkeypatch.setattr(windows_gpu_smoke, '_run_bridge_oneshot', lambda *_args: (
+        {
+            'type': 'started',
+            'backend_available': 'cuda',
+            'backend_used': 'cuda',
+            'offloaded_layers': 32,
+            'kv_cache_device': 'cuda',
+            'interpreter': 'C:/Python312/python.exe',
+            'llama_module_path': 'C:/Python312/Lib/site-packages/llama_cpp/__init__.py',
+        },
+        [{'type': 'started'}],
+        '',
+    ))
+
+    status = windows_gpu_smoke.main()
+    assert status == 0
+
+
+def test_main_fails_when_bridge_reports_cpu_fallback(monkeypatch, tmp_path):
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('stub', encoding='utf-8')
+    repo_root = tmp_path / 'repo'
+    repo_root.mkdir()
+
+    monkeypatch.setattr(windows_gpu_smoke.sys, 'platform', 'win32')
+    monkeypatch.setattr(windows_gpu_smoke, '_repo_root', lambda: repo_root)
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        'parse_args',
+        lambda _self: argparse.Namespace(model=str(model_path), mode='gpu'),
+    )
+    monkeypatch.setattr(windows_gpu_smoke.os.path, 'exists', lambda _path: True)
+    monkeypatch.setattr(windows_gpu_smoke, '_load_compute_runtime_diagnostics', lambda *_args: {
+        'backend_available': 'cuda',
+        'backend_used': 'cuda',
+        'offloaded_layers': 16,
+        'kv_cache_device': 'cuda',
+        'fallback_reason': '',
+        'runtime_setup': {
+            'runtime_action': 'already_supported',
+            'interpreter': 'C:/Python312/python.exe',
+            'llama_module_path': 'C:/Python312/Lib/site-packages/llama_cpp/__init__.py',
+        },
+    })
+    monkeypatch.setattr(windows_gpu_smoke, '_run_bridge_oneshot', lambda *_args: (
+        {
+            'type': 'started',
+            'backend_available': 'cpu',
+            'backend_used': 'cpu',
+            'offloaded_layers': 0,
+            'kv_cache_device': 'cpu',
+            'interpreter': 'C:/Python312/python.exe',
+            'llama_module_path': 'C:/Python312/Lib/site-packages/llama_cpp/__init__.py',
+        },
+        [{'type': 'started'}],
+        '',
+    ))
+
+    status = windows_gpu_smoke.main()
+    assert status == 1

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -289,7 +289,7 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     assert 'failed to initialize model runtime' in payload['message']
 
 
-def test_run_disables_runtime_reexec_to_avoid_pre_startup_exit(capsys, monkeypatch):
+def test_run_allows_runtime_reexec_when_cuda_runtime_is_repaired(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)
     reexec_flags = []
@@ -314,7 +314,7 @@ def test_run_disables_runtime_reexec_to_avoid_pre_startup_exit(capsys, monkeypat
     status = compute_node_bridge.run(args)
 
     assert status == 0
-    assert reexec_flags == [False]
+    assert reexec_flags == [True]
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert events[0]['type'] == 'started'
     assert events[-1]['type'] == 'stopped'

--- a/tests/unit/test_desktop_packaged_layout.py
+++ b/tests/unit/test_desktop_packaged_layout.py
@@ -58,6 +58,7 @@ def test_linux_no_bundle_layout_contains_python_runtime_resources() -> None:
         ("python/path_bootstrap.py", "resources/python/path_bootstrap.py"),
         "python/path_bootstrap.py",
     )
+    _assert_any_exists(staging_root, ("requirements.txt", "resources/requirements.txt"), "requirements.txt")
     _assert_any_exists(staging_root, ("utils", "resources/utils"), "utils/")
     _assert_any_exists(staging_root, ("config.py", "resources/config.py"), "config.py")
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -570,6 +570,75 @@ def test_windows_packaged_layout_without_requirements_falls_back_without_excepti
     assert 'falling back to unpinned llama-cpp-python source reinstall' in result['fallback_reason']
 
 
+def test_resolve_requirements_path_prefers_packaged_resources_when_repo_root_missing(tmp_path):
+    target_root = tmp_path / 'token-place-installed'
+    packaged_requirements = target_root / 'resources' / 'requirements.txt'
+    packaged_requirements.parent.mkdir(parents=True)
+    packaged_requirements.write_text('llama-cpp-python==0.3.16\n', encoding='utf-8')
+
+    resolved = desktop_runtime_setup._resolve_requirements_path(target_root)
+
+    assert resolved == packaged_requirements
+
+
+def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_unpinned_fallback(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
+    monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
+    captured = {}
+
+    def _capture_plans(*, platform, requirements_path):
+        captured['platform'] = platform
+        captured['requirements_path'] = requirements_path
+        return []
+
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', _capture_plans)
+    packaged_root = tmp_path / 'AppData' / 'Local' / 'token.place'
+    packaged_requirements = packaged_root / 'resources' / 'requirements.txt'
+    packaged_requirements.parent.mkdir(parents=True)
+    packaged_requirements.write_text('llama-cpp-python==0.3.16\n', encoding='utf-8')
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=packaged_root)
+
+    assert result['runtime_action'] == 'failed'
+    assert captured['platform'] == 'win32'
+    assert captured['requirements_path'] == packaged_requirements
+
+
+def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cuda',
+            package_spec='llama-cpp-python==0.3.16',
+            cmake_args=None,
+            force_cmake=False,
+            index_url='https://abetlen.github.io/llama-cpp-python/whl/cu124',
+            extra_index_url='https://pypi.org/simple',
+            only_binary=True,
+            no_binary=False,
+        )
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    captured = {}
+
+    def _capture_run(cmd, env, timeout_seconds=desktop_runtime_setup.PIP_INSTALL_TIMEOUT_SECONDS):
+        captured['cmd'] = cmd
+        return False, 'failed'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _capture_run)
+
+    desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert captured['cmd'][:5] == [sys.executable, '-m', 'pip', 'install', '--force-reinstall']
+
+
 def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
     repo_root = tmp_path / 'RepoRoot'
     repo_root.mkdir(parents=True)


### PR DESCRIPTION
### Motivation
- Ensure desktop GPU modes (`auto`/`gpu`/`hybrid`) reliably use a GPU-capable `llama-cpp-python` runtime rather than silently falling back to CPU. 
- Fix a divergence where the operator bridge suppressed the post-install re-exec needed to pick up CUDA-enabled `llama-cpp-python`. 
- Capture the incident formally and add regression + e2e contract tests so future changes don't reintroduce the CPU-fallback regression. 

### Description
- Added a `Desktop GPU acceleration (llama_cpp_python)` section to `AGENTS.md` documenting the README hardware-acceleration guidance and test expectations. 
- Restored the bridge re-exec contract by removing the `allow_reexec=False` override and calling `maybe_reexec_for_runtime_refresh(runtime_setup)` in `desktop-tauri/src-tauri/python/compute_node_bridge.py`. 
- Updated the bridge unit test to assert re-exec is allowed when runtime setup reports `installed_cuda_reexec` by changing `tests/unit/test_desktop_compute_node_bridge.py`. 
- Added an e2e-style contract test `tests/e2e/test_windows_nvidia_gpu_smoke_contract.py` that verifies the Windows NVIDIA smoke-test accepts an `installed_cuda_reexec` path and fails closed when the bridge reports CPU fallback. 
- Added an outage record (`outages/2026-04-18-desktop-tauri-windows-gpu-runtime-reexec-skipped.{json,md}`) documenting root cause, impact, fix and follow-ups. 

### Testing
- Ran the focused Python tests with `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py tests/e2e/test_windows_nvidia_gpu_smoke_contract.py`, and all tests passed (16 passed). 
- Ran `npm run lint` which completed successfully. 
- Attempted the full CI run via `npm run test:ci`, which failed in this environment because required Python test dependencies are not installed (e.g. missing `requests` and `cryptography`), so the broader Python test suites did not complete here. 
- `pre-commit run --all-files` could not be executed in this environment because `pre-commit` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e329de4f08832f8587a4edb6b39fca)