### PR TITLE
Fail-close localhost relay root chat demo when API key endpoint is unavailable

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -8,18 +8,45 @@ new Vue({
         clientPublicKey: null,
         isGeneratingResponse: false,
         isTouchInput: false,
-        activeStreamController: null
+        activeStreamController: null,
+        chatAvailable: true,
+        chatAvailabilityReason: ''
     },
     mounted() {
         this.detectTouchInput();
-        this.getServerPublicKey().then(() => {
-            this.generateClientKeys();
-        });
+        this.initializeChatAvailability();
         this.$nextTick(() => {
             this.adjustMessageInputHeight();
         });
     },
     methods: {
+        async initializeChatAvailability() {
+            const publicKeyLoaded = await this.getServerPublicKey();
+            if (publicKeyLoaded) {
+                this.chatAvailable = true;
+                this.chatAvailabilityReason = '';
+                this.generateClientKeys();
+                return;
+            }
+
+            this.chatAvailable = false;
+            if (this.isLoopbackHost()) {
+                this.chatAvailabilityReason =
+                    'Local relay-only mode is active on localhost, so the root page cannot run the public chat demo endpoints.';
+                return;
+            }
+            this.chatAvailabilityReason =
+                'The relay root page could not initialize chat because /api/v1/public-key is unavailable.';
+        },
+
+        isLoopbackHost() {
+            if (typeof window === 'undefined' || !window.location) {
+                return false;
+            }
+            const host = (window.location.hostname || '').toLowerCase();
+            return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+        },
+
         detectTouchInput() {
             try {
                 const hasWindow = typeof window !== 'undefined';
@@ -50,17 +77,18 @@ new Vue({
                     if (response.ok) {
                         return response.json();
                     }
-                    throw new Error('Failed to fetch server public key');
+                    return null;
                 })
                 .then(data => {
                     if (data && data.public_key) {
                         this.serverPublicKey = data.public_key;
-                    } else {
-                        console.error('Unexpected server public key format:', data);
+                        return true;
                     }
+                    return false;
                 })
                 .catch(error => {
                     console.error('Error fetching server public key:', error);
+                    return false;
                 });
         },
         generateClientKeys() {
@@ -1087,7 +1115,7 @@ new Vue({
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
-            if (!messageContent || !this.serverPublicKey || this.isGeneratingResponse) {
+            if (!this.chatAvailable || !messageContent || !this.serverPublicKey || this.isGeneratingResponse) {
                 return;
             }
 

--- a/static/index.html
+++ b/static/index.html
@@ -140,6 +140,28 @@
         .send-button:hover {
             background-color: #ffffff;
         }
+        .relay-status-panel {
+            margin: 10px 0 20px 0;
+            padding: 14px 16px;
+            border-radius: 6px;
+            border: 1px solid rgba(255, 165, 0, 0.6);
+            background-color: rgba(255, 165, 0, 0.12);
+        }
+        .relay-status-panel h3 {
+            margin-top: 0;
+            margin-bottom: 8px;
+        }
+        .relay-status-panel p {
+            margin: 8px 0;
+            padding: 0;
+        }
+        .relay-status-panel ul {
+            margin: 8px 0 0 20px;
+            padding: 0;
+        }
+        .relay-status-panel li {
+            margin-bottom: 6px;
+        }
         .mode-toggle-container {
             display: flex;
             justify-content: center;
@@ -271,6 +293,10 @@
         body.light-mode .send-button:hover {
             background-color: #0056b3;
         }
+        body.light-mode .relay-status-panel {
+            border-color: rgba(255, 140, 0, 0.6);
+            background-color: rgba(255, 165, 0, 0.2);
+        }
 
         body.light-mode a {
             color: #007bff;
@@ -317,6 +343,17 @@
 
         <h2>Try it out:</h2>
         <div class="chat-container" v-cloak>
+            <div v-if="!chatAvailable" class="relay-status-panel">
+                <h3>Chat demo unavailable in this relay mode</h3>
+                <p>{{ chatAvailabilityReason }}</p>
+                <ul>
+                    <li>Relay process status: <strong>up</strong> (this page loaded from the relay root).</li>
+                    <li>Operator registration and heartbeat endpoint: <code>/sink</code>.</li>
+                    <li>Relay diagnostics: <a href="/relay/diagnostics">/relay/diagnostics</a>.</li>
+                    <li>Local end-to-end smoke testing belongs in the desktop app.</li>
+                </ul>
+            </div>
+            <template v-else>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>
             </div>
@@ -343,6 +380,7 @@
                     Send
                 </button>
             </div>
+            </template>
         </div>
 
         <hr>

--- a/tests/unit/test_relay_root_chat_availability.py
+++ b/tests/unit/test_relay_root_chat_availability.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_relay_root_template_shows_relay_mode_diagnostics_when_chat_unavailable():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    assert 'v-if="!chatAvailable"' in index_html
+    assert "Chat demo unavailable in this relay mode" in index_html
+    assert "/relay/diagnostics" in index_html
+    assert "/sink" in index_html
+
+
+def test_chat_js_disables_send_flow_when_relay_chat_is_unavailable():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "initializeChatAvailability" in chat_js
+    assert "isLoopbackHost" in chat_js
+    assert "!this.chatAvailable || !messageContent" in chat_js
+    assert "Local relay-only mode is active on localhost" in chat_js


### PR DESCRIPTION
### Motivation
- The relay root (`/`) was presenting an interactive “Try it out” chat UI that calls `/api/v1/public-key` and chat endpoints, which is misleading for relay-only local instances that do not provide a working chat backend. 
- Prefer a minimal, explicit fail-closed behavior so local relay debugging does not lead users into a broken generic chat failure message.

### Description
- Add a relay-status panel to `static/index.html` shown when chat is unavailable that explains relay-only/local mode and links to `/relay/diagnostics` and `/sink` for actionable diagnostics. 
- Add `chatAvailable` state and `initializeChatAvailability()` to `static/chat.js` that probes `/api/v1/public-key`, detects loopback hosts, sets user-facing reason text, and prevents the interactive chat send flow when unavailable. 
- Guard `sendMessage()` so the UI cannot enter the broken chat path when `chatAvailable` is false. 
- Add `tests/unit/test_relay_root_chat_availability.py` with lightweight assertions to lock in the fallback UI and JS gating logic.

### Testing
- Ran `pre-commit run --all-files`; many hooks executed and JavaScript tests ran successfully, but the overall `run-checks` step failed in this execution environment due to missing project Python dependencies (e.g. `psutil`, `cryptography`), so the full pre-commit check did not complete. 
- Ran targeted pytest invocation for the new unit tests (`pytest -q tests/unit/test_relay_root_chat_availability.py tests/unit/test_touch_ui.py`); it failed to run to completion because `tests/conftest.py` requires repository-level Python deps that are not installed in this environment (error path: missing `playwright`/`psutil`). 
- The new tests are simple template/JS assertions and should pass in CI where test runner dependencies are available; the change is intentionally small and limited to `static/index.html`, `static/chat.js`, and the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dfefc4ac832fa02e142dac218922)