### PR TITLE
🔧 fix: route encrypted v1 traffic via relay queue and prevent llama_cpp shim shadowing

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -14,9 +14,15 @@ from typing import Any, Dict, Optional, Protocol
 
 import requests
 
-from api.v1.models import generate_response
-
 logger = logging.getLogger("api.v1.compute_provider")
+
+
+def generate_response(model_id: str, messages: list[dict[str, Any]], **options: Any):
+    """Compatibility wrapper for local generation (kept for tests monkeypatching this symbol)."""
+
+    from api.v1.models import generate_response as _generate_response
+
+    return _generate_response(model_id, messages, **options)
 
 
 class ComputeProviderError(Exception):
@@ -47,6 +53,8 @@ class LocalApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
+        # Import lazily so distributed-only relay runtime does not eagerly import
+        # api.v1.models (which can in turn import llama_cpp at module import time).
         updated_messages = generate_response(model_id, messages, **(options or {}))
         if not updated_messages:
             raise ComputeProviderError("model returned an empty message list")
@@ -160,6 +168,9 @@ def _build_api_v1_compute_provider(mode: str, distributed_url: str) -> ApiV1Comp
         return local_provider
 
     distributed_provider = DistributedApiV1ComputeProvider(base_url=distributed_url)
+    allow_fallback = os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip() != "0"
+    if not allow_fallback:
+        return distributed_provider
     return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
 
 
@@ -168,4 +179,12 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
     distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
-    return _build_api_v1_compute_provider(mode, distributed_url)
+    provider = _build_api_v1_compute_provider(mode, distributed_url)
+    logger.info(
+        "api.v1.compute_provider.selected mode=%s distributed_url_configured=%s fallback_enabled=%s provider=%s",
+        mode,
+        bool(distributed_url),
+        os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip() != "0",
+        provider.__class__.__name__,
+    )
+    return provider

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -12,7 +12,9 @@ import uuid
 import logging
 import os
 import math
+import sys
 
+import requests
 from api.v1.encryption import encryption_manager
 from api.security import ensure_operator_access
 from api.v1.moderation import evaluate_messages_for_policy
@@ -122,6 +124,69 @@ def _configured_relay_servers() -> list[str]:
 
 
 _image_generator = LocalImageGenerator()
+
+
+def _running_inside_relay_process() -> bool:
+    return os.path.basename(sys.argv[0]).lower() == "relay.py"
+
+
+def _try_relay_encrypted_round_trip(payload: dict) -> tuple[dict | None, str | None]:
+    """Forward encrypted API v1 payloads through relay queue endpoints when available."""
+
+    base_url = request.host_url.rstrip("/")
+    timeout_seconds = float(os.environ.get("TOKENPLACE_API_V1_RELAY_TIMEOUT_SECONDS", "30"))
+
+    try:
+        next_server_response = requests.get(f"{base_url}/next_server", timeout=5)
+        next_server_response.raise_for_status()
+        next_server_payload = next_server_response.json()
+    except Exception as exc:
+        return None, f"failed to resolve relay compute node: {exc}"
+
+    server_public_key = next_server_payload.get("server_public_key")
+    if not isinstance(server_public_key, str) or not server_public_key:
+        return None, "relay /next_server returned no server_public_key"
+
+    encrypted_messages = payload.get("messages") or {}
+    faucet_payload = {
+        "server_public_key": server_public_key,
+        "client_public_key": payload.get("client_public_key"),
+        "chat_history": encrypted_messages.get("ciphertext"),
+        "cipherkey": encrypted_messages.get("cipherkey"),
+        "iv": encrypted_messages.get("iv"),
+        "stream": False,
+    }
+
+    try:
+        faucet_response = requests.post(f"{base_url}/faucet", json=faucet_payload, timeout=5)
+        faucet_response.raise_for_status()
+    except Exception as exc:
+        return None, f"failed to enqueue relay request: {exc}"
+
+    deadline = time.time() + timeout_seconds
+    retrieve_payload = {"client_public_key": payload.get("client_public_key")}
+    while time.time() < deadline:
+        try:
+            retrieve_response = requests.post(
+                f"{base_url}/retrieve",
+                json=retrieve_payload,
+                timeout=5,
+            )
+            retrieve_response.raise_for_status()
+            retrieve_data = retrieve_response.json()
+        except Exception as exc:
+            return None, f"failed to poll relay response: {exc}"
+
+        if isinstance(retrieve_data, dict) and retrieve_data.get("chat_history"):
+            return {
+                "ciphertext": retrieve_data.get("chat_history"),
+                "cipherkey": retrieve_data.get("cipherkey"),
+                "iv": retrieve_data.get("iv"),
+            }, None
+
+        time.sleep(0.2)
+
+    return None, f"timed out waiting for relay response after {timeout_seconds:.0f}s"
 
 
 def format_error_response(message, error_type="invalid_request_error", param=None, code=None, status_code=400):
