### PR TITLE
🐛 fix: enforce API v1-only relay landing chat path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,21 @@ make k8s-deploy    # deploy manifests
 
 ## Development Workflow
 
+## API version boundary for v0.1.0 (critical)
+
+Until API v1 is fully launched on sugarkube, contributors must keep relay-path and network
+traffic on API v1 only:
+
+- Desktop Tauri app network/API calls: **API v1-only**
+- `relay.py`: **API v1-only**
+- Relay landing-page chat (`/`, `static/chat.js`): **API v1-only**, **non-streaming**
+- `server.py` OpenAI-compatible network/API traffic in this phase: **API v1-first**
+
+API v2 is deferred for these paths until after API v1 launch on sugarkube.
+
+Important nuance: desktop local prompt smoke tests may continue to use local
+`llama_cpp_python` streaming because that path is local-only and not relay/API traffic.
+
 ### Running the server
 
 ```bash

--- a/api/v1/encryption.py
+++ b/api/v1/encryption.py
@@ -5,6 +5,7 @@ Encryption manager for token.place API v1
 import json
 import base64
 import logging
+import textwrap
 from typing import Dict, Any, Union, Optional
 
 from encrypt import generate_keys, encrypt, decrypt
@@ -16,6 +17,38 @@ except ImportError:
     RSA_KEY_SIZE = 2048
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_client_public_key_bytes(client_public_key: Union[str, bytes]) -> bytes:
+    """Normalize client public key input to PEM bytes accepted by ``encrypt.encrypt``."""
+
+    if isinstance(client_public_key, bytes):
+        key_bytes = client_public_key
+    else:
+        cleaned = client_public_key.strip()
+        if "-----BEGIN" in cleaned:
+            return cleaned.encode("utf-8")
+
+        decoded = base64.b64decode(cleaned)
+        if b"-----BEGIN" in decoded:
+            return decoded
+
+        der_b64 = base64.b64encode(decoded).decode("ascii")
+        lines = textwrap.wrap(der_b64, 64)
+        pem = "\n".join(
+            ["-----BEGIN PUBLIC KEY-----", *lines, "-----END PUBLIC KEY-----", ""]
+        )
+        return pem.encode("utf-8")
+
+    if b"-----BEGIN" in key_bytes:
+        return key_bytes
+
+    der_b64 = base64.b64encode(bytes(key_bytes)).decode("ascii")
+    lines = textwrap.wrap(der_b64, 64)
+    pem = "\n".join(
+        ["-----BEGIN PUBLIC KEY-----", *lines, "-----END PUBLIC KEY-----", ""]
+    )
+    return pem.encode("utf-8")
 
 
 class EncryptionManager:
@@ -50,12 +83,10 @@ class EncryptionManager:
             # Convert data to JSON
             json_data = json.dumps(data).encode('utf-8')
 
-            # Make sure client_public_key is bytes
-            if isinstance(client_public_key, str):
-                client_public_key = base64.b64decode(client_public_key)
+            normalized_client_public_key = _normalize_client_public_key_bytes(client_public_key)
 
             # Encrypt the data
-            ciphertext_dict, cipherkey, iv = encrypt(json_data, client_public_key)
+            ciphertext_dict, cipherkey, iv = encrypt(json_data, normalized_client_public_key)
 
             # Encode to base64 for JSON
             ciphertext_b64 = base64.b64encode(ciphertext_dict['ciphertext']).decode('utf-8')

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,8 +33,15 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - Treat repository-root `server.py` as the canonical compute-node entrypoint.
 - Keep `server/server_app.py` as compatibility-only shim behavior.
 - Keep sugarkube/k3s scope relay-only (`relay.py`) in short-to-medium-term planning.
-- Keep desktop/server parity work on the legacy relay sink/source contract until explicitly
-  approved API v1 distributed migration phase.
+- **v0.1.0 API boundary (must-follow):**
+  - Desktop Tauri app network/API calls are **API v1-only**.
+  - `relay.py` traffic is **API v1-only**.
+  - Relay landing-page chat (`static/index.html` + `static/chat.js`) is **API v1-only**.
+  - `server.py` OpenAI-compatible network/API surface stays **API v1-first** for this phase.
+  - API v2 is deferred until after API v1 is launched on sugarkube.
+  - Streaming is a non-goal for any relay-path traffic in v0.1.0.
+  - Desktop local prompt smoke tests may still use local `llama_cpp_python` streaming because
+    that path is local-only and not relay/API traffic.
 
 ## Documentation
 

--- a/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.json
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.json
@@ -1,8 +1,8 @@
 {
   "date": "2026-04-20",
   "slug": "relay-landing-chat-api-v1-key-format-regression",
-  "summary": "Relay landing-page chat at / regressed after API v1 key-format migration because static/chat.js consumed public_key as direct PEM while the API returned Base64-encoded PEM bytes, causing browser encryption bootstrap to fail and chat completions to fall back to generic error messaging.",
-  "impact": "Users running local relay mode could not complete end-to-end landing-page chat conversations, blocking validation of the primary browser chat journey.",
-  "fix": "Normalized API public keys in static/chat.js to support both direct PEM and Base64-encoded PEM, and added an e2e regression that validates successful landing-page response rendering through v1 fallback when v2 streaming fails.",
-  "lessons": "Browser crypto bootstrapping must enforce explicit key-format normalization and regression tests should include key-format compatibility plus v2->v1 chat fallback coverage."
+  "summary": "The first fix corrected server public-key normalization but left relay landing chat on a v2-streaming-first browser path and did not normalize API v1 response encryption input for browser-formatted client_public_key values.",
+  "impact": "Relay landing-page chat still produced no real assistant response in local relay mode; browser logs showed v2 streaming noise and API v1 returned 500 Failed to encrypt response.",
+  "fix": "Forced relay landing chat to API v1-only non-streaming behavior, normalized API v1 client_public_key values into PEM before encryption, and added regressions that fail if relay landing chat reintroduces v2/streaming dependencies.",
+  "lessons": "Fixes must align with architecture boundaries (v0.1.0 relay path is API v1-only, non-streaming) and browser key-format contracts must be verified end-to-end for encrypted responses."
 }

--- a/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md
@@ -5,7 +5,7 @@
 - **Affected area:** relay landing page chat UI at `/` (`static/index.html` + `static/chat.js`)
 
 ## Summary
-The relay landing page continued to render at `/`, but user chat messages could no longer complete end-to-end in local relay mode. The UI fell back to a generic assistant failure message instead of rendering a real model response.
+The initial fix only normalized server public-key format handling in `static/chat.js`, but left the relay landing page on a v2-streaming-first browser path. That meant relay-path traffic still attempted `/api/v2/chat/completions` before v1, and API v1 response encryption still failed for browser-formatted client keys.
 
 ## Symptoms
 - Landing page loads normally at `http://127.0.0.1:5010/`.
