### PR TITLE
🐛 Fix desktop operator stop lock contention in compute-node lifecycle

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -323,9 +323,9 @@ pub async fn start_compute_node(
     state: ComputeNodeState,
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
+    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     {
         let mut child_slot = state.child.lock().await;
         if child_slot
@@ -440,6 +440,7 @@ pub async fn start_compute_node(
             last_error: None,
         };
     }
+    drop(_lifecycle_lock);
 
     let log_policy = SubprocessLogPolicy::from_env();
     let stderr_task = tokio::spawn(async move {
@@ -481,6 +482,7 @@ pub async fn start_compute_node(
         eprintln!("desktop.compute_node.stderr_task_join_error error={err}");
     }
 
+    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     let running_child = {
         let mut child_slot = state.child.lock().await;
         child_slot.take()
@@ -502,13 +504,12 @@ pub async fn start_compute_node(
         status.registered = false;
     }
     *state.stdin.lock().await = None;
+    drop(_lifecycle_lock);
 
     Ok(())
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
-
     if let Some(stdin) = state.stdin.lock().await.as_mut() {
         stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
         stdin.flush().await?;
@@ -522,11 +523,14 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         };
 
         if child.try_wait()?.is_some() {
-            *child_lock = None;
-            *state.stdin.lock().await = None;
-            let mut status = state.status.lock().await;
-            status.running = false;
-            status.registered = false;
+            {
+                let _lifecycle_lock = state.lifecycle_lock.lock().await;
+                *child_lock = None;
+                *state.stdin.lock().await = None;
+                let mut status = state.status.lock().await;
+                status.running = false;
+                status.registered = false;
+            }
             return Ok(());
         }
 
@@ -542,9 +546,10 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
     }
 
-    *state.child.lock().await = None;
-    *state.stdin.lock().await = None;
     {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
+        *state.child.lock().await = None;
+        *state.stdin.lock().await = None;
         let mut status = state.status.lock().await;
         status.running = false;
         status.registered = false;
@@ -560,6 +565,7 @@ mod tests {
     use tempfile::TempDir;
     use tokio::io::AsyncBufReadExt;
     use tokio::process::Command;
+    use tokio::time::{timeout, Duration as TokioDuration};
 
     fn success_exit_status() -> ExitStatus {
         #[cfg(windows)]
@@ -626,6 +632,72 @@ mod tests {
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn stop_compute_node_does_not_wait_on_lifecycle_lock() {
+        let state = ComputeNodeState::default();
+        let lifecycle_guard = state.lifecycle_lock.lock().await;
+
+        timeout(
+            TokioDuration::from_millis(200),
+            stop_compute_node(state.clone()),
+        )
+        .await
+        .expect("stop should not block on lifecycle lock")
+        .expect("stop should succeed with empty state");
+        drop(lifecycle_guard);
+    }
+
+    #[tokio::test]
+    async fn stop_compute_node_sends_cancel_and_updates_stopped_status() {
+        let mut child = {
+            #[cfg(windows)]
+            {
+                let mut command = Command::new("python");
+                command.args([
+                    "-c",
+                    "import sys\nline=sys.stdin.readline().strip()\nraise SystemExit(0 if line == '{\"type\":\"cancel\"}' else 1)",
+                ]);
+                command
+            }
+            #[cfg(not(windows))]
+            {
+                let mut command = Command::new("sh");
+                command.args([
+                    "-c",
+                    "read line; [ \"$line\" = '{\"type\":\"cancel\"}' ]",
+                ]);
+                command
+            }
+        }
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("spawn cancel test child");
+
+        let stdin = child.stdin.take().expect("stdin");
+        let state = ComputeNodeState::default();
+        *state.child.lock().await = Some(child);
+        *state.stdin.lock().await = Some(stdin);
+        {
+            let mut status = state.status.lock().await;
+            status.running = true;
+            status.registered = true;
+        }
+
+        timeout(
+            TokioDuration::from_secs(2),
+            stop_compute_node(state.clone()),
+        )
+        .await
+        .expect("stop should not hang")
+        .expect("stop should succeed");
+
+        let status = state.status.lock().await.clone();
+        assert!(!status.running);
+        assert!(!status.registered);
+        assert!(state.child.lock().await.is_none());
+        assert!(state.stdin.lock().await.is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The operator stop path could deadlock because `start_compute_node` held `lifecycle_lock` for the entire bridge stdout/event loop lifetime and `stop_compute_node` attempted to acquire the same lock before sending the cancel message. 
- That contention prevented the cancel JSON from ever reaching the running bridge, producing a no-op/hang when the UI requested stop. 

### Description
- Move `lifecycle_lock` usage in `start_compute_node` to short critical sections only: acquire during startup/child/stdin/status initialization and re-acquire only around final teardown, then explicitly drop the lock before entering the long-running stdout loop. 
- Remove the global lock acquisition from `stop_compute_node` so a cancel JSON (`{"type":"cancel"}`) can be written immediately to the bridge stdin; mutate `child`, `stdin`, and `status` only inside short, localized critical sections protected by `lifecycle_lock`. 
- Preserve existing invariants: prevent concurrent operator sessions by checking `state.child` at startup, and ensure `state.child`, `state.stdin`, and `state.status` are updated coherently within locked sections. 
- Keep graceful-first shutdown semantics: send cancel on stdin, poll for a short window for normal exit, and fall back to `kill()` if needed, while ensuring final status ends `running=false` and `registered=false`. 
- Add two focused Rust tests that would have caught the regression: `stop_compute_node_does_not_wait_on_lifecycle_lock` and `stop_compute_node_sends_cancel_and_updates_stopped_status`. 

### Testing
- Ran Python unit suite with `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` and it passed (23 tests). 
- Ran desktop JS tests with `npm --prefix desktop-tauri run test -- src/App.test.tsx` and they passed (5 tests). 
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and `cargo test ... stop_compute_node`, but Rust build failed in this environment due to missing system `glib-2.0` dev libs (pkg-config/`glib-2.0.pc`), so the new Rust tests could not be executed here. 
- `pre-commit run --all-files` was not executed because `pre-commit` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e560b5f738832f8fc026fd2b330117)