### PR TITLE
Add relay /unregister and best-effort unregister on operator shutdown

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -389,7 +389,7 @@ def _evict_stale_servers() -> list[str]:
     for server_public_key, payload in list(known_servers.items()):
         if _server_ping_age_seconds(payload.get("last_ping")) <= stale_after:
             continue
-        known_servers.pop(server_public_key, None)
+        _remove_server_state(server_public_key)
         evicted.append(server_public_key)
     return evicted
 
@@ -405,6 +405,27 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
         })
     diagnostics.sort(key=lambda node: node["server_public_key"])
     return diagnostics
+
+
+def _remove_server_state(server_public_key: str) -> None:
+    """Remove relay state associated with a compute node."""
+
+    known_servers.pop(server_public_key, None)
+    client_inference_requests.pop(server_public_key, None)
+
+    with stream_lock:
+        stale_session_ids = [
+            session_id
+            for session_id, session in streaming_sessions.items()
+            if session.get('server_public_key') == server_public_key
+        ]
+        for session_id in stale_session_ids:
+            session = streaming_sessions.pop(session_id, None)
+            if not session:
+                continue
+            client_key = session.get('client_public_key')
+            if client_key:
+                streaming_sessions_by_client.pop(client_key, None)
 
 
 def _can_resolve_gpu_host(hostname: str) -> bool:
@@ -811,6 +832,26 @@ def source():
         'iv': iv
     }
     return jsonify({'message': 'Response received and queued for client'}), 200
+
+
+@app.route('/unregister', methods=['POST'])
+def unregister():
+    """Allow compute nodes to unregister from relay state immediately."""
+
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    server_public_key = data.get('server_public_key')
+    if not isinstance(server_public_key, str) or not server_public_key.strip():
+        return jsonify({'error': 'Invalid public key'}), 400
+
+    _remove_server_state(server_public_key)
+    return jsonify({'message': 'Server unregistered'}), 200
 
 
 @app.route('/stream/source', methods=['POST'])

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -316,3 +316,23 @@ def test_compute_node_runtime_stop_delegates_to_relay_client():
 
     runtime.stop()
     relay_client.stop.assert_called_once_with()
