### PR TITLE
Deterministic desktop GPU bootstrap wiring for sidecar and compute-node launches

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import queue
 import sys
 import threading
@@ -40,6 +41,8 @@ ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
+REQUIRE_GPU_RUNTIME_ENV = "TOKEN_PLACE_DESKTOP_REQUIRE_GPU_RUNTIME"
+GPU_MODES = {"auto", "gpu", "hybrid"}
 _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 
@@ -171,6 +174,28 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+    runtime_action = runtime_setup.get("runtime_action", "none")
+    if (
+        os.getenv(REQUIRE_GPU_RUNTIME_ENV) == "1"
+        and str(args.mode).lower() in GPU_MODES
+        and runtime_action != "unavailable"
+    ):
+        selected_backend = runtime_setup.get("selected_backend", "cpu")
+        if runtime_action in {"failed", "installed_cpu_fallback", "probe_only"} or (
+            selected_backend == "cpu"
+        ):
+            fallback_reason = runtime_setup.get("fallback_reason") or "unknown runtime failure"
+            emit(
+                {
+                    "type": "error",
+                    "message": (
+                        "GPU runtime provisioning failed during desktop launch. "
+                        f"action={runtime_action}; reason={fallback_reason}. "
+                        "Switch to CPU mode or repair CUDA-enabled llama-cpp-python."
+                    ),
+                }
+            )
+            return 1
 
     try:
         from utils.compute_node_runtime import (

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -25,6 +25,8 @@ ensure_runtime_import_paths(__file__)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
+REQUIRE_GPU_RUNTIME_ENV = "TOKEN_PLACE_DESKTOP_REQUIRE_GPU_RUNTIME"
+GPU_MODES = {"auto", "gpu", "hybrid"}
 _stdin_reader_lock = threading.Lock()
 
 
@@ -178,6 +180,25 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+    runtime_action = runtime_setup.get("runtime_action", "none")
+    if (
+        os.getenv(REQUIRE_GPU_RUNTIME_ENV) == "1"
+        and str(args.mode).lower() in GPU_MODES
+        and runtime_action != "unavailable"
+    ):
+        selected_backend = runtime_setup.get("selected_backend", "cpu")
+        if runtime_action in {"failed", "installed_cpu_fallback", "probe_only"} or (
+            selected_backend == "cpu"
+        ):
+            fallback_reason = runtime_setup.get("fallback_reason") or "unknown runtime failure"
+            return emit_error(
+                "gpu_runtime_unavailable",
+                (
+                    "GPU runtime provisioning failed during desktop launch. "
+                    f"action={runtime_action}; reason={fallback_reason}. "
+                    "Switch to CPU mode or repair CUDA-enabled llama-cpp-python."
+                ),
+            )
 
     manager = get_model_manager()
     manager.model_path = args.model

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,7 @@
 use crate::backend::ComputeMode;
+use crate::desktop_runtime_bootstrap::{
+    should_provision_gpu_runtime, ENABLE_BOOTSTRAP_ENV, REQUIRE_GPU_RUNTIME_ENV,
+};
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
@@ -143,6 +146,13 @@ fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path, brid
                 command.env("PYTHONPATH", import_root);
             }
         }
+    }
+}
+
+fn configure_runtime_bootstrap(command: &mut Command, mode: &ComputeMode) {
+    if should_provision_gpu_runtime(mode) {
+        command.env(ENABLE_BOOTSTRAP_ENV, "1");
+        command.env(REQUIRE_GPU_RUNTIME_ENV, "1");
     }
 }
 
@@ -343,6 +353,7 @@ pub async fn start_compute_node(
         }
     };
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
+    configure_runtime_bootstrap(&mut bridge_command, &request.mode);
 
     let spawn_result = bridge_command
         .arg("--model")
