### PR TITLE
Wire deterministic desktop runtime bootstrap for Windows CUDA modes

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -108,6 +108,28 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
         f"kv_cache_device={diagnostics.get('kv_cache_device') or 'unknown'}"
     )
 
+def _gpu_provisioning_failure_message(mode: str, runtime_setup: Dict[str, Any]) -> Optional[str]:
+    selected_mode = (mode or "auto").strip().lower()
+    runtime_action = str(runtime_setup.get("runtime_action") or "").strip().lower()
+    detected_device = str(runtime_setup.get("detected_device") or "").strip().lower()
+    selected_backend = str(runtime_setup.get("selected_backend") or "").strip().lower()
+    fallback_reason = runtime_setup.get("fallback_reason") or "unknown"
+    if selected_mode not in {"auto", "gpu", "hybrid"}:
+        return None
+    if not sys.platform.startswith("win"):
+        return None
+    if detected_device not in {"cuda", "nvidia", "gpu"}:
+        return None
+    if selected_backend in {"cuda", "metal"}:
+        return None
+    if runtime_action not in {"failed", "installed_cpu_fallback", "probe_only"}:
+        return None
+    return (
+        "GPU runtime provisioning failed for Windows CUDA mode "
+        f"(action={runtime_action}, fallback_reason={fallback_reason}). "
+        "Verify CUDA toolkit/build tools and retry."
+    )
+
 
 def _start_stdin_reader() -> None:
     global _stdin_reader_started
@@ -171,6 +193,10 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+    provisioning_error = _gpu_provisioning_failure_message(args.mode, runtime_setup)
+    if provisioning_error:
+        emit({"type": "error", "message": provisioning_error})
+        return 1
 
     try:
         from utils.compute_node_runtime import (

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -152,6 +152,29 @@ def _extract_text_from_completion(completion: Dict[str, Any]) -> str:
     return message.get("content", "") if isinstance(message, dict) else ""
 
 
+def _gpu_provisioning_failure_message(mode: str, runtime_setup: Dict[str, Any]) -> Optional[str]:
+    selected_mode = (mode or "auto").strip().lower()
+    runtime_action = str(runtime_setup.get("runtime_action") or "").strip().lower()
+    detected_device = str(runtime_setup.get("detected_device") or "").strip().lower()
+    selected_backend = str(runtime_setup.get("selected_backend") or "").strip().lower()
+    fallback_reason = runtime_setup.get("fallback_reason") or "unknown"
+    if selected_mode not in {"auto", "gpu", "hybrid"}:
+        return None
+    if not sys.platform.startswith("win"):
+        return None
+    if detected_device not in {"cuda", "nvidia", "gpu"}:
+        return None
+    if selected_backend in {"cuda", "metal"}:
+        return None
+    if runtime_action not in {"failed", "installed_cpu_fallback", "probe_only"}:
+        return None
+    return (
+        "GPU runtime provisioning failed for Windows CUDA mode "
+        f"(action={runtime_action}, fallback_reason={fallback_reason}). "
+        "Verify CUDA toolkit/build tools and retry."
+    )
+
+
 def run(args: argparse.Namespace) -> int:
     if not os.path.exists(args.model):
         return emit_error("bad_model", "model path not found")
@@ -178,6 +201,9 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
+    provisioning_error = _gpu_provisioning_failure_message(args.mode, runtime_setup)
+    if provisioning_error:
+        return emit_error("gpu_provisioning_failed", provisioning_error)
 
     manager = get_model_manager()
     manager.model_path = args.model

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,8 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::python_runtime::{
+    configure_runtime_bootstrap_env, resolve_python_launcher, resolve_runtime_import_root,
+    PythonLauncher,
+};
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -343,6 +346,7 @@ pub async fn start_compute_node(
         }
     };
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
+    configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
 
     let spawn_result = bridge_command
         .arg("--model")
