### PR TITLE
Add explicit relay /unregister and best-effort client unregister on shutdown

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -407,6 +407,29 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
     return diagnostics
 
 
+def _purge_server_state(server_public_key: str) -> None:
+    """Remove relay state associated with a compute node."""
+
+    known_servers.pop(server_public_key, None)
+    client_inference_requests.pop(server_public_key, None)
+
+    with stream_lock:
+        stale_session_ids = [
+            session_id
+            for session_id, session in streaming_sessions.items()
+            if session.get("server_public_key") == server_public_key
+        ]
+        for session_id in stale_session_ids:
+            session = streaming_sessions.pop(session_id, None)
+            if not session:
+                continue
+            client_public_key = session.get("client_public_key")
+            if client_public_key:
+                mapped = streaming_sessions_by_client.get(client_public_key)
+                if mapped == session_id:
+                    streaming_sessions_by_client.pop(client_public_key, None)
+
+
 def _can_resolve_gpu_host(hostname: str) -> bool:
     try:
         socket.getaddrinfo(hostname, None)
@@ -785,6 +808,26 @@ def sink():
             response_data['batch'] = batch
 
     return jsonify(response_data)
+
+
+@app.route('/unregister', methods=['POST'])
+def unregister():
+    """Explicitly remove a compute node from relay registration."""
+
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    public_key = data.get('server_public_key')
+    if not isinstance(public_key, str) or not public_key.strip():
+        return jsonify({'error': 'Invalid public key'}), 400
+
+    _purge_server_state(public_key)
+    return jsonify({'message': 'Server unregistered'}), 200
 
 @app.route('/source', methods=['POST'])
 def source():

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -314,5 +314,27 @@ def test_compute_node_runtime_stop_delegates_to_relay_client():
         crypto_manager=crypto_manager,
     )
 
+    relay_client.unregister.return_value = True
+
     runtime.stop()
