### PR TITLE
🐛 Fix desktop operator re-exec __main__ launch failure on Windows

### DIFF
--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -20,6 +20,7 @@ TAURI_ROOT = DESKTOP_ROOT / "src-tauri"
 WEBDRIVER_URL = "http://127.0.0.1:4444"
 LOGS_DIR = REPO_ROOT / ".desktop-e2e-logs"
 BOOTSTRAP_LOG = LOGS_DIR / "bootstrap.log"
+RUNNING_STABILITY_WINDOW_SECONDS = 25
 
 # Ensure diagnostics artifact directory exists before fragile bootstrap/import steps.
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
@@ -523,6 +524,23 @@ def main() -> int:
                 "//p[contains(.,'Registered:')]//strong[normalize-space()='yes']",
             )
         )
+        time.sleep(RUNNING_STABILITY_WINDOW_SECONDS)
+        running_after_window = driver.find_element(
+            By.XPATH,
+            "//p[contains(.,'Running:')]//strong",
+        ).text
+        registered_after_window = driver.find_element(
+            By.XPATH,
+            "//p[contains(.,'Registered:')]//strong",
+        ).text
+        assert running_after_window.strip().lower() == "yes", (
+            "operator stopped during post-start stability window "
+            f"({RUNNING_STABILITY_WINDOW_SECONDS}s)"
+        )
+        assert registered_after_window.strip().lower() == "yes", (
+            "operator became unregistered during post-start stability window "
+            f"({RUNNING_STABILITY_WINDOW_SECONDS}s)"
+        )
 
         prompt = driver.find_element(
             By.XPATH,
@@ -547,6 +565,9 @@ def main() -> int:
         )
         assert "importerror" not in lowered_last_error, (
             f"Last error still indicates import failure: {last_error_text}"
+        )
+        assert "can't find '__main__' module" not in lowered_last_error, (
+            f"Last error still indicates Python __main__ launch failure: {last_error_text}"
         )
         assert_relay_roundtrip(relay_url, relay_log, driver_log, driver)
     except TimeoutException as exc:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import queue
 import sys
 import threading
@@ -44,6 +45,8 @@ except ModuleNotFoundError:
         return
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
+if "TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT" not in os.environ:
+    os.environ["TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT"] = str(Path(__file__).resolve())
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -348,10 +348,16 @@ def maybe_reexec_for_runtime_refresh(
         return
     if os.environ.get(REEXEC_GUARD_ENV) == "1":
         return
+    script_hint = os.environ.get("TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT", "").strip()
+    reexec_argv = [sys.executable, *sys.argv]
+    if len(sys.argv) > 0:
+        script_candidate = Path(sys.argv[0]).expanduser()
+        if script_candidate.is_dir() and script_hint and Path(script_hint).is_file():
+            reexec_argv = [sys.executable, script_hint, *sys.argv[1:]]
     env = os.environ.copy()
     env[REEXEC_GUARD_ENV] = "1"
     try:
-        os.execve(sys.executable, [sys.executable, *sys.argv], env)
+        os.execve(sys.executable, reexec_argv, env)
     except OSError:
         return
 

--- a/desktop-tauri/src-tauri/python/inference_sidecar.py
+++ b/desktop-tauri/src-tauri/python/inference_sidecar.py
@@ -26,6 +26,8 @@ from desktop_runtime_setup import (
 )
 
 ensure_runtime_import_paths(__file__)
+if "TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT" not in os.environ:
+    os.environ["TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT"] = str(Path(__file__).resolve())
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False

--- a/outages/2026-04-19-desktop-tauri-runtime-reexec-main-module-launch-failure.json
+++ b/outages/2026-04-19-desktop-tauri-runtime-reexec-main-module-launch-failure.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-19",
+  "slug": "desktop-tauri-runtime-reexec-main-module-launch-failure",
+  "summary": "Desktop-tauri operator startup on Windows could re-exec Python with a directory argv, causing a '__main__' module launch failure and operator exit before relay registration.",
+  "impact": "Users saw Start operator briefly run and then stop with Running=no, Registered=no, and no relay connection on localhost.",
+  "fix": "Added a TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT hint in desktop entrypoints, hardened maybe_reexec_for_runtime_refresh(...) to replace directory argv[0] with the script hint, and added unit + desktop UI e2e regression coverage for post-start stability and __main__ failures.",
+  "lessons": "When process re-exec is part of runtime bootstrap, argv must be validated and normalized; inherited argv values from desktop launchers can be structurally invalid for Python script relaunch."
+}

