### PR TITLE
Fix desktop runtime probe root resolution for sidecar/compute-node startup

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -74,19 +74,42 @@ print(json.dumps(payload))
 """.strip()
 
 
+def _resolve_runtime_root() -> Path:
+    explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    if explicit_import_root:
+        candidate = Path(explicit_import_root).resolve()
+        if candidate.exists():
+            return candidate
+
+    script_path = Path(__file__).resolve()
+    candidates = [
+        script_path.parents[3] if len(script_path.parents) > 3 else None,
+        script_path.parent.parent,
+        script_path.parent.parent / "resources",
+        script_path.parent.parent / "Resources",
+    ]
+    for candidate in candidates:
+        if candidate is None or not candidate.exists():
+            continue
+        if (candidate / "utils").is_dir() or (candidate / "config.py").is_file():
+            return candidate.resolve()
+
+    return script_path.parents[3] if len(script_path.parents) > 3 else script_path.parent.parent
+
+
 def _probe_llama_runtime() -> RuntimeProbe:
-    repo_root = Path(__file__).resolve().parents[3]
+    runtime_root = _resolve_runtime_root()
     python_root = Path(__file__).resolve().parent
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH", "")
-    pythonpath_entries = [str(python_root), str(repo_root)]
+    pythonpath_entries = [str(python_root), str(runtime_root)]
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     env["TOKEN_PLACE_DESKTOP_PYTHON_ROOT"] = str(python_root)
     env["TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT"] = str(Path(__file__).resolve())
-    env["TOKEN_PLACE_PROBE_REPO_ROOT"] = str(repo_root)
+    env["TOKEN_PLACE_PROBE_REPO_ROOT"] = str(runtime_root)
     try:
         result = subprocess.run(
             cmd,
@@ -94,7 +117,7 @@ def _probe_llama_runtime() -> RuntimeProbe:
             capture_output=True,
             text=True,
             timeout=30,
-            cwd=str(repo_root),
+            cwd=str(runtime_root),
             env=env,
         )
     except Exception as exc:
@@ -325,7 +348,7 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
-    target_root = (repo_root or Path(__file__).resolve().parents[3]).resolve()
+    target_root = (repo_root or _resolve_runtime_root()).resolve()
     before = _probe_llama_runtime()
     if _is_repo_local_llama_module(before.llama_module_path, target_root):
         return {

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -647,3 +648,49 @@ def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
 
     module_path = str(shim.resolve()).upper()
     assert desktop_runtime_setup._is_repo_local_llama_module(module_path, repo_root) is True
+
+
+def test_resolve_runtime_root_prefers_explicit_import_root_env(monkeypatch, tmp_path):
+    explicit_root = tmp_path / 'token-place-runtime'
+    explicit_root.mkdir(parents=True)
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(explicit_root))
+
+    resolved = desktop_runtime_setup._resolve_runtime_root()
+
+    assert resolved == explicit_root.resolve()
+
+
+def test_probe_uses_resolved_runtime_root_for_pythonpath_and_cwd(monkeypatch, tmp_path):
+    runtime_root = tmp_path / 'resources'
+    runtime_root.mkdir(parents=True)
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda: runtime_root)
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    captured = {}
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                'backend': 'cpu',
+                'gpu_offload_supported': False,
+                'detected_device': 'cpu',
+                'interpreter': sys.executable,
+                'prefix': sys.prefix,
+                'llama_module_path': 'missing',
+                'error': None,
+            }
+        )
+        stderr = ''
+
+    def _capture_run(*_args, **kwargs):
+        captured['cwd'] = kwargs['cwd']
+        captured['env'] = kwargs['env']
+        return _Result()
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _capture_run)
+
+    desktop_runtime_setup._probe_llama_runtime()
+
+    assert captured['cwd'] == str(runtime_root)
+    assert captured['env']['TOKEN_PLACE_PROBE_REPO_ROOT'] == str(runtime_root)
+    assert captured['env']['PYTHONPATH'].split(os.pathsep)[1] == str(runtime_root)


### PR DESCRIPTION
### Motivation
- The probe used by desktop sidecar/compute-node always used a hardcoded repo root (`parents[3]`), which can be incorrect in packaged desktop layouts and causes the probe/bootstrap to run from the wrong cwd and PYTHONPATH.
- When the runtime probe runs from the wrong root the bootstrap may attempt unnecessary or failing repair steps and block before emitting the first structured `started` event, leaving both inference and compute-node registration pending.
- The change makes the probe honor the import root set by the Tauri launcher so packaged launches probe the correct runtime layout and emit startup events promptly.

### Description
- Added `_resolve_runtime_root()` to `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` that prefers `TOKEN_PLACE_PYTHON_IMPORT_ROOT` and falls back to packaged/layout candidates when present.
- Updated `_probe_llama_runtime()` to use the resolved runtime root for `PYTHONPATH`, `TOKEN_PLACE_PROBE_REPO_ROOT`, and the probe subprocess `cwd` so imports and probe behavior align with the desktop import root.
- Updated `ensure_desktop_llama_runtime()` to use the same resolver for its default `target_root` selection, preserving consistent bootstrap behavior.
- Added two focused unit tests in `tests/unit/test_desktop_runtime_setup.py`: `test_resolve_runtime_root_prefers_explicit_import_root_env` and `test_probe_uses_resolved_runtime_root_for_pythonpath_and_cwd` and a small `os` import required by the tests.

### Testing
- Ran unit suites: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and observed all tests pass (`48 passed`).
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in this execution environment, so the hook was not executed here.
- Manual end-to-end verification against a real GGUF + local `relay.py` was not performed in this environment; verification was done via the updated unit tests that cover the resolved root behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e335efe990832fbb26fa2e165f41b6)