### PR TITLE
Fix desktop runtime probe import coupling that blocked sidecar/bridge startup

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -55,11 +55,6 @@ if bootstrap_script:
 
 repo_root = Path(os.environ.get("TOKEN_PLACE_PROBE_REPO_ROOT", Path.cwd())).resolve()
 
-from utils.llm.model_manager import detect_llama_runtime_capabilities
-# NOTE: detect_llama_runtime_capabilities must keep `import llama_cpp` lazy
-# (inside the function body). We sanitize sys.path below before that import
-# runs so site-packages can win over a repo-local llama_cpp.py shim.
-
 repo_root_resolved = str(repo_root.resolve())
 sanitized = []
 for entry in sys.path:
@@ -69,7 +64,57 @@ for entry in sys.path:
     sanitized.append(entry)
 sys.path[:] = sanitized
 
-payload = detect_llama_runtime_capabilities()
+try:
+    import llama_cpp
+except Exception as exc:
+    payload = {
+        "backend": "missing",
+        "gpu_offload_supported": False,
+        "detected_device": "none",
+        "error": str(exc),
+    }
+else:
+    backend = "cpu"
+    cuda_markers = (
+        "GGML_USE_CUDA",
+        "GGML_CUDA",
+        "LLAMA_CUDA",
+        "GGML_USE_CUBLAS",
+        "LLAMA_CUBLAS",
+    )
+    metal_markers = (
+        "GGML_USE_METAL",
+        "GGML_METAL",
+        "LLAMA_METAL",
+    )
+    if any(bool(getattr(llama_cpp, marker, False)) for marker in cuda_markers):
+        backend = "cuda"
+    elif any(bool(getattr(llama_cpp, marker, False)) for marker in metal_markers):
+        backend = "metal"
+
+    supports_gpu = getattr(llama_cpp, "llama_supports_gpu_offload", None)
+    gpu_offload_supported = False
+    if callable(supports_gpu):
+        try:
+            gpu_offload_supported = bool(supports_gpu())
+        except Exception:
+            gpu_offload_supported = False
+    else:
+        gpu_offload_supported = backend in {"cuda", "metal"}
+
+    if gpu_offload_supported and backend == "cpu":
+        backend = "metal" if sys.platform == "darwin" else "cuda"
+
+    payload = {
+        "backend": backend,
+        "gpu_offload_supported": gpu_offload_supported,
+        "detected_device": backend if gpu_offload_supported else "cpu",
+        "interpreter": sys.executable,
+        "prefix": sys.prefix,
+        "llama_module_path": getattr(llama_cpp, "__file__", "unknown"),
+        "error": None,
+    }
+
 print(json.dumps(payload))
 """.strip()
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -425,6 +425,8 @@ def test_probe_subprocess_sanitizes_repo_root_before_llama_import(monkeypatch):
     assert probe.backend == 'cuda'
     assert 'ensure_runtime_import_paths' in desktop_runtime_setup._PROBE_SNIPPET
     assert "Path(entry or \".\").resolve()" in desktop_runtime_setup._PROBE_SNIPPET
+    assert 'import llama_cpp' in desktop_runtime_setup._PROBE_SNIPPET
+    assert 'utils.llm.model_manager' not in desktop_runtime_setup._PROBE_SNIPPET
     assert captured['cmd'][:2] == [sys.executable, '-c']
     assert captured['env']['PYTHONPATH'].split(desktop_runtime_setup.os.pathsep)[:2] == [
         str(PYTHON_MODULE_DIR),


### PR DESCRIPTION
### Motivation
- The desktop runtime probe subprocess previously imported `utils.llm.model_manager` which transitively pulled in optional app deps and could fail in packaged desktop runtimes, causing the shared preflight to report a missing runtime and trigger long bootstrap paths before any structured `started` event.
- This failure mode stalled both the inference sidecar and compute-node bridge startup sequence because they both call `ensure_desktop_llama_runtime(...)` before emitting NDJSON startup events.

### Description
- Replaced the probe subprocess snippet in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` to import `llama_cpp` directly and perform a self-contained capability probe instead of importing `utils.llm.model_manager` in the probe subprocess.
- Preserved the existing probe semantics (backend detection, gpu_offload_supported inference, llama_module_path, interpreter/prefix fields) while avoiding heavy transitive imports that can fail early.
- Added a regression assertion in `tests/unit/test_desktop_runtime_setup.py` that the probe snippet contains `import llama_cpp` and does not reference `utils.llm.model_manager` to prevent reintroduction of the coupling.

### Testing
- Unit tests: ran `pytest -q tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (`46 passed`).
- Sidecar unit tests: ran `pytest -q tests/unit/test_desktop_inference_sidecar.py` and all tests passed (`23 passed`).
- Manual smoke: invoked the compute-node bridge against a local relay target and observed the bridge emit structured `started` and subsequent `status` events (showing reachable error when relay was unreachable), demonstrating the bridge no longer blocks before its first events; full end-to-end relay registration with `relay.py` could not be validated in this container because `flask` is not available to start `relay.py` here.
- Pre-commit/checks: attempted `pre-commit run --all-files`; repository hooks exercise broader integration checks (e.g., `bandit`, API tests) and failed in this environment due to missing runtime test deps (for example `flask`, `bandit`) rather than the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e335efe990832fbb26fa2e165f41b6)