### PR TITLE
Normalize API v1 relay errors and surface meaningful landing-page messages

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -27,6 +27,20 @@ _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
 class ComputeProviderError(Exception):
     """Raised when a compute provider cannot satisfy a request."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_type: str = "server_error",
+        code: str = "compute_provider_error",
+        status_code: int = 502,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+        self.code = code
+        self.status_code = status_code
+
 
 class ApiV1ComputeProvider(Protocol):
     """Contract for API v1-compatible compute providers."""
@@ -92,30 +106,72 @@ class DistributedApiV1ComputeProvider:
                 json=payload,
                 timeout=self.timeout_seconds,
             )
-        except Exception as exc:
-            raise ComputeProviderError(f"distributed provider request failed: {exc}") from exc
+        except requests.Timeout as exc:
+            raise ComputeProviderError(
+                "Timed out waiting for a relay compute node response.",
+                code="relay_bridge_timeout",
+                status_code=504,
+            ) from exc
+        except requests.RequestException as exc:
+            raise ComputeProviderError(
+                "Unable to reach relay compute node bridge.",
+                code="relay_bridge_unreachable",
+                status_code=502,
+            ) from exc
 
         if response.status_code != 200:
+            default_message = f"Relay compute node request failed with status {response.status_code}."
+            error_type = "server_error"
+            error_code = "relay_bridge_error"
+            try:
+                body = response.json()
+                if isinstance(body, dict):
+                    error = body.get("error")
+                    if isinstance(error, dict):
+                        default_message = str(error.get("message") or default_message)
+                        error_type = str(error.get("type") or error_type)
+                        error_code = str(error.get("code") or error_code)
+            except ValueError:
+                pass
             raise ComputeProviderError(
-                f"distributed provider returned status {response.status_code}"
+                default_message,
+                error_type=error_type,
+                code=error_code,
+                status_code=response.status_code,
             )
 
         try:
             body = response.json()
         except ValueError as exc:
-            raise ComputeProviderError("distributed provider returned non-JSON response") from exc
+            raise ComputeProviderError(
+                "Relay compute node bridge returned non-JSON response.",
+                code="relay_bridge_invalid_payload",
+                status_code=502,
+            ) from exc
 
         choices = body.get("choices")
         if not isinstance(choices, list) or not choices:
-            raise ComputeProviderError("distributed provider returned no choices")
+            raise ComputeProviderError(
+                "Relay compute node bridge returned no completion choices.",
+                code="relay_bridge_invalid_payload",
+                status_code=502,
+            )
 
         first_choice = choices[0]
         if not isinstance(first_choice, dict):
-            raise ComputeProviderError("distributed provider choice payload is invalid")
+            raise ComputeProviderError(
+                "Relay compute node bridge returned an invalid choice payload.",
+                code="relay_bridge_invalid_payload",
+                status_code=502,
+            )
 
         message = first_choice.get("message")
         if not isinstance(message, dict):
-            raise ComputeProviderError("distributed provider response missing message")
+            raise ComputeProviderError(
+                "Relay compute node bridge response is missing a message payload.",
+                code="relay_bridge_invalid_payload",
+                status_code=502,
+            )
 
         _last_backend_path.set("registered_desktop_compute_node")
         return message

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -421,9 +421,10 @@ def _handle_chat_completion_request(data):
         )
     except ComputeProviderError as e:
         return format_error_response(
-            str(e),
-            error_type="server_error",
-            status_code=502,
+            e.message,
+            error_type=e.error_type,
+            code=e.code,
+            status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
         log_error("Unexpected error in create_chat_completion endpoint", exc_info=True)
@@ -558,9 +559,10 @@ def _handle_text_completion_request(data):
         )
     except ComputeProviderError as e:
         return format_error_response(
-            str(e),
-            error_type="server_error",
-            status_code=502,
+            e.message,
+            error_type=e.error_type,
+            code=e.code,
+            status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
         log_error("Unexpected error in create_completion endpoint")

--- a/relay.py
+++ b/relay.py
@@ -695,19 +695,45 @@ def relay_diagnostics():
 def relay_api_v1_chat_completions():
     """Queue API v1 chat requests for registered compute nodes and wait for completion."""
 
+    def _api_v1_error(message: str, *, code: str, status_code: int) -> tuple[Response, int]:
+        return (
+            jsonify(
+                {
+                    "error": {
+                        "message": message,
+                        "type": "server_error" if status_code >= 500 else "invalid_request_error",
+                        "code": code,
+                    }
+                }
+            ),
+            status_code,
+        )
+
     _evict_stale_servers()
     payload = request.get_json() or {}
     if not isinstance(payload, dict):
-        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+        return _api_v1_error(
+            "Invalid request data.",
+            code="invalid_request_data",
+            status_code=400,
+        )
 
     model = payload.get('model')
     messages = payload.get('messages')
     if not isinstance(model, str) or not model.strip() or not isinstance(messages, list):
-        return jsonify({'error': {'message': 'Invalid API v1 payload', 'code': 400}}), 400
+        return _api_v1_error(
+            "Invalid API v1 payload.",
+            code="invalid_request_payload",
+            status_code=400,
+        )
 
     available_servers = list(known_servers.keys())
     if not available_servers:
-        return jsonify({'error': {'message': 'No registered compute nodes available', 'code': 503}}), 503
+        return _api_v1_error(
+            "No LLM servers are available right now.",
+            code="no_registered_compute_nodes",
+            status_code=503,
+        )
 
     selected_server = secrets.choice(available_servers)
     request_id = secrets.token_urlsafe(16)
@@ -730,14 +756,26 @@ def relay_api_v1_chat_completions():
     timeout_seconds = float(os.environ.get('TOKENPLACE_RELAY_API_V1_TIMEOUT_SECONDS', '45'))
     response_payload = _await_api_v1_response(request_id, timeout_seconds)
     if response_payload is None:
-        return jsonify({'error': {'message': 'Timed out waiting for registered compute node', 'code': 504}}), 504
+        return _api_v1_error(
+            "Timed out waiting for an LLM server response.",
+            code="relay_compute_node_timeout",
+            status_code=504,
+        )
 
     if response_payload.get('error'):
-        return jsonify({'error': {'message': response_payload['error'], 'code': 502}}), 502
+        return _api_v1_error(
+            "LLM server failed to process the request.",
+            code="relay_compute_node_error",
+            status_code=502,
+        )
 
     message = response_payload.get('message')
     if not isinstance(message, dict):
-        return jsonify({'error': {'message': 'Compute node returned invalid response', 'code': 502}}), 502
+        return _api_v1_error(
+            "LLM server returned an invalid response payload.",
+            code="relay_compute_node_invalid_payload",
+            status_code=502,
+        )
 
     return jsonify(
         {

--- a/static/chat.js
+++ b/static/chat.js
@@ -368,7 +368,7 @@ new Vue({
         async sendMessageApi() {
             if (!this.serverPublicKey) {
                 console.error('Server public key not available');
-                return null;
+                return { response: null, error: this.normalizeApiError(null) };
             }
 
             try {
@@ -400,8 +400,16 @@ new Vue({
                 });
 
                 if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(`API error: ${errorData.error?.message || 'Unknown error'}`);
+                    let errorData = null;
+                    try {
+                        errorData = await response.json();
+                    } catch (_parseError) {
+                        errorData = null;
+                    }
+                    return {
+                        response: null,
+                        error: this.normalizeApiError(errorData)
+                    };
                 }
 
                 const responseData = await response.json();
@@ -418,14 +426,14 @@ new Vue({
                         throw new Error('Failed to decrypt response');
                     }
 
-                    return JSON.parse(decryptedJson);
+                    return { response: JSON.parse(decryptedJson), error: null };
                 }
 
                 // Handle unencrypted response (should not happen with encrypted=true)
-                return responseData;
+                return { response: responseData, error: null };
             } catch (error) {
                 console.error('API request error:', error);
-                return null;
+                return { response: null, error: this.normalizeApiError(null) };
             }
         },
 
@@ -475,6 +483,47 @@ new Vue({
             return message.content;
         },
 
+        normalizeApiError(errorPayload) {
+            const fallback = {
+                message: 'Request failed',
+                type: 'server_error',
+                code: 'unknown_error'
+            };
+
+            if (!errorPayload || typeof errorPayload !== 'object') {
+                return fallback;
+            }
+
+            const error = errorPayload.error && typeof errorPayload.error === 'object'
+                ? errorPayload.error
+                : errorPayload;
+
+            return {
+                message: typeof error.message === 'string' ? error.message : fallback.message,
+                type: typeof error.type === 'string' ? error.type : fallback.type,
+                code: typeof error.code === 'string' ? error.code : fallback.code
+            };
+        },
+
+        userFacingErrorMessage(apiError) {
+            if (!apiError || typeof apiError !== 'object') {
+                return 'Sorry, I encountered an issue generating a response. Please try again.';
+            }
+
+            const code = apiError.code || '';
+            if (code === 'no_registered_compute_nodes') {
+                return 'No LLM servers are available right now.';
+            }
+            if (code === 'relay_compute_node_timeout' || code === 'relay_bridge_timeout') {
+                return 'LLM servers took too long to respond. Please try again.';
+            }
+            if (code === 'relay_compute_node_invalid_payload' || code === 'relay_bridge_invalid_payload') {
+                return 'LLM servers returned an invalid response. Please try again.';
+            }
+
+            return 'Sorry, I encountered an issue generating a response. Please try again.';
+        },
+
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
@@ -491,10 +540,16 @@ new Vue({
 
             try {
                 // Relay-path landing chat in v0.1.0 is API v1-only and non-streaming.
-                let response = await this.sendMessageApi();
+                const apiResult = await this.sendMessageApi();
 
                 // Process the response
-                if (response) {
+                if (apiResult && apiResult.error) {
+                    this.chatHistory.push({
+                        role: 'assistant',
+                        content: this.userFacingErrorMessage(apiResult.error)
+                    });
+                } else if (apiResult && apiResult.response) {
+                    const response = apiResult.response;
                     // For API response, extract last message
                     if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -249,6 +249,58 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     assert v2_requests == []
 
 
+def test_landing_chat_no_servers_shows_meaningful_api_v1_error(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+
+    page.route(
+        "**/api/v1/public-key",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        ),
+    )
+    page.route(
+        "**/api/v1/chat/completions",
+        lambda route: route.fulfill(
+            status=503,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "error": {
+                        "message": "No LLM servers are available right now.",
+                        "type": "server_error",
+                        "code": "no_registered_compute_nodes",
+                    }
+                }
+            ),
+        ),
+    )
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    page.locator("textarea").first.fill("hello")
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+    assert "No LLM servers are available right now." in assistant_message.inner_text()
+
+
 @pytest.mark.e2e
 def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     page: Page,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,7 +300,7 @@ def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client,
     assert response.get_json()['choices'][0]['message']['content'] == 'local fallback response'
 
 
-def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monkeypatch):
+def test_api_v1_chat_completion_distributed_no_fallback_returns_upstream_status(client, monkeypatch):
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')
     monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
@@ -314,7 +314,16 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monk
 
     monkeypatch.setattr(
         'api.v1.compute_provider.requests.post',
-        lambda _url, json=None, timeout=None: MagicMock(status_code=503, json=lambda: {'error': 'down'}),
+        lambda _url, json=None, timeout=None: MagicMock(
+            status_code=503,
+            json=lambda: {
+                'error': {
+                    'message': 'No LLM servers are available right now.',
+                    'type': 'server_error',
+                    'code': 'no_registered_compute_nodes',
+                }
+            },
+        ),
     )
 
     local_generate = MagicMock(side_effect=AssertionError('local generation should not run'))
@@ -328,7 +337,8 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monk
         },
     )
 
-    assert response.status_code == 502
+    assert response.status_code == 503
+    assert response.get_json()['error']['code'] == 'no_registered_compute_nodes'
     local_generate.assert_not_called()
 
 

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -94,6 +94,36 @@ def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatc
         )
 
 
+def test_distributed_compute_provider_preserves_structured_relay_error(monkeypatch):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(
+            status_code=503,
+            json=lambda: {
+                "error": {
+                    "message": "No LLM servers are available right now.",
+                    "type": "server_error",
+                    "code": "no_registered_compute_nodes",
+                }
+            },
+        ),
+    )
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
+
+    with pytest.raises(ComputeProviderError) as exc_info:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    err = exc_info.value
+    assert err.status_code == 503
+    assert err.error_type == "server_error"
+    assert err.code == "no_registered_compute_nodes"
+    assert err.message == "No LLM servers are available right now."
+
+
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -210,6 +210,38 @@ def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monk
     assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
 
 
+def test_chat_completion_returns_structured_compute_provider_error(client, monkeypatch):
+    class _FailingProvider:
+        def complete_chat(self, model_id, messages, options):
+            raise compute_provider.ComputeProviderError(
+                "No LLM servers are available right now.",
+                error_type="server_error",
+                code="no_registered_compute_nodes",
+                status_code=503,
+            )
+
+    payload = {
+        "model": "llama-3-8b-instruct",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _FailingProvider())
+    monkeypatch.setattr(routes, "get_api_v1_resolved_provider_path", lambda _provider: "distributed")
+
+    response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": {
+            "message": "No LLM servers are available right now.",
+            "type": "server_error",
+            "code": "no_registered_compute_nodes",
+        }
+    }
+
+
 def test_chat_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,3 +30,10 @@ def test_landing_chat_js_disables_incremental_typing_for_relay_v1():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "relayApiV1NonStreaming: true" in chat_js
     assert "incremental character streaming" in chat_js
+
+
+def test_landing_chat_js_maps_structured_api_errors_to_user_messages():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "no_registered_compute_nodes" in chat_js
+    assert "No LLM servers are available right now." in chat_js
+    assert "normalizeApiError" in chat_js


### PR DESCRIPTION
### Motivation
- Replace the opaque/stub UX on the relay landing chat with explicit, stable API v1 error shapes so the UI can present clear user-facing text when known failure modes occur. 
- Start with the “no LLM servers available” case and add structured error semantics that can be extended for other failure modes (timeouts, bridge/unreachable, invalid payloads). 

### Description
- Introduced structured `ComputeProviderError` metadata (`message`, `error_type`, `code`, `status_code`) and updated the distributed provider to map relay/bridge failures (timeouts, request exceptions, non-200 responses, non-JSON or invalid payloads) into these structured errors in `api/v1/compute_provider.py`.
- Propagated structured compute-provider error fields through API v1 endpoints so `api/v1` responses preserve `error.message`, `error.type`, and `error.code` and set the HTTP status using `status_code` in `api/v1/routes.py`.
- Normalized relay-side `/relay/api/v1/chat/completions` responses to return stable, machine-readable error objects for invalid request data/payloads, no registered compute nodes (`no_registered_compute_nodes` with message "No LLM servers are available right now."), compute-node timeouts, compute-node errors, and invalid compute-node payloads in `relay.py`.
- Updated landing-page JS (`static/chat.js`) to parse normalized API errors (`normalizeApiError`) and map known `code`s to safe user messages (`userFacingErrorMessage`), showing the explicit no-servers copy instead of the previous generic/stub text.
- Added focused regression tests that cover: structured relay error preservation at provider level, route-level structured error pass-through, landing-chat JS presence of error mappings, and an e2e route mock asserting the no-servers message is rendered; also updated one API test expectation to preserve upstream 503/code semantics when distributed mode has no fallback.

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all tests passed (9 passed).
- Ran `python -m pytest -q tests/unit/test_touch_ui.py` and all tests passed (5 passed).
- Ran the targeted e2e selection `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming or no_servers'`; the selected tests were exercised (the no-servers scenario is included) and were skipped by suite guardrails in this environment, as expected.
- Ran `python -m pytest -q tests/test_api.py -k distributed_no_fallback_returns_upstream_status` to validate preserved upstream status/code behavior and it passed.
- Ran `pre-commit run --all-files` and the project checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea75263844832f9f59bee03bf0e230)