### PR TITLE
Enforce non-streaming relay landing chat and surface API v1 provider diagnostics

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -35,6 +35,9 @@ class ApiV1ComputeProvider(Protocol):
     ) -> dict[str, Any]:
         """Return an assistant message payload compatible with OpenAI chat responses."""
 
+    def diagnostics(self) -> Dict[str, Any]:
+        """Return resolved-provider diagnostics for request-path assertions."""
+
 
 @dataclass(frozen=True)
 class LocalApiV1ComputeProvider:
@@ -54,6 +57,14 @@ class LocalApiV1ComputeProvider:
         if not isinstance(assistant_message, dict):
             raise ComputeProviderError("assistant response must be a message object")
         return assistant_message
+
+    def diagnostics(self) -> Dict[str, Any]:
+        return {
+            "resolved_provider": "local",
+            "resolved_provider_class": self.__class__.__name__,
+            "resolved_target": "in-process",
+            "fallback_enabled": False,
+        }
 
 
 @dataclass(frozen=True)
@@ -113,6 +124,14 @@ class DistributedApiV1ComputeProvider:
 
         return message
 
+    def diagnostics(self) -> Dict[str, Any]:
+        return {
+            "resolved_provider": "distributed",
+            "resolved_provider_class": self.__class__.__name__,
+            "resolved_target": self.base_url.rstrip("/"),
+            "fallback_enabled": False,
+        }
+
 
 @dataclass(frozen=True)
 class FallbackApiV1ComputeProvider:
@@ -141,6 +160,17 @@ class FallbackApiV1ComputeProvider:
                 messages=messages,
                 options=options,
             )
+
+    def diagnostics(self) -> Dict[str, Any]:
+        primary = self.primary.diagnostics()
+        fallback = self.fallback.diagnostics()
+        return {
+            "resolved_provider": "distributed_with_local_fallback",
+            "resolved_provider_class": self.__class__.__name__,
+            "resolved_target": primary.get("resolved_target"),
+            "fallback_enabled": True,
+            "fallback_provider": fallback.get("resolved_provider"),
+        }
 
 
 @lru_cache(maxsize=8)

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -321,7 +321,11 @@ def _handle_chat_completion_request(data):
 
         log_info(f"Generating response using model {model_id}")
         provider = get_api_v1_compute_provider()
-        log_info(f"API v1 compute provider selected: {provider.__class__.__name__}")
+        provider_diagnostics = provider.diagnostics()
+        log_info(
+            "API v1 compute provider resolved: "
+            f"{json.dumps(provider_diagnostics, sort_keys=True)}"
+        )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,
@@ -381,9 +385,17 @@ def _handle_chat_completion_request(data):
                     status_code=500,
                 )
 
-            return jsonify({"encrypted": True, "data": encrypted_response})
+            response = jsonify({"encrypted": True, "data": encrypted_response})
+            response.headers["X-TokenPlace-ApiV1-Provider"] = str(
+                provider_diagnostics.get("resolved_provider", "unknown")
+            )
+            return response
 
-        return jsonify(response_data)
+        response = jsonify(response_data)
+        response.headers["X-TokenPlace-ApiV1-Provider"] = str(
+            provider_diagnostics.get("resolved_provider", "unknown")
+        )
+        return response
 
     except ValidationError as e:
         return format_error_response(
@@ -471,6 +483,11 @@ def _handle_text_completion_request(data):
 
         log_info(f"Generating response using model {model_id}")
         provider = get_api_v1_compute_provider()
+        provider_diagnostics = provider.diagnostics()
+        log_info(
+            "API v1 completions provider resolved: "
+            f"{json.dumps(provider_diagnostics, sort_keys=True)}"
+        )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,
@@ -507,9 +524,17 @@ def _handle_text_completion_request(data):
                     error_type="server_error",
                     status_code=500,
                 )
-            return jsonify({"encrypted": True, "data": encrypted_response})
+            response = jsonify({"encrypted": True, "data": encrypted_response})
+            response.headers["X-TokenPlace-ApiV1-Provider"] = str(
+                provider_diagnostics.get("resolved_provider", "unknown")
+            )
+            return response
 
-        return jsonify(response_data)
+        response = jsonify(response_data)
+        response.headers["X-TokenPlace-ApiV1-Provider"] = str(
+            provider_diagnostics.get("resolved_provider", "unknown")
+        )
+        return response
 
     except ModelError as e:
         log_warning(f"Model error during response generation: {e.message}")

