### PR TITLE
🐛 fix: restore relay landing chat with API v1 public-key normalization

### DIFF
--- a/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.json
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-20",
+  "slug": "relay-landing-chat-api-v1-key-format-regression",
+  "summary": "Relay landing-page chat at / regressed after API v1 key-format migration because static/chat.js consumed public_key as direct PEM while the API returned Base64-encoded PEM bytes, causing browser encryption bootstrap to fail and chat completions to fall back to generic error messaging.",
+  "impact": "Users running local relay mode could not complete end-to-end landing-page chat conversations, blocking validation of the primary browser chat journey.",
+  "fix": "Normalized API public keys in static/chat.js to support both direct PEM and Base64-encoded PEM, and added an e2e regression that validates successful landing-page response rendering through v1 fallback when v2 streaming fails.",
+  "lessons": "Browser crypto bootstrapping must enforce explicit key-format normalization and regression tests should include key-format compatibility plus v2->v1 chat fallback coverage."
+}

--- a/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md
@@ -1,0 +1,36 @@
+# Outage: relay landing-page chat failed after API v1 key-format migration
+
+- **Date:** 2026-04-20
+- **Slug:** `relay-landing-chat-api-v1-key-format-regression`
+- **Affected area:** relay landing page chat UI at `/` (`static/index.html` + `static/chat.js`)
+
+## Summary
+The relay landing page continued to render at `/`, but user chat messages could no longer complete end-to-end in local relay mode. The UI fell back to a generic assistant failure message instead of rendering a real model response.
+
+## Symptoms
+- Landing page loads normally at `http://127.0.0.1:5010/`.
+- Sending a chat message from the landing-page composer does not produce a real assistant reply.
+- The chat history shows: `Sorry, I encountered an issue generating a response. Please try again.`
+
+## Impact
+Local relay validation of the core browser chat journey was broken. Users and developers could not verify the `relay.py` + API v1 compute path through the landing-page UI, despite the page and endpoint docs appearing healthy.
+
+## Root cause
+1. API v1/v2 `GET /api/v1/public-key` and `GET /api/v2/public-key` return the server key as Base64-encoded PEM bytes.
+2. Landing-page `static/chat.js` treated `public_key` as directly usable PEM and passed it unchanged to `JSEncrypt#setPublicKey`.
+3. The resulting client-side encryption path failed, so both streaming and non-stream chat attempts failed before a valid completion payload could be processed.
+
+## Remediation
+- Added `normalizeServerPublicKey` in `static/chat.js` to accept both:
+  - legacy/plain PEM key strings, and
+  - API v1 Base64-encoded PEM key payloads (decoded before use).
+- Updated `getServerPublicKey` to normalize the API response before storing `serverPublicKey`.
+- Added Playwright regression coverage to assert the landing page can:
+  - fetch a Base64 public key,
+  - fail over from `/api/v2/chat/completions` streaming failure,
+  - and still receive/render a real assistant response from `/api/v1/chat/completions`.
+
+## Follow-up / prevention
+- Preserve browser tests that explicitly validate key-format compatibility for landing-page crypto bootstrapping.
+- Keep relay landing-page chat tests exercising both `/api/v2/chat/completions` and `/api/v1/chat/completions` fallback behavior.
+- Require outage notes for any future API key-format/transport changes that affect browser encryption initialization.

--- a/static/chat.js
+++ b/static/chat.js
@@ -43,6 +43,32 @@ new Vue({
                 this.isTouchInput = false;
             }
         },
