### PR TITLE
🔧 Route landing-page API v1 chat through registered relay compute nodes

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -32,8 +32,17 @@ class ApiV1ComputeProvider(Protocol):
         model_id: str,
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
-    ) -> dict[str, Any]:
-        """Return an assistant message payload compatible with OpenAI chat responses."""
+    ) -> "ApiV1ComputeResult":
+        """Return assistant payload + backend diagnostics for API v1 chat responses."""
+
+
+@dataclass(frozen=True)
+class ApiV1ComputeResult:
+    """Structured result for API v1 compute execution."""
+
+    assistant_message: dict[str, Any]
+    backend_path: str
+    backend_provider: str
 
 
 @dataclass(frozen=True)
@@ -46,14 +55,18 @@ class LocalApiV1ComputeProvider:
         model_id: str,
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
-    ) -> dict[str, Any]:
+    ) -> ApiV1ComputeResult:
         updated_messages = generate_response(model_id, messages, **(options or {}))
         if not updated_messages:
             raise ComputeProviderError("model returned an empty message list")
         assistant_message = updated_messages[-1]
         if not isinstance(assistant_message, dict):
             raise ComputeProviderError("assistant response must be a message object")
-        return assistant_message
+        return ApiV1ComputeResult(
+            assistant_message=assistant_message,
+            backend_path="local",
+            backend_provider=self.__class__.__name__,
+        )
 
 
 @dataclass(frozen=True)
@@ -69,7 +82,7 @@ class DistributedApiV1ComputeProvider:
         model_id: str,
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
-    ) -> dict[str, Any]:
+    ) -> ApiV1ComputeResult:
         payload: Dict[str, Any] = {
             "model": model_id,
             "messages": messages,
@@ -111,7 +124,59 @@ class DistributedApiV1ComputeProvider:
         if not isinstance(message, dict):
             raise ComputeProviderError("distributed provider response missing message")
 
-        return message
+        return ApiV1ComputeResult(
+            assistant_message=message,
+            backend_path="distributed",
+            backend_provider=self.__class__.__name__,
+        )
+
+
+@dataclass(frozen=True)
+class RelayRegisteredApiV1ComputeProvider:
+    """Provider that routes API v1 chat to a registered relay compute node."""
+
+    relay_base_url: str
+    timeout_seconds: float = 60.0
+
+    def complete_chat(
+        self,
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        options: Optional[Dict[str, Any]] = None,
+    ) -> ApiV1ComputeResult:
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "messages": messages,
+            "stream": False,
+            "options": {k: v for k, v in (options or {}).items() if k != "stream"},
+        }
+        try:
+            response = requests.post(
+                f"{self.relay_base_url.rstrip('/')}/relay/api-v1/chat/dispatch",
+                json=payload,
+                timeout=self.timeout_seconds,
+            )
+        except Exception as exc:
+            raise ComputeProviderError(f"relay registered-node request failed: {exc}") from exc
+
+        if response.status_code != 200:
+            raise ComputeProviderError(
+                f"relay registered-node provider returned status {response.status_code}"
+            )
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise ComputeProviderError("relay registered-node provider returned non-JSON response") from exc
+
+        message = body.get("message")
+        if not isinstance(message, dict):
+            raise ComputeProviderError("relay registered-node response missing message")
+        return ApiV1ComputeResult(
+            assistant_message=message,
+            backend_path="relay_registered_node",
+            backend_provider=self.__class__.__name__,
+        )
 
 
 @dataclass(frozen=True)
@@ -127,7 +192,7 @@ class FallbackApiV1ComputeProvider:
         model_id: str,
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
-    ) -> dict[str, Any]:
+    ) -> ApiV1ComputeResult:
         try:
             return self.primary.complete_chat(
                 model_id=model_id,
@@ -136,10 +201,15 @@ class FallbackApiV1ComputeProvider:
             )
         except ComputeProviderError as exc:
             logger.warning("distributed compute fallback triggered: %s", exc)
