### PR TITLE
🛠️ fix: harden llama_cpp runtime pathing, provider selection, and landing-page e2e honesty

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -116,7 +116,7 @@ class DistributedApiV1ComputeProvider:
 
 @dataclass(frozen=True)
 class FallbackApiV1ComputeProvider:
-    """Wrap distributed execution with local fallback for migration safety."""
+    """Wrap distributed execution with optional local fallback."""
 
     primary: ApiV1ComputeProvider
     fallback: ApiV1ComputeProvider
@@ -144,23 +144,35 @@ class FallbackApiV1ComputeProvider:
 
 
 @lru_cache(maxsize=8)
-def _build_api_v1_compute_provider(mode: str, distributed_url: str) -> ApiV1ComputeProvider:
+def _build_api_v1_compute_provider(
+    mode: str,
+    distributed_url: str,
+    allow_fallback: bool,
+) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
     local_provider = LocalApiV1ComputeProvider()
 
     if mode != "distributed":
+        logger.info("api_v1.compute_provider.selected mode=%s provider=local", mode)
         return local_provider
 
     if not distributed_url:
         logger.warning(
             "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed set without "
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback"
+            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local provider"
         )
         return local_provider
 
     distributed_provider = DistributedApiV1ComputeProvider(base_url=distributed_url)
-    return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
+    if allow_fallback:
+        logger.warning(
+            "api_v1.compute_provider.selected mode=distributed provider=distributed+local_fallback"
+        )
+        return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
+
+    logger.info("api_v1.compute_provider.selected mode=distributed provider=distributed")
+    return distributed_provider
 
 
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
@@ -168,4 +180,21 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
     distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
-    return _build_api_v1_compute_provider(mode, distributed_url)
+    allow_fallback = os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+    return _build_api_v1_compute_provider(mode, distributed_url, allow_fallback)
+
+
+def get_api_v1_compute_provider_diagnostics() -> Dict[str, str]:
+    """Return compact provider-selection diagnostics for API v1 request logging."""
+
+    return {
+        "mode": os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower() or "local",
+        "distributed_url_configured": "1"
+        if bool(os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip())
+        else "0",
+        "distributed_fallback_enabled": "1"
+        if os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0").strip().lower() in {"1", "true", "yes", "on"}
+        else "0",
+    }

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -33,7 +33,11 @@ from api.v1.models import (
     generate_response as _generate_response,
     get_model_instance as _get_model_instance,
 )
-from api.v1.compute_provider import get_api_v1_compute_provider, ComputeProviderError
+from api.v1.compute_provider import (
+    ComputeProviderError,
+    get_api_v1_compute_provider,
+    get_api_v1_compute_provider_diagnostics,
+)
 from api.v1.validation import (
     ValidationError, validate_required_fields, validate_field_type,
     validate_model_name as _validate_model_name,
@@ -321,6 +325,16 @@ def _handle_chat_completion_request(data):
 
         log_info(f"Generating response using model {model_id}")
         provider = get_api_v1_compute_provider()
+        provider_diag = get_api_v1_compute_provider_diagnostics()
+        log_info(
+            "api_v1.compute_route provider_mode=%s distributed_url=%s fallback=%s use_mock_llm=%s"
+            % (
+                provider_diag.get("mode"),
+                provider_diag.get("distributed_url_configured"),
+                provider_diag.get("distributed_fallback_enabled"),
+                os.environ.get("USE_MOCK_LLM", "0"),
+            )
+        )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,
@@ -380,9 +394,13 @@ def _handle_chat_completion_request(data):
                     status_code=500,
                 )
 
-            return jsonify({"encrypted": True, "data": encrypted_response})
+            response = jsonify({"encrypted": True, "data": encrypted_response})
+            response.headers["X-Tokenplace-Api-V1-Provider"] = provider_diag.get("mode", "local")
+            return response
 
