### PR TITLE
🐛 Gate desktop runtime bootstrap behind opt-in to avoid startup stalls

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -35,6 +35,7 @@ PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 INSTALL_ERROR_SUMMARY_MAX_LEN = 512
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
+ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
 
 _PROBE_SNIPPET = """
@@ -412,6 +413,17 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "selected_backend": "cpu",
             "fallback_reason": (
                 f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
+            ),
+            "runtime_action": "probe_only",
+            **_probe_result_payload(before),
+        }
+
+    if os.getenv(ENABLE_BOOTSTRAP_ENV) != "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                "GPU runtime unavailable and desktop runtime bootstrap is disabled by default; "
+                f"set {ENABLE_BOOTSTRAP_ENV}=1 to opt in to repair/install"
             ),
             "runtime_action": "probe_only",
             **_probe_result_payload(before),

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -39,6 +39,10 @@ def _probe(*, backend='cpu', gpu=False, device='cpu', error=None):
     )
 
 
+def _enable_runtime_bootstrap(monkeypatch):
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+
+
 def test_skip_runtime_bootstrap_for_cpu_mode(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
@@ -49,6 +53,7 @@ def test_skip_runtime_bootstrap_for_cpu_mode(monkeypatch):
 
 def test_windows_runtime_bootstrap_auto_repairs_and_requests_reexec(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
@@ -134,6 +139,7 @@ def test_ensure_runtime_uses_custom_repo_root_for_initial_probe_and_post_repair_
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
@@ -196,6 +202,7 @@ def test_probe_uses_resolved_runtime_root_for_subprocess_cwd_and_pythonpath(monk
 
 def test_windows_runtime_bootstrap_surfaces_source_repair_detail_when_probe_stays_cpu(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     captured = {}
 
@@ -234,6 +241,7 @@ def test_runtime_bootstrap_noop_when_gpu_runtime_is_already_present(monkeypatch)
 
 def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
@@ -283,6 +291,7 @@ def test_maybe_reexec_for_runtime_refresh_reexecs_once(monkeypatch):
 def test_windows_runtime_bootstrap_respects_opt_out_env(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
     invoked = {'source_repair': False}
     monkeypatch.setattr(
@@ -300,6 +309,7 @@ def test_windows_runtime_bootstrap_respects_opt_out_env(monkeypatch):
 
 def test_windows_runtime_bootstrap_success_reexec_is_guarded_to_one_attempt(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
     monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
@@ -477,6 +487,7 @@ def test_maybe_reexec_for_runtime_refresh_handles_execve_oserror(monkeypatch):
 
 def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     state_path = tmp_path / 'runtime_state.json'
     monkeypatch.setattr(desktop_runtime_setup, '_runtime_state_path', lambda: state_path)
     now = 1_000.0
@@ -680,6 +691,7 @@ def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp
 
 def test_windows_packaged_layout_without_requirements_falls_back_without_exception(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
     monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
@@ -717,6 +729,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
     monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
@@ -742,6 +755,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
 
 def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    _enable_runtime_bootstrap(monkeypatch)
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda: _probe())
     monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
     plans = [
@@ -779,3 +793,20 @@ def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
 
     module_path = str(shim.resolve()).upper()
     assert desktop_runtime_setup._is_repo_local_llama_module(module_path, repo_root) is True
+
+
+def test_windows_runtime_bootstrap_defaults_to_probe_only_without_opt_in(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
+    invoked = {'source_repair': False}
+
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_windows_cuda_source_repair',
+        lambda _requirements_path: (invoked.update(source_repair=True), '') and (False, 'unexpected'),
+    )
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+
+    assert result['runtime_action'] == 'probe_only'
+    assert desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert invoked['source_repair'] is False


### PR DESCRIPTION
### Motivation
- The desktop bridge and sidecar call `ensure_desktop_llama_runtime()` before emitting first structured startup events, allowing expensive Windows repair/install work to run during ordinary startup and stall the process.  
- This caused the UI to remain at pending (no `desktop.runtime_setup` / `started` logs) while the child process hung in bootstrap.  
- PR 760 only fixed later relay heartbeat handling after the bridge reached its poll loop, so it did not address this earlier runtime-bootstrap stall.

### Description
- Add an opt-in gate `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` and default to a fast probe-only path when GPU runtime is missing so normal desktop startup does not trigger repair/install actions.  
- Preserve existing `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1` behavior and keep its precedence.  
- Update unit tests in `tests/unit/test_desktop_runtime_setup.py` to explicitly set the opt-in env for tests that exercise install/repair/reexec logic and add a regression test asserting default probe-only behavior.  
- No changes to relay polling or heartbeat logic were made; the fix narrows scope to runtime bootstrap ordering and opt-in behavior in `desktop_runtime_setup.py`.

### Testing
- Ran unit tests with `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (`59 passed`).  
- Performed Python compile check with `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py` which completed successfully.  
- Ran `npm test` in `desktop-tauri` which passed the JS unit tests, while `npm test -- --runInBand` is incompatible with the current Vitest CLI (reported as unsupported).  
- Ran `cargo test` in `desktop-tauri/src-tauri` but it failed in this environment due to a missing system dependency (`glib-2.0` / pkg-config) unrelated to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48187ba28832fb596ce0f533ef75a)