### PR TITLE
🐛 fix: enforce API v1-only relay landing chat path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,18 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Always run `pre-commit run --all-files` before pushing. This executes
   `./run_all_tests.sh` and mirrors CI.
 
+## API rollout guardrail (v0.1.0)
+- Until API v1 is fully launched on sugarkube, keep relay-path/network traffic API v1-only
+  for:
+  - Desktop Tauri app network/API calls
+  - `relay.py`
+  - landing-page chat served by `relay.py`
+  - `server.py`
+- API v2 is deferred for relay-path traffic until after the API v1 sugarkube launch.
+- Relay-path streaming is a non-goal in v0.1.0.
+- Desktop local prompt smoke-test streaming via local `llama_cpp_python` remains allowed
+  because it is local-only and outside relay/API traffic.
+
 ## Desktop GPU acceleration (llama_cpp_python)
 - For desktop-tauri GPU modes (`auto`, `gpu`, `hybrid`), treat GPU-capable
   `llama-cpp-python` builds as a release requirement, not an optimization.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,19 @@ make k8s-deploy    # deploy manifests
 
 ## Development Workflow
 
+### API version boundary (v0.1.0 release guardrail)
+
+- Until API v1 is fully launched on sugarkube, treat relay-path traffic as **API v1-only**:
+  - Desktop Tauri app network/API calls
+  - `relay.py`
+  - landing-page chat served by `relay.py`
+  - `server.py`
+- API v2 is deferred for relay-path/browser traffic during v0.1.0 stabilization.
+- Relay-path streaming is a non-goal in v0.1.0 (no `/api/v2/chat/completions` usage for the
+  landing-page relay chat path).
+- Desktop local smoke tests may still use local `llama_cpp_python` streaming because that path
+  is local-only and not relay/API traffic.
+
 ### Running the server
 
 ```bash

--- a/api/v1/encryption.py
+++ b/api/v1/encryption.py
@@ -18,6 +18,24 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _normalize_client_public_key_bytes(client_public_key: Union[str, bytes]) -> bytes:
+    """Accept client keys as PEM text, base64 DER text, or bytes."""
+
+    if isinstance(client_public_key, bytes):
+        return client_public_key
+
+    if not isinstance(client_public_key, str):
+        raise TypeError(
+            f"Unsupported client public key type: {type(client_public_key).__name__}"
+        )
+
+    cleaned = client_public_key.strip()
+    if "-----BEGIN" in cleaned:
+        return cleaned.encode("utf-8")
+
+    return base64.b64decode("".join(cleaned.split()))
+
+
 class EncryptionManager:
     """
     Manages encryption/decryption operations for the API
@@ -50,9 +68,7 @@ class EncryptionManager:
             # Convert data to JSON
             json_data = json.dumps(data).encode('utf-8')
 
-            # Make sure client_public_key is bytes
-            if isinstance(client_public_key, str):
-                client_public_key = base64.b64decode(client_public_key)
+            client_public_key = _normalize_client_public_key_bytes(client_public_key)
 
             # Encrypt the data
             ciphertext_dict, cipherkey, iv = encrypt(json_data, client_public_key)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,8 +33,17 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - Treat repository-root `server.py` as the canonical compute-node entrypoint.
 - Keep `server/server_app.py` as compatibility-only shim behavior.
 - Keep sugarkube/k3s scope relay-only (`relay.py`) in short-to-medium-term planning.
-- Keep desktop/server parity work on the legacy relay sink/source contract until explicitly
-  approved API v1 distributed migration phase.
+- For `v0.1.0`, keep all relay-path/network traffic API v1-only until API v1 is fully launched
+  on sugarkube. This includes:
+  - Desktop Tauri app network/API calls
+  - `relay.py`
+  - landing-page chat served by `relay.py`
+  - `server.py`
+- API v2 is explicitly deferred for relay-path traffic until after the API v1 sugarkube launch.
+- Relay-path streaming is a non-goal in `v0.1.0` (no relay/browser/API routing through
+  `/api/v2/chat/completions` for landing-page chat).
+- Desktop local prompt smoke tests may still use local `llama_cpp_python` streaming because
+  that flow is local-only and not relay/API traffic.
 
 ## Documentation
 

--- a/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.json
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.json
@@ -1,8 +1,8 @@
 {
   "date": "2026-04-20",
   "slug": "relay-landing-chat-api-v1-key-format-regression",
-  "summary": "Relay landing-page chat at / regressed after API v1 key-format migration because static/chat.js consumed public_key as direct PEM while the API returned Base64-encoded PEM bytes, causing browser encryption bootstrap to fail and chat completions to fall back to generic error messaging.",
-  "impact": "Users running local relay mode could not complete end-to-end landing-page chat conversations, blocking validation of the primary browser chat journey.",
-  "fix": "Normalized API public keys in static/chat.js to support both direct PEM and Base64-encoded PEM, and added an e2e regression that validates successful landing-page response rendering through v1 fallback when v2 streaming fails.",
-  "lessons": "Browser crypto bootstrapping must enforce explicit key-format normalization and regression tests should include key-format compatibility plus v2->v1 chat fallback coverage."
+  "summary": "Relay landing-page chat at / regressed across two coupled issues: browser key bootstrap initially mishandled Base64 public_key payloads, and a follow-up left relay-path chat on a v2-streaming-first branch that violated the v0.1.0 API v1-only requirement while API v1 response encryption still rejected PEM-formatted client_public_key strings.",
+  "impact": "Users running local relay mode saw noisy v2 streaming errors and could hit API v1 500 'Failed to encrypt response', preventing reliable end-to-end validation of landing-page chat.",
+  "fix": "Kept key normalization, removed relay landing-page v2 streaming attempts in favor of API v1 non-streaming only, hardened API v1 encryption to accept PEM or Base64 client_public_key formats, and added regressions that fail if relay chat touches v2/streaming or if PEM response encryption regresses.",
+  "lessons": "v0.1.0 relay-path traffic must remain API v1-only/non-streaming and crypto contracts should accept both PEM and Base64 key encodings to avoid brittle client/server mismatches."
 }

--- a/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md
+++ b/outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md
@@ -18,19 +18,19 @@ Local relay validation of the core browser chat journey was broken. Users and de
 ## Root cause
 1. API v1/v2 `GET /api/v1/public-key` and `GET /api/v2/public-key` return the server key as Base64-encoded PEM bytes.
 2. Landing-page `static/chat.js` treated `public_key` as directly usable PEM and passed it unchanged to `JSEncrypt#setPublicKey`.
