### PR TITLE
Restore relay landing-page chat: accept base64 PEM from `/api/v1/public-key`

### DIFF
--- a/outages/2026-04-20-relay-landing-page-chat-api-v1-key-format-regression.json
+++ b/outages/2026-04-20-relay-landing-page-chat-api-v1-key-format-regression.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-20",
+  "slug": "relay-landing-page-chat-api-v1-key-format-regression",
+  "summary": "The relay landing-page chat UI at '/' regressed after API v1 key serialization changes: the browser client treated /api/v1/public-key as raw PEM even when API v1 returned base64-encoded PEM, causing encryption setup failure and generic assistant error fallbacks.",
+  "impact": "Users running local relay flows could no longer send and receive real chat responses from the landing page, breaking primary homepage chat validation in v0.1.0 architecture.",
+  "fix": "Normalized public key handling in static/chat.js to accept both raw PEM and base64-encoded PEM from /api/v1/public-key, and added a focused Playwright UI regression test that verifies end-to-end landing-page chat request/response behavior with base64 key payloads.",
+  "lessons": "Client crypto bootstrap logic must tolerate API-safe key serialization formats and regression tests should assert actual landing-page send/receive behavior, not just page render success."
+}

--- a/outages/2026-04-20-relay-landing-page-chat-api-v1-key-format-regression.md
+++ b/outages/2026-04-20-relay-landing-page-chat-api-v1-key-format-regression.md
@@ -1,0 +1,31 @@
+# Outage: relay landing-page chat failed after API v1 migration key-format mismatch
+
+- **Date:** 2026-04-20
+- **Slug:** `relay-landing-page-chat-api-v1-key-format-regression`
+- **Affected area:** relay landing page (`/`) chat UI and end-to-end local relay chat flow
+
+## Summary
+The relay landing page loaded successfully, but sending a message from the `/` chat UI failed and fell back to the generic assistant error response instead of returning a real completion.
+
+## Symptoms
+- Visiting `http://127.0.0.1:5010/` showed the chat UI as expected.
+- Sending a chat message displayed the generic failure message (`Sorry, I encountered an issue generating a response. Please try again.`).
+- Browser requests reached `/api/v1/public-key`, but follow-up encrypted chat requests failed before successful completion rendering.
+
+## Impact
+Local relay users lost the primary landing-page chat interaction and could not validate end-to-end chat from the relay homepage during development or smoke testing.
+
+## Root cause
+During the API v1 migration, the public key endpoint standardized on base64-encoded PEM (`public_key`) while the landing-page chat encryption path continued treating that field as a raw PEM string. This key-format mismatch caused client-side RSA setup to fail, which then prevented successful encrypted chat requests and produced the generic fallback error in the UI.
+
+## Remediation
+- Updated `static/chat.js` to normalize server public keys by accepting either raw PEM or base64-encoded PEM from `/api/v1/public-key`.
+- Kept the landing-page chat on the API v1/v2 architecture (no rollback to legacy relay transport):
+  - key fetch remains `/api/v1/public-key`
+  - streaming/non-stream chat routes remain `/api/v2/chat/completions` and `/api/v1/chat/completions`
+- Added a focused UI regression test that mocks a base64-encoded API v1 public key and verifies the landing-page chat sends a real request and renders a real assistant response.
+
+## Follow-up / prevention
+- Keep regression coverage for base64-formatted API v1 public keys in the landing-page chat path.
+- Preserve compatibility in the chat client for both PEM and base64 PEM input formats when API key serialization changes.
+- Include relay landing-page chat send/receive checks in local release smoke tests.