@@ -17,20 +17,19 @@ Local relay validation of the core browser chat journey was broken. Users and de
 
 ## Root cause
 1. API v1/v2 `GET /api/v1/public-key` and `GET /api/v2/public-key` return the server key as Base64-encoded PEM bytes.
-2. Landing-page `static/chat.js` treated `public_key` as directly usable PEM and passed it unchanged to `JSEncrypt#setPublicKey`.
-3. The resulting client-side encryption path failed, so both streaming and non-stream chat attempts failed before a valid completion payload could be processed.
+2. The prior patch corrected server-key normalization but kept landing chat behavior as v2-streaming-first with v1 fallback.
+3. The browser sends `client_public_key` as Base64 body content (without PEM headers), while `api/v1/encryption.py` decoded that field to DER bytes and passed those bytes directly to `encrypt.encrypt`, which requires PEM. This mismatch caused API v1 to return `500 Failed to encrypt response`.
 
 ## Remediation
 - Added `normalizeServerPublicKey` in `static/chat.js` to accept both:
   - legacy/plain PEM key strings, and
   - API v1 Base64-encoded PEM key payloads (decoded before use).
-- Updated `getServerPublicKey` to normalize the API response before storing `serverPublicKey`.
-- Added Playwright regression coverage to assert the landing page can:
-  - fetch a Base64 public key,
-  - fail over from `/api/v2/chat/completions` streaming failure,
-  - and still receive/render a real assistant response from `/api/v1/chat/completions`.
+- Updated relay landing-page send flow to use API v1 only and non-streaming behavior.
+- Updated `api/v1/encryption.py` to normalize `client_public_key` into PEM before response encryption.
+- Updated Playwright coverage to enforce relay landing chat API v1-only/non-streaming behavior and fail if `/api/v2/chat/completions` is called.
+- Added API v1 encryption regression tests for Base64-body `client_public_key` formatting.
 
 ## Follow-up / prevention
 - Preserve browser tests that explicitly validate key-format compatibility for landing-page crypto bootstrapping.
