### PR TITLE
Fix Windows packaged compute-node bridge resolution; require relay registration in packaged e2e

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -103,3 +103,24 @@ jobs:
           path: .desktop-e2e-logs/
           include-hidden-files: true
           if-no-files-found: warn
+
+  desktop-operator-packaged-e2e-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run packaged operator bridge e2e (Windows)
+        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -128,6 +128,7 @@ def main() -> int:
             selector.register(bridge.stdout, selectors.EVENT_READ)
 
             saw_started = False
+            saw_registered = False
             buffered = ""
             deadline = time.time() + 20
 
@@ -158,16 +159,24 @@ def main() -> int:
                             raise RuntimeError(f"bridge emitted error event: {payload}")
                         if payload.get("type") == "started" and payload.get("running") is True:
                             saw_started = True
+                        if payload.get("registered") is True:
+                            saw_registered = True
+                        if saw_started and saw_registered:
                             bridge.stdin.write(b'{"type":"cancel"}\n')
                             bridge.stdin.flush()
                             break
 
-                if saw_started:
+                if saw_started and saw_registered:
                     break
 
             if not saw_started:
                 raise RuntimeError(
                     "bridge did not emit started/running event; output="
+                    f"{bridge_output[-2000:]}"
+                )
+            if not saw_registered:
+                raise RuntimeError(
+                    "bridge never reported registered=true (relay connection missing); output="
                     f"{bridge_output[-2000:]}"
                 )
 

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -73,10 +73,12 @@ def create_packaged_layout(tmp_root: Path) -> Path:
 
 
 def enqueue_bridge_stdout(stdout: object, output_queue: queue.Queue[bytes]) -> None:
-    if not hasattr(stdout, "read"):
+    if not hasattr(stdout, "readline"):
         return
+
+    readline = stdout.readline
     while True:
-        chunk = stdout.read(4096)
+        chunk = readline()
         if not chunk:
             return
         output_queue.put(chunk)

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 import json
 import os
-import selectors
+import queue
 import shutil
 import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 from urllib.request import urlopen
@@ -71,6 +72,16 @@ def create_packaged_layout(tmp_root: Path) -> Path:
     return python_dir / "compute_node_bridge.py"
 
 
+def enqueue_bridge_stdout(stdout: object, output_queue: queue.Queue[bytes]) -> None:
+    if not hasattr(stdout, "read"):
+        return
+    while True:
+        chunk = stdout.read(4096)
+        if not chunk:
+            return
+        output_queue.put(chunk)
+
+
 def main() -> int:
     relay_port = reserve_free_port()
     env = os.environ.copy()
@@ -98,7 +109,7 @@ def main() -> int:
 
         bridge: subprocess.Popen[bytes] | None = None
         bridge_output = ""
