### PR TITLE
🐛 Fix relay SIGINT shutdown deadlock

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -887,11 +887,25 @@ def serve(host: str, port: int) -> None:
     ctx.push()
 
     shutdown_requested = threading.Event()
+    shutdown_dispatched = threading.Event()
+
+    def _dispatch_server_shutdown() -> None:
+        """Request server shutdown without blocking the signal handler thread."""
+
+        if shutdown_dispatched.is_set():
+            return
+        shutdown_dispatched.set()
+        threading.Thread(
+            target=server.shutdown,
+            name="relay-server-shutdown",
+            daemon=True,
+        ).start()
 
     def _handle_signal(signum, _frame):
         LOGGER.info("relay.shutdown_signal", extra={"signal": signum})
+        DRAINING.set()
         shutdown_requested.set()
-        server.shutdown()
+        _dispatch_server_shutdown()
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
@@ -911,7 +925,10 @@ def serve(host: str, port: int) -> None:
         ctx.pop()
         LOGGER.info(
             "relay.shutdown",
-            extra={"requested": shutdown_requested.is_set()},
+            extra={
+                "requested": shutdown_requested.is_set(),
+                "dispatched": shutdown_dispatched.is_set(),
+            },
         )
 
 

--- a/tests/unit/test_relay_signal_shutdown.py
+++ b/tests/unit/test_relay_signal_shutdown.py
@@ -1,0 +1,63 @@
+"""Regression tests for relay signal-driven shutdown behavior."""
+
+from __future__ import annotations
+
+import signal
+import threading
+import time
+
+import relay
+
+
+def test_serve_sigint_handler_does_not_block_on_shutdown(monkeypatch) -> None:
+    """SIGINT should dispatch shutdown asynchronously so the handler returns quickly."""
+
+    captured_handler = None
+    shutdown_entered = threading.Event()
+    allow_shutdown_to_finish = threading.Event()
+
+    class FakeServer:
+        def shutdown(self) -> None:
+            shutdown_entered.set()
+            allow_shutdown_to_finish.wait(timeout=2)
+
+        def serve_forever(self) -> None:
+            # Simulate a running server that exits once shutdown starts.
+            shutdown_entered.wait(timeout=2)
+
+    class DummyAppContext:
+        def push(self) -> None:
+            return None
+
+        def pop(self) -> None:
+            return None
+
+    monkeypatch.setattr(relay, "make_server", lambda *_args, **_kwargs: FakeServer())
+    monkeypatch.setattr(relay.app, "app_context", lambda: DummyAppContext())
+
+    def fake_signal(sig, handler):
+        nonlocal captured_handler
+        if sig == signal.SIGINT:
+            captured_handler = handler
+        return handler
+
+    monkeypatch.setattr(relay.signal, "signal", fake_signal)
+
+    serve_thread = threading.Thread(target=relay.serve, args=("127.0.0.1", 0), daemon=True)
+    serve_thread.start()
+
+    deadline = time.time() + 1
+    while captured_handler is None and time.time() < deadline:
+        time.sleep(0.01)
+
+    assert captured_handler is not None
+
+    start = time.perf_counter()
+    captured_handler(signal.SIGINT, None)
+    duration = time.perf_counter() - start
+    assert duration < 0.2
+    assert shutdown_entered.wait(timeout=1)
+
+    allow_shutdown_to_finish.set()
+    serve_thread.join(timeout=1)
+    assert not serve_thread.is_alive()


### PR DESCRIPTION
### Motivation
- The relay process could log receipt of `SIGINT`/`SIGTERM` (e.g. when pressing Ctrl+C) but then hang because `server.shutdown()` was invoked inline from the signal handler and could block waiting on the serving loop. 
- Make termination responsive and observable while preserving draining state for readiness probes and logs.

### Description
- Move shutdown request off the signal handler stack by adding a `shutdown_dispatched` `threading.Event` and an `_dispatch_server_shutdown()` helper that spawns a daemon thread to call `server.shutdown()`.
- Update the runtime signal handler to set `DRAINING`, mark `shutdown_requested`, and call `_dispatch_server_shutdown()` instead of calling `server.shutdown()` inline.
- Emit `dispatched` alongside `requested` in the final `relay.shutdown` log for clearer telemetry.
- Add a regression test `tests/unit/test_relay_signal_shutdown.py` that monkeypatches `make_server` and `signal` to verify the handler returns quickly while shutdown executes asynchronously.

### Testing
- Ran `python -m py_compile relay.py tests/unit/test_relay_signal_shutdown.py`, which succeeded.
- Attempted `pytest -q tests/unit/test_relay_signal_shutdown.py`, which failed in this environment due to a missing dependency (`tests/conftest.py` imports `requests`), not due to the new test itself.
- `pre-commit run --all-files` was attempted but is not available in this environment (`pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41772687c832f951824eb24c3d523)