### PR TITLE
🛠️ fix: harden relay v1 desktop runtime path

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -1,8 +1,4 @@
-"""Compute provider abstraction for API v1 request handling.
-
-This module allows API v1 routes to target either local llama execution or a
-remote distributed compute-node endpoint while preserving a local fallback.
-"""
+"""Compute provider abstraction for API v1 request handling."""
 
 from __future__ import annotations
 
@@ -143,13 +139,41 @@ class FallbackApiV1ComputeProvider:
             )
 
 
+@dataclass(frozen=True)
+class StrictDistributedApiV1ComputeProvider:
+    """Distributed-only provider that refuses silent local fallback."""
+
+    primary: ApiV1ComputeProvider
+
+    def complete_chat(
+        self,
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        options: Optional[Dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        return self.primary.complete_chat(
+            model_id=model_id,
+            messages=messages,
+            options=options,
+        )
+
+
 @lru_cache(maxsize=8)
-def _build_api_v1_compute_provider(mode: str, distributed_url: str) -> ApiV1ComputeProvider:
+def _build_api_v1_compute_provider(
+    mode: str,
+    distributed_url: str,
+    allow_local_fallback: bool,
+) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
     local_provider = LocalApiV1ComputeProvider()
 
+    if mode == "auto":
+        mode = "distributed" if distributed_url else "local"
+
     if mode != "distributed":
+        logger.info("api.v1.compute_provider.selected provider=local mode=%s", mode)
         return local_provider
 
     if not distributed_url:
@@ -160,12 +184,28 @@ def _build_api_v1_compute_provider(mode: str, distributed_url: str) -> ApiV1Comp
         return local_provider
 
     distributed_provider = DistributedApiV1ComputeProvider(base_url=distributed_url)
-    return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
+    logger.info(
+        "api.v1.compute_provider.selected provider=distributed "
+        "distributed_url=%s local_fallback=%s",
+        distributed_url.rstrip("/"),
+        allow_local_fallback,
+    )
+    if allow_local_fallback:
+        return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
+    return StrictDistributedApiV1ComputeProvider(primary=distributed_provider)
 
 
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     """Resolve the active provider based on environment configuration."""
 
-    mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
+    mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "auto").strip().lower()
     distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
-    return _build_api_v1_compute_provider(mode, distributed_url)
+    if "TOKENPLACE_API_V1_DISTRIBUTED_ALLOW_LOCAL_FALLBACK" in os.environ:
+        allow_local_fallback = (
+            os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_ALLOW_LOCAL_FALLBACK") == "1"
+        )
+    else:
+        # Preserve explicit distributed mode behavior while making auto-distributed
+        # fail closed by default for relay/desktop wiring validation.
+        allow_local_fallback = mode == "distributed"
+    return _build_api_v1_compute_provider(mode, distributed_url, allow_local_fallback)

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -320,6 +320,12 @@ def _handle_chat_completion_request(data):
             ]
 
         log_info(f"Generating response using model {model_id}")
+        log_info(
+            "API v1 chat provider request "
+            f"mode={os.environ.get('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'auto')} "
+            f"distributed_url_set={bool(os.environ.get('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', '').strip())} "
+            f"mock_mode={os.environ.get('USE_MOCK_LLM') == '1'}"
+        )
         provider = get_api_v1_compute_provider()
         assistant_message = provider.complete_chat(
             model_id=model_id,
@@ -469,6 +475,12 @@ def _handle_text_completion_request(data):
             )
 
         log_info(f"Generating response using model {model_id}")
