### PR TITLE
🔧 Fix relay API v1 landing chat to use registered desktop compute nodes

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -6,8 +6,12 @@ remote distributed compute-node endpoint while preserving a local fallback.
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import os
+import time
+from contextvars import ContextVar
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
@@ -15,12 +19,27 @@ from typing import Any, Dict, Optional, Protocol
 import requests
 
 from api.v1.models import generate_response
+from encrypt import decrypt, encrypt, generate_keys
 
 logger = logging.getLogger("api.v1.compute_provider")
+_last_execution_path: ContextVar[str] = ContextVar(
+    "api_v1_compute_provider_execution_path",
+    default="unknown",
+)
 
 
 class ComputeProviderError(Exception):
     """Raised when a compute provider cannot satisfy a request."""
+
+
+def _set_execution_path(path: str) -> None:
+    _last_execution_path.set(path)
+
+
+def get_api_v1_last_execution_path() -> str:
+    """Return the execution-path marker for the current request context."""
+
+    return _last_execution_path.get()
 
 
 class ApiV1ComputeProvider(Protocol):
@@ -53,6 +72,7 @@ class LocalApiV1ComputeProvider:
         assistant_message = updated_messages[-1]
         if not isinstance(assistant_message, dict):
             raise ComputeProviderError("assistant response must be a message object")
+        _set_execution_path("local_in_process")
         return assistant_message
 
 
@@ -111,6 +131,7 @@ class DistributedApiV1ComputeProvider:
         if not isinstance(message, dict):
             raise ComputeProviderError("distributed provider response missing message")
 
+        _set_execution_path("distributed_api_v1")
         return message
 
 
@@ -136,11 +157,146 @@ class FallbackApiV1ComputeProvider:
             )
         except ComputeProviderError as exc:
             logger.warning("distributed compute fallback triggered: %s", exc)
