### PR TITLE
🐛 Fix desktop operator stop lock contention in compute-node lifecycle

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -421,26 +421,48 @@ pub async fn start_compute_node(
         .take()
         .ok_or_else(|| anyhow::anyhow!("missing compute-node bridge stdin"))?;
 
-    {
+    let mut pending_child = Some(child);
+    let mut pending_stdin = Some(stdin);
+    let installed = {
         let _lifecycle_lock = state.lifecycle_lock.lock().await;
         let mut child_slot = state.child.lock().await;
-        *child_slot = Some(child);
-        let mut stdin_slot = state.stdin.lock().await;
-        *stdin_slot = Some(stdin);
-        let mut status = state.status.lock().await;
-        *status = ComputeNodeStatus {
-            running: true,
-            registered: false,
-            active_relay_url: request.relay_base_url.clone(),
-            requested_mode: format!("{:?}", request.mode).to_lowercase(),
-            effective_mode: "cpu".into(),
-            backend_available: "unknown".into(),
-            backend_selected: "cpu".into(),
-            backend_used: "cpu".into(),
-            fallback_reason: None,
-            model_path: request.model_path.clone(),
-            last_error: None,
-        };
+        if child_slot
+            .as_mut()
+            .is_some_and(|existing| existing.try_wait().ok().flatten().is_none())
+        {
+            false
+        } else {
+            *child_slot = pending_child.take();
+            let mut stdin_slot = state.stdin.lock().await;
+            *stdin_slot = pending_stdin.take();
+            let mut status = state.status.lock().await;
+            *status = ComputeNodeStatus {
+                running: true,
+                registered: false,
+                active_relay_url: request.relay_base_url.clone(),
+                requested_mode: format!("{:?}", request.mode).to_lowercase(),
+                effective_mode: "cpu".into(),
+                backend_available: "unknown".into(),
+                backend_selected: "cpu".into(),
+                backend_used: "cpu".into(),
+                fallback_reason: None,
+                model_path: request.model_path.clone(),
+                last_error: None,
+            };
+            true
+        }
+    };
+
+    if !installed {
+        if let Some(mut abandoned_stdin) = pending_stdin.take() {
+            let _ = abandoned_stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
+            let _ = abandoned_stdin.flush().await;
+        }
+        if let Some(mut abandoned_child) = pending_child.take() {
+            let _ = abandoned_child.kill().await;
+            let _ = abandoned_child.wait().await;
+        }
+        anyhow::bail!("compute node already running; stop it before starting a new session");
     }
 
     let log_policy = SubprocessLogPolicy::from_env();
@@ -513,46 +535,40 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    if let Some(stdin) = state.stdin.lock().await.as_mut() {
-        stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
-        stdin.flush().await?;
+    let mut stdin_handle = {
+        let mut stdin_lock = state.stdin.lock().await;
+        stdin_lock.take()
+    };
+    if let Some(stdin) = stdin_handle.as_mut() {
+        let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
+        let _ = stdin.flush().await;
     }
 
-    let mut should_kill = false;
+    let mut owned_child = None;
     for _ in 0..20 {
-        let mut child_lock = state.child.lock().await;
-        let Some(child) = child_lock.as_mut() else {
+        if let Some(child) = state.child.lock().await.take() {
+            owned_child = Some(child);
             break;
-        };
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
 
-        if child.try_wait()?.is_some() {
-            drop(child_lock);
-            let _lifecycle_lock = state.lifecycle_lock.lock().await;
-            *state.child.lock().await = None;
-            *state.stdin.lock().await = None;
-            {
-                let mut status = state.status.lock().await;
-                status.running = false;
-                status.registered = false;
+    if let Some(mut child) = owned_child {
+        let mut exited = child.try_wait()?.is_some();
+        for _ in 0..20 {
+            if exited {
+                break;
             }
-            return Ok(());
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            exited = child.try_wait()?.is_some();
         }
 
-        should_kill = true;
-        drop(child_lock);
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
-    if should_kill {
-        let mut child_lock = state.child.lock().await;
-        if let Some(child) = child_lock.as_mut() {
+        if !exited {
             let _ = child.kill().await;
+            let _ = child.wait().await;
         }
     }
 
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
-    *state.child.lock().await = None;
-    *state.stdin.lock().await = None;
     {
         let mut status = state.status.lock().await;
         status.running = false;

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -323,10 +323,10 @@ pub async fn start_compute_node(
     state: ComputeNodeState,
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
     {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
         let mut child_slot = state.child.lock().await;
         if child_slot
             .as_mut()
@@ -395,14 +395,15 @@ pub async fn start_compute_node(
         Ok(child) => child,
         Err(err) => {
             {
+                let _lifecycle_lock = state.lifecycle_lock.lock().await;
                 let mut status = state.status.lock().await;
                 *status = startup_failure_status(
                     &request,
                     format!("failed to start compute-node bridge: {err}"),
                 );
+                *state.child.lock().await = None;
+                *state.stdin.lock().await = None;
             }
-            *state.child.lock().await = None;
-            *state.stdin.lock().await = None;
             anyhow::bail!("failed to spawn compute-node bridge: {err}");
         }
     };
@@ -421,6 +422,7 @@ pub async fn start_compute_node(
         .ok_or_else(|| anyhow::anyhow!("missing compute-node bridge stdin"))?;
 
     {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
         let mut child_slot = state.child.lock().await;
         *child_slot = Some(child);
         let mut stdin_slot = state.stdin.lock().await;
@@ -482,6 +484,7 @@ pub async fn start_compute_node(
     }
 
     let running_child = {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
         let mut child_slot = state.child.lock().await;
         child_slot.take()
     };
@@ -501,14 +504,15 @@ pub async fn start_compute_node(
         status.running = false;
         status.registered = false;
     }
-    *state.stdin.lock().await = None;
+    {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
+        *state.stdin.lock().await = None;
+    }
 
     Ok(())
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
-
     if let Some(stdin) = state.stdin.lock().await.as_mut() {
         stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
         stdin.flush().await?;
@@ -522,11 +526,15 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         };
 
         if child.try_wait()?.is_some() {
-            *child_lock = None;
+            drop(child_lock);
+            let _lifecycle_lock = state.lifecycle_lock.lock().await;
+            *state.child.lock().await = None;
             *state.stdin.lock().await = None;
-            let mut status = state.status.lock().await;
-            status.running = false;
-            status.registered = false;
+            {
+                let mut status = state.status.lock().await;
+                status.running = false;
+                status.registered = false;
+            }
             return Ok(());
         }
 
@@ -542,6 +550,7 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
     }
 
+    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     *state.child.lock().await = None;
     *state.stdin.lock().await = None;
     {
@@ -626,6 +635,19 @@ mod tests {
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn stop_compute_node_does_not_wait_on_lifecycle_lock() {
+        let state = ComputeNodeState::default();
+        let lifecycle_guard = state.lifecycle_lock.lock().await;
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(200), stop_compute_node(state.clone()))
+                .await;
+
+        assert!(result.is_ok(), "stop should not block on lifecycle lock");
+        drop(lifecycle_guard);
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -666,6 +666,55 @@ mod tests {
         drop(lifecycle_guard);
     }
 
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn stop_compute_node_stops_running_child_with_cancel_message() {
+        let state = ComputeNodeState::default();
+        let temp = TempDir::new().expect("tempdir");
+        let observed_cancel_path = temp.path().join("observed-cancel.json");
+
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                "IFS= read -r line; printf '%s' \"$line\" > \"$1\"; [ \"$line\" = '{\"type\":\"cancel\"}' ]",
+                "sh",
+                observed_cancel_path
+                    .to_str()
+                    .expect("cancel path should be valid UTF-8"),
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cancel observer bridge");
+        let child_stdin = child.stdin.take().expect("child stdin");
+
+        *state.child.lock().await = Some(child);
+        *state.stdin.lock().await = Some(child_stdin);
+        {
+            let mut status = state.status.lock().await;
+            status.running = true;
+            status.registered = true;
+        }
+
+        let stop_result =
+            tokio::time::timeout(Duration::from_secs(2), stop_compute_node(state.clone())).await;
+        assert!(stop_result.is_ok(), "stop should complete without hanging");
+        stop_result
+            .expect("timeout result")
+            .expect("stop should succeed");
+
+        let observed_cancel = std::fs::read_to_string(&observed_cancel_path)
+            .expect("cancel message should be recorded");
+        assert_eq!(observed_cancel, "{\"type\":\"cancel\"}");
+        assert!(state.child.lock().await.is_none(), "child handle should be cleared");
+        assert!(state.stdin.lock().await.is_none(), "stdin handle should be cleared");
+
+        let final_status = state.status.lock().await.clone();
+        assert!(!final_status.running);
+        assert!(!final_status.registered);
+    }
+
     #[test]
     fn startup_failure_status_records_resolver_error_and_not_running() {
         let request = ComputeNodeRequest {


### PR DESCRIPTION
### Motivation
- `start_compute_node` previously held `lifecycle_lock` for the entire bridge lifetime so `stop_compute_node` blocked acquiring the same lock and could not write the cancel message to the bridge stdin. 
- The change breaks that contention so the UI "Stop operator" action can reliably reach the running bridge and request graceful shutdown.

### Description
- Narrowed `lifecycle_lock` usage in `start_compute_node` to short critical sections (preflight child checks, spawn-error status update, child/stdin install, and final stdin cleanup) instead of holding it across the stdout event loop. 
- Updated `stop_compute_node` to write the cancel JSON to bridge stdin without taking `lifecycle_lock`, then poll briefly for a graceful exit and only `kill()` as a fallback, performing final state cleanup under short lock sections. 
- Kept invariants: prevents concurrent sessions by checking `state.child` before start and keeps `state.child`, `state.stdin`, and `state.status` coherent during updates. 
- Added a focused regression test `stop_compute_node_does_not_wait_on_lifecycle_lock` that holds `lifecycle_lock` and asserts `stop_compute_node` completes under a timeout.

### Testing
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not complete in this environment due to missing system `glib-2.0`/`pkg-config` dev libraries required by Tauri (build error). 
- `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` passed: 23 tests OK. 
- `npm --prefix desktop-tauri run test -- src/App.test.tsx` passed: 5 tests OK. 
- `pre-commit run --all-files` was not executed here because `pre-commit` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e560b5f738832f8fc026fd2b330117)