### PR TITLE
🔧 fix: surface structured API v1 relay errors in landing chat

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -27,6 +27,19 @@ _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
 class ComputeProviderError(Exception):
     """Raised when a compute provider cannot satisfy a request."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "compute_provider_error",
+        error_type: str = "server_error",
+        status_code: int = 502,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.error_type = error_type
+        self.status_code = status_code
+
 
 class ApiV1ComputeProvider(Protocol):
     """Contract for API v1-compatible compute providers."""
@@ -92,30 +105,105 @@ class DistributedApiV1ComputeProvider:
                 json=payload,
                 timeout=self.timeout_seconds,
             )
-        except Exception as exc:
-            raise ComputeProviderError(f"distributed provider request failed: {exc}") from exc
+        except requests.Timeout as exc:
+            raise ComputeProviderError(
+                "Timed out while contacting the LLM compute bridge.",
+                code="compute_bridge_timeout",
+                error_type="timeout_error",
+                status_code=504,
+            ) from exc
+        except requests.RequestException as exc:
+            raise ComputeProviderError(
+                "Unable to reach the LLM compute bridge.",
+                code="compute_node_unreachable",
+                error_type="server_error",
+                status_code=503,
+            ) from exc
 
         if response.status_code != 200:
+            payload = None
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = None
+
+            relay_message = None
+            relay_code = None
+            if isinstance(payload, dict):
+                error_payload = payload.get("error")
+                if isinstance(error_payload, dict):
+                    relay_message = error_payload.get("message")
+                    relay_code = error_payload.get("code")
+
+            if response.status_code == 503 and (
+                relay_message == "No registered compute nodes available" or relay_code == 503
+            ):
+                raise ComputeProviderError(
+                    "No LLM servers are available right now.",
+                    code="no_compute_nodes_available",
+                    error_type="service_unavailable_error",
+                    status_code=503,
+                )
+
+            if response.status_code == 504:
+                raise ComputeProviderError(
+                    "Timed out waiting for an LLM server response.",
+                    code="compute_node_timeout",
+                    error_type="timeout_error",
+                    status_code=504,
+                )
+
+            if response.status_code == 502:
+                raise ComputeProviderError(
+                    "The LLM server returned an invalid response.",
+                    code="compute_node_invalid_payload",
+                    error_type="server_error",
+                    status_code=502,
+                )
+
             raise ComputeProviderError(
-                f"distributed provider returned status {response.status_code}"
+                f"distributed provider returned status {response.status_code}",
+                code="compute_node_bridge_error",
+                error_type="server_error",
+                status_code=502,
             )
 
         try:
             body = response.json()
         except ValueError as exc:
-            raise ComputeProviderError("distributed provider returned non-JSON response") from exc
+            raise ComputeProviderError(
+                "The LLM compute bridge returned a non-JSON response.",
+                code="compute_node_invalid_payload",
+                error_type="server_error",
+                status_code=502,
+            ) from exc
 
         choices = body.get("choices")
         if not isinstance(choices, list) or not choices:
-            raise ComputeProviderError("distributed provider returned no choices")
+            raise ComputeProviderError(
+                "The LLM server returned an invalid response payload.",
+                code="compute_node_invalid_payload",
+                error_type="server_error",
+                status_code=502,
+            )
 
         first_choice = choices[0]
         if not isinstance(first_choice, dict):
-            raise ComputeProviderError("distributed provider choice payload is invalid")
+            raise ComputeProviderError(
+                "The LLM server returned an invalid response payload.",
+                code="compute_node_invalid_payload",
+                error_type="server_error",
+                status_code=502,
+            )
 
         message = first_choice.get("message")
         if not isinstance(message, dict):
-            raise ComputeProviderError("distributed provider response missing message")
+            raise ComputeProviderError(
+                "The LLM server returned an invalid response payload.",
+                code="compute_node_invalid_payload",
+                error_type="server_error",
+                status_code=502,
+            )
 
         _last_backend_path.set("registered_desktop_compute_node")
         return message

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -422,8 +422,9 @@ def _handle_chat_completion_request(data):
     except ComputeProviderError as e:
         return format_error_response(
             str(e),
-            error_type="server_error",
-            status_code=502,
+            error_type=getattr(e, "error_type", "server_error"),
+            code=getattr(e, "code", "compute_provider_error"),
+            status_code=getattr(e, "status_code", 502),
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
         log_error("Unexpected error in create_chat_completion endpoint", exc_info=True)
@@ -559,8 +560,9 @@ def _handle_text_completion_request(data):
     except ComputeProviderError as e:
         return format_error_response(
             str(e),
-            error_type="server_error",
-            status_code=502,
+            error_type=getattr(e, "error_type", "server_error"),
+            code=getattr(e, "code", "compute_provider_error"),
+            status_code=getattr(e, "status_code", 502),
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
         log_error("Unexpected error in create_completion endpoint")

--- a/static/chat.js
+++ b/static/chat.js
@@ -365,6 +365,43 @@ new Vue({
         },
 
         // Send a message to the server using the new API
+        mapApiErrorToUserMessage(error) {
+            const code = error && typeof error.code === 'string' ? error.code : '';
+            if (code === 'no_compute_nodes_available') {
+                return 'No LLM servers are available right now.';
+            }
+            if (code === 'compute_node_timeout' || code === 'compute_bridge_timeout') {
+                return 'LLM servers are taking too long to respond. Please try again.';
+            }
+            if (code === 'compute_node_unreachable' || code === 'compute_node_bridge_error') {
+                return 'Unable to reach an LLM server right now. Please try again.';
+            }
+            if (code === 'compute_node_invalid_payload') {
+                return 'An LLM server returned an invalid response. Please try again.';
+            }
+            return 'Sorry, I encountered an issue generating a response. Please try again.';
+        },
+
+        async parseApiError(response) {
+            let errorData = null;
+            try {
+                errorData = await response.json();
+            } catch (_ignored) {
+                errorData = null;
+            }
+
+            const errorPayload = errorData && errorData.error && typeof errorData.error === 'object'
+                ? errorData.error
+                : {};
+
+            return {
+                status: response.status,
+                message: typeof errorPayload.message === 'string' ? errorPayload.message : 'Unknown error',
+                type: typeof errorPayload.type === 'string' ? errorPayload.type : 'server_error',
+                code: typeof errorPayload.code === 'string' ? errorPayload.code : 'unknown_error',
+            };
+        },
+
         async sendMessageApi() {
             if (!this.serverPublicKey) {
                 console.error('Server public key not available');
@@ -400,8 +437,9 @@ new Vue({
                 });
 
                 if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(`API error: ${errorData.error?.message || 'Unknown error'}`);
+                    const apiError = await this.parseApiError(response);
+                    apiError.userMessage = this.mapApiErrorToUserMessage(apiError);
+                    throw apiError;
                 }
 
                 const responseData = await response.json();
@@ -425,7 +463,7 @@ new Vue({
                 return responseData;
             } catch (error) {
                 console.error('API request error:', error);
-                return null;
+                throw error;
             }
         },
 
@@ -526,7 +564,9 @@ new Vue({
                 console.error('Error sending message:', error);
                 this.chatHistory.push({
                     role: 'assistant',
-                    content: 'Sorry, an error occurred while sending your message. Please try again.'
+                    content: error && typeof error.userMessage === 'string'
+                        ? error.userMessage
+                        : 'Sorry, an error occurred while sending your message. Please try again.'
                 });
             } finally {
                 this.isGeneratingResponse = false;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -249,6 +249,60 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     assert v2_requests == []
 
 
+def test_landing_chat_no_servers_shows_specific_message(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """Landing chat should render a clear no-servers message for structured API errors."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+
+    page.route(
+        "**/api/v1/public-key",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        ),
+    )
+    page.route(
+        "**/api/v1/chat/completions",
+        lambda route: route.fulfill(
+            status=503,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "error": {
+                        "message": "No LLM servers are available right now.",
+                        "type": "service_unavailable_error",
+                        "code": "no_compute_nodes_available",
+                    }
+                }
+            ),
+        ),
+    )
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    page.locator("textarea").first.fill("hello")
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+    assert assistant_message.inner_text().strip() == "No LLM servers are available right now."
+
+
 @pytest.mark.e2e
 def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     page: Page,

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -13,6 +13,13 @@ from api.v1.compute_provider import (
 from relay import app
 
 
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
 def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
     captured = {}
 
@@ -92,6 +99,69 @@ def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatc
             model_id="llama-3-8b-instruct",
             messages=[{"role": "user", "content": "hello"}],
         )
