### PR TITLE
Restore landing-page chat encryption compatibility (PKCS#1 v1.5)

### DIFF
--- a/api/v1/encryption.py
+++ b/api/v1/encryption.py
@@ -55,7 +55,11 @@ class EncryptionManager:
                 client_public_key = base64.b64decode(client_public_key)
 
             # Encrypt the data
-            ciphertext_dict, cipherkey, iv = encrypt(json_data, client_public_key)
+            ciphertext_dict, cipherkey, iv = encrypt(
+                json_data,
+                client_public_key,
+                use_pkcs1v15=True,
+            )
 
             # Encode to base64 for JSON
             ciphertext_b64 = base64.b64encode(ciphertext_dict['ciphertext']).decode('utf-8')

--- a/api/v2/routes.py
+++ b/api/v2/routes.py
@@ -680,6 +680,7 @@ def create_chat_completion():
                                     plaintext_bytes,
                                     client_public_key_bytes,
                                     session=stream_session,
+                                    use_pkcs1v15=True,
                                 )
                             except Exception:
                                 log_error("Failed to encrypt streaming chunk", exc_info=True)

--- a/outages/2026-04-20-relay-landing-page-chat-api-v1-regression.json
+++ b/outages/2026-04-20-relay-landing-page-chat-api-v1-regression.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-20",
+  "slug": "relay-landing-page-chat-api-v1-regression",
+  "summary": "Relay landing-page chat regressed after API v1 migration because encrypted response session keys were wrapped with OAEP while the browser client expected PKCS#1 v1.5, causing client-side decrypt failures and generic assistant error fallbacks.",
+  "impact": "Users could no longer complete a real chat message/response flow from the relay landing page at / in local v0.1.0 mode.",
+  "fix": "Switched API encrypted response key wrapping and v2 encrypted streaming first-chunk key wrapping to PKCS#1 v1.5 compatibility mode for browser clients, and added regression tests that verify PKCS#1 v1.5 decryptability of returned session keys.",
+  "lessons": "Browser crypto compatibility (padding mode) must be validated end-to-end whenever encryption helpers change, especially for landing-page chat paths that rely on JSEncrypt."
+}

--- a/outages/2026-04-20-relay-landing-page-chat-api-v1-regression.md
+++ b/outages/2026-04-20-relay-landing-page-chat-api-v1-regression.md
@@ -1,0 +1,31 @@
+# Outage: relay landing-page chat failed after API v1 migration
+
+- **Date:** 2026-04-20
+- **Slug:** `relay-landing-page-chat-api-v1-regression`
+- **Affected area:** relay landing page chat UI at `/` (`static/index.html` + `static/chat.js`) when connected to local v0.1.0 API paths
+
+## Summary
+The relay landing page rendered, but user chat messages failed end-to-end and the UI fell back to the generic assistant failure text instead of returning a real model response.
+
+## Symptoms
+- Opening `http://127.0.0.1:5010/` showed the chat widget normally.
+- Sending a message produced `Sorry, I encountered an issue generating a response. Please try again.`
+- Network requests reached `/api/v1/chat/completions` and `/api/v2/chat/completions`, but response decryption in the browser failed.
+
+## Impact
+Local relay demos and operator verification flows could no longer validate the core landing-page chat journey, even though the rest of the v0.1.0 API surface was reachable.
+
+## Root cause
+- During the v0.1.0 migration, API responses for encrypted chat payloads began RSA-wrapping AES session keys using OAEP defaults in backend encryption helpers.
+- The landing-page browser client still relies on JSEncrypt for private-key operations, which expects PKCS#1 v1.5 wrapped session keys.
+- This padding mismatch caused client-side decrypt failures, which then surfaced as the generic assistant error in the UI.
+
+## Remediation
+- Updated API encrypted response key-wrapping to use PKCS#1 v1.5 compatibility mode for browser chat clients.
+- Updated v2 encrypted streaming chunk generation to use the same key-wrapping mode for first-chunk session keys.
+- Added regression tests that assert encrypted response/session keys are decryptable via PKCS#1 v1.5 client behavior.
+
+## Follow-up / prevention
+- Keep landing-page chat compatibility checks in API encryption regression tests (non-stream + streaming).
+- Add a browser smoke test in CI that validates a real message/response cycle from `/` through API v1/v2 endpoints.
+- Treat RSA padding changes as compatibility-sensitive API changes requiring explicit migration notes.

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -123,3 +123,22 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
 
     # Ensure raw HTML isn't rendered unsanitized
     assert assistant_message.locator("script").count() == 0