-- Keep relay landing-page chat tests exercising both `/api/v2/chat/completions` and `/api/v1/chat/completions` fallback behavior.
+- Enforce API v1-only, non-streaming relay-path behavior in tests and contributor docs.
 - Require outage notes for any future API key-format/transport changes that affect browser encryption initialization.

--- a/static/chat.js
+++ b/static/chat.js
@@ -599,8 +599,8 @@ new Vue({
 
         // Send a message to the server using the new API
         async sendMessageApi() {
-            if (!this.serverPublicKey) {
-                console.error('Server public key not available');
+            if (!this.serverPublicKey || !this.clientPublicKey) {
+                console.error('Server/client public keys are not available');
                 return null;
             }
 
@@ -1127,13 +1127,7 @@ new Vue({
             });
 
             try {
-                const historySnapshot = this.chatHistory.slice();
-                const streamed = await this.sendStreamingMessage(historySnapshot);
-                if (streamed) {
-                    return;
-                }
-
-                // Send the message via the API
+                // Relay landing-page chat is API v1-only and non-streaming for v0.1.0.
                 let response = await this.sendMessageApi();
 
                 // Process the response

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -129,12 +129,12 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
     assert assistant_message.locator("script").count() == 0
 
 
-def test_landing_chat_accepts_base64_public_key_and_falls_back_to_v1(
+def test_landing_chat_uses_v1_only_non_streaming_with_base64_public_key(
     page: Page,
     base_url: str,
     setup_servers,
 ):
-    """Landing chat should accept API v1 Base64 keys and still render a reply."""
+    """Landing chat should use API v1-only (non-streaming) and render a reply."""
 
     server_public_key_pem = """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
@@ -154,16 +154,16 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
             body=json.dumps({"public_key": server_public_key_b64}),
         )
 
-    def handle_stream_fail(route):
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"error": {"message": "stream unavailable"}}),
-        )
+    seen_v2_request = {"value": False}
+
+    def handle_v2_route(route):
+        seen_v2_request["value"] = True
+        route.fulfill(status=500, body="relay landing chat must not call api v2")
 
     def handle_v1_chat(route):
         request_json = route.request.post_data_json
         assert request_json.get("encrypted") is True
+        assert request_json.get("stream") in (None, False)
         assert isinstance(request_json.get("client_public_key"), str) and request_json[
             "client_public_key"
         ]
@@ -215,7 +215,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
         )
 
     page.route("**/api/v1/public-key", handle_public_key)
-    page.route("**/api/v2/chat/completions", handle_stream_fail)
+    page.route("**/api/v2/chat/completions", handle_v2_route)
     page.route("**/api/v1/chat/completions", handle_v1_chat)
 
     page.goto(base_url)
@@ -239,4 +239,5 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
         arg={"selector": ".assistant-message", "expectedText": "Relay chat path restored."},
     )
     assert "Relay chat path restored." in assistant_message.inner_text()
+    assert seen_v2_request["value"] is False
     assert "Sorry, I encountered an issue generating a response." not in page.content()

--- a/tests/unit/test_api_v1_encryption.py
+++ b/tests/unit/test_api_v1_encryption.py
@@ -1,0 +1,33 @@
+import base64
+import json
+
+from api.v1.encryption import (
+    _normalize_client_public_key_bytes,
+    encryption_manager,
+)
+from encrypt import decrypt, generate_keys
+
+
+def test_normalize_client_public_key_base64_body_to_pem():
+    _, public_key = generate_keys()
+    public_key_body = "".join(public_key.decode("utf-8").splitlines()[1:-1])
+
+    normalized = _normalize_client_public_key_bytes(public_key_body)
+
+    normalized_text = normalized.decode("utf-8")
+    assert normalized_text.startswith("-----BEGIN PUBLIC KEY-----")
+    assert normalized_text.endswith("-----END PUBLIC KEY-----\n")
+
+
+def test_encrypt_message_accepts_base64_body_public_key():
+    private_key, public_key = generate_keys()
+    public_key_body = "".join(public_key.decode("utf-8").splitlines()[1:-1])
+
+    encrypted = encryption_manager.encrypt_message({"ok": True}, public_key_body)
+
+    assert encrypted is not None
+    ciphertext = base64.b64decode(encrypted["ciphertext"])
+    cipherkey = base64.b64decode(encrypted["cipherkey"])
+    iv = base64.b64decode(encrypted["iv"])
+    decrypted = decrypt({"ciphertext": ciphertext, "iv": iv}, cipherkey, private_key)
+    assert json.loads(decrypted.decode("utf-8"))["ok"] is True


### PR DESCRIPTION
### Motivation
- The relay landing-page chat still attempted an API v2 streaming path and API v1 returned `500 Failed to encrypt response` because of a client_public_key format mismatch; the v0.1.0 rollout requires relay-path traffic to be API v1-only and non-streaming.
- The prior browser-key normalization patch fixed server public-key parsing but left a v2-first client flow and did not normalize browser-sent `client_public_key` into PEM for server-side encryption.

### Description
- Enforce v1-only, non-streaming relay landing chat by removing the v2-streaming-first path from `sendMessage()` so the landing page always posts to `/api/v1/chat/completions` for relay flows (`static/chat.js`).
- Fix API v1 encryption contract by normalizing `client_public_key` into PEM bytes before calling `encrypt.encrypt` in `api/v1/encryption.py` so browser Base64-body keys decrypt/encrypt correctly.
- Add unit and e2e regression coverage: `tests/unit/test_api_v1_encryption.py` (key normalization + encrypt/decrypt) and updated Playwright UI test `tests/e2e/test_ui.py` to assert landing chat is API v1-only and non-streaming (and fail if a `/api/v2/chat/completions` request is observed).
- Make the API-version boundary explicit in docs by updating `docs/AGENTS.md` and `CONTRIBUTING.md` with a v0.1.0 section that states Desktop/relay/landing-page/server are API v1-only, API v2 is deferred, and relay-path streaming is a non-goal; amend the existing outage record (`outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.*`) to reflect the completed root-cause analysis and remediation.

### Testing
- Performed quick static checks with `python -m py_compile api/v1/encryption.py tests/e2e/test_ui.py tests/unit/test_api_v1_encryption.py`, which succeeded.
- Attempted to run the focused unit/e2e automation with `python -m pytest tests/unit/test_api_v1_encryption.py -q` and `python -m pytest tests/e2e/test_ui.py -k landing_chat_uses_v1_only_non_streaming_with_base64_public_key -q`, but full collection/execution was blocked in this environment by test-suite bootstrap dependencies (Playwright, PIL and other runtime dependencies); I installed several missing packages to exercise tests where possible but remaining global test fixtures prevented a green run here.
- `pre-commit run --all-files` was not executed in this environment because `pre-commit` was not available; please run locally/CI to validate linters and the full test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e671f11c28832fb9d90b4f58b008cd)