--- a/static/chat.js
+++ b/static/chat.js
@@ -429,88 +429,14 @@ new Vue({
         },
 
 
-        calculateTypingChunkSize(content) {
-            if (!content || typeof content !== 'string') {
-                return 1;
-            }
-            const length = content.length;
-            if (length <= 24) {
-                return 1;
-            }
-            if (length <= 96) {
-                return 2;
-            }
-            if (length <= 180) {
-                return 3;
-            }
-            return Math.min(6, Math.ceil(length / 48));
-        },
-
         appendAssistantMessage(message) {
             if (!message || typeof message !== 'object') {
                 return;
             }
-
-            const content = message.content;
-            const typingFactory = typeof ChatTypingEffect !== 'undefined'
-                && ChatTypingEffect
-                && typeof ChatTypingEffect.createTypingAnimator === 'function';
-
-            const shouldAnimate = typingFactory && typeof content === 'string' && content.trim().length > 0;
-
-            if (!shouldAnimate) {
-                const entry = Object.assign({}, message, { isTyping: false });
-                this.chatHistory.push(entry);
-                return;
-            }
-
-            const finalText = content;
-            const entry = Object.assign({}, message, {
-                content: finalText,
-                displayContent: '',
-                isTyping: true
-            });
-            const chunkSize = this.calculateTypingChunkSize(finalText);
-
-            const animator = ChatTypingEffect.createTypingAnimator({
-                fullText: finalText,
-                chunkSize,
-                onUpdate: (partial) => {
-                    entry.displayContent = partial;
-                },
-                onComplete: () => {
-                    entry.isTyping = false;
-                    if (entry._animator && typeof entry._animator.cancel === 'function') {
-                        entry._animator.cancel();
-                    }
-                    delete entry._animator;
-                    if (typeof this.$delete === 'function') {
-                        this.$delete(entry, 'displayContent');
-                    } else {
-                        delete entry.displayContent;
-                    }
-                },
-                schedule: (fn, delay) => {
-                    if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
-                        return window.setTimeout(fn, delay);
-                    }
-                    return setTimeout(fn, delay);
-                },
-                cancelScheduled: (id) => {
-                    if (typeof window !== 'undefined' && typeof window.clearTimeout === 'function') {
-                        window.clearTimeout(id);
-                    } else {
-                        clearTimeout(id);
-                    }
-                }
-            });
-
-            entry._animator = animator;
+            // Relay landing-page chat in v0.1.0 is API v1-only and non-streaming.
+            // Render assistant content atomically once the JSON response arrives.
+            const entry = Object.assign({}, message, { isTyping: false });
             this.chatHistory.push(entry);
-
-            this.$nextTick(() => {
-                animator.start();
-            });
         },
 
         getDisplayContent(message) {
@@ -583,16 +509,7 @@ new Vue({
             }
         }
     },
