### PR TITLE
🐛 Fix relay SIGINT/SIGTERM shutdown deadlock

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -891,7 +891,13 @@ def serve(host: str, port: int) -> None:
     def _handle_signal(signum, _frame):
         LOGGER.info("relay.shutdown_signal", extra={"signal": signum})
         shutdown_requested.set()
-        server.shutdown()
+        # BaseServer.shutdown() must be invoked from a different thread than
+        # serve_forever() to avoid deadlocking while handling SIGINT/SIGTERM.
+        threading.Thread(
+            target=server.shutdown,
+            name="relay-shutdown",
+            daemon=True,
+        ).start()
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,10 +1,12 @@
 import pytest
 import time
 import base64
+from types import SimpleNamespace
 from flask import Flask
 import sys
 import os
 from datetime import datetime, timedelta
+from unittest.mock import Mock
 
 # Add project root to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -19,6 +21,7 @@ from relay import (
     streaming_sessions,
     streaming_sessions_by_client,
 )
+import relay
 
 # Generate dummy keys for testing
 # (You might want to use the generate_keys function from encrypt.py if needed)
@@ -358,6 +361,53 @@ def test_livez_remains_alive_when_draining(client):
 
     assert response.status_code == 200
     assert response.get_json()["status"] == "alive"
+
+
+def test_serve_signal_handler_runs_shutdown_off_main_thread(monkeypatch):
+    """Signal handler should request shutdown without deadlocking."""
+    fake_server = SimpleNamespace(
+        shutdown=Mock(),
+        serve_forever=Mock(),
+    )
+    fake_ctx = SimpleNamespace(push=Mock(), pop=Mock())
+
+    def fake_make_server(_host, _port, _app, threaded):
+        assert threaded is True
+        return fake_server
+
+    handlers = {}
+
+    def fake_signal(sig, handler):
+        handlers[sig] = handler
+
+    started = []
+
+    class _ImmediateThread:
+        def __init__(self, *, target, name, daemon):
+            self._target = target
+            self.name = name
+            self.daemon = daemon
+            started.append(self)
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(relay, "make_server", fake_make_server)
+    monkeypatch.setattr(relay.app, "app_context", lambda: fake_ctx)
+    monkeypatch.setattr(relay.signal, "signal", fake_signal)
+    monkeypatch.setattr(relay.threading, "Thread", _ImmediateThread)
+
+    def _trigger_signal():
+        handlers[relay.signal.SIGINT](relay.signal.SIGINT, None)
+
+    fake_server.serve_forever.side_effect = _trigger_signal
+
+    relay.serve("127.0.0.1", 5010)
+
+    fake_server.shutdown.assert_called_once_with()
+    assert len(started) == 1
+    assert started[0].name == "relay-shutdown"
+    assert started[0].daemon is True
 
 # --- Test /source ---
 


### PR DESCRIPTION
### Motivation
- Calling `BaseServer.shutdown()` directly from a signal handler can deadlock when the serving loop (`serve_forever()`) runs on the same thread, preventing `Ctrl+C`/`SIGTERM` from terminating the process promptly.
- Ensure the relay process enters draining and terminates quickly after receiving shutdown signals while preserving readiness/liveness behavior.
- Add regression coverage to prevent reintroduction of the deadlock in future changes.

### Description
- Change `serve()` signal handler to run `server.shutdown()` on a background daemon thread named `relay-shutdown` instead of calling it inline in the handler to avoid deadlocking the main serve thread (`relay.py`).
- Add a regression test `test_serve_signal_handler_runs_shutdown_off_main_thread` that monkeypatches `make_server`/`signal`/`Thread` to assert shutdown is invoked from a background thread and that `serve()` triggers the handler when `serve_forever()` receives a signal (`tests/test_relay.py`).
- Add small test imports and module-level `relay` reference required by the new regression test (`tests/test_relay.py`).

### Testing
- Ran `pytest -q tests/test_relay.py -k "serve_signal_handler_runs_shutdown_off_main_thread or healthz_returns_draining_when_shutdown_flag_set"`, which attempted to run the new regression test but failed to load test bootstrap due to a missing runtime dependency (`ModuleNotFoundError: No module named 'requests'`).
- Attempted `pre-commit run --all-files` which could not be executed in this environment because the `pre-commit` command is not installed.
- Secret-scan hook (`./scripts/scan-secrets.py`) is not present in this environment so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41772687c832f951824eb24c3d523)