@@ -455,12 +459,7 @@ pub async fn start_compute_node(
         let exit_status = running_child.wait().await?;
         let exit_payload = {
             let mut status = state.status.lock().await;
-            finalize_bridge_exit(
-                &mut status,
-                exit_status,
-                saw_startup_event,
-                saw_error_event,
-            )
+            finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
         if let Some(payload) = exit_payload {
@@ -660,10 +659,7 @@ mod tests {
             .expect("status last_error should be set");
         assert!(last_error.contains("before emitting a startup event"));
         assert_eq!(payload.get("type").and_then(Value::as_str), Some("error"));
-        assert_eq!(
-            payload.get("running").and_then(Value::as_bool),
-            Some(false)
-        );
+        assert_eq!(payload.get("running").and_then(Value::as_bool), Some(false));
         assert_eq!(
             payload.get("registered").and_then(Value::as_bool),
             Some(false)

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1,6 +1,11 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::backend::ComputeMode;
+
+pub const ENABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP";
+pub const DISABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
+
 #[derive(Debug, Clone)]
 pub struct PythonLauncher {
     pub program: String,
@@ -182,20 +187,50 @@ pub fn resolve_runtime_import_root(
         }
     }
 
-    candidates.into_iter().find(|candidate| {
-        candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-    })
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+}
+
+pub fn should_enable_runtime_bootstrap(
+    mode: &ComputeMode,
+    target_os: &str,
+    target_arch: &str,
+    disable_env: Option<&str>,
+) -> bool {
+    if disable_env == Some("1") {
+        return false;
+    }
+    if target_os != "windows" || target_arch != "x86_64" {
+        return false;
+    }
+    matches!(
+        mode,
+        ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid
+    )
+}
+
+pub fn configure_runtime_bootstrap_env(command: &mut tokio::process::Command, mode: &ComputeMode) {
+    let disable = std::env::var(DISABLE_RUNTIME_BOOTSTRAP_ENV).ok();
+    if should_enable_runtime_bootstrap(
+        mode,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        disable.as_deref(),
+    ) {
+        command.env(ENABLE_RUNTIME_BOOTSTRAP_ENV, "1");
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -230,6 +265,60 @@ mod tests {
         assert!(is_python_3_version("Python 3.12.1", ""));
         assert!(is_python_3_version("", "Python 3.11.9"));
         assert!(!is_python_3_version("Python 2.7.18", ""));
+    }
+
+    #[test]
+    fn runtime_bootstrap_enabled_for_windows_gpu_modes() {
+        assert!(should_enable_runtime_bootstrap(
+            &ComputeMode::Auto,
+            "windows",
+            "x86_64",
+            None
+        ));
+        assert!(should_enable_runtime_bootstrap(
+            &ComputeMode::Gpu,
+            "windows",
+            "x86_64",
+            None
+        ));
+        assert!(should_enable_runtime_bootstrap(
+            &ComputeMode::Hybrid,
+            "windows",
+            "x86_64",
+            None
+        ));
+    }
+
+    #[test]
+    fn runtime_bootstrap_disabled_for_cpu_or_non_windows_targets() {
+        assert!(!should_enable_runtime_bootstrap(
+            &ComputeMode::Cpu,
+            "windows",
+            "x86_64",
+            None
+        ));
+        assert!(!should_enable_runtime_bootstrap(
+            &ComputeMode::Auto,
+            "linux",
+            "x86_64",
+            None
+        ));
+        assert!(!should_enable_runtime_bootstrap(
+            &ComputeMode::Auto,
+            "windows",
+            "aarch64",
+            None
+        ));
+    }
+
+    #[test]
+    fn runtime_bootstrap_respects_disable_env() {
+        assert!(!should_enable_runtime_bootstrap(
+            &ComputeMode::Auto,
+            "windows",
+            "x86_64",
+            Some("1")
+        ));
     }
 
     #[test]
@@ -356,8 +445,13 @@ mod tests {
     #[test]
     fn resolve_runtime_import_root_detects_nested_up_layout() {
         let temp = TempDir::new().expect("tempdir");
-        let script = temp.path().join("resources").join("python").join("model_bridge.py");
-        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script dir");
+        let script = temp
+            .path()
+            .join("resources")
+            .join("python")
+            .join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create script dir");
         std::fs::write(&script, "#!/usr/bin/env python3\n").expect("write script");
         let import_root = temp.path().join("resources").join("_up_").join("_up_");
         std::fs::create_dir_all(import_root.join("utils")).expect("create utils dir");

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -1,5 +1,8 @@
 use crate::backend::ComputeMode;
-use crate::python_runtime::{resolve_python_launcher, resolve_runtime_import_root, PythonLauncher};
+use crate::python_runtime::{
+    configure_runtime_bootstrap_env, resolve_python_launcher, resolve_runtime_import_root,
+    PythonLauncher,
+};
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -250,6 +253,7 @@ pub async fn start_sidecar(
 
     let mut sidecar_command = build_sidecar_command(&sidecar_script, launcher)?;
     configure_runtime_pythonpath(&mut sidecar_command, &sidecar_script);
+    configure_runtime_bootstrap_env(&mut sidecar_command, &request.mode);
 
     let mut child = sidecar_command
         .arg("--model")

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -422,6 +422,46 @@ def test_run_probe_only_runtime_setup_does_not_trigger_repair_reexec(capsys, mon
     assert reexec_calls == [('probe_only', True)]
 
 
+def test_run_emits_error_when_windows_cuda_provisioning_fails(capsys, monkeypatch):
+    _reset_cancel_queue()
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cuda',
+            'runtime_action': 'failed',
+            'fallback_reason': 'pip install failed',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    monkeypatch.setattr(compute_node_bridge.sys, 'platform', 'win32', raising=False)
+    status = compute_node_bridge.run(
+        SimpleNamespace(
+            model='/tmp/model.gguf',
+            mode='auto',
+            relay_url='https://token.place',
+            relay_port=None,
+        )
+    )
+
+    assert status == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events == [
+        {
+            'type': 'error',
+            'message': (
+                'GPU runtime provisioning failed for Windows CUDA mode '
+                '(action=failed, fallback_reason=pip install failed). '
+                'Verify CUDA toolkit/build tools and retry.'
+            ),
+        }
+    ]
+
+
 def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)

--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -593,3 +593,34 @@ def test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_
     assert 'desktop.runtime_setup' in captured.err
     assert 'action=probe_only' in captured.err
     assert repair_calls == {'source': 0, 'retry_gate': 0}
+
+
+def test_run_emits_gpu_provisioning_error_for_windows_cuda_probe_failure(
+    tmp_path, capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    model_path = tmp_path / 'model.gguf'
+    model_path.write_text('fake-model')
+    _install_fake_manager_module(FakeManager())
+
+    monkeypatch.setattr(
+        inference_sidecar,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cuda',
+            'runtime_action': 'failed',
+            'fallback_reason': 'pip install failed',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+    monkeypatch.setattr(inference_sidecar.sys, 'platform', 'win32', raising=False)
+
+    status = inference_sidecar.run(SimpleNamespace(model=str(model_path), mode='auto', prompt='h'))
+
+    assert status == 1
+    event = json.loads(capsys.readouterr().out.strip())
+    assert event['type'] == 'error'
+    assert event['code'] == 'gpu_provisioning_failed'
+    assert 'pip install failed' in event['message']


### PR DESCRIPTION
### Motivation
- PR 763 removed the silent startup hang but left GPU bootstrap opt-in unwired so desktop launches stayed `probe_only` and never attempted GPU repair/install. 
- The desktop launcher must deterministically enable runtime provisioning on Windows x64 when compute mode prefers GPU (`auto`/`gpu`/`hybrid`) without reintroducing silent pre-startup work. 
- Provide clear, actionable failure diagnostics instead of silently falling back to CPU when CUDA provisioning was expected.

### Description
- Add deterministic bootstrap wiring in the Rust launcher by introducing `configure_runtime_bootstrap_env` and constants (`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` / `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP`) in `desktop-tauri/src-tauri/src/python_runtime.rs` and using it when spawning Python children. 
- Propagate the bootstrap env to both Python child paths by calling the helper from `desktop-tauri/src-tauri/src/sidecar.rs` and `desktop-tauri/src-tauri/src/compute_node.rs`. 
- Fail fast with actionable messages when Windows CUDA is expected/detected but runtime setup remains CPU-only by adding `_gpu_provisioning_failure_message` and emitting errors in `desktop-tauri/src-tauri/python/inference_sidecar.py` and `desktop-tauri/src-tauri/python/compute_node_bridge.py`. 
- Add focused regression tests: Rust unit tests for the bootstrap decision logic and Python unit tests that assert the sidecar and compute-node bridge emit the new error behavior on Windows CUDA provisioning failures, while respecting `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP`.

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py` and all tests passed (86 passed). 
- Verified Python files compile with `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/src-tauri/python/inference_sidecar.py` which succeeded. 
- Ran desktop frontend tests with `cd desktop-tauri && npm test` which passed, while `cd desktop-tauri/src-tauri && cargo test` failed in this CI/container due to a missing system `glib-2.0` pkg-config dependency unrelated to the change. 
- `pre-commit run --all-files` was not executed in this environment because `pre-commit` is not installed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e488b26884832f83cd2c77e917798d)