### PR TITLE
Harden relay landing chat against repo-local llama_cpp shim and tighten real-inference e2e

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -144,12 +144,15 @@ class FallbackApiV1ComputeProvider:
 
 
 @lru_cache(maxsize=8)
-def _build_api_v1_compute_provider(mode: str, distributed_url: str) -> ApiV1ComputeProvider:
+def _build_api_v1_compute_provider(
+    mode: str, distributed_url: str, distributed_fallback_enabled: bool
+) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
     local_provider = LocalApiV1ComputeProvider()
 
     if mode != "distributed":
+        logger.info("api_v1.compute_provider.selected provider=local mode=%s", mode)
         return local_provider
 
     if not distributed_url:
@@ -160,6 +163,21 @@ def _build_api_v1_compute_provider(mode: str, distributed_url: str) -> ApiV1Comp
         return local_provider
 
     distributed_provider = DistributedApiV1ComputeProvider(base_url=distributed_url)
+    if not distributed_fallback_enabled:
+        logger.info(
+            "api_v1.compute_provider.selected provider=distributed mode=%s "
+            "fallback_enabled=false target=%s",
+            mode,
+            distributed_url.rstrip("/"),
+        )
+        return distributed_provider
+
+    logger.info(
+        "api_v1.compute_provider.selected provider=distributed_with_local_fallback "
+        "mode=%s fallback_enabled=true target=%s",
+        mode,
+        distributed_url.rstrip("/"),
+    )
     return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
 
 
@@ -168,4 +186,8 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
     distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
-    return _build_api_v1_compute_provider(mode, distributed_url)
+    distributed_fallback_enabled = (
+        os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
+        not in {"0", "false", "no", "off"}
+    )
+    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -156,9 +156,23 @@ def _build_api_v1_compute_provider(
         return local_provider
 
     if not distributed_url:
+        if not distributed_fallback_enabled:
+            message = (
+                "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed requires "
+                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL when "
+                "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK is disabled"
+            )
+            logger.error(
+                "%s (fallback_enabled=%s)",
+                message,
+                distributed_fallback_enabled,
+            )
+            raise ComputeProviderError(message)
         logger.warning(
             "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed set without "
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback"
+            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback "
+            "(fallback_enabled=%s)",
+            distributed_fallback_enabled,
         )
         return local_provider
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -321,6 +321,7 @@ def _handle_chat_completion_request(data):
 
         log_info(f"Generating response using model {model_id}")
         provider = get_api_v1_compute_provider()
+        log_info(f"API v1 compute provider selected: {provider.__class__.__name__}")
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -45,7 +45,11 @@ except ModuleNotFoundError:
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
-from utils.llm.model_manager import _is_repo_llama_cpp_shim
+try:
+    from utils.llm.model_manager import _is_repo_llama_cpp_shim
+except ModuleNotFoundError:
+    def _is_repo_llama_cpp_shim(_module_path: Any) -> bool:
+        return False
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
@@ -266,7 +270,7 @@ def run(args: argparse.Namespace) -> int:
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "llama_repo_stub_imported": repo_llama_cpp_shim_imported,
-            "use_mock_llm": bool(runtime.model_manager.use_mock_llm),
+            "use_mock_llm": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
             "model_path": args.model,
             "last_error": None,
         }

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -45,7 +45,7 @@ except ModuleNotFoundError:
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
-from utils.llm.model_manager import _is_repo_llama_cpp_shim as model_manager_is_repo_llama_cpp_shim
+from utils.llm.model_manager import _is_repo_llama_cpp_shim
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
@@ -116,11 +116,6 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
         f"offloaded_layers={diagnostics.get('offloaded_layers', diagnostics.get('n_gpu_layers'))} "
         f"kv_cache_device={diagnostics.get('kv_cache_device') or 'unknown'}"
     )
