### PR TITLE
test: unskip focused relay landing e2e via -k gate

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,7 @@ BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
 }
+FOCUSED_RELAY_E2E_KEYWORD = "landing_chat_uses_api_v1_only_non_streaming"
 
 @pytest.fixture(scope="module")
 def setup_servers(
@@ -168,8 +169,14 @@ def setup_servers(
     focused_e2e_only = bool(selected_nodeids) and selected_nodeids.issubset(
         FOCUSED_RELAY_E2E_NODEIDS
     )
+    keyword_expr = request.config.getoption("-k") or ""
+    focused_e2e_keyword = FOCUSED_RELAY_E2E_KEYWORD in keyword_expr
 
-    if os.environ.get("RUN_RELAY_REGISTRATION_TESTS", "0") != "1" and not focused_e2e_only:
+    if (
+        os.environ.get("RUN_RELAY_REGISTRATION_TESTS", "0") != "1"
+        and not focused_e2e_only
+        and not focused_e2e_keyword
+    ):
         pytest.skip(
             "Relay/server registration smoke tests are disabled by default; "
             "set RUN_RELAY_REGISTRATION_TESTS=1 to enable.",
@@ -216,7 +223,7 @@ def setup_servers(
         print(f"Relay stderr: {stderr}")
         pytest.skip("Relay server failed to start")
 
-    if focused_e2e_only:
+    if focused_e2e_only or focused_e2e_keyword:
         print("Focused relay e2e mode enabled: skipping server registration bootstrap")
         yield relay_process, None
         relay_process.terminate()


### PR DESCRIPTION
### Motivation
- The landing-page relay e2e was still being skipped when collection/context didn’t satisfy the nodeid-subset heuristic while `RUN_RELAY_REGISTRATION_TESTS` remained unset. 
- The goal is to allow the exact targeted test to run in Codex-focused verification after bootstrap without changing product behavior. 
- Keep the change minimal and confined to test gating/bootstrap surfaces.

### Description
- Added a new `FOCUSED_RELAY_E2E_KEYWORD` and logic in `tests/conftest.py` to detect `-k landing_chat_uses_api_v1_only_non_streaming` from `pytest` invocation. 
- When the keyword is present the fixture now treats the run as focused and performs the relay-only bootstrap (skips server registration bootstrap) rather than calling the general skip gate. 
- The change is localized to `tests/conftest.py` only (one file modified) and preserves the existing `RUN_RELAY_REGISTRATION_TESTS` guard and all test assertions.

### Testing
- Bootstrapped focused verification with `./scripts/bootstrap_focused_verification.sh` which completed successfully. 
- Ran the exact targeted test with `python -m pytest tests/e2e/test_ui.py -k "landing_chat_uses_api_v1_only_non_streaming" -q` which executed (not skipped) and passed, producing: `collected 5 items / 4 deselected / 1 selected` and `tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming PASSED` and `1 passed, 4 deselected in 11.63s`. 
- Verified related checks with `python -m pytest tests/unit/test_touch_ui.py -q` which produced `3 passed in 0.14s`, `node -e "new Function(require('fs').readFileSync('static/chat.js','utf8'))"` which returned no error, and `pre-commit run --all-files` which completed with hooks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682692a48832fa18fa7e9ed057848)