### PR TITLE
Make desktop runtime bootstrap opt-in to avoid startup hangs

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -38,17 +38,17 @@ npm ci
 npm run tauri dev
 ```
 
-During normal startup, desktop sidecars probe the active sidecar interpreter and, on
-Windows in `auto`/`gpu`/`hybrid` modes, automatically run a one-time CUDA runtime
-repair when the runtime is CPU-only. They emit:
+During normal startup, desktop sidecars probe the active sidecar interpreter and
+emit:
 
 - `desktop.runtime_setup ...` during sidecar start (backend selected + fallback reason)
 - `compute_runtime ...` after `Llama(...)` init (backend actually used, offloaded
   layers, KV cache placement, and fallback reason)
 
-Set `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1` to explicitly disable the
-Windows auto-repair path and keep startup in probe-only mode (useful for
-packaging/troubleshooting while preserving normal CPU fallback diagnostics).
+By default, startup is probe-only (no install/repair work before first structured
+events). Set `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` to opt into Windows
+runtime repair/install during startup for `auto`/`gpu`/`hybrid` mode. You can still
+force probe-only mode with `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1`.
 
 When Windows CUDA repair is needed, desktop uses the same interpreter binary that
 launches the sidecar process (`sys.executable`) and applies the repo

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -35,6 +35,7 @@ PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 INSTALL_ERROR_SUMMARY_MAX_LEN = 512
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
+ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
 
 _PROBE_SNIPPET = """
@@ -412,6 +413,17 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "selected_backend": "cpu",
             "fallback_reason": (
                 f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
+            ),
+            "runtime_action": "probe_only",
+            **_probe_result_payload(before),
+        }
+
+    if os.getenv(ENABLE_BOOTSTRAP_ENV) != "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                f"desktop runtime bootstrap skipped by default; set {ENABLE_BOOTSTRAP_ENV}=1 "
+                "to enable install/repair during startup"
             ),
             "runtime_action": "probe_only",
             **_probe_result_payload(before),

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -49,6 +49,7 @@ def test_skip_runtime_bootstrap_for_cpu_mode(monkeypatch):
 
 def test_windows_runtime_bootstrap_auto_repairs_and_requests_reexec(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
@@ -134,6 +135,7 @@ def test_ensure_runtime_uses_custom_repo_root_for_initial_probe_and_post_repair_
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
@@ -196,6 +198,7 @@ def test_probe_uses_resolved_runtime_root_for_subprocess_cwd_and_pythonpath(monk
 
 def test_windows_runtime_bootstrap_surfaces_source_repair_detail_when_probe_stays_cpu(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     captured = {}
 
@@ -232,8 +235,28 @@ def test_runtime_bootstrap_noop_when_gpu_runtime_is_already_present(monkeypatch)
     assert result['selected_backend'] == 'cuda'
 
 
+def test_windows_runtime_bootstrap_is_probe_only_by_default(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
+    invoked = {'source_repair': False}
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_windows_cuda_source_repair',
+        lambda _requirements_path: (invoked.update(source_repair=True), '') and (False, 'unexpected call'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+
+    assert result['runtime_action'] == 'probe_only'
+    assert desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert invoked['source_repair'] is False
+
+
 def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
@@ -282,6 +305,7 @@ def test_maybe_reexec_for_runtime_refresh_reexecs_once(monkeypatch):
 
 def test_windows_runtime_bootstrap_respects_opt_out_env(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
     monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
     invoked = {'source_repair': False}
@@ -300,6 +324,7 @@ def test_windows_runtime_bootstrap_respects_opt_out_env(monkeypatch):
 
 def test_windows_runtime_bootstrap_success_reexec_is_guarded_to_one_attempt(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
@@ -477,6 +502,7 @@ def test_maybe_reexec_for_runtime_refresh_handles_execve_oserror(monkeypatch):
 
 def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     state_path = tmp_path / 'runtime_state.json'
     monkeypatch.setattr(desktop_runtime_setup, '_runtime_state_path', lambda: state_path)
     now = 1_000.0
@@ -680,6 +706,7 @@ def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp
 
 def test_windows_packaged_layout_without_requirements_falls_back_without_exception(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
@@ -717,6 +744,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
     monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
@@ -742,6 +770,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
 
 def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
     plans = [


### PR DESCRIPTION
### Motivation
- The compute-node bridge and inference sidecar were stalling before emitting their first structured events because `ensure_desktop_llama_runtime(...)` ran heavyweight install/repair work during normal startup when a GPU-capable runtime was not present. 
- This early bootstrap stall left the UI in indefinite `pending` state and blocked both operator registration and local inference startup. 
- Prior fix in PR 760 addressed late relay/heartbeat handling but did not touch the early shared runtime bootstrap path that is the true root cause. 

### Description
- Introduced an opt-in env `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` and made install/repair bootstrap probe-only by default to avoid blocking startup. 
- Preserved the existing `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP` behavior and added a clear fallback message that instructs how to opt into bootstrap. 
- Updated `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` to return `runtime_action: probe_only` unless the new enable env is set when Windows auto-repair would otherwise run. 
- Updated unit tests in `tests/unit/test_desktop_runtime_setup.py` to explicitly set `ENABLE_BOOTSTRAP_ENV` for tests that exercise install/repair flows and added a regression test asserting probe-only default; updated docs in `desktop-tauri/README.md`. 

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (`59 passed`). 
- Ran `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py` and compilation succeeded. 
- Ran `cd desktop-tauri && npm test` and the frontend test suite passed; attempting `npm test -- --runInBand` failed due to Vitest option mismatch (not a regression). 
- Ran `cd desktop-tauri/src-tauri && cargo test` but it could not complete in this environment due to missing system `glib-2.0`/`pkg-config` (environment limitation, unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48187ba28832fb596ce0f533ef75a)