+        log_info(
+            "API v1 completion provider request "
+            f"mode={os.environ.get('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'auto')} "
+            f"distributed_url_set={bool(os.environ.get('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', '').strip())} "
+            f"mock_mode={os.environ.get('USE_MOCK_LLM') == '1'}"
+        )
         provider = get_api_v1_compute_provider()
         assistant_message = provider.complete_chat(
             model_id=model_id,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -105,6 +105,7 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
 
     return (
         "desktop.compute_node_bridge.runtime_state "
+        f"mock_mode={diagnostics.get('mock_mode')} "
         f"requested_mode={diagnostics.get('requested_mode')} "
         f"effective_mode={diagnostics.get('effective_mode')} "
         f"backend_selected={diagnostics.get('backend_selected')} "
@@ -167,6 +168,8 @@ def _sleep_with_cancel(seconds: float) -> bool:
 def run(args: argparse.Namespace) -> int:
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
+    llama_module_path = str(runtime_setup.get("llama_module_path", "missing"))
+    repo_llama_shim = llama_module_path.replace("\\", "/").lower().endswith("/llama_cpp.py")
     print(
         "desktop.runtime_setup "
         f"mode={args.mode} "
@@ -174,7 +177,8 @@ def run(args: argparse.Namespace) -> int:
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
         f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
-        f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
+        f"llama_module_path={llama_module_path} "
+        f"repo_llama_shim={repo_llama_shim} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
@@ -237,6 +241,7 @@ def run(args: argparse.Namespace) -> int:
 
     print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
+    diagnostics["mock_mode"] = bool(getattr(runtime.model_manager, "use_mock_llm", False))
     print(_runtime_diagnostics_summary(diagnostics), file=sys.stderr)
     last_error: Optional[str] = None
     emit(
@@ -256,6 +261,7 @@ def run(args: argparse.Namespace) -> int:
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "model_path": args.model,
+            "mock_mode": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
             "last_error": None,
         }
     )
@@ -308,6 +314,7 @@ def run(args: argparse.Namespace) -> int:
                 last_error = None
 
             diagnostics = compute_mode_diagnostics(runtime.model_manager)
+            diagnostics["mock_mode"] = bool(getattr(runtime.model_manager, "use_mock_llm", False))
             emit(
                 {
                     "type": "status",
@@ -327,6 +334,7 @@ def run(args: argparse.Namespace) -> int:
                     "interpreter": runtime_setup.get("interpreter", sys.executable),
                     "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
                     "model_path": args.model,
+                    "mock_mode": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
                     "last_error": last_error,
                 }
             )
@@ -339,6 +347,7 @@ def run(args: argparse.Namespace) -> int:
         runtime.stop()
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
+    diagnostics["mock_mode"] = bool(getattr(runtime.model_manager, "use_mock_llm", False))
     emit(
         {
             "type": "stopped",
@@ -356,6 +365,7 @@ def run(args: argparse.Namespace) -> int:
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "model_path": args.model,
+            "mock_mode": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
             "last_error": None,
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,8 @@ E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
-    "tests/e2e/test_ui.py::test_landing_chat_round_trip_with_desktop_bridge_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_mock_plumbing_with_desktop_bridge_api_v1",
+    "tests/e2e/test_ui.py::test_landing_chat_real_desktop_inference_requires_non_stub_runtime",
 }
 
 
@@ -166,7 +167,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
-        "landing_chat_round_trip_with_desktop_bridge_api_v1",
+        "landing_chat_mock_plumbing_with_desktop_bridge_api_v1",
+        "landing_chat_real_desktop_inference_requires_non_stub_runtime",
     }
     target_path = "tests/e2e/test_ui.py"
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -251,17 +251,12 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
 
 @pytest.mark.e2e
-def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
+def test_landing_chat_mock_plumbing_with_desktop_bridge_api_v1(
     page: Page,
     base_url: str,
     setup_servers,
 ):
-    """
-    Validate relay landing chat end-to-end through the desktop compute-node bridge.
-
-    This test intentionally avoids route mocking so CI verifies the real wiring:
-    browser UI -> relay.py API v1 -> relay sink/source -> desktop bridge runtime.
-    """
+    """Validate desktop bridge mock plumbing only (not real llama.cpp inference)."""
 
     relay_process, _ = setup_servers
     assert relay_process is not None
@@ -329,6 +324,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         start_deadline = time.time() + 25
         registered = False
         started = False
+        started_payload = {}
 
         while time.time() < start_deadline:
             try:
@@ -349,6 +345,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
 
             if event_type == "started":
                 started = bool(payload.get("running"))
+                started_payload = payload
             if event_type == "status" and payload.get("registered") is True:
                 registered = True
                 break
@@ -357,6 +354,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
 
         assert started, "desktop bridge did not emit a started event"
         assert registered, "desktop bridge never reported relay registration"
+        assert started_payload.get("mock_mode") is True
 
         page.goto(base_url)
         page.wait_for_load_state("networkidle")
@@ -397,6 +395,7 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
+        assert assistant_text != "stub"
     finally:
         if bridge_process.stdin:
             try:
@@ -406,6 +405,134 @@ def test_landing_chat_round_trip_with_desktop_bridge_api_v1(
             except (BrokenPipeError, ValueError):
                 pass
 
+        try:
+            bridge_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            bridge_process.kill()
+
+
+@pytest.mark.e2e
+def test_landing_chat_real_desktop_inference_requires_non_stub_runtime(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """
+    Validate real desktop inference wiring when an explicit local GGUF model is configured.
+    """
+
+    relay_process, _ = setup_servers
+    assert relay_process is not None
+
+    real_model_path = os.environ.get("TOKENPLACE_REAL_DESKTOP_E2E_MODEL_PATH", "").strip()
+    if not real_model_path or not os.path.exists(real_model_path):
+        pytest.skip(
+            "Real desktop inference e2e requires TOKENPLACE_REAL_DESKTOP_E2E_MODEL_PATH "
+            "pointing to a local GGUF model."
+        )
+
+    test_env = os.environ.copy()
+    test_env["TOKEN_PLACE_ENV"] = "testing"
+    test_env.pop("USE_MOCK_LLM", None)
+
+    bridge_process = subprocess.Popen(
+        [
+            sys.executable,
+            "desktop-tauri/src-tauri/python/compute_node_bridge.py",
+            "--model",
+            real_model_path,
+            "--mode",
+            "cpu",
+            "--relay-url",
+            base_url,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=test_env,
+    )
+
+    stdout_queue: "queue.Queue[str]" = queue.Queue()
+    stderr_lines: list[str] = []
+
+    def _drain_stream(stream, output_queue=None, collector=None):
+        for stream_line in iter(stream.readline, ""):
+            if output_queue is not None:
+                output_queue.put(stream_line)
+            if collector is not None:
+                collector.append(stream_line)
+
+    threading.Thread(target=_drain_stream, args=(bridge_process.stdout, stdout_queue, None), daemon=True).start()
+    threading.Thread(target=_drain_stream, args=(bridge_process.stderr, None, stderr_lines), daemon=True).start()
+
+    v1_requests = []
+    v2_requests = []
+
+    page.route("**/api/v1/chat/completions", lambda route: (v1_requests.append(route.request), route.continue_()))
+    page.route("**/api/v2/chat/completions", lambda route: (v2_requests.append(route.request.url), route.continue_()))
+
+    try:
+        start_deadline = time.time() + 35
+        registered = False
+        started_payload = {}
+        while time.time() < start_deadline:
+            try:
+                line = stdout_queue.get(timeout=0.5)
+            except queue.Empty:
+                if bridge_process.poll() is not None:
+                    raise AssertionError(
+                        f"desktop bridge exited early rc={bridge_process.returncode}\n{''.join(stderr_lines)}"
+                    )
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") == "started":
+                started_payload = payload
+            if payload.get("type") == "status" and payload.get("registered") is True:
+                registered = True
+                break
+            if payload.get("type") == "error":
+                raise AssertionError(f"desktop bridge error event: {payload}")
+
+        assert registered, "desktop bridge never reported relay registration"
+        assert started_payload.get("mock_mode") is False
+        llama_module_path = str(started_payload.get("llama_module_path") or "")
+        assert not llama_module_path.replace("\\", "/").lower().endswith("/llama_cpp.py")
+
+        page.goto(base_url)
+        page.wait_for_load_state("networkidle")
+        page.locator("textarea").first.fill("hello relay + real desktop inference")
+        page.locator("button", has_text="Send").click()
+
+        assistant_message = page.locator(".assistant-message").last
+        assistant_message.wait_for(state="visible")
+
+        page.wait_for_function(
+            """
+            ({ selector }) => {
+                const nodes = document.querySelectorAll(selector);
+                return nodes.length > 0 && nodes[nodes.length - 1].textContent.trim().length > 0;
+            }
+            """,
+            arg={"selector": ".assistant-message"},
+        )
+        assistant_text = assistant_message.inner_text().strip()
+        assert assistant_text
+        assert assistant_text != "stub"
+        assert "Mock Response:" not in assistant_text
+        assert len(v1_requests) >= 1
+        assert v2_requests == []
+    finally:
+        if bridge_process.stdin:
+            try:
+                bridge_process.stdin.write(json.dumps({"type": "cancel"}) + "\n")
+                bridge_process.stdin.flush()
+                bridge_process.stdin.close()
+            except (BrokenPipeError, ValueError):
+                pass
         try:
             bridge_process.wait(timeout=10)
         except subprocess.TimeoutExpired:

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -7,6 +7,8 @@ from api.v1.compute_provider import (
     DistributedApiV1ComputeProvider,
     FallbackApiV1ComputeProvider,
     LocalApiV1ComputeProvider,
+    StrictDistributedApiV1ComputeProvider,
+    _build_api_v1_compute_provider,
 )
 
 
@@ -89,3 +91,31 @@ def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatc
             model_id="llama-3-8b-instruct",
             messages=[{"role": "user", "content": "hello"}],
         )
+
+
+def test_build_provider_auto_mode_prefers_distributed_when_url_present():
+    provider = _build_api_v1_compute_provider("auto", "https://compute.example", False)
+    assert isinstance(provider, StrictDistributedApiV1ComputeProvider)
+
+
+def test_build_provider_distributed_without_fallback_does_not_call_local(monkeypatch):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=503, json=lambda: {"error": "down"}),
+    )
+
+    local_called = {"value": False}
+
+    def _should_not_call_local(_model, messages, **_kwargs):
+        local_called["value"] = True
+        return messages
+
+    monkeypatch.setattr("api.v1.compute_provider.generate_response", _should_not_call_local)
+
+    provider = _build_api_v1_compute_provider("distributed", "https://compute.example", False)
+    with pytest.raises(ComputeProviderError):
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    assert local_called["value"] is False

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -361,6 +361,27 @@ class TestModelManager:
             assert llm is not None
             assert llm == mock_llama
 
+    def test_get_llm_instance_rejects_repo_llama_shim(self, model_manager):
+        """Real runtime fails closed when llama_cpp resolves to the repo shim."""
+        fake_runtime_identity = {
+            'backend': 'cpu',
+            'gpu_offload_supported': False,
+            'detected_device': 'cpu',
+            'interpreter': sys.executable,
+            'prefix': sys.prefix,
+            'llama_module_path': str(Path.cwd() / 'llama_cpp.py'),
+            'error': None,
+        }
+        model_manager.use_mock_llm = False
+        model_manager.llm = None
+
+        with patch('os.path.exists', return_value=True), \
+             patch('llama_cpp.Llama', return_value=MagicMock(), create=True), \
+             patch('utils.llm.model_manager.detect_llama_runtime_capabilities', return_value=fake_runtime_identity):
+            llm = model_manager.get_llm_instance()
+
+        assert llm is None
+
     @patch('os.path.exists')
     def test_get_llm_instance_real_mode_no_model(self, mock_exists, model_manager):
         """Test get_llm_instance in real mode when the model file doesn't exist."""

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -18,6 +18,17 @@ from utils.system import resource_monitor
 logger = logging.getLogger('model_manager')
 
 
+def _looks_like_repo_llama_shim(module_path: Optional[str]) -> bool:
+    """Return True when runtime imported the repository-local llama_cpp shim."""
+
+    if not module_path:
+        return False
+    normalized = Path(module_path).resolve().as_posix().lower()
+    if not normalized.endswith("/llama_cpp.py"):
+        return False
+    return "/site-packages/" not in normalized and "/dist-packages/" not in normalized
+
+
 def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     """Return backend/offload capability details from the installed llama_cpp runtime."""
     try:
@@ -454,6 +465,13 @@ class ModelManager:
                             compute_plan['device_name'] = 'unreported'
                             self.last_compute_diagnostics = compute_plan
                             runtime_identity = detect_llama_runtime_capabilities()
+                            if _looks_like_repo_llama_shim(
+                                runtime_identity.get('llama_module_path')
+                            ):
+                                raise RuntimeError(
+                                    "Detected repository-local llama_cpp.py shim in runtime import path; "
+                                    "refusing to start real inference runtime."
+                                )
                             self.log_info(
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "


### PR DESCRIPTION
### Motivation
- Prevent false-success paths where the repo-local `llama_cpp.py` shim or mock plumbing silently satisfy what should be real desktop LLM inference.
- Make API v1 compute-provider selection explicit and observable so `relay` + desktop bridge wiring cannot be masked by local fallbacks.
- Improve runtime diagnostics (mock mode, llama module path, repo-shim detection) to make miswiring easy to detect in logs.

### Description
- Add strict distributed-provider variant and change provider resolution to `auto` by default, preferring distributed when `TOKENPLACE_DISTRIBUTED_COMPUTE_URL` is set and making auto-distributed fail-closed unless fallback is explicitly allowed via `TOKENPLACE_API_V1_DISTRIBUTED_ALLOW_LOCAL_FALLBACK`; preserve legacy fallback for explicit `distributed` when the env override is set. (`api/v1/compute_provider.py`)
- Emit concise provider selection diagnostics at the route level for chat/completion requests indicating provider mode, whether a distributed URL is configured, and whether mock mode is active. (`api/v1/routes.py`)
- Add runtime guard in the model manager to detect repository-local `llama_cpp.py` shim imports and refuse to initialize real inference if the shim is detected. (`utils/llm/model_manager.py`)
- Expand desktop bridge diagnostics to include `mock_mode` and an explicit `repo_llama_shim` indicator, and include `mock_mode` in `started`/`status`/`stopped` events to aid triage. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Replace the previous single landing-chat e2e with two honest tests: a mock-plumbing desktop-bridge test and an environment-gated real-inference desktop-bridge test that requires `TOKENPLACE_REAL_DESKTOP_E2E_MODEL_PATH` and asserts non-`"stub"` output and only `/api/v1` use. Also update focused e2e gating. (`tests/e2e/test_ui.py`, `tests/conftest.py`)
- Add targeted unit tests to lock behavior: provider selection contract and strict-distributed behavior plus model-manager rejection of repo shim imports. (`tests/unit/test_api_v1_compute_provider.py`, `tests/unit/test_model_manager.py`)

### Testing
- Ran targeted unit tests that exercise the changed logic and regressions: `python -m pytest -q tests/unit/test_api_v1_compute_provider.py tests/unit/test_model_manager.py -k "compute_provider or rejects_repo_llama_shim"` which passed.
- Ran additional unit suites: `python -m pytest -q tests/unit/test_crypto_manager.py tests/unit/test_encryption_manager.py` which passed.
- Attempted the landing-page e2e (`python -m pytest -q tests/e2e/test_ui.py -k "landing_chat"`); initial runs failed due to Playwright/browser binaries not installed in the environment (this change includes an environment-gated real-inference e2e that requires `TOKENPLACE_REAL_DESKTOP_E2E_MODEL_PATH`).
- Ran the project-wide test runner (`./run_all_tests.sh`) as part of verification; the script installed Playwright browsers but the full CI run surfaced unrelated environment/dependency gaps (missing `bandit`, optional `openai` test dependency, and other infra issues) outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72a68eb68832fa24e32b5b4af28a3)