@@ -234,6 +299,24 @@ def _handle_chat_completion_request(data):
         client_public_key = None
 
         if is_encrypted_request:
+            relay_round_trip_enabled = (
+                os.environ.get("TOKENPLACE_API_V1_USE_RELAY_QUEUE", "1").strip() != "0"
+            )
+            relay_round_trip_strict = _running_inside_relay_process()
+            if relay_round_trip_enabled:
+                relay_encrypted_payload, relay_error = _try_relay_encrypted_round_trip(data)
+                if relay_encrypted_payload:
+                    log_info("API v1 encrypted completion routed via relay queue path")
+                    return jsonify({"encrypted": True, "data": relay_encrypted_payload})
+                if relay_error:
+                    log_warning(f"Relay queue path unavailable for encrypted request: {relay_error}")
+                    if relay_round_trip_strict:
+                        return format_error_response(
+                            f"Relay queue path failed: {relay_error}",
+                            error_type="server_error",
+                            status_code=502,
+                        )
+
             log_info("Processing encrypted request")
 
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,8 @@ E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
-    "tests/e2e/test_ui.py::test_landing_chat_round_trip_with_desktop_bridge_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_mock_bridge_round_trip_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_real_inference_desktop_bridge_api_v1",
 }
 
 
@@ -166,7 +167,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
-        "landing_chat_round_trip_with_desktop_bridge_api_v1",
+        "landing_chat_mock_bridge_round_trip_api_v1",
+        "landing_chat_real_inference_desktop_bridge_api_v1",
     }
     target_path = "tests/e2e/test_ui.py"
 
@@ -217,17 +219,27 @@ def setup_servers(
     # Ensure environment variables are set properly
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
-    test_env["USE_MOCK_LLM"] = "1"  # This is the key setting for mocking the LLM
+    focused_real_inference = os.environ.get("RUN_REAL_DESKTOP_INFERENCE_E2E", "0") == "1"
+    if focused_e2e_only and focused_real_inference:
+        test_env["USE_MOCK_LLM"] = "0"
+    else:
+        test_env["USE_MOCK_LLM"] = "1"  # default to mocked runtime for non-focused and mock tests
 
-    # Start the relay server with the --use_mock_llm flag
+    relay_cmd = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]
+    if test_env["USE_MOCK_LLM"] == "1":
+        relay_cmd.append("--use_mock_llm")
+
+    # Start relay server
     relay_process = subprocess.Popen(
-        [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT), "--use_mock_llm"],
+        relay_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         env=test_env
     )
