### PR TITLE
Fix desktop operator registration: bypass loopback proxy and add bridge diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -82,6 +82,12 @@ def emit(payload: Dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
+def log_debug(message: str) -> None:
+    """Emit bridge diagnostics to stderr for the desktop command-line window."""
+
+    print(f"desktop.compute_node.bridge {message}", file=sys.stderr, flush=True)
+
+
 def _sleep_with_cancel(seconds: float) -> bool:
     deadline = time.time() + max(seconds, 0)
     while time.time() < deadline:
@@ -92,10 +98,13 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
+    log_debug(
+        f"startup model={args.model} mode={args.mode} relay_url={args.relay_url} relay_port={args.relay_port}"
+    )
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
-    print(
-        "desktop.runtime_setup "
+    log_debug(
+        "runtime_setup "
         f"mode={args.mode} "
         f"selected_backend={runtime_setup.get('selected_backend', 'cpu')} "
         f"device={runtime_setup.get('detected_device', 'cpu')} "
@@ -103,7 +112,6 @@ def run(args: argparse.Namespace) -> int:
         f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
         f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
-        file=sys.stderr,
     )
 
     try:
@@ -122,6 +130,7 @@ def run(args: argparse.Namespace) -> int:
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
+    log_debug(f"relay_target resolved_url={relay_url} resolved_port={relay_port}")
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(
@@ -132,9 +141,12 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
+    log_debug(f"model_path configured model={runtime.model_manager.model_path}")
     apply_compute_mode(runtime.model_manager, args.mode)
+    log_debug(f"compute_mode_applied requested={args.mode}")
 
     if not runtime.ensure_model_ready():
+        log_debug("model_ready failed")
         emit(
             {
                 "type": "error",
@@ -143,8 +155,20 @@ def run(args: argparse.Namespace) -> int:
             }
         )
         return 1
+    log_debug("model_ready success")
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
+    log_debug(
+        "llama_diagnostics "
+        f"requested_mode={diagnostics.get('requested_mode')} "
+        f"effective_mode={diagnostics.get('effective_mode')} "
+        f"backend_available={diagnostics.get('backend_available')} "
+        f"backend_selected={diagnostics.get('backend_selected')} "
+        f"backend_used={diagnostics.get('backend_used')} "
+        f"offloaded_layers={diagnostics.get('offloaded_layers', diagnostics.get('n_gpu_layers'))} "
+        f"kv_cache_device={diagnostics.get('kv_cache_device')} "
+        f"fallback_reason={diagnostics.get('fallback_reason') or 'none'}"
+    )
     last_error: Optional[str] = None
     emit(
         {
@@ -169,26 +193,40 @@ def run(args: argparse.Namespace) -> int:
 
     try:
         while not stop_requested():
+            log_debug("relay_poll begin")
             relay_response = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
             legacy_payload = is_legacy_relay_payload(relay_response)
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
             registered = "error" not in relay_response and (legacy_payload or heartbeat_ack)
+            log_debug(
+                "relay_poll result "
+                f"active_relay_url={active_relay_url} "
+                f"registered={registered} "
+                f"legacy_payload={legacy_payload} "
+                f"heartbeat_ack={heartbeat_ack} "
+                f"keys={sorted(relay_response.keys())}"
+            )
 
             if not registered:
                 if "error" in relay_response:
                     last_error = str(relay_response.get("error", "relay registration failed"))
+                    log_debug(f"relay_poll registration_error error={last_error}")
                 else:
                     last_error = (
                         "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
                         "operator; update relay.py to repo HEAD"
                     )
+                    log_debug("relay_poll incompatible_response")
             elif legacy_payload:
+                log_debug("relay_request processing legacy payload")
                 processed = runtime.process_relay_request(relay_response)
                 if not processed:
                     last_error = "failed to process relay request"
+                    log_debug("relay_request processing_failed")
                 else:
                     last_error = None
+                    log_debug("relay_request processing_succeeded")
             else:
                 last_error = None
 
@@ -217,10 +255,14 @@ def run(args: argparse.Namespace) -> int:
             )
 
             wait_seconds = float(relay_response.get("next_ping_in_x_seconds", 1))
+            log_debug(f"relay_poll sleep seconds={wait_seconds}")
             if _sleep_with_cancel(wait_seconds):
+                log_debug("relay_poll cancellation_requested")
                 break
     finally:
+        log_debug("runtime.stop begin")
         runtime.stop()
+        log_debug("runtime.stop complete")
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     emit(
@@ -258,8 +300,10 @@ def main() -> int:
         from utils.compute_node_runtime import normalize_compute_mode
 
         args.mode = normalize_compute_mode(args.mode)
+        log_debug(f"args_normalized mode={args.mode}")
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
+        log_debug(f"fatal_error error={exc}")
         emit({"type": "error", "message": f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"})
         return 1
 

--- a/outages/2026-04-18-desktop-operator-relay-registration-stalled.json
+++ b/outages/2026-04-18-desktop-operator-relay-registration-stalled.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-18",
+  "slug": "desktop-operator-relay-registration-stalled",
+  "summary": "Desktop Start operator sessions could remain unregistered because loopback relay requests could inherit environment proxies instead of connecting directly to localhost, while command-line diagnostics were too limited to isolate the failure point quickly.",
+  "impact": "Operators could not reliably register with relay.py (especially on loopback) and had limited visibility into startup, registration, and llama runtime state during failures.",
+  "fix": "Bypassed HTTP(S) proxies for loopback relay targets in RelayClient and expanded compute-node bridge stderr diagnostics to cover startup parameters, runtime/llama setup, relay poll outcomes, registration errors, relay request handling, and shutdown flow.",
+  "lessons": "Desktop relay transport must explicitly handle loopback/proxy interactions, and every critical bridge-to-relay and llama runtime step should emit actionable diagnostics in the desktop command window."
+}

--- a/outages/2026-04-18-desktop-operator-relay-registration-stalled.md
+++ b/outages/2026-04-18-desktop-operator-relay-registration-stalled.md
@@ -1,0 +1,35 @@
+# Outage: desktop operator relay registration stalled after Start operator
+
+- **Date:** 2026-04-18
+- **Slug:** `desktop-operator-relay-registration-stalled`
+- **Affected area:** desktop-tauri compute node operator (`Start operator`) and relay connectivity diagnostics
+
+## Summary
+Desktop operator sessions could remain stuck at **Registered: no** even when users pointed the app
+at a running `relay.py` endpoint, including loopback targets like `http://127.0.0.1:<port>`.
+
+## Symptoms
+- `Start operator` transitioned to running, but registration never flipped to `yes`.
+- Desktop command-line logs were too sparse to pinpoint where the handshake failed.
+- Operators could not quickly determine whether failure came from relay connectivity,
+  relay compatibility, or runtime/model initialization.
+
+## Impact
+Desktop operators could not reliably register with local or network relays in environments
+with global HTTP(S) proxy settings, and troubleshooting required guesswork.
+
+## Root cause
+Relay client requests inherited environment proxy settings by default, which can route
+loopback relay URLs through a proxy instead of direct localhost transport.
+
+## Remediation
+- Force direct (no-proxy) transport for loopback relay targets in `RelayClient`.
+- Add detailed bridge stderr diagnostics for critical lifecycle points:
+  startup args, runtime/llama setup, relay polling outcomes, registration failures,
+  request processing, sleep/cancel, and shutdown.
+- Preserve unit coverage for loopback proxy bypass behavior.
+
+## Follow-up / prevention
+- Keep explicit transport diagnostics around relay `/sink` and `/source` interactions.
+- Keep model/runtime diagnostics visible so llama runtime fallback behavior is obvious.
+- Treat loopback registration as a required regression path for desktop operator changes.

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -256,6 +256,7 @@ class TestRelayClient:
         mock_post.assert_called_once_with(
             'http://localhost:5000/sink',
             json={'server_public_key': 'mock_public_key_b64'},
+            proxies={'http': None, 'https': None},
             timeout=relay_client._request_timeout
         )
 
@@ -737,8 +738,17 @@ class TestRelayClient:
         mock_post.assert_called_once_with(
             'http://localhost:5000/source',
             json=expected_payload,
+            proxies={'http': None, 'https': None},
             timeout=relay_client._request_timeout
         )
+
+    def test_request_kwargs_for_target_disables_proxy_for_loopback(self, relay_client):
+        kwargs = relay_client._request_kwargs_for_target('http://127.0.0.1:5000')
+        assert kwargs == {'proxies': {'http': None, 'https': None}}
+
+    def test_request_kwargs_for_target_keeps_network_targets_default(self, relay_client):
+        kwargs = relay_client._request_kwargs_for_target('https://token.place')
+        assert kwargs == {}
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_rejects_mismatched_bound_client_key(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -430,6 +430,17 @@ class RelayClient:
             return {}
         return {"X-Relay-Server-Token": self._registration_token}
 
+    def _request_kwargs_for_target(self, relay_url: str) -> Dict[str, Any]:
+        """Return per-target request kwargs (for example proxy bypass on loopback)."""
+
+        if not self._is_local_url(relay_url):
+            return {}
+
+        # Avoid routing loopback relay requests through system HTTP(S) proxies.
+        # This is especially important on desktop hosts where global proxy env
+        # variables are frequently configured by enterprise tooling.
+        return {'proxies': {'http': None, 'https': None}}
+
     def start(self):
         """Start the polling loop by setting stop_polling to False"""
         self.stop_polling = False
@@ -478,6 +489,7 @@ class RelayClient:
                 response = requests.post(
                     f'{candidate_url}/sink',
                     timeout=timeout,
+                    **self._request_kwargs_for_target(candidate_url),
                     **request_kwargs,
                 )
 
@@ -600,6 +612,7 @@ class RelayClient:
                 stream_response = requests.post(
                     f'{self.relay_url}/stream/source',
                     timeout=timeout,
+                    **self._request_kwargs_for_target(self.relay_url),
                     **request_kwargs,
                 )
                 if stream_response.status_code != 200:
@@ -642,6 +655,7 @@ class RelayClient:
             source_response = requests.post(
                 f'{self.relay_url}/source',
                 timeout=timeout,
+                **self._request_kwargs_for_target(self.relay_url),
                 **request_kwargs
             )
 


### PR DESCRIPTION
### Motivation
- `Start operator` could remain `Registered: no` when pointed at a running local `relay.py` because loopback relay requests were routed through system HTTP(S) proxies. 
- The desktop command-line window lacked actionable diagnostics for key lifecycle points between the Tauri host, the Python bridge, and the relay, making troubleshooting difficult.
- A reproducible regression and outage record was required for tracking and follow-up.

### Description
- Added loopback proxy bypass in `RelayClient` by introducing `_request_kwargs_for_target` and supplying `proxies: {'http': None, 'https': None}` for local URLs so `/sink`, `/source`, and `/stream/source` requests use direct transport instead of inheriting system proxies (`utils/networking/relay_client.py`).
- Emitted detailed debug diagnostics from the desktop compute-node bridge to `stderr` with a new `log_debug` helper and logs at critical points including startup args, runtime/llama setup, relay target resolution, model readiness, relay poll results, registration errors, request processing outcomes, sleep/cancel, and shutdown (`desktop-tauri/src-tauri/python/compute_node_bridge.py`).
- Updated unit tests to assert loopback proxy-bypass behavior and adjusted existing `ping_relay`/`process_client_request` expectations to include per-target request kwargs (`tests/unit/test_relay_client.py`).
- Added an outage report documenting the regression and remediation (`outages/2026-04-18-desktop-operator-relay-registration-stalled.md` and `.json`).

### Testing
- Ran static compile checks: `python -m py_compile desktop-tauri/src-tauri/python/compute_node_bridge.py utils/networking/relay_client.py tests/unit/test_relay_client.py` which succeeded. 
- Attempted unit test run `python -m pytest tests/unit/test_relay_client.py tests/unit/test_desktop_compute_node_bridge.py` but execution environment lacked the `requests` dependency, causing `ModuleNotFoundError: No module named 'requests'` and preventing full test execution. 
- `pre-commit run --all-files` could not be run in this environment because `pre-commit` is not installed, and repository secret-scan hook could not be executed due to missing `./scripts/scan-secrets.py` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41898357c832f80c7d984a4c83a3e)