-3. The resulting client-side encryption path failed, so both streaming and non-stream chat attempts failed before a valid completion payload could be processed.
+3. The prior fix restored key normalization but left a relay-path `/api/v2/chat/completions` streaming-first branch in place, which contradicts the v0.1.0 API v1-first rollout.
+4. API v1 response encryption still assumed `client_public_key` strings were Base64 only. If a PEM-formatted key string reached the endpoint, response encryption failed with `500 Failed to encrypt response`.
 
 ## Remediation
 - Added `normalizeServerPublicKey` in `static/chat.js` to accept both:
   - legacy/plain PEM key strings, and
   - API v1 Base64-encoded PEM key payloads (decoded before use).
-- Updated `getServerPublicKey` to normalize the API response before storing `serverPublicKey`.
-- Added Playwright regression coverage to assert the landing page can:
-  - fetch a Base64 public key,
-  - fail over from `/api/v2/chat/completions` streaming failure,
-  - and still receive/render a real assistant response from `/api/v1/chat/completions`.
+- Updated `sendMessage` in `static/chat.js` to use API v1 non-streaming only for relay landing-page chat (no v2-first streaming attempt).
+- Hardened API v1 response encryption key handling to accept both PEM strings and Base64 key strings for `client_public_key`.
+- Updated Playwright coverage to fail if relay landing-page chat attempts `/api/v2/chat/completions`, and to assert `stream` is not set on `/api/v1/chat/completions`.
+- Added unit coverage for API v1 encryption manager PEM-key compatibility.
 
 ## Follow-up / prevention
 - Preserve browser tests that explicitly validate key-format compatibility for landing-page crypto bootstrapping.
-- Keep relay landing-page chat tests exercising both `/api/v2/chat/completions` and `/api/v1/chat/completions` fallback behavior.
+- Keep relay landing-page chat tests enforcing API v1-only, non-streaming behavior for v0.1.0.
 - Require outage notes for any future API key-format/transport changes that affect browser encryption initialization.

