### PR TITLE
🐛 fix: unblock desktop operator relay registration and add detailed subprocess logs

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -43,6 +43,14 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 
 
+def log_stderr(event: str, **fields: Any) -> None:
+    payload = " ".join(f"{key}={fields[key]}" for key in sorted(fields))
+    if payload:
+        print(f"desktop.compute_node_bridge.{event} {payload}", file=sys.stderr)
+    else:
+        print(f"desktop.compute_node_bridge.{event}", file=sys.stderr)
+
+
 def _start_stdin_reader() -> None:
     global _stdin_reader_started
     with _stdin_reader_lock:
@@ -92,6 +100,13 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
+    log_stderr(
+        "startup",
+        relay_url=args.relay_url,
+        relay_port=args.relay_port,
+        mode=args.mode,
+        model=args.model,
+    )
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -122,6 +137,7 @@ def run(args: argparse.Namespace) -> int:
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
+    log_stderr("relay_target", relay_url=relay_url, relay_port=relay_port)
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(
@@ -133,16 +149,8 @@ def run(args: argparse.Namespace) -> int:
 
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
-
-    if not runtime.ensure_model_ready():
-        emit(
-            {
-                "type": "error",
-                "message": "failed to initialize model runtime",
-                "active_relay_url": runtime.relay_client.relay_url,
-            }
-        )
-        return 1
+    model_ready = False
+    model_init_attempted = False
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     last_error: Optional[str] = None
@@ -163,17 +171,37 @@ def run(args: argparse.Namespace) -> int:
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "model_path": args.model,
+            "model_runtime_ready": model_ready,
             "last_error": None,
         }
     )
 
     try:
         while not stop_requested():
+            log_stderr("poll.begin", active_relay_url=runtime.relay_client.relay_url)
             relay_response = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
             legacy_payload = is_legacy_relay_payload(relay_response)
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
             registered = "error" not in relay_response and (legacy_payload or heartbeat_ack)
+            log_stderr(
+                "poll.result",
+                active_relay_url=active_relay_url,
+                registered=registered,
+                has_error="error" in relay_response,
+                has_legacy_payload=legacy_payload,
+                heartbeat_ack=heartbeat_ack,
+            )
+
+            if not model_ready and (not model_init_attempted or legacy_payload):
+                model_init_attempted = True
+                log_stderr("model_init.begin", model=args.model, mode=args.mode)
+                model_ready = runtime.ensure_model_ready()
+                if model_ready:
+                    log_stderr("model_init.success")
+                else:
+                    last_error = "failed to initialize model runtime"
+                    log_stderr("model_init.failed", error=last_error)
 
             if not registered:
                 if "error" in relay_response:
@@ -184,11 +212,18 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
             elif legacy_payload:
-                processed = runtime.process_relay_request(relay_response)
-                if not processed:
-                    last_error = "failed to process relay request"
+                if not model_ready:
+                    last_error = "model runtime is not ready; cannot process relay request"
+                    log_stderr("request.skipped", reason=last_error)
                 else:
-                    last_error = None
+                    log_stderr("request.process.begin")
+                    processed = runtime.process_relay_request(relay_response)
+                    if not processed:
+                        last_error = "failed to process relay request"
+                        log_stderr("request.process.failed", error=last_error)
+                    else:
+                        last_error = None
+                        log_stderr("request.process.success")
             else:
                 last_error = None
 
@@ -212,11 +247,13 @@ def run(args: argparse.Namespace) -> int:
                     "interpreter": runtime_setup.get("interpreter", sys.executable),
                     "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
                     "model_path": args.model,
+                    "model_runtime_ready": model_ready,
                     "last_error": last_error,
                 }
             )
 
             wait_seconds = float(relay_response.get("next_ping_in_x_seconds", 1))
+            log_stderr("poll.sleep", seconds=wait_seconds)
             if _sleep_with_cancel(wait_seconds):
                 break
     finally:

--- a/outages/2026-04-18-desktop-tauri-operator-registration-blocked-by-model-init.json
+++ b/outages/2026-04-18-desktop-tauri-operator-registration-blocked-by-model-init.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-tauri-operator-registration-blocked-by-model-init",
+  "summary": "Desktop Tauri operator startup gated relay polling behind model initialization, causing operators to remain unregistered when model readiness was slow or failed.",
+  "impact": "Desktop compute nodes could appear running but fail to register against relay.py, preventing relay-routed inference.",
+  "fix": "Updated compute_node_bridge.py to enter relay polling/registration before model readiness, lazily initialize model runtime, and emit detailed phase-level diagnostics plus model_runtime_ready status metadata.",
+  "lessons": "Relay registration and model runtime readiness must be decoupled and independently observable in logs and status events."
+}