--- a/outages/2026-04-19-desktop-tauri-runtime-reexec-main-module-launch-failure.md
+++ b/outages/2026-04-19-desktop-tauri-runtime-reexec-main-module-launch-failure.md
@@ -1,0 +1,40 @@
+# Outage: desktop-tauri operator re-exec could relaunch Python with a directory argv
+
+- **Date:** 2026-04-19
+- **Slug:** `desktop-tauri-runtime-reexec-main-module-launch-failure`
+- **Affected area:** desktop-tauri operator startup and runtime repair re-exec on Windows
+
+## Summary
+After clicking **Start operator**, the desktop app could report `Running: yes` briefly and then
+flip back to `Running: no` around 20 seconds later. The bridge process exited before relay
+registration completed, leaving `Registered: no`.
+
+## Symptoms
+- Operator status toggled to `Running: yes` and then reverted to `Running: no`.
+- `Registered` never reached `yes`, so relay registration on localhost did not complete.
+- stderr surfaced:
+  - `python.exe: can't find '__main__' module in '...\\token.place'`
+
+## Impact
+Desktop operators on Windows could not reliably complete startup after runtime repair/reload,
+which blocked relay connectivity and local operator inference workflows.
+
+## Root cause
+Runtime refresh logic (`maybe_reexec_for_runtime_refresh`) reused `sys.argv` directly for
+`os.execve(...)`. In affected desktop launches, `sys.argv[0]` could be a directory path during
+re-exec. That produced a Python relaunch targeting a folder instead of the bridge script,
+triggering a `__main__` module resolution failure and early operator exit.
+
+## Fix
+- Added a re-exec script hint (`TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT`) in desktop bridge/sidecar
+  entrypoints.
+- Hardened runtime re-exec logic to replace directory-valued `sys.argv[0]` with the script hint
+  before calling `os.execve(...)`.
+- Added unit regression coverage for the directory-argv re-exec case.
+- Strengthened desktop operator UI e2e coverage to keep the operator running/registered past a
+  25-second stability window and assert `__main__` launch errors are absent.
+
+## Follow-up / prevention
+- Keep runtime re-exec argument construction explicit in sidecar entrypoints.
+- Preserve a post-start stability window in desktop operator e2e checks so delayed startup exits
+  are caught in CI.

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -530,6 +530,37 @@ def test_maybe_reexec_for_runtime_refresh_handles_execve_oserror(monkeypatch):
     desktop_runtime_setup.maybe_reexec_for_runtime_refresh({'runtime_action': 'installed_cuda_reexec'})
 
 
+def test_maybe_reexec_for_runtime_refresh_replaces_directory_argv_with_script_hint(
+    monkeypatch, tmp_path
+):
+    class _DirectoryArgvSysStub:
+        platform = 'win32'
+        executable = sys.executable
+        prefix = sys.prefix
+        argv = [str(tmp_path), '--mode', 'auto']
+
+    script_path = tmp_path / 'compute_node_bridge.py'
+    script_path.write_text('print("ok")\n', encoding='utf-8')
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _DirectoryArgvSysStub)
+    monkeypatch.delenv(desktop_runtime_setup.REEXEC_GUARD_ENV, raising=False)
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT', str(script_path))
+
+    called: dict[str, object] = {}
+
+    def fake_execve(prog, argv, env):
+        called['prog'] = prog
+        called['argv'] = argv
+        called['guard'] = env.get(desktop_runtime_setup.REEXEC_GUARD_ENV)
+
+    monkeypatch.setattr(desktop_runtime_setup.os, 'execve', fake_execve)
+
+    desktop_runtime_setup.maybe_reexec_for_runtime_refresh({'runtime_action': 'installed_cuda_reexec'})
+
+    assert called['prog'] == sys.executable
+    assert called['guard'] == '1'
+    assert called['argv'] == [sys.executable, str(script_path), '--mode', 'auto']
+
+
 def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')


### PR DESCRIPTION
### Motivation
- A desktop operator startup regression caused the app to flip from `Running: yes` back to `Running: no` and emit `python.exe: can't find '__main__' module ...`, preventing relay registration. 
- The root cause was that runtime refresh re-exec reused `sys.argv` verbatim and `sys.argv[0]` could be a directory when launched from the desktop, causing Python to relaunch into a directory rather than a script.

### Description
- Hardened `maybe_reexec_for_runtime_refresh(...)` to normalize the re-exec argv and replace a directory-valued `sys.argv[0]` with a validated script hint before calling `os.execve(...)` (desktop-tauri/src-tauri/python/desktop_runtime_setup.py). 
- Exposed a re-exec script hint via the `TOKEN_PLACE_DESKTOP_REEXEC_SCRIPT` env var in desktop entrypoints so re-exec has a concrete script target (desktop bridge and sidecar files). 
- Added a unit regression test that simulates a directory `argv[0]` and asserts the re-exec argv is rewritten to the hinted script while preserving args (tests/unit/test_desktop_runtime_setup.py). 
- Strengthened the desktop UI e2e script to include a 25s post-start stability window and assertions that `Running`/`Registered` remain `yes` and that `can't find '__main__' module` does not appear in the Last error, and added a structured outage report documenting the regression (desktop-tauri/scripts/test_desktop_operator_ui_e2e.py and outages/...).

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_runtime_setup.py`, which passed (44 passed). 
- Ran `pytest -q --noconftest tests/e2e/test_windows_nvidia_gpu_smoke_contract.py`, which passed (2 passed). 
- A full `pytest -q tests/unit/test_desktop_runtime_setup.py` run failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'requests'` from `tests/conftest.py`), which is an environment limitation rather than a code failure. 
- `pre-commit run --all-files` could not be executed in this environment because `pre-commit` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54cb2a654832f8399cb660b3710d5)