--- a/static/chat.js
+++ b/static/chat.js
@@ -1127,14 +1127,8 @@ new Vue({
             });
 
             try {
-                const historySnapshot = this.chatHistory.slice();
-                const streamed = await this.sendStreamingMessage(historySnapshot);
-                if (streamed) {
-                    return;
-                }
-
-                // Send the message via the API
-                let response = await this.sendMessageApi();
+                // Relay-path chat is API v1-only and non-streaming in v0.1.0.
+                const response = await this.sendMessageApi();
 
                 // Process the response
                 if (response) {

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -129,12 +129,12 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
     assert assistant_message.locator("script").count() == 0
 
 
-def test_landing_chat_accepts_base64_public_key_and_falls_back_to_v1(
+def test_landing_chat_uses_v1_only_non_streaming(
     page: Page,
     base_url: str,
     setup_servers,
 ):
-    """Landing chat should accept API v1 Base64 keys and still render a reply."""
+    """Landing chat should use API v1 only and still render a reply."""
 
     server_public_key_pem = """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
@@ -154,16 +154,20 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
             body=json.dumps({"public_key": server_public_key_b64}),
         )
 
-    def handle_stream_fail(route):
+    v2_attempts = []
+
+    def handle_v2_fail_fast(route):
+        v2_attempts.append(route.request.url)
         route.fulfill(
-            status=200,
+            status=500,
             headers={"Content-Type": "application/json"},
-            body=json.dumps({"error": {"message": "stream unavailable"}}),
+            body=json.dumps({"error": {"message": "relay landing chat must not call API v2"}}),
         )
 
     def handle_v1_chat(route):
         request_json = route.request.post_data_json
         assert request_json.get("encrypted") is True
+        assert request_json.get("stream") in (None, False)
         assert isinstance(request_json.get("client_public_key"), str) and request_json[
             "client_public_key"
         ]
@@ -215,7 +219,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
         )
 
     page.route("**/api/v1/public-key", handle_public_key)
-    page.route("**/api/v2/chat/completions", handle_stream_fail)
+    page.route("**/api/v2/chat/completions", handle_v2_fail_fast)
     page.route("**/api/v1/chat/completions", handle_v1_chat)
 
     page.goto(base_url)
@@ -240,3 +244,4 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     )
     assert "Relay chat path restored." in assistant_message.inner_text()
     assert "Sorry, I encountered an issue generating a response." not in page.content()
+    assert not v2_attempts

--- a/tests/unit/test_encryption_manager.py
+++ b/tests/unit/test_encryption_manager.py
@@ -21,6 +21,22 @@ def test_encrypt_message_roundtrip():
     assert json.loads(plaintext.decode()) == data
 
 
+def test_encrypt_message_accepts_pem_client_key_string():
+    manager = EncryptionManager()
+    client_priv, client_pub = generate_keys()
+    data = {"hello": "world"}
+
+    enc = manager.encrypt_message(data, client_pub.decode("utf-8"))
+    assert enc and enc["encrypted"] is True
+
+    plaintext = decrypt(
+        {"ciphertext": base64.b64decode(enc["ciphertext"]), "iv": base64.b64decode(enc["iv"])},
+        base64.b64decode(enc["cipherkey"]),
+        client_priv,
+    )
+    assert json.loads(plaintext.decode()) == data
+
+
 def test_decrypt_message_success():
     manager = EncryptionManager()
     data = {"foo": 1}


### PR DESCRIPTION
### Motivation
- The landing-page chat was still attempting an API v2 streaming path and producing noisy streaming errors while API v1 responses sometimes 500'd with `Failed to encrypt response` due to a client key format mismatch.
- For `v0.1.0` the relay-path must be API v1-only and non-streaming until API v1 is fully launched on sugarkube, so the landing-page UI and relay must not route through `/api/v2/chat/completions`.

### Description
- Force landing-page relay send flow to use API v1 non-streaming only by changing `sendMessage()` in `static/chat.js` to call `sendMessageApi()` directly (remove v2 streaming-first branch).
- Harden API v1 response encryption by adding `_normalize_client_public_key_bytes` to `api/v1/encryption.py` so `encrypt_message()` accepts PEM text, Base64 DER text, or raw bytes for `client_public_key` before encrypting a response.
- Add regression tests: update Playwright e2e `tests/e2e/test_ui.py` to assert landing-page chat does not call `/api/v2/chat/completions` and that `stream` is absent/false for v1 requests, and add a unit test in `tests/unit/test_encryption_manager.py` to validate PEM client-key compatibility.
- Make the rollout boundary impossible to miss by updating contributor docs and agent guidance in `AGENTS.md`, `docs/AGENTS.md`, and `CONTRIBUTING.md` to explicitly state: relay-path traffic (Desktop Tauri, `relay.py`, landing-page chat, `server.py`) is API v1-only and relay-path streaming is a non-goal for `v0.1.0`.
- Amend the existing outage record (`outages/2026-04-20-relay-landing-chat-api-v1-key-format-regression.md` and `.json`) to explain why the prior fix was incomplete and to record the corrected root cause and remediation.

### Testing
- Ran the focused unit test for the encryption manager with: `python -m pytest tests/unit/test_encryption_manager.py -q`, and it passed (5 passed).
- Ran the e2e landing-page test that verifies v1-only/non-streaming behavior with: `python -m pytest tests/e2e/test_ui.py -k "landing_chat_uses_v1_only_non_streaming" -q`; the test is present and asserts no `/api/v2` attempts, but it is skipped in this environment unless `RUN_RELAY_REGISTRATION_TESTS=1` is enabled (skipped by suite gating).
- Executed repository checks via: `pre-commit run --all-files` which completed successfully in this environment after installing test deps.
- Notes: additional CI will run the full test matrix; local installations were used to run the focused tests (some test suites require Playwright / system deps and are gated or skipped in CI-local runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e671f11c28832fb9d90b4f58b008cd)