### PR TITLE
Route relay API v1 chat through registered desktop compute nodes

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -53,7 +53,7 @@ class LocalApiV1ComputeProvider:
         assistant_message = updated_messages[-1]
         if not isinstance(assistant_message, dict):
             raise ComputeProviderError("assistant response must be a message object")
-        return assistant_message
+        return {**assistant_message, "__tokenplace_backend_path": "local_in_process"}
 
 
 @dataclass(frozen=True)
@@ -62,6 +62,7 @@ class DistributedApiV1ComputeProvider:
 
     base_url: str
     timeout_seconds: float = 30.0
+    endpoint_path: str = "/relay/api/v1/chat/completions"
 
     def complete_chat(
         self,
@@ -82,7 +83,7 @@ class DistributedApiV1ComputeProvider:
 
         try:
             response = requests.post(
-                f"{self.base_url.rstrip('/')}/api/v1/chat/completions",
+                f"{self.base_url.rstrip('/')}{self.endpoint_path}",
                 json=payload,
                 timeout=self.timeout_seconds,
             )
@@ -111,7 +112,12 @@ class DistributedApiV1ComputeProvider:
         if not isinstance(message, dict):
             raise ComputeProviderError("distributed provider response missing message")
 
-        return message
+        response_headers = getattr(response, "headers", {}) or {}
+        relay_compute_path = response_headers.get("X-Tokenplace-Relay-Compute-Path", "").strip()
+        backend_path = "registered_compute_node"
+        if relay_compute_path and relay_compute_path != "registered_compute_node":
+            backend_path = relay_compute_path
+        return {**message, "__tokenplace_backend_path": backend_path}
 
 
 @dataclass(frozen=True)
@@ -136,11 +142,17 @@ class FallbackApiV1ComputeProvider:
             )
         except ComputeProviderError as exc:
             logger.warning("distributed compute fallback triggered: %s", exc)
-            return self.fallback.complete_chat(
+            fallback_message = self.fallback.complete_chat(
                 model_id=model_id,
                 messages=messages,
                 options=options,
             )
+            if isinstance(fallback_message, dict):
+                fallback_message = {
+                    **fallback_message,
+                    "__tokenplace_backend_path": "fallback_to_local_in_process",
+                }
+            return fallback_message
 
 
 @lru_cache(maxsize=8)

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -336,6 +336,7 @@ def _handle_chat_completion_request(data):
             messages=messages,
             options=_extract_chat_completion_options(data),
         )
+        backend_path = assistant_message.pop("__tokenplace_backend_path", "unknown")
         log_info("Response generated successfully")
 
         tool_calls = assistant_message.get("tool_calls")
@@ -393,12 +394,14 @@ def _handle_chat_completion_request(data):
             response = jsonify({"encrypted": True, "data": encrypted_response})
             response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
             response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Backend-Path"] = backend_path
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
         response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
         response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Backend-Path"] = backend_path
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 
@@ -499,6 +502,7 @@ def _handle_text_completion_request(data):
             messages=messages,
             options=_extract_chat_completion_options(data),
         )
+        backend_path = assistant_message.pop("__tokenplace_backend_path", "unknown")
         log_info("Response generated successfully")
 
         response_data = {
@@ -533,12 +537,14 @@ def _handle_text_completion_request(data):
             response = jsonify({"encrypted": True, "data": encrypted_response})
             response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
             response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+            response.headers["X-Tokenplace-API-V1-Backend-Path"] = backend_path
             response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
             return response
 
         response = jsonify(response_data)
         response.headers["X-Tokenplace-API-V1-Provider"] = resolved_provider_name
         response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] = resolved_provider_path
+        response.headers["X-Tokenplace-API-V1-Backend-Path"] = backend_path
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -95,12 +95,13 @@ def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
     has_payload = all(
         key in relay_response for key in ("client_public_key", "chat_history", "cipherkey", "iv")
     )
