### PR TITLE
🐛 Fix relay signal shutdown deadlock

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -889,9 +889,7 @@ def serve(host: str, port: int) -> None:
     shutdown_requested = threading.Event()
 
     def _handle_signal(signum, _frame):
-        LOGGER.info("relay.shutdown_signal", extra={"signal": signum})
-        shutdown_requested.set()
-        server.shutdown()
+        _request_relay_shutdown(server, shutdown_requested, signum)
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
@@ -913,6 +911,30 @@ def serve(host: str, port: int) -> None:
             "relay.shutdown",
             extra={"requested": shutdown_requested.is_set()},
         )
+
+
+def _shutdown_server_async(server: Any) -> threading.Thread:
+    """Invoke server.shutdown() on a background daemon thread."""
+
+    thread = threading.Thread(
+        target=server.shutdown,
+        name="relay-server-shutdown",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _request_relay_shutdown(server: Any, shutdown_requested: threading.Event, signum: int) -> None:
+    """Initiate relay shutdown after receiving an OS signal."""
+
+    if shutdown_requested.is_set():
+        return
+
+    LOGGER.info("relay.shutdown_signal", extra={"signal": signum})
+    DRAINING.set()
+    shutdown_requested.set()
+    _shutdown_server_async(server)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/unit/test_relay_shutdown_signal.py
+++ b/tests/unit/test_relay_shutdown_signal.py
@@ -1,0 +1,58 @@
+"""Signal-driven shutdown behavior for the relay server."""
+
+from __future__ import annotations
+
+import signal
+import threading
+
+import pytest
+
+import relay
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.shutdown_calls = 0
+        self.shutdown_thread_ids: list[int] = []
+        self.shutdown_event = threading.Event()
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self.shutdown_thread_ids.append(threading.get_ident())
+        self.shutdown_event.set()
+
+
+@pytest.fixture()
+def _clear_draining_flag():
+    relay.DRAINING.clear()
+    yield
+    relay.DRAINING.clear()
+
+
+def test_request_relay_shutdown_sets_draining_and_runs_shutdown_async(_clear_draining_flag):
+    """SIGINT/SIGTERM should set draining state and call shutdown in another thread."""
+
+    fake_server = _FakeServer()
+    shutdown_requested = threading.Event()
+    calling_thread_id = threading.get_ident()
+
+    relay._request_relay_shutdown(fake_server, shutdown_requested, signal.SIGINT)
+
+    assert shutdown_requested.is_set() is True
+    assert relay.DRAINING.is_set() is True
+    assert fake_server.shutdown_event.wait(timeout=1.0) is True
+    assert fake_server.shutdown_calls == 1
+    assert fake_server.shutdown_thread_ids[0] != calling_thread_id
+
+
+def test_request_relay_shutdown_is_idempotent(_clear_draining_flag):
+    """Duplicate shutdown signals should not trigger repeated server shutdown calls."""
+
+    fake_server = _FakeServer()
+    shutdown_requested = threading.Event()
+
+    relay._request_relay_shutdown(fake_server, shutdown_requested, signal.SIGTERM)
+    assert fake_server.shutdown_event.wait(timeout=1.0) is True
+
+    relay._request_relay_shutdown(fake_server, shutdown_requested, signal.SIGINT)
+    assert fake_server.shutdown_calls == 1


### PR DESCRIPTION
### Motivation
- The relay process could hang after receiving SIGINT/SIGTERM because `server.shutdown()` was invoked directly from the signal handler while the server thread was running `serve_forever()`, preventing timely termination and readiness updates.

### Description
- Replace the inline signal handler inside `serve()` to call a new helper ` _request_relay_shutdown(server, shutdown_requested, signum)` instead of calling `server.shutdown()` directly.
- Add `_shutdown_server_async(server)` to invoke `server.shutdown()` on a background daemon thread and make shutdown initiation idempotent. 
- Ensure the global `DRAINING` flag is set immediately when a shutdown signal is requested so `/healthz` reflects draining right away. 
- Add regression tests in `tests/unit/test_relay_shutdown_signal.py` that assert async shutdown is performed on a separate thread and that duplicate signals are idempotent.

### Testing
- `python -m py_compile relay.py tests/unit/test_relay_shutdown_signal.py` succeeded.
- Attempting `pytest -q tests/unit/test_relay_shutdown_signal.py` in this environment failed due to a missing test dependency (`ModuleNotFoundError: No module named 'requests'` from `tests/conftest.py`).
- `pre-commit run --all-files` could not be executed in this environment because the `pre-commit` command is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41772687c832f951824eb24c3d523)