--- a/static/chat.js
+++ b/static/chat.js
@@ -54,7 +54,7 @@ new Vue({
                 })
                 .then(data => {
                     if (data && data.public_key) {
-                        this.serverPublicKey = data.public_key;
+                        this.serverPublicKey = this.normalizePublicKey(data.public_key);
                     } else {
                         console.error('Unexpected server public key format:', data);
                     }
@@ -62,6 +62,28 @@ new Vue({
                 .catch(error => {
                     console.error('Error fetching server public key:', error);
                 });
+        },
+
+        normalizePublicKey(publicKeyValue) {
+            if (typeof publicKeyValue !== 'string') {
+                return null;
+            }
+
+            const trimmed = publicKeyValue.trim();
+            if (!trimmed) {
+                return null;
+            }
+
+            if (trimmed.includes('BEGIN PUBLIC KEY')) {
+                return trimmed;
+            }
+
+            try {
+                return atob(trimmed);
+            } catch (error) {
+                console.error('Failed to decode server public key from base64:', error);
+                return null;
+            }
         },
         generateClientKeys() {
             const crypt = new JSEncrypt({ default_key_size: 2048 });

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import pytest
 from playwright.sync_api import Page
@@ -69,6 +70,61 @@ def test_multi_turn_conversation(page: Page, base_url: str, setup_servers):
     # Verify app has initialized
     assert page.locator("#app").count() > 0, "Vue app should be initialized"
     print("✓ Vue app initialization verified")
+
+
+def test_send_message_with_base64_public_key(page: Page, base_url: str, setup_servers):
+    """Landing page chat should work when API v1 returns a base64-encoded public key."""
+
+    public_key_pem = """-----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfdlv9h2X4xVZW7eo87nxP8E1TqYQf7
+FRwqjJH8Vbo0YX5xTL6qv4d4pClwK8X+6I9BJ2R8Bf4S8vQhF8gZKwkCAwEAAQ==
+-----END PUBLIC KEY-----"""
+    encoded_public_key = base64.b64encode(public_key_pem.encode("utf-8")).decode("ascii")
+
+    requests_seen = {"v2": 0}
+
+    def handle_public_key(route):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": encoded_public_key}),
+        )
+
+    def handle_streaming_request(route):
+        requests_seen["v2"] += 1
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "Relay chat restored",
+                            }
+                        }
+                    ]
+                }
+            ),
+        )
+
+    page.route("**/api/v1/public-key", handle_public_key)
+    page.route("**/api/v2/chat/completions", handle_streaming_request)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("hello relay")
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+
+    assert requests_seen["v2"] == 1
+    assert "Relay chat restored" in assistant_message.inner_text()
+
 
 # Add more E2E tests here as the UI evolves
 


### PR DESCRIPTION
### Motivation
- The landing-page chat UI at `/` regressed after API v1 standardized `public_key` as a base64-encoded PEM, while the client assumed a raw PEM string, breaking RSA bootstrap and causing generic assistant failures.
- The goal is to restore the user-visible behavior (open `/`, send a message, receive a real assistant response) while remaining aligned with the `v0.1.0` API v1/v2 architecture (no legacy transport rollback).

### Description
- Normalize server public key handling in the browser chat client by adding `normalizePublicKey()` and using it when consuming `/api/v1/public-key` in `static/chat.js` so the client accepts either raw PEM or base64-encoded PEM before starting encryption.
- Add a focused Playwright UI regression test `test_send_message_with_base64_public_key` to `tests/e2e/test_ui.py` that mocks a base64 `public_key`, sends a message from `/`, asserts `/api/v2/chat/completions` is hit, and verifies assistant output renders.
- Add outage documentation files `outages/2026-04-20-relay-landing-page-chat-api-v1-key-format-regression.md` and `.json` describing the incident, root cause, remediation and follow-ups to match existing conventions.
- Small test adjustment: import `base64` in the new/modified test to encode the PEM fixture.

### Testing
- Syntax sanity: ran `node -e "new Function(require('fs').readFileSync('static/chat.js','utf8')); console.log('chat.js syntax ok')"` and it reported `chat.js syntax ok` (pass).
- Outage JSON validation: ran a `jsonschema` validation against `outages/schema.json` for the new `.json` file and it validated successfully (pass).
- E2E regression test: added `tests/e2e/test_ui.py::test_send_message_with_base64_public_key`; running `pytest tests/e2e/test_ui.py -k "base64_public_key"` in this environment produced a skipped result because relay/server registration smoke tests are gated and the local relay process failed to fully start due to missing runtime dependencies (`flask_limiter`), so the test was skipped rather than executed end-to-end (skipped). 
- Manual smoke commands to run locally (expected verification steps): `python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm` then `RUN_RELAY_REGISTRATION_TESTS=1 pytest -q tests/e2e/test_ui.py -k "base64_public_key"`; full manual smoke couldn't be completed in this CI-like environment due to missing local runtime deps, but the change is minimal and covered by the added e2e regression test when run in a fully provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e2f47798832fac9ac62257f784e6)