-    print(f"Started relay server on port {E2E_RELAY_PORT} with --use_mock_llm flag")
+    print(
+        f"Started relay server on port {E2E_RELAY_PORT} with USE_MOCK_LLM={test_env['USE_MOCK_LLM']}"
+    )
 
     # Wait for relay to start - increased wait time
     time.sleep(3)

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -250,27 +250,8 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     assert v2_requests == []
 
 
-@pytest.mark.e2e
-def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
-    page: Page,
-    base_url: str,
-    setup_servers,
-):
-    """
-    Validate relay landing chat end-to-end through the desktop compute-node bridge.
-
-    This test intentionally avoids route mocking so CI verifies the real wiring:
-    browser UI -> relay.py API v1 -> relay sink/source -> desktop bridge runtime.
-    """
-
-    relay_process, _ = setup_servers
-    assert relay_process is not None
-
-    test_env = os.environ.copy()
-    test_env["TOKEN_PLACE_ENV"] = "testing"
-    test_env["USE_MOCK_LLM"] = "1"
-
-    bridge_process = subprocess.Popen(
+def _start_bridge_process(test_env: dict, base_url: str):
+    return subprocess.Popen(
         [
             sys.executable,
             "desktop-tauri/src-tauri/python/compute_node_bridge.py",
@@ -287,6 +268,25 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         text=True,
         env=test_env,
     )
+
+
+@pytest.mark.e2e
+def test_landing_chat_mock_bridge_round_trip_api_v1(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """
+    Validate relay landing chat with the desktop bridge in explicit mock mode.
+    """
+
+    relay_process, _ = setup_servers
+    assert relay_process is not None
+
+    test_env = os.environ.copy()
+    test_env["TOKEN_PLACE_ENV"] = "testing"
+    test_env["USE_MOCK_LLM"] = "1"
+    bridge_process = _start_bridge_process(test_env, base_url)
 
     stdout_queue: "queue.Queue[str]" = queue.Queue()
     stderr_lines: list[str] = []
@@ -329,6 +329,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         start_deadline = time.time() + 25
         registered = False
         started = False
+        started_payload = None
 
         while time.time() < start_deadline:
             try:
@@ -349,6 +350,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
 
             if event_type == "started":
                 started = bool(payload.get("running"))
+                started_payload = payload
             if event_type == "status" and payload.get("registered") is True:
                 registered = True
                 break
@@ -357,6 +359,8 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
 
         assert started, "desktop bridge did not emit a started event"
         assert registered, "desktop bridge never reported relay registration"
+        assert isinstance(started_payload, dict)
+        assert str(started_payload.get("llama_module_path", "")).strip()
 
         page.goto(base_url)
         page.wait_for_load_state("networkidle")
@@ -387,6 +391,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         assert "capital" in assistant_text.lower()
         assert "Sorry, I encountered an issue generating a response." not in page.content()
         assert "Unknown streaming error" not in page.content()
+        assert assistant_text.strip() != "stub"
 
         assert len(v1_requests) >= 1
         assert v2_requests == []
@@ -406,6 +411,122 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
             except (BrokenPipeError, ValueError):
                 pass
 
+        try:
+            bridge_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            bridge_process.kill()
+
+
+@pytest.mark.e2e
+def test_landing_chat_real_inference_desktop_bridge_api_v1(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """
+    Validate real desktop-bridge inference wiring (no USE_MOCK_LLM).
+
+    Set RUN_REAL_DESKTOP_INFERENCE_E2E=1 to enable this test.
+    """
+
+    if os.environ.get("RUN_REAL_DESKTOP_INFERENCE_E2E", "0") != "1":
+        pytest.skip("Real desktop inference e2e disabled; set RUN_REAL_DESKTOP_INFERENCE_E2E=1")
+
+    relay_process, _ = setup_servers
+    assert relay_process is not None
+
+    test_env = os.environ.copy()
+    test_env["TOKEN_PLACE_ENV"] = "testing"
+    test_env["USE_MOCK_LLM"] = "0"
+    bridge_process = _start_bridge_process(test_env, base_url)
+
+    stdout_queue: "queue.Queue[str]" = queue.Queue()
+    stderr_lines: list[str] = []
+
+    def _drain_stream(stream, output_queue=None, collector=None):
+        for stream_line in iter(stream.readline, ""):
+            if output_queue is not None:
+                output_queue.put(stream_line)
+            if collector is not None:
+                collector.append(stream_line)
+
+    threading.Thread(
+        target=_drain_stream,
+        args=(bridge_process.stdout, stdout_queue, None),
+        daemon=True,
+    ).start()
+    threading.Thread(
+        target=_drain_stream,
+        args=(bridge_process.stderr, None, stderr_lines),
+        daemon=True,
+    ).start()
+
+    v1_requests = []
+    v2_requests = []
+
+    def _record_v1(route):
+        v1_requests.append(route.request)
+        route.continue_()
+
+    def _record_v2(route):
+        v2_requests.append(route.request.url)
+        route.continue_()
+
+    page.route("**/api/v1/chat/completions", _record_v1)
+    page.route("**/api/v2/chat/completions", _record_v2)
+
+    try:
+        start_deadline = time.time() + 25
+        started_payload = None
+        registered = False
+        while time.time() < start_deadline:
+            try:
+                payload = json.loads(stdout_queue.get(timeout=0.5))
+            except queue.Empty:
+                if bridge_process.poll() is not None:
+                    raise AssertionError(
+                        f"desktop bridge exited early rc={bridge_process.returncode}\n{''.join(stderr_lines)}"
+                    )
+                continue
+            except json.JSONDecodeError:
+                continue
+
+            if payload.get("type") == "started":
+                started_payload = payload
+            if payload.get("type") == "status" and payload.get("registered") is True:
+                registered = True
+                break
+            if payload.get("type") == "error":
+                raise AssertionError(f"desktop bridge error event: {payload}")
+
+        assert registered, "desktop bridge never reported relay registration"
+        assert started_payload, "desktop bridge did not emit started payload"
+        assert started_payload.get("llama_module_path"), "llama_module_path missing from startup payload"
+        assert "llama_cpp.py" not in str(started_payload.get("llama_module_path", "")).replace("\\", "/").rstrip("/"), (
+            "real inference must not import repo llama_cpp.py shim"
+        )
+
+        page.goto(base_url)
+        page.wait_for_load_state("networkidle")
+        page.locator("textarea").first.fill("hello relay + desktop bridge")
+        page.locator("button", has_text="Send").click()
+
+        assistant_message = page.locator(".assistant-message").last
+        assistant_message.wait_for(state="visible")
+        assistant_text = assistant_message.inner_text()
+
+        assert assistant_text.strip() != "stub"
+        assert "Mock Response" not in assistant_text
+        assert len(v1_requests) >= 1
+        assert v2_requests == []
+    finally:
+        if bridge_process.stdin:
+            try:
+                bridge_process.stdin.write(json.dumps({"type": "cancel"}) + "\n")
+                bridge_process.stdin.flush()
+                bridge_process.stdin.close()
+            except (BrokenPipeError, ValueError):
+                pass
         try:
             bridge_process.wait(timeout=10)
         except subprocess.TimeoutExpired:

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import api.v1.compute_provider as compute_provider
 from api.v1.compute_provider import (
     ComputeProviderError,
     DistributedApiV1ComputeProvider,
@@ -89,3 +90,32 @@ def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatc
             model_id="llama-3-8b-instruct",
             messages=[{"role": "user", "content": "hello"}],
         )
+
+
+def test_distributed_provider_without_fallback_never_imports_local_models(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    def fake_post(_url, json=None, timeout=None):
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"choices": [{"message": {"role": "assistant", "content": "remote"}}]},
+        )
+
+    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
+    monkeypatch.setattr(
+        "api.v1.compute_provider.LocalApiV1ComputeProvider.complete_chat",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("local provider should never be called when fallback disabled")
+        ),
+    )
+
+    provider = compute_provider.get_api_v1_compute_provider()
+    result = provider.complete_chat(
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    assert result["content"] == "remote"
+    compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -30,6 +30,27 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
             'error': str(exc),
         }
 
+    llama_module_path = str(getattr(llama_cpp, '__file__', 'unknown'))
+    repo_root = Path(__file__).resolve().parents[2]
+    repo_shim = str((repo_root / 'llama_cpp.py').resolve())
+    shim_imported = False
+    try:
+        shim_imported = str(Path(llama_module_path).resolve()) == repo_shim
+    except Exception:
+        shim_imported = llama_module_path == repo_shim
+
+    if shim_imported:
+        return {
+            'backend': 'missing',
+            'gpu_offload_supported': False,
+            'detected_device': 'none',
+            'interpreter': sys.executable,
+            'prefix': sys.prefix,
+            'llama_module_path': llama_module_path,
+            'repo_llama_cpp_shim_imported': True,
+            'error': 'repo-local llama_cpp.py shim imported instead of installed llama_cpp package',
+        }
+
     backend = 'cpu'
     cuda_markers = (
         'GGML_USE_CUDA',
@@ -70,7 +91,8 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'detected_device': backend if gpu_offload_supported else 'cpu',
         'interpreter': sys.executable,
         'prefix': sys.prefix,
-        'llama_module_path': getattr(llama_cpp, '__file__', 'unknown'),
+        'llama_module_path': llama_module_path,
+        'repo_llama_cpp_shim_imported': False,
         'error': None,
     }
 
@@ -466,6 +488,7 @@ class ModelManager:
                                 f"kv_cache={compute_plan['kv_cache_device']} "
                                 f"interpreter={runtime_identity.get('interpreter', sys.executable)} "
                                 f"llama_module_path={runtime_identity.get('llama_module_path', 'unknown')} "
+                                f"repo_llama_cpp_shim_imported={runtime_identity.get('repo_llama_cpp_shim_imported', False)} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
                             self.log_info("Llama model initialized successfully.")


### PR DESCRIPTION
### Motivation
- Landing-page relay chat could return the repo-local stub/mock response because runtime imports or test wiring allowed `llama_cpp.py` in the repo root to shadow the installed `llama-cpp-python` package.  
- The prior e2e test proved mock plumbing but did not guarantee real desktop inference, so encrypted API v1 payloads needed to be routed through the relay queue when running in relay mode.  
- Improve runtime diagnostics and make provider selection/import behavior explicit to prevent silent fallback to stub paths.

### Description
- Route encrypted API v1 chat completions through the relay queue when appropriate by adding `_try_relay_encrypted_round_trip()` and routing logic in `api/v1/routes.py`, with strict failure behavior when running inside `relay.py` and environment guards (`TOKENPLACE_API_V1_USE_RELAY_QUEUE`, `TOKENPLACE_API_V1_RELAY_TIMEOUT_SECONDS`).
- Make local generation imports lazy in `api/v1/compute_provider.py` by adding a compatibility `generate_response()` wrapper and delaying import of `api.v1.models` to avoid eager `llama_cpp` resolution; add `TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK=0` handling to allow truly no-fallback distributed mode and emit a provider selection info log.
- Harden runtime diagnostics in `utils/llm/model_manager.py` to detect and flag when the repo-local `llama_cpp.py` shim is imported and surface `repo_llama_cpp_shim_imported` in compute diagnostics to make shadowing obvious.
- E2E tests and fixtures updated: `tests/e2e/test_ui.py` split the previous bridge test into an explicit mock-bridge plumbing test and an environment-gated real-inference test (`RUN_REAL_DESKTOP_INFERENCE_E2E=1`) that asserts no stub/mocks are used and that only API v1 requests are observed; `tests/conftest.py` updated to allow focused real-inference runs to disable `USE_MOCK_LLM`; added a unit regression test ensuring distributed mode with fallback disabled does not invoke local generation.  

### Testing
- Installed focused verification deps: `pip install -r config/requirements_codex_verification.txt` (succeeded).  
- Unit tests run: `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` — passed.  
- Additional unit tests: `python -m pytest -q tests/unit/test_crypto_manager.py tests/unit/test_encryption_manager.py` — passed.  
- Focused e2e: `python -m pytest -q tests/e2e/test_ui.py -k "landing_chat"` initially errored in this session because Playwright browser binaries were not present (Playwright reports `playwright install` must be run); the e2e real-inference test is gated and requires `RUN_REAL_DESKTOP_INFERENCE_E2E=1` and available Playwright browsers to run.  
- Broad suite attempts (`python -m pytest -q tests -k "relay or chat or desktop or e2e or api"` / `./run_all_tests.sh`) began browser installation and ran many unit tests (unit suites passed), but some full e2e conversation-flow tests failed in this environment unrelated to the narrow changes; the new checks and assertions will cause the real-inference e2e to fail fast if the repo shim or mock path is used.  

Notes: focused changes are intentionally small and scoped to the files listed in the task; real-desktop e2e requires Playwright browser binaries and an environment with desktop runtime available to validate full Llama inference. If you want, I can follow up to (1) run the gated real-inference e2e in a CI job with Playwright browsers installed, or (2) add a short README note describing how to run the real-inference gate (`RUN_REAL_DESKTOP_INFERENCE_E2E=1` + `playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72a68eb68832fa24e32b5b4af28a3)