### PR TITLE
Fix desktop operator relay registration regression and expand bridge diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -11,6 +11,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 if __package__ in (None, ""):
     script_dir = str(Path(__file__).resolve().parent)
@@ -52,7 +53,23 @@ def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
     if isinstance(raw_error, str):
         normalized = raw_error.strip()
         return normalized or None
+    if not raw_error:
+        return None
     return str(raw_error)
+
+
+def _sanitize_relay_target(relay_url: Any) -> str:
+    """Return a redacted relay target that never includes userinfo/query/fragment."""
+
+    if not isinstance(relay_url, str):
+        return "unknown"
+
+    parsed = urlsplit(relay_url.strip())
+    if not parsed.scheme or not parsed.hostname:
+        return "unknown"
+
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunsplit((parsed.scheme, f"{parsed.hostname}{port}", "", "", ""))
 
 
 def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
@@ -157,7 +174,9 @@ def run(args: argparse.Namespace) -> int:
     relay_port = resolve_relay_port(args.relay_port, relay_url)
     print(
         "desktop.compute_node_bridge.start "
-        f"model={args.model} mode={args.mode} relay_url={relay_url} relay_port={relay_port or 'none'}",
+        f"model={args.model} mode={args.mode} "
+        f"relay_url={_sanitize_relay_target(relay_url)} "
+        f"relay_port={relay_port if relay_port is not None else 'none'}",
         file=sys.stderr,
     )
 
@@ -219,7 +238,7 @@ def run(args: argparse.Namespace) -> int:
 
             print(
                 "desktop.compute_node_bridge.relay_poll "
-                f"relay={active_relay_url} registered={registered} "
+                f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
                 f"legacy_payload={legacy_payload} heartbeat_ack={heartbeat_ack} "
                 f"summary={_relay_response_summary(relay_response)}",
                 file=sys.stderr,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -93,6 +93,22 @@ def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
     )
 
 
+def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
+    """Return a compact runtime diagnostics summary for stderr logging."""
+
+    return (
+        "desktop.compute_node_bridge.runtime_state "
+        f"requested_mode={diagnostics.get('requested_mode')} "
+        f"effective_mode={diagnostics.get('effective_mode')} "
+        f"backend_selected={diagnostics.get('backend_selected')} "
+        f"backend_used={diagnostics.get('backend_used')} "
+        f"backend_available={diagnostics.get('backend_available')} "
+        f"fallback_reason={diagnostics.get('fallback_reason') or 'none'} "
+        f"offloaded_layers={diagnostics.get('offloaded_layers', diagnostics.get('n_gpu_layers'))} "
+        f"kv_cache_device={diagnostics.get('kv_cache_device') or 'unknown'}"
+    )
+
+
 def _start_stdin_reader() -> None:
     global _stdin_reader_started
     with _stdin_reader_lock:
@@ -179,6 +195,11 @@ def run(args: argparse.Namespace) -> int:
         f"relay_port={relay_port if relay_port is not None else 'none'}",
         file=sys.stderr,
     )
