### PR TITLE
🐛 Fix desktop operator stop lock contention

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -323,9 +323,8 @@ pub async fn start_compute_node(
     state: ComputeNodeState,
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-
+    let lifecycle_lock = state.lifecycle_lock.lock().await;
     {
         let mut child_slot = state.child.lock().await;
         if child_slot
@@ -440,6 +439,7 @@ pub async fn start_compute_node(
             last_error: None,
         };
     }
+    drop(lifecycle_lock);
 
     let log_policy = SubprocessLogPolicy::from_env();
     let stderr_task = tokio::spawn(async move {
@@ -507,8 +507,6 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
-
     if let Some(stdin) = state.stdin.lock().await.as_mut() {
         stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
         stdin.flush().await?;
@@ -560,6 +558,7 @@ mod tests {
     use tempfile::TempDir;
     use tokio::io::AsyncBufReadExt;
     use tokio::process::Command;
+    use tokio::time::timeout;
 
     fn success_exit_status() -> ExitStatus {
         #[cfg(windows)]
@@ -626,6 +625,47 @@ mod tests {
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn stop_compute_node_sends_cancel_without_waiting_for_lifecycle_lock() {
+        let temp = TempDir::new().expect("tempdir");
+        let cancel_path = temp.path().join("cancel.jsonl");
+        let script = format!(
+            "IFS= read -r line; printf '%s' \"$line\" > '{}'",
+            cancel_path.display()
+        );
+        let mut child = Command::new("sh")
+            .args(["-c", &script])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn bridge stub");
+        let stdin = child.stdin.take().expect("stdin");
+
+        let state = ComputeNodeState::default();
+        *state.child.lock().await = Some(child);
+        *state.stdin.lock().await = Some(stdin);
+        {
+            let mut status = state.status.lock().await;
+            status.running = true;
+            status.registered = true;
+        }
+
+        let lifecycle_guard = state.lifecycle_lock.lock().await;
+        timeout(Duration::from_secs(3), stop_compute_node(state.clone()))
+            .await
+            .expect("stop should not block on lifecycle lock")
+            .expect("stop should succeed");
+        drop(lifecycle_guard);
+
+        let cancel_line = std::fs::read_to_string(&cancel_path).expect("cancel payload");
+        assert_eq!(cancel_line, "{\"type\":\"cancel\"}");
+        let status = state.status.lock().await;
+        assert!(!status.running);
+        assert!(!status.registered);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The operator `start_compute_node()` previously held `lifecycle_lock` for the entire bridge process lifetime (stdout/stderr/event loop), which prevented `stop_compute_node()` from acquiring the same lock and sending the cancel message while the operator was running.  
- The intent is to allow `stop_compute_node()` to always reach the bridge stdin to request graceful shutdown while preserving the invariant that only one operator session may run at a time.  
- Exact deadlock fixed: `start_compute_node()` acquired `lifecycle_lock` and never released it until the bridge exited, and `stop_compute_node()` attempted to acquire that lock before writing `{"type":"cancel"}`, so stop would block forever; the lock is now released before the long-lived loop and stop no longer depends on it.

### Description

- Narrowed the `lifecycle_lock` scope in `start_compute_node()` so the lock is held only for the startup/slot-installation critical section and explicitly released (`drop(lifecycle_lock)`) before entering the long-lived bridge stdout/stderr loop.  
- Removed the `lifecycle_lock` acquisition from `stop_compute_node()` so it can immediately write `{"type":"cancel"}` to the bridge stdin, then proceed with the existing graceful-wait-then-kill fallback and final status cleanup.  
- Added a targeted regression test `stop_compute_node_sends_cancel_without_waiting_for_lifecycle_lock` (in `desktop-tauri/src-tauri/src/compute_node.rs` test module) that holds `lifecycle_lock` while calling `stop_compute_node()` and verifies the cancel line was written and `status.running`/`status.registered` are cleared.  
- Changes are minimal and focused to `desktop-tauri/src-tauri/src/compute_node.rs` and preserve existing semantics: concurrent-start is still rejected, `state.child`/`state.stdin`/`state.status` remain coherent, and shutdown still prefers graceful cancel + wait then kill.

### Testing

- Ran `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py` and all tests passed.  
- Ran `npm --prefix desktop-tauri run test -- src/App.test.tsx` and the desktop UI tests passed.  
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml stop_compute_node_sends_cancel_without_waiting_for_lifecycle_lock`, but the container build failed due to a missing system `glib-2.0` pkg-config dependency required by the Tauri toolchain (this is an environment issue, not a logic failure); the added test is designed to pass in a normal developer environment with system deps installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e560b5f738832f8fc026fd2b330117)