-    beforeDestroy() {
-        if (!Array.isArray(this.chatHistory)) {
-            return;
-        }
-        this.chatHistory.forEach((entry) => {
-            if (entry && entry._animator && typeof entry._animator.cancel === 'function') {
-                entry._animator.cancel();
-            }
-        });
-    },
+    beforeDestroy() {},
     updated() {
         this.$nextTick(() => {
             const container = this.$el.querySelector(".chat-container");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,9 @@ FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
+REAL_DESKTOP_RELAY_E2E_NODEID = (
+    "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1"
+)
 
 
 def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bool:
@@ -187,6 +190,19 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
 
     return False
 
+
+def _is_real_desktop_bridge_landing_chat_request(request: pytest.FixtureRequest) -> bool:
+    selected_nodeids = {item.nodeid for item in request.session.items}
+    if REAL_DESKTOP_RELAY_E2E_NODEID in selected_nodeids:
+        return True
+
+    invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
+    return any(
+        arg == REAL_DESKTOP_RELAY_E2E_NODEID
+        or "landing_chat_real_inference_with_desktop_bridge_api_v1" in arg
+        for arg in invocation_args
+    )
+
 @pytest.fixture(scope="module")
 def setup_servers(
     request: pytest.FixtureRequest,
@@ -202,6 +218,7 @@ def setup_servers(
     5. Cleans up the processes after tests
     """
     focused_e2e_only = _is_focused_relay_landing_chat_request(request)
+    real_desktop_bridge_e2e = _is_real_desktop_bridge_landing_chat_request(request)
 
     # Fixes the Codex-focused skip case where this guard skipped runs when
     # RUN_RELAY_REGISTRATION_TESTS != "1" and focused detection did not
@@ -217,17 +234,23 @@ def setup_servers(
     # Ensure environment variables are set properly
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
-    test_env["USE_MOCK_LLM"] = "1"  # This is the key setting for mocking the LLM
+    test_env["USE_MOCK_LLM"] = "0" if real_desktop_bridge_e2e else "1"
 
     # Start the relay server with the --use_mock_llm flag
+    relay_cmd = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]
+    if not real_desktop_bridge_e2e:
+        relay_cmd.append("--use_mock_llm")
     relay_process = subprocess.Popen(
-        [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT), "--use_mock_llm"],
+        relay_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         env=test_env
     )
-    print(f"Started relay server on port {E2E_RELAY_PORT} with --use_mock_llm flag")
+    print(
+        f"Started relay server on port {E2E_RELAY_PORT} "
+        f"with USE_MOCK_LLM={test_env['USE_MOCK_LLM']}"
+    )
 
     # Wait for relay to start - increased wait time
     time.sleep(3)

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -200,7 +200,10 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
         route.fulfill(
             status=200,
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "X-TokenPlace-ApiV1-Provider": "distributed",
+            },
             body=json.dumps(
                 {
                     "encrypted": True,
@@ -245,6 +248,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
         arg={"selector": ".assistant-message", "expectedText": "Relay chat path restored."},
     )
     assert "Relay chat path restored." in assistant_message.inner_text()
+    assert assistant_message.inner_text().strip() == "Relay chat path restored."
     assert "Sorry, I encountered an issue generating a response." not in page.content()
     assert v2_requests == []
 
@@ -261,12 +265,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     This test intentionally avoids route mocking so it verifies the real wiring:
     browser UI -> relay.py API v1 -> relay sink/source -> desktop bridge runtime.
     """
-    if os.environ.get("RUN_REAL_DESKTOP_INFERENCE_E2E", "0") != "1":
-        pytest.skip(
-            "Real desktop inference e2e is disabled by default; "
-            "set RUN_REAL_DESKTOP_INFERENCE_E2E=1 to run this test."
-        )
-
     relay_process, _ = setup_servers
     assert relay_process is not None
 
@@ -275,12 +273,12 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     test_env["USE_MOCK_LLM"] = "0"
     preprovisioned_model_path = os.environ.get("TOKENPLACE_REAL_E2E_MODEL_PATH", "").strip()
     if not preprovisioned_model_path:
-        pytest.skip(
-            "Set TOKENPLACE_REAL_E2E_MODEL_PATH to an existing GGUF path for "
-            "RUN_REAL_DESKTOP_INFERENCE_E2E=1 runs."
+        pytest.fail(
+            "TOKENPLACE_REAL_E2E_MODEL_PATH must be set for the always-on relay "
+            "landing-page desktop-bridge e2e guardrail."
         )
     if not os.path.isfile(preprovisioned_model_path):
-        pytest.skip(
+        pytest.fail(
             "TOKENPLACE_REAL_E2E_MODEL_PATH must point to an existing model file "
             f"(got: {preprovisioned_model_path})."
         )
@@ -381,6 +379,21 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         page.goto(base_url)
         page.wait_for_load_state("networkidle")
+        page.evaluate(
+            """
+            () => {
+                window.__assistantMutationLengths = [];
+                const observer = new MutationObserver(() => {
+                    const nodes = document.querySelectorAll('.assistant-message');
+                    if (!nodes.length) return;
+                    const latest = nodes[nodes.length - 1];
+                    window.__assistantMutationLengths.push((latest.textContent || '').length);
+                });
+                observer.observe(document.body, { subtree: true, childList: true, characterData: true });
+                window.__assistantMutationObserver = observer;
+            }
+            """
+        )
 
         textarea = page.locator("textarea").first
         textarea.fill("What is the capital of France? Respond with one word.")
@@ -406,6 +419,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assistant_text = assistant_message.inner_text()
         assert "paris" in assistant_text.lower()
+        assert assistant_text.strip().lower() != "stub"
         assert "Sorry, I encountered an issue generating a response." not in page.content()
         assert "Unknown streaming error" not in page.content()
 
@@ -418,7 +432,30 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
+        mutation_lengths = page.evaluate(
+            "() => Array.isArray(window.__assistantMutationLengths) ? window.__assistantMutationLengths : []"
+        )
+        assert mutation_lengths, "expected assistant DOM mutation activity"
+        assert mutation_lengths[-1] == len(assistant_text)
+        assert len(set(mutation_lengths)) <= 2, (
+            "relay landing-page API v1 flow must render non-streaming responses "
+            "without incremental letter-by-letter output"
+        )
     finally:
+        try:
+            page.evaluate(
+                """
+                () => {
+                    if (window.__assistantMutationObserver) {
+                        window.__assistantMutationObserver.disconnect();
+                        delete window.__assistantMutationObserver;
+                    }
+                }
+                """
+            )
+        except Exception:
+            pass
+
         if bridge_process.stdin:
             try:
                 bridge_process.stdin.write(json.dumps({"type": "cancel"}) + "\n")

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -102,6 +102,7 @@ def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
         provider = compute_provider.get_api_v1_compute_provider()
 
         assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.diagnostics()["resolved_provider"] == "distributed"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
@@ -117,3 +118,14 @@ def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monk
             compute_provider.get_api_v1_compute_provider()
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_fallback_provider_reports_resolved_diagnostics():
+    provider = FallbackApiV1ComputeProvider(
+        primary=DistributedApiV1ComputeProvider(base_url="https://node-a.example"),
+        fallback=LocalApiV1ComputeProvider(),
+    )
+    diagnostics = provider.diagnostics()
+    assert diagnostics["resolved_provider"] == "distributed_with_local_fallback"
+    assert diagnostics["resolved_target"] == "https://node-a.example"
+    assert diagnostics["fallback_provider"] == "local"

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -24,3 +24,6 @@ def test_landing_chat_js_avoids_relay_v2_streaming_path():
     assert "sendStreamingMessage(" not in chat_js, (
         "landing chat must not include streaming relay send helper call chain"
     )
+    assert "ChatTypingEffect.createTypingAnimator" not in chat_js, (
+        "landing chat relay API v1 path must not animate responses incrementally"
+    )


### PR DESCRIPTION
### Motivation
- Landing-page chat was rendering assistant replies letter-by-letter and returning the repo `"stub"` result in some flows, which violates the v0.1.0 contract that relay landing-page traffic must be API v1-only and non-streaming. 
- Tests and diagnostics were insufficient to prove the browser -> relay(API v1) -> desktop bridge runtime path; the real-desktop e2e was gated/skippable and could silently fall back to local/mock behavior.
- The goal is to make the landing-path render atomically, report the resolved provider used, and ensure an always-on guarded e2e that fails loudly when the real desktop bridge proof is misconfigured.

### Description
- UI: removed incremental typing animation from `static/chat.js` so landing-page assistant responses are appended atomically for the API v1 path (non-streaming UI behavior). 
- Provider diagnostics: added a `diagnostics()` method to API v1 compute providers (`LocalApiV1ComputeProvider`, `DistributedApiV1ComputeProvider`, `FallbackApiV1ComputeProvider`) and used it in `api/v1/routes.py` to log the resolved provider and attach `X-TokenPlace-ApiV1-Provider` to chat/completions responses for explicit evidence of the resolved path. 
- E2E fixture and tests: updated `tests/conftest.py` to detect the real-desktop-bridge landing test and start the relay without forced mock mode when that test is targeted; hardened `tests/e2e/test_ui.py` to fail-loud when `TOKENPLACE_REAL_E2E_MODEL_PATH` is missing, assert non-`"stub"` assistant output, assert API v1-only (no v2 calls), and assert non-incremental DOM mutation behaviour (guard against letter-by-letter rendering). 
- Unit tests: added assertions in `tests/unit/test_api_v1_compute_provider.py` for the new provider diagnostics and tightened the UI touch test in `tests/unit/test_touch_ui.py` to ensure the typing animator is not used for the relay landing-path.

### Testing
- Ran JavaScript tests via `npm run test:js` (invoked as part of the test runner); the JS suite passed in this environment. 
- Attempted targeted Python tests: `python -m pytest -q tests/unit/test_api_v1_compute_provider.py`, `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py`, and `python -m pytest -q tests/e2e/test_ui.py -k "landing_chat"`, but they failed to run in this environment due to missing Python dependencies (`ModuleNotFoundError: No module named 'requests'` and missing `cryptography`), not due to the changes themselves. 
- Ran the full runner `./run_all_tests.sh`; the JS portions passed but several Python test stages failed to start because required Python packages were not installed in this execution environment (same missing `requests` / `cryptography` errors). 

If CI installs the repository Python deps, the updated unit and e2e tests exercise and assert: an API v1 `/api/v1/chat/completions` request, zero `/api/v2` calls, `use_mock_llm` false for the real-desktop-bridge guardrail run, no `"stub"` assistant content, and non-streaming / atomic assistant rendering in the landing-page path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90ed1fd50832fa6fe7d87372415e4)