+    print(
+        "desktop.compute_node_bridge.relay_target.resolved "
+        f"relay={_sanitize_relay_target(relay_url)}",
+        file=sys.stderr,
+    )
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(
@@ -205,6 +226,7 @@ def run(args: argparse.Namespace) -> int:
 
     print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
+    print(_runtime_diagnostics_summary(diagnostics), file=sys.stderr)
     last_error: Optional[str] = None
     emit(
         {

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -43,6 +43,39 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 
 
+def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
+    """Return a normalized relay error message if the response includes one."""
+
+    raw_error = relay_response.get("error")
+    if raw_error is None:
+        return None
+    if isinstance(raw_error, str):
+        normalized = raw_error.strip()
+        return normalized or None
+    return str(raw_error)
+
+
+def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
+    """Return a compact summary string for relay registration diagnostics."""
+
+    if not isinstance(relay_response, dict):
+        return f"non-dict response type={type(relay_response).__name__}"
+
+    keys = sorted(relay_response.keys())
+    has_payload = all(
+        key in relay_response for key in ("client_public_key", "chat_history", "cipherkey", "iv")
+    )
+    has_heartbeat = "next_ping_in_x_seconds" in relay_response
+    relay_error = _relay_error_message(relay_response)
+    wait_seconds = relay_response.get("next_ping_in_x_seconds", "missing")
+
+    return (
+        f"keys={keys} has_legacy_payload={has_payload} "
+        f"has_heartbeat={has_heartbeat} wait={wait_seconds} "
+        f"error={relay_error or 'none'}"
+    )
+
+
 def _start_stdin_reader() -> None:
     global _stdin_reader_started
     with _stdin_reader_lock:
@@ -122,6 +155,11 @@ def run(args: argparse.Namespace) -> int:
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
+    print(
+        "desktop.compute_node_bridge.start "
+        f"model={args.model} mode={args.mode} relay_url={relay_url} relay_port={relay_port or 'none'}",
+        file=sys.stderr,
+    )
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(
@@ -134,6 +172,7 @@ def run(args: argparse.Namespace) -> int:
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
 
+    print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
     if not runtime.ensure_model_ready():
         emit(
             {
@@ -142,8 +181,10 @@ def run(args: argparse.Namespace) -> int:
                 "active_relay_url": runtime.relay_client.relay_url,
             }
         )
+        print("desktop.compute_node_bridge.model_init.failed", file=sys.stderr)
         return 1
 
+    print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     last_error: Optional[str] = None
     emit(
@@ -173,22 +214,44 @@ def run(args: argparse.Namespace) -> int:
             active_relay_url = runtime.relay_client.relay_url
             legacy_payload = is_legacy_relay_payload(relay_response)
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
-            registered = "error" not in relay_response and (legacy_payload or heartbeat_ack)
+            relay_error = _relay_error_message(relay_response)
+            registered = relay_error is None and (legacy_payload or heartbeat_ack)
+
+            print(
+                "desktop.compute_node_bridge.relay_poll "
+                f"relay={active_relay_url} registered={registered} "
+                f"legacy_payload={legacy_payload} heartbeat_ack={heartbeat_ack} "
+                f"summary={_relay_response_summary(relay_response)}",
+                file=sys.stderr,
+            )
 
             if not registered:
-                if "error" in relay_response:
-                    last_error = str(relay_response.get("error", "relay registration failed"))
+                if relay_error is not None:
+                    last_error = relay_error
                 else:
                     last_error = (
                         "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
                         "operator; update relay.py to repo HEAD"
                     )
             elif legacy_payload:
+                print(
+                    "desktop.compute_node_bridge.process_request.start "
+                    f"stream={relay_response.get('stream') is True}",
+                    file=sys.stderr,
+                )
                 processed = runtime.process_relay_request(relay_response)
                 if not processed:
                     last_error = "failed to process relay request"
+                    print(
+                        "desktop.compute_node_bridge.process_request.failed",
+                        file=sys.stderr,
+                    )
                 else:
                     last_error = None
+                    print(
+                        "desktop.compute_node_bridge.process_request.ok",
+                        file=sys.stderr,
+                    )
             else:
                 last_error = None
 
@@ -220,6 +283,7 @@ def run(args: argparse.Namespace) -> int:
             if _sleep_with_cancel(wait_seconds):
                 break
     finally:
+        print("desktop.compute_node_bridge.stop", file=sys.stderr)
         runtime.stop()
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)

--- a/outages/2026-04-18-desktop-tauri-operator-relay-registration-regression.json
+++ b/outages/2026-04-18-desktop-tauri-operator-relay-registration-regression.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-tauri-operator-relay-registration-regression",
+  "summary": "Desktop operator registration could remain false when relay heartbeats included a nullable error field, and subprocess stderr lacked sufficient diagnostics to explain registration/runtime state transitions.",
+  "impact": "Desktop users saw Running=yes but Registered=no and had limited visibility into relay handshake and llama runtime setup progress.",
+  "fix": "Normalized relay error handling to treat null/empty error fields as non-errors when heartbeat responses are present, and added detailed compute-node bridge stderr logs for startup args, model init, relay polling summaries, request processing outcomes, and shutdown lifecycle.",
+  "lessons": "Operator registration logic must distinguish nullable metadata from actionable errors, and desktop child-process logs should include explicit, structured milestones for relay handshakes and llama runtime setup/invocation."
+}

--- a/outages/2026-04-18-desktop-tauri-operator-relay-registration-regression.md
+++ b/outages/2026-04-18-desktop-tauri-operator-relay-registration-regression.md
@@ -1,0 +1,43 @@
+# Outage: desktop-tauri operator failed to show relay registration
+
+- **Date:** 2026-04-18
+- **Slug:** `desktop-tauri-operator-relay-registration-regression`
+- **Affected area:** desktop MVP operator flow (`desktop-v0.1.0`) with `relay.py` on loopback and LAN
+
+## Summary
+After clicking **Start operator** in the desktop app, the operator could remain in
+`Registered: no` even while relay heartbeats were being accepted.
+
+## Symptoms
+- UI stayed at `Registered: no` while `Running: yes`.
+- `Last error` could show relay incompatibility text despite relay being reachable.
+- Desktop command-line output lacked step-by-step registration diagnostics.
+
+## Impact
+Operators appeared offline, making local testing and network rollout look broken.
+Teams had limited visibility into whether failures came from relay connectivity,
+protocol mismatch, or runtime setup.
+
+## Root cause
+1. The desktop bridge registration check treated any presence of `error` as a hard
+   failure, even when relays returned heartbeat payloads with `"error": null`.
+2. Bridge stderr diagnostics were too sparse around registration polling,
+   request processing, and model/runtime initialization.
+
+## Remediation
+- Normalized relay error handling so `null`/empty `error` values are treated as
+  non-errors while valid heartbeat responses mark the operator as registered.
+- Added detailed bridge stderr instrumentation for:
+  - bridge startup arguments and relay target
+  - model runtime initialization start/ready/failure
+  - each relay poll summary (keys, heartbeat, payload, error, wait interval)
+  - request processing start/success/failure
+  - bridge shutdown
+- Kept existing `desktop.runtime_setup ...` output so llama-cpp runtime
+  selection and fallback details are visible alongside operator lifecycle logs.
+
+## Follow-up / prevention
+- Preserve regression coverage for heartbeat responses that include nullable
+  `error` fields.
+- Keep critical desktop↔relay and llama runtime transitions explicitly logged
+  on stderr for easy diagnosis in packaged app command windows.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -123,6 +123,19 @@ class ProcessingFailureRuntime(FakeRuntime):
         return False
 
 
+class NullErrorHeartbeatRuntime(FakeRuntime):
+    def __init__(self, _config):
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClient()
+        self._responses = [
+            {
+                'next_ping_in_x_seconds': 0,
+                'error': None,
+            },
+        ]
+        self._processed = []
+
+
 class IncompatibleRelayRuntime(FakeRuntime):
     def __init__(self, _config):
         self.model_manager = FakeModelManager()
@@ -393,6 +406,33 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
     status_events = [event for event in events if event['type'] == 'status']
     assert any(event.get('registered') is True for event in status_events)
 
+
+
+def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=NullErrorHeartbeatRuntime)
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    status_events = [event for event in events if event['type'] == 'status']
+    assert status_events
+    assert status_events[0]['registered'] is True
+    assert status_events[0]['last_error'] is None
 
 def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch):
     _reset_cancel_queue()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -144,6 +144,19 @@ class IncompatibleRelayRuntime(FakeRuntime):
         self._processed = []
 
 
+class FalseErrorHeartbeatRuntime(FakeRuntime):
+    def __init__(self, _config):
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClient()
+        self._responses = [
+            {
+                'next_ping_in_x_seconds': 0,
+                'error': False,
+            },
+        ]
+        self._processed = []
+
+
 def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
     module = ModuleType('utils.compute_node_runtime')
 
@@ -407,7 +420,6 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
     assert any(event.get('registered') is True for event in status_events)
 
 
-
 def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=NullErrorHeartbeatRuntime)