+    has_api_v1_payload = isinstance(relay_response.get("api_v1_request"), dict)
     has_heartbeat = "next_ping_in_x_seconds" in relay_response
     relay_error = _relay_error_message(relay_response)
     wait_seconds = relay_response.get("next_ping_in_x_seconds", "missing")
 
     return (
-        f"keys={keys} has_legacy_payload={has_payload} "
+        f"keys={keys} has_legacy_payload={has_payload} has_api_v1_payload={has_api_v1_payload} "
         f"has_heartbeat={has_heartbeat} wait={wait_seconds} "
         f"error={relay_error or 'none'}"
     )
@@ -281,14 +282,16 @@ def run(args: argparse.Namespace) -> int:
             relay_response = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
             legacy_payload = is_legacy_relay_payload(relay_response)
+            api_v1_payload = isinstance(relay_response.get("api_v1_request"), dict)
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
             relay_error = _relay_error_message(relay_response)
-            registered = relay_error is None and (legacy_payload or heartbeat_ack)
+            registered = relay_error is None and (legacy_payload or api_v1_payload or heartbeat_ack)
 
             print(
                 "desktop.compute_node_bridge.relay_poll "
                 f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
-                f"legacy_payload={legacy_payload} heartbeat_ack={heartbeat_ack} "
+                f"legacy_payload={legacy_payload} api_v1_payload={api_v1_payload} "
+                f"heartbeat_ack={heartbeat_ack} "
                 f"summary={_relay_response_summary(relay_response)}",
                 file=sys.stderr,
             )
@@ -301,10 +304,11 @@ def run(args: argparse.Namespace) -> int:
                         "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
                         "operator; update relay.py to repo HEAD"
                     )
-            elif legacy_payload:
+            elif legacy_payload or api_v1_payload:
+                payload_kind = "api_v1" if api_v1_payload else "legacy"
                 print(
                     "desktop.compute_node_bridge.process_request.start "
-                    f"stream={relay_response.get('stream') is True}",
+                    f"kind={payload_kind} stream={relay_response.get('stream') is True}",
                     file=sys.stderr,
                 )
                 processed = runtime.process_relay_request(relay_response)

--- a/relay.py
+++ b/relay.py
@@ -379,6 +379,7 @@ def _validate_server_registration():
 known_servers = {}
 client_inference_requests = {}
 client_responses = {}
+api_v1_request_results = {}
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -435,6 +436,9 @@ def _unregister_server(server_public_key: str) -> bool:
 
     removed = known_servers.pop(server_public_key, None) is not None
     client_inference_requests.pop(server_public_key, None)