-        selector: selectors.BaseSelector | None = None
+        output_queue: queue.Queue[bytes] | None = None
         try:
             wait_for_livez(relay, relay_port)
             bridge = subprocess.Popen(  # noqa: S603
@@ -123,9 +134,12 @@ def main() -> int:
             assert bridge.stdout is not None
             assert bridge.stdin is not None
 
-            os.set_blocking(bridge.stdout.fileno(), False)
-            selector = selectors.DefaultSelector()
-            selector.register(bridge.stdout, selectors.EVENT_READ)
+            output_queue = queue.Queue()
+            threading.Thread(
+                target=enqueue_bridge_stdout,
+                args=(bridge.stdout, output_queue),
+                daemon=True,
+            ).start()
 
             saw_started = False
             saw_registered = False
@@ -134,37 +148,36 @@ def main() -> int:
 
             while time.time() < deadline:
                 timeout = max(0.0, min(0.25, deadline - time.time()))
-                events = selector.select(timeout=timeout)
-                if not events and bridge.poll() is not None:
-                    break
+                try:
+                    chunk = output_queue.get(timeout=timeout)
+                except queue.Empty:
+                    if bridge.poll() is not None:
+                        break
+                    continue
 
-                for key, _ in events:
-                    chunk = os.read(key.fileobj.fileno(), 4096)
-                    if not chunk:
+                text = chunk.decode("utf-8", errors="replace")
+                bridge_output += text
+                buffered += text
+
+                while "\n" in buffered:
+                    line, buffered = buffered.split("\n", 1)
+                    line = line.strip()
+                    if not line:
                         continue
-                    text = chunk.decode("utf-8", errors="replace")
-                    bridge_output += text
-                    buffered += text
-
-                    while "\n" in buffered:
-                        line, buffered = buffered.split("\n", 1)
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            payload = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if payload.get("type") == "error":
-                            raise RuntimeError(f"bridge emitted error event: {payload}")
-                        if payload.get("type") == "started" and payload.get("running") is True:
-                            saw_started = True
-                        if payload.get("registered") is True:
-                            saw_registered = True
-                        if saw_started and saw_registered:
-                            bridge.stdin.write(b'{"type":"cancel"}\n')
-                            bridge.stdin.flush()
-                            break
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("type") == "error":
+                        raise RuntimeError(f"bridge emitted error event: {payload}")
+                    if payload.get("type") == "started" and payload.get("running") is True:
+                        saw_started = True
+                    if payload.get("registered") is True:
+                        saw_registered = True
+                    if saw_started and saw_registered:
+                        bridge.stdin.write(b'{"type":"cancel"}\n')
+                        bridge.stdin.flush()
+                        break
 
                 if saw_started and saw_registered:
                     break
@@ -185,8 +198,6 @@ def main() -> int:
                 raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
 
         finally:
-            if selector is not None:
-                selector.close()
             if bridge is not None and bridge.poll() is None:
                 bridge.kill()
             if relay.poll() is None:

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -75,8 +75,14 @@ fn is_python_script(path: &str) -> bool {
 fn bridge_script_candidates(
     exe_path: Option<&Path>,
     manifest_dir: &Path,
+    resource_dir: Option<&Path>,
 ) -> Vec<std::path::PathBuf> {
     let mut candidates = Vec::new();
+
+    if let Some(resource_dir) = resource_dir {
+        candidates.push(resource_dir.join("python").join("compute_node_bridge.py"));
+        candidates.push(resource_dir.join("compute_node_bridge.py"));
+    }
 
     if let Some(exe_path) = exe_path {
         if let Some(exe_dir) = exe_path.parent() {
@@ -88,6 +94,13 @@ fn bridge_script_candidates(
             );
             candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
             if let Some(parent_dir) = exe_dir.parent() {
+                candidates.push(
+                    parent_dir
+                        .join("_up_")
+                        .join("resources")
+                        .join("python")
+                        .join("compute_node_bridge.py"),
+                );
                 candidates.push(
                     parent_dir
                         .join("Resources")
@@ -108,10 +121,12 @@ fn bridge_script_candidates(
     candidates
 }
 
-fn resolve_bridge_script() -> String {
+fn resolve_bridge_script(app: &AppHandle) -> String {
     let exe_path = std::env::current_exe().ok();
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let candidates = bridge_script_candidates(exe_path.as_deref(), manifest_dir);
+    let resource_dir = app.path().resource_dir().ok();
+    let candidates =
+        bridge_script_candidates(exe_path.as_deref(), manifest_dir, resource_dir.as_deref());
 
     if let Some(path) = first_existing_script(candidates) {
         return path;
@@ -323,7 +338,7 @@ pub async fn start_compute_node(
         *state.stdin.lock().await = None;
     }
 
-    let bridge_script = resolve_bridge_script();
+    let bridge_script = resolve_bridge_script(&app);
     let launcher = if is_python_script(&bridge_script) {
         match tokio::task::spawn_blocking(|| resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON"))
             .await
@@ -475,12 +490,7 @@ pub async fn start_compute_node(
         let exit_status = running_child.wait().await?;
         let exit_payload = {
             let mut status = state.status.lock().await;
-            finalize_bridge_exit(
-                &mut status,
-                exit_status,
-                saw_startup_event,
-                saw_error_event,
-            )
+            finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
         if let Some(payload) = exit_payload {
@@ -515,7 +525,10 @@ mod tests {
     fn configure_runtime_bootstrap_env_omits_enable_flag_for_cpu_mode_and_when_disabled() {
         let mut cpu_command = Command::new("python");
         configure_runtime_bootstrap_env(&mut cpu_command, &ComputeMode::Cpu);
-        assert_eq!(command_env_value(&cpu_command, ENABLE_RUNTIME_BOOTSTRAP_ENV), None);
+        assert_eq!(
+            command_env_value(&cpu_command, ENABLE_RUNTIME_BOOTSTRAP_ENV),
+            None
+        );
 
         let disable_key = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
         let previous = std::env::var(disable_key).ok();
@@ -728,10 +741,7 @@ mod tests {
             .expect("status last_error should be set");
         assert!(last_error.contains("before emitting a startup event"));
         assert_eq!(payload.get("type").and_then(Value::as_str), Some("error"));
-        assert_eq!(
-            payload.get("running").and_then(Value::as_bool),
-            Some(false)
-        );
+        assert_eq!(payload.get("running").and_then(Value::as_bool), Some(false));
         assert_eq!(
             payload.get("registered").and_then(Value::as_bool),
             Some(false)
@@ -753,7 +763,7 @@ mod tests {
             .join("repo")
             .join("desktop-tauri")
             .join("src-tauri");
-        let candidates = bridge_script_candidates(Some(&exe_path), &manifest_dir);
+        let candidates = bridge_script_candidates(Some(&exe_path), &manifest_dir, None);
 
         assert!(candidates
             .iter()
@@ -777,7 +787,7 @@ mod tests {
         std::fs::write(&bridge, "print('ok')\n").expect("write bridge");
 
         let exe_path = exe_dir.join("token.place.exe");
-        let candidates = bridge_script_candidates(Some(&exe_path), temp.path());
+        let candidates = bridge_script_candidates(Some(&exe_path), temp.path(), None);
         let resolved = first_existing_script(candidates).expect("resolved bridge path");
 
         assert_eq!(Path::new(&resolved), bridge);
@@ -798,9 +808,27 @@ mod tests {
         std::fs::write(&resources_bridge, "print('resources')\n").expect("write resources bridge");
 
         let exe_path = exe_dir.join("token.place");
-        let candidates = bridge_script_candidates(Some(&exe_path), temp.path());
+        let candidates = bridge_script_candidates(Some(&exe_path), temp.path(), None);
         let resolved = first_existing_script(candidates).expect("resolved bridge path");
 
         assert_eq!(Path::new(&resolved), resources_bridge);
+    }
+
+    #[test]
+    fn bridge_script_candidates_include_runtime_resource_and_windows_updater_paths() {
+        let temp = TempDir::new().expect("tempdir");
+        let resource_dir = temp.path().join("runtime-resources");
+        let exe_dir = temp.path().join("Local").join("token.place");
+        let exe_path = exe_dir.join("token.place.exe");
+        let candidates =
+            bridge_script_candidates(Some(&exe_path), temp.path(), Some(&resource_dir));
+
+        assert_eq!(
+            candidates.first().expect("first candidate"),
+            &resource_dir.join("python").join("compute_node_bridge.py")
+        );
+        assert!(candidates.iter().any(|candidate| {
+            candidate.ends_with("_up_/resources/python/compute_node_bridge.py")
+        }));
     }
 }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
@@ -506,57 +506,6 @@ pub async fn start_compute_node(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn configure_runtime_bootstrap_env_sets_enable_flag_for_gpu_mode() {
-        let mut command = Command::new("python");
-        configure_runtime_bootstrap_env(&mut command, &ComputeMode::Hybrid);
-
-        assert_eq!(
-            command_env_value(&command, ENABLE_RUNTIME_BOOTSTRAP_ENV).as_deref(),
-            Some("1")
-        );
-    }
-
-    #[test]
-    fn configure_runtime_bootstrap_env_omits_enable_flag_for_cpu_mode_and_when_disabled() {
-        let mut cpu_command = Command::new("python");
-        configure_runtime_bootstrap_env(&mut cpu_command, &ComputeMode::Cpu);
-        assert_eq!(
-            command_env_value(&cpu_command, ENABLE_RUNTIME_BOOTSTRAP_ENV),
-            None
-        );
-
-        let disable_key = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
-        let previous = std::env::var(disable_key).ok();
-        // SAFETY: This unit test mutates process env in a tightly scoped block and restores it.
-        unsafe {
-            std::env::set_var(disable_key, "1");
-        }
-        let mut disabled_command = Command::new("python");
-        configure_runtime_bootstrap_env(&mut disabled_command, &ComputeMode::Gpu);
-        if let Some(value) = previous {
-            // SAFETY: restore prior process env for test isolation.
-            unsafe {
-                std::env::set_var(disable_key, value);
-            }
-        } else {
-            // SAFETY: restore prior process env for test isolation.
-            unsafe {
-                std::env::remove_var(disable_key);
-            }
-        }
-
-        assert_eq!(
-            command_env_value(&disabled_command, ENABLE_RUNTIME_BOOTSTRAP_ENV),
-            None
-        );
-    }
-}
-
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
     let _lifecycle_lock = state.lifecycle_lock.lock().await;
 
@@ -830,5 +779,51 @@ mod tests {
         assert!(candidates.iter().any(|candidate| {
             candidate.ends_with("_up_/resources/python/compute_node_bridge.py")
         }));
+    }
+
+    #[test]
+    fn configure_runtime_bootstrap_env_sets_enable_flag_for_gpu_mode() {
+        let mut command = Command::new("python");
+        configure_runtime_bootstrap_env(&mut command, &ComputeMode::Hybrid);
+
+        assert_eq!(
+            command_env_value(&command, ENABLE_RUNTIME_BOOTSTRAP_ENV).as_deref(),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn configure_runtime_bootstrap_env_omits_enable_flag_for_cpu_mode_and_when_disabled() {
+        let mut cpu_command = Command::new("python");
+        configure_runtime_bootstrap_env(&mut cpu_command, &ComputeMode::Cpu);
+        assert_eq!(
+            command_env_value(&cpu_command, ENABLE_RUNTIME_BOOTSTRAP_ENV),
+            None
+        );
+
+        let disable_key = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
+        let previous = std::env::var(disable_key).ok();
+        // SAFETY: This unit test mutates process env in a tightly scoped block and restores it.
+        unsafe {
+            std::env::set_var(disable_key, "1");
+        }
+        let mut disabled_command = Command::new("python");
+        configure_runtime_bootstrap_env(&mut disabled_command, &ComputeMode::Gpu);
+        if let Some(value) = previous {
+            // SAFETY: restore prior process env for test isolation.
+            unsafe {
+                std::env::set_var(disable_key, value);
+            }
+        } else {
+            // SAFETY: restore prior process env for test isolation.
+            unsafe {
+                std::env::remove_var(disable_key);
+            }
+        }
+
+        assert_eq!(
+            command_env_value(&disabled_command, ENABLE_RUNTIME_BOOTSTRAP_ENV),
+            None
+        );
     }
 }

--- a/outages/2026-04-19-desktop-tauri-operator-bridge-script-resolution-windows.json
+++ b/outages/2026-04-19-desktop-tauri-operator-bridge-script-resolution-windows.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-19",
+  "slug": "desktop-tauri-operator-bridge-script-resolution-windows",
+  "summary": "Desktop operator startup could regress on Windows packaged installs when compute_node_bridge.py was not resolved from runtime resources, causing the bridge process to terminate before registration and leaving the UI in Running=no / Registered=no.",
+  "impact": "Windows desktop operators could not connect to local relays after clicking Start operator, blocking operator bring-up and relay-backed inference validation.",
+  "fix": "Updated desktop-tauri compute-node bridge resolution to include runtime resource_dir candidates and Windows updater resource layouts, plus added CI coverage on windows-latest for packaged operator e2e and strengthened packaged e2e assertions to require registered=true before shutdown.",
+  "lessons": "Packaged desktop path resolution must be validated against runtime resource locations (including updater layouts), and operator e2e tests must assert relay registration, not only process startup."
+}

--- a/outages/2026-04-19-desktop-tauri-operator-bridge-script-resolution-windows.md
+++ b/outages/2026-04-19-desktop-tauri-operator-bridge-script-resolution-windows.md
@@ -1,0 +1,39 @@
+# Outage: desktop-tauri operator bridge script resolution failed on Windows packaged installs
+
+- **Date:** 2026-04-19
+- **Slug:** `desktop-tauri-operator-bridge-script-resolution-windows`
+- **Affected area:** desktop-tauri operator flow (`Start operator`) on Windows packaged app installs
+
+## Summary
+After clicking **Start operator**, the desktop app could briefly transition to running and then
+fall back to `Running: no` while never reaching `Registered: yes`.
+
+## Symptoms
+- UI flipped from `Running: yes` back to `Running: no` shortly after startup.
+- `Registered: yes` never appeared.
+- stderr logs included Python startup failures like:
+  - `python.exe: can't find '__main__' module in '...\\token.place'`
+
+## Impact
+Operators could not complete desktop→relay registration on Windows packaged installs,
+blocking local relay validation and operator-assisted inference flows.
+
+## Root cause
+1. Compute-node bridge script discovery did not prioritize runtime resource directory paths exposed
+   by Tauri at runtime.
+2. Candidate coverage for Windows updater layouts was incomplete, increasing the chance that
+   packaged bridge script resolution would miss the real `compute_node_bridge.py` location.
+3. Existing packaged e2e only asserted startup, not successful relay registration.
+
+## Remediation
+- Added runtime `resource_dir` bridge candidates in compute-node script resolution.
+- Added Windows updater-style resource candidate paths (`_up_/resources/python/...`).
+- Expanded regression coverage:
+  - Rust unit test asserts runtime resource and updater candidates are included.
+  - Packaged operator e2e now requires `registered=true` before shutdown.
+  - CI now runs packaged operator e2e on `windows-latest`.
+
+## Follow-up / prevention
+- Keep Windows packaged operator e2e mandatory for desktop-tauri bridge/path changes.
+- Preserve registration-state assertions (`registered=true`) in relay-connected e2e tests.
+- Continue logging bridge stderr at startup so path-resolution failures remain diagnosable.


### PR DESCRIPTION
### Motivation
- Packaged Windows desktop launches could miss `compute_node_bridge.py` (Tauri runtime resource layout/updater paths), causing the bridge to exit with Python `__main__` errors and the UI to flip from `Running: yes` back to `Running: no` without ever becoming `Registered: yes`.
- Strengthen regression coverage so the operator e2e asserts successful relay registration (not just process startup) to prevent regressions that mask missing runtime resources.

### Description
- Update `desktop-tauri/src-tauri/src/compute_node.rs` to accept a runtime `resource_dir` and prefer Tauri `resource_dir` candidates when resolving the compute-node bridge script, and add Windows updater-style `_up_/resources/python/...` candidate paths. 
- Wire `start_compute_node` to call the app-aware `resolve_bridge_script(&app)` so runtime resource candidates are actually considered during operator startup.
- Add a Rust unit test in `compute_node.rs` that asserts the runtime resource and Windows updater candidate paths are included in candidate generation. 
- Strengthen the packaged operator e2e (`desktop-tauri/scripts/test_packaged_operator_e2e.py`) to require both `started && registered == true` from the bridge before shutting down. 
- Add a Windows CI job in `.github/workflows/desktop-operator-e2e.yml` to run the packaged operator e2e on `windows-latest`. 
- Add outage documentation files `outages/2026-04-19-desktop-tauri-operator-bridge-script-resolution-windows.{md,json}` describing the regression, root cause, remediation, and follow-up.

### Testing
- Ran `npm run lint` which succeeded for JS/TS linting. (Passed)
- Ran `npm run test:ci` which shows JS tests passed but the overall run failed due to missing Python deps (`requests`, `cryptography`) in this environment; JS tests portion passed while Python test stages failed. (Partial: JS passed, Python tests failed)
- Attempted `python desktop-tauri/scripts/test_packaged_operator_e2e.py` locally but it failed because the runtime environment lacked required Python packages (relay/Flask); the script changes add the `registered=true` assertion. (Failed due to missing deps)
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` which began compiling but failed in this environment due to missing system `glib-2.0`/pkg-config libraries; the new Rust unit test is present and should pass in CI with proper toolchain. (Failed in this environment)
- Ran `cargo fmt`/`rustfmt` to format Rust changes. (Passed)

Notes: automated CI on upstream runners (with Python deps and system libs) should run the new Windows packaged e2e job and the updated Rust test; local failures above are environment constraints, not regressions in the changeset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54cb2a654832f8399cb660b3710d5)