### PR TITLE
Restore relay landing-page chat key compatibility (API v1 public-key format)

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -650,7 +650,10 @@ def _public_key_response(log_label: str | None = None):
             return format_error_response(
                 "Failed to retrieve public key: encryption is not initialized",
             )
-        return jsonify({'public_key': encryption_manager.public_key_b64})
+        public_key_b64 = encryption_manager.public_key_b64
+        wrapped_lines = "\n".join(public_key_b64[i:i + 64] for i in range(0, len(public_key_b64), 64))
+        public_key_pem = f"-----BEGIN PUBLIC KEY-----\n{wrapped_lines}\n-----END PUBLIC KEY-----"
+        return jsonify({'public_key': public_key_b64, 'public_key_pem': public_key_pem})
     except Exception as exc:
         log_error("Error in get_public_key endpoint", exc_info=True)
         return format_error_response(

--- a/api/v2/routes.py
+++ b/api/v2/routes.py
@@ -259,7 +259,10 @@ def _public_key_response(log_label: str | None = None):
         if log_label is None:
             log_label = f"{request.method.upper()} {request.path}"
         log_info(f"API request: {log_label}")
-        return jsonify({'public_key': encryption_manager.public_key_b64})
+        public_key_b64 = encryption_manager.public_key_b64
+        wrapped_lines = "\n".join(public_key_b64[i:i + 64] for i in range(0, len(public_key_b64), 64))
+        public_key_pem = f"-----BEGIN PUBLIC KEY-----\n{wrapped_lines}\n-----END PUBLIC KEY-----"
+        return jsonify({'public_key': public_key_b64, 'public_key_pem': public_key_pem})
     except Exception:
         log_error("Error in get_public_key endpoint", exc_info=True)
         return format_error_response(

--- a/outages/2026-04-20-relay-landing-chat-api-v1-public-key-format-regression.json
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-public-key-format-regression.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-20",
+  "slug": "relay-landing-chat-api-v1-public-key-format-regression",
+  "summary": "Relay landing-page chat at / failed after API v1 key-format migration because the browser expected a PEM public key while /api/v1/public-key returned base64 DER, causing client-side encryption and chat completion requests to fail.",
+  "impact": "Users running local relay and compute-node flows could not complete landing-page chat round-trips and only saw fallback error messaging.",
+  "fix": "Normalized server public keys to PEM in static/chat.js, added a public_key_pem field to API v1/v2 public-key responses while keeping public_key for compatibility, and added regression tests for both API response shape and landing-page key-normalization behavior.",
+  "lessons": "Browser encryption clients are sensitive to key serialization format changes; API migrations must include compatibility fields or client normalization, plus targeted regression coverage for landing-page chat UX."
+}

--- a/outages/2026-04-20-relay-landing-chat-api-v1-public-key-format-regression.md
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-public-key-format-regression.md
@@ -1,0 +1,37 @@
+# Outage: relay landing-page chat failed after API v1 key-format migration
+
+- **Date:** 2026-04-20
+- **Slug:** `relay-landing-chat-api-v1-public-key-format-regression`
+- **Affected area:** relay landing page chat UI (`/`) in local relay + compute-node flows
+
+## Summary
+The landing-page chat UI rendered correctly, but sending a message failed and fell back to the
+assistant's generic failure copy instead of returning a real response.
+
+## Symptoms
+- Visiting `http://127.0.0.1:5010/` showed the chat widget normally.
+- User messages were accepted in the UI, but no assistant response arrived.
+- The UI displayed `Sorry, I encountered an issue generating a response. Please try again.`
+
+## Impact
+Local validation of relay landing-page chat was blocked. Operators could not verify end-to-end
+chat behavior from the main relay page, despite the rest of the page loading successfully.
+
+## Root cause
+1. During API v1 migration, `/api/v1/public-key` standardized on base64-encoded DER output.
+2. The landing-page browser client still treated `public_key` as PEM input for `JSEncrypt`.
+3. The frontend's request encryption path failed because the server key format was incompatible,
+   causing both streaming and non-streaming chat calls to fail.
+
+## Remediation
+- Updated landing-page chat key loading to normalize either PEM or base64 public keys to PEM
+  before encryption.
+- Added `public_key_pem` to API public-key responses (v1 and v2) while preserving existing
+  `public_key` for compatibility.
+- Added regression tests that assert the landing-page chat key-normalization path and public-key
+  response shape.
+
+## Follow-up / prevention
+- Keep browser chat tests aligned with API key format contracts whenever key serialization changes.
+- Preserve dual-format response compatibility (`public_key` + `public_key_pem`) for browser clients.
+- Treat relay landing-page chat as a release gate for API surface migrations.

--- a/static/chat.js
+++ b/static/chat.js
@@ -53,8 +53,13 @@ new Vue({
                     throw new Error('Failed to fetch server public key');
                 })
                 .then(data => {
-                    if (data && data.public_key) {
-                        this.serverPublicKey = data.public_key;
+                    const candidateKey = data && (
+                        data.public_key_pem
+                        || data.public_key
+                    );
+                    const normalizedKey = this.normalizeServerPublicKey(candidateKey);
+                    if (normalizedKey) {
+                        this.serverPublicKey = normalizedKey;
                     } else {
                         console.error('Unexpected server public key format:', data);
                     }
@@ -62,6 +67,36 @@ new Vue({
                 .catch(error => {
                     console.error('Error fetching server public key:', error);
                 });
+        },
+        normalizeServerPublicKey(value) {
+            if (typeof value !== 'string') {
+                return null;
+            }
+
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return null;
+            }
+
+            if (trimmed.includes('-----BEGIN PUBLIC KEY-----')) {
+                return trimmed;
+            }
+
+            const cleanedBase64 = trimmed.replace(/\s+/g, '');
+            if (!/^[A-Za-z0-9+/=]+$/.test(cleanedBase64)) {
+                return null;
+            }
+
+            const chunkedLines = cleanedBase64.match(/.{1,64}/g);
+            if (!Array.isArray(chunkedLines) || chunkedLines.length === 0) {
+                return null;
+            }
+
+            return [
+                '-----BEGIN PUBLIC KEY-----',
+                chunkedLines.join('\n'),
+                '-----END PUBLIC KEY-----'
+            ].join('\n');
         },
         generateClientKeys() {
             const crypt = new JSEncrypt({ default_key_size: 2048 });

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -178,6 +178,9 @@ def test_get_public_key(client):
     data = response.get_json()
     assert 'public_key' in data
     assert len(data['public_key']) > 0
+    assert 'public_key_pem' in data
+    assert data['public_key_pem'].startswith("-----BEGIN PUBLIC KEY-----")
+    assert data['public_key_pem'].endswith("-----END PUBLIC KEY-----")
 
 
 def test_server_provider_directory(client):

--- a/tests/unit/test_landing_chat_public_key_regression.py
+++ b/tests/unit/test_landing_chat_public_key_regression.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_landing_chat_normalizes_base64_public_keys_to_pem():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "normalizeServerPublicKey" in chat_js
+    assert "public_key_pem" in chat_js
+    assert "-----BEGIN PUBLIC KEY-----" in chat_js
+    assert "-----END PUBLIC KEY-----" in chat_js


### PR DESCRIPTION
### Motivation
- The landing-page chat UI stopped producing real responses because API v1 public-key serialization switched to base64 DER while the browser client still expected PEM, causing client-side RSA encryption to fail.
- The fix must preserve the `v0.1.0` API v1 architecture (do not revert legacy transport) while restoring the user-visible chat behavior observed in `v0.0.1`.

### Description
- Normalize server public keys in the landing-page client by adding `normalizeServerPublicKey` and accepting `public_key_pem` or base64 `public_key` before constructing a PEM string in `static/chat.js`.
- Make API public-key endpoints on both v1 and v2 include a PEM-compatible field `public_key_pem` (while keeping the existing `public_key` base64 field) in `api/v1/routes.py` and `api/v2/routes.py` to preserve compatibility.
- Add regression coverage: a unit test that verifies the landing-page client contains the normalization helper and an API test assertion that `public_key_pem` is present and PEM-formatted (`tests/unit/test_landing_chat_public_key_regression.py`, and a small addition to `tests/test_api.py`).
- Document the incident and remediation in a new outages entry (Markdown + JSON) following the repo convention (`outages/2026-04-20-relay-landing-chat-api-v1-public-key-format-regression.{md,json}`).

### Testing
- Ran focused unit test: `python -m pytest tests/unit/test_landing_chat_public_key_regression.py -q` but collection failed in this environment due to missing test dependencies (Playwright) declared by the shared `tests/conftest.py` (failure: `ModuleNotFoundError: No module named 'playwright'`).
- Ran targeted API test: `python -m pytest tests/test_api.py -k "get_public_key" -q` but it also failed to collect for the same missing dependency error (Playwright). 
- Executed `pre-commit run --all-files`; JavaScript checks and JS unit tests ran and passed inside hooks, but the overall hooks failed because the environment is missing Python dev dependencies (Playwright, cryptography) required by the repository test runner hook (`run-checks`).
- Manual smoke attempts to verify end-to-end failed in this sandbox due to missing runtime packages: `python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm` and `python server.py --server_host 127.0.0.1 --server_port 3000 --relay_url http://127.0.0.1:5010 --relay_port 5010 --use_mock_llm` both raised `ModuleNotFoundError: No module named 'flask'` in this environment.
- Summary of results: code and tests added; JS checks passed in the pre-commit run, but full Python test-suite and manual smoke-tests could not be exercised here due to missing system/test dependencies (Playwright/Flask/cryptography).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e2f47798832fac9ac62257f784e6)