### PR TITLE
🐛 Fail-closed chat demo on relay localhost — show relay-only notice

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -8,11 +8,19 @@ new Vue({
         clientPublicKey: null,
         isGeneratingResponse: false,
         isTouchInput: false,
-        activeStreamController: null
+        activeStreamController: null,
+        isRelayOnlyLocalMode: false
     },
-    mounted() {
+    async mounted() {
         this.detectTouchInput();
-        this.getServerPublicKey().then(() => {
+        await this.detectRelayOnlyLocalMode();
+        if (this.isRelayOnlyLocalMode) {
+            return;
+        }
+        this.getServerPublicKey().then((loaded) => {
+            if (!loaded) {
+                return;
+            }
             this.generateClientKeys();
         });
         this.$nextTick(() => {
@@ -20,6 +28,39 @@ new Vue({
         });
     },
     methods: {
+        isLocalhostRuntime() {
+            if (typeof window === 'undefined' || !window.location) {
+                return false;
+            }
+            const hostname = window.location.hostname;
+            return hostname === 'localhost'
+                || hostname === '127.0.0.1'
+                || hostname === '::1';
+        },
+        async detectRelayOnlyLocalMode() {
+            if (!this.isLocalhostRuntime()) {
+                return;
+            }
+
+            const requestOptions = {
+                method: 'GET',
+                headers: { Accept: 'application/json' },
+                cache: 'no-store'
+            };
+
+            try {
+                const [publicKeyResponse, relayDiagnosticsResponse] = await Promise.all([
+                    fetch('/api/v1/public-key', requestOptions),
+                    fetch('/relay/diagnostics', requestOptions)
+                ]);
+
+                const missingPublicKeyApi = publicKeyResponse.status === 404;
+                const relayDiagnosticsAvailable = relayDiagnosticsResponse.ok;
+                this.isRelayOnlyLocalMode = missingPublicKeyApi && relayDiagnosticsAvailable;
+            } catch (error) {
+                console.warn('Unable to detect relay-only localhost mode:', error);
+            }
+        },
         detectTouchInput() {
             try {
                 const hasWindow = typeof window !== 'undefined';
@@ -55,12 +96,15 @@ new Vue({
                 .then(data => {
                     if (data && data.public_key) {
                         this.serverPublicKey = data.public_key;
+                        return true;
                     } else {
                         console.error('Unexpected server public key format:', data);
+                        return false;
                     }
                 })
                 .catch(error => {
                     console.error('Error fetching server public key:', error);
+                    return false;
                 });
         },
         generateClientKeys() {
@@ -1087,6 +1131,9 @@ new Vue({
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
+            if (this.isRelayOnlyLocalMode) {
+                return;
+            }
             if (!messageContent || !this.serverPublicKey || this.isGeneratingResponse) {
                 return;
             }

--- a/static/index.html
+++ b/static/index.html
@@ -306,6 +306,29 @@
         body.light-mode .api-endpoint {
             border-left-color: #007bff;
         }
+
+        .relay-mode-notice {
+            border: 1px solid #3a3a3a;
+            border-radius: 12px;
+            padding: 16px;
+            background-color: #1b1b1b;
+            margin-bottom: 16px;
+        }
+
+        .relay-mode-notice h3 {
+            margin-top: 0;
+        }
+
+        .relay-mode-notice ul {
+            margin-top: 12px;
+            margin-bottom: 0;
+            padding-left: 20px;
+        }
+
+        body.light-mode .relay-mode-notice {
+            background-color: #f8f9fa;
+            border-color: #d0d7de;
+        }
     </style>
 </head>
 <body class="dark-mode">
@@ -316,7 +339,19 @@
         <hr>
 
         <h2>Try it out:</h2>
-        <div class="chat-container" v-cloak>
+        <div v-if="isRelayOnlyLocalMode" class="relay-mode-notice" v-cloak>
+            <h3>Chat demo is unavailable in relay-only localhost mode</h3>
+            <p>
+                This relay root is online, but browser chat testing is not wired in this mode.
+                Use the links below to verify relay health and registration instead.
+            </p>
+            <ul>
+                <li><strong>Relay status:</strong> <a href="/relay/diagnostics" target="_blank" rel="noopener noreferrer">/relay/diagnostics</a></li>
+                <li><strong>Compute registration:</strong> POST heartbeats to <code>/sink</code></li>
+                <li><strong>Local chat smoke tests:</strong> use the desktop app</li>
+            </ul>
+        </div>
+        <div v-else class="chat-container" v-cloak>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>
             </div>

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -53,6 +53,25 @@ def test_inference_endpoint_removed(client):
     response = client.post("/inference", json={})
     assert response.status_code == 404
 
+
+def test_root_page_includes_relay_only_localhost_notice(client):
+    """Relay root should explain relay-only localhost mode instead of a broken chat promise."""
+    response = client.get("/")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Chat demo is unavailable in relay-only localhost mode" in body
+    assert "/relay/diagnostics" in body
+    assert "/sink" in body
+
+
+def test_chat_js_contains_relay_only_localhost_detection(client):
+    """Client script should detect relay-only localhost mode and fail closed."""
+    response = client.get("/static/chat.js")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "detectRelayOnlyLocalMode" in body
+    assert "isRelayOnlyLocalMode" in body
+
 # --- Test /next_server ---
 
 def test_next_server_no_servers(client):


### PR DESCRIPTION
### Motivation
- The relay root serves `static/index.html` but many local relay deployments do not expose the chat API paths the demo expects, producing a misleading broken “Try it out” flow.
- Apply a minimal, scoped fix that makes the landing page honest in localhost relay-only mode instead of attempting a partial/fragile local chat wiring.

### Description
- Added a small relay-only notice UI to `static/index.html` that replaces the chat panel when the client detects relay-only localhost mode and surfaces actionable links (`/relay/diagnostics`, `/sink`) and a desktop smoke-test note.
- Implemented `isLocalhostRuntime()` and `detectRelayOnlyLocalMode()` in `static/chat.js` which probe `/api/v1/public-key` and `/relay/diagnostics` on localhost and set `isRelayOnlyLocalMode` to fail-closed when the public-key API is missing and diagnostics are present.
- Fail-closed behavior: the client skips chat key/bootstrap and prevents sending messages when `isRelayOnlyLocalMode` is true so users do not reach the generic broken response path.
- Added regression assertions in `tests/test_relay.py` to verify the landing page includes the notice text and that `static/chat.js` contains the detection logic.

### Testing
- Ran targeted pytest invocation for modified relay tests (`pytest -q tests/test_relay.py -k "relay_only_localhost_notice or chat_js_contains_relay_only_localhost_detection or relay_diagnostics_distinguishes_configured_and_live_nodes"`), which failed in this environment due to missing test dependencies (`ModuleNotFoundError: No module named 'requests'`).
- Attempted a Flask test-client smoke script that checks `/` and `/static/chat.js`, which could not run here because `flask` is not installed in the container (import error during import of `relay`).
- Pre-commit checks were not run in this environment due to `pre-commit` not being available; please run `pre-commit run --all-files` and `./run_all_tests.sh` in CI or a dev environment with dependencies installed to validate end-to-end.
- Manual verification steps to run locally: start the relay (`python relay.py` / `docker compose up`) and visit `http://127.0.0.1:5010/` to confirm the page shows the relay-only notice and that `/relay/diagnostics` remains functional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dfefc4ac832fa02e142dac218922)