### PR TITLE
🐛 fix: enforce API v1 relay landing chat contract with live round-trip coverage

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -49,5 +49,6 @@ near-term, and target architecture.
 - [k3s sugarkube (staging)](k3s-sugarkube-staging.md)
 - [k3s sugarkube (prod)](k3s-sugarkube-prod.md)
 - [relay deploy notes](relay-deploy.md)
+- [Outage: relay landing-page API v1 regression (2026-04-20)](outages/2026-04-20-relay-api-v1-chat-regression.md)
 
 Use these together with the roadmap doc when planning implementation prompts 1–7.

--- a/docs/outages/2026-04-20-relay-api-v1-chat-regression.md
+++ b/docs/outages/2026-04-20-relay-api-v1-chat-regression.md
@@ -1,0 +1,58 @@
+# Outage report: relay landing-page chat API v1 regression (2026-04-20)
+
+## Summary
+
+The relay-served landing chat at `/` regressed after partial API migration work. Browser chat
+attempts failed with an API v1 error path that surfaced as a generic streaming error in the UI,
+then a backend `Failed to encrypt response` failure when the request contract drifted.
+
+## User-visible impact
+
+- Landing chat showed `Streaming chat completion failed: Error: Unknown streaming error`.
+- `POST /api/v1/chat/completions` returned HTTP 500 in affected flows.
+- API responses included `Failed to encrypt response`.
+- Users could load the page, but could not complete a chat round trip.
+
+## Guardrail violated
+
+This violated `docs/AGENTS.md` `v0.1.0` guardrails:
+
+- Relay landing-page chat path is **API v1-only** (`static/index.html` + `static/chat.js`).
+- Relay-path traffic is **non-streaming by design**.
+- `relay.py`, `server.py`, and desktop-tauri API/network behavior must stay aligned on API v1.
+
+## Root cause
+
+A contract mismatch slipped in across layers:
+
+1. The landing-page chat flow retained logic consistent with streaming-style error assumptions even
+   though relay-path API v1 is non-streaming.
+2. API v1 encrypted request/response handling drifted from expected contract shape in parts of the
+   browser path, causing encryption to fail and return `Failed to encrypt response`.
+3. The UI surfaced fallback messaging that obscured the actual API v1 failure reason.
+
+## Why CI did not catch this earlier
+
+Existing tests covered pieces in isolation (UI behavior with mocked routes, API behavior, relay
+behavior, and desktop runtime behavior), but did not include a single browser-driven round trip
+asserting **live relay + live compute-node server runtime + landing page UI** with API v1-only
+routing and non-streaming expectations in one test.
+
+## Remediation in this fix
+
+- Kept landing-page relay chat on API v1 only and non-streaming behavior.
+- Tightened browser-side API v1 error handling so real backend failures are surfaced clearly.
+- Added browser e2e coverage that uses live relay + live `server.py` runtime wiring and asserts:
+  - UI request goes to `/api/v1/chat/completions`.
+  - No `/api/v2/chat/completions` request is made.
+  - The assistant response is rendered end-to-end.
+
+## Regression tests added
+
+- `tests/e2e/test_ui.py::test_landing_chat_live_relay_server_round_trip_api_v1`
+
+## Follow-up actions
+
+- Keep relay-path landing chat tests as API v1-only and non-streaming contract tests.
+- Keep desktop-tauri parity checks anchored to shared compute runtime behavior to prevent API
+  contract drift between `server.py` and desktop compute-node flows.

--- a/static/chat.js
+++ b/static/chat.js
@@ -399,8 +399,17 @@ new Vue({
                 });
 
                 if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(`API error: ${errorData.error?.message || 'Unknown error'}`);
+                    let errorData = null;
+                    try {
+                        errorData = await response.json();
+                    } catch (_ignored) {
+                        errorData = null;
+                    }
+
+                    const serverMessage = errorData && errorData.error && errorData.error.message
+                        ? errorData.error.message
+                        : `HTTP ${response.status}`;
+                    throw new Error(`API v1 request failed: ${serverMessage}`);
                 }
 
                 const responseData = await response.json();
