### PR TITLE
Gate desktop runtime auto-repair behind opt-in to avoid startup stalls

### DIFF
--- a/desktop-tauri/scripts/verify_desktop_runtime.py
+++ b/desktop-tauri/scripts/verify_desktop_runtime.py
@@ -27,7 +27,10 @@ def main() -> int:
     repo_llama_shim = str((repo_root / 'llama_cpp.py').resolve())
 
     from utils.llm.model_manager import detect_llama_runtime_capabilities
-    from desktop_runtime_setup import ensure_desktop_llama_runtime
+    from desktop_runtime_setup import ENABLE_BOOTSTRAP_ENV, ensure_desktop_llama_runtime
+
+    # This manual verification flow is an explicit runtime-repair entrypoint.
+    os.environ.setdefault(ENABLE_BOOTSTRAP_ENV, '1')
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode, repo_root=repo_root)
     runtime = detect_llama_runtime_capabilities()

--- a/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
+++ b/desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py
@@ -35,10 +35,11 @@ def _offloaded_layer_count(value: Any) -> int:
 
 
 def _load_compute_runtime_diagnostics(model_path: str, mode: str) -> dict[str, Any]:
-    from desktop_runtime_setup import ensure_desktop_llama_runtime
+    from desktop_runtime_setup import ENABLE_BOOTSTRAP_ENV, ensure_desktop_llama_runtime
     from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
     from utils.llm.model_manager import get_model_manager
 
