### PR TITLE
🐛 Normalize API v1 relay error semantics for landing chat

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -24,8 +24,18 @@ _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
 )
 
 
+@dataclass(frozen=True)
 class ComputeProviderError(Exception):
     """Raised when a compute provider cannot satisfy a request."""
+
+    message: str
+    error_type: str = "server_error"
+    code: str = "compute_provider_error"
+    status_code: int = 502
+    public_message: str = "Sorry, an LLM server error occurred."
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ApiV1ComputeProvider(Protocol):
@@ -92,30 +102,103 @@ class DistributedApiV1ComputeProvider:
                 json=payload,
                 timeout=self.timeout_seconds,
             )
-        except Exception as exc:
-            raise ComputeProviderError(f"distributed provider request failed: {exc}") from exc
+        except requests.Timeout as exc:
+            raise ComputeProviderError(
+                message=f"distributed provider request timed out: {exc}",
+                code="relay_provider_timeout",
+                status_code=504,
+                public_message="The LLM server timed out while processing your request.",
+            ) from exc
+        except requests.RequestException as exc:
+            raise ComputeProviderError(
+                message=f"distributed provider request failed: {exc}",
+                code="relay_provider_unreachable",
+                status_code=502,
+                public_message="Unable to reach an LLM server right now.",
+            ) from exc
 
         if response.status_code != 200:
+            error_message = None
+            try:
+                body = response.json()
+            except ValueError:
+                body = {}
+
+            if isinstance(body, dict):
+                error_obj = body.get("error")
+                if isinstance(error_obj, dict):
+                    error_message = error_obj.get("message")
+                elif isinstance(error_obj, str):
+                    error_message = error_obj
+
+            if response.status_code == 503:
+                raise ComputeProviderError(
+                    message=(
+                        "distributed provider returned status 503 "
+                        f"(error={error_message!r})"
+                    ),
+                    code="no_registered_compute_nodes",
+                    status_code=503,
+                    public_message="No LLM servers are available right now.",
+                )
+
+            if response.status_code == 504:
+                raise ComputeProviderError(
+                    message=(
+                        "distributed provider returned status 504 "
+                        f"(error={error_message!r})"
+                    ),
+                    code="relay_provider_timeout",
+                    status_code=504,
+                    public_message="The LLM server timed out while processing your request.",
+                )
+
             raise ComputeProviderError(
-                f"distributed provider returned status {response.status_code}"
+                message=(
+                    f"distributed provider returned status {response.status_code} "
+                    f"(error={error_message!r})"
+                ),
+                code="relay_provider_error",
+                status_code=502,
+                public_message="Sorry, an LLM server error occurred.",
             )
 
         try:
             body = response.json()
         except ValueError as exc:
-            raise ComputeProviderError("distributed provider returned non-JSON response") from exc
+            raise ComputeProviderError(
+                message="distributed provider returned non-JSON response",
+                code="relay_invalid_payload",
+                status_code=502,
+                public_message="The LLM server returned an invalid response.",
+            ) from exc
 
         choices = body.get("choices")
         if not isinstance(choices, list) or not choices:
-            raise ComputeProviderError("distributed provider returned no choices")
+            raise ComputeProviderError(
+                message="distributed provider returned no choices",
+                code="relay_invalid_payload",
+                status_code=502,
+                public_message="The LLM server returned an invalid response.",
+            )
 
         first_choice = choices[0]
         if not isinstance(first_choice, dict):
-            raise ComputeProviderError("distributed provider choice payload is invalid")
+            raise ComputeProviderError(
+                message="distributed provider choice payload is invalid",
+                code="relay_invalid_payload",
+                status_code=502,
+                public_message="The LLM server returned an invalid response.",
+            )
 
         message = first_choice.get("message")
         if not isinstance(message, dict):
-            raise ComputeProviderError("distributed provider response missing message")
+            raise ComputeProviderError(
+                message="distributed provider response missing message",
+                code="relay_invalid_payload",
+                status_code=502,
+                public_message="The LLM server returned an invalid response.",
+            )
 
         _last_backend_path.set("registered_desktop_compute_node")
         return message

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -421,9 +421,10 @@ def _handle_chat_completion_request(data):
         )
     except ComputeProviderError as e:
         return format_error_response(
-            str(e),
-            error_type="server_error",
-            status_code=502,
+            e.public_message,
+            error_type=e.error_type,
+            code=e.code,
+            status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
         log_error("Unexpected error in create_chat_completion endpoint", exc_info=True)
@@ -558,9 +559,10 @@ def _handle_text_completion_request(data):
         )
     except ComputeProviderError as e:
         return format_error_response(
-            str(e),
-            error_type="server_error",
-            status_code=502,
+            e.public_message,
+            error_type=e.error_type,
+            code=e.code,
+            status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
         log_error("Unexpected error in create_completion endpoint")

--- a/static/chat.js
+++ b/static/chat.js
@@ -400,8 +400,20 @@ new Vue({
                 });
 
                 if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(`API error: ${errorData.error?.message || 'Unknown error'}`);
+                    let apiError = null;
+                    try {
+                        const errorData = await response.json();
+                        if (errorData && typeof errorData === 'object') {
+                            apiError = errorData.error || null;
+                        }
+                    } catch (_parseError) {
+                        apiError = null;
+                    }
+                    throw {
+                        type: 'api_error',
+                        error: apiError,
+                        userMessage: this.getUserFacingApiErrorMessage(apiError)
+                    };
                 }
 
                 const responseData = await response.json();
@@ -425,7 +437,13 @@ new Vue({
                 return responseData;
             } catch (error) {
                 console.error('API request error:', error);
-                return null;
+                if (error && error.type === 'api_error') {
+                    return { error: error.error, userMessage: error.userMessage };
+                }
+                return {
+                    error: null,
+                    userMessage: 'Sorry, an error occurred while sending your message. Please try again.'
+                };
             }
         },
 