@@ -433,6 +445,34 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     assert status_events
     assert status_events[0]['registered'] is True
     assert status_events[0]['last_error'] is None
+
+
+def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FalseErrorHeartbeatRuntime)
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    status_events = [event for event in events if event['type'] == 'status']
+    assert status_events
+    assert status_events[0]['registered'] is True
+    assert status_events[0]['last_error'] is None
+
 
 def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch):
     _reset_cancel_queue()
@@ -802,3 +842,15 @@ def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch
     assert setup['runtime_action'] == 'unavailable'
     assert 'module missing' in setup['fallback_reason']
     assert module.maybe_reexec_for_runtime_refresh(setup, allow_reexec=False) is None
+
+
+def test_sanitize_relay_target_redacts_credentials_query_and_fragment():
+    sanitized = compute_node_bridge._sanitize_relay_target(
+        'https://user:pass@token.place:8443/sink?token=abc#debug'
+    )
+    assert sanitized == 'https://token.place:8443'
+
+
+def test_sanitize_relay_target_returns_unknown_for_invalid_values():
+    assert compute_node_bridge._sanitize_relay_target(None) == 'unknown'
+    assert compute_node_bridge._sanitize_relay_target('not-a-valid-url') == 'unknown'

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -440,11 +440,20 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     status = compute_node_bridge.run(args)
 
     assert status == 0