-            return self.fallback.complete_chat(
+            fallback_result = self.fallback.complete_chat(
                 model_id=model_id,
                 messages=messages,
                 options=options,
+            )
+            return ApiV1ComputeResult(
+                assistant_message=fallback_result.assistant_message,
+                backend_path=f"fallback:{fallback_result.backend_path}",
+                backend_provider=fallback_result.backend_provider,
             )
 
 
@@ -150,6 +220,19 @@ def _build_api_v1_compute_provider(
     """Create a compute provider for the normalized environment inputs."""
 
     local_provider = LocalApiV1ComputeProvider()
+
+    if mode == "relay_registered":
+        if not distributed_url:
+            raise ComputeProviderError(
+                "TOKENPLACE_API_V1_COMPUTE_PROVIDER=relay_registered requires "
+                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL to point at relay base URL"
+            )
+        logger.info(
+            "api_v1.compute_provider.selected provider=relay_registered mode=%s target=%s",
+            mode,
+            distributed_url.rstrip("/"),
+        )
+        return RelayRegisteredApiV1ComputeProvider(relay_base_url=distributed_url)
 
     if mode != "distributed":
         logger.info("api_v1.compute_provider.selected provider=local mode=%s", mode)
@@ -214,6 +297,8 @@ def get_api_v1_resolved_provider_path(provider: ApiV1ComputeProvider) -> str:
         return "distributed_with_local_fallback"
     if isinstance(provider, DistributedApiV1ComputeProvider):
         return "distributed"
+    if isinstance(provider, RelayRegisteredApiV1ComputeProvider):
+        return "relay_registered"
     if isinstance(provider, LocalApiV1ComputeProvider):
         return "local"
     return "unknown"

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -331,11 +331,12 @@ def _handle_chat_completion_request(data):
             "api_v1_provider_selection provider_class=%s resolved_provider_path=%s stream_mode=non-streaming"
             % (resolved_provider_name, resolved_provider_path)
         )
-        assistant_message = provider.complete_chat(
+        compute_result = provider.complete_chat(
             model_id=model_id,
             messages=messages,
             options=_extract_chat_completion_options(data),
         )
+        assistant_message = compute_result.assistant_message
         log_info("Response generated successfully")
 
         tool_calls = assistant_message.get("tool_calls")
@@ -391,14 +392,18 @@ def _handle_chat_completion_request(data):
                 )
 
             response = jsonify({"encrypted": True, "data": encrypted_response})
-            response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
-            response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Provider"] = compute_result.backend_provider
+            response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = compute_result.backend_path
+            response.headers["X-Tokenplace-API-V1-Configured-Provider"] = resolved_provider_name
+            response.headers["X-Tokenplace-API-V1-Configured-Provider-Path"] = resolved_provider_path
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
-        response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
-        response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Provider"] = compute_result.backend_provider
+        response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = compute_result.backend_path
+        response.headers["X-Tokenplace-API-V1-Configured-Provider"] = resolved_provider_name
+        response.headers["X-Tokenplace-API-V1-Configured-Provider-Path"] = resolved_provider_path
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 
@@ -494,11 +499,12 @@ def _handle_text_completion_request(data):
             "api_v1_provider_selection provider_class=%s resolved_provider_path=%s stream_mode=non-streaming"
             % (resolved_provider_name, resolved_provider_path)
         )