-        return jsonify(response_data)
+        response = jsonify(response_data)
+        response.headers["X-Tokenplace-Api-V1-Provider"] = provider_diag.get("mode", "local")
+        return response
 
     except ValidationError as e:
         return format_error_response(

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -9,6 +9,7 @@ import queue
 import sys
 import threading
 import time
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urlsplit, urlunsplit
@@ -167,6 +168,10 @@ def _sleep_with_cancel(seconds: float) -> bool:
 def run(args: argparse.Namespace) -> int:
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
+    use_mock_llm = bool(os.environ.get('USE_MOCK_LLM') == '1')
+    llama_module_path = str(runtime_setup.get('llama_module_path', 'missing'))
+    repo_llama_stub = llama_module_path.replace('\\', '/').endswith('/llama_cpp.py')
+
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
@@ -174,7 +179,9 @@ def run(args: argparse.Namespace) -> int:
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
         f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
-        f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
+        f"llama_module_path={llama_module_path} "
+        f"llama_repo_stub_imported={repo_llama_stub} "
+        f"use_mock_llm={use_mock_llm} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
@@ -257,6 +264,8 @@ def run(args: argparse.Namespace) -> int:
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "model_path": args.model,
             "last_error": None,
+            "use_mock_llm": use_mock_llm,
+            "llama_repo_stub_imported": repo_llama_stub,
         }
     )
 
@@ -328,6 +337,8 @@ def run(args: argparse.Namespace) -> int:
                     "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
                     "model_path": args.model,
                     "last_error": last_error,
+            "use_mock_llm": use_mock_llm,
+            "llama_repo_stub_imported": repo_llama_stub,
                 }
             )
 
@@ -357,6 +368,8 @@ def run(args: argparse.Namespace) -> int:
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "model_path": args.model,
             "last_error": None,
+            "use_mock_llm": use_mock_llm,
+            "llama_repo_stub_imported": repo_llama_stub,
         }
     )
     return 0

--- a/llama_cpp.py
+++ b/llama_cpp.py
@@ -1,6 +1,23 @@
+"""Test-only llama_cpp shim.
+
+This module must never be imported in real runtime flows. Opt in explicitly with
+TOKENPLACE_ENABLE_REPO_LLAMA_CPP_STUB=1 for narrowly-scoped tests.
+"""
+
+import os
+
+if os.getenv("TOKENPLACE_ENABLE_REPO_LLAMA_CPP_STUB") != "1":
+    raise RuntimeError(
+        "Repo-local llama_cpp.py stub was imported. This shadows llama-cpp-python; "
+        "remove repo root from import precedence or install/use the real package."
+    )
+
+
 class Llama:
-    """Minimal stub of llama_cpp.Llama for testing purposes."""
+    """Minimal stub of llama_cpp.Llama for explicit test opt-in only."""
+
     def __init__(self, *args, **kwargs):
         pass
+
     def create_chat_completion(self, *args, **kwargs):
         return {"choices": [{"message": {"role": "assistant", "content": "stub"}}]}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,8 @@ E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
-    "tests/e2e/test_ui.py::test_landing_chat_round_trip_with_desktop_bridge_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_round_trip_with_desktop_bridge_mock_plumbing_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_round_trip_with_desktop_bridge_real_inference_api_v1",
 }
 
 
@@ -166,7 +167,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
-        "landing_chat_round_trip_with_desktop_bridge_api_v1",
+        "landing_chat_round_trip_with_desktop_bridge_mock_plumbing_api_v1",
+        "landing_chat_round_trip_with_desktop_bridge_real_inference_api_v1",
     }
     target_path = "tests/e2e/test_ui.py"
 
@@ -217,17 +219,25 @@ def setup_servers(
     # Ensure environment variables are set properly
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
-    test_env["USE_MOCK_LLM"] = "1"  # This is the key setting for mocking the LLM
+    use_mock_llm = os.environ.get("E2E_USE_MOCK_LLM", "1") == "1"
+    if use_mock_llm:
+        test_env["USE_MOCK_LLM"] = "1"
+    else:
+        test_env.pop("USE_MOCK_LLM", None)
 
-    # Start the relay server with the --use_mock_llm flag
+    relay_cmd = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]
+    if use_mock_llm:
+        relay_cmd.append("--use_mock_llm")
+
+    # Start the relay server with optional mock mode
     relay_process = subprocess.Popen(
-        [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT), "--use_mock_llm"],
+        relay_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         env=test_env
     )
-    print(f"Started relay server on port {E2E_RELAY_PORT} with --use_mock_llm flag")
+    print(f"Started relay server on port {E2E_RELAY_PORT} with use_mock_llm={use_mock_llm}")
 
     # Wait for relay to start - increased wait time
     time.sleep(3)