-            return self.fallback.complete_chat(
+            message = self.fallback.complete_chat(
                 model_id=model_id,
                 messages=messages,
                 options=options,
             )
+            _set_execution_path("fallback_local_in_process")
+            return message
+
+
+@dataclass(frozen=True)
+class RelayRegisteredApiV1ComputeProvider:
+    """Provider that routes API v1 calls through relay registered compute nodes."""
+
+    base_url: str
+    timeout_seconds: float = 30.0
+    retrieve_max_attempts: int = 60
+    retrieve_retry_seconds: float = 0.25
+
+    def complete_chat(
+        self,
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        options: Optional[Dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        del model_id, options  # relay /sink path consumes only the message history payload
+        relay_url = self.base_url.rstrip("/")
+        private_key, public_key = generate_keys()
+        client_public_key_b64 = base64.b64encode(public_key).decode("utf-8")
+
+        try:
+            next_server_response = requests.get(
+                f"{relay_url}/next_server",
+                timeout=self.timeout_seconds,
+            )
+        except Exception as exc:
+            raise ComputeProviderError(f"relay next_server request failed: {exc}") from exc
+        if next_server_response.status_code != 200:
+            raise ComputeProviderError(
+                f"relay next_server returned status {next_server_response.status_code}"
+            )
+        try:
+            next_server_payload = next_server_response.json()
+        except ValueError as exc:
+            raise ComputeProviderError("relay next_server returned non-JSON response") from exc
+
+        server_public_key_b64 = next_server_payload.get("server_public_key")
+        if not isinstance(server_public_key_b64, str) or not server_public_key_b64.strip():
+            raise ComputeProviderError("relay next_server did not return a server_public_key")
+        try:
+            server_public_key = base64.b64decode(server_public_key_b64)
+        except Exception as exc:
+            raise ComputeProviderError("relay returned invalid server_public_key encoding") from exc
+
+        wrapped_payload = {
+            "chat_history": messages,
+            "client_public_key": client_public_key_b64,
+        }
+        encrypted_payload, encrypted_key, iv = encrypt(
+            json.dumps(wrapped_payload).encode("utf-8"),
+            server_public_key,
+        )
+        faucet_payload = {
+            "client_public_key": client_public_key_b64,
+            "server_public_key": server_public_key_b64,
+            "chat_history": base64.b64encode(encrypted_payload["ciphertext"]).decode("utf-8"),
+            "cipherkey": base64.b64encode(encrypted_key).decode("utf-8"),
+            "iv": base64.b64encode(iv).decode("utf-8"),
+        }
+        try:
+            faucet_response = requests.post(
+                f"{relay_url}/faucet",
+                json=faucet_payload,
+                timeout=self.timeout_seconds,
+            )
+        except Exception as exc:
+            raise ComputeProviderError(f"relay faucet request failed: {exc}") from exc
+        if faucet_response.status_code != 200:
+            raise ComputeProviderError(f"relay faucet returned status {faucet_response.status_code}")
+
+        retrieve_payload = {"client_public_key": client_public_key_b64}
+        for _ in range(max(1, self.retrieve_max_attempts)):
+            try:
+                retrieve_response = requests.post(
+                    f"{relay_url}/retrieve",
+                    json=retrieve_payload,
+                    timeout=self.timeout_seconds,
+                )
+            except Exception as exc:
+                raise ComputeProviderError(f"relay retrieve request failed: {exc}") from exc
+
+            if retrieve_response.status_code != 200:
+                raise ComputeProviderError(
+                    f"relay retrieve returned status {retrieve_response.status_code}"
+                )
+            try:
+                retrieve_body = retrieve_response.json()
+            except ValueError as exc:
+                raise ComputeProviderError("relay retrieve returned non-JSON response") from exc
+
+            if "error" in retrieve_body:
+                error_text = str(retrieve_body.get("error"))
+                if "No response available" in error_text:
+                    time.sleep(max(0.0, self.retrieve_retry_seconds))
+                    continue
+                raise ComputeProviderError(f"relay retrieve error: {error_text}")
+
+            if not all(key in retrieve_body for key in ("chat_history", "cipherkey", "iv")):
+                raise ComputeProviderError("relay retrieve response missing encrypted fields")
+
+            try:
+                decrypted_response = decrypt(
+                    {
+                        "ciphertext": base64.b64decode(retrieve_body["chat_history"]),
+                        "iv": base64.b64decode(retrieve_body["iv"]),
+                    },
+                    base64.b64decode(retrieve_body["cipherkey"]),
+                    private_key,
+                )
+            except Exception as exc:
+                raise ComputeProviderError(f"failed to decrypt relay response: {exc}") from exc
+
+            if decrypted_response is None:
+                raise ComputeProviderError("failed to decrypt relay response")
+
+            try:
+                decoded_response = json.loads(decrypted_response.decode("utf-8"))
+            except Exception as exc:
+                raise ComputeProviderError(f"relay response was not valid JSON: {exc}") from exc
+            if not isinstance(decoded_response, list) or not decoded_response:
+                raise ComputeProviderError("relay response chat history is empty or invalid")
+
+            for candidate in reversed(decoded_response):
+                if isinstance(candidate, dict) and candidate.get("role") == "assistant":
+                    _set_execution_path("relay_registered_compute_node")
+                    return candidate
+
+            raise ComputeProviderError("relay response missing assistant message")
+
+        raise ComputeProviderError("timed out waiting for relay retrieve response")
 
 
 @lru_cache(maxsize=8)
@@ -150,6 +306,19 @@ def _build_api_v1_compute_provider(
     """Create a compute provider for the normalized environment inputs."""
 
     local_provider = LocalApiV1ComputeProvider()
+
+    if mode == "relay_registered":
+        if not distributed_url:
+            raise ComputeProviderError(
+                "TOKENPLACE_API_V1_COMPUTE_PROVIDER=relay_registered requires "
+                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL"
+            )
+        logger.info(
+            "api_v1.compute_provider.selected provider=relay_registered mode=%s target=%s",
+            mode,
+            distributed_url.rstrip("/"),
+        )
+        return RelayRegisteredApiV1ComputeProvider(base_url=distributed_url)
 
     if mode != "distributed":
         logger.info("api_v1.compute_provider.selected provider=local mode=%s", mode)
@@ -210,6 +379,8 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
 def get_api_v1_resolved_provider_path(provider: ApiV1ComputeProvider) -> str:
     """Return a stable diagnostics label for the resolved provider instance."""
 
+    if isinstance(provider, RelayRegisteredApiV1ComputeProvider):
+        return "relay_registered"
     if isinstance(provider, FallbackApiV1ComputeProvider):
         return "distributed_with_local_fallback"
     if isinstance(provider, DistributedApiV1ComputeProvider):

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -35,6 +35,7 @@ from api.v1.models import (
 )
 from api.v1.compute_provider import (
     get_api_v1_compute_provider,
+    get_api_v1_last_execution_path,
     get_api_v1_resolved_provider_path,
     ComputeProviderError,
 )
@@ -336,6 +337,11 @@ def _handle_chat_completion_request(data):
             messages=messages,
             options=_extract_chat_completion_options(data),
         )
+        execution_path = get_api_v1_last_execution_path()
+        log_info(
+            "api_v1_provider_execution resolved_provider_path=%s execution_path=%s"
+            % (resolved_provider_path, execution_path)
+        )
         log_info("Response generated successfully")
 
         tool_calls = assistant_message.get("tool_calls")
@@ -393,12 +399,14 @@ def _handle_chat_completion_request(data):
             response = jsonify({"encrypted": True, "data": encrypted_response})
             response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
             response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Execution-Path"] = execution_path
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
         response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
         response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Execution-Path"] = execution_path
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 
@@ -499,6 +507,11 @@ def _handle_text_completion_request(data):
             messages=messages,
             options=_extract_chat_completion_options(data),
         )
+        execution_path = get_api_v1_last_execution_path()
+        log_info(
+            "api_v1_provider_execution resolved_provider_path=%s execution_path=%s"
+            % (resolved_provider_path, execution_path)
+        )
         log_info("Response generated successfully")
 
         response_data = {
@@ -533,12 +546,14 @@ def _handle_text_completion_request(data):
             response = jsonify({"encrypted": True, "data": encrypted_response})
             response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
             response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Execution-Path"] = execution_path
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
         response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
         response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Execution-Path"] = execution_path
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 

--- a/relay.py
+++ b/relay.py
@@ -174,6 +174,25 @@ def _enforce_api_v1_distributed_guardrail() -> None:
     )
 
 
+def _configure_api_v1_relay_registered_provider(host: str, port: int) -> None:
+    """Default relay API v1 chat handling to registered compute nodes."""
+
+    if not os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip():
+        os.environ["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "relay_registered"
+
+    if not os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip():
+        host_for_url = "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+        os.environ["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = f"http://{host_for_url}:{port}"
+
+    LOGGER.info(
+        "relay.api_v1_provider.defaulted",
+        extra={
+            "provider_mode": os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER"),
+            "distributed_url": os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL"),
+        },
+    )
+
+
 def _build_cli_parser(*, add_help: bool = True) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="token.place relay server", add_help=add_help)
     parser.add_argument(
@@ -1016,6 +1035,7 @@ def main(argv: list[str] | None = None) -> None:
         port = args.port
 
     _configure_mock_mode(args.use_mock_llm)
+    _configure_api_v1_relay_registered_provider(host, port)
     serve(host, port)
 
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -456,23 +456,29 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         stream_mode = latest_headers.get("x-tokenplace-api-v1-stream-mode")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
+        execution_path = latest_headers.get("x-tokenplace-api-v1-execution-path")
         provider_diagnostics = (
             "landing-page real-provider guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"execution_path={execution_path!r}, stream_mode={stream_mode!r}; "
+            "expected provider_class='RelayRegisteredApiV1ComputeProvider', "
+            "resolved_provider_path='relay_registered', execution_path='relay_registered_compute_node', "
+            "stream_mode='non-streaming'"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
+        assert provider_class == "RelayRegisteredApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
+        assert resolved_provider_path == "relay_registered", (
             "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+            f"'relay_registered'. {provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
+        assert execution_path == "relay_registered_compute_node", provider_diagnostics
+        if runtime_supports_real_inference:
             assert assistant_text.strip().lower() != "stub", (
                 "assistant response must not be stub when runtime reports real inference support "
                 f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"
             )
+        bridge_stderr = "".join(stderr_lines)
+        assert "desktop.compute_node_bridge.process_request.start" in bridge_stderr
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -8,6 +8,7 @@ from api.v1.compute_provider import (
     DistributedApiV1ComputeProvider,
     FallbackApiV1ComputeProvider,
     LocalApiV1ComputeProvider,
+    RelayRegisteredApiV1ComputeProvider,
     get_api_v1_resolved_provider_path,
 )
 
@@ -107,6 +108,77 @@ def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
+def test_relay_registered_provider_uses_next_server_faucet_retrieve(monkeypatch):
+    calls = []
+
+    def fake_generate_keys():
+        return b"private", b"public"
+
+    def fake_encrypt(plaintext, server_public_key):
+        assert server_public_key == b"server-public"
+        assert b'"chat_history"' in plaintext
+        return {"ciphertext": b"ciphertext"}, b"cipher-key", b"iv"
+
+    assistant_history = (
+        b'[{"role":"user","content":"hi"},{"role":"assistant","content":"hello from relay"}]'
+    )
+
+    def fake_decrypt(ciphertext_dict, encrypted_key, private_key):
+        assert ciphertext_dict["ciphertext"] == b"resp-cipher"
+        assert encrypted_key == b"resp-key"
+        assert private_key == b"private"
+        return assistant_history
+
+    def fake_get(url, timeout=None):
+        calls.append(("GET", url))
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"server_public_key": "c2VydmVyLXB1YmxpYw=="},
+        )
+
+    retrieve_attempts = {"count": 0}
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append(("POST", url, json))
+        if url.endswith("/faucet"):
+            return SimpleNamespace(status_code=200, json=lambda: {"message": "Request received"})
+        if url.endswith("/retrieve"):
+            retrieve_attempts["count"] += 1
+            if retrieve_attempts["count"] == 1:
+                return SimpleNamespace(status_code=200, json=lambda: {"error": "No response available for the given public key"})
+            return SimpleNamespace(
+                status_code=200,
+                json=lambda: {
+                    "chat_history": "cmVzcC1jaXBoZXI=",
+                    "cipherkey": "cmVzcC1rZXk=",
+                    "iv": "aXY=",
+                },
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr("api.v1.compute_provider.generate_keys", fake_generate_keys)
+    monkeypatch.setattr("api.v1.compute_provider.encrypt", fake_encrypt)
+    monkeypatch.setattr("api.v1.compute_provider.decrypt", fake_decrypt)
+    monkeypatch.setattr("api.v1.compute_provider.requests.get", fake_get)
+    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
+    monkeypatch.setattr("api.v1.compute_provider.time.sleep", lambda _s: None)
+
+    provider = RelayRegisteredApiV1ComputeProvider(
+        base_url="https://relay.example",
+        retrieve_max_attempts=2,
+        retrieve_retry_seconds=0,
+    )
+    result = provider.complete_chat(
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert result == {"role": "assistant", "content": "hello from relay"}
+    assert calls[0] == ("GET", "https://relay.example/next_server")
+    assert calls[1][0] == "POST" and calls[1][1] == "https://relay.example/faucet"
+    assert calls[2][0] == "POST" and calls[2][1] == "https://relay.example/retrieve"
+
+
 def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "")
@@ -123,9 +195,11 @@ def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monk
 def test_get_api_v1_resolved_provider_path_labels_instance_types():
     local = LocalApiV1ComputeProvider()
     distributed = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
+    relay_registered = RelayRegisteredApiV1ComputeProvider(base_url="https://relay.example")
     fallback = FallbackApiV1ComputeProvider(primary=distributed, fallback=local)
 
     assert get_api_v1_resolved_provider_path(local) == "local"
     assert get_api_v1_resolved_provider_path(distributed) == "distributed"
+    assert get_api_v1_resolved_provider_path(relay_registered) == "relay_registered"
     assert get_api_v1_resolved_provider_path(fallback) == "distributed_with_local_fallback"
     assert get_api_v1_resolved_provider_path(object()) == "unknown"


### PR DESCRIPTION
### Motivation
- Ensure the landing-page `/api/v1/chat/completions` path is served end-to-end by a registered desktop compute node instead of silently falling back to local in-process inference.
- Preserve OpenAI-compatible API v1 request/response shape and keep the flow non-streaming.
- Add deterministic runtime diagnostics so operators can prove which backend actually served each API v1 request.

### Description
- Added `RelayRegisteredApiV1ComputeProvider` that implements API v1 chat by driving the relay registration flow (`/next_server` → `/faucet` → `/retrieve`) and decrypting the registered-node response. (`api/v1/compute_provider.py`).
- Added per-request execution-path markers via a `ContextVar` and helpers (`get_api_v1_last_execution_path`) and set markers for `local_in_process`, `distributed_api_v1`, `fallback_local_in_process`, and `relay_registered_compute_node`. (`api/v1/compute_provider.py`).
- Exposed the execution-path in API responses and logs using header `X-Tokenplace-API-V1-Execution-Path` and route logs for provider selection/execution. (`api/v1/routes.py`).
- Defaulted relay runtime to use the `relay_registered` provider mode and set `TOKENPLACE_DISTRIBUTED_COMPUTE_URL` to the relay host when missing so the landing-page provider does not silently use local inference. (`relay.py`).
- Updated unit and e2e guardrail tests to cover the relay-registered provider path and to assert the new execution diagnostics, and added a focused unit test for the relay-registered provider. (`tests/unit/test_api_v1_compute_provider.py`, `tests/e2e/test_ui.py`).

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all tests passed (7 passed). 
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (24 passed).
- Ran broader API unit suite `python -m pytest -q tests/test_api.py` and it passed (52 passed).
- End-to-end Playwright UI test `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming'` errored in this environment because Playwright Chromium binaries are not installed, so E2E verification is environment-gated (install with `playwright install`).
- Attempted `pre-commit run --all-files` which exercised project checks; `run-checks` failed in this environment (reported Python Integration Tests + Bandit results), so full pre-commit checks should be re-run in CI or a fully provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e17ea7d8832fbc629f6545db1a05)