@@ -475,6 +493,22 @@ new Vue({
             return message.content;
         },
 
+        getUserFacingApiErrorMessage(error) {
+            const code = error && typeof error.code === 'string' ? error.code : '';
+            const mappedMessages = {
+                no_registered_compute_nodes: 'No LLM servers are available right now.',
+                relay_provider_timeout: 'The LLM server timed out while processing your request.',
+                relay_invalid_payload: 'The LLM server returned an invalid response.',
+                relay_provider_unreachable: 'Unable to reach an LLM server right now.'
+            };
+
+            if (code && mappedMessages[code]) {
+                return mappedMessages[code];
+            }
+
+            return 'Sorry, I encountered an issue generating a response. Please try again.';
+        },
+
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
@@ -495,6 +529,13 @@ new Vue({
 
                 // Process the response
                 if (response) {
+                    if (response.userMessage) {
+                        this.chatHistory.push({
+                            role: 'assistant',
+                            content: response.userMessage
+                        });
+                        return;
+                    }
                     // For API response, extract last message
                     if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -249,6 +249,61 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     assert v2_requests == []
 
 
+def test_landing_chat_no_servers_shows_explicit_message(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """Landing chat should render a clear no-servers message from API v1 structured errors."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+
+    def handle_public_key(route):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        )
+
+    def handle_v1_chat_error(route):
+        route.fulfill(
+            status=503,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "error": {
+                        "type": "server_error",
+                        "code": "no_registered_compute_nodes",
+                        "message": "No LLM servers are available right now.",
+                    }
+                }
+            ),
+        )
+
+    page.route("**/api/v1/public-key", handle_public_key)
+    page.route("**/api/v1/chat/completions", handle_v1_chat_error)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("hello")
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+    assert "No LLM servers are available right now." in assistant_message.inner_text()
+
+
 @pytest.mark.e2e
 def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     page: Page,

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -132,6 +132,76 @@ def test_get_api_v1_resolved_provider_path_labels_instance_types():
     assert get_api_v1_resolved_provider_path(object()) == "unknown"
 
 
+def test_api_v1_chat_completion_maps_no_registered_nodes_to_structured_error(monkeypatch):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(
+            status_code=503,
+            json=lambda: {
+                "error": {
+                    "message": "No registered compute nodes available",
+                    "code": 503,
+                }
+            },
+        ),
+    )
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    try:
+        assert response.status_code == 503
+        payload = response.get_json()
+        assert payload["error"]["type"] == "server_error"
+        assert payload["error"]["code"] == "no_registered_compute_nodes"
+        assert payload["error"]["message"] == "No LLM servers are available right now."
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_api_v1_chat_completion_maps_invalid_provider_payload_to_structured_error(monkeypatch):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(
+            status_code=200,
+            json=lambda: {"choices": [{"not_message": True}]},
+        ),
+    )
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    try:
+        assert response.status_code == 502
+        payload = response.get_json()
+        assert payload["error"]["code"] == "relay_invalid_payload"
+        assert payload["error"]["message"] == "The LLM server returned an invalid response."
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
 @pytest.mark.parametrize(
     ("post_status", "expected_backend_path"),
     [

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,3 +30,10 @@ def test_landing_chat_js_disables_incremental_typing_for_relay_v1():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "relayApiV1NonStreaming: true" in chat_js
     assert "incremental character streaming" in chat_js
+
+
+def test_landing_chat_js_maps_structured_api_errors_to_user_messages():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "getUserFacingApiErrorMessage" in chat_js
+    assert "no_registered_compute_nodes" in chat_js
+    assert "No LLM servers are available right now." in chat_js


### PR DESCRIPTION
### Motivation
- Make API v1 relay/compute-provider failures machine-readable so the UI can show clear, specific user messages instead of vague stubs or generic failures.
- Surface a stable `type`/`code`/`message` shape for known distributed failure modes to allow future mapping of distinct error cases.

### Description
- Extend `ComputeProviderError` to carry structured fields (`message`, `error_type`, `code`, `status_code`, `public_message`) and a sensible `__str__` implementation. (see `api/v1/compute_provider.py`).
- Map common distributed failure modes to explicit codes/messages in the distributed provider, including `no_registered_compute_nodes`, `relay_provider_timeout`, `relay_provider_unreachable`, and `relay_invalid_payload`. (see `api/v1/compute_provider.py`).
- Update API v1 routes to return the provider `public_message`, `error_type`, `code`, and the configured `status_code` when a `ComputeProviderError` is raised, preserving the existing `/api/v1` error envelope. (see `api/v1/routes.py`).
- Update the landing-page UI (`static/chat.js`) to parse structured API v1 errors and map known `code` values to user-facing messages (for example, presenting: `No LLM servers are available right now.` for the `no_registered_compute_nodes` case) while keeping a safe generic fallback. (see `static/chat.js`).
- Add focused regression tests: unit tests for the API error contract and UI mapping and an E2E scenario exercising the no-servers client-visible message. (see `tests/unit/test_api_v1_compute_provider.py`, `tests/unit/test_touch_ui.py`, `tests/e2e/test_ui.py`).

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and the suite passed (includes new cases asserting structured `code`/`message` and HTTP status mapping).
- Ran `python -m pytest -q tests/unit/test_touch_ui.py` and the suite passed (includes UI assertions for the error mapping helper in `static/chat.js`).
- Ran `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming or no_servers'` and the selected E2E scenarios executed in this environment (the real-inference E2E test is gated/skipped in CI-like environments and the explicit no-servers scenario is present to validate rendering).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea75263844832f9f59bee03bf0e230)