### PR TITLE
Wire deterministic desktop GPU runtime bootstrap on Windows x64

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -42,6 +42,7 @@ _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
+GPU_PREFERRED_MODES = {"auto", "gpu", "hybrid"}
 
 
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
@@ -171,6 +172,24 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+    if (
+        sys.platform.startswith("win")
+        and args.mode in GPU_PREFERRED_MODES
+        and runtime_setup.get("selected_backend") == "cpu"
+        and runtime_setup.get("runtime_action") in {"failed", "installed_cpu_fallback", "probe_only"}
+    ):
+        reason = runtime_setup.get("fallback_reason") or "unknown GPU runtime provisioning failure"
+        emit(
+            {
+                "type": "error",
+                "message": (
+                    "GPU runtime provisioning failed for Windows desktop launch; "
+                    f"requested mode={args.mode}, action={runtime_setup.get('runtime_action')}, "
+                    f"reason={reason}. Switch to CPU mode or repair CUDA runtime."
+                ),
+            }
+        )
+        return 1
 
     try:
         from utils.compute_node_runtime import (

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -26,6 +26,7 @@ ensure_runtime_import_paths(__file__)
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+GPU_PREFERRED_MODES = {"auto", "gpu", "hybrid"}
 
 
 def _start_stdin_reader() -> None:
@@ -178,6 +179,19 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+    if (
+        sys.platform.startswith("win")
+        and args.mode in GPU_PREFERRED_MODES
+        and runtime_setup.get("selected_backend") == "cpu"
+        and runtime_setup.get("runtime_action") in {"failed", "installed_cpu_fallback", "probe_only"}
+    ):
+        reason = runtime_setup.get("fallback_reason") or "unknown GPU runtime provisioning failure"
+        return emit_error(
+            "gpu_runtime_unavailable",
+            "GPU runtime provisioning failed for Windows desktop launch; "
+            f"requested mode={args.mode}, action={runtime_setup.get('runtime_action')}, "
+            f"reason={reason}. Switch to CPU mode or repair CUDA runtime.",
+        )
 
     manager = get_model_manager()
     manager.model_path = args.model

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,8 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::python_runtime::{
+    configure_runtime_bootstrap_env, resolve_python_launcher, resolve_runtime_import_root,
+    PythonLauncher,
+};
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -343,6 +346,7 @@ pub async fn start_compute_node(
         }
     };
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
+    configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
 
     let spawn_result = bridge_command
         .arg("--model")