+
+
+def test_distributed_compute_provider_maps_no_nodes_to_structured_error(monkeypatch):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(
+            status_code=503,
+            json=lambda: {
+                "error": {
+                    "message": "No registered compute nodes available",
+                    "code": 503,
+                }
+            },
+        ),
+    )
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
+
+    with pytest.raises(ComputeProviderError) as exc_info:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert exc_info.value.code == "no_compute_nodes_available"
+    assert exc_info.value.error_type == "service_unavailable_error"
+    assert exc_info.value.status_code == 503
+
+
+def test_api_v1_chat_completion_returns_structured_no_nodes_error(client, monkeypatch):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(
+            status_code=503,
+            json=lambda: {
+                "error": {
+                    "message": "No registered compute nodes available",
+                    "code": 503,
+                }
+            },
+        ),
+    )
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    try:
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["message"] == "No LLM servers are available right now."
+    assert payload["error"]["type"] == "service_unavailable_error"
+    assert payload["error"]["code"] == "no_compute_nodes_available"
 
 
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,3 +30,10 @@ def test_landing_chat_js_disables_incremental_typing_for_relay_v1():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "relayApiV1NonStreaming: true" in chat_js
     assert "incremental character streaming" in chat_js
+
+
+def test_landing_chat_js_maps_structured_api_errors_to_user_messages():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "mapApiErrorToUserMessage" in chat_js
+    assert "no_compute_nodes_available" in chat_js
+    assert "No LLM servers are available right now." in chat_js


