### PR TITLE
Add explicit relay unregister flow on compute-node shutdown

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -389,9 +389,32 @@ def _evict_stale_servers() -> list[str]:
     for server_public_key, payload in list(known_servers.items()):
         if _server_ping_age_seconds(payload.get("last_ping")) <= stale_after:
             continue
-        known_servers.pop(server_public_key, None)
+        _remove_server_state(server_public_key)
         evicted.append(server_public_key)
     return evicted
+
+
+def _remove_server_state(server_public_key: str) -> bool:
+    """Remove relay state for a compute node key and return whether it was known."""
+
+    removed = known_servers.pop(server_public_key, None) is not None
+    client_inference_requests.pop(server_public_key, None)
+
+    with stream_lock:
+        stale_sessions = [
+            session_id
+            for session_id, session in streaming_sessions.items()
+            if session.get("server_public_key") == server_public_key
+        ]
+        for session_id in stale_sessions:
+            session = streaming_sessions.pop(session_id, None)
+            if not session:
+                continue
+            client_public_key = session.get("client_public_key")
+            if client_public_key:
+                streaming_sessions_by_client.pop(client_public_key, None)
+
+    return removed
 
 
 def _live_server_diagnostics() -> list[dict[str, Any]]:
@@ -811,6 +834,30 @@ def source():
         'iv': iv
     }
     return jsonify({'message': 'Response received and queued for client'}), 200
+
+
+@app.route('/unregister', methods=['POST'])
+def unregister():
+    """Remove a compute node registration and per-node queueing state."""
+
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    server_public_key = data.get('server_public_key')
+    if not server_public_key:
+        return jsonify({'error': 'Invalid public key'}), 400
+
+    removed = _remove_server_state(server_public_key)
+    return jsonify({
+        'message': 'Server unregistered' if removed else 'Server not registered',
+        'server_public_key': server_public_key,
+        'removed': removed,
+    }), 200
 
 
 @app.route('/stream/source', methods=['POST'])

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -316,3 +316,21 @@ def test_compute_node_runtime_stop_delegates_to_relay_client():
 
     runtime.stop()
     relay_client.stop.assert_called_once_with()