+        normalizeServerPublicKey(rawKey) {
+            if (typeof rawKey !== 'string') {
+                return null;
+            }
+
+            const trimmed = rawKey.trim();
+            if (!trimmed) {
+                return null;
+            }
+
+            if (trimmed.includes('-----BEGIN')) {
+                return trimmed;
+            }
+
+            try {
+                const decoded = atob(trimmed).trim();
+                if (decoded.includes('-----BEGIN')) {
+                    return decoded;
+                }
+            } catch (error) {
+                console.warn('Server public key is not Base64-encoded PEM:', error);
+            }
+
+            return null;
+        },
+
         getServerPublicKey() {
             // Fetch the server's public key from the API
             return fetch('/api/v1/public-key')
@@ -53,8 +79,9 @@ new Vue({
                     throw new Error('Failed to fetch server public key');
                 })
                 .then(data => {
-                    if (data && data.public_key) {
-                        this.serverPublicKey = data.public_key;
+                    const normalizedKey = this.normalizeServerPublicKey(data && data.public_key);
+                    if (normalizedKey) {
+                        this.serverPublicKey = normalizedKey;
                     } else {
                         console.error('Unexpected server public key format:', data);
                     }

--- a/static/chat.js
+++ b/static/chat.js
@@ -58,7 +58,8 @@ new Vue({
             }
 
             try {
-                const decoded = atob(trimmed).trim();
+                const cleanedBase64 = trimmed.replace(/\s+/g, '');
+                const decoded = atob(cleanedBase64).trim();
                 if (decoded.includes('-----BEGIN')) {
                     return decoded;
                 }

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -153,7 +153,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     def handle_stream_fail(route):
         route.fulfill(
-            status=500,
+            status=200,
             headers={"Content-Type": "application/json"},
             body=json.dumps({"error": {"message": "stream unavailable"}}),
         )
@@ -196,5 +196,16 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
+    page.wait_for_function(
+        """
+        ({ selector, expectedText }) => {
+            const nodes = document.querySelectorAll(selector);
+            if (!nodes.length) return false;
+            const latest = nodes[nodes.length - 1];
+            return latest.textContent.includes(expectedText);
+        }
+        """,
+        arg={"selector": ".assistant-message", "expectedText": "Relay chat path restored."},
+    )
     assert "Relay chat path restored." in assistant_message.inner_text()
     assert "Sorry, I encountered an issue generating a response." not in page.content()

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -3,6 +3,9 @@ import json
 import pytest
 from playwright.sync_api import Page
 import time
+import textwrap
+
+from encrypt import encrypt
 
 # This test now implicitly uses the `setup_servers` and `page` fixtures
 # defined in tests/conftest.py
@@ -164,12 +167,23 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
         assert isinstance(request_json.get("client_public_key"), str) and request_json[
             "client_public_key"
         ]
-        assert isinstance(request_json.get("messages"), dict)
 
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(
+        encrypted_request = request_json.get("messages")
+        assert isinstance(encrypted_request, dict)
+        assert isinstance(encrypted_request.get("ciphertext"), str) and encrypted_request["ciphertext"]
+        assert isinstance(encrypted_request.get("cipherkey"), str) and encrypted_request["cipherkey"]
+        assert isinstance(encrypted_request.get("iv"), str) and encrypted_request["iv"]
+
+        client_public_key_pem = "\n".join(
+            [
+                "-----BEGIN PUBLIC KEY-----",
+                *textwrap.wrap(request_json["client_public_key"], 64),
+                "-----END PUBLIC KEY-----",
+            ]
+        ).encode("utf-8")
+
+        encrypted_response_body, encrypted_key, iv = encrypt(
+            json.dumps(
                 {
                     "choices": [
                         {
@@ -179,6 +193,23 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
                             }
                         }
                     ]
+                }
+            ).encode("utf-8"),
+            client_public_key_pem,
+            use_pkcs1v15=True,
+        )
+
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "encrypted": True,
+                    "data": {
+                        "ciphertext": base64.b64encode(encrypted_response_body["ciphertext"]).decode("utf-8"),
+                        "cipherkey": base64.b64encode(encrypted_key).decode("utf-8"),
+                        "iv": base64.b64encode(iv).decode("utf-8"),
+                    },
                 }
             ),
         )

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import pytest
 from playwright.sync_api import Page
@@ -123,3 +124,77 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
 
     # Ensure raw HTML isn't rendered unsanitized
     assert assistant_message.locator("script").count() == 0
+
+
+def test_landing_chat_accepts_base64_public_key_and_falls_back_to_v1(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """Landing chat should accept API v1 Base64 keys and still render a reply."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+
+    def handle_public_key(route):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        )
+
+    def handle_stream_fail(route):
+        route.fulfill(
+            status=500,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"error": {"message": "stream unavailable"}}),
+        )
+
+    def handle_v1_chat(route):
+        request_json = route.request.post_data_json
+        assert request_json.get("encrypted") is True
+        assert isinstance(request_json.get("client_public_key"), str) and request_json[
+            "client_public_key"
+        ]
+        assert isinstance(request_json.get("messages"), dict)
+
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "Relay chat path restored.",
+                            }
+                        }
+                    ]
+                }
+            ),
+        )
+
+    page.route("**/api/v1/public-key", handle_public_key)
+    page.route("**/api/v2/chat/completions", handle_stream_fail)
+    page.route("**/api/v1/chat/completions", handle_v1_chat)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("hello")
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+    assert "Relay chat path restored." in assistant_message.inner_text()
+    assert "Sorry, I encountered an issue generating a response." not in page.content()


### PR DESCRIPTION
### Motivation
- Restore the relay landing-page chat UX so visiting `/` allows a user to send a message and receive a real assistant response under the API v0.1.0 (API v1) architecture. 
- The migration to API v1 started returning the server public key as Base64-encoded PEM bytes, which broke the browser-side encryption bootstrap and caused the generic assistant failure message.

### Description
- Add `normalizeServerPublicKey` to `static/chat.js` and use it from `getServerPublicKey` so the client accepts both direct PEM and Base64-encoded PEM returned by `/api/v1/public-key`.
- Preserve the v0.1.0 flow by keeping the `/api/v2/chat/completions` streaming attempt and falling back to `/api/v1/chat/completions` when streaming fails (client-side fallback already exercised by the new test).
- Add a Playwright e2e regression in `tests/e2e/test_ui.py` that simulates a Base64 public-key response, forces a v2 streaming failure, and asserts the UI recovers via the v1 path and renders a real assistant reply.
- Add an outage record in both Markdown and JSON at `outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.*` documenting the regression, root cause, remediation, and follow-up, matching the repo pattern.

### Testing
- Ran the targeted Playwright e2e pytest command `python -m pytest tests/e2e/test_ui.py -k base64_public_key_and_falls_back_to_v1`, which could not execute in this environment due to missing test environment dependencies (`ModuleNotFoundError: No module named 'requests'` from `tests/conftest.py`).
- Attempted `pre-commit run --all-files`, which was not available in the environment (`pre-commit: command not found`).
- Attempted to start the local relay and server (`python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm` and `python server.py --server_host 127.0.0.1 --server_port 3000 --relay_url http://127.0.0.1:5010 --use_mock_llm`), both of which failed here due to missing runtime dependency `flask`.
- The regression test has been added and should pass in CI or a local dev environment after installing test/runtime dependencies (`pip install -r config/requirements_server.txt` and test deps) and running `python -m pytest tests/e2e/test_ui.py -k base64_public_key_and_falls_back_to_v1` to validate the fix locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e2f47798832fac9ac62257f784e6)