### PR TITLE
🧪 Harden focused relay e2e skip-gate nodeid matching

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,9 +146,15 @@ E2E_SERVER_PORT = 8010
 E2E_RELAY_PORT = 5010
 E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
-FOCUSED_RELAY_E2E_NODEIDS = {
+FOCUSED_RELAY_E2E_NODEID_SUFFIXES = (
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
-}
+)
+
+
+def _is_focused_relay_e2e_nodeid(nodeid: str) -> bool:
+    """Return True when the selected nodeid targets the focused relay landing-page e2e."""
+    normalized = nodeid.replace('\\', '/')
+    return any(normalized.endswith(suffix) for suffix in FOCUSED_RELAY_E2E_NODEID_SUFFIXES)
 
 @pytest.fixture(scope="module")
 def setup_servers(
@@ -165,8 +171,8 @@ def setup_servers(
     5. Cleans up the processes after tests
     """
     selected_nodeids = {item.nodeid for item in request.session.items}
-    focused_e2e_only = bool(selected_nodeids) and selected_nodeids.issubset(
-        FOCUSED_RELAY_E2E_NODEIDS
+    focused_e2e_only = bool(selected_nodeids) and all(
+        _is_focused_relay_e2e_nodeid(nodeid) for nodeid in selected_nodeids
     )
 
     if os.environ.get("RUN_RELAY_REGISTRATION_TESTS", "0") != "1" and not focused_e2e_only:


### PR DESCRIPTION
### Motivation
- Make the focused relay landing-page e2e reliably executable after focused bootstrap by fixing a fragile exact-nodeid skip gate that caused the test to be accidentally skipped across runner/path variations.

### Description
- Narrow, localized change in `tests/conftest.py`: replaced the exact `FOCUSED_RELAY_E2E_NODEIDS` membership test with a normalized suffix-based allowlist (`FOCUSED_RELAY_E2E_NODEID_SUFFIXES`) and added `_is_focused_relay_e2e_nodeid()`; the existing skip gate in `setup_servers` (skip when `RUN_RELAY_REGISTRATION_TESTS != "1"` and not focused-only) is unchanged but now correctly recognizes the targeted nodeid.

### Testing
- Ran `./scripts/bootstrap_focused_verification.sh` and then `python -m pytest tests/e2e/test_ui.py -k "landing_chat_uses_api_v1_only_non_streaming" -q`, which executed the targeted test and reported `tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming PASSED` with `1 passed, 4 deselected in 11.14s`, and also ran `python -m pytest tests/unit/test_touch_ui.py -q` (all unit tests passed), `node -e "new Function(require('fs').readFileSync('static/chat.js','utf8'))"` (syntax check passed), and `pre-commit run --all-files` (all hooks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682692a48832fa18fa7e9ed057848)