-    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
     assert status_events[0]['registered'] is True
     assert status_events[0]['last_error'] is None
+    stderr = output.err
+    assert 'desktop.compute_node_bridge.start' in stderr
+    assert 'desktop.compute_node_bridge.relay_target.resolved' in stderr
+    assert 'desktop.compute_node_bridge.model_init.start' in stderr
+    assert 'desktop.compute_node_bridge.model_init.ready' in stderr
+    assert 'desktop.compute_node_bridge.runtime_state' in stderr
+    assert 'desktop.compute_node_bridge.relay_poll' in stderr
+    assert 'desktop.compute_node_bridge.stop' in stderr
 
 
 def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- The desktop operator could stay `Registered: no` despite healthy relay heartbeats because the bridge treated any present `error` field (including `null`) as fatal, and command-window logs lacked the detail needed to debug tauri↔relay and llama runtime lifecycle transitions.
- Users needed richer, structured stderr diagnostics from the compute-node bridge to surface startup, model init, relay handshake, request-processing, and shutdown milestones for easier debugging in the desktop command window.

### Description
- Normalize relay error handling in `compute_node_bridge.py` so `error: null` / empty error values are treated as non-fatal and heartbeat-only `/sink` responses count as registration acks, preventing false `Registered: no` states.
- Add detailed, prefixed stderr diagnostics in `desktop-tauri/src-tauri/python/compute_node_bridge.py` for startup arguments, model initialization (`start/ready/failed`), per-poll relay summaries (keys, heartbeat, payload, error, wait interval), request-processing (`start/ok/failed`), and bridge shutdown.
- Add a unit regression (`tests/unit/test_desktop_compute_node_bridge.py`) covering heartbeat responses with `error: None` to prevent future regressions.
- Add an outages entry (`outages/2026-04-18-desktop-tauri-operator-relay-registration-regression.{md,json}`) documenting symptoms, root cause, remediation, impact, and follow-up notes.

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` and all tests in that module passed (15 passed). 
- Attempted full `pytest -q tests/unit/test_desktop_compute_node_bridge.py` but it failed in this environment due to a missing external `requests` dependency pulled in by the repo `conftest.py` (environment issue, not a regression in the changes). 
- `pre-commit run --all-files` and `git diff --cached | ./scripts/scan-secrets.py` were attempted but could not run in this environment because `pre-commit` is not installed and `./scripts/scan-secrets.py` is missing respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41898357c832f80c7d984a4c83a3e)