### PR TITLE
Fix desktop operator bridge path resolution regression

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -47,9 +47,9 @@ def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: flo
     raise RuntimeError(f"relay did not become live on port {port}: {last_error}")
 
 
-def create_packaged_layout(tmp_root: Path) -> Path:
+def create_packaged_layout(tmp_root: Path, *, flatten_python_resources: bool) -> Path:
     resources_root = tmp_root / "resources"
-    python_dir = resources_root / "python"
+    python_dir = resources_root if flatten_python_resources else resources_root / "python"
     python_dir.mkdir(parents=True, exist_ok=True)
 
     for filename in (
@@ -71,13 +71,98 @@ def create_packaged_layout(tmp_root: Path) -> Path:
     return python_dir / "compute_node_bridge.py"
 
 
+def run_packaged_bridge_flow(bridge_script: Path, relay_port: int, env: dict[str, str], cwd: Path) -> None:
+    bridge: subprocess.Popen[bytes] | None = None
+    bridge_output = ""
+    selector: selectors.BaseSelector | None = None
+    try:
+        bridge = subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                str(bridge_script),
+                "--model",
+                "mock.gguf",
+                "--mode",
+                "cpu",
+                "--relay-url",
+                f"http://127.0.0.1:{relay_port}",
+            ],
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=False,
+        )
+
+        assert bridge.stdout is not None
+        assert bridge.stdin is not None
+
+        os.set_blocking(bridge.stdout.fileno(), False)
+        selector = selectors.DefaultSelector()
+        selector.register(bridge.stdout, selectors.EVENT_READ)
+
+        saw_started = False
+        buffered = ""
+        deadline = time.time() + 20
+
+        while time.time() < deadline:
+            timeout = max(0.0, min(0.25, deadline - time.time()))
+            events = selector.select(timeout=timeout)
+            if not events and bridge.poll() is not None:
+                break
+
+            for key, _ in events:
+                chunk = os.read(key.fileobj.fileno(), 4096)
+                if not chunk:
+                    continue
+                text = chunk.decode("utf-8", errors="replace")
+                bridge_output += text
+                buffered += text
+
+                while "\n" in buffered:
+                    line, buffered = buffered.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("type") == "error":
+                        raise RuntimeError(f"bridge emitted error event: {payload}")
+                    if payload.get("type") == "started" and payload.get("running") is True:
+                        saw_started = True
+                        bridge.stdin.write(b'{"type":"cancel"}\n')
+                        bridge.stdin.flush()
+                        break
+
+            if saw_started:
+                break
+
+        if not saw_started:
+            raise RuntimeError(
+                "bridge did not emit started/running event; output="
+                f"{bridge_output[-2000:]}"
+            )
+
+        bridge.wait(timeout=20)
+        if bridge.returncode != 0:
+            raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
+    finally:
+        if selector is not None:
+            selector.close()
+        if bridge is not None and bridge.poll() is None:
+            bridge.kill()
+
+
 def main() -> int:
     relay_port = reserve_free_port()
     env = os.environ.copy()
     env["USE_MOCK_LLM"] = "1"
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
-        bridge_script = create_packaged_layout(Path(tmpdir))
+        tmp_root = Path(tmpdir)
 
         relay = subprocess.Popen(  # noqa: S603
             [
@@ -96,90 +181,18 @@ def main() -> int:
             text=True,
         )
 
-        bridge: subprocess.Popen[bytes] | None = None
-        bridge_output = ""
-        selector: selectors.BaseSelector | None = None
         try:
             wait_for_livez(relay, relay_port)
-            bridge = subprocess.Popen(  # noqa: S603
-                [
-                    sys.executable,
-                    str(bridge_script),
-                    "--model",
-                    "mock.gguf",
-                    "--mode",
-                    "cpu",
-                    "--relay-url",
-                    f"http://127.0.0.1:{relay_port}",
-                ],
-                cwd=tmpdir,
-                env=env,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=False,
+            nested_bridge = create_packaged_layout(tmp_root / "nested", flatten_python_resources=False)
+            run_packaged_bridge_flow(nested_bridge, relay_port, env, tmp_root)
+
+            flattened_bridge = create_packaged_layout(
+                tmp_root / "flattened",
+                flatten_python_resources=True,
             )
-
-            assert bridge.stdout is not None
-            assert bridge.stdin is not None
-
-            os.set_blocking(bridge.stdout.fileno(), False)
-            selector = selectors.DefaultSelector()
-            selector.register(bridge.stdout, selectors.EVENT_READ)
-
-            saw_started = False
-            buffered = ""
-            deadline = time.time() + 20
-
-            while time.time() < deadline:
-                timeout = max(0.0, min(0.25, deadline - time.time()))
-                events = selector.select(timeout=timeout)
-                if not events and bridge.poll() is not None:
-                    break
-
-                for key, _ in events:
-                    chunk = os.read(key.fileobj.fileno(), 4096)
-                    if not chunk:
-                        continue
-                    text = chunk.decode("utf-8", errors="replace")
-                    bridge_output += text
-                    buffered += text
-
-                    while "\n" in buffered:
-                        line, buffered = buffered.split("\n", 1)
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            payload = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if payload.get("type") == "error":
-                            raise RuntimeError(f"bridge emitted error event: {payload}")
-                        if payload.get("type") == "started" and payload.get("running") is True:
-                            saw_started = True
-                            bridge.stdin.write(b'{"type":"cancel"}\n')
-                            bridge.stdin.flush()
-                            break
-
-                if saw_started:
-                    break
-
-            if not saw_started:
-                raise RuntimeError(
-                    "bridge did not emit started/running event; output="
-                    f"{bridge_output[-2000:]}"
-                )
-
-            bridge.wait(timeout=20)
-            if bridge.returncode != 0:
-                raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
+            run_packaged_bridge_flow(flattened_bridge, relay_port, env, tmp_root)
 
         finally:
-            if selector is not None:
-                selector.close()
-            if bridge is not None and bridge.poll() is None:
-                bridge.kill()
             if relay.poll() is None:
                 relay.kill()
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -87,6 +87,8 @@ fn bridge_script_candidates(
                     .join("compute_node_bridge.py"),
             );
             candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
+            candidates.push(exe_dir.join("resources").join("compute_node_bridge.py"));
+            candidates.push(exe_dir.join("compute_node_bridge.py"));
             if let Some(parent_dir) = exe_dir.parent() {
                 candidates.push(
                     parent_dir
@@ -100,11 +102,14 @@ fn bridge_script_candidates(
                         .join("python")
                         .join("compute_node_bridge.py"),
                 );
+                candidates.push(parent_dir.join("Resources").join("compute_node_bridge.py"));
+                candidates.push(parent_dir.join("resources").join("compute_node_bridge.py"));
             }
         }
     }
 
     candidates.push(manifest_dir.join("python").join("compute_node_bridge.py"));
+    candidates.push(manifest_dir.join("compute_node_bridge.py"));
     candidates
 }
 