@@ -270,7 +280,9 @@ def setup_servers(
         text=True,
         env=test_env
     )
-    print(f"Started server on port {E2E_SERVER_PORT} with USE_MOCK_LLM=1 (via environment variable)")
+    print(
+        f"Started server on port {E2E_SERVER_PORT} with USE_MOCK_LLM={'1' if use_mock_llm else '0'}"
+    )
 
     # Wait longer for server to start and register with relay
     time.sleep(5)

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -251,16 +251,16 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
 
 @pytest.mark.e2e
-def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
+def test_landing_chat_round_trip_with_desktop_bridge_mock_plumbing_api_v1(
     page: Page,
     base_url: str,
     setup_servers,
 ):
     """
-    Validate relay landing chat end-to-end through the desktop compute-node bridge.
+    Validate relay landing chat mock plumbing through desktop compute-node bridge wiring.
 
-    This test intentionally avoids route mocking so CI verifies the real wiring:
-    browser UI -> relay.py API v1 -> relay sink/source -> desktop bridge runtime.
+    This test intentionally runs with USE_MOCK_LLM=1 and validates queue/bridge
+    registration plumbing only (not real llama.cpp inference).
     """
 
     relay_process, _ = setup_servers
@@ -269,6 +269,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "1"
+    test_env["TOKENPLACE_ENABLE_REPO_LLAMA_CPP_STUB"] = "1"
 
     bridge_process = subprocess.Popen(
         [
@@ -384,7 +385,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         )
 
         assistant_text = assistant_message.inner_text()
-        assert "capital" in assistant_text.lower()
+        assert "mock response" in assistant_text.lower()
         assert "Sorry, I encountered an issue generating a response." not in page.content()
         assert "Unknown streaming error" not in page.content()
 
@@ -406,6 +407,139 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
             except (BrokenPipeError, ValueError):
                 pass
 
+        try:
+            bridge_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            bridge_process.kill()
+
+
+@pytest.mark.e2e
+def test_landing_chat_round_trip_with_desktop_bridge_real_inference_api_v1(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """
+    Validate real desktop inference wiring without mock mode.
+
+    This test is environment-gated because it requires a real llama-cpp-python
+    runtime + model and a relay deployment that serves /api/v1 endpoints for
+    the landing page origin.
+    """
+
+    if os.environ.get("RUN_REAL_DESKTOP_INFERENCE_E2E", "0") != "1":
+        pytest.skip("Set RUN_REAL_DESKTOP_INFERENCE_E2E=1 to run real desktop inference e2e")
+
+    relay_process, _ = setup_servers
+    assert relay_process is not None
+
+    test_env = os.environ.copy()
+    test_env["TOKEN_PLACE_ENV"] = "testing"
+    test_env["USE_MOCK_LLM"] = "0"
+    test_env.pop("TOKENPLACE_ENABLE_REPO_LLAMA_CPP_STUB", None)
+
+    bridge_process = subprocess.Popen(
+        [
+            sys.executable,
+            "desktop-tauri/src-tauri/python/compute_node_bridge.py",
+            "--model",
+            os.environ.get("E2E_REAL_LLAMACPP_MODEL_PATH", os.path.join(tempfile.gettempdir(), "missing.gguf")),
+            "--mode",
+            os.environ.get("E2E_REAL_LLAMACPP_MODE", "cpu"),
+            "--relay-url",
+            base_url,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=test_env,
+    )
+
+    stdout_queue: "queue.Queue[str]" = queue.Queue()
+    stderr_lines: list[str] = []
+
+    def _drain_stream(stream, output_queue=None, collector=None):
+        for stream_line in iter(stream.readline, ""):
+            if output_queue is not None:
+                output_queue.put(stream_line)
+            if collector is not None:
+                collector.append(stream_line)
+
+    threading.Thread(target=_drain_stream, args=(bridge_process.stdout, stdout_queue, None), daemon=True).start()
+    threading.Thread(target=_drain_stream, args=(bridge_process.stderr, None, stderr_lines), daemon=True).start()
+
+    v1_requests = []
+    v2_requests = []
+
+    def record_v1_request(route):
+        v1_requests.append(route.request)
+        route.continue_()
+
+    def record_v2_request(route):
+        v2_requests.append(route.request.url)
+        route.continue_()
+
+    page.route("**/api/v1/chat/completions", record_v1_request)
+    page.route("**/api/v2/chat/completions", record_v2_request)
+
+    try:
+        start_deadline = time.time() + 30
+        started_payload = None
+        registered = False
+
+        while time.time() < start_deadline:
+            try:
+                line = stdout_queue.get(timeout=0.5)
+            except queue.Empty:
+                if bridge_process.poll() is not None:
+                    raise AssertionError(
+                        f"desktop bridge exited early rc={bridge_process.returncode}\n{''.join(stderr_lines)}"
+                    )
+                continue
+
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if payload.get("type") == "started":
+                started_payload = payload
+            if payload.get("type") == "status" and payload.get("registered") is True:
+                registered = True
+                break
+            if payload.get("type") == "error":
+                raise AssertionError(f"desktop bridge error event: {payload}")
+
+        assert started_payload is not None
+        assert started_payload.get("use_mock_llm") is False
+        assert started_payload.get("llama_repo_stub_imported") is False
+        assert registered
+
+        page.goto(base_url)
+        page.wait_for_load_state("networkidle")
+
+        textarea = page.locator("textarea").first
+        textarea.fill("hello from real desktop inference")
+        page.locator("button", has_text="Send").click()
+
+        assistant_message = page.locator(".assistant-message").last
+        assistant_message.wait_for(state="visible")
+        assistant_text = assistant_message.inner_text().strip()
+
+        assert assistant_text
+        assert assistant_text != "stub"
+        assert "Mock Response" not in assistant_text
+        assert len(v1_requests) >= 1
+        assert v2_requests == []
+    finally:
+        if bridge_process.stdin:
+            try:
+                bridge_process.stdin.write(json.dumps({"type": "cancel"}) + "\n")
+                bridge_process.stdin.flush()
+                bridge_process.stdin.close()
+            except (BrokenPipeError, ValueError):
+                pass
         try:
             bridge_process.wait(timeout=10)
         except subprocess.TimeoutExpired:

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from api.v1.compute_provider import (
+    get_api_v1_compute_provider,
     ComputeProviderError,
     DistributedApiV1ComputeProvider,
     FallbackApiV1ComputeProvider,
@@ -89,3 +90,21 @@ def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatc
             model_id="llama-3-8b-instruct",
             messages=[{"role": "user", "content": "hello"}],
         )
+
+
+def test_distributed_provider_default_disables_local_fallback(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.delenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", raising=False)
+
+    provider = get_api_v1_compute_provider()
+    assert isinstance(provider, DistributedApiV1ComputeProvider)
+
+
+def test_distributed_provider_opt_in_local_fallback(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1")
+
+    provider = get_api_v1_compute_provider()
+    assert isinstance(provider, FallbackApiV1ComputeProvider)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -18,16 +18,45 @@ from utils.system import resource_monitor
 logger = logging.getLogger('model_manager')
 
 
-def detect_llama_runtime_capabilities() -> Dict[str, Any]:
-    """Return backend/offload capability details from the installed llama_cpp runtime."""
+def _repo_llama_stub_path() -> Path:
+    return (Path(__file__).resolve().parents[2] / 'llama_cpp.py').resolve()
+
+
+def _is_repo_llama_stub(module_file: str | None) -> bool:
+    if not module_file:
+        return False
+    try:
+        return Path(module_file).resolve() == _repo_llama_stub_path()
+    except Exception:
+        return False
+
+
+def _llama_runtime_identity() -> Dict[str, Any]:
     try:
         import llama_cpp
     except Exception as exc:
+        return {'module': None, 'module_path': None, 'import_error': str(exc), 'repo_stub': False}
+
+    module_path = getattr(llama_cpp, '__file__', None)
+    return {
+        'module': llama_cpp,
+        'module_path': module_path,
+        'import_error': None,
+        'repo_stub': _is_repo_llama_stub(module_path),
+    }
+
+
+def detect_llama_runtime_capabilities() -> Dict[str, Any]:
+    """Return backend/offload capability details from the installed llama_cpp runtime."""
+    identity = _llama_runtime_identity()
+    llama_cpp = identity.get('module')
+    if llama_cpp is None:
         return {
             'backend': 'missing',
             'gpu_offload_supported': False,
             'detected_device': 'none',
-            'error': str(exc),
+            'llama_repo_stub_imported': False,
+            'error': identity.get('import_error'),
         }
 
     backend = 'cpu'
@@ -70,7 +99,8 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'detected_device': backend if gpu_offload_supported else 'cpu',
         'interpreter': sys.executable,
         'prefix': sys.prefix,
-        'llama_module_path': getattr(llama_cpp, '__file__', 'unknown'),
+        'llama_module_path': identity.get('module_path') or 'unknown',
+        'llama_repo_stub_imported': bool(identity.get('repo_stub')),
         'error': None,
     }
 
@@ -408,6 +438,18 @@ class ModelManager:
                     else:
                         try:
                             # Dynamically import Llama only when needed
+                            runtime_identity = _llama_runtime_identity()
+                            if runtime_identity.get('module') is None:
+                                raise RuntimeError(
+                                    f"Failed to import llama_cpp runtime: {runtime_identity.get('import_error')}"
+                                )
+                            if runtime_identity.get('repo_stub') and os.getenv(
+                                'TOKENPLACE_ALLOW_REPO_LLAMA_SHIM', '0'
+                            ) != '1':
+                                raise RuntimeError(
+                                    'Refusing to initialize runtime with repo-local llama_cpp.py shim '
+                                    '(set TOKENPLACE_ALLOW_REPO_LLAMA_SHIM=1 only for isolated tests)'
+                                )
                             from llama_cpp import Llama
 
                             compute_plan = self._resolve_compute_plan()


### PR DESCRIPTION
### Motivation
- Prevent real app or desktop bridge runs from accidentally importing the repo-root `llama_cpp.py` test shim which produced silent "stub" responses. 
- Make API v1 provider selection and relay→desktop wiring explicit so the landing-page flow cannot report success while using mock/stub paths. 
- Improve runtime diagnostics so mock/shim/fallback signals are visible at runtime and in tests.

### Description
- Disarm the repo-local shim by making `llama_cpp.py` raise unless `TOKENPLACE_ENABLE_REPO_LLAMA_CPP_STUB=1` is explicitly set for tests.  
- Add runtime identity helpers to `utils/llm/model_manager.py` and refuse to initialize a non-mock runtime when the repo shim is imported unless `TOKENPLACE_ALLOW_REPO_LLAMA_SHIM=1` is set.  
- Add `use_mock_llm` and `llama_repo_stub_imported` diagnostics to `desktop-tauri/src-tauri/python/compute_node_bridge.py` startup/status payloads and logs.  
- Tighten API v1 provider selection in `api/v1/compute_provider.py` so `distributed` mode is strict by default and local fallback is opt-in via `TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK=1`, and expose `get_api_v1_compute_provider_diagnostics()`.  
- Surface provider diagnostics and provider-mode header `X-Tokenplace-Api-V1-Provider` in `api/v1/routes.py` responses.  
- Split and clarify e2e tests in `tests/e2e/test_ui.py`: the previous bridge test is now `*_mock_plumbing_*` (explicit mock plumbing with `USE_MOCK_LLM=1`), and a new environment-gated `*_real_inference_*` test asserts no mock/shim signals, that assistant content != `"stub"`, and that at least one `/api/v1/chat/completions` request occurred and zero `/api/v2/chat/completions` requests occurred.  
- Make `tests/conftest.py` support selecting mock vs real bridge via `E2E_USE_MOCK_LLM` and update focused test selection.  
- Add unit tests for provider-selection behavior (strict distributed default vs explicit fallback opt-in) in `tests/unit/test_api_v1_compute_provider.py`.

### Testing
- Compiled touched Python files with `python -m py_compile` which succeeded for all modified files.  
- Ran `npm run lint` which passed.  
- Ran the repo test runner via `npm run test:ci` / `./run_all_tests.sh`; JavaScript checks passed but the Python test suites could not be fully executed in this environment due to missing or incompatible system Python dependencies (Playwright/Chromium, `cryptography`, `psutil`, `numpy` constraints), so Python unit/integration suites were blocked; see CI for full verification.  
- Added and executed targeted unit coverage locally where possible; new provider-selection unit tests were added to assert behavior.  

If you want, I can open a follow-up to (1) remove the repo shim entirely and move it to `tests/` or (2) run the full Python test matrix in CI and iterate on any uncovered regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72a68eb68832fa24e32b5b4af28a3)