### PR TITLE
🧪 fix: harden desktop-bridge relay landing e2e guardrails

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,10 +222,13 @@ def setup_servers(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0" if run_real_bridge_e2e else "1"
-    # NOTE: keep API v1 provider selection local for the desktop-bridge landing-page
-    # guardrail. Pointing TOKENPLACE_DISTRIBUTED_COMPUTE_URL at the relay causes
-    # recursive /api/v1/chat/completions self-calls and deterministic failures.
-    test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
+    if run_real_bridge_e2e:
+        test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "1"
+        test_env["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "distributed"
+        test_env["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = E2E_BASE_URL
+        test_env["TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"] = "0"
+    else:
+        test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
 
     # Start the relay server with the --use_mock_llm flag
     relay_command = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -400,7 +400,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         start_deadline = time.time() + 25
         registered = False
         started = False
-        runtime_supports_real_inference = False
 
         while time.time() < start_deadline:
             try:
@@ -427,7 +426,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 assert isinstance(llama_module_path, str) and llama_module_path
                 assert not llama_module_path.endswith("/llama_cpp.py")
                 assert not llama_module_path.endswith("\\llama_cpp.py")
-                runtime_supports_real_inference = llama_module_path != "missing"
             if event_type == "status" and payload.get("registered") is True:
                 registered = True
                 break
@@ -514,20 +512,26 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_diagnostics = (
             "landing-page real-provider guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"stream_mode={stream_mode!r}; expected distributed non-fallback API v1 path"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
+        assert provider_class == "DistributedApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
-            "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+        assert resolved_provider_path == "distributed", (
+            "landing-page real-provider guardrail requires distributed provider path without local fallback. "
+            f"{provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
-            assert assistant_text.strip().lower() != "stub", (
-                "assistant response must not be stub when runtime reports real inference support "
-                f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"
-            )
+
+        bridge_stderr_output = "".join(stderr_lines)
+        assert "desktop.compute_node_bridge.process_request.ok" in bridge_stderr_output, (
+            "desktop bridge must process at least one real relay request; heartbeat-only registration "
+            "is insufficient for this guardrail"
+        )
+        assert "desktop.compute_node_bridge.process_request.start stream=True" not in bridge_stderr_output, (
+            "landing-page relay API v1 guardrail forbids streaming request processing"
+        )
+        assert "legacy_payload=True api_v1_payload=False" not in bridge_stderr_output, (
+            "landing-page relay API v1 guardrail forbids legacy relay payload processing"
+        )
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -53,6 +53,38 @@ def test_create_completion_model_error(client, monkeypatch):
     assert resp.status_code == 400
 
 
+def test_chat_completion_rejects_streaming_requests(client):
+    payload = {
+        "model": "llama-3-8b-instruct",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }
+
+    response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    error = response.get_json()["error"]
+    assert error["param"] == "stream"
+    assert "Streaming is not supported for API v1 chat completions" in error["message"]
+    assert "/api/v2/chat/completions" in error["message"]
+
+
+def test_legacy_completion_rejects_streaming_requests(client):
+    payload = {
+        "model": "llama-3-8b-instruct",
+        "prompt": "hi",
+        "stream": True,
+    }
+
+    response = client.post("/api/v1/completions", json=payload)
+
+    assert response.status_code == 400
+    error = response.get_json()["error"]
+    assert error["param"] == "stream"
+    assert "Streaming is not supported for API v1 completions" in error["message"]
+    assert "/api/v2/chat/completions" in error["message"]
+
+
 def test_health_check_exception(client, monkeypatch):
     orig_jsonify = routes.jsonify
     def fake_jsonify(*args, **kwargs):

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -16,8 +16,14 @@ def test_chat_js_defines_touch_detection_hook():
     assert "detectTouchInput" in chat_js, "chat.js must implement touch detection helper"
 
 
-def test_landing_chat_js_avoids_relay_v2_streaming_path():
+def test_landing_chat_js_uses_api_v1_chat_only_and_avoids_v2_streaming():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "/api/v1/chat/completions" in chat_js, (
+        "landing chat must target relay API v1 chat completions endpoint"
+    )
+    assert "/api/v1/completions" not in chat_js, (
+        "landing chat must not use the legacy API v1 text completions endpoint"
+    )
     assert "/api/v2/chat/completions" not in chat_js, (
         "landing chat must not call relay v2 chat completions endpoint"
     )


### PR DESCRIPTION
### Motivation
- The existing real desktop-bridge landing-page guardrail accepted local/fallback provider resolution and heartbeats as success, masking bypasses and migration regressions.
- Tests must enforce the true browser -> relay API v1 -> desktop compute-node bridge flow and reject local, legacy, API v2, or streaming paths.

### Description
- Adjusted the E2E harness in `tests/conftest.py` to force distributed API v1 routing for the real-bridge guardrail by setting `TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED=1`, `TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed`, `TOKENPLACE_DISTRIBUTED_COMPUTE_URL=http://localhost:5010`, and `TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK=0` when running the real bridge scenario.
- Tightened `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1` to assert the response headers indicate a `DistributedApiV1ComputeProvider`, `resolved_provider_path == "distributed"`, `X-Tokenplace-API-V1-Stream-Mode == "non-streaming"`, and to fail if any API v2 requests were observed.
- Added runtime-proof checks in the real-bridge E2E that the desktop bridge emitted a real request-processing marker (`desktop.compute_node_bridge.process_request.ok`) and rejected cases where only heartbeats, legacy relay payloads, or streaming processing were observed.
- Added unit tests in `tests/unit/test_api_v1_routes_additional.py` that assert API v1 chat and legacy completions reject `stream=true` with the expected v2 guidance, and updated `tests/unit/test_touch_ui.py` to assert the landing JS targets `/api/v1/chat/completions` and excludes legacy `/api/v1/completions` and `/api/v2/chat/completions` streaming helpers.

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all tests passed (`17 passed`).
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (`25 passed`).
- Ran `python -m pytest -q tests/unit/test_touch_ui.py` and all tests passed (`5 passed`).
- Ran `python -m pytest -q tests/unit/test_api_v1_routes_additional.py -k 'rejects_streaming_requests'` and the new streaming-rejection tests passed (`2 passed`).
- Attempted the focused E2E runs with `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' -s` and `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_uses_api_v1_only_non_streaming'`, but these errored in this environment because Playwright browser binaries are not installed (Playwright requested `playwright install`), so the harness-level E2E assertions should be verified in an environment with Playwright browsers available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8885e67c832faccfb203ba7e0219)