### PR TITLE
🛠️ fix(desktop-tauri): force reinstall llama-cpp GPU wheels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,19 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 ### Prompt Agent
 - **When:** you run `flywheel prompt`
 - **Does:** generate context-aware prompts for Codex or other LLM assistants
+
+## Hardware acceleration (`llama_cpp_python`)
+
+- Follow [`README.md#hardware-acceleration`](README.md#hardware-acceleration)
+  when enabling desktop/server GPU support.
+- On Windows + NVIDIA, run these in the same virtualenv used by token.place:
+  - Command Prompt:
+    - `set CMAKE_ARGS=-DGGML_CUDA=on`
+    - `set FORCE_CMAKE=1`
+  - PowerShell:
+    - `$env:CMAKE_ARGS="-DGGML_CUDA=on"`
+    - `$env:FORCE_CMAKE=1`
+  - Then reinstall:
+    - `pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose`
+- Keep `n_gpu_layers` non-zero (typically `-1` for full offload) when GPU/hybrid
+  execution is expected.

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -20,9 +20,10 @@ class LlamaCppInstallPlan:
     extra_index_url: str | None = None
     only_binary: bool = False
     no_binary: bool = False
+    force_reinstall: bool = True
 
     def pip_install_args(self) -> list[str]:
-        args = ["--upgrade", "--no-cache-dir"]
+        args = ["--force-reinstall", "--upgrade", "--no-cache-dir"]
         if self.index_url:
             args.extend(["--index-url", self.index_url])
         if self.extra_index_url:

--- a/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-cpu-fallback.json
+++ b/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-cpu-fallback.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-tauri-windows-gpu-runtime-cpu-fallback",
+  "summary": "Desktop-tauri Windows GPU bootstrap could remain CPU-only because the wheel repair path installed llama-cpp-python without --force-reinstall, allowing pip to keep an already-installed CPU wheel of the same version.",
+  "impact": "Windows 11 NVIDIA users could choose auto/gpu/hybrid but still run inference on CPU, resulting in lower throughput and higher latency.",
+  "fix": "Added --force-reinstall to desktop llama-cpp-python wheel install plans and added regression/e2e contract tests that assert CUDA reinstall attempts replace existing CPU wheels before CPU fallback.",
+  "lessons": "GPU bootstrap/install contracts must force replacement when binary capability is encoded by wheel variant rather than version number; tests should verify command flags and repair sequencing."
+}

--- a/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-cpu-fallback.md
+++ b/outages/2026-04-18-desktop-tauri-windows-gpu-runtime-cpu-fallback.md
@@ -1,0 +1,27 @@
+# Outage: desktop-tauri Windows GPU runtime stayed on CPU after CUDA repair attempts
+
+- **Date:** 2026-04-18
+- **Slug:** `desktop-tauri-windows-gpu-runtime-cpu-fallback`
+- **Affected area:** desktop-tauri local inference/operator GPU modes on Windows 11 + NVIDIA
+
+## Summary
+Desktop GPU and hybrid modes could repeatedly fall back to CPU even on Windows hosts with NVIDIA GPUs and CUDA-capable drivers/tooling.
+
+## Impact
+- Desktop users could select `auto`, `gpu`, or `hybrid` and still run fully on CPU.
+- Throughput/latency remained CPU-bound.
+- Runtime logs suggested bootstrap activity, but the installed runtime often remained CPU-only.
+
+## Root cause
+The wheel-based runtime repair/install path did **not** pass `--force-reinstall` to `pip install`.
+When a CPU-only `llama-cpp-python` of the same version was already present (common in packaged installs),
+pip treated the requirement as satisfied and skipped replacing it with the CUDA wheel, leaving the runtime CPU-only.
+
+## Resolution
+- Updated desktop GPU packaging install arguments to always include `--force-reinstall` so wheel repair paths can replace a preinstalled CPU wheel with a GPU-capable build of the same version.
+- Added/updated tests that assert force-reinstall behavior in both packaging helper contracts and runtime bootstrap command construction.
+- Added a high-level e2e contract test covering Windows bootstrap sequencing, ensuring CUDA reinstall is attempted and can promote runtime action to CUDA reexec before CPU fallback.
+
+## Follow-up / prevention
+- Keep GPU install/repair commands aligned with the README hardware-acceleration guidance (`--force-reinstall`, `--upgrade`, `--no-cache-dir`).
+- Preserve test coverage around Windows repair sequencing to avoid future regressions that silently keep CPU wheels in place.