-
-
-def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
-    """Return True when diagnostics indicate the repo-local llama_cpp.py shim."""
-    return model_manager_is_repo_llama_cpp_shim(module_path)
 
 
 def _start_stdin_reader() -> None:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -45,6 +45,8 @@ except ModuleNotFoundError:
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
+from utils.llm.model_manager import _is_repo_llama_cpp_shim as model_manager_is_repo_llama_cpp_shim
+
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
@@ -118,10 +120,7 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
     """Return True when diagnostics indicate the repo-local llama_cpp.py shim."""
-    if not isinstance(module_path, str) or not module_path.strip():
-        return False
-    resolved = Path(module_path).resolve()
-    return resolved.name == "llama_cpp.py" and (resolved.parent / "relay.py").is_file()
+    return model_manager_is_repo_llama_cpp_shim(module_path)
 
 
 def _start_stdin_reader() -> None:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -116,6 +116,14 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
     )
 
 
+def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
+    """Return True when diagnostics indicate the repo-local llama_cpp.py shim."""
+    if not isinstance(module_path, str) or not module_path.strip():
+        return False
+    resolved = Path(module_path).resolve()
+    return resolved.name == "llama_cpp.py" and (resolved.parent / "relay.py").is_file()
+
+
 def _start_stdin_reader() -> None:
     global _stdin_reader_started
     with _stdin_reader_lock:
@@ -176,6 +184,14 @@ def run(args: argparse.Namespace) -> int:
         f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
         f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
+        file=sys.stderr,
+    )
+    repo_llama_cpp_shim_imported = _is_repo_llama_cpp_shim(
+        runtime_setup.get("llama_module_path", "")
+    )
+    print(
+        "desktop.runtime_setup.import_guard "
+        f"repo_llama_cpp_shim_imported={repo_llama_cpp_shim_imported}",
         file=sys.stderr,
     )
     gpu_runtime_error = desktop_gpu_runtime_failure_message(args.mode, runtime_setup)
@@ -255,6 +271,8 @@ def run(args: argparse.Namespace) -> int:
             "fallback_reason": diagnostics.get("fallback_reason"),
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
+            "llama_repo_stub_imported": repo_llama_cpp_shim_imported,
+            "use_mock_llm": bool(runtime.model_manager.use_mock_llm),
             "model_path": args.model,
             "last_error": None,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
-    "tests/e2e/test_ui.py::test_landing_chat_round_trip_with_desktop_bridge_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
 
 
@@ -166,7 +166,7 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
-        "landing_chat_round_trip_with_desktop_bridge_api_v1",
+        "landing_chat_real_inference_with_desktop_bridge_api_v1",
     }
     target_path = "tests/e2e/test_ui.py"
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -5,7 +5,6 @@ import pytest
 import queue
 import subprocess
 import sys
-import tempfile
 import threading
 from playwright.sync_api import Page
 import time