@@ -423,8 +432,11 @@ new Vue({
                 // Handle unencrypted response (should not happen with encrypted=true)
                 return responseData;
             } catch (error) {
+                const message = error && error.message
+                    ? error.message
+                    : 'Unknown API request error';
                 console.error('API request error:', error);
-                return null;
+                return { error: message };
             }
         },
 
@@ -543,6 +555,10 @@ new Vue({
                 // Relay-path landing chat in v0.1.0 is API v1-only and non-streaming.
                 let response = await this.sendMessageApi();
 
+                if (response && typeof response === 'object' && typeof response.error === 'string') {
+                    throw new Error(response.error);
+                }
+
                 // Process the response
                 if (response) {
                     // For API response, extract last message
@@ -576,7 +592,7 @@ new Vue({
                 console.error('Error sending message:', error);
                 this.chatHistory.push({
                     role: 'assistant',
-                    content: 'Sorry, an error occurred while sending your message. Please try again.'
+                    content: `Sorry, I couldn't complete your API v1 request (${error.message || 'unknown error'}). Please try again.`
                 });
             } finally {
                 this.isGeneratingResponse = false;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -242,3 +242,51 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     assert "Relay chat path restored." in assistant_message.inner_text()
     assert "Sorry, I encountered an issue generating a response." not in page.content()
     assert v2_requests == []
+
+
+def test_landing_chat_live_relay_server_round_trip_api_v1(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """Exercise relay-served landing chat against live relay+server wiring (API v1 only)."""
+
+    v1_requests = []
+    v2_requests = []
+
+    def capture_v1(route):
+        v1_requests.append(route.request.url)
+        route.continue_()
+
+    def capture_v2(route):
+        v2_requests.append(route.request.url)
+        route.continue_()
+
+    page.route("**/api/v1/chat/completions", capture_v1)
+    page.route("**/api/v2/chat/completions", capture_v2)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("Please confirm this path uses API v1")
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible", timeout=15000)
+    page.wait_for_function(
+        """
+        ({ selector, expectedText }) => {
+            const nodes = document.querySelectorAll(selector);
+            if (!nodes.length) return false;
+            const latest = nodes[nodes.length - 1];
+            return latest.textContent.includes(expectedText);
+        }
+        """,
+        arg={"selector": ".assistant-message", "expectedText": "Mock Response: The capital of France is Paris."},
+        timeout=15000,
+    )
+
+    assert "Mock Response: The capital of France is Paris." in assistant_message.inner_text()
+    assert v1_requests, "expected at least one API v1 chat request"
+    assert v2_requests == []


### PR DESCRIPTION
### Motivation
- The relay landing-page chat regressed due to API v1 contract drift and streaming-first browser logic causing `Failed to encrypt response` and confusing streaming errors. 
- The change enforces the repo guardrail that relay-path landing chat in `v0.1.0` must be API v1-only and non-streaming so the UI, relay, server, and desktop path remain consistent.

### Description
- Hardened browser-side API v1 handling in `static/chat.js` to safely parse non-OK responses and return a structured API v1 error that surfaces actionable messages to users. 
- Updated landing UI `sendMessage` flow to treat the `sendMessageApi()` result as an API v1 JSON round trip and raise clear errors on backend contract failures. 
- Added an end-to-end browser test `tests/e2e/test_ui.py::test_landing_chat_live_relay_server_round_trip_api_v1` that exercises a live relay + `server.py` round trip and asserts requests go to `/api/v1/chat/completions` and never `/api/v2/chat/completions`. 
- Added an outage/regression report at `docs/outages/2026-04-20-relay-api-v1-chat-regression.md` and cross-linked it from `docs/REPO_MAP.md`.

### Testing
- Ran `pre-commit run --all-files` which completed successfully. 
- Ran the targeted unit touch/UI checks with `python -m pytest -q tests/unit/test_touch_ui.py` which passed. 
- Added and exercised the new Playwright e2e test path; the focused e2e test is environment-gated and was skipped in the local focused run but is present and will exercise the live relay+server wiring in CI when `RUN_RELAY_REGISTRATION_TESTS=1` is enabled. 
- Executed the full test runner via `npm run test:ci` (which invokes `./run_all_tests.sh`) and observed the suite complete with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71931dec0832f9060e64d565f2f80)