@@ -455,12 +459,7 @@ pub async fn start_compute_node(
         let exit_status = running_child.wait().await?;
         let exit_payload = {
             let mut status = state.status.lock().await;
-            finalize_bridge_exit(
-                &mut status,
-                exit_status,
-                saw_startup_event,
-                saw_error_event,
-            )
+            finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
         if let Some(payload) = exit_payload {
@@ -660,10 +659,7 @@ mod tests {
             .expect("status last_error should be set");
         assert!(last_error.contains("before emitting a startup event"));
         assert_eq!(payload.get("type").and_then(Value::as_str), Some("error"));
-        assert_eq!(
-            payload.get("running").and_then(Value::as_bool),
-            Some(false)
-        );
+        assert_eq!(payload.get("running").and_then(Value::as_bool), Some(false));
         assert_eq!(
             payload.get("registered").and_then(Value::as_bool),
             Some(false)

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,5 +1,8 @@
+use crate::backend::ComputeMode;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+pub const ENABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP";
 
 #[derive(Debug, Clone)]
 pub struct PythonLauncher {
@@ -182,20 +185,53 @@ pub fn resolve_runtime_import_root(
         }
     }
 
-    candidates.into_iter().find(|candidate| {
-        candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-    })
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+}
+
+pub fn should_enable_runtime_bootstrap(mode: &ComputeMode) -> bool {
+    cfg!(all(target_os = "windows", target_arch = "x86_64"))
+        && matches!(
+            mode,
+            ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid
+        )
+}
+
+pub fn configure_runtime_bootstrap_env(command: &mut tokio::process::Command, mode: &ComputeMode) {
+    if should_enable_runtime_bootstrap(mode) {
+        command.env(ENABLE_RUNTIME_BOOTSTRAP_ENV, "1");
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
+
+    #[test]
+    fn bootstrap_env_is_enabled_for_gpu_like_modes_on_windows_x64_only() {
+        let auto = should_enable_runtime_bootstrap(&ComputeMode::Auto);
+        let gpu = should_enable_runtime_bootstrap(&ComputeMode::Gpu);
+        let hybrid = should_enable_runtime_bootstrap(&ComputeMode::Hybrid);
+        let cpu = should_enable_runtime_bootstrap(&ComputeMode::Cpu);
+
+        if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+            assert!(auto);
+            assert!(gpu);
+            assert!(hybrid);
+        } else {
+            assert!(!auto);
+            assert!(!gpu);
+            assert!(!hybrid);
+        }
+        assert!(!cpu);
+    }
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -356,8 +392,13 @@ mod tests {
     #[test]
     fn resolve_runtime_import_root_detects_nested_up_layout() {
         let temp = TempDir::new().expect("tempdir");
-        let script = temp.path().join("resources").join("python").join("model_bridge.py");
-        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script dir");
+        let script = temp
+            .path()
+            .join("resources")
+            .join("python")
+            .join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create script dir");
         std::fs::write(&script, "#!/usr/bin/env python3\n").expect("write script");
         let import_root = temp.path().join("resources").join("_up_").join("_up_");
         std::fs::create_dir_all(import_root.join("utils")).expect("create utils dir");

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,5 +1,8 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::python_runtime::{
+    configure_runtime_bootstrap_env, resolve_python_launcher, resolve_runtime_import_root,
+    PythonLauncher,
+};
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -250,6 +253,7 @@ pub async fn start_sidecar(
 
     let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
     configure_runtime_pythonpath(&mut sidecar_command, &sidecar_script);
+    configure_runtime_bootstrap_env(&mut sidecar_command, &request.mode);
 
     let mut child = sidecar_command
         .arg("--model")

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -903,3 +903,39 @@ def test_sanitize_relay_target_redacts_credentials_query_and_fragment():
 def test_sanitize_relay_target_returns_unknown_for_invalid_values():
     assert compute_node_bridge._sanitize_relay_target(None) == 'unknown'
     assert compute_node_bridge._sanitize_relay_target('not-a-valid-url') == 'unknown'
+
+
+def test_run_emits_error_when_windows_gpu_provisioning_fails(monkeypatch, capsys):
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime)
+    _reset_cancel_queue()
+    monkeypatch.setattr(compute_node_bridge.sys, 'platform', 'win32')
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'runtime_action': 'failed',
+            'fallback_reason': 'CUDA wheel install failed',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'maybe_reexec_for_runtime_refresh',
+        lambda _setup, *, allow_reexec=True: None,
+    )
+
+    args = SimpleNamespace(
+        model='model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert events
+    assert events[0]['type'] == 'error'
+    assert 'CUDA wheel install failed' in events[0]['message']

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -323,6 +323,37 @@ def test_run_emits_runtime_unavailable_when_model_manager_missing(tmp_path, caps
     assert event['code'] == 'runtime_unavailable'
 
 
+def test_run_emits_gpu_runtime_unavailable_when_windows_gpu_provisioning_fails(
+    tmp_path, capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+    _install_fake_manager_module(FakeManager())
+
+    monkeypatch.setattr(inference_sidecar.sys, 'platform', 'win32')
+    monkeypatch.setattr(
+        inference_sidecar,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'runtime_action': 'failed',
+            'fallback_reason': 'CUDA build failed',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 1
+    event = json.loads(capsys.readouterr().out.strip())
+    assert event['type'] == 'error'
+    assert event['code'] == 'gpu_runtime_unavailable'
+    assert 'CUDA build failed' in event['message']
+
+
 def test_run_emits_bad_model_when_runtime_returns_no_llm(tmp_path, capsys):
     _reset_cancel_queue()
     model_path = tmp_path / 'model.gguf'


### PR DESCRIPTION
### Motivation
- PR 763 made desktop runtime bootstrap probe-only by default to avoid silent startup hangs but left the desktop launcher paths un-wired to opt into the repair/install flow. 
- As a result, on Windows x64 with `auto`/`gpu`/`hybrid` modes the Python children stayed CPU-only (`probe_only`) and never attempted deterministic GPU provisioning. 
- The goal is to enable deterministic, observable GPU provisioning from the desktop launcher while preserving PR 763’s no-hang safety property.

### Description
- Added a small shared launcher helper in `desktop-tauri/src-tauri/src/python_runtime.rs`: `should_enable_runtime_bootstrap` and `configure_runtime_bootstrap_env` which sets `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` when on Windows x64 and mode is `auto|gpu|hybrid`. 
- Wired the helper into both spawn paths so sidecar and compute-node child processes inherit the bootstrap opt-in by calling `configure_runtime_bootstrap_env` in `start_sidecar` and `start_compute_node` (Rust changes in `sidecar.rs` and `compute_node.rs`).
- Made Python child processes fail fast with actionable diagnostics when a Windows GPU-preferred launch still ends up CPU-only by adding explicit error emission in `inference_sidecar.py` and `compute_node_bridge.py` when provisioning reports `failed`/`installed_cpu_fallback`/`probe_only` for GPU modes. 
- Added focused unit tests that assert the new failure surfacing and launcher wiring (`tests/unit/test_desktop_inference_sidecar.py`, `tests/unit/test_desktop_compute_node_bridge.py`) and a Rust unit test for the bootstrap gating predicate.

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py` and all Python unit tests passed (`86 passed`).
- Verified Python modules compile with `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py` which succeeded. 
- Ran `cd desktop-tauri && npm test` and JS tests passed in this environment. 
- Attempted `cd desktop-tauri/src-tauri && cargo test` in the Linux container but it failed due to missing system `glib-2.0`/`pkg-config` dependency, so full Rust integration tests should be executed on a platform with the system deps installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e488b26884832f83cd2c77e917798d)