### PR TITLE
Enable focused relay landing e2e gate by normalizing pytest nodeids

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,12 @@ FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
 }
 
+
+def _normalize_nodeid(nodeid: str) -> str:
+    """Normalize pytest nodeids by stripping parametrization suffixes."""
+    return nodeid.split("[", 1)[0]
+
+
 @pytest.fixture(scope="module")
 def setup_servers(
     request: pytest.FixtureRequest,
@@ -164,7 +170,7 @@ def setup_servers(
     4. Yields the processes
     5. Cleans up the processes after tests
     """
-    selected_nodeids = {item.nodeid for item in request.session.items}
+    selected_nodeids = {_normalize_nodeid(item.nodeid) for item in request.session.items}
     focused_e2e_only = bool(selected_nodeids) and selected_nodeids.issubset(
         FOCUSED_RELAY_E2E_NODEIDS
     )


### PR DESCRIPTION
### Motivation
- The focused relay E2E gate in `tests/conftest.py` relied on exact pytest `nodeid` strings, which caused the landing-page E2E to be skipped when pytest produced parametrized nodeid variants (e.g. `...[...]`).

### Description
- Add `_normalize_nodeid(nodeid: str)` to strip parametrization suffixes from pytest nodeids. 
- Use the normalizer when building `selected_nodeids` so the focused allowlist `FOCUSED_RELAY_E2E_NODEIDS` matches parametrized collections. 
- Change is limited to `tests/conftest.py` and only affects test gating; no product/runtime files were modified.

### Testing
- Ran the bootstrap script `./scripts/bootstrap_focused_verification.sh`, which completed successfully. 
- Ran the targeted E2E command `python -m pytest tests/e2e/test_ui.py -k "landing_chat_uses_api_v1_only_non_streaming" -q` and the test executed (not skipped): the run showed `collected 5 items / 4 deselected / 1 selected` and the test passed as `tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming PASSED [100%]` with summary `1 passed, 4 deselected`.
- Also ran `python -m pytest tests/unit/test_touch_ui.py -q` which passed (3 tests). 
- Verified `node -e "new Function(require('fs').readFileSync('static/chat.js','utf8'))"` returned without error. 
- Ran `pre-commit run --all-files` which passed project checks. 
- `git diff --stat` shows a small change: one file modified (`tests/conftest.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682692a48832fa18fa7e9ed057848)