### PR TITLE
Fix Windows desktop CUDA runtime fallback; bundle requirements and prefer CUDA source build

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -10,6 +10,7 @@ on:
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
+      - 'tests/e2e/test_windows_gpu_runtime_contract.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -25,6 +26,7 @@ on:
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
+      - 'tests/e2e/test_windows_gpu_runtime_contract.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -94,6 +96,9 @@ jobs:
 
       - name: Run packaged operator bridge e2e
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+      - name: Run Windows GPU runtime contract e2e
+        run: python -m pytest -q tests/e2e/test_windows_gpu_runtime_contract.py
 
       - name: Upload desktop e2e logs on failure
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,17 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
   components and hooks.
 - Use **Tailwind CSS** for styling and keep custom CSS minimal.
 
+## Hardware acceleration (llama-cpp-python)
+- Follow the canonical setup instructions in
+  [`README.md#hardware-acceleration`](README.md#hardware-acceleration) when
+  working on desktop/server runtime packaging and diagnostics.
+- For **Windows 11 + NVIDIA GPUs**, expect CUDA source builds to set
+  `CMAKE_ARGS=-DGGML_CUDA=on` and `FORCE_CMAKE=1` so `llama-cpp-python` is
+  built with CUDA offload support instead of CPU-only defaults.
+- Keep `n_gpu_layers` semantics intact (`-1` full offload, `0` CPU-only,
+  positive values for hybrid) and ensure diagnostics clearly report
+  `backend_available`, `backend_used`, and fallback reasons.
+
 ## Agents
 
 ### Code Linter Agent

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -65,6 +65,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
 
     shutil.copy2(REPO_ROOT / "config.py", resources_root / "config.py")
     shutil.copy2(REPO_ROOT / "encrypt.py", resources_root / "encrypt.py")
+    shutil.copy2(REPO_ROOT / "requirements.txt", resources_root / "requirements.txt")
     shutil.copytree(REPO_ROOT / "utils", resources_root / "utils", dirs_exist_ok=True)
 
     return python_dir / "compute_node_bridge.py"

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -73,11 +73,12 @@ def llama_cpp_install_plan(
             platform=detected_platform,
             backend="cuda",
             package_spec=package_spec,
-            cmake_args=None,
-            force_cmake=False,
-            index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
-            extra_index_url="https://pypi.org/simple",
-            only_binary=True,
+            cmake_args="-DGGML_CUDA=on",
+            force_cmake=True,
+            index_url="https://pypi.org/simple",
+            extra_index_url=None,
+            only_binary=False,
+            no_binary=True,
         )
 
     if detected_platform == "darwin":
@@ -111,10 +112,24 @@ def llama_cpp_install_plan_fallbacks(
     plans = [primary]
 
     if primary.platform.startswith("win"):
-        # CUDA wheels may be unavailable for a given Python ABI on Windows.
-        # First, fall back to an unpinned CUDA wheel so CI can use the newest
-        # available CUDA binary (e.g. when requirements pin is newer than
-        # published CUDA wheels on the mirror index).
+        # CUDA source builds can fail on user machines without Visual Studio
+        # Build Tools / CUDA Toolkit. Fall back to CUDA wheels where possible.
+        plans.append(
+            LlamaCppInstallPlan(
+                platform=primary.platform,
+                backend="cuda",
+                package_spec=primary.package_spec,
+                cmake_args=None,
+                force_cmake=False,
+                index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+                extra_index_url="https://pypi.org/simple",
+                only_binary=True,
+                no_binary=False,
+            )
+        )
+
+        # If the pinned version is unavailable on the CUDA wheel index, try an
+        # unpinned CUDA wheel before giving up to CPU-only fallback.
         plans.append(
             LlamaCppInstallPlan(
                 platform=primary.platform,
@@ -122,8 +137,8 @@ def llama_cpp_install_plan_fallbacks(
                 package_spec="llama-cpp-python",
                 cmake_args=None,
                 force_cmake=False,
-                index_url=primary.index_url,
-                extra_index_url=primary.extra_index_url,
+                index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+                extra_index_url="https://pypi.org/simple",
                 only_binary=True,
                 no_binary=False,
             )

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -249,6 +249,22 @@ def _runtime_state_path() -> Path:
     return Path.home() / ".token_place_desktop_runtime_state.json"
 
 
+def _resolve_requirements_path(target_root: Path) -> Path:
+    """Return best-effort requirements path for repo and packaged desktop layouts."""
+
+    candidates = (
+        target_root / "requirements.txt",
+        target_root / "resources" / "requirements.txt",
+        target_root / "Resources" / "requirements.txt",
+        target_root / "_up_" / "requirements.txt",
+        target_root / "_up_" / "_up_" / "requirements.txt",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return candidates[0]
+
+
 def _load_runtime_state() -> dict:
     path = _runtime_state_path()
     try:
@@ -364,7 +380,7 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    requirements_path = target_root / "requirements.txt"
+    requirements_path = _resolve_requirements_path(target_root)
     last_error = ""
 
     should_repair, repair_skip_reason = _should_attempt_source_repair()

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -33,7 +33,8 @@
       "python/path_bootstrap.py",
       "../../utils",
       "../../config.py",
-      "../../encrypt.py"
+      "../../encrypt.py",
+      "../../requirements.txt"
     ],
     "icon": [
       "icons/32x32.png",

--- a/outages/2026-04-18-desktop-tauri-windows-cuda-runtime-fallback.json
+++ b/outages/2026-04-18-desktop-tauri-windows-cuda-runtime-fallback.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-tauri-windows-cuda-runtime-fallback",
+  "summary": "Windows desktop GPU-preferred sessions frequently initialized on CPU because packaged runtime repair lacked the pinned requirements metadata and install-plan ordering favored wheel-only CUDA attempts before a deterministic CUDA source build.",
+  "impact": "Windows 11 + NVIDIA desktop operators often ran CPU-only inference in auto/gpu modes, reducing performance and confidence in desktop release GPU readiness.",
+  "fix": "Bundled requirements.txt into desktop resources, taught runtime setup to resolve packaged requirements paths, reordered Windows llama-cpp-python plans to attempt CUDA source build first (CMAKE_ARGS/FORCE_CMAKE with --no-binary) before CUDA wheel fallbacks, and added regression plus e2e-style contract tests for packaging/runtime expectations.",
+  "lessons": "Desktop GPU support depends on both runtime metadata availability and deterministic install ordering; packaged apps must carry pinned dependency metadata and treat CPU fallback in GPU-preferred modes as a release-risk signal requiring explicit smoke-test validation on real Windows NVIDIA hardware."
+}

--- a/outages/2026-04-18-desktop-tauri-windows-cuda-runtime-fallback.md
+++ b/outages/2026-04-18-desktop-tauri-windows-cuda-runtime-fallback.md
@@ -1,0 +1,49 @@
+# Outage: desktop-tauri Windows CUDA runtime repeatedly fell back to CPU
+
+- **Date:** 2026-04-18
+- **Slug:** `desktop-tauri-windows-cuda-runtime-fallback`
+- **Affected area:** desktop-tauri Windows 11 operator/local inference GPU flows
+
+## Summary
+Desktop Windows users with NVIDIA GPUs saw `mode=auto`/`mode=gpu` sessions start in CPU mode.
+Runtime bootstrap frequently reported CPU fallback after install attempts, reducing throughput and
+invalidating expected desktop GPU parity.
+
+## Symptoms
+- `desktop.runtime_setup ... selected_backend=cpu ... fallback_reason=...`
+- `compute_node_bridge.py` startup/status events reported `backend_used=cpu` and
+  `offloaded_layers=0`.
+- Packaged runtime repair logs frequently mentioned missing `requirements.txt` and unpinned
+  reinstall paths.
+
+## Impact
+- Desktop operators on Windows 11 + NVIDIA often ran CPU-only inference despite GPU hardware.
+- GPU confidence for desktop release artifacts dropped because CI lacks direct NVIDIA validation.
+
+## Root cause
+Two packaging/bootstrap gaps combined:
+
+1. **Packaged desktop resources did not include `requirements.txt`.**  
+   Runtime repair could not resolve the pinned `llama-cpp-python` version and fell back to
+   unpinned install behavior.
+2. **Windows install plan prioritized wheel-only CUDA attempts before source-compiled CUDA.**  
+   This increased the chance of landing on CPU fallback paths when CUDA wheel compatibility
+   mismatched Python ABI/version constraints.
+
+## Resolution
+- Bundled `requirements.txt` into desktop Tauri resources so packaged runtime repair can use the
+  repo-pinned `llama-cpp-python` contract.
+- Updated runtime setup to search packaged resource layouts for `requirements.txt` before defaulting
+  to unpinned behavior.
+- Updated Windows desktop install plan ordering to try **CUDA source build first** (`CMAKE_ARGS`
+  + `FORCE_CMAKE`, `--no-binary llama-cpp-python`), then pinned/unpinned CUDA wheel fallbacks, then
+  CPU fallback as a last resort.
+- Added regression and E2E-style contract tests to lock plan ordering and packaged-resource
+  expectations.
+
+## Follow-up / prevention
+- Keep README hardware-acceleration instructions mirrored in AGENTS guidance for desktop/runtime
+  contributors.
+- Treat CPU fallback in `mode=gpu`/`mode=auto` as a release-risk signal for Windows desktop builds.
+- Continue running `desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py` on real Windows +
+  NVIDIA hardware before desktop release publication.

--- a/tests/e2e/test_windows_gpu_runtime_contract.py
+++ b/tests/e2e/test_windows_gpu_runtime_contract.py
@@ -1,0 +1,52 @@
+"""E2E-style regression checks for Windows desktop GPU runtime packaging contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_PYTHON = REPO_ROOT / "desktop-tauri" / "src-tauri" / "python"
+
+if str(DESKTOP_PYTHON) not in sys.path:
+    sys.path.insert(0, str(DESKTOP_PYTHON))
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_windows_cuda_contract_prefers_source_then_cuda_wheels_then_cpu_fallback() -> None:
+    desktop_gpu_packaging = _load_module(
+        "desktop_gpu_packaging",
+        DESKTOP_PYTHON / "desktop_gpu_packaging.py",
+    )
+    plans = desktop_gpu_packaging.llama_cpp_install_plan_fallbacks(
+        platform="win32",
+        requirements_path=REPO_ROOT / "requirements.txt",
+    )
+
+    # Ordered expectations for deterministic bootstrap behavior:
+    # 1) Source build with CUDA flags (README hardware acceleration contract)
+    # 2) Pinned CUDA wheel fallback
+    # 3) Unpinned CUDA wheel fallback
+    # 4) CPU wheel fallback
+    assert [plan.backend for plan in plans] == ["cuda", "cuda", "cuda", "cpu"]
+    assert plans[0].no_binary is True
+    assert plans[0].pip_env() == {"CMAKE_ARGS": "-DGGML_CUDA=on", "FORCE_CMAKE": "1"}
+    assert plans[1].only_binary is True
+    assert plans[1].index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert plans[2].package_spec == "llama-cpp-python"
+
+
+def test_packaged_resources_include_requirements_for_runtime_repair() -> None:
+    tauri_conf = (REPO_ROOT / "desktop-tauri" / "src-tauri" / "tauri.conf.json").read_text(
+        encoding="utf-8"
+    )
+    assert '"../../requirements.txt"' in tauri_conf

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -18,17 +18,26 @@ from desktop_gpu_packaging import (
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    assert len(plans) == 3
+    assert len(plans) == 4
 
     gpu_plan = plans[0]
     assert gpu_plan.backend == "cuda"
     assert gpu_plan.package_spec.startswith("llama-cpp-python==")
-    assert gpu_plan.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
-    assert gpu_plan.extra_index_url == "https://pypi.org/simple"
-    assert gpu_plan.only_binary is True
-    assert gpu_plan.pip_env() == {}
+    assert gpu_plan.index_url == "https://pypi.org/simple"
+    assert gpu_plan.extra_index_url is None
+    assert gpu_plan.only_binary is False
+    assert gpu_plan.no_binary is True
+    assert gpu_plan.pip_env() == {"CMAKE_ARGS": "-DGGML_CUDA=on", "FORCE_CMAKE": "1"}
 
     unpinned_cuda_fallback = plans[1]
+    assert unpinned_cuda_fallback.backend == "cuda"
+    assert unpinned_cuda_fallback.package_spec.startswith("llama-cpp-python==")
+    assert unpinned_cuda_fallback.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    assert unpinned_cuda_fallback.extra_index_url == "https://pypi.org/simple"
+    assert unpinned_cuda_fallback.only_binary is True
+    assert unpinned_cuda_fallback.no_binary is False
+
+    unpinned_cuda_fallback = plans[2]
     assert unpinned_cuda_fallback.backend == "cuda"
     assert unpinned_cuda_fallback.package_spec == "llama-cpp-python"
     assert unpinned_cuda_fallback.index_url == "https://abetlen.github.io/llama-cpp-python/whl/cu124"
@@ -36,7 +45,7 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert unpinned_cuda_fallback.only_binary is True
     assert unpinned_cuda_fallback.no_binary is False
 
-    cpu_fallback = plans[2]
+    cpu_fallback = plans[3]
     assert cpu_fallback.backend == "cpu"
     assert cpu_fallback.package_spec == "llama-cpp-python"
     assert cpu_fallback.index_url == "https://pypi.org/simple"
@@ -145,7 +154,7 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
 
 def test_windows_cpu_fallback_install_args_are_binary_only():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    cpu_fallback = plans[2]
+    cpu_fallback = plans[3]
 
     assert cpu_fallback.pip_install_args() == [
         "--upgrade",
@@ -179,7 +188,8 @@ def test_llama_cpp_install_plan_uses_current_platform_for_windows(monkeypatch):
 
     assert plan.platform == "win32"
     assert plan.backend == "cuda"
-    assert plan.only_binary is True
+    assert plan.only_binary is False
+    assert plan.no_binary is True
 
 
 def test_llama_cpp_install_plan_darwin_selects_metal_wheel_index():

--- a/tests/unit/test_desktop_packaged_layout.py
+++ b/tests/unit/test_desktop_packaged_layout.py
@@ -60,6 +60,11 @@ def test_linux_no_bundle_layout_contains_python_runtime_resources() -> None:
     )
     _assert_any_exists(staging_root, ("utils", "resources/utils"), "utils/")
     _assert_any_exists(staging_root, ("config.py", "resources/config.py"), "config.py")
+    _assert_any_exists(
+        staging_root,
+        ("requirements.txt", "resources/requirements.txt"),
+        "requirements.txt",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -570,6 +570,46 @@ def test_windows_packaged_layout_without_requirements_falls_back_without_excepti
     assert 'falling back to unpinned llama-cpp-python source reinstall' in result['fallback_reason']
 
 
+def test_windows_packaged_layout_prefers_resources_requirements_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [])
+
+    captured = {}
+
+    def _fake_repair(requirements_path):
+        captured['requirements_path'] = str(requirements_path)
+        return False, 'compile failed'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_windows_cuda_source_repair', _fake_repair)
+
+    packaged_root = tmp_path / 'token.place'
+    resources = packaged_root / 'resources'
+    resources.mkdir(parents=True)
+    (resources / 'requirements.txt').write_text(
+        "llama-cpp-python==0.3.16\n",
+        encoding='utf-8',
+    )
+
+    desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=packaged_root)
+
+    assert captured['requirements_path'].endswith('/resources/requirements.txt')
+
+
+def test_resolve_requirements_path_supports_packaged_layouts(tmp_path):
+    root = tmp_path / 'bundle-root'
+    root.mkdir()
+    assert desktop_runtime_setup._resolve_requirements_path(root) == (root / 'requirements.txt')
+
+    resources = root / 'resources'
+    resources.mkdir()
+    (resources / 'requirements.txt').write_text("llama-cpp-python==0.3.16\n", encoding='utf-8')
+    assert desktop_runtime_setup._resolve_requirements_path(root) == (resources / 'requirements.txt')
+
+
 def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
     repo_root = tmp_path / 'RepoRoot'
     repo_root.mkdir(parents=True)


### PR DESCRIPTION
### Motivation
- Desktop Windows users with NVIDIA GPUs frequently started sessions in CPU mode because packaged runtime repair lacked pinned `llama-cpp-python` metadata and install-plan ordering favored wheel-only attempts before a deterministic CUDA source build.

### Description
- Added a Hardware acceleration section to `AGENTS.md` pointing to `README.md#hardware-acceleration` and documenting expected CUDA build env (`CMAKE_ARGS=-DGGML_CUDA=on`, `FORCE_CMAKE=1`) and diagnostics (`backend_available`, `backend_used`).
- Reworked Windows `llama-cpp-python` install plan to prefer a CUDA source build first (set `CMAKE_ARGS`/`FORCE_CMAKE` and `--no-binary`) and then try pinned CUDA wheel, unpinned CUDA wheel, and CPU fallback in that order (`desktop-tauri/src-tauri/python/desktop_gpu_packaging.py`).
- Taught runtime bootstrap to resolve `requirements.txt` from typical packaged resource locations via `_resolve_requirements_path(...)` and use it during source-repair attempts (`desktop-tauri/src-tauri/python/desktop_runtime_setup.py`).
- Bundled `requirements.txt` into Tauri `bundle.resources` so packaged apps include pinned dependency metadata (`desktop-tauri/src-tauri/tauri.conf.json`) and updated packaged-layout test fixture to copy `requirements.txt` for e2e validation (`desktop-tauri/scripts/test_packaged_operator_e2e.py`).
- Added regression and e2e-style tests to lock the install-plan ordering and packaged-resource expectations (`tests/unit/test_desktop_gpu_packaging.py`, `tests/unit/test_desktop_runtime_setup.py`, `tests/unit/test_desktop_packaged_layout.py`, `tests/e2e/test_windows_gpu_runtime_contract.py`).
- Documented the outage, root cause, fix, and follow-ups in `outages/2026-04-18-desktop-tauri-windows-cuda-runtime-fallback.{md,json}`.
- Wired the new Windows GPU runtime contract test into the desktop operator e2e workflow (`.github/workflows/desktop-operator-e2e.yml`).

### Testing
- Ran targeted pytest suites: `python -m pytest -q --noconftest tests/unit/test_desktop_gpu_packaging.py tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_packaged_layout.py tests/e2e/test_windows_gpu_runtime_contract.py` and observed all added/related tests pass (48 passed, 1 skipped).
- Ran `pre-commit run --all-files`; hooks executed but the full pre-commit test-runner flagged failures tied to missing system-level CI dependencies and the pinned `requirements.txt` Python ABI mismatch in the container; this is environmental rather than a logic regression.
- Attempted `pip install -r requirements.txt` in the container which failed due to `numpy==2.3.4` requiring a newer Python ABI; this is an environment constraint and unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e329de4f08832f8587a4edb6b39fca)