-        assistant_message = provider.complete_chat(
+        compute_result = provider.complete_chat(
             model_id=model_id,
             messages=messages,
             options=_extract_chat_completion_options(data),
         )
+        assistant_message = compute_result.assistant_message
         log_info("Response generated successfully")
 
         response_data = {
@@ -537,8 +543,10 @@ def _handle_text_completion_request(data):
             return response
 
         response = jsonify(response_data)
-        response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
-        response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Provider"] = compute_result.backend_provider
+        response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = compute_result.backend_path
+        response.headers["X-Tokenplace-API-V1-Configured-Provider"] = resolved_provider_name
+        response.headers["X-Tokenplace-API-V1-Configured-Provider-Path"] = resolved_provider_path
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urlsplit, urlunsplit
 
+import requests
+
 if __package__ in (None, ""):
     script_dir = str(Path(__file__).resolve().parent)
     if script_dir not in sys.path:
@@ -281,9 +283,10 @@ def run(args: argparse.Namespace) -> int:
             relay_response = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
             legacy_payload = is_legacy_relay_payload(relay_response)
+            api_v1_chat_request = relay_response.get("api_v1_chat_request")
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
             relay_error = _relay_error_message(relay_response)
-            registered = relay_error is None and (legacy_payload or heartbeat_ack)
+            registered = relay_error is None and (legacy_payload or heartbeat_ack or isinstance(api_v1_chat_request, dict))
 
             print(
                 "desktop.compute_node_bridge.relay_poll "
@@ -320,6 +323,56 @@ def run(args: argparse.Namespace) -> int:
                         "desktop.compute_node_bridge.process_request.ok",
                         file=sys.stderr,
                     )
+            elif isinstance(api_v1_chat_request, dict):
+                request_id = api_v1_chat_request.get("request_id")
+                request_messages = api_v1_chat_request.get("messages")
+                request_model = api_v1_chat_request.get("model")
+                request_options = api_v1_chat_request.get("options")
+                print(
+                    "desktop.compute_node_bridge.process_api_v1_request.start "
+                    f"request_id={request_id}",
+                    file=sys.stderr,
+                )
+                result_payload: Dict[str, Any] = {"request_id": request_id}
+                try:
+                    if not isinstance(request_messages, list):
+                        raise ValueError("api_v1 request missing messages list")
+                    if not isinstance(request_model, str) or not request_model.strip():
+                        raise ValueError("api_v1 request missing model")
+
+                    if isinstance(request_options, dict):
+                        llama_history = runtime.model_manager.llama_cpp_get_response(
+                            request_messages, **request_options
+                        )
+                    else:
+                        llama_history = runtime.model_manager.llama_cpp_get_response(request_messages)
+                    if not llama_history or not isinstance(llama_history[-1], dict):
+                        raise ValueError("api_v1 request produced invalid assistant message")
+                    result_payload["message"] = llama_history[-1]
+                    last_error = None
+                    print(
+                        "desktop.compute_node_bridge.process_api_v1_request.ok "
+                        f"request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                except Exception as exc:
+                    result_payload["error"] = str(exc)
+                    last_error = str(exc)
+                    print(
+                        "desktop.compute_node_bridge.process_api_v1_request.failed "
+                        f"request_id={request_id} error={exc}",
+                        file=sys.stderr,
+                    )
+                headers = {}
+                relay_token = runtime.relay_client.server_registration_token
+                if relay_token:
+                    headers["X-Relay-Server-Token"] = relay_token
+                requests.post(
+                    f"{active_relay_url.rstrip('/')}/relay/api-v1/chat/result",
+                    json=result_payload,
+                    headers=headers or None,
+                    timeout=runtime.relay_client._request_timeout,
+                )
             else:
                 last_error = None
 

--- a/relay.py
+++ b/relay.py
@@ -379,6 +379,10 @@ def _validate_server_registration():
 known_servers = {}
 client_inference_requests = {}
 client_responses = {}
+api_v1_chat_requests = {}
+api_v1_chat_responses = {}
+api_v1_chat_response_lock = threading.Lock()
+api_v1_chat_response_condition = threading.Condition(api_v1_chat_response_lock)
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -425,6 +429,7 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
             "age_seconds": round(_server_ping_age_seconds(payload.get("last_ping")), 3),
             "next_ping_in_x_seconds": payload.get("last_ping_duration"),
             "queue_depth": len(client_inference_requests.get(server_public_key, [])),
+            "api_v1_queue_depth": len(api_v1_chat_requests.get(server_public_key, [])),
         })
     diagnostics.sort(key=lambda node: node["server_public_key"])
     return diagnostics
@@ -435,6 +440,7 @@ def _unregister_server(server_public_key: str) -> bool:
 
     removed = known_servers.pop(server_public_key, None) is not None
     client_inference_requests.pop(server_public_key, None)
+    api_v1_chat_requests.pop(server_public_key, None)
 
     with stream_lock:
         stale_session_ids = [
@@ -804,6 +810,7 @@ def sink():
 
     # Check if there are any client requests for this server
     queued_requests = client_inference_requests.get(public_key, [])
+    queued_api_v1_requests = api_v1_chat_requests.get(public_key, [])
     if queued_requests:
         batch = []
         while queued_requests and len(batch) < max_batch_size:
@@ -831,8 +838,88 @@ def sink():
 
         if max_batch_size > 1:
             response_data['batch'] = batch
+    elif queued_api_v1_requests:
+        response_data["api_v1_chat_request"] = queued_api_v1_requests.pop(0)
 
     return jsonify(response_data)
+
+
+@app.route('/relay/api-v1/chat/dispatch', methods=['POST'])
+def relay_api_v1_chat_dispatch():
+    """Dispatch a non-streaming API v1 chat request to a registered compute node."""
+    _evict_stale_servers()
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    model = data.get("model")
+    messages = data.get("messages")
+    if not isinstance(model, str) or not model.strip():
+        return jsonify({'error': 'Invalid model'}), 400
+    if not isinstance(messages, list) or not messages:
+        return jsonify({'error': 'Invalid messages'}), 400
+
+    server_public_key = data.get("server_public_key")
+    if server_public_key is None:
+        if not known_servers:
+            return jsonify({'error': 'No registered compute nodes available'}), 503
+        server_public_key = secrets.choice(list(known_servers.keys()))
+    if server_public_key not in known_servers:
+        return jsonify({'error': 'Server with the specified public key not found'}), 404
+
+    request_id = secrets.token_urlsafe(18)
+    request_payload = {
+        "request_id": request_id,
+        "model": model,
+        "messages": messages,
+        "options": data.get("options") if isinstance(data.get("options"), dict) else {},
+    }
+    api_v1_chat_requests.setdefault(server_public_key, []).append(request_payload)
+
+    timeout_seconds = float(data.get("timeout_seconds") or 65.0)
+    deadline = time.time() + max(timeout_seconds, 0.1)
+    with api_v1_chat_response_condition:
+        while time.time() < deadline:
+            response_payload = api_v1_chat_responses.pop(request_id, None)
+            if response_payload is not None:
+                if response_payload.get("error"):
+                    return jsonify({"error": response_payload["error"]}), 502
+                return jsonify(response_payload), 200
+            remaining = deadline - time.time()
+            api_v1_chat_response_condition.wait(timeout=min(max(remaining, 0), 0.5))
+
+    return jsonify({'error': 'Timed out waiting for registered compute-node response'}), 504
+
+
+@app.route('/relay/api-v1/chat/result', methods=['POST'])
+def relay_api_v1_chat_result():
+    """Accept API v1 chat completion results from registered compute nodes."""
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+    request_id = data.get("request_id")
+    if not isinstance(request_id, str) or not request_id.strip():
+        return jsonify({'error': 'Invalid request_id'}), 400
+
+    payload = {"request_id": request_id}
+    message = data.get("message")
+    error = data.get("error")
+    if isinstance(message, dict):
+        payload["message"] = message
+    elif error:
+        payload["error"] = str(error)
+    else:
+        return jsonify({'error': 'Invalid result payload'}), 400
+
+    with api_v1_chat_response_condition:
+        api_v1_chat_responses[request_id] = payload
+        api_v1_chat_response_condition.notify_all()
+
+    return jsonify({'message': 'API v1 result received'}), 200
 
 
 @app.route('/unregister', methods=['POST'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,10 +220,10 @@ def setup_servers(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0" if run_real_bridge_e2e else "1"
-    # NOTE: keep API v1 provider selection local for the desktop-bridge landing-page
-    # guardrail. Pointing TOKENPLACE_DISTRIBUTED_COMPUTE_URL at the relay causes
-    # recursive /api/v1/chat/completions self-calls and deterministic failures.
     test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
+    if run_real_bridge_e2e:
+        test_env["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "relay_registered"
+        test_env["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = E2E_BASE_URL
 
     # Start the relay server with the --use_mock_llm flag
     relay_command = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -459,16 +459,16 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_diagnostics = (
             "landing-page real-provider guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"stream_mode={stream_mode!r}; expected provider_class='RelayRegisteredApiV1ComputeProvider', "
+            "resolved_provider_path='relay_registered_node', stream_mode='non-streaming'"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
+        assert provider_class == "RelayRegisteredApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
+        assert resolved_provider_path == "relay_registered_node", (
             "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+            f"'relay_registered_node'. {provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
+        if runtime_supports_real_inference and resolved_provider_path != "relay_registered_node":
             assert assistant_text.strip().lower() != "stub", (
                 "assistant response must not be stub when runtime reports real inference support "
                 f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -49,7 +49,8 @@ def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
     assert captured["json"]["stream"] is False
     assert captured["json"]["temperature"] == 0.2
     assert "stream" not in captured["json"] or captured["json"]["stream"] is False
-    assert message["content"] == "distributed response"
+    assert message.assistant_message["content"] == "distributed response"
+    assert message.backend_path == "distributed"
 
 
 def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):
@@ -75,7 +76,8 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(mon
         messages=[{"role": "user", "content": "hello"}],
     )
 
-    assert result == fallback_message
+    assert result.assistant_message == fallback_message
+    assert result.backend_path == "fallback:local"
 
 
 def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatch):
@@ -129,3 +131,36 @@ def test_get_api_v1_resolved_provider_path_labels_instance_types():
     assert get_api_v1_resolved_provider_path(distributed) == "distributed"
     assert get_api_v1_resolved_provider_path(fallback) == "distributed_with_local_fallback"
     assert get_api_v1_resolved_provider_path(object()) == "unknown"
+
+
+def test_relay_registered_compute_provider_posts_dispatch_contract(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"message": {"role": "assistant", "content": "from relay node"}},
+        )
+
+    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
+
+    provider = compute_provider.RelayRegisteredApiV1ComputeProvider(
+        relay_base_url="https://relay.example",
+        timeout_seconds=9,
+    )
+    result = provider.complete_chat(
+        model_id="llama",
+        messages=[{"role": "user", "content": "hi"}],
+        options={"temperature": 0.3, "stream": True},
+    )
+
+    assert captured["url"] == "https://relay.example/relay/api-v1/chat/dispatch"
+    assert captured["timeout"] == 9
+    assert captured["json"]["stream"] is False
+    assert captured["json"]["options"]["temperature"] == 0.3
+    assert "stream" not in captured["json"]["options"]
+    assert result.assistant_message["content"] == "from relay node"
+    assert result.backend_path == "relay_registered_node"

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -7,6 +7,7 @@ import pytest
 import relay
 from relay import app
 from api.v1 import compute_provider, routes
+from api.v1.compute_provider import ApiV1ComputeResult
 from api.v1.models import ModelError
 from api.v1.validation import ValidationError
 
@@ -190,7 +191,11 @@ def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monk
         def complete_chat(self, model_id, messages, options):
             assert model_id == "llama-3-8b-instruct"
             assert isinstance(options, dict)
-            return {"role": "assistant", "content": "Paris"}
+            return ApiV1ComputeResult(
+                assistant_message={"role": "assistant", "content": "Paris"},
+                backend_path="distributed",
+                backend_provider="_DistributedProvider",
+            )
 
     payload = {
         "model": "llama-3-8b-instruct",
@@ -215,7 +220,11 @@ def test_chat_completion_encrypted_response_sets_provider_headers(client, monkey
         def complete_chat(self, model_id, messages, options):
             assert model_id == "llama-3-8b-instruct"
             assert isinstance(options, dict)
-            return {"role": "assistant", "content": "Paris"}
+            return ApiV1ComputeResult(
+                assistant_message={"role": "assistant", "content": "Paris"},
+                backend_path="distributed",
+                backend_provider="_DistributedProvider",
+            )
 
     encrypted_payload = {
         "ciphertext": base64.b64encode(
@@ -265,7 +274,11 @@ def test_legacy_completion_sets_provider_headers(client, monkeypatch):
             assert model_id == "llama-3-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
-            return {"role": "assistant", "content": "hello"}
+            return ApiV1ComputeResult(
+                assistant_message={"role": "assistant", "content": "hello"},
+                backend_path="local",
+                backend_provider="_LocalProvider",
+            )
 
     payload = {
         "model": "llama-3-8b-instruct",
@@ -290,7 +303,11 @@ def test_legacy_completion_encrypted_response_sets_provider_headers(client, monk
             assert model_id == "llama-3-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
-            return {"role": "assistant", "content": "hello"}
+            return ApiV1ComputeResult(
+                assistant_message={"role": "assistant", "content": "hello"},
+                backend_path="local",
+                backend_provider="_LocalProvider",
+            )
 
     payload = {
         "model": "llama-3-8b-instruct",

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -103,6 +103,30 @@ class StreamingRuntime(FakeRuntime):
         return self.relay_client.process_client_request(payload)
 
 
+class ApiV1Runtime(FakeRuntime):
+    def __init__(self, _config):
+        self.model_manager = FakeModelManager()
+        self.relay_client = SimpleNamespace(
+            relay_url='https://token.place',
+            _request_timeout=2,
+            server_registration_token='',
+        )
+        self._responses = [
+            {
+                'next_ping_in_x_seconds': 0,
+                'api_v1_chat_request': {
+                    'request_id': 'req-1',
+                    'model': 'llama',
+                    'messages': [{'role': 'user', 'content': 'hi'}],
+                    'options': {'temperature': 0.2},
+                },
+            },
+        ]
+        self.model_manager.llama_cpp_get_response = (
+            lambda messages, **_kwargs: messages + [{'role': 'assistant', 'content': 'hello'}]
+        )
+
+
 class ProcessingFailureRuntime(FakeRuntime):
     def __init__(self, _config):
         self.model_manager = FakeModelManager()
@@ -599,6 +623,45 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
     assert endpoint == '/stream/source'
     assert payload['stream'] is True
     assert payload['stream_session_id'] == 'session-123'
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    status_events = [event for event in events if event['type'] == 'status']
+    assert any(event.get('registered') is True for event in status_events)
+
+
+def test_run_api_v1_payload_posts_result_to_relay(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1Runtime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+    sleep_counter = {'count': 0}
+
+    def fake_sleep_with_cancel(_seconds):
+        sleep_counter['count'] += 1
+        return sleep_counter['count'] > 1
+
+    posted = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted['url'] = url
+        posted['json'] = json
+        posted['headers'] = headers
+        posted['timeout'] = timeout
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', fake_sleep_with_cancel)
+    monkeypatch.setattr(compute_node_bridge.requests, 'post', fake_post)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert posted['url'] == 'https://token.place/relay/api-v1/chat/result'
+    assert posted['json']['request_id'] == 'req-1'
+    assert posted['json']['message']['content'] == 'hello'
 
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']


### PR DESCRIPTION
### Motivation
- The landing-page UI already posts to `/api/v1/chat/completions` while the desktop bridge only handled legacy `/sink` payloads, allowing a registered desktop to appear healthy but never actually serve landing-page requests.
- Provide a minimal migration path so API v1 landing-page chat is handled end-to-end by a registered desktop compute node without adding streaming/v2 semantics.
- Emit stable runtime diagnostics so callers can tell whether the response was served by local, distributed, or relay-registered compute backends.

### Description
- Introduced a structured compute result `ApiV1ComputeResult` and updated the compute provider contract to return backend diagnostics alongside the assistant message. (`api/v1/compute_provider.py`)
- Added a new `relay_registered` provider mode `RelayRegisteredApiV1ComputeProvider` that dispatches non-streaming API v1 chat jobs to registered relay compute nodes via a relay dispatch endpoint. (`api/v1/compute_provider.py`)
- Updated API v1 routes to consume the structured result and set explicit headers showing both the configured provider and the actual backend path used (e.g. `X-Tokenplace-API-V1-Provider`, `X-Tokenplace-API-V1-Resolved-Provider-Path`, `X-Tokenplace-API-V1-Configured-Provider*`). (`api/v1/routes.py`)
- Extended the relay with queued API v1 job state plus two endpoints: `/relay/api-v1/chat/dispatch` (enqueue + wait for result) and `/relay/api-v1/chat/result` (bridge posts completed result), and surfaced API v1 queue depth in diagnostics; made `/sink` able to deliver `api_v1_chat_request` to registered nodes. (`relay.py`)
- Updated desktop compute-node bridge to detect `api_v1_chat_request` in its poll loop, perform non-streaming inference with the shared runtime, and POST results back to the relay result endpoint, emitting clear stderr diagnostics for request start/ok/fail. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Tests and test harness updated to enable the focused real-bridge e2e guardrail by selecting `TOKENPLACE_API_V1_COMPUTE_PROVIDER=relay_registered` when running the real-bridge e2e scenario, and E2E assertions updated to expect the relay-registered provider diagnostics. (`tests/conftest.py`, `tests/e2e/test_ui.py`)
- Updated and added unit tests to validate the new provider contract, relay dispatch contract, and bridge behavior. (`tests/unit/*`)

### Testing
- Ran unit provider tests: `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all tests passed (7 passed). 
- Ran desktop bridge unit tests: `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (25 passed).
- Ran focused API v1 routes provider assertions: `python -m pytest -q tests/unit/test_api_v1_routes_additional.py -k 'provider'` and selected provider assertions passed.
- Ran `pre-commit run --all-files` and hooks completed successfully in this environment.
- Attempted the Playwright E2E checks (`python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming'` and `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' -s`), but Playwright browser binaries are not installed in this environment so those E2E runs errored with a prompt to run `playwright install`; the code changes and E2E harness are prepared for those runs once browsers are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9de3bf408832f8ae69c7e6028d55c)