### PR TITLE
Fix desktop runtime probe startup regression when requests is missing

### DIFF
--- a/tests/unit/test_model_manager_runtime_import.py
+++ b/tests/unit/test_model_manager_runtime_import.py
@@ -1,0 +1,25 @@
+"""Regression coverage for lightweight runtime capability probing imports."""
+
+import builtins
+import importlib.util
+from pathlib import Path
+
+
+def test_model_manager_import_does_not_require_requests_dependency(monkeypatch):
+    module_path = Path(__file__).resolve().parents[2] / 'utils' / 'llm' / 'model_manager.py'
+    spec = importlib.util.spec_from_file_location('model_manager_without_requests', module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'requests':
+            raise ModuleNotFoundError("No module named 'requests'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    spec.loader.exec_module(module)
+
+    assert hasattr(module, 'detect_llama_runtime_capabilities')
+    assert module.requests is None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -4,7 +4,10 @@ Model manager module for handling LLM model downloading, initialization and infe
 import os
 import time
 import logging
-import requests
+try:
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - exercised via desktop probe import path
+    requests = None
 import json
 import sys
 from pathlib import Path
@@ -286,7 +289,17 @@ class ModelManager:
             bool: True if download was successful, False otherwise
         """
         chunk_size_bytes = chunk_size_mb * 1024 * 1024  # Convert MB to bytes
-        response = requests.get(url, stream=True, timeout=self.download_timeout)
+        requests_module = requests
+        if requests_module is None:
+            try:
+                import importlib
+
+                requests_module = importlib.import_module('requests')
+            except ModuleNotFoundError:
+                self.log_error('Error: requests dependency missing; unable to download model.')
+                return False
+
+        response = requests_module.get(url, stream=True, timeout=self.download_timeout)
 
         if response.status_code != 200:
             self.log_error(f"Error: Unable to download file, status code {response.status_code}")


### PR DESCRIPTION
### Motivation
- The desktop sidecar and compute-node bridge both import shared runtime probe helpers from `utils.llm.model_manager`, and an unconditional `requests` import caused module import failure in minimal/packaged desktop Python runtimes, blocking startup before any structured `started` event.
- This left the Tauri app in a pending state (no `started`/`status` events) for both local inference and compute-node registration when `requests` was absent in the runtime.
- Keep the fix minimal and focused on making probing resilient while preserving explicit diagnostics for real download-time failures.

### Description
- Make `requests` optional at module import in `utils/llm/model_manager.py` by wrapping the import in a `try/except` and assigning `requests = None` when missing. 
- Lazily import `requests` inside `ModelManager.download_file_in_chunks` and emit a clear `log_error` and return `False` if `requests` is unavailable at download time. 
- Add `tests/unit/test_model_manager_runtime_import.py` which simulates `ModuleNotFoundError` for `requests` during import and asserts `detect_llama_runtime_capabilities` remains available and `module.requests is None`.

### Testing
- Ran unit tests covering the change: `pytest -q tests/unit/test_model_manager_runtime_import.py tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and observed all tests pass (47 passed in the run). 
- Manual verification: `USE_MOCK_LLM=1 python desktop-tauri/src-tauri/python/inference_sidecar.py --model /tmp/fake.gguf --mode auto --prompt "Say hello in one sentence."` emitted `desktop.inference.summary`, `started`, `token`, and `done` events as expected. 
- Manual compute-node check: `USE_MOCK_LLM=1 timeout 8s python desktop-tauri/src-tauri/python/compute_node_bridge.py --model /tmp/fake.gguf --mode auto --relay-url http://127.0.0.1:5010` emitted `started` immediately (probe no longer crashes); relay registration failed in this container run because the local `relay.py` endpoint was not reachable here, but the bridge now reports actionable `last_error` rather than being stuck in import failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e335efe990832fbb26fa2e165f41b6)