### PR TITLE
Fix desktop bridge/sidecar startup stall from eager utils imports

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -42,6 +42,18 @@ _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "gpu", "hybrid"})
+LEGACY_COMPUTE_MODE_ALIASES = {"cuda": "gpu", "metal": "gpu"}
+
+
+def normalize_compute_mode(mode: Optional[str]) -> str:
+    """Normalize compute mode without importing the shared runtime package early."""
+
+    selected = (mode or "auto").strip().lower()
+    selected = LEGACY_COMPUTE_MODE_ALIASES.get(selected, selected)
+    if selected in SUPPORTED_COMPUTE_MODES:
+        return selected
+    return "auto"
 
 
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
@@ -360,8 +372,6 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        from utils.compute_node_runtime import normalize_compute_mode
-
         args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -11,7 +11,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Tuple
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 if __package__ in (None, ""):
     script_dir = str(Path(__file__).resolve().parent)
@@ -26,6 +26,18 @@ ensure_runtime_import_paths(__file__)
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+SUPPORTED_COMPUTE_MODES = frozenset({"auto", "cpu", "gpu", "hybrid"})
+LEGACY_COMPUTE_MODE_ALIASES = {"cuda": "gpu", "metal": "gpu"}
+
+
+def normalize_compute_mode(mode: Optional[str]) -> str:
+    """Normalize compute mode without importing the shared runtime package early."""
+
+    selected = (mode or "auto").strip().lower()
+    selected = LEGACY_COMPUTE_MODE_ALIASES.get(selected, selected)
+    if selected in SUPPORTED_COMPUTE_MODES:
+        return selected
+    return "auto"
 
 
 def _start_stdin_reader() -> None:
@@ -156,15 +168,6 @@ def run(args: argparse.Namespace) -> int:
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
 
-    try:
-        from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
-        from utils.llm.model_manager import ModelManager, get_model_manager
-    except ModuleNotFoundError as exc:
-        return emit_error(
-            "runtime_unavailable",
-            f"Missing Python dependency for local inference ({exc}).",
-        )
-
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -178,6 +181,15 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+
+    try:
+        from utils.compute_node_runtime import apply_compute_mode, compute_mode_diagnostics
+        from utils.llm.model_manager import ModelManager, get_model_manager
+    except ModuleNotFoundError as exc:
+        return emit_error(
+            "runtime_unavailable",
+            f"Missing Python dependency for local inference ({exc}).",
+        )
 
     manager = get_model_manager()
     manager.model_path = args.model
@@ -293,8 +305,6 @@ def main() -> int:
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
     try:
-        from utils.compute_node_runtime import normalize_compute_mode
-
         args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort error handling

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -667,9 +667,7 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     assert status == 1
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
-    assert payload['message'].startswith(
-        'compute-node bridge exited before emitting a startup event:'
-    )
+    assert payload['message'].startswith('runtime unavailable:')
 
 
 def test_main_normalizes_mode_before_run(monkeypatch):

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -318,8 +318,10 @@ def test_run_cancels_during_streaming_after_started(tmp_path, capsys):
     assert [event['type'] for event in events] == ['started', 'canceled']
 
 
-def test_main_emits_inference_failed_when_compute_runtime_missing(capsys, monkeypatch):
+def test_main_emits_runtime_unavailable_when_compute_runtime_missing(tmp_path, capsys, monkeypatch):
     real_import = __import__
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
 
     def fake_import(name, *args, **kwargs):
         if name == 'utils.compute_node_runtime':
@@ -333,7 +335,7 @@ def test_main_emits_inference_failed_when_compute_runtime_missing(capsys, monkey
         [
             'inference_sidecar.py',
             '--model',
-            '/tmp/model.gguf',
+            str(model_path),
             '--mode',
             'auto',
             '--prompt',
@@ -346,8 +348,8 @@ def test_main_emits_inference_failed_when_compute_runtime_missing(capsys, monkey
     assert status == 1
     event = json.loads(capsys.readouterr().out.strip())
     assert event['type'] == 'error'
-    assert event['code'] == 'inference_failed'
-    assert 'bridge failure:' in event['message']
+    assert event['code'] == 'runtime_unavailable'
+    assert "Missing Python dependency for local inference" in event['message']
 
 
 def test_main_normalizes_mode_before_run(monkeypatch):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,12 +1,33 @@
-"""
-Utilities package for token.place.
+"""Utilities package for token.place.
+
+Avoid importing heavyweight runtime dependencies at module import time. Desktop
+sidecars import ``utils.compute_node_runtime`` during early startup, and eager
+imports here can trigger unrelated dependency failures before sidecar bootstrap
+runs.
 """
 
-# Import key utilities for easier access
-from utils.path_handling import get_temp_dir
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
+from __future__ import annotations
 
-# Re-export the high-level helpers and Relay client
-__all__ = ['get_model_manager', 'get_crypto_manager', 'get_temp_dir', 'RelayClient']
+from importlib import import_module
+from typing import Any
+
+__all__ = ["get_model_manager", "get_crypto_manager", "get_temp_dir", "RelayClient"]
+
+_ATTR_TO_MODULE = {
+    "get_temp_dir": ("utils.path_handling", "get_temp_dir"),
+    "get_model_manager": ("utils.llm.model_manager", "get_model_manager"),
+    "get_crypto_manager": ("utils.crypto.crypto_manager", "get_crypto_manager"),
+    "RelayClient": ("utils.networking.relay_client", "RelayClient"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_attr = _ATTR_TO_MODULE.get(name)
+    if module_attr is None:
+        raise AttributeError(f"module 'utils' has no attribute {name!r}")
+
+    module_name, attr_name = module_attr
+    module = import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value


### PR DESCRIPTION
### Motivation
- The desktop bridge and sidecar could hang before emitting any `desktop.runtime_setup` or `started` events because `utils.compute_node_runtime` was imported too early, and `utils/__init__.py` performed heavyweight imports that can fail in constrained desktop child environments.
- This caused the UI to remain stuck at pending and prevented both operator registration and local inference from progressing.
- PR 760 fixed relay/heartbeat handling later in the bridge lifecycle but did not address the earlier import/bootstrap ordering regression that prevented the bridge/sidecar from reaching that stage. 

### Description
- Avoid importing shared runtime modules during CLI argument normalization by adding a local `normalize_compute_mode` helper in both `compute_node_bridge.py` and `inference_sidecar.py`. 
- Move desktop runtime bootstrap logging (`ensure_desktop_llama_runtime(...)` + structured `desktop.runtime_setup` print) to run before importing `utils.llm.model_manager` in the inference sidecar so early diagnostics are always emitted. 
- Make `utils/__init__.py` lazy by implementing `__getattr__` that imports heavy submodules on-demand to prevent side-effectful imports during child startup. 
- Adjust unit tests to reflect the new early-error surface and normalized mode behavior so the bridge/sidecar emit structured errors from `run()` instead of failing at module-import time. 

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py` and all tests passed (`81 passed`).
- Ran `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py` and compilation succeeded.
- Noted environment-specific integration commands (`cargo test` in `desktop-tauri/src-tauri`, `npm test`) fail in this container due to missing system dev deps or incompatible CLI flags, but these are unrelated to the Python startup fix and were not required to validate the regression fix in unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48187ba28832fb596ce0f533ef75a)