+    for request_id, result_payload in list(api_v1_request_results.items()):
+        if result_payload.get("server_public_key") == server_public_key:
+            api_v1_request_results.pop(request_id, None)
 
     with stream_lock:
         stale_session_ids = [
@@ -453,6 +457,51 @@ def _unregister_server(server_public_key: str) -> bool:
                     streaming_sessions_by_client.pop(client_public_key, None)
 
     return removed
+
+
+def _queue_api_v1_compute_request(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    options: dict[str, Any],
+    timeout_seconds: float,
+) -> tuple[int, dict[str, Any]]:
+    """Queue an API v1 compute request for a registered node and await completion."""
+
+    _evict_stale_servers()
+    if not known_servers:
+        return 503, {"error": "No registered compute nodes available"}
+
+    server_public_key = secrets.choice(list(known_servers.keys()))
+    request_id = secrets.token_urlsafe(18)
+    queued_payload = {
+        "api_v1_request": {
+            "request_id": request_id,
+            "model": model,
+            "messages": messages,
+            "options": options,
+            "stream": False,
+        }
+    }
+    if server_public_key not in client_inference_requests:
+        client_inference_requests[server_public_key] = []
+    client_inference_requests[server_public_key].append(queued_payload)
+
+    deadline = time.time() + max(float(timeout_seconds), 0.1)
+    while time.time() < deadline:
+        result_payload = api_v1_request_results.pop(request_id, None)
+        if isinstance(result_payload, dict):
+            status_code = int(result_payload.get("status_code", 502))
+            body = result_payload.get("body")
+            if not isinstance(body, dict):
+                body = {"error": "Invalid compute-node response payload"}
+                status_code = 502
+            body["relay_backend"] = "registered_compute_node"
+            body["server_public_key"] = result_payload.get("server_public_key")
+            return status_code, body
+        time.sleep(0.05)
+
+    return 504, {"error": "Timed out waiting for registered compute node"}
 
 
 def _can_resolve_gpu_host(hostname: str) -> bool:
@@ -818,21 +867,95 @@ def sink():
             batch.append(request_payload)
 
         first_request = batch[0]
-        response_data.update({
-            'client_public_key': first_request['client_public_key'],
-            'chat_history': first_request['chat_history'],
-            'cipherkey': first_request['cipherkey'],
-            'iv': first_request.get('iv', ''),
-        })
+        if isinstance(first_request, dict) and isinstance(first_request.get("api_v1_request"), dict):
+            response_data["api_v1_request"] = first_request["api_v1_request"]
+        else:
+            response_data.update({
+                'client_public_key': first_request['client_public_key'],
+                'chat_history': first_request['chat_history'],
+                'cipherkey': first_request['cipherkey'],
+                'iv': first_request.get('iv', ''),
+            })
 
-        if first_request.get('stream') and first_request.get('stream_session_id'):
-            response_data['stream'] = True
-            response_data['stream_session_id'] = first_request['stream_session_id']
+            if first_request.get('stream') and first_request.get('stream_session_id'):
+                response_data['stream'] = True
+                response_data['stream_session_id'] = first_request['stream_session_id']
 
         if max_batch_size > 1:
             response_data['batch'] = batch
 
     return jsonify(response_data)
+
+
+@app.route('/relay/api/v1/chat/completions', methods=['POST'])
+def relay_api_v1_chat_completions():
+    """Dispatch API v1 chat-completion compute to registered compute nodes."""
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    model = data.get("model")
+    messages = data.get("messages")
+    if not isinstance(model, str) or not model.strip():
+        return jsonify({'error': 'Invalid model'}), 400
+    if not isinstance(messages, list):
+        return jsonify({'error': 'Invalid messages'}), 400
+    if data.get("stream") is True:
+        return jsonify({'error': 'Streaming is not supported for API v1 relay compute'}), 400
+
+    options = {
+        key: value
+        for key, value in data.items()
+        if key not in {"model", "messages", "stream"} and value is not None
+    }
+    timeout_seconds = float(data.get("relay_timeout_seconds", 30))
+    status_code, result = _queue_api_v1_compute_request(
+        model=model,
+        messages=messages,
+        options=options,
+        timeout_seconds=timeout_seconds,
+    )
+    response = jsonify(result)
+    response.status_code = status_code
+    response.headers["X-Tokenplace-Relay-Compute-Path"] = (
+        "registered_compute_node" if status_code == 200 else "registered_compute_node_error"
+    )
+    return response
+
+
+@app.route('/relay/api/v1/chat/completions/result', methods=['POST'])
+def relay_api_v1_chat_completions_result():
+    """Accept API v1 compute results emitted by registered compute nodes."""
+
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    request_id = data.get("request_id")
+    if not isinstance(request_id, str) or not request_id.strip():
+        return jsonify({'error': 'Invalid request_id'}), 400
+
+    status_code = data.get("status_code", 200)
+    try:
+        status_code = int(status_code)
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Invalid status_code'}), 400
+
+    body = data.get("body")
+    if not isinstance(body, dict):
+        return jsonify({'error': 'Invalid body'}), 400
+
+    api_v1_request_results[request_id] = {
+        "status_code": status_code,
+        "body": body,
+        "server_public_key": data.get("server_public_key"),
+    }
+    return jsonify({'message': 'result accepted'}), 200
 
 
 @app.route('/unregister', methods=['POST'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,10 +220,11 @@ def setup_servers(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0" if run_real_bridge_e2e else "1"
-    # NOTE: keep API v1 provider selection local for the desktop-bridge landing-page
-    # guardrail. Pointing TOKENPLACE_DISTRIBUTED_COMPUTE_URL at the relay causes
-    # recursive /api/v1/chat/completions self-calls and deterministic failures.
     test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
+    if run_real_bridge_e2e:
+        test_env["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "distributed"
+        test_env["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = E2E_BASE_URL
+        test_env["TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"] = "0"
 
     # Start the relay server with the --use_mock_llm flag
     relay_command = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -456,19 +456,22 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         stream_mode = latest_headers.get("x-tokenplace-api-v1-stream-mode")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
+        backend_path = latest_headers.get("x-tokenplace-api-v1-backend-path")
         provider_diagnostics = (
             "landing-page real-provider guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"backend_path={backend_path!r}, stream_mode={stream_mode!r}; expected "
+            "provider_class='DistributedApiV1ComputeProvider', resolved_provider_path='distributed', "
+            "backend_path='registered_compute_node', stream_mode='non-streaming'"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
+        assert provider_class == "DistributedApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
+        assert backend_path == "registered_compute_node", provider_diagnostics
+        assert resolved_provider_path == "distributed", (
             "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+            f"'distributed'. {provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
+        if runtime_supports_real_inference and resolved_provider_path != "distributed":
             assert assistant_text.strip().lower() != "stub", (
                 "assistant response must not be stub when runtime reports real inference support "
                 f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,7 +262,7 @@ def test_api_v1_chat_completion_supports_distributed_provider_contract(client, m
     data = response.get_json()
     assert data['choices'][0]['message']['content'] == 'distributed-path response'
 
-    assert captured['url'] == 'https://compute.example/api/v1/chat/completions'
+    assert captured['url'] == 'https://compute.example/relay/api/v1/chat/completions'
     assert captured['json']['model'] == 'remote-only-model'
     assert captured['json']['messages'][0]['content'] == 'Ping distributed runtime'
     assert captured['json']['stream'] is False

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -42,7 +42,7 @@ def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
         options={"temperature": 0.2, "stream": True},
     )
 
-    assert captured["url"] == "https://node-a.example/api/v1/chat/completions"
+    assert captured["url"] == "https://node-a.example/relay/api/v1/chat/completions"
     assert captured["timeout"] == 5
     assert captured["json"]["model"] == "llama-3-8b-instruct"
     assert captured["json"]["messages"] == [{"role": "user", "content": "hi"}]
@@ -50,6 +50,7 @@ def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
     assert captured["json"]["temperature"] == 0.2
     assert "stream" not in captured["json"] or captured["json"]["stream"] is False
     assert message["content"] == "distributed response"
+    assert message["__tokenplace_backend_path"] == "registered_compute_node"
 
 
 def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):
@@ -75,7 +76,9 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(mon
         messages=[{"role": "user", "content": "hello"}],
     )
 
-    assert result == fallback_message
+    assert result["role"] == fallback_message["role"]
+    assert result["content"] == fallback_message["content"]
+    assert result["__tokenplace_backend_path"] == "fallback_to_local_in_process"
 
 
 def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatch):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -51,6 +51,7 @@ class ComputeNodeRuntimeConfig:
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
+API_V1_RELAY_REQUIRED_FIELDS = frozenset({"request_id", "model", "messages"})
 
 
 def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
@@ -82,6 +83,20 @@ class LegacyRelayRequestAdapter:
 
     def process(self, request_data: Dict[str, Any]) -> bool:
         return self._relay_client.process_client_request(request_data)
+
+
+class ApiV1RelayRequestAdapter:
+    """Adapter for relay-dispatched API v1 chat-completion payloads."""
+
+    def __init__(self, relay_client: "RelayClient"):
+        self._relay_client = relay_client
+
+    def can_process(self, request_data: Dict[str, Any]) -> bool:
+        payload = request_data.get("api_v1_request")
+        return isinstance(payload, dict) and API_V1_RELAY_REQUIRED_FIELDS.issubset(payload.keys())
+
+    def process(self, request_data: Dict[str, Any]) -> bool:
+        return self._relay_client.process_api_v1_chat_request(request_data)
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -243,7 +258,10 @@ class ComputeNodeRuntime:
             include_configured_servers=runtime_config.use_configured_relay_fallbacks,
         )
         if request_adapters is None:
-            self.request_adapters = [LegacyRelayRequestAdapter(self.relay_client)]
+            self.request_adapters = [
+                LegacyRelayRequestAdapter(self.relay_client),
+                ApiV1RelayRequestAdapter(self.relay_client),
+            ]
         else:
             self.request_adapters = list(request_adapters)
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -733,6 +733,78 @@ class RelayClient:
             log_error("Exception during request processing: {}", str(e), exc_info=True)
             return False
 
+    def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
+        """Process a relay-dispatched API v1 chat request and return result to relay."""
+
+        api_v1_request = request_data.get("api_v1_request")
+        if not isinstance(api_v1_request, dict):
+            return False
+
+        request_id = api_v1_request.get("request_id")
+        messages = api_v1_request.get("messages")
+        if not isinstance(request_id, str) or not request_id.strip():
+            log_error("Invalid API v1 relay request: missing request_id")
+            return False
+        if not isinstance(messages, list):
+            log_error("Invalid API v1 relay request: messages must be a list")
+            return False
+
+        status_code = 200
+        result_body: Dict[str, Any]
+        try:
+            response_history = self.model_manager.llama_cpp_get_response(messages)
+            if not response_history or not isinstance(response_history[-1], dict):
+                raise ValueError("model returned invalid response history")
+            assistant_message = response_history[-1]
+            result_body = {
+                "id": f"relaychat-{int(time.time() * 1000)}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": api_v1_request.get("model", "unknown"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": assistant_message.get("role", "assistant"),
+                            "content": assistant_message.get("content", ""),
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        except Exception as exc:
+            status_code = 502
+            result_body = {"error": str(exc)}
+
+        result_payload = {
+            "request_id": request_id,
+            "status_code": status_code,
+            "body": result_body,
+            "server_public_key": self.crypto_manager.public_key_b64,
+        }
+
+        request_kwargs = {
+            "json": result_payload,
+            "timeout": self._request_timeout,
+        }
+        headers = self._auth_headers()
+        if headers:
+            request_kwargs["headers"] = headers
+
+        timeout = request_kwargs.pop("timeout", self._request_timeout)
+        result_response = requests.post(
+            f"{self.relay_url}/relay/api/v1/chat/completions/result",
+            timeout=timeout,
+            **request_kwargs,
+        )
+        if result_response.status_code != 200:
+            log_error(
+                "Error status from /relay/api/v1/chat/completions/result: {}",
+                result_response.status_code,
+            )
+            return False
+        return True
+
     def poll_relay_continuously(self):  # pragma: no cover
         """
         Continuously poll the relay for new chat messages and process them.


### PR DESCRIPTION
### Motivation
- The landing-page UI posts to `/api/v1/chat/completions` but the desktop bridge only processed legacy `/sink` payloads, causing registered desktop nodes to appear healthy while not serving landing-page requests.
- Provide a single, non-streaming API v1 path that lets the relay dispatch landing-page chat work to a registered desktop compute node end-to-end.
- Surface stable runtime diagnostics so we can prove at runtime which backend actually served a request (local vs registered node vs fallback).

### Description
- Add a relay-native non-streaming dispatch/result flow: new endpoints `POST /relay/api/v1/chat/completions` (dispatch) and `POST /relay/api/v1/chat/completions/result` (result) and an in-relay request queue keyed by registered server public keys (`api_v1_request_results`).
- Wire `api.v1.compute_provider` distributed provider to call the relay dispatch path by default and attach `__tokenplace_backend_path` diagnostics to provider responses, surfaced as response header `X-Tokenplace-API-V1-Backend-Path`.
- Extend the compute runtime and desktop bridge to recognize and process the new `api_v1_request` relay envelope via a new `ApiV1RelayRequestAdapter`, and add bridge logging that distinguishes `api_v1_payload` vs legacy payloads.
- Add `RelayClient.process_api_v1_chat_request` so registered compute nodes generate an OpenAI-compatible, non-streaming completion and POST results back to the relay result endpoint; update tests/fixtures to assert the distributed+registered-node path.

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and it passed successfully. 
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and it passed successfully (24 tests).
- Attempted focused E2E `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming'` and the run errored in this container because Playwright Chromium is not installed; the code-paths and tests were updated to enable these E2E checks when browsers are installed (`playwright install`).
- Ran `pre-commit run --all-files` which completed and reported all hooks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e17ea7d8832fbc629f6545db1a05)