### PR TITLE
Fix desktop operator stop lock contention

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -323,16 +323,15 @@ pub async fn start_compute_node(
     state: ComputeNodeState,
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
     {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
         let mut child_slot = state.child.lock().await;
-        if child_slot
-            .as_mut()
-            .is_some_and(|child| child.try_wait().ok().flatten().is_none())
-        {
-            anyhow::bail!("compute node already running; stop it before starting a new session");
+        if let Some(child) = child_slot.as_mut() {
+            if child.try_wait()?.is_none() {
+                anyhow::bail!("compute node already running; stop it before starting a new session");
+            }
         }
         *child_slot = None;
         *state.stdin.lock().await = None;
@@ -421,7 +420,13 @@ pub async fn start_compute_node(
         .ok_or_else(|| anyhow::anyhow!("missing compute-node bridge stdin"))?;
 
     {
+        let _lifecycle_lock = state.lifecycle_lock.lock().await;
         let mut child_slot = state.child.lock().await;
+        if let Some(existing_child) = child_slot.as_mut() {
+            if existing_child.try_wait()?.is_none() {
+                anyhow::bail!("compute node already running; stop it before starting a new session");
+            }
+        }
         *child_slot = Some(child);
         let mut stdin_slot = state.stdin.lock().await;
         *stdin_slot = Some(stdin);
@@ -507,8 +512,6 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    let _lifecycle_lock = state.lifecycle_lock.lock().await;
-
     if let Some(stdin) = state.stdin.lock().await.as_mut() {
         stdin.write_all(b"{\"type\":\"cancel\"}\n").await?;
         stdin.flush().await?;
@@ -626,6 +629,22 @@ mod tests {
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn stop_compute_node_does_not_wait_on_lifecycle_lock() {
+        let state = ComputeNodeState::default();
+        let lifecycle_guard = state.lifecycle_lock.lock().await;
+
+        let stop_result = tokio::time::timeout(
+            Duration::from_millis(200),
+            stop_compute_node(state.clone()),
+        )
+        .await;
+
+        drop(lifecycle_guard);
+        assert!(stop_result.is_ok(), "stop should not block on lifecycle lock");
+        assert!(stop_result.expect("timeout result").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The `Stop operator` UI was ineffective because `start_compute_node()` held `lifecycle_lock` for the entire bridge stdout/stderr/event loop, which prevented `stop_compute_node()` from acquiring the same lock and delivering the cancel message to the bridge stdin. 
- The change must keep the single-session invariant and preserve graceful shutdown semantics while ensuring `stop_compute_node()` can always reach the running bridge process.

### Description
- Narrow `lifecycle_lock` usage in `start_compute_node()` to short critical sections (preflight checks and the child/stdin/status installation) instead of holding it through the long-running stdout event loop. 
- Remove the `lifecycle_lock` acquisition from `stop_compute_node()` so it can immediately write `{"type":"cancel"}` to the bridge stdin while the operator is active. 
- Preserve the single-session invariant by re-checking for a still-running child under the short lock before installing a new child. 
- Add a focused regression test `stop_compute_node_does_not_wait_on_lifecycle_lock` that proves `stop_compute_node()` does not block when `lifecycle_lock` is already held.

### Testing
- Ran `pytest -q --noconftest tests/unit/test_desktop_compute_node_bridge.py`, which passed all tests (23 passed). 
- Ran `npm --prefix desktop-tauri run test -- src/App.test.tsx`, which passed the desktop UI tests (1 file, 5 tests passed). 
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml`, but it could not complete in this container due to a missing system dependency (`glib-2.0` / pkg-config), so Rust integration/unit tests could not be executed here; the change includes a new Rust unit test and should be verified in an environment with the required system libs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e560b5f738832f8fc026fd2b330117)