### PR TITLE
🐛 Fix desktop operator bridge launch-path regression on Windows

### DIFF
--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -317,6 +317,33 @@ def wait_for_start_operator_enabled(
         ) from exc
 
 
+def assert_operator_status_stable(
+    driver: webdriver.Remote,
+    *,
+    stable_seconds: float,
+) -> None:
+    """Verify Running/Registered remain yes for a continuous window."""
+
+    deadline = time.time() + stable_seconds
+    while time.time() < deadline:
+        running_text = (
+            driver.find_element(By.XPATH, "//p[contains(.,'Running:')]//strong")
+            .text.strip()
+            .lower()
+        )
+        registered_text = (
+            driver.find_element(By.XPATH, "//p[contains(.,'Registered:')]//strong")
+            .text.strip()
+            .lower()
+        )
+        if running_text != "yes" or registered_text != "yes":
+            raise AssertionError(
+                "operator status became unstable during hold window: "
+                f"running={running_text} registered={registered_text}"
+            )
+        time.sleep(0.25)
+
+
 def assert_relay_roundtrip(
     relay_url: str,
     relay_log: Path,
@@ -523,6 +550,7 @@ def main() -> int:
                 "//p[contains(.,'Registered:')]//strong[normalize-space()='yes']",
             )
         )
+        assert_operator_status_stable(driver, stable_seconds=25.0)
 
         prompt = driver.find_element(
             By.XPATH,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -104,6 +104,16 @@ fn bridge_script_candidates(
         }
     }
 
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(
+            cwd.join("resources")
+                .join("python")
+                .join("compute_node_bridge.py"),
+        );
+        candidates.push(cwd.join("python").join("compute_node_bridge.py"));
+        candidates.push(cwd.join("compute_node_bridge.py"));
+    }
+
     candidates.push(manifest_dir.join("python").join("compute_node_bridge.py"));
     candidates
 }
@@ -765,6 +775,32 @@ mod tests {
             candidates.last().expect("manifest candidate"),
             &manifest_dir.join("python").join("compute_node_bridge.py")
         );
+    }
+
+    #[test]
+    fn bridge_script_candidates_include_current_working_directory_locations() {
+        let temp = TempDir::new().expect("tempdir");
+        let original_cwd = std::env::current_dir().expect("original cwd");
+        std::env::set_current_dir(temp.path()).expect("set cwd");
+
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let candidates = bridge_script_candidates(None, &manifest_dir);
+
+        std::env::set_current_dir(original_cwd).expect("restore cwd");
+
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("resources/python/compute_node_bridge.py")));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("python/compute_node_bridge.py")));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("compute_node_bridge.py")));
     }
 
     #[test]

--- a/outages/2026-04-19-desktop-tauri-operator-bridge-launch-path-regression.md
+++ b/outages/2026-04-19-desktop-tauri-operator-bridge-launch-path-regression.md
@@ -1,0 +1,37 @@
+# Outage: desktop-tauri operator bridge launch path regression
+
+- **Date:** 2026-04-19
+- **Slug:** `desktop-tauri-operator-bridge-launch-path-regression`
+- **Affected area:** desktop-tauri `Start operator` launch path resolution on Windows
+
+## Summary
+On some Windows desktop installs, clicking **Start operator** briefly showed `Running: yes` and
+then returned to `Running: no` with stderr reporting:
+
+`python.exe: can't find '__main__' module in '...\\AppData\\Local\\token.place'`
+
+`Registered` never switched to `yes`, so the operator did not connect to the local relay.
+
+## Symptoms
+- `Running` flipped to `yes`, then back to `no` after startup polling.
+- `Registered` stayed `no`.
+- stderr included `can't find '__main__' module in '...token.place'`.
+- Relay round-trip was never established from desktop operator mode.
+
+## Root cause
+Desktop compute-node bridge script candidate resolution was too narrow for packaged/runtime launch
+contexts and could miss the bridge script in current working directory based layouts. In those
+contexts the bridge spawn path could degrade into an invalid Python invocation that treated the
+app data directory as an entry module target.
+
+## Remediation
+- Expanded compute-node bridge script candidate discovery to include working-directory packaged
+  layouts (`./resources/python`, `./python`, and `./compute_node_bridge.py`) before fallback.
+- Added a Rust unit regression test that asserts current-working-directory candidates are included.
+- Strengthened desktop operator UI e2e to require `Running: yes` and `Registered: yes` to remain
+  stable for 25 seconds after startup, catching delayed startup regressions.
+
+## Follow-up / prevention
+- Keep desktop launcher path discovery aligned between packaged and dev layouts.
+- Preserve UI-level operator stability assertions (not just initial transition to `yes`).
+- Continue validating relay registration and inference round-trip in the same e2e flow.


### PR DESCRIPTION
### Motivation
- A reported regression caused the desktop operator to flip from `Running: yes` back to `Running: no` and emit `python.exe: can't find '__main__' module in '...\AppData\Local\token.place'`, which prevented relay registration.  
- Root cause analysis indicated the compute-node bridge script discovery missed packaged layouts rooted at the current working directory, leading to an invalid Python invocation.  
- The change aims to make bridge discovery robust across packaged/dev/CWD layouts and to add regression coverage that catches delayed flip-backs after startup.

### Description
- Expanded `bridge_script_candidates` in `desktop-tauri/src-tauri/src/compute_node.rs` to include current-working-directory packaged locations (`./resources/python/compute_node_bridge.py`, `./python/compute_node_bridge.py`, and `./compute_node_bridge.py`) before falling back to the manifest candidate.  
- Added a Rust unit test `bridge_script_candidates_include_current_working_directory_locations` to lock in CWD candidate coverage (in `compute_node.rs` tests).  
- Hardened the desktop UI e2e `test_desktop_operator_ui_e2e.py` by adding `assert_operator_status_stable(...)` and asserting `Running: yes` and `Registered: yes` remain stable for 25 seconds after startup.  
- Documented the incident and remediation in `outages/2026-04-19-desktop-tauri-operator-bridge-launch-path-regression.md`.

### Testing
- Ran `python -m py_compile desktop-tauri/scripts/test_desktop_operator_ui_e2e.py`, which succeeded.  
- Attempted `cargo test -p token-place-desktop-tauri compute_node::tests::bridge_script_candidates_include_current_working_directory_locations --manifest-path desktop-tauri/src-tauri/Cargo.toml`, but the container environment lacked system `glib-2.0`/`pkg-config` and the build failed; the test is present and should pass in CI/hosts with the normal Rust toolchain dependencies.  
- `pre-commit run --all-files` was not executed in this environment because `pre-commit` is not available here; please run it in CI or locally before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54cb2a654832f8399cb660b3710d5)