+
+
+def test_compute_node_runtime_stop_is_best_effort_when_relay_stop_fails():
+    relay_client = MagicMock()
+    relay_client.stop.side_effect = RuntimeError("shutdown failure")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+    )
+
+    runtime.stop()
+    relay_client.stop.assert_called_once_with()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -238,6 +238,68 @@ class TestRelayClient:
         assert relay_client.stop_polling is True
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_success(self, mock_post, relay_client):
+        """Compute nodes should explicitly unregister during shutdown."""
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert relay_client.unregister_from_relay() is True
+        mock_post.assert_called_once_with(
+            'http://localhost:5000/unregister',
+            json={'server_public_key': 'mock_public_key_b64'},
+            timeout=relay_client._request_timeout,
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_uses_registration_token(
+        self,
+        mock_post,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Unregister should carry the same registration token auth header as /sink."""
+
+        config_values = {
+            'relay.request_timeout': 15,
+            'relay.server_registration_token': 'alpha-token',
+        }
+
+        with patch('utils.networking.relay_client.get_config_lazy') as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.is_production = False
+            mock_config.get.side_effect = lambda key, default=None: config_values.get(key, default)
+            mock_get_config.return_value = mock_config
+            client = RelayClient(
+                base_url="http://localhost",
+                port=5000,
+                crypto_manager=mock_crypto_manager,
+                model_manager=mock_model_manager,
+            )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert client.unregister_from_relay() is True
+        assert mock_post.call_args.kwargs['headers'] == {'X-Relay-Server-Token': 'alpha-token'}
+
+    def test_stop_swallows_unregister_failures(self, relay_client):
+        """Shutdown should not fail even when unregister errors."""
+
+        with patch.object(
+            relay_client,
+            "unregister_from_relay",
+            side_effect=RuntimeError("relay unavailable"),
+        ) as mock_unregister:
+            relay_client.start()
+            relay_client.stop()
+
+        assert relay_client.stop_polling is True
+        mock_unregister.assert_called_once_with()
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_ping_relay_success(self, mock_post, relay_client, mock_crypto_manager):
         """Test successful ping to relay."""
         # Setup mock response

--- a/tests/unit/test_relay_registration_token.py
+++ b/tests/unit/test_relay_registration_token.py
@@ -121,3 +121,61 @@ def test_sink_accepts_plural_registration_tokens(monkeypatch: pytest.MonkeyPatch
     finally:
         for name in MODULES_TO_CLEAR:
             sys.modules.pop(name, None)
+
+
+def test_unregister_requires_registration_token(relay_module) -> None:
+    """/unregister should enforce token auth parity with /sink and /source."""
+
+    relay_module.known_servers.clear()
+    client = relay_module.app.test_client()
+
+    client.post(
+        "/sink",
+        json={"server_public_key": "abc"},
+        headers={"X-Relay-Server-Token": "unit-token"},
+    )
+    assert "abc" in relay_module.known_servers
+
+    unauthorised = client.post("/unregister", json={"server_public_key": "abc"})
+    assert unauthorised.status_code == 401
+    assert "abc" in relay_module.known_servers
+
+    authorised = client.post(
+        "/unregister",
+        json={"server_public_key": "abc"},
+        headers={"X-Relay-Server-Token": "unit-token"},
+    )
+    assert authorised.status_code == 200
+    assert authorised.get_json()["removed"] is True
+    assert "abc" not in relay_module.known_servers
+
+
+def test_unregister_removes_server_and_diagnostics_immediately(relay_module) -> None:
+    """Relay diagnostics should no longer list a server right after /unregister."""
+
+    relay_module.known_servers.clear()
+    relay_module.client_inference_requests.clear()
+    client = relay_module.app.test_client()
+    headers = {"X-Relay-Server-Token": "unit-token"}
+
+    server_key = "server-a"
+    client.post("/sink", json={"server_public_key": server_key}, headers=headers)
+    relay_module.client_inference_requests[server_key] = [{"chat_history": "queued"}]
+
+    before = client.get("/relay/diagnostics")
+    before_payload = before.get_json()
+    assert before_payload["total_registered_compute_nodes"] == 1
+
+    response = client.post(
+        "/unregister",
+        json={"server_public_key": server_key},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.get_json()["removed"] is True
+    assert relay_module.client_inference_requests.get(server_key) is None
+
+    after = client.get("/relay/diagnostics")
+    after_payload = after.get_json()
+    assert after_payload["registered_compute_nodes"] == []
+    assert after_payload["total_registered_compute_nodes"] == 0

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -284,5 +284,7 @@ class ComputeNodeRuntime:
 
     def stop(self) -> None:
         """Stop relay polling and network activity."""
-
-        self.relay_client.stop()
+        try:
+            self.relay_client.stop()
+        except Exception:
+            _log_error("Failed to stop relay client cleanly", exc_info=True)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -435,9 +435,51 @@ class RelayClient:
         self.stop_polling = False
 
     def stop(self):
-        """Stop the polling loop by setting stop_polling to True"""
+        """Stop polling and best-effort unregister this compute node."""
         log_info("Stopping relay polling")
         self.stop_polling = True
+        try:
+            self.unregister_from_relay()
+        except Exception as exc:  # pragma: no cover - defensive shutdown guard
+            log_error("Unexpected unregister failure during shutdown: {}", str(exc), exc_info=True)
+
+    def unregister_from_relay(self) -> bool:
+        """Best-effort removal of this compute node from relay registration state."""
+
+        public_key = getattr(self.crypto_manager, "public_key_b64", None)
+        if not public_key:
+            log_error("Skipping relay unregister because compute-node public key is missing")
+            return False
+
+        relay_indexes = [self._active_relay_index]
+        relay_indexes.extend(
+            index for index in range(len(self._relay_urls)) if index != self._active_relay_index
+        )
+
+        headers = self._auth_headers()
+        for index in relay_indexes:
+            relay_url = self._relay_urls[index]
+            try:
+                request_kwargs = {
+                    "json": {"server_public_key": public_key},
+                    "timeout": self._request_timeout,
+                }
+                if headers:
+                    request_kwargs["headers"] = headers
+                response = requests.post(f"{relay_url}/unregister", **request_kwargs)
+                if response.status_code == 200:
+                    self._active_relay_index = index
+                    log_info("Successfully unregistered compute node from relay {}", relay_url)
+                    return True
+                log_error(
+                    "Relay unregister failed at {} with status {}",
+                    relay_url,
+                    response.status_code,
+                )
+            except requests.RequestException as exc:
+                log_error("Relay unregister request failed at {}: {}", relay_url, str(exc), exc_info=True)
+
+        return False
 
     def ping_relay(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
### Motivation
- Ensure a clean, immediate removal of stopped compute nodes from the relay so the desktop operator stop path does not rely on stale TTL eviction.
- Keep the protocol surface minimal by adding a single-purpose unregister endpoint and reusing existing conventions for server-token auth.
- Make shutdown best-effort: attempts to unregister should not block or fail operator shutdown if the relay is unreachable.

### Description
- Added a new `/unregister` relay endpoint that enforces the same `X-Relay-Server-Token` authentication as `/sink` and `/source` and removes the supplied `server_public_key` from `known_servers`.  The endpoint also returns whether a server was removed. (`relay.py`)
- Centralized per-server cleanup into `_remove_server_state(server_public_key)` and reused it from `_evict_stale_servers()` and the new `/unregister` endpoint so eviction and explicit unregister share identical cleanup behavior. (`relay.py`)
- Implemented a best-effort client-side unregister in `RelayClient.unregister_from_relay()` and call it from `RelayClient.stop()` during shutdown; the client sends the registration token header when configured and tries the active relay first, then fallbacks. (`utils/networking/relay_client.py`)
- Made `ComputeNodeRuntime.stop()` resilient by catching errors from the relay client stop/unregister path so runtime shutdown remains successful even if unregister fails. (`utils/compute_node_runtime.py`)
- Added focused unit tests covering unregister auth/behavior, client unregister/token behavior, and best-effort shutdown semantics. (`tests/unit/test_relay_registration_token.py`, `tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`)

### Testing
- Ran `pytest -q tests/unit/test_relay_client.py` and all tests in that file passed (45 passed). 
- Ran `pytest -q tests/unit/test_desktop_compute_node_bridge.py` and all tests in that file passed (23 passed).
- Ran `pytest -q tests/unit/test_relay_registration_token.py` and `pytest -q tests/unit/test_compute_node_runtime.py` and both passed (5 passed and 21 passed respectively), verifying unregister auth, immediate diagnostics update, and runtime stop behavior.
- Ran `pre-commit run --all-files`; standard hooks completed but the integrated `run-checks` test harness reported unrelated environment-level failures in this runner (Playwright/browser artifacts and integration checks), so project hooks mostly passed while the full project check step failed in this CI-like environment and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d6ca0414832f8be0549734f673a2)