@@ -396,10 +407,10 @@ pub async fn start_compute_node(
             registered: false,
             active_relay_url: request.relay_base_url.clone(),
             requested_mode: format!("{:?}", request.mode).to_lowercase(),
-            effective_mode: "cpu".into(),
+            effective_mode: "pending".into(),
             backend_available: "unknown".into(),
-            backend_selected: "cpu".into(),
-            backend_used: "cpu".into(),
+            backend_selected: "unknown".into(),
+            backend_used: "unknown".into(),
             fallback_reason: None,
             model_path: request.model_path.clone(),
             last_error: None,
@@ -455,12 +466,7 @@ pub async fn start_compute_node(
         let exit_status = running_child.wait().await?;
         let exit_payload = {
             let mut status = state.status.lock().await;
-            finalize_bridge_exit(
-                &mut status,
-                exit_status,
-                saw_startup_event,
-                saw_error_event,
-            )
+            finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
         if let Some(payload) = exit_payload {
@@ -660,10 +666,7 @@ mod tests {
             .expect("status last_error should be set");
         assert!(last_error.contains("before emitting a startup event"));
         assert_eq!(payload.get("type").and_then(Value::as_str), Some("error"));
-        assert_eq!(
-            payload.get("running").and_then(Value::as_bool),
-            Some(false)
-        );
+        assert_eq!(payload.get("running").and_then(Value::as_bool), Some(false));
         assert_eq!(
             payload.get("registered").and_then(Value::as_bool),
             Some(false)
@@ -734,5 +737,29 @@ mod tests {
         let resolved = first_existing_script(candidates).expect("resolved bridge path");
 
         assert_eq!(Path::new(&resolved), resources_bridge);
+    }
+
+    #[test]
+    fn configure_runtime_bootstrap_sets_desktop_gpu_env_for_hybrid_mode() {
+        let mut command = Command::new("python3");
+        configure_runtime_bootstrap(&mut command, &ComputeMode::Hybrid);
+        let envs: std::collections::HashMap<_, _> = command
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| v.map(|value| (k.to_owned(), value.to_owned())))
+            .collect();
+
+        if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new(ENABLE_BOOTSTRAP_ENV)),
+                Some(&std::ffi::OsString::from("1"))
+            );
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new(REQUIRE_GPU_RUNTIME_ENV)),
+                Some(&std::ffi::OsString::from("1"))
+            );
+        } else {
+            assert!(!envs.contains_key(std::ffi::OsStr::new(ENABLE_BOOTSTRAP_ENV)));
+        }
     }
 }

--- a/desktop-tauri/src-tauri/src/desktop_runtime_bootstrap.rs
+++ b/desktop-tauri/src-tauri/src/desktop_runtime_bootstrap.rs
@@ -1,0 +1,85 @@
+use crate::backend::ComputeMode;
+
+pub const ENABLE_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP";
+pub const DISABLE_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
+pub const REQUIRE_GPU_RUNTIME_ENV: &str = "TOKEN_PLACE_DESKTOP_REQUIRE_GPU_RUNTIME";
+
+fn gpu_runtime_mode(mode: &ComputeMode) -> bool {
+    matches!(
+        mode,
+        ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid
+    )
+}
+
+pub fn should_provision_gpu_runtime_for_desktop(
+    mode: &ComputeMode,
+    target_os: &str,
+    target_arch: &str,
+    disable_bootstrap: Option<&str>,
+) -> bool {
+    if !gpu_runtime_mode(mode) {
+        return false;
+    }
+    if target_os != "windows" || target_arch != "x86_64" {
+        return false;
+    }
+    disable_bootstrap != Some("1")
+}
+
+pub fn should_provision_gpu_runtime(mode: &ComputeMode) -> bool {
+    should_provision_gpu_runtime_for_desktop(
+        mode,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        std::env::var(DISABLE_BOOTSTRAP_ENV).ok().as_deref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enables_bootstrap_for_windows_x64_gpu_modes() {
+        assert!(should_provision_gpu_runtime_for_desktop(
+            &ComputeMode::Auto,
+            "windows",
+            "x86_64",
+            None
+        ));
+        assert!(should_provision_gpu_runtime_for_desktop(
+            &ComputeMode::Gpu,
+            "windows",
+            "x86_64",
+            None
+        ));
+        assert!(should_provision_gpu_runtime_for_desktop(
+            &ComputeMode::Hybrid,
+            "windows",
+            "x86_64",
+            None
+        ));
+    }
+
+    #[test]
+    fn disables_bootstrap_for_cpu_mode_non_windows_or_explicit_opt_out() {
+        assert!(!should_provision_gpu_runtime_for_desktop(
+            &ComputeMode::Cpu,
+            "windows",
+            "x86_64",
+            None
+        ));
+        assert!(!should_provision_gpu_runtime_for_desktop(
+            &ComputeMode::Auto,
+            "linux",
+            "x86_64",
+            None
+        ));
+        assert!(!should_provision_gpu_runtime_for_desktop(
+            &ComputeMode::Auto,
+            "windows",
+            "x86_64",
+            Some("1")
+        ));
+    }
+}

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod compute_node;
 mod config;
+mod desktop_runtime_bootstrap;
 mod forward;
 mod keygen;
 mod logging;

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -182,20 +182,20 @@ pub fn resolve_runtime_import_root(
         }
     }
 