+    os.environ.setdefault(ENABLE_BOOTSTRAP_ENV, '1')
     runtime_setup = ensure_desktop_llama_runtime(mode)
 
     manager = get_model_manager()

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -35,6 +35,7 @@ PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 INSTALL_ERROR_SUMMARY_MAX_LEN = 512
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
+ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
 
 _PROBE_SNIPPET = """
@@ -412,6 +413,17 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "selected_backend": "cpu",
             "fallback_reason": (
                 f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
+            ),
+            "runtime_action": "probe_only",
+            **_probe_result_payload(before),
+        }
+
+    if os.getenv(ENABLE_BOOTSTRAP_ENV) != "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                "desktop runtime bootstrap skipped during normal startup; set "
+                f"{ENABLE_BOOTSTRAP_ENV}=1 to allow runtime repair/install"
             ),
             "runtime_action": "probe_only",
             **_probe_result_payload(before),

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -382,6 +382,46 @@ def test_run_continues_when_runtime_setup_reports_missing_packaged_requirements(
     assert '[Errno 2]' not in json.dumps(events)
 
 
+def test_run_probe_only_runtime_setup_does_not_trigger_repair_reexec(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    reexec_calls = []
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cpu',
+            'runtime_action': 'probe_only',
+            'fallback_reason': 'startup default is probe-only without bootstrap opt-in',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'maybe_reexec_for_runtime_refresh',
+        lambda setup, *, allow_reexec=True: reexec_calls.append(
+            (setup.get('runtime_action'), allow_reexec)
+        ),
+    )
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+    assert events[-1]['type'] == 'stopped'
+    assert reexec_calls == [('probe_only', True)]
+
+
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -89,11 +89,16 @@ class FakeLongStreamLlm:
 @pytest.fixture(autouse=True)
 def restore_model_manager_module():
     original = sys.modules.get('utils.llm.model_manager')
+    original_compute_runtime = sys.modules.get('utils.compute_node_runtime')
     yield
     if original is None:
         sys.modules.pop('utils.llm.model_manager', None)
     else:
         sys.modules['utils.llm.model_manager'] = original
+    if original_compute_runtime is None:
+        sys.modules.pop('utils.compute_node_runtime', None)
+    else:
+        sys.modules['utils.compute_node_runtime'] = original_compute_runtime
 
 
 def _install_fake_manager_module(manager):
@@ -107,6 +112,41 @@ def _install_fake_manager_module(manager):
 
     module.ModelManager = _ModelManager
     sys.modules['utils.llm.model_manager'] = module
+
+    compute_module = ModuleType('utils.compute_node_runtime')
+    supported_modes = {'auto', 'cpu', 'gpu', 'hybrid'}
+    aliases = {'cuda': 'gpu', 'metal': 'gpu'}
+
+    def _normalize(mode):
+        normalized = aliases.get(str(mode).lower(), str(mode).lower())
+        return normalized if normalized in supported_modes else 'auto'
+
+    def _apply_compute_mode(model_manager, mode):
+        normalized = _normalize(mode)
+        if normalized == 'cpu':
+            model_manager.default_n_gpu_layers = 0
+        elif normalized == 'hybrid':
+            model_manager.default_n_gpu_layers = 24
+        else:
+            model_manager.default_n_gpu_layers = -1
+        model_manager.requested_compute_mode = normalized
+        return normalized
+
+    def _compute_mode_diagnostics(model_manager):
+        requested_mode = getattr(model_manager, 'requested_compute_mode', 'auto')
+        effective_mode = 'cpu' if requested_mode == 'cpu' else 'gpu'
+        return {
+            'requested_mode': requested_mode,
+            'effective_mode': effective_mode,
+            'backend_used': effective_mode,
+            'n_gpu_layers': model_manager.default_n_gpu_layers,
+            'fallback_reason': None,
+        }
+
+    compute_module.normalize_compute_mode = _normalize
+    compute_module.apply_compute_mode = _apply_compute_mode
+    compute_module.compute_mode_diagnostics = _compute_mode_diagnostics
+    sys.modules['utils.compute_node_runtime'] = compute_module
 
 
 def _reset_cancel_queue():
@@ -352,6 +392,7 @@ def test_main_emits_inference_failed_when_compute_runtime_missing(capsys, monkey
 
 def test_main_normalizes_mode_before_run(monkeypatch):
     captured = {}
+    _install_fake_manager_module(FakeManager())
 
     def fake_run(args):
         captured['mode'] = args.mode
@@ -491,3 +532,64 @@ def test_run_done_without_token_when_stream_and_fallback_are_empty(tmp_path, cap
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert [event['type'] for event in events] == ['started', 'done']
+
+
+def test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_work(
+    tmp_path, capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+
+    runtime_setup_module = sys.modules['desktop_runtime_setup']
+
+    class _WinSysStub:
+        platform = 'win32'
+        executable = sys.executable
+
+    probe = runtime_setup_module.RuntimeProbe(
+        backend='cpu',
+        detected_device='cpu',
+        gpu_offload_supported=False,
+        error='missing cuda runtime',
+        interpreter=sys.executable,
+        llama_module_path='missing',
+        prefix='',
+    )
+    repair_calls = {'source': 0, 'retry_gate': 0}
+
+    monkeypatch.setattr(runtime_setup_module, 'sys', _WinSysStub)
+    monkeypatch.delenv(runtime_setup_module.DISABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.delenv(runtime_setup_module.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(runtime_setup_module, '_probe_llama_runtime', lambda **_: probe)
+    monkeypatch.setattr(
+        runtime_setup_module,
+        '_windows_cuda_source_repair',
+        lambda _requirements_path: (
+            repair_calls.__setitem__('source', repair_calls['source'] + 1) or True,
+            'ok',
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_setup_module,
+        '_should_attempt_source_repair',
+        lambda: (
+            repair_calls.__setitem__('retry_gate', repair_calls['retry_gate'] + 1) or True,
+            '',
+        ),
+    )
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 0
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.out.splitlines()]
+    assert events[0]['type'] == 'started'
+    assert events[-1]['type'] == 'done'
+    assert 'desktop.runtime_setup' in captured.err
+    assert 'action=probe_only' in captured.err
+    assert repair_calls == {'source': 0, 'retry_gate': 0}

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -49,6 +49,7 @@ def test_skip_runtime_bootstrap_for_cpu_mode(monkeypatch):
 
 def test_windows_runtime_bootstrap_auto_repairs_and_requests_reexec(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
@@ -134,6 +135,7 @@ def test_ensure_runtime_uses_custom_repo_root_for_initial_probe_and_post_repair_
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
@@ -196,6 +198,7 @@ def test_probe_uses_resolved_runtime_root_for_subprocess_cwd_and_pythonpath(monk
 
 def test_windows_runtime_bootstrap_surfaces_source_repair_detail_when_probe_stays_cpu(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     captured = {}
 
@@ -234,6 +237,7 @@ def test_runtime_bootstrap_noop_when_gpu_runtime_is_already_present(monkeypatch)
 
 def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
@@ -298,8 +302,28 @@ def test_windows_runtime_bootstrap_respects_opt_out_env(monkeypatch):
     assert invoked['source_repair'] is False
 
 
+def test_windows_runtime_bootstrap_defaults_to_probe_only_without_opt_in(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
+    monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    invoked = {'source_repair': False}
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_windows_cuda_source_repair',
+        lambda _requirements_path: (invoked.update(source_repair=True), '') and (False, 'unexpected call'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+
+    assert result['runtime_action'] == 'probe_only'
+    assert desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert invoked['source_repair'] is False
+
+
 def test_windows_runtime_bootstrap_success_reexec_is_guarded_to_one_attempt(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
@@ -477,6 +501,7 @@ def test_maybe_reexec_for_runtime_refresh_handles_execve_oserror(monkeypatch):
 
 def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     state_path = tmp_path / 'runtime_state.json'
     monkeypatch.setattr(desktop_runtime_setup, '_runtime_state_path', lambda: state_path)
     now = 1_000.0
@@ -680,6 +705,7 @@ def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp
 
 def test_windows_packaged_layout_without_requirements_falls_back_without_exception(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
@@ -717,6 +743,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
     monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
@@ -742,6 +769,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
 
 def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
     plans = [


### PR DESCRIPTION
### Motivation
- The desktop bridge and sidecar call `ensure_desktop_llama_runtime(...)` before emitting any startup events, which allowed heavyweight Windows GPU repair/install flows to run during normal startup and stall the process indefinitely. 
- This early blocking runtime bootstrap is the real cause of the UI/operator hang (bridge never reached `started`/poll loop); PR 760 fixed late relay heartbeat handling but did not address this earlier bootstrap stall. 
- We need a minimal, deterministic change so ordinary desktop launches are fast and only explicit repair flows perform long-running installs/rebuilds.

### Description
- Add an explicit opt-in environment gate `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` and define `ENABLE_BOOTSTRAP_ENV` in `desktop_runtime_setup.py`. 
- On Windows, if the opt-in is not set, `ensure_desktop_llama_runtime` returns probe-only immediately with a clear `fallback_reason` and `runtime_action='probe_only'`, avoiding implicit pip/source-build/reexec work during normal startup. 
- Preserve the existing repair/install + re-exec behavior when `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` so dedicated repair flows continue to work. 
- Update unit tests in `tests/unit/test_desktop_runtime_setup.py` to opt-in where necessary and add `test_windows_runtime_bootstrap_defaults_to_probe_only_without_opt_in` to cover the new default fast-path.

### Testing
- Ran unit tests: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py`, result: 59 passed. 
- Verified Python modules compile: `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py`, result: success. 
- Attempted Rust unit tests: `cd desktop-tauri/src-tauri && cargo test` failed in CI environment due to missing system `glib-2.0` / pkg-config dependency (environment limitation). 
- Attempted frontend tests: `cd desktop-tauri && npm test -- --runInBand` failed in this environment because the vitest runner does not accept `--runInBand` (flag incompatibility).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48187ba28832fb596ce0f533ef75a)