+    relay_client.unregister_from_relay.assert_called_once_with()
+
+
+def test_compute_node_runtime_stop_swallows_unregister_exceptions():
+    relay_client = MagicMock()
+    relay_client.unregister_from_relay.side_effect = RuntimeError("network gone")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+    )
+
+    runtime.stop()
+    relay_client.stop.assert_called_once_with()
+    relay_client.unregister_from_relay.assert_called_once_with()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -238,6 +238,56 @@ class TestRelayClient:
         assert relay_client.stop_polling is True
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_success(self, mock_post, relay_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert relay_client.unregister_from_relay() is True
+        mock_post.assert_called_once_with(
+            'http://localhost:5000/unregister',
+            json={'server_public_key': 'mock_public_key_b64'},
+            timeout=relay_client._request_timeout,
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_uses_registration_token_when_configured(
+        self,
+        mock_post,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        with patch('utils.networking.relay_client.get_config_lazy') as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.is_production = False
+            mock_config.get.side_effect = lambda key, default: {
+                'relay.request_timeout': 12,
+                'relay.server_registration_token': 'alpha-token',
+            }.get(key, default)
+            mock_get_config.return_value = mock_config
+
+            relay_client = RelayClient(
+                base_url='http://localhost',
+                port=5000,
+                crypto_manager=mock_crypto_manager,
+                model_manager=mock_model_manager,
+            )
+
+        assert relay_client.unregister_from_relay() is True
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs['headers'] == {'X-Relay-Server-Token': 'alpha-token'}
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_is_best_effort_on_failures(self, mock_post, relay_client):
+        mock_post.side_effect = requests.ConnectionError("offline")
+
+        assert relay_client.unregister_from_relay() is False
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_ping_relay_success(self, mock_post, relay_client, mock_crypto_manager):
         """Test successful ping to relay."""
         # Setup mock response

--- a/tests/unit/test_relay_registration_token.py
+++ b/tests/unit/test_relay_registration_token.py
@@ -121,3 +121,34 @@ def test_sink_accepts_plural_registration_tokens(monkeypatch: pytest.MonkeyPatch
     finally:
         for name in MODULES_TO_CLEAR:
             sys.modules.pop(name, None)
+
+
+def test_unregister_requires_registration_token(relay_module) -> None:
+    """/unregister should enforce the same registration token auth as /sink and /source."""
+
+    client = relay_module.app.test_client()
+    relay_module.known_servers.clear()
+    relay_module.known_servers["abc"] = {
+        "public_key": "abc",
+        "last_ping": relay_module.datetime.now(),
+        "last_ping_duration": 10,
+    }
+
+    unauthorised = client.post("/unregister", json={"server_public_key": "abc"})
+    assert unauthorised.status_code == 401
+
+    payload = unauthorised.get_json()
+    assert payload == {
+        "error": {
+            "code": 401,
+            "message": "Missing or invalid relay server token",
+        }
+    }
+
+    authorised = client.post(
+        "/unregister",
+        json={"server_public_key": "abc"},
+        headers={"X-Relay-Server-Token": "unit-token"},
+    )
+    assert authorised.status_code == 200
+    assert authorised.get_json() == {"message": "Server unregistered"}

--- a/tests/unit/test_relay_unregister.py
+++ b/tests/unit/test_relay_unregister.py
@@ -1,0 +1,84 @@
+"""Unit tests for relay compute-node unregister flow."""
+
+import importlib
+import sys
+
+import pytest
+
+MODULES_TO_CLEAR = ("relay", "config", "api", "api.v1", "api.v1.routes")
+
+
+@pytest.fixture()
+def relay_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "testing")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_SERVER_TOKEN", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_SERVER_TOKENS", raising=False)
+
+    for name in MODULES_TO_CLEAR:
+        sys.modules.pop(name, None)
+
+    relay = importlib.import_module("relay")
+    relay.app.config["TESTING"] = True
+
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    relay.streaming_sessions.clear()
+    relay.streaming_sessions_by_client.clear()
+
+    yield relay
+
+    for name in MODULES_TO_CLEAR:
+        sys.modules.pop(name, None)
+
+
+def test_unregister_removes_server_and_related_state(relay_module) -> None:
+    client = relay_module.app.test_client()
+
+    relay_module.known_servers["server-key"] = {
+        "public_key": "server-key",
+        "last_ping": relay_module.datetime.now(),
+        "last_ping_duration": 10,
+    }
+    relay_module.client_inference_requests["server-key"] = [{"chat_history": "cipher"}]
+    relay_module.streaming_sessions["session-1"] = {
+        "session_id": "session-1",
+        "server_public_key": "server-key",
+        "client_public_key": "client-key",
+        "chunks": [],
+        "status": "open",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    relay_module.streaming_sessions_by_client["client-key"] = "session-1"
+
+    diagnostics_before = client.get("/relay/diagnostics")
+    assert diagnostics_before.status_code == 200
+    assert diagnostics_before.get_json()["total_registered_compute_nodes"] == 1
+
+    response = client.post("/unregister", json={"server_public_key": "server-key"})
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Server unregistered"}
+
+    assert "server-key" not in relay_module.known_servers
+    assert "server-key" not in relay_module.client_inference_requests
+    assert "session-1" not in relay_module.streaming_sessions
+    assert "client-key" not in relay_module.streaming_sessions_by_client
+
+    diagnostics_after = client.get("/relay/diagnostics")
+    assert diagnostics_after.status_code == 200
+    payload = diagnostics_after.get_json()
+    assert payload["registered_compute_nodes"] == []
+    assert payload["total_registered_compute_nodes"] == 0
+
+
+def test_unregister_requires_server_public_key(relay_module) -> None:
+    client = relay_module.app.test_client()
+
+    missing_key = client.post("/unregister", json={})
+    assert missing_key.status_code == 400
+    assert missing_key.get_json() == {"error": "Invalid public key"}
+
+    invalid_data = client.post("/unregister", data="[]", content_type="application/json")
+    assert invalid_data.status_code == 400
+    assert invalid_data.get_json() == {"error": "Invalid request data"}

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -286,3 +286,11 @@ class ComputeNodeRuntime:
         """Stop relay polling and network activity."""
 
         self.relay_client.stop()
+        try:
+            unregistered = self.relay_client.unregister_from_relay()
+            if unregistered:
+                _log_info("Relay unregister completed")
+            else:
+                _log_error("Relay unregister did not succeed on any configured relay target")
+        except Exception:
+            _log_error("Relay unregister failed during shutdown", exc_info=True)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -439,6 +439,48 @@ class RelayClient:
         log_info("Stopping relay polling")
         self.stop_polling = True
 
+    def unregister_from_relay(self) -> bool:
+        """Best-effort relay unregister call used during operator shutdown."""
+
+        payload = {'server_public_key': self.crypto_manager.public_key_b64}
+        headers = self._auth_headers()
+        any_success = False
+
+        for relay_url in self._relay_urls:
+            try:
+                log_info("Unregistering compute node from {}/unregister", relay_url)
+                request_kwargs = {
+                    'json': payload,
+                    'timeout': self._request_timeout,
+                }
+                if headers:
+                    request_kwargs['headers'] = headers
+                response = requests.post(f'{relay_url}/unregister', **request_kwargs)
+                if response.status_code == 200:
+                    any_success = True
+                    continue
+                log_error(
+                    "Relay unregister failed for {} with status {}",
+                    relay_url,
+                    response.status_code,
+                )
+            except requests.RequestException as exc:
+                log_error(
+                    "Relay unregister request failed for {}: {}",
+                    relay_url,
+                    str(exc),
+                    exc_info=True,
+                )
+            except Exception as exc:  # pragma: no cover - defensive logging path
+                log_error(
+                    "Unexpected relay unregister failure for {}: {}",
+                    relay_url,
+                    str(exc),
+                    exc_info=True,
+                )
+
+        return any_success
+
     def ping_relay(self) -> Dict[str, Any]:
         """
         Send a ping to the relay server to register this server and check for client requests.


### PR DESCRIPTION
### Motivation
- Stopping a desktop operator did not remove its entry from the relay immediately, leaving stale state visible until TTL eviction.  
- Provide an explicit, minimal unregister flow so a clean shutdown removes compute-node state from the relay right away.  
- Keep the change small and compatible with the existing `/sink`/`/source` contract and server-token auth path.

### Description
- Add `_remove_server_state(server_public_key)` in `relay.py` to centralize removal of `known_servers`, `client_inference_requests`, and streaming session mappings.  
- Add authenticated `POST /unregister` in `relay.py` which validates the server token via the existing `_validate_server_registration()` and calls `_remove_server_state()` to immediately clear node state.  
- Change `_evict_stale_servers()` to reuse `_remove_server_state()` for consistent cleanup on TTL expiry.  
- Add `RelayClient.unregister_from_relay()` in `utils/networking/relay_client.py` which posts to `/unregister` (propagating the registration token when configured) with best-effort semantics, and call it from `ComputeNodeRuntime.stop()` in `utils/compute_node_runtime.py` inside a guarded `try` block so shutdown is not blocked by unregister failures.  
- Add focused unit tests and updates: new `tests/unit/test_relay_unregister.py`, and updates to `tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`, and `tests/unit/test_relay_registration_token.py` to cover endpoint behavior, auth, client unregister behavior, and runtime shutdown handling.

### Testing
- Ran `pytest -q tests/unit/test_relay_client.py` and all tests passed.  
- Ran `pytest -q tests/unit/test_desktop_compute_node_bridge.py` and all tests passed.  
- Ran `pytest -q tests/unit/test_relay_registration_token.py tests/unit/test_relay_unregister.py` and all tests passed.  
- Ran `pytest -q tests/unit/test_compute_node_runtime.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d6ca0414832f8be0549734f673a2)