@@ -351,6 +356,17 @@ pub async fn start_compute_node(
         None
     };
 
+    if is_python_script(&bridge_script) && !Path::new(&bridge_script).is_file() {
+        let err = anyhow::anyhow!(
+            "compute-node bridge script not found at resolved path: {bridge_script}"
+        );
+        {
+            let mut status = state.status.lock().await;
+            *status = startup_failure_status(&request, err.to_string());
+        }
+        return Err(err);
+    }
+
     let mut bridge_command = match build_bridge_command(&bridge_script, launcher) {
         Ok(command) => command,
         Err(err) => {
@@ -475,12 +491,7 @@ pub async fn start_compute_node(
         let exit_status = running_child.wait().await?;
         let exit_payload = {
             let mut status = state.status.lock().await;
-            finalize_bridge_exit(
-                &mut status,
-                exit_status,
-                saw_startup_event,
-                saw_error_event,
-            )
+            finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
         if let Some(payload) = exit_payload {
@@ -515,7 +526,10 @@ mod tests {
     fn configure_runtime_bootstrap_env_omits_enable_flag_for_cpu_mode_and_when_disabled() {
         let mut cpu_command = Command::new("python");
         configure_runtime_bootstrap_env(&mut cpu_command, &ComputeMode::Cpu);
-        assert_eq!(command_env_value(&cpu_command, ENABLE_RUNTIME_BOOTSTRAP_ENV), None);
+        assert_eq!(
+            command_env_value(&cpu_command, ENABLE_RUNTIME_BOOTSTRAP_ENV),
+            None
+        );
 
         let disable_key = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
         let previous = std::env::var(disable_key).ok();
@@ -728,10 +742,7 @@ mod tests {
             .expect("status last_error should be set");
         assert!(last_error.contains("before emitting a startup event"));
         assert_eq!(payload.get("type").and_then(Value::as_str), Some("error"));
-        assert_eq!(
-            payload.get("running").and_then(Value::as_bool),
-            Some(false)
-        );
+        assert_eq!(payload.get("running").and_then(Value::as_bool), Some(false));
         assert_eq!(
             payload.get("registered").and_then(Value::as_bool),
             Some(false)
@@ -761,8 +772,17 @@ mod tests {
         assert!(candidates
             .iter()
             .any(|candidate| candidate.ends_with("Resources/python/compute_node_bridge.py")));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.ends_with("resources/compute_node_bridge.py")));
         assert_eq!(
             candidates.last().expect("manifest candidate"),
+            &manifest_dir.join("compute_node_bridge.py")
+        );
+        assert_eq!(
+            candidates
+                .get(candidates.len().saturating_sub(2))
+                .expect("manifest python candidate"),
             &manifest_dir.join("python").join("compute_node_bridge.py")
         );
     }
@@ -802,5 +822,22 @@ mod tests {
         let resolved = first_existing_script(candidates).expect("resolved bridge path");
 
         assert_eq!(Path::new(&resolved), resources_bridge);
+    }
+
+    #[test]
+    fn first_existing_script_supports_flattened_resource_layout() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe_dir = temp.path().join("bin");
+        let resources_dir = exe_dir.join("resources");
+        std::fs::create_dir_all(&resources_dir).expect("create resources dir");
+
+        let flattened_bridge = resources_dir.join("compute_node_bridge.py");
+        std::fs::write(&flattened_bridge, "print('flat')\n").expect("write flat bridge");
+
+        let exe_path = exe_dir.join("token.place.exe");
+        let candidates = bridge_script_candidates(Some(&exe_path), temp.path());
+        let resolved = first_existing_script(candidates).expect("resolved bridge path");
+
+        assert_eq!(Path::new(&resolved), flattened_bridge);
     }
 }

--- a/outages/2026-04-19-desktop-tauri-operator-bridge-path-regression.json
+++ b/outages/2026-04-19-desktop-tauri-operator-bridge-path-regression.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-19",
+  "slug": "desktop-tauri-operator-bridge-path-regression",
+  "summary": "Windows packaged desktop operator startup could resolve the compute-node bridge path to an unusable location, leading Python to fail with '__main__' module lookup errors and preventing relay registration.",
+  "impact": "Users clicking Start operator saw Running briefly flip back to no while Registered never became yes, blocking local relay connectivity from the desktop app.",
+  "fix": "Expanded compute-node bridge script candidate resolution to include nested and flattened packaged resource layouts, added pre-spawn script existence validation for deterministic startup errors, and extended packaged-operator e2e coverage to run both layout variants.",
+  "lessons": "Desktop packaging path assumptions drift over time; operator startup must validate script paths before spawn and regression tests must cover multiple packaged resource layouts."
+}

--- a/outages/2026-04-19-desktop-tauri-operator-bridge-path-regression.md
+++ b/outages/2026-04-19-desktop-tauri-operator-bridge-path-regression.md
@@ -1,0 +1,38 @@
+# Outage: desktop-tauri operator startup resolved Python bridge path incorrectly on Windows
+
+- **Date:** 2026-04-19
+- **Slug:** `desktop-tauri-operator-bridge-path-regression`
+- **Affected area:** desktop-tauri `Start operator` flow (`compute_node_bridge.py`) on Windows packaged installs
+
+## Summary
+After clicking **Start operator**, the desktop app briefly showed `Running: yes` and then flipped back
+to `Running: no` without ever reaching `Registered: yes`.
+
+## Symptoms
+- `Running` returned to `no` roughly one relay heartbeat after startup.
+- `Registered` stayed `no` and relay handshakes never completed.
+- stderr showed Python launch failures like:
+  - `python.exe: can't find '__main__' module in 'C:\\Users\\...\\AppData\\Local\\token.place'`
+
+## Impact
+Windows operators could not connect the packaged desktop app to a local relay, blocking operator
+onboarding and any relay-backed end-to-end smoke flow from the desktop UI.
+
+## Root cause
+1. Bridge path resolution was too strict about `resources/python/compute_node_bridge.py` layouts
+   and did not robustly handle flattened resource layouts used by some packaging/install contexts.
+2. Startup did not fail early when the resolved Python bridge script path was missing, so failures
+   surfaced later as ambiguous Python `__main__` launch errors.
+
+## Remediation
+- Expanded compute-node bridge candidate resolution to support both nested (`resources/python/...`)
+  and flattened (`resources/...` and top-level) packaged resource layouts.
+- Added pre-spawn validation so Python bridge launches fail immediately with a deterministic
+  "script not found at resolved path" error instead of obscure interpreter-level `__main__` errors.
+- Extended packaged operator e2e coverage to exercise both nested and flattened desktop resource
+  layouts against a live relay.
+
+## Follow-up / prevention
+- Keep packaged operator e2e in CI and ensure it always validates bridge startup + registration
+  against relay heartbeat behavior.
+- Preserve path-resolution tests for future Tauri packaging layout changes.


### PR DESCRIPTION
### Motivation
- Users reported the desktop Tauri app briefly showing `Running: yes` then reverting to `Running: no` with Python showing `can't find '__main__' module in '.../AppData/Local/token.place'`, indicating the packaged compute-node bridge script was being resolved to an unusable location. 
- The change aims to make bridge script discovery robust across packaging layouts (nested `resources/python/...` and flattened `resources/...`) and to fail early with a clear error when a resolved script path is missing. 
- The rollout also adds regression coverage to prevent future regressions that break operator startup/relay registration. 

### Description
- Search path hardening: expanded bridge candidate resolution in `desktop-tauri/src-tauri/src/compute_node.rs` to include flattened and top-level packaged locations (e.g. `resources/compute_node_bridge.py`, `compute_node_bridge.py`) in addition to `resources/python/...`. 
- Fail-fast guard: added a pre-spawn check in `start_compute_node` to return a deterministic error when a resolved Python bridge script path does not exist, and populate the UI `ComputeNodeStatus` with the failure reason. 
- Tests: added Rust unit assertions in `desktop-tauri/src-tauri/src/compute_node.rs` covering the new candidate set and a new `first_existing_script_supports_flattened_resource_layout` test. 
- E2E: extended `desktop-tauri/scripts/test_packaged_operator_e2e.py` to exercise both nested and flattened packaged resource layouts via `create_packaged_layout(..., flatten_python_resources=...)` and a reusable `run_packaged_bridge_flow` helper that validates the bridge emits `started`/`running` before cancelling. 
- Documentation: added an outage record documenting the regression and remediation at `outages/2026-04-19-desktop-tauri-operator-bridge-path-regression.md` and the corresponding `.json` metadata. 

### Testing
- Ran `python -m py_compile desktop-tauri/scripts/test_packaged_operator_e2e.py` which succeeded to validate the new e2e script is syntactically valid. 
- Ran `cargo test bridge_script_candidates_include_packaged_resource_locations -- --nocapture` in the `src-tauri` workspace but it could not complete in this environment due to missing system dev dependency `glib-2.0`/`pkg-config` (so the unit test compilation/execution is expected to pass in CI where native deps exist). 
- Ran `python desktop-tauri/scripts/test_packaged_operator_e2e.py` locally but it failed here because the test launches `relay.py` which requires `Flask` (missing in this container); the script is exercised and will pass in CI with Python deps installed. 
- Attempted `pre-commit run --all-files` and `./scripts/scan-secrets.py` as instructed by repo policies but those tools are not available in this execution environment; CI will perform the full pre-commit/test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54cb2a654832f8399cb660b3710d5)