### PR DESCRIPTION
### Motivation
- Users on the relay landing page were seeing vague failures (and sometimes the `stub` placeholder) when desktop compute nodes were unavailable, which is unhelpful. 
- The API v1 error contract needs stable, machine-readable failure codes so the UI can map distinct failure modes to clear user messages. 
- Start by handling the “no LLM servers available” case and add groundwork to map other relay/bridge failure modes consistently.

### Description
- Extend `ComputeProviderError` in `api/v1/compute_provider.py` with structured metadata (`code`, `error_type`, `status_code`) and map common distributed failure modes (no nodes, timeouts, unreachable bridge, invalid payload) to stable codes/messages. 
- Update API v1 route error handling in `api/v1/routes.py` to preserve and surface the provider `code`/`type`/`status_code` via the standard `format_error_response` envelope. 
- Add client-side parsing and mapping in `static/chat.js` (`parseApiError`, `mapApiErrorToUserMessage`) and use those to render safe, specific user-visible messages (e.g., `No LLM servers are available right now.`) instead of generic/fallback text. 
- Add focused regression tests: unit tests for the compute-provider mapping and API-level error shape, a unit test to assert UI helper presence, and an e2e test that asserts the landing chat renders the no-servers message.

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and it passed (all unit assertions for the provider and API contract succeeded). 
- Ran `python -m pytest -q tests/unit/test_touch_ui.py` and it passed (UI JS presence/tests succeeded). 
- Ran `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming or no_servers'` and tests were discovered but skipped in this environment (E2E fixtures are environment-dependent). 
- Ran `pre-commit run --all-files` and hooks passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea75263844832f9f59bee03bf0e230)