### PR TITLE
🧪 Harden landing desktop-bridge API v1 guardrail tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,10 +222,12 @@ def setup_servers(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0" if run_real_bridge_e2e else "1"
-    # NOTE: keep API v1 provider selection local for the desktop-bridge landing-page
-    # guardrail. Pointing TOKENPLACE_DISTRIBUTED_COMPUTE_URL at the relay causes
-    # recursive /api/v1/chat/completions self-calls and deterministic failures.
-    test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
+    if run_real_bridge_e2e:
+        # Real desktop-bridge guardrail must use relay-distributed API v1 compute
+        # without local fallback so bypasses fail closed.
+        test_env["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "distributed"
+        test_env["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = E2E_BASE_URL
+        test_env["TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"] = "0"
 
     # Start the relay server with the --use_mock_llm flag
     relay_command = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -511,23 +511,40 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         stream_mode = latest_headers.get("x-tokenplace-api-v1-stream-mode")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
+        execution_backend_path = latest_headers.get("x-tokenplace-api-v1-execution-backend-path")
         provider_diagnostics = (
             "landing-page real-provider guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"execution_backend_path={execution_backend_path!r}, stream_mode={stream_mode!r}; "
+            "expected provider_class='DistributedApiV1ComputeProvider', "
+            "resolved_provider_path='distributed', "
+            "execution_backend_path='registered_desktop_compute_node', "
+            "stream_mode='non-streaming'"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
+        assert provider_class == "DistributedApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
+        assert resolved_provider_path == "distributed", (
             "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+            f"'distributed'. {provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
+        assert execution_backend_path == "registered_desktop_compute_node", provider_diagnostics
+        if runtime_supports_real_inference:
             assert assistant_text.strip().lower() != "stub", (
-                "assistant response must not be stub when runtime reports real inference support "
-                f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"
+                "assistant response must not be stub when runtime reports real inference support. "
+                f"{provider_diagnostics}"
             )
+
+        processed_request_lines = [
+            line for line in stderr_lines if "desktop.compute_node_bridge.process_request.ok" in line
+        ]
+        assert processed_request_lines, (
+            "desktop bridge must process at least one relay request; heartbeat-only "
+            f"registration is insufficient. stderr_lines={stderr_lines}"
+        )
+        assert not any("legacy_payload=True" in line for line in stderr_lines), (
+            "landing-page flow must not use legacy relay payload processing. "
+            f"stderr_lines={stderr_lines}"
+        )
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -343,6 +343,53 @@ def test_api_v1_chat_completion_emits_execution_backend_path_header(
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
+def test_api_v1_chat_completion_emits_provider_diagnostics_headers_for_distributed_path(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "api.v1.compute_provider.requests.post",
+        lambda _url, json=None, timeout=None: SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "distributed response",
+                        }
+                    }
+                ]
+            },
+        ),
+    )
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    try:
+        assert response.status_code == 200
+        assert response.headers["X-Tokenplace-API-V1-Provider"] == "DistributedApiV1ComputeProvider"
+        assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
+        assert (
+            response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"]
+            == "registered_desktop_compute_node"
+        )
+        assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
 def test_api_v1_chat_completion_returns_structured_error_for_no_registered_nodes(
     monkeypatch,
 ):

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -24,6 +24,12 @@ def test_landing_chat_js_avoids_relay_v2_streaming_path():
     assert "sendStreamingMessage(" not in chat_js, (
         "landing chat must not include streaming relay send helper call chain"
     )
+    assert "/api/v1/completions" not in chat_js, (
+        "landing chat must not use legacy API v1 completions endpoint"
+    )
+    assert "/relay/api/v1/chat/completions" not in chat_js, (
+        "landing chat browser flow must call relay /api/v1/chat/completions only"
+    )
 
 
 def test_landing_chat_js_disables_incremental_typing_for_relay_v1():


### PR DESCRIPTION
### Motivation

- The existing real desktop-bridge guardrail could pass while requests resolved to the local provider or used legacy/streaming paths, which did not validate the intended relay -> API v1 -> desktop compute-node bridge flow.
- Tests must reject local/fallback behavior, streaming/API v2 traffic, and legacy bypasses to ensure the landing-page flow exercises the real distributed desktop bridge.
- The harness needed to be aligned so the focused real-inference guardrail runs the compute provider in distributed mode without local fallback.

### Description

- Updated `tests/conftest.py` to force the real-desktop-bridge guardrail to run with `TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed`, `TOKENPLACE_DISTRIBUTED_COMPUTE_URL` set to the relay, and `TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK=0` when executing the real bridge e2e path.
- Hardened `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1` to assert the response headers indicate a `DistributedApiV1ComputeProvider`, `resolved_provider_path='distributed'`, `X-Tokenplace-API-V1-Execution-Backend-Path='registered_desktop_compute_node'`, and `X-Tokenplace-API-V1-Stream-Mode='non-streaming'`, to verify at least one request was processed by the desktop bridge and to fail if legacy payload handling or API v2/streaming is observed.
- Added a unit-level test `test_api_v1_chat_completion_emits_provider_diagnostics_headers_for_distributed_path` in `tests/unit/test_api_v1_compute_provider.py` to validate provider diagnostics headers for the distributed non-streaming path.
- Tightened UI guardrail checks in `tests/unit/test_touch_ui.py` to explicitly forbid legacy `/api/v1/completions` and browser-side `/relay/api/v1/chat/completions` usage and to continue blocking `/api/v2/chat/completions` and streaming helpers.

### Testing

- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all unit tests in that file passed (`18 passed`).
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and `python -m pytest -q tests/unit/test_touch_ui.py` and both suites passed (`25 passed` and `5 passed` respectively).
- Focused E2E runs (`RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' -s` and the `landing_chat_uses_api_v1_only_non_streaming` selection) could not complete in this environment because the Playwright browser binaries were not installed, causing Playwright to error; the tests are otherwise exercised by CI where Playwright browsers are available.
- Ran `pre-commit run --all-files` and it completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8885e67c832faccfb203ba7e0219)