+
+
+def test_landing_page_chat_round_trip_with_local_api_v1_stack(page: Page, base_url: str, setup_servers):
+    """The relay landing page should send a prompt and render a real assistant reply."""
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("Say hello from the landing page")
+    page.locator("button", has_text="Send").click()
+
+    assistant_messages = page.locator(".assistant-message")
+    assistant_messages.last.wait_for(state="visible", timeout=30000)
+
+    assistant_text = assistant_messages.last.inner_text().strip()
+    assert assistant_text
+    assert "Sorry, I encountered an issue generating a response" not in assistant_text
+    assert "Sorry, an error occurred while sending your message" not in assistant_text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,8 @@ import importlib
 import inspect
 from unittest.mock import MagicMock, patch
 from encrypt import encrypt, decrypt, generate_keys, decrypt_stream_chunk
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padding
 import sys
 import os
 
@@ -1130,6 +1132,62 @@ def test_chat_completion_unexpected_exception(client, monkeypatch):
     resp = client.post('/api/v1/chat/completions', json=payload)
     assert resp.status_code == 500
     assert 'Internal server error' in resp.get_json()['error']['message']
+
+
+def test_v1_encrypted_response_uses_pkcs1v15_cipherkey_for_browser_compat(client, monkeypatch):
+    """Encrypted API responses should use PKCS#1 v1.5 RSA wrapping for landing-page compatibility."""
+
+    class _Provider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            assert model_id == "llama-3-8b-instruct"
+            assert messages[-1]["content"] == "hello"
+            return {"role": "assistant", "content": "hi from compute"}
+
+    monkeypatch.setattr("api.v1.routes.get_api_v1_compute_provider", lambda: _Provider())
+
+    server_key_response = client.get("/api/v1/public-key")
+    assert server_key_response.status_code == 200
+    server_public_key = base64.b64decode(server_key_response.get_json()["public_key"])
+
+    client_private_key, client_public_key = generate_keys()
+    encrypted_messages, encrypted_key, iv = encrypt(
+        json.dumps([{"role": "user", "content": "hello"}]).encode("utf-8"),
+        server_public_key,
+        use_pkcs1v15=True,
+    )
+
+    payload = {
+        "model": "llama-3-8b-instruct",
+        "encrypted": True,
+        "client_public_key": base64.b64encode(client_public_key).decode("ascii"),
+        "messages": {
+            "ciphertext": base64.b64encode(encrypted_messages["ciphertext"]).decode("ascii"),
+            "cipherkey": base64.b64encode(encrypted_key).decode("ascii"),
+            "iv": base64.b64encode(iv).decode("ascii"),
+        },
+    }
+
+    response = client.post("/api/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["encrypted"] is True
+
+    encrypted_response = body["data"]
+    cipherkey_bytes = base64.b64decode(encrypted_response["cipherkey"])
+    private_key = serialization.load_pem_private_key(client_private_key, password=None)
+    decrypted_session_key_b64 = private_key.decrypt(cipherkey_bytes, asymmetric_padding.PKCS1v15())
+    assert isinstance(base64.b64decode(decrypted_session_key_b64), bytes)
+
+    decrypted_body = decrypt(
+        {
+            "ciphertext": base64.b64decode(encrypted_response["ciphertext"]),
+            "iv": base64.b64decode(encrypted_response["iv"]),
+        },
+        cipherkey_bytes,
+        client_private_key,
+    )
+    parsed = json.loads(decrypted_body.decode("utf-8"))
+    assert parsed["choices"][0]["message"]["content"] == "hi from compute"
 
 
 def test_completions_invalid_body(client):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,6 +5,8 @@ from itertools import accumulate
 from types import SimpleNamespace
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padding
 
 from relay import app as relay_app
 from api.v1 import routes as v1_routes
@@ -191,6 +193,12 @@ def test_v2_encrypted_streaming_emits_encrypted_chunks(client, monkeypatch):
         if index == 0:
             assert "cipherkey" in payload_body
             encrypted_key_bytes = base64.b64decode(payload_body["cipherkey"])
+            private_key = serialization.load_pem_private_key(client_private_key, password=None)
+            decrypted_session_key_b64 = private_key.decrypt(
+                encrypted_key_bytes,
+                asymmetric_padding.PKCS1v15(),
+            )
+            assert isinstance(base64.b64decode(decrypted_session_key_b64), bytes)
         else:
             assert "cipherkey" not in payload_body
             encrypted_key_bytes = None


### PR DESCRIPTION
### Motivation
- The relay landing-page chat UI at `/` stopped working end‑to‑end after the v0.1.0 API v1 migration because encrypted response/session keys returned by the API used OAEP-style wrapping while the browser client (JSEncrypt) expects PKCS#1 v1.5, causing client-side decryption failures and a generic assistant error in the UI.
- The fix must preserve the v0.1.0 API v1/v2 architecture and not revert to the legacy relay inter-node contract while restoring the exact user-visible behavior from `v0.0.1` (send a message from `/` and receive a real assistant response).

### Description
- Use PKCS#1 v1.5 RSA wrapping for API responses: updated `api/v1/encryption.py` to call `encrypt(..., use_pkcs1v15=True)` when producing encrypted responses so the browser client can decrypt session keys.
- Apply the same compatibility mode for encrypted streaming first-chunk keys: passed `use_pkcs1v15=True` into `encrypt_stream_chunk` in `api/v2/routes.py` so SSE encrypted chunks are browser-decryptable.
- Add focused regression tests: `tests/test_api.py` (assert v1 encrypted responses are PKCS#1 v1.5-decryptable), `tests/test_streaming.py` (assert first streaming chunk cipherkey is PKCS#1 v1.5-decryptable), and an E2E Playwright test `tests/e2e/test_ui.py::test_landing_page_chat_round_trip_with_local_api_v1_stack` that exercises the landing-page round-trip through the local relay/server stack.
- Document the regression and remediation with a new outage entry in both Markdown and JSON at `outages/2026-04-20-relay-landing-page-chat-api-v1-regression.{md,json}` matching the repo convention.

### Testing
- Ran targeted unit tests: `python -m pytest tests/test_api.py -k "pkcs1v15_cipherkey_for_browser_compat" -q` passed, and `python -m pytest tests/test_streaming.py -k "encrypted_streaming_emits_encrypted_chunks" -q` passed, verifying PKCS#1 v1.5 compatibility for v1 responses and v2 streaming first-chunk keys respectively.
- Added E2E smoke test: `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest tests/e2e/test_ui.py -k "landing_page_chat_round_trip_with_local_api_v1_stack" -q` is present to validate a full browser round-trip, but in this execution environment the `setup_servers` fixture timed out because the compute process did not finish relay registration; the test is included to catch regressions in CI where the relay/server are started by the fixture.
- Ran repository checks: `pre-commit run --all-files` was executed but the environment lacked the `bandit` package so the pre-commit test hook (security audit) failed in this local run; CI should run full `pre-commit` and `./run_all_tests.sh` where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e2f47798832fac9ac62257f784e6)