--- a/tests/e2e/test_desktop_windows_gpu_bootstrap_contract.py
+++ b/tests/e2e/test_desktop_windows_gpu_bootstrap_contract.py
@@ -1,0 +1,91 @@
+"""High-level contract test for Windows desktop GPU bootstrap behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_PYTHON = ROOT / "desktop-tauri" / "src-tauri" / "python"
+if str(DESKTOP_PYTHON) not in sys.path:
+    sys.path.insert(0, str(DESKTOP_PYTHON))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MODULE_PATH = DESKTOP_PYTHON / "desktop_runtime_setup.py"
+SPEC = importlib.util.spec_from_file_location("desktop_runtime_setup_e2e", MODULE_PATH)
+desktop_runtime_setup = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules["desktop_runtime_setup_e2e"] = desktop_runtime_setup
+SPEC.loader.exec_module(desktop_runtime_setup)
+
+
+class _SysStub:
+    platform = "win32"
+    executable = sys.executable
+    prefix = sys.prefix
+    argv = [str(MODULE_PATH)]
+
+
+def _probe(*, backend="cpu", gpu=False, device="cpu"):
+    return desktop_runtime_setup.RuntimeProbe(
+        backend=backend,
+        gpu_offload_supported=gpu,
+        detected_device=device,
+        interpreter=sys.executable,
+        prefix=sys.prefix,
+        llama_module_path="C:/Python/Lib/site-packages/llama_cpp/__init__.py",
+        error=None,
+    )
+
+
+def test_windows_gpu_bootstrap_contract_prefers_cuda_reinstall_before_cpu_fallback(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, "sys", _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, "_should_attempt_source_repair", lambda: (False, "cooldown"))
+    probes = iter([_probe(), _probe(backend="cuda", gpu=True, device="cuda")])
+    monkeypatch.setattr(desktop_runtime_setup, "_probe_llama_runtime", lambda: next(probes))
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        "llama_cpp_install_plan_fallbacks",
+        lambda **_kwargs: [
+            desktop_runtime_setup.LlamaCppInstallPlan(
+                platform="win32",
+                backend="cuda",
+                package_spec="llama-cpp-python==0.3.16",
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+                extra_index_url="https://pypi.org/simple",
+                only_binary=True,
+                no_binary=False,
+            ),
+            desktop_runtime_setup.LlamaCppInstallPlan(
+                platform="win32",
+                backend="cpu",
+                package_spec="llama-cpp-python",
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://pypi.org/simple",
+                extra_index_url=None,
+                only_binary=True,
+                no_binary=False,
+            ),
+        ],
+    )
+    pip_cmds: list[list[str]] = []
+
+    def _run_pip(cmd, env, timeout_seconds=0):
+        pip_cmds.append(cmd)
+        return True, "ok"
+
+    monkeypatch.setattr(desktop_runtime_setup, "_run_pip_install", _run_pip)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime("auto", repo_root=Path.cwd())
+
+    assert result["runtime_action"] == "installed_cuda_reexec"
+    assert result["selected_backend"] == "cuda"
+    assert len(pip_cmds) == 1
+    assert "--force-reinstall" in pip_cmds[0]
+    assert pip_cmds[0][-1] == "llama-cpp-python==0.3.16"

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -74,7 +74,7 @@ def test_linux_install_plan_remains_cpu_default():
     plan = plans[0]
     assert plan.backend == "cpu"
     assert plan.pip_env() == {}
-    assert plan.pip_install_args() == ["--upgrade", "--no-cache-dir"]
+    assert plan.pip_install_args() == ["--force-reinstall", "--upgrade", "--no-cache-dir"]
 
 
 def test_requirement_spec_parses_comments_and_blank_lines(tmp_path):
@@ -121,6 +121,7 @@ def test_pip_install_args_include_index_and_binary_flags():
     )
 
     assert plan.pip_install_args() == [
+        "--force-reinstall",
         "--upgrade",
         "--no-cache-dir",
         "--index-url",
@@ -148,6 +149,7 @@ def test_windows_cpu_fallback_install_args_are_binary_only():
     cpu_fallback = plans[2]
 
     assert cpu_fallback.pip_install_args() == [
+        "--force-reinstall",
         "--upgrade",
         "--no-cache-dir",
         "--index-url",
@@ -163,6 +165,7 @@ def test_macos_source_fallback_install_args_force_source_build():
     source_fallback = plans[1]
 
     assert source_fallback.pip_install_args() == [
+        "--force-reinstall",
         "--upgrade",
         "--no-cache-dir",
         "--index-url",

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -130,6 +130,43 @@ def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
     assert result['selected_backend'] == 'cpu'
 
 
+def test_runtime_bootstrap_uses_force_reinstall_for_wheel_repair_plans(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        'llama_cpp_install_plan_fallbacks',
+        lambda **_kwargs: [
+            desktop_runtime_setup.LlamaCppInstallPlan(
+                platform='win32',
+                backend='cuda',
+                package_spec='llama-cpp-python==0.3.16',
+                cmake_args=None,
+                force_cmake=False,
+                index_url='https://abetlen.github.io/llama-cpp-python/whl/cu124',
+                extra_index_url='https://pypi.org/simple',
+                only_binary=True,
+                no_binary=False,
+            )
+        ],
+    )
+    captured = {}
+
+    def _run_pip(cmd, env, timeout_seconds=0):
+        captured['cmd'] = cmd
+        return False, 'simulated pip failure'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _run_pip)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
+
+    assert result['runtime_action'] == 'failed'
+    install_cmd = captured['cmd']
+    assert install_cmd[:4] == [sys.executable, '-m', 'pip', 'install']
+    assert '--force-reinstall' in install_cmd
+
+
 def test_maybe_reexec_for_runtime_refresh_reexecs_once(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     called = {}


### PR DESCRIPTION
### Motivation

- Prevent desktop Tauri from silently staying CPU-only on Windows when a CPU-only `llama-cpp-python` wheel of the same version is already installed by ensuring GPU wheel installs replace existing wheels.  

### Description

- Add a `Hardware acceleration (llama_cpp_python)` subsection to `AGENTS.md` that references the README hardware-acceleration instructions and documents the Windows/CUDA reinstall contract.  
- Update `LlamaCppInstallPlan` to include `--force-reinstall` in pip arguments so wheel-based CUDA/Metal repairs always replace an existing wheel of the same version (`desktop-tauri/src-tauri/python/desktop_gpu_packaging.py`).  
- Update unit tests that exercise install plan arguments to expect `--force-reinstall` (`tests/unit/test_desktop_gpu_packaging.py`).  
- Add a regression unit test to ensure runtime bootstrap wheel-repair commands include `--force-reinstall` (`tests/unit/test_desktop_runtime_setup.py`).  
- Add a high-level Windows e2e contract test asserting the bootstrap flow prefers CUDA reinstall and that the pip command includes `--force-reinstall` (`tests/e2e/test_desktop_windows_gpu_bootstrap_contract.py`).  
- Add outage documentation (`outages/2026-04-18-desktop-tauri-windows-gpu-runtime-cpu-fallback.md` and `.json`) describing root cause, impact, fix and follow-up actions.

### Testing

- Ran the localized pytest set: `pytest -q tests/unit/test_desktop_gpu_packaging.py tests/unit/test_desktop_runtime_setup.py tests/e2e/test_desktop_windows_gpu_bootstrap_contract.py` and all targeted tests passed (46 tests total).  
- Attempted `pre-commit run --all-files`; this check surfaced unrelated environment/CI dependencies and integration startup conditions in this sandbox (Playwright, full Python deps, and relay startup), so the full repo hook suite could not be completed here; the targeted unit/e2e tests for this change passed and the `pre-commit` note is documented for CI verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e329de4f08832f8587a4edb6b39fca)