@@ -274,13 +273,24 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0"
+    preprovisioned_model_path = os.environ.get("TOKENPLACE_REAL_E2E_MODEL_PATH", "").strip()
+    if not preprovisioned_model_path:
+        pytest.skip(
+            "Set TOKENPLACE_REAL_E2E_MODEL_PATH to an existing GGUF path for "
+            "RUN_REAL_DESKTOP_INFERENCE_E2E=1 runs."
+        )
+    if not os.path.isfile(preprovisioned_model_path):
+        pytest.skip(
+            "TOKENPLACE_REAL_E2E_MODEL_PATH must point to an existing model file "
+            f"(got: {preprovisioned_model_path})."
+        )
 
     bridge_process = subprocess.Popen(
         [
             sys.executable,
             "desktop-tauri/src-tauri/python/compute_node_bridge.py",
             "--model",
-            os.path.join(tempfile.gettempdir(), "mock-model.gguf"),
+            preprovisioned_model_path,
             "--mode",
             "cpu",
             "--relay-url",
@@ -373,7 +383,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         page.wait_for_load_state("networkidle")
 
         textarea = page.locator("textarea").first
-        textarea.fill("hello relay + desktop bridge")
+        textarea.fill("What is the capital of France? Respond with one word.")
         page.locator("button", has_text="Send").click()
 
         assistant_message = page.locator(".assistant-message").last
@@ -390,13 +400,12 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             """,
             arg={
                 "selector": ".assistant-message",
-                "expectedText": "capital",
+                "expectedText": "paris",
             },
         )
 
         assistant_text = assistant_message.inner_text()
-        assert assistant_text.strip() != "stub"
-        assert "capital" in assistant_text.lower()
+        assert "paris" in assistant_text.lower()
         assert "Sorry, I encountered an issue generating a response." not in page.content()
         assert "Unknown streaming error" not in page.content()
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -251,7 +251,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
 
 @pytest.mark.e2e
-def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
+def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     page: Page,
     base_url: str,
     setup_servers,
@@ -259,16 +259,21 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
     """
     Validate relay landing chat end-to-end through the desktop compute-node bridge.
 
-    This test intentionally avoids route mocking so CI verifies the real wiring:
+    This test intentionally avoids route mocking so it verifies the real wiring:
     browser UI -> relay.py API v1 -> relay sink/source -> desktop bridge runtime.
     """
+    if os.environ.get("RUN_REAL_DESKTOP_INFERENCE_E2E", "0") != "1":
+        pytest.skip(
+            "Real desktop inference e2e is disabled by default; "
+            "set RUN_REAL_DESKTOP_INFERENCE_E2E=1 to run this test."
+        )
 
     relay_process, _ = setup_servers
     assert relay_process is not None
 
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
-    test_env["USE_MOCK_LLM"] = "1"
+    test_env["USE_MOCK_LLM"] = "0"
 
     bridge_process = subprocess.Popen(
         [
@@ -349,6 +354,12 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
 
             if event_type == "started":
                 started = bool(payload.get("running"))
+                assert payload.get("use_mock_llm") is False
+                assert payload.get("llama_repo_stub_imported") is False
+                llama_module_path = payload.get("llama_module_path", "")
+                assert isinstance(llama_module_path, str) and llama_module_path
+                assert not llama_module_path.endswith("/llama_cpp.py")
+                assert not llama_module_path.endswith("\\llama_cpp.py")
             if event_type == "status" and payload.get("registered") is True:
                 registered = True
                 break
@@ -384,6 +395,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         )
 
         assistant_text = assistant_message.inner_text()
+        assert assistant_text.strip() != "stub"
         assert "capital" in assistant_text.lower()
         assert "Sorry, I encountered an issue generating a response." not in page.content()
         assert "Unknown streaming error" not in page.content()

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -101,7 +101,7 @@ def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
     try:
         provider = compute_provider.get_api_v1_compute_provider()
 
-        assert isinstance(provider, DistributedApiV1ComputeProvider)
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,4 +1,3 @@
-import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -98,7 +97,23 @@ def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
 
-    importlib.reload(compute_provider)
-    provider = compute_provider.get_api_v1_compute_provider()
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
 
-    assert isinstance(provider, DistributedApiV1ComputeProvider)
+        assert isinstance(provider, DistributedApiV1ComputeProvider)
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        with pytest.raises(ComputeProviderError, match="requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL"):
+            compute_provider.get_api_v1_compute_provider()
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,7 +1,9 @@
+import importlib
 from types import SimpleNamespace
 
 import pytest
 
+from api.v1 import compute_provider
 from api.v1.compute_provider import (
     ComputeProviderError,
     DistributedApiV1ComputeProvider,
@@ -89,3 +91,14 @@ def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatc
             model_id="llama-3-8b-instruct",
             messages=[{"role": "user", "content": "hello"}],
         )
+
+
+def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    importlib.reload(compute_provider)
+    provider = compute_provider.get_api_v1_compute_provider()
+
+    assert isinstance(provider, DistributedApiV1ComputeProvider)

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1038,6 +1038,24 @@ def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch
     assert module.maybe_reexec_for_runtime_refresh(setup, allow_reexec=False) is None
 
 
+def test_module_level_fallback_when_model_manager_is_missing(monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'utils.llm.model_manager':
+            raise ModuleNotFoundError("No module named 'utils.llm'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+
+    module = ModuleType('compute_node_bridge_no_model_manager')
+    module.__file__ = str(MODULE_PATH)
+    code = compile(MODULE_PATH.read_text(encoding='utf-8'), str(MODULE_PATH), 'exec')
+    exec(code, module.__dict__)
+
+    assert module._is_repo_llama_cpp_shim('/tmp/llama_cpp.py') is False
+
+
 def test_sanitize_relay_target_redacts_credentials_query_and_fragment():
     sanitized = compute_node_bridge._sanitize_relay_target(
         'https://user:pass@token.place:8443/sink?token=abc#debug'

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -257,10 +257,10 @@ class TestModelManager:
     @patch('utils.llm.model_manager.os.path.getsize', return_value=4_000_000_000)
     @patch('utils.llm.model_manager.os.path.exists', return_value=True)
     @patch('utils.llm.model_manager.resource_monitor.can_allocate_gpu_memory', return_value=False)
-    @patch('llama_cpp.Llama', create=True)
+    @patch('utils.llm.model_manager._import_llama_cpp_runtime')
     def test_get_llm_instance_falls_back_to_cpu_on_low_gpu_memory(
         self,
-        mock_llama,
+        mock_import_llama_cpp_runtime,
         mock_can_allocate,
         mock_exists,
         _mock_getsize,
@@ -268,8 +268,10 @@ class TestModelManager:
     ):
         """When GPU headroom is insufficient the model should load on CPU."""
 
+        mock_llama = MagicMock()
         instance = MagicMock()
         mock_llama.return_value = instance
+        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(Llama=mock_llama)
 
         with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
              patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
@@ -284,10 +286,10 @@ class TestModelManager:
     @patch('utils.llm.model_manager.os.path.getsize', return_value=4_000_000_000)
     @patch('utils.llm.model_manager.os.path.exists', return_value=True)
     @patch('utils.llm.model_manager.resource_monitor.can_allocate_gpu_memory', return_value=True)
-    @patch('llama_cpp.Llama', create=True)
+    @patch('utils.llm.model_manager._import_llama_cpp_runtime')
     def test_get_llm_instance_uses_gpu_when_headroom_available(
         self,
-        mock_llama,
+        mock_import_llama_cpp_runtime,
         mock_can_allocate,
         mock_exists,
         _mock_getsize,
@@ -295,8 +297,10 @@ class TestModelManager:
     ):
         """When memory is available the model continues to use the GPU."""
 
+        mock_llama = MagicMock()
         instance = MagicMock()
         mock_llama.return_value = instance
+        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(Llama=mock_llama)
 
         with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
              patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
@@ -312,7 +316,8 @@ class TestModelManager:
 
         instance = MagicMock()
 
-        with patch('llama_cpp.Llama', return_value=instance, create=True) as mock_llama, \
+        mock_llama = MagicMock(return_value=instance)
+        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama)), \
              patch('utils.llm.model_manager.resource_monitor.can_allocate_gpu_memory') as mock_can_allocate, \
              patch('utils.llm.model_manager.os.path.exists', return_value=True), \
              patch('utils.llm.model_manager.os.path.getsize', side_effect=OSError('stat failed')), \
@@ -352,7 +357,7 @@ class TestModelManager:
 
         # Patch everything needed
         with patch('os.path.exists', return_value=True), \
-             patch('llama_cpp.Llama', return_value=mock_llama, create=True):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=MagicMock(return_value=mock_llama))):
 
             # Call the method
             llm = model_manager.get_llm_instance()
@@ -569,10 +574,13 @@ class TestModelManager:
             assert isinstance(manager, ModelManager)
             assert mock_get_config.called
 
-    @patch('llama_cpp.Llama', side_effect=Exception('fail'), create=True)
+    @patch('utils.llm.model_manager._import_llama_cpp_runtime')
     @patch('os.path.exists', return_value=True)
-    def test_get_llm_instance_init_failure(self, mock_exists, mock_llama, model_manager):
+    def test_get_llm_instance_init_failure(self, mock_exists, mock_import_llama_cpp_runtime, model_manager):
         """Return None if Llama initialization raises an exception."""
+        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(
+            Llama=MagicMock(side_effect=Exception('fail'))
+        )
         llm = model_manager.get_llm_instance()
         assert llm is None
 
@@ -794,7 +802,7 @@ class TestModelManager:
         )
 
         with patch('utils.llm.model_manager.sys.platform', 'linux'), \
-             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             backend = ModelManager._platform_gpu_backend()
 
         assert backend == 'cuda'
@@ -809,7 +817,7 @@ class TestModelManager:
         )
 
         with patch('utils.llm.model_manager.sys.platform', 'linux'), \
-             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             backend = ModelManager._platform_gpu_backend()
 
         assert backend == 'cuda'
@@ -821,7 +829,7 @@ class TestModelManager:
             raise RuntimeError("probe failed")
 
         fake_llama = SimpleNamespace(llama_supports_gpu_offload=_raise_runtime_error)
-        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             assert ModelManager._llama_gpu_offload_available() is False
 
     def test_get_llm_instance_mock_mode_refreshes_compute_diagnostics(self, model_manager):
@@ -852,7 +860,7 @@ class TestModelManager:
         )
 
         with patch('utils.llm.model_manager.sys.platform', 'linux'), \
-             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             backend = ModelManager._platform_gpu_backend()
 
         assert backend == 'metal'
@@ -867,7 +875,7 @@ class TestModelManager:
         )
 
         with patch('utils.llm.model_manager.sys.platform', 'linux'), \
-             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             backend = ModelManager._platform_gpu_backend()
 
         assert backend == 'metal'
@@ -881,7 +889,7 @@ class TestModelManager:
         )
 
         with patch('utils.llm.model_manager.sys.platform', 'linux'), \
-             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             backend = ModelManager._platform_gpu_backend()
 
         assert backend == 'cuda'
@@ -899,7 +907,7 @@ class TestModelManager:
         )
 
         with patch('utils.llm.model_manager.sys.platform', 'linux'), \
-             patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+             patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             backend = ModelManager._platform_gpu_backend()
 
         assert backend is None
@@ -912,7 +920,7 @@ class TestModelManager:
             llama_supports_gpu_offload=None,
         )
 
-        with patch.dict(sys.modules, {'llama_cpp': fake_llama}):
+        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama):
             assert ModelManager._llama_gpu_offload_available() is True
 
     def test_resolve_compute_plan_gpu_and_hybrid_success_paths(self, model_manager):
@@ -952,17 +960,12 @@ class TestModelManager:
             assert ModelManager._llama_gpu_offload_available() is True
 
     def test_detect_runtime_capabilities_reports_missing_module_error(self):
-        import builtins
         from utils.llm import model_manager as mm
 
-        real_import = builtins.__import__
-
-        def fake_import(name, *args, **kwargs):
-            if name == 'llama_cpp':
-                raise ModuleNotFoundError("No module named 'llama_cpp'")
-            return real_import(name, *args, **kwargs)
-
-        with patch('builtins.__import__', side_effect=fake_import):
+        with patch(
+            'utils.llm.model_manager._import_llama_cpp_runtime',
+            side_effect=ModuleNotFoundError("No module named 'llama_cpp'"),
+        ):
             payload = mm.detect_llama_runtime_capabilities()
 
         assert payload['backend'] == 'missing'
@@ -979,7 +982,7 @@ class TestModelManager:
         model_manager.requested_compute_mode = 'gpu'
         model_manager.log_info = lambda message: log_lines.append(message)
 
-        with patch('llama_cpp.Llama', FakeLlama), \
+        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=FakeLlama)), \
              patch.object(model_manager, '_resolve_compute_plan', return_value={
                  'requested_mode': 'gpu',
                  'effective_mode': 'cpu_fallback',

--- a/tests/unit/test_model_manager_llama_import_guard.py
+++ b/tests/unit/test_model_manager_llama_import_guard.py
@@ -1,0 +1,17 @@
+import types
+
+import pytest
+
+from utils.llm import model_manager
+
+
+def test_import_guard_rejects_repo_local_llama_cpp_shim(monkeypatch):
+    fake_module = types.SimpleNamespace(
+        __file__=str(model_manager.REPO_LLAMA_CPP_SHIM),
+        Llama=object,
+    )
+
+    monkeypatch.setattr(model_manager.importlib, "import_module", lambda _name: fake_module)
+
+    with pytest.raises(ImportError, match="repository-local llama_cpp.py shim"):
+        model_manager._import_llama_cpp_runtime(require_real_runtime=True)

--- a/tests/unit/test_model_manager_llama_import_guard.py
+++ b/tests/unit/test_model_manager_llama_import_guard.py
@@ -5,6 +5,27 @@ import pytest
 from utils.llm import model_manager
 
 
+def test_import_guard_rejects_repo_local_shim_before_import(monkeypatch):
+    fake_spec = types.SimpleNamespace(origin=str(model_manager.REPO_LLAMA_CPP_SHIM))
+    monkeypatch.setattr(model_manager.importlib.util, "find_spec", lambda _name: fake_spec)
+    monkeypatch.setitem(model_manager.sys.modules, "llama_cpp", object())
+
+    import_attempted = False
+
+    def _unexpected_import(_name):
+        nonlocal import_attempted
+        import_attempted = True
+        return object()
+
+    monkeypatch.setattr(model_manager.importlib, "import_module", _unexpected_import)
+
+    with pytest.raises(ImportError, match="repository-local llama_cpp.py shim"):
+        model_manager._import_llama_cpp_runtime(require_real_runtime=True)
+
+    assert not import_attempted
+    assert "llama_cpp" not in model_manager.sys.modules
+
+
 def test_import_guard_rejects_repo_local_llama_cpp_shim(monkeypatch):
     fake_module = types.SimpleNamespace(
         __file__=str(model_manager.REPO_LLAMA_CPP_SHIM),
@@ -15,3 +36,13 @@ def test_import_guard_rejects_repo_local_llama_cpp_shim(monkeypatch):
 
     with pytest.raises(ImportError, match="repository-local llama_cpp.py shim"):
         model_manager._import_llama_cpp_runtime(require_real_runtime=True)
+
+
+def test_import_guard_allows_repo_shim_when_real_runtime_not_required(monkeypatch):
+    fake_spec = types.SimpleNamespace(origin=str(model_manager.REPO_LLAMA_CPP_SHIM))
+    fake_module = types.SimpleNamespace(__file__=str(model_manager.REPO_LLAMA_CPP_SHIM), Llama=object)
+    monkeypatch.setattr(model_manager.importlib.util, "find_spec", lambda _name: fake_spec)
+    monkeypatch.setattr(model_manager.importlib, "import_module", lambda _name: fake_module)
+
+    loaded = model_manager._import_llama_cpp_runtime(require_real_runtime=False)
+    assert loaded is fake_module

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -33,6 +33,16 @@ def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
 
 def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
     """Import llama_cpp while guarding against the repo-local test shim."""
+    llama_spec = importlib.util.find_spec('llama_cpp')
+    llama_module_path = getattr(llama_spec, 'origin', None)
+
+    if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
+        sys.modules.pop('llama_cpp', None)
+        raise ImportError(
+            "Refusing to use repository-local llama_cpp.py shim for runtime inference; "
+            "install llama-cpp-python and ensure site-packages wins import priority."
+        )
+
     llama_cpp = importlib.import_module('llama_cpp')
     llama_module_path = getattr(llama_cpp, '__file__', None)
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -7,6 +7,7 @@ import logging
 import requests
 import json
 import sys
+import importlib
 from pathlib import Path
 from threading import Lock
 from unittest.mock import MagicMock
@@ -16,12 +17,38 @@ from utils.system import resource_monitor
 
 # Configure logging
 logger = logging.getLogger('model_manager')
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
+
+
+def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
+    """Return True when llama_cpp resolves to the repository-local shim."""
+    if not module_path:
+        return False
+    try:
+        return Path(str(module_path)).resolve() == REPO_LLAMA_CPP_SHIM
+    except (TypeError, ValueError, OSError):
+        return False
+
+
+def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
+    """Import llama_cpp while guarding against the repo-local test shim."""
+    llama_cpp = importlib.import_module('llama_cpp')
+    llama_module_path = getattr(llama_cpp, '__file__', None)
+
+    if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
+        raise ImportError(
+            "Refusing to use repository-local llama_cpp.py shim for runtime inference; "
+            "install llama-cpp-python and ensure site-packages wins import priority."
+        )
+
+    return llama_cpp
 
 
 def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     """Return backend/offload capability details from the installed llama_cpp runtime."""
     try:
-        import llama_cpp
+        llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
     except Exception as exc:
         return {
             'backend': 'missing',
@@ -408,7 +435,8 @@ class ModelManager:
                     else:
                         try:
                             # Dynamically import Llama only when needed
-                            from llama_cpp import Llama
+                            llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
+                            Llama = llama_cpp.Llama
 
                             compute_plan = self._resolve_compute_plan()
                             n_gpu_layers = int(compute_plan['n_gpu_layers'])

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -37,6 +37,7 @@ def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
     llama_module_path = getattr(llama_cpp, '__file__', None)
 
     if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
+        sys.modules.pop('llama_cpp', None)
         raise ImportError(
             "Refusing to use repository-local llama_cpp.py shim for runtime inference; "
             "install llama-cpp-python and ensure site-packages wins import priority."


### PR DESCRIPTION
### Motivation
- The landing-page relay flow could silently return the repository-local `llama_cpp.py` test shim (producing the exact string `"stub"`) or run in mock mode while e2e claimed real inference, so real desktop `llama_cpp_python` inference was not reliably exercised.
- Keep the fix minimal and targeted to prevent import-shadowing, remove the false-success e2e shape, and make provider selection explicit and observable at runtime.

### Description
- Add an import guard in `utils/llm/model_manager.py` that refuses to use a repository-local `llama_cpp.py` shim for runtime capability detection and inference, and centralize guarded imports via `_import_llama_cpp_runtime` and `_is_repo_llama_cpp_shim`.
- Add a `TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK` switch and provider-selection diagnostics in `api/v1/compute_provider.py` so distributed mode can run without an automatic local fallback, and log selections for visibility.
- Emit the chosen compute provider class in `api/v1/routes.py` during `/api/v1/chat/completions` handling for runtime diagnostics.
- Extend desktop bridge diagnostics in `desktop-tauri/src-tauri/python/compute_node_bridge.py` to report `llama_repo_stub_imported` and `use_mock_llm` on startup and print an import-guard status to stderr.
- Replace the prior misleading e2e with an honest guarded test in `tests/e2e/test_ui.py` (renamed and gated by `RUN_REAL_DESKTOP_INFERENCE_E2E=1`), force `USE_MOCK_LLM=0` for the bridge run, and assert the bridge did not import the repo shim and that assistant output is not exactly `"stub"` while preserving v1-only/no-v2 checks.
- Add focused regression/unit tests: `tests/unit/test_model_manager_llama_import_guard.py` to assert the import guard rejects the repo shim, and an API unit test update `tests/unit/test_api_v1_compute_provider.py` to verify fallback-disable behavior; update `tests/conftest.py` focused-nodeids accordingly.

### Testing
- Ran repository inspections with `git grep` patterns to confirm mock flags, imports, and stub occurrences; those searches completed and informed targeted edits.
- Attempted to run narrow pytest commands such as `python -m pytest -q tests/e2e/test_ui.py -k "landing_chat"` and `python -m pytest -q tests/unit/test_api_v1_compute_provider.py tests/unit/test_model_manager_llama_import_guard.py`, but test execution is blocked in this environment due to missing Python test dependencies (notably `requests` and `cryptography`), causing `ModuleNotFoundError` failures in `tests/conftest.py` and crypto modules.
- Ran the repository test runner `./run_all_tests.sh` which showed JavaScript tests passed, but the Python phases failed for the same missing dependencies; `pre-commit run --all-files` is unavailable in the environment (`pre-commit: command not found`).
- Unit-level assertions and CI-friendly guards were added so future CI runs with proper dependencies will fail fast if the repo shim or mock path is used where real inference is expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72a68eb68832fa24e32b5b4af28a3)