-    candidates.into_iter().find(|candidate| {
-        candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-    })
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -356,8 +356,13 @@ mod tests {
     #[test]
     fn resolve_runtime_import_root_detects_nested_up_layout() {
         let temp = TempDir::new().expect("tempdir");
-        let script = temp.path().join("resources").join("python").join("model_bridge.py");
-        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script dir");
+        let script = temp
+            .path()
+            .join("resources")
+            .join("python")
+            .join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create script dir");
         std::fs::write(&script, "#!/usr/bin/env python3\n").expect("write script");
         let import_root = temp.path().join("resources").join("_up_").join("_up_");
         std::fs::create_dir_all(import_root.join("utils")).expect("create utils dir");

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,4 +1,7 @@
 use crate::backend::ComputeMode;
+use crate::desktop_runtime_bootstrap::{
+    should_provision_gpu_runtime, ENABLE_BOOTSTRAP_ENV, REQUIRE_GPU_RUNTIME_ENV,
+};
 use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
@@ -213,6 +216,13 @@ fn configure_runtime_pythonpath(command: &mut Command, sidecar_path: &str) {
     }
 }
 
+fn configure_runtime_bootstrap(command: &mut Command, mode: &ComputeMode) {
+    if should_provision_gpu_runtime(mode) {
+        command.env(ENABLE_BOOTSTRAP_ENV, "1");
+        command.env(REQUIRE_GPU_RUNTIME_ENV, "1");
+    }
+}
+
 pub async fn start_sidecar(
     app: AppHandle,
     state: SidecarState,
@@ -250,6 +260,7 @@ pub async fn start_sidecar(
 
     let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
     configure_runtime_pythonpath(&mut sidecar_command, &sidecar_script);
+    configure_runtime_bootstrap(&mut sidecar_command, &request.mode);
 
     let mut child = sidecar_command
         .arg("--model")
@@ -560,5 +571,29 @@ mod tests {
         let resolved = first_existing_script(candidates).expect("resolved sidecar path");
 
         assert_eq!(Path::new(&resolved), resources_sidecar);
+    }
+
+    #[test]
+    fn configure_runtime_bootstrap_sets_desktop_gpu_env_for_auto_mode() {
+        let mut command = Command::new("python3");
+        configure_runtime_bootstrap(&mut command, &ComputeMode::Auto);
+        let envs: std::collections::HashMap<_, _> = command
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| v.map(|value| (k.to_owned(), value.to_owned())))
+            .collect();
+
+        if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new(ENABLE_BOOTSTRAP_ENV)),
+                Some(&std::ffi::OsString::from("1"))
+            );
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new(REQUIRE_GPU_RUNTIME_ENV)),
+                Some(&std::ffi::OsString::from("1"))
+            );
+        } else {
+            assert!(!envs.contains_key(std::ffi::OsStr::new(ENABLE_BOOTSTRAP_ENV)));
+        }
     }
 }

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -422,6 +422,38 @@ def test_run_probe_only_runtime_setup_does_not_trigger_repair_reexec(capsys, mon
     assert reexec_calls == [('probe_only', True)]
 
 
+def test_run_emits_actionable_error_when_desktop_requires_gpu_runtime(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setenv(compute_node_bridge.REQUIRE_GPU_RUNTIME_ENV, '1')
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cpu',
+            'runtime_action': 'failed',
+            'fallback_reason': 'CUDA wheel install failed',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 1
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload['type'] == 'error'
+    assert 'GPU runtime provisioning failed during desktop launch' in payload['message']
+    assert 'CUDA wheel install failed' in payload['message']
+
+
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -593,3 +593,34 @@ def test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_
     assert 'desktop.runtime_setup' in captured.err
     assert 'action=probe_only' in captured.err
     assert repair_calls == {'source': 0, 'retry_gate': 0}
+
+
+def test_run_emits_actionable_error_when_desktop_requires_gpu_runtime(tmp_path, capsys, monkeypatch):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+    manager = FakeManager()
+    _install_fake_manager_module(manager)
+    monkeypatch.setenv(inference_sidecar.REQUIRE_GPU_RUNTIME_ENV, '1')
+    monkeypatch.setattr(
+        inference_sidecar,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cpu',
+            'runtime_action': 'probe_only',
+            'fallback_reason': 'bootstrap was not enabled',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+
+    args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')
+    status = inference_sidecar.run(args)
+
+    assert status == 1
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload['type'] == 'error'
+    assert payload['code'] == 'gpu_runtime_unavailable'
+    assert 'bootstrap was not enabled' in payload['message']
+    monkeypatch.delenv(inference_sidecar.REQUIRE_GPU_RUNTIME_ENV, raising=False)


### PR DESCRIPTION
### Motivation
- Ensure desktop-tauri deterministically enables GPU runtime provisioning for Windows x64 when compute mode is `auto`/`gpu`/`hybrid` without reverting to the pre-PR-763 opaque startup hang. 
- PR 763 made bootstrap opt-in (`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1`) which prevented hangs but left desktop launchers never opting in, so processes stayed `probe_only` and CUDA was never attempted. 
- Provide explicit, actionable failure reporting when the desktop intentionally requires a GPU runtime but provisioning remains CPU-only or fails, and avoid misleading initial operator status during startup.

### Description
- Add a small shared Rust helper `desktop_runtime_bootstrap.rs` that centralizes the desktop policy to decide when to provision GPU runtime (Windows x64 + GPU modes) and expose constants `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` and `TOKEN_PLACE_DESKTOP_REQUIRE_GPU_RUNTIME`.
- Wire deterministic bootstrap env propagation into both Python child launchers by calling `configure_runtime_bootstrap(...)` from `src-tauri/src/sidecar.rs` and `src-tauri/src/compute_node.rs`, which sets `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1` and `TOKEN_PLACE_DESKTOP_REQUIRE_GPU_RUNTIME=1` when appropriate.
- Add early, explicit failure handling in Python child entrypoints (`desktop-tauri/src-tauri/python/inference_sidecar.py` and `compute_node_bridge.py`) that returns/emits an actionable error if `TOKEN_PLACE_DESKTOP_REQUIRE_GPU_RUNTIME=1` is present and `ensure_desktop_llama_runtime(...)` reports `probe_only`/`failed`/CPU fallback.
- Improve initial compute-node startup status to `effective_mode=pending` and `backend_selected/backend_used=unknown` to avoid showing stale/misleading CPU diagnostics before the child emits its actual runtime status.
- Add focused unit tests that assert: the Rust launchers set the bootstrap env when expected and the Python launch paths emit actionable errors when the desktop requires GPU runtime but the runtime setup remains CPU/probe-only.

### Testing
- Ran targeted Python unit tests: `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py` and all tests passed locally (`86 passed`).
- Verified Python child scripts compile with `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py` (success).
- Ran JS unit tests with `cd desktop-tauri && npm test` which passed; `npm test -- --runInBand` is not supported by Vitest in this environment.
- Attempted `cd desktop-tauri/src-tauri && cargo test` but the container lacks system `glib-2.0`/`pkg-config` dev libs required to build Tauri host tests so Rust integration tests could not be completed in this Linux container (CI on Windows/macOS should build normally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e488b26884832f83cd2c77e917798d)