### PR TITLE
🛠️ harden: enforce/diagnose API v1 desktop route + make landing chat non‑streaming

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -35,6 +35,9 @@ class ApiV1ComputeProvider(Protocol):
     ) -> dict[str, Any]:
         """Return an assistant message payload compatible with OpenAI chat responses."""
 
+    def diagnostics(self) -> Dict[str, Any]:
+        """Return resolved provider diagnostics for request-path observability."""
+
 
 @dataclass(frozen=True)
 class LocalApiV1ComputeProvider:
@@ -54,6 +57,14 @@ class LocalApiV1ComputeProvider:
         if not isinstance(assistant_message, dict):
             raise ComputeProviderError("assistant response must be a message object")
         return assistant_message
+
+    def diagnostics(self) -> Dict[str, Any]:
+        return {
+            "provider_class": self.__class__.__name__,
+            "resolved_path": "local",
+            "distributed_target": None,
+            "fallback_enabled": False,
+        }
 
 
 @dataclass(frozen=True)
@@ -113,6 +124,14 @@ class DistributedApiV1ComputeProvider:
 
         return message
 
+    def diagnostics(self) -> Dict[str, Any]:
+        return {
+            "provider_class": self.__class__.__name__,
+            "resolved_path": "distributed",
+            "distributed_target": self.base_url.rstrip("/"),
+            "fallback_enabled": False,
+        }
+
 
 @dataclass(frozen=True)
 class FallbackApiV1ComputeProvider:
@@ -141,6 +160,19 @@ class FallbackApiV1ComputeProvider:
                 messages=messages,
                 options=options,
             )
+
+    def diagnostics(self) -> Dict[str, Any]:
+        primary_diag = (
+            self.primary.diagnostics()
+            if hasattr(self.primary, "diagnostics")
+            else {"provider_class": self.primary.__class__.__name__, "distributed_target": None}
+        )
+        return {
+            "provider_class": self.__class__.__name__,
+            "resolved_path": "distributed_with_local_fallback",
+            "distributed_target": primary_diag.get("distributed_target"),
+            "fallback_enabled": True,
+        }
 
 
 @lru_cache(maxsize=8)

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -321,7 +321,14 @@ def _handle_chat_completion_request(data):
 
         log_info(f"Generating response using model {model_id}")
         provider = get_api_v1_compute_provider()
-        log_info(f"API v1 compute provider selected: {provider.__class__.__name__}")
+        provider_diagnostics = provider.diagnostics()
+        log_info(
+            "API v1 compute provider resolved: "
+            f"class={provider_diagnostics.get('provider_class')} "
+            f"path={provider_diagnostics.get('resolved_path')} "
+            f"target={provider_diagnostics.get('distributed_target') or 'none'} "
+            f"fallback_enabled={provider_diagnostics.get('fallback_enabled')}"
+        )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,
@@ -381,9 +388,29 @@ def _handle_chat_completion_request(data):
                     status_code=500,
                 )
 
-            return jsonify({"encrypted": True, "data": encrypted_response})
+            encrypted_response_payload = jsonify({"encrypted": True, "data": encrypted_response})
+            encrypted_response_payload.headers[
+                "X-Tokenplace-Api-V1-Provider-Class"
+            ] = str(provider_diagnostics.get("provider_class", "unknown"))
+            encrypted_response_payload.headers[
+                "X-Tokenplace-Api-V1-Resolved-Path"
+            ] = str(provider_diagnostics.get("resolved_path", "unknown"))
+            encrypted_response_payload.headers[
+                "X-Tokenplace-Api-V1-Distributed-Target"
+            ] = str(provider_diagnostics.get("distributed_target") or "")
+            return encrypted_response_payload
 