--- a/outages/2026-04-18-desktop-tauri-operator-registration-blocked-by-model-init.md
+++ b/outages/2026-04-18-desktop-tauri-operator-registration-blocked-by-model-init.md
@@ -1,0 +1,40 @@
+# Outage: desktop-tauri operator registration was blocked by model initialization
+
+- **Date:** 2026-04-18
+- **Severity:** medium
+- **Status:** resolved
+
+## Summary
+Desktop Tauri operator startup attempted to fully initialize `llama_cpp_python` before the first
+relay `/sink` poll. On slower model loads, backend fallback paths, or failed runtime initialization,
+the compute node never reached the relay registration loop in time, so UI state remained
+"Running: yes" and "Registered: no" even when `relay.py` was healthy on loopback/network targets.
+
+## Symptoms
+- Clicking **Start operator** left registration stuck at **no**.
+- Relay health checks were green, but no successful operator registration was observed.
+- Desktop command-line output lacked enough phase-level diagnostics to pinpoint where startup was
+  blocked.
+
+## Impact
+Desktop operators could appear online locally while never participating in relay request routing,
+which prevented inference dispatch through the operator path.
+
+## Root cause
+The bridge startup sequence in `compute_node_bridge.py` performed `runtime.ensure_model_ready()` as
+a hard gate before any relay registration/poll work. This coupled relay liveness to model runtime
+initialization and made relay registration contingent on local model readiness.
+
+## Fix
+- Moved model readiness to a lazy path inside the polling loop so relay registration can happen
+  immediately.
+- Added phase-level stderr diagnostics for startup, relay targeting, poll begin/result/sleep, model
+  initialization begin/success/failure, and request-processing begin/success/failure/skip.
+- Extended status payloads with `model_runtime_ready` so UI/diagnostics can distinguish "registered
+  but model not ready" from transport failures.
+
+## Follow-up / prevention
+- Keep relay registration and model readiness as independently observable states.
+- Ensure desktop bridge startup logs include every critical hand-off: runtime setup, relay
+  registration attempt, and inference processing lifecycle.
+- Maintain regression tests that verify registration can succeed even when model initialization fails.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -274,6 +274,13 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
             return False
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRuntime)
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
 
     args = SimpleNamespace(
         model='/tmp/model.gguf',
@@ -283,10 +290,13 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     )
     status = compute_node_bridge.run(args)
 
-    assert status == 1
-    payload = json.loads(capsys.readouterr().out.strip())
-    assert payload['type'] == 'error'
-    assert 'failed to initialize model runtime' in payload['message']
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+    status_events = [event for event in events if event['type'] == 'status']
+    assert status_events
+    assert status_events[0]['model_runtime_ready'] is False
+    assert status_events[0]['registered'] is True
 
 
 def test_run_allows_runtime_reexec_when_cuda_runtime_is_repaired(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Operators were stuck `Running: yes` but `Registered: no` because `compute_node_bridge.run` blocked relay `/sink` registration behind `runtime.ensure_model_ready()` when model init was slow or failed.  This reduced reliability and made debugging relay/sidecar handoffs difficult. 
- Improve runtime visibility so the desktop CLI window and Tauri UI can show precise phase-level diagnostics for relay registration, polling, and LLM runtime lifecycle.

### Description
- Decoupled relay registration from model bootstrap by removing the hard `runtime.ensure_model_ready()` gate at startup and performing lazy model initialization inside the polling loop (added `model_ready` / `model_init_attempted` logic). 
- Added `log_stderr` helper and emitted phase-level stderr diagnostics for `startup`, `relay_target`, `poll.begin`, `poll.result`, `model_init.begin`, `model_init.success`, `model_init.failed`, `request.process.begin`, `request.process.success`, `request.process.failed`, `request.skipped`, and `poll.sleep` to aid CLI/Tauri debugging. 
- Extended emitted status payloads with `model_runtime_ready` so UI/state consumers can distinguish transport registration from model readiness. 
- Updated `tests/unit/test_desktop_compute_node_bridge.py` to exercise the model-init-failure case and assert the bridge still enters the relay polling path and emits `model_runtime_ready: false`. 
- Added outage documentation files `outages/2026-04-18-desktop-tauri-operator-registration-blocked-by-model-init.md` and `.json` describing the incident and remediation.

### Testing
- Ran `pytest -q tests/unit/test_desktop_compute_node_bridge.py` in this environment but the run failed due to the test harness requiring the `requests` dependency from `tests/conftest.py` (error: `ModuleNotFoundError: No module named 'requests'`).
- Attempted `pre-commit run --all-files` in this environment but the `pre-commit` command was not available; ensure CI runs `pre-commit` and `npm run test:ci` prior to merge. 
- The modified unit test file adds coverage for the new behavior (bridge can register while `model_runtime_ready` is false) and should pass in CI where test deps are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41898357c832f80c7d984a4c83a3e)