### PR TITLE
🔧 route relay API v1 chat through registered desktop compute node

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import lru_cache
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Protocol
 
 import requests
@@ -36,9 +36,11 @@ class ApiV1ComputeProvider(Protocol):
         """Return an assistant message payload compatible with OpenAI chat responses."""
 
 
-@dataclass(frozen=True)
+@dataclass
 class LocalApiV1ComputeProvider:
     """Default provider that executes inference in-process via llama.cpp."""
+
+    _last_served_by: str = field(default="local_in_process", init=False)
 
     def complete_chat(
         self,
@@ -53,15 +55,17 @@ class LocalApiV1ComputeProvider:
         assistant_message = updated_messages[-1]
         if not isinstance(assistant_message, dict):
             raise ComputeProviderError("assistant response must be a message object")
+        self._last_served_by = "local_in_process"
         return assistant_message
 
 
-@dataclass(frozen=True)
+@dataclass
 class DistributedApiV1ComputeProvider:
     """Provider that forwards API v1 chat payloads to a remote compute endpoint."""
 
     base_url: str
     timeout_seconds: float = 30.0
+    _last_served_by: str = field(default="registered_desktop_node", init=False)
 
     def complete_chat(
         self,
@@ -82,7 +86,7 @@ class DistributedApiV1ComputeProvider:
 
         try:
             response = requests.post(
-                f"{self.base_url.rstrip('/')}/api/v1/chat/completions",
+                f"{self.base_url.rstrip('/')}/relay/api/v1/chat/completions",
                 json=payload,
                 timeout=self.timeout_seconds,
             )
@@ -111,15 +115,17 @@ class DistributedApiV1ComputeProvider:
         if not isinstance(message, dict):
             raise ComputeProviderError("distributed provider response missing message")
 
+        self._last_served_by = "registered_desktop_node"
         return message
 
 
-@dataclass(frozen=True)
+@dataclass
 class FallbackApiV1ComputeProvider:
     """Wrap distributed execution with local fallback for migration safety."""
 
     primary: ApiV1ComputeProvider
     fallback: ApiV1ComputeProvider
+    _last_served_by: str = field(default="unknown", init=False)
 
     def complete_chat(
         self,
@@ -129,18 +135,22 @@ class FallbackApiV1ComputeProvider:
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
         try:
-            return self.primary.complete_chat(
+            message = self.primary.complete_chat(
                 model_id=model_id,
                 messages=messages,
                 options=options,
             )
+            self._last_served_by = "registered_desktop_node"
+            return message
         except ComputeProviderError as exc:
             logger.warning("distributed compute fallback triggered: %s", exc)
-            return self.fallback.complete_chat(
+            message = self.fallback.complete_chat(
                 model_id=model_id,
                 messages=messages,
                 options=options,
             )
+            self._last_served_by = "fallback_local_in_process"
+            return message
 
 
 @lru_cache(maxsize=8)
@@ -216,4 +226,13 @@ def get_api_v1_resolved_provider_path(provider: ApiV1ComputeProvider) -> str:
         return "distributed"
     if isinstance(provider, LocalApiV1ComputeProvider):
         return "local"
+    return "unknown"
+
+
+def get_api_v1_served_backend(provider: ApiV1ComputeProvider) -> str:
+    """Return a stable diagnostics label for the backend that served the last request."""
+
+    served_by = getattr(provider, "_last_served_by", None)
+    if isinstance(served_by, str) and served_by.strip():
+        return served_by
     return "unknown"

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -36,6 +36,7 @@ from api.v1.models import (
 from api.v1.compute_provider import (
     get_api_v1_compute_provider,
     get_api_v1_resolved_provider_path,
+    get_api_v1_served_backend,
     ComputeProviderError,
 )
 from api.v1.validation import (
@@ -337,6 +338,7 @@ def _handle_chat_completion_request(data):
             options=_extract_chat_completion_options(data),
         )
         log_info("Response generated successfully")
+        served_backend = get_api_v1_served_backend(provider)
 
         tool_calls = assistant_message.get("tool_calls")
 
@@ -393,12 +395,14 @@ def _handle_chat_completion_request(data):
             response = jsonify({"encrypted": True, "data": encrypted_response})
             response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
             response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Served-By"] = served_backend
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
         response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
         response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Served-By"] = served_backend
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 
@@ -500,6 +504,7 @@ def _handle_text_completion_request(data):
             options=_extract_chat_completion_options(data),
         )
         log_info("Response generated successfully")
+        served_backend = get_api_v1_served_backend(provider)
 
         response_data = {
             "id": f"cmpl-{uuid.uuid4().hex[:12]}",
@@ -533,12 +538,14 @@ def _handle_text_completion_request(data):
             response = jsonify({"encrypted": True, "data": encrypted_response})
             response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
             response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Served-By"] = served_backend
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
         response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
         response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Served-By"] = served_backend
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import queue
+import requests
 import sys
 import threading
 import time
@@ -95,15 +96,65 @@ def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
     has_payload = all(
         key in relay_response for key in ("client_public_key", "chat_history", "cipherkey", "iv")
     )
+    has_api_v1_request = isinstance(relay_response.get("api_v1_request"), dict)
     has_heartbeat = "next_ping_in_x_seconds" in relay_response
     relay_error = _relay_error_message(relay_response)
     wait_seconds = relay_response.get("next_ping_in_x_seconds", "missing")
 
     return (
-        f"keys={keys} has_legacy_payload={has_payload} "
+        f"keys={keys} has_legacy_payload={has_payload} has_api_v1_request={has_api_v1_request} "
         f"has_heartbeat={has_heartbeat} wait={wait_seconds} "
         f"error={relay_error or 'none'}"
     )
+
+
+def _process_api_v1_request(runtime: Any, relay_response: Dict[str, Any]) -> bool:
+    """Process an API v1 request payload polled from relay /sink."""
+
+    request_payload = relay_response.get("api_v1_request")
+    if not isinstance(request_payload, dict):
+        return False
+
+    request_id = request_payload.get("request_id")
+    model_id = request_payload.get("model")
+    messages = request_payload.get("messages")
+    if not isinstance(request_id, str) or not request_id.strip():
+        return False
+    if not isinstance(model_id, str) or not model_id.strip() or not isinstance(messages, list):
+        return False
+    try:
+        response_history = runtime.model_manager.llama_cpp_get_response(messages)
+        assistant_message = response_history[-1] if isinstance(response_history, list) else None
+        if not isinstance(assistant_message, dict):
+            assistant_message = {"role": "assistant", "content": ""}
+        publish_payload = {
+            "request_id": request_id,
+            "message": {
+                "role": assistant_message.get("role", "assistant"),
+                "content": assistant_message.get("content", ""),
+            },
+        }
+    except Exception as exc:
+        publish_payload = {
+            "request_id": request_id,
+            "error": f"desktop compute failed: {exc}",
+        }
+
+    request_kwargs = {
+        "json": publish_payload,
+        "timeout": 30,
+    }
+    auth_headers = getattr(runtime.relay_client, "_auth_headers", None)
+    if callable(auth_headers):
+        headers = auth_headers()
+        if headers:
+            request_kwargs["headers"] = headers
+
+    response = requests.post(
+        f"{runtime.relay_client.relay_url}/relay/api/v1/source",
+        **request_kwargs,
+    )
+    return response.status_code == 200
 
 
 def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
@@ -281,14 +332,16 @@ def run(args: argparse.Namespace) -> int:
             relay_response = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
             legacy_payload = is_legacy_relay_payload(relay_response)
+            api_v1_payload = isinstance(relay_response.get("api_v1_request"), dict)
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
             relay_error = _relay_error_message(relay_response)
-            registered = relay_error is None and (legacy_payload or heartbeat_ack)
+            registered = relay_error is None and (legacy_payload or api_v1_payload or heartbeat_ack)
 
             print(
                 "desktop.compute_node_bridge.relay_poll "
                 f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
-                f"legacy_payload={legacy_payload} heartbeat_ack={heartbeat_ack} "
+                f"legacy_payload={legacy_payload} api_v1_payload={api_v1_payload} "
+                f"heartbeat_ack={heartbeat_ack} "
                 f"summary={_relay_response_summary(relay_response)}",
                 file=sys.stderr,
             )
@@ -318,6 +371,24 @@ def run(args: argparse.Namespace) -> int:
                     last_error = None
                     print(
                         "desktop.compute_node_bridge.process_request.ok",
+                        file=sys.stderr,
+                    )
+            elif api_v1_payload:
+                print(
+                    "desktop.compute_node_bridge.process_api_v1_request.start",
+                    file=sys.stderr,
+                )
+                processed = _process_api_v1_request(runtime, relay_response)
+                if not processed:
+                    last_error = "failed to process relay api v1 request"
+                    print(
+                        "desktop.compute_node_bridge.process_api_v1_request.failed",
+                        file=sys.stderr,
+                    )
+                else:
+                    last_error = None
+                    print(
+                        "desktop.compute_node_bridge.process_api_v1_request.ok",
                         file=sys.stderr,
                     )
             else:

--- a/relay.py
+++ b/relay.py
@@ -379,6 +379,8 @@ def _validate_server_registration():
 known_servers = {}
 client_inference_requests = {}
 client_responses = {}
+api_v1_pending_requests = {}
+api_v1_pending_responses = {}
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -435,6 +437,7 @@ def _unregister_server(server_public_key: str) -> bool:
 
     removed = known_servers.pop(server_public_key, None) is not None
     client_inference_requests.pop(server_public_key, None)
+    api_v1_pending_requests.pop(server_public_key, None)
 
     with stream_lock:
         stale_session_ids = [
@@ -453,6 +456,10 @@ def _unregister_server(server_public_key: str) -> bool:
                     streaming_sessions_by_client.pop(client_public_key, None)
 
     return removed
+
+
+def _is_api_v1_compute_request(payload: Dict[str, Any]) -> bool:
+    return isinstance(payload, dict) and payload.get("kind") == "api_v1_chat_completion"
 
 
 def _can_resolve_gpu_host(hostname: str) -> bool:
@@ -803,11 +810,17 @@ def sink():
     }
 
     # Check if there are any client requests for this server
-    queued_requests = client_inference_requests.get(public_key, [])
+    legacy_queue = client_inference_requests.get(public_key, [])
+    api_v1_queue = api_v1_pending_requests.get(public_key, [])
+    queued_requests = legacy_queue if legacy_queue else api_v1_queue
     if queued_requests:
         batch = []
         while queued_requests and len(batch) < max_batch_size:
             request_payload = queued_requests.pop(0)
+            if _is_api_v1_compute_request(request_payload):
+                batch.append(request_payload)
+                continue
+
             if request_payload.get('stream'):
                 session = _register_stream_session(
                     public_key,
@@ -818,21 +831,107 @@ def sink():
             batch.append(request_payload)
 
         first_request = batch[0]
-        response_data.update({
-            'client_public_key': first_request['client_public_key'],
-            'chat_history': first_request['chat_history'],
-            'cipherkey': first_request['cipherkey'],
-            'iv': first_request.get('iv', ''),
-        })
+        if _is_api_v1_compute_request(first_request):
+            response_data['api_v1_request'] = {
+                'request_id': first_request['request_id'],
+                'model': first_request['model'],
+                'messages': first_request['messages'],
+                'options': first_request.get('options', {}),
+                'stream': False,
+            }
+        else:
+            response_data.update({
+                'client_public_key': first_request['client_public_key'],
+                'chat_history': first_request['chat_history'],
+                'cipherkey': first_request['cipherkey'],
+                'iv': first_request.get('iv', ''),
+            })
 
-        if first_request.get('stream') and first_request.get('stream_session_id'):
-            response_data['stream'] = True
-            response_data['stream_session_id'] = first_request['stream_session_id']
+            if first_request.get('stream') and first_request.get('stream_session_id'):
+                response_data['stream'] = True
+                response_data['stream_session_id'] = first_request['stream_session_id']
 
         if max_batch_size > 1:
             response_data['batch'] = batch
 
     return jsonify(response_data)
+
+
+@app.route('/relay/api/v1/chat/completions', methods=['POST'])
+def relay_api_v1_chat_completions():
+    """Queue API v1 chat completions for registered compute nodes and await a response."""
+
+    _evict_stale_servers()
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    messages = data.get('messages')
+    model = data.get('model')
+    if not isinstance(model, str) or not model.strip():
+        return jsonify({'error': 'Missing required parameter: model'}), 400
+    if not isinstance(messages, list) or not messages:
+        return jsonify({'error': 'Missing required parameter: messages'}), 400
+    if bool(data.get('stream')):
+        return jsonify({'error': 'Streaming is not supported for relay API v1 chat'}), 400
+
+    if not known_servers:
+        return jsonify({'error': 'No registered compute nodes available'}), 503
+
+    server_public_key = secrets.choice(list(known_servers.keys()))
+    request_id = secrets.token_urlsafe(12)
+    request_payload = {
+        'kind': 'api_v1_chat_completion',
+        'request_id': request_id,
+        'model': model,
+        'messages': messages,
+        'options': data.get('options', {}),
+    }
+    if server_public_key not in api_v1_pending_requests:
+        api_v1_pending_requests[server_public_key] = []
+    api_v1_pending_requests[server_public_key].append(request_payload)
+
+    timeout_seconds = 30.0
+    started = time.time()
+    while (time.time() - started) < timeout_seconds:
+        response_payload = api_v1_pending_responses.pop(request_id, None)
+        if response_payload is not None:
+            if response_payload.get('error'):
+                return jsonify({'error': response_payload['error']}), 502
+            message = response_payload.get('message')
+            if not isinstance(message, dict):
+                return jsonify({'error': 'Invalid relay compute response'}), 502
+            return jsonify({
+                'id': f'chatcmpl-relay-{request_id}',
+                'object': 'chat.completion',
+                'choices': [{'index': 0, 'message': message, 'finish_reason': 'stop'}],
+            }), 200
+        time.sleep(0.05)
+
+    return jsonify({'error': 'Timed out waiting for registered compute node'}), 504
+
+
+@app.route('/relay/api/v1/source', methods=['POST'])
+def relay_api_v1_source():
+    """Accept API v1 compute results emitted by registered compute nodes."""
+
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    request_id = data.get('request_id')
+    if not isinstance(request_id, str) or not request_id.strip():
+        return jsonify({'error': 'Missing request_id'}), 400
+
+    api_v1_pending_responses[request_id] = {
+        'message': data.get('message'),
+        'error': data.get('error'),
+    }
+    return jsonify({'message': 'API v1 response received'}), 200
 
 
 @app.route('/unregister', methods=['POST'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,7 +262,7 @@ def test_api_v1_chat_completion_supports_distributed_provider_contract(client, m
     data = response.get_json()
     assert data['choices'][0]['message']['content'] == 'distributed-path response'
 
-    assert captured['url'] == 'https://compute.example/api/v1/chat/completions'
+    assert captured['url'] == 'https://compute.example/relay/api/v1/chat/completions'
     assert captured['json']['model'] == 'remote-only-model'
     assert captured['json']['messages'][0]['content'] == 'Ping distributed runtime'
     assert captured['json']['stream'] is False

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -42,7 +42,7 @@ def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
         options={"temperature": 0.2, "stream": True},
     )
 
-    assert captured["url"] == "https://node-a.example/api/v1/chat/completions"
+    assert captured["url"] == "https://node-a.example/relay/api/v1/chat/completions"
     assert captured["timeout"] == 5
     assert captured["json"]["model"] == "llama-3-8b-instruct"
     assert captured["json"]["messages"] == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
### Motivation

- Ensure landing-page `/api/v1/chat/completions` requests are actually serviced by a registered desktop compute node instead of being silently handled locally. 
- Preserve non-streaming API v1 semantics and OpenAI-compatible request/response shapes while adding runtime diagnostics to prove which backend served each request. 

### Description

- Add a relay-backed API v1 handoff: new relay endpoints `/relay/api/v1/chat/completions` (enqueue/wait) and `/relay/api/v1/source` (node publishes results) and in-relay queues (`api_v1_pending_requests`, `api_v1_pending_responses`) so registered nodes can be the true API v1 backend (changes in `relay.py`).
- Route distributed `ApiV1` requests to the relay handoff path by updating `DistributedApiV1ComputeProvider` to POST to `/relay/api/v1/chat/completions` and track per-provider served backend state (changes in `api/v1/compute_provider.py`).
- Expose served-backend diagnostics in API responses using the header `X-Tokenplace-API-V1-Served-By` and retain provider class/path headers (changes in `api/v1/routes.py`).
- Extend the desktop compute-node bridge to consume `api_v1_request` payloads from `/sink`, run real (non-streaming) inference, post results to `/relay/api/v1/source`, and emit structured logs for API v1 processing lifecycle (changes in `desktop-tauri/src-tauri/python/compute_node_bridge.py`).
- Preserve legacy relay behavior while allowing `/sink` to return either legacy payloads or the new `api_v1_request` payload; update a few tests to expect the new relay path for distributed provider calls (changes in `tests/test_api.py` and `tests/unit/test_api_v1_compute_provider.py`).

### Testing

- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all unit tests in that file passed. 
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and the desktop bridge unit suite passed. 
- Ran the focused e2e check `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming'` and it passed; the full relay registration real-inference guardrail `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' -s` was not executed successfully here because `TOKENPLACE_REAL_E2E_MODEL_PATH` was not set to a local GGUF model in this environment. 
- Ran `pre-commit run --all-files` which passed; `./scripts/scan-secrets.py` referenced by local commit checks was not present in this environment (noted but unrelated to functional tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e17ea7d8832fbc629f6545db1a05)