+    relay_client.unregister.assert_called_once_with()
+    relay_client.stop.assert_called_once_with()
+
+
+def test_compute_node_runtime_stop_continues_when_unregister_fails():
+    relay_client = MagicMock()
+    relay_client.unregister.return_value = False
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+    )
+
+    runtime.stop()
+    relay_client.unregister.assert_called_once_with()
     relay_client.stop.assert_called_once_with()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -316,6 +316,52 @@ class TestRelayClient:
         assert result['error'] == "HTTP 500"
         assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_posts_server_public_key(self, mock_post, relay_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert relay_client.unregister() is True
+        mock_post.assert_called_once_with(
+            'http://localhost:5000/unregister',
+            json={'server_public_key': 'mock_public_key_b64'},
+            timeout=relay_client._request_timeout,
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_uses_registration_token_header(
+        self,
+        mock_post,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        config_values = {
+            'relay.request_timeout': 15,
+            'relay.server_registration_token': 'alpha-token',
+        }
+
+        with patch('utils.networking.relay_client.get_config_lazy') as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.is_production = False
+            mock_config.get.side_effect = lambda key, default=None: config_values.get(key, default)
+            mock_get_config.return_value = mock_config
+
+            client = RelayClient(
+                base_url='http://localhost',
+                port=5000,
+                crypto_manager=mock_crypto_manager,
+                model_manager=mock_model_manager,
+            )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert client.unregister() is True
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs['headers'] == {'X-Relay-Server-Token': 'alpha-token'}
+
     def test_ping_relay_failover_to_additional_servers(
         self,
         mock_crypto_manager,

--- a/tests/unit/test_relay_registration_token.py
+++ b/tests/unit/test_relay_registration_token.py
@@ -90,6 +90,30 @@ def test_source_requires_registration_token(relay_module) -> None:
     assert queued == {"message": "Response received and queued for client"}
 
 
+def test_unregister_requires_registration_token(relay_module) -> None:
+    """/unregister should require the server token when registration auth is enabled."""
+
+    relay_module.known_servers.clear()
+    relay_module.known_servers["abc"] = {
+        "public_key": "abc",
+        "last_ping": relay_module.datetime.now(),
+        "last_ping_duration": 10,
+    }
+    client = relay_module.app.test_client()
+
+    unauthorised = client.post("/unregister", json={"server_public_key": "abc"})
+    assert unauthorised.status_code == 401
+
+    authorised = client.post(
+        "/unregister",
+        json={"server_public_key": "abc"},
+        headers={"X-Relay-Server-Token": "unit-token"},
+    )
+    assert authorised.status_code == 200
+    assert authorised.get_json() == {"message": "Server unregistered"}
+    assert "abc" not in relay_module.known_servers
+
+
 def test_sink_accepts_plural_registration_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
     """Plural env var should allow any listed registration token."""
 

--- a/tests/unit/test_relay_unregister.py
+++ b/tests/unit/test_relay_unregister.py
@@ -1,0 +1,83 @@
+"""Tests for explicit compute-node unregister relay behaviour."""
+
+import importlib
+import sys
+import time
+from typing import Iterator
+
+import pytest
+
+MODULES_TO_CLEAR = ("relay", "config", "api", "api.v1", "api.v1.routes")
+
+
+@pytest.fixture(autouse=True)
+def reset_modules(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "testing")
+    for name in MODULES_TO_CLEAR:
+        sys.modules.pop(name, None)
+    yield
+    for name in MODULES_TO_CLEAR:
+        sys.modules.pop(name, None)
+
+
+def test_unregister_removes_server_and_related_queue_state() -> None:
+    relay = importlib.import_module("relay")
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.streaming_sessions.clear()
+    relay.streaming_sessions_by_client.clear()
+
+    server_public_key = "server-key"
+    client_public_key = "client-key"
+    relay.known_servers[server_public_key] = {
+        "public_key": server_public_key,
+        "last_ping": relay.datetime.now(),
+        "last_ping_duration": 10,
+    }
+    relay.client_inference_requests[server_public_key] = [{"chat_history": "cipher"}]
+    relay.streaming_sessions["session-1"] = {
+        "session_id": "session-1",
+        "server_public_key": server_public_key,
+        "client_public_key": client_public_key,
+        "chunks": [],
+        "status": "open",
+        "created_at": time.time(),
+        "updated_at": time.time(),
+    }
+    relay.streaming_sessions_by_client[client_public_key] = "session-1"
+
+    client = relay.app.test_client()
+    response = client.post("/unregister", json={"server_public_key": server_public_key})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Server unregistered"}
+    assert server_public_key not in relay.known_servers
+    assert server_public_key not in relay.client_inference_requests
+    assert "session-1" not in relay.streaming_sessions
+    assert client_public_key not in relay.streaming_sessions_by_client
+
+
+def test_unregister_removes_node_from_relay_diagnostics_immediately() -> None:
+    relay = importlib.import_module("relay")
+    relay.known_servers.clear()
+
+    server_public_key = "server-key"
+    relay.known_servers[server_public_key] = {
+        "public_key": server_public_key,
+        "last_ping": relay.datetime.now(),
+        "last_ping_duration": 10,
+    }
+
+    client = relay.app.test_client()
+    before = client.get("/relay/diagnostics")
+    assert before.status_code == 200
+    listed_before = before.get_json()["registered_compute_nodes"]
+    assert any(node["server_public_key"] == server_public_key for node in listed_before)
+
+    unregister = client.post("/unregister", json={"server_public_key": server_public_key})
+    assert unregister.status_code == 200
+
+    after = client.get("/relay/diagnostics")
+    assert after.status_code == 200
+    listed_after = after.get_json()["registered_compute_nodes"]
+    assert all(node["server_public_key"] != server_public_key for node in listed_after)

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -285,4 +285,10 @@ class ComputeNodeRuntime:
     def stop(self) -> None:
         """Stop relay polling and network activity."""
 
+        unregister = getattr(self.relay_client, "unregister", None)
+        if callable(unregister):
+            if unregister():
+                _log_info("Relay compute node unregistered")
+            else:
+                _log_error("Relay compute node unregister failed; continuing shutdown")
         self.relay_client.stop()

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -439,6 +439,36 @@ class RelayClient:
         log_info("Stopping relay polling")
         self.stop_polling = True
 
+    def unregister(self) -> bool:
+        """Best-effort compute-node unregister request."""
+
+        payload = {'server_public_key': self.crypto_manager.public_key_b64}
+        request_kwargs: Dict[str, Any] = {
+            'json': payload,
+            'timeout': self._request_timeout,
+        }
+        headers = self._auth_headers()
+        if headers:
+            request_kwargs['headers'] = headers
+
+        try:
+            timeout = request_kwargs.pop('timeout', self._request_timeout)
+            response = requests.post(
+                f'{self.relay_url}/unregister',
+                timeout=timeout,
+                **request_kwargs,
+            )
+            if response.status_code != 200:
+                log_error("Error from relay /unregister: status {}", response.status_code)
+                return False
+            return True
+        except requests.RequestException as exc:
+            log_error("Failed to unregister relay compute node: {}", str(exc), exc_info=True)
+            return False
+        except Exception as exc:  # pragma: no cover - defensive path
+            log_error("Unexpected unregister failure: {}", str(exc), exc_info=True)
+            return False
+
     def ping_relay(self) -> Dict[str, Any]:
         """
         Send a ping to the relay server to register this server and check for client requests.


### PR DESCRIPTION
### Motivation
- Operators that stop currently rely on TTL-based eviction, causing stale entries to linger in relay diagnostics; an explicit unregister allows immediate removal.
- Keep the protocol extension minimal and consistent with existing server-token authentication when tokens are configured.
- Ensure shutdown remains best-effort: unregister attempts should not block or fail the runtime shutdown.

### Description
- Added `_purge_server_state(server_public_key)` to `relay.py` to remove a server's `known_servers`, its `client_inference_requests`, and any streaming session mappings. 
- Added `POST /unregister` to `relay.py` that enforces the same registration-token auth as `/sink` and calls `_purge_server_state` when a valid `server_public_key` is provided. 
- Implemented `RelayClient.unregister()` in `utils/networking/relay_client.py` to POST the node public key to `/unregister`, include auth header when configured, and return a boolean (best-effort) without raising on failures. 
- Updated `ComputeNodeRuntime.stop()` in `utils/compute_node_runtime.py` to call `relay_client.unregister()` (if present) before stopping polling and to log success/failure while always continuing shutdown. 
- Added and updated focused unit tests to cover the new behavior: `tests/unit/test_relay_unregister.py` (new), updates to `tests/unit/test_relay_client.py`, `tests/unit/test_relay_registration_token.py`, and `tests/unit/test_compute_node_runtime.py` to assert auth enforcement, client header propagation, queue/session cleanup, diagnostics removal, and best-effort shutdown semantics.

### Testing
- Ran `pytest -q tests/unit/test_relay_client.py` and all relay-client tests passed (44 passed). 
- Ran `pytest -q tests/unit/test_desktop_compute_node_bridge.py` and bridge tests passed (23 passed).
- Ran `pytest -q tests/unit/test_relay_registration_token.py tests/unit/test_relay_unregister.py` and registration/unregister tests passed (6 passed).
- Ran `pytest -q tests/unit/test_compute_node_runtime.py` along with the above and observed the runtime-stop tests exercising the best-effort unregister path pass. 
- Note: `pre-commit run --all-files` was not available in the execution environment (`pre-commit: command not found`) and `./scripts/scan-secrets.py` was not present where referenced, so those checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d6ca0414832f8be0549734f673a2)