-        return jsonify(response_data)
+        response = jsonify(response_data)
+        response.headers["X-Tokenplace-Api-V1-Provider-Class"] = str(
+            provider_diagnostics.get("provider_class", "unknown")
+        )
+        response.headers["X-Tokenplace-Api-V1-Resolved-Path"] = str(
+            provider_diagnostics.get("resolved_path", "unknown")
+        )
+        response.headers["X-Tokenplace-Api-V1-Distributed-Target"] = str(
+            provider_diagnostics.get("distributed_target") or ""
+        )
+        return response
 
     except ValidationError as e:
         return format_error_response(
@@ -471,6 +498,14 @@ def _handle_text_completion_request(data):
 
         log_info(f"Generating response using model {model_id}")
         provider = get_api_v1_compute_provider()
+        provider_diagnostics = provider.diagnostics()
+        log_info(
+            "API v1 text completions provider resolved: "
+            f"class={provider_diagnostics.get('provider_class')} "
+            f"path={provider_diagnostics.get('resolved_path')} "
+            f"target={provider_diagnostics.get('distributed_target') or 'none'} "
+            f"fallback_enabled={provider_diagnostics.get('fallback_enabled')}"
+        )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,
@@ -507,9 +542,29 @@ def _handle_text_completion_request(data):
                     error_type="server_error",
                     status_code=500,
                 )
-            return jsonify({"encrypted": True, "data": encrypted_response})
+            encrypted_response_payload = jsonify({"encrypted": True, "data": encrypted_response})
+            encrypted_response_payload.headers[
+                "X-Tokenplace-Api-V1-Provider-Class"
+            ] = str(provider_diagnostics.get("provider_class", "unknown"))
+            encrypted_response_payload.headers[
+                "X-Tokenplace-Api-V1-Resolved-Path"
+            ] = str(provider_diagnostics.get("resolved_path", "unknown"))
+            encrypted_response_payload.headers[
+                "X-Tokenplace-Api-V1-Distributed-Target"
+            ] = str(provider_diagnostics.get("distributed_target") or "")
+            return encrypted_response_payload
 
-        return jsonify(response_data)
+        response = jsonify(response_data)
+        response.headers["X-Tokenplace-Api-V1-Provider-Class"] = str(
+            provider_diagnostics.get("provider_class", "unknown")
+        )
+        response.headers["X-Tokenplace-Api-V1-Resolved-Path"] = str(
+            provider_diagnostics.get("resolved_path", "unknown")
+        )
+        response.headers["X-Tokenplace-Api-V1-Distributed-Target"] = str(
+            provider_diagnostics.get("distributed_target") or ""
+        )
+        return response
 
     except ModelError as e:
         log_warning(f"Model error during response generation: {e.message}")

--- a/relay.py
+++ b/relay.py
@@ -238,6 +238,33 @@ def _load_upstream_config() -> Dict[str, Any]:
 UPSTREAM_CONFIG = _load_upstream_config()
 
 
+def _configure_api_v1_compute_provider_defaults() -> None:
+    """Default relay-hosted API v1 traffic to distributed compute-node routing."""
+
+    if os.environ.get("TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED", "0") != "1":
+        return
+
+    if not os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip():
+        os.environ["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "distributed"
+
+    if not os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip():
+        os.environ["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = UPSTREAM_CONFIG["upstream_url"].rstrip("/")
+
+    if not os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "").strip():
+        os.environ["TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"] = "0"
+
+    LOGGER.info(
+        "relay.api_v1.provider_defaults "
+        "provider=%s target=%s fallback=%s",
+        os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER"),
+        os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL"),
+        os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"),
+    )
+
+
+_configure_api_v1_compute_provider_defaults()
+
+
 def _load_public_base_url() -> str | None:
     """Return the externally reachable relay URL when configured."""
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -429,88 +429,14 @@ new Vue({
         },
 
 
-        calculateTypingChunkSize(content) {
-            if (!content || typeof content !== 'string') {
-                return 1;
-            }
-            const length = content.length;
-            if (length <= 24) {
-                return 1;
-            }
-            if (length <= 96) {
-                return 2;
-            }
-            if (length <= 180) {
-                return 3;
-            }
-            return Math.min(6, Math.ceil(length / 48));
-        },
-
         appendAssistantMessage(message) {
             if (!message || typeof message !== 'object') {
                 return;
             }
-
-            const content = message.content;
-            const typingFactory = typeof ChatTypingEffect !== 'undefined'
-                && ChatTypingEffect
-                && typeof ChatTypingEffect.createTypingAnimator === 'function';
-
-            const shouldAnimate = typingFactory && typeof content === 'string' && content.trim().length > 0;
-
-            if (!shouldAnimate) {
-                const entry = Object.assign({}, message, { isTyping: false });
-                this.chatHistory.push(entry);
-                return;
-            }
-
-            const finalText = content;
-            const entry = Object.assign({}, message, {
-                content: finalText,
-                displayContent: '',
-                isTyping: true
-            });
-            const chunkSize = this.calculateTypingChunkSize(finalText);
-
-            const animator = ChatTypingEffect.createTypingAnimator({
-                fullText: finalText,
-                chunkSize,
-                onUpdate: (partial) => {
-                    entry.displayContent = partial;
-                },
-                onComplete: () => {
-                    entry.isTyping = false;
-                    if (entry._animator && typeof entry._animator.cancel === 'function') {
-                        entry._animator.cancel();
-                    }
-                    delete entry._animator;
-                    if (typeof this.$delete === 'function') {
-                        this.$delete(entry, 'displayContent');
-                    } else {
-                        delete entry.displayContent;
-                    }
-                },
-                schedule: (fn, delay) => {
-                    if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
-                        return window.setTimeout(fn, delay);
-                    }
-                    return setTimeout(fn, delay);
-                },
-                cancelScheduled: (id) => {
-                    if (typeof window !== 'undefined' && typeof window.clearTimeout === 'function') {
-                        window.clearTimeout(id);
-                    } else {
-                        clearTimeout(id);
-                    }
-                }
-            });
-
-            entry._animator = animator;
+            // Relay-path landing chat in v0.1.0 is API v1-only and non-streaming.
+            // Render assistant content atomically once the JSON response is complete.
+            const entry = Object.assign({}, message, { isTyping: false });
             this.chatHistory.push(entry);
-
-            this.$nextTick(() => {
-                animator.start();
-            });
         },
 
         getDisplayContent(message) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,9 @@ FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
+ALWAYS_ON_RELAY_E2E_NODEID = (
+    "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1"
+)
 
 
 def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bool:
@@ -202,11 +205,17 @@ def setup_servers(
     5. Cleans up the processes after tests
     """
     focused_e2e_only = _is_focused_relay_landing_chat_request(request)
+    selected_nodeids = {item.nodeid for item in request.session.items}
+    requires_always_on_guardrail = ALWAYS_ON_RELAY_E2E_NODEID in selected_nodeids
 
     # Fixes the Codex-focused skip case where this guard skipped runs when
     # RUN_RELAY_REGISTRATION_TESTS != "1" and focused detection did not
     # recognize `tests/e2e/test_ui.py -k landing_chat_uses_api_v1_only_non_streaming`.
-    if os.environ.get("RUN_RELAY_REGISTRATION_TESTS", "0") != "1" and not focused_e2e_only:
+    if (
+        os.environ.get("RUN_RELAY_REGISTRATION_TESTS", "0") != "1"
+        and not focused_e2e_only
+        and not requires_always_on_guardrail
+    ):
         pytest.skip(
             "Relay/server registration smoke tests are disabled by default; "
             "set RUN_RELAY_REGISTRATION_TESTS=1 to enable.",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -261,12 +261,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     This test intentionally avoids route mocking so it verifies the real wiring:
     browser UI -> relay.py API v1 -> relay sink/source -> desktop bridge runtime.
     """
-    if os.environ.get("RUN_REAL_DESKTOP_INFERENCE_E2E", "0") != "1":
-        pytest.skip(
-            "Real desktop inference e2e is disabled by default; "
-            "set RUN_REAL_DESKTOP_INFERENCE_E2E=1 to run this test."
-        )
-
     relay_process, _ = setup_servers
     assert relay_process is not None
 
@@ -274,16 +268,14 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0"
     preprovisioned_model_path = os.environ.get("TOKENPLACE_REAL_E2E_MODEL_PATH", "").strip()
-    if not preprovisioned_model_path:
-        pytest.skip(
-            "Set TOKENPLACE_REAL_E2E_MODEL_PATH to an existing GGUF path for "
-            "RUN_REAL_DESKTOP_INFERENCE_E2E=1 runs."
-        )
-    if not os.path.isfile(preprovisioned_model_path):
-        pytest.skip(
-            "TOKENPLACE_REAL_E2E_MODEL_PATH must point to an existing model file "
-            f"(got: {preprovisioned_model_path})."
-        )
+    assert preprovisioned_model_path, (
+        "TOKENPLACE_REAL_E2E_MODEL_PATH must be configured for the always-on "
+        "desktop bridge landing chat e2e guardrail."
+    )
+    assert os.path.isfile(preprovisioned_model_path), (
+        "TOKENPLACE_REAL_E2E_MODEL_PATH must point to an existing model file "
+        f"(got: {preprovisioned_model_path})."
+    )
 
     bridge_process = subprocess.Popen(
         [
@@ -328,6 +320,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
     v1_requests = []
     v2_requests = []
+    v1_response_headers = []
 
     def record_v1_request(route):
         v1_requests.append(route.request)
@@ -339,6 +332,12 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
     page.route("**/api/v1/chat/completions", record_v1_request)
     page.route("**/api/v2/chat/completions", record_v2_request)
+    page.on(
+        "response",
+        lambda response: v1_response_headers.append(dict(response.headers))
+        if "/api/v1/chat/completions" in response.url
+        else None,
+    )
 
     try:
         start_deadline = time.time() + 25
@@ -406,11 +405,35 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assistant_text = assistant_message.inner_text()
         assert "paris" in assistant_text.lower()
+        assert assistant_text.strip().lower() != "stub"
         assert "Sorry, I encountered an issue generating a response." not in page.content()
         assert "Unknown streaming error" not in page.content()
 
         assert len(v1_requests) >= 1
         assert v2_requests == []
+        assert v1_response_headers, "Expected at least one /api/v1/chat/completions response"
+        resolved_paths = {
+            headers.get("x-tokenplace-api-v1-resolved-path", "").strip().lower()
+            for headers in v1_response_headers
+        }
+        assert resolved_paths == {"distributed"}, (
+            "Landing chat should resolve API v1 requests through distributed provider only"
+        )
+        assert all(
+            headers.get("x-tokenplace-api-v1-provider-class") == "DistributedApiV1ComputeProvider"
+            for headers in v1_response_headers
+        )
+
+        # Relay landing-page path is intentionally non-streaming; assistant text
+        # should render atomically without UI typing deltas.
+        samples = []
+        for _ in range(5):
+            samples.append(assistant_message.inner_text())
+            time.sleep(0.05)
+        assert all(sample == samples[0] for sample in samples), (
+            "Assistant text changed after initial render; non-streaming flow should be atomic."
+        )
+        assert assistant_text in samples
 
         encrypted_request = v1_requests[0].post_data_json
         assert encrypted_request.get("encrypted") is True

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -117,3 +117,21 @@ def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monk
             compute_provider.get_api_v1_compute_provider()
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_distributed_provider_diagnostics_reflect_resolved_runtime(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+        diagnostics = provider.diagnostics()
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    assert diagnostics["provider_class"] == "DistributedApiV1ComputeProvider"
+    assert diagnostics["resolved_path"] == "distributed"
+    assert diagnostics["distributed_target"] == "https://node-a.example"
+    assert diagnostics["fallback_enabled"] is False

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -24,3 +24,6 @@ def test_landing_chat_js_avoids_relay_v2_streaming_path():
     assert "sendStreamingMessage(" not in chat_js, (
         "landing chat must not include streaming relay send helper call chain"
     )
+    assert "ChatTypingEffect.createTypingAnimator" not in chat_js, (
+        "landing chat must not animate assistant text incrementally for relay API v1 responses"
+    )


### PR DESCRIPTION
### Motivation
- Ensure the relay landing-page chat path uses the intended API v1 -> desktop/distributed compute route (no silent local/mock/stub fallback) and surface the *resolved* provider path for observability. 
- Prevent letter-by-letter incremental assistant rendering on the relay landing-page by guaranteeing non-streaming API v1 UI behavior. 
- Convert the real-desktop e2e proof from opt-in/skippable to an always-on guardrail that fails loudly when misconfigured.

### Description
- Add provider diagnostics to API v1 compute providers via a `diagnostics()` contract on `ApiV1ComputeProvider` and concrete implementations for `LocalApiV1ComputeProvider`, `DistributedApiV1ComputeProvider`, and `FallbackApiV1ComputeProvider` so code can report the resolved provider instance and path. (`api/v1/compute_provider.py`)
- Surface resolved provider diagnostics in logs and attach headers `X-Tokenplace-Api-V1-Provider-Class`, `X-Tokenplace-Api-V1-Resolved-Path`, and `X-Tokenplace-Api-V1-Distributed-Target` on `/api/v1/chat/completions` and legacy completions responses (including encrypted responses) so browser tests can assert the actual provider used. (`api/v1/routes.py`)
- Add relay-side defaults that make API v1 traffic default to distributed provider and disallow fallback when explicitly enforced by CI via `TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED=1`, so enforced runs fail closed instead of drifting to local/mock. (`relay.py`) 
- Remove the landing-page incremental typing animation and ensure assistant content for the relay landing-page is appended atomically (non-streaming) in the landing UI. (`static/chat.js`) 
- Strengthen tests and fixtures to make the real-desktop landing-chat guardrail observable and fail loudly when misconfigured: the desktop bridge e2e now asserts `TOKENPLACE_REAL_E2E_MODEL_PATH` is present and points to a file, records `/api/v1/chat/completions` response headers and enforces non-streaming rendering and non-`"stub"` output; `tests/conftest.py` updated so the always-on e2e node is not skipped when collected. Also added a unit test that asserts distributed provider diagnostics and a unit UI test to assert the typing animator path is absent. (`tests/e2e/test_ui.py`, `tests/conftest.py`, `tests/unit/test_api_v1_compute_provider.py`, `tests/unit/test_touch_ui.py`) 

### Testing
- Ran static/compile checks: `python -m py_compile api/v1/compute_provider.py api/v1/routes.py relay.py tests/e2e/test_ui.py tests/conftest.py` — succeeded.
- Ran focused test commands and CI harness: `./run_all_tests.sh` — JavaScript tests passed, but full Python test execution failed in this environment due to missing runtime dependencies (`requests`, `cryptography`) and missing `pre-commit` binary; these missing packages prevented execution of the Python unit/e2e suites here. 
- Attempted `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and `python -m pytest -q tests/e2e/test_ui.py -k "landing_chat"` — both could not run to completion due to `ModuleNotFoundError: No module named 'requests'` in the test fixture environment. 

Notes: the change is intentionally conservative and gated: relay enforcement of distributed-only API v1 behavior is enabled only when `TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED=1` so CI can opt into failing-closed guardrails; the e2e guardrail requires `TOKENPLACE_REAL_E2E_MODEL_PATH` to be set to a real model artifact so CI runs must supply that artifact (or configure dedicated runners) to keep the always-on proof durable. Full Python test verification should be re-run in CI (or locally) with `requests` and `cryptography` installed and with `TOKENPLACE_REAL_E2E_MODEL_PATH` configured to validate the end-to-end guardrail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90ed1fd50832fa6fe7d87372415e4)