### PR TITLE
🧪 Fix landing desktop-bridge guardrail tests to enforce real API v1 relay path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,10 +222,13 @@ def setup_servers(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0" if run_real_bridge_e2e else "1"
-    # NOTE: keep API v1 provider selection local for the desktop-bridge landing-page
-    # guardrail. Pointing TOKENPLACE_DISTRIBUTED_COMPUTE_URL at the relay causes
-    # recursive /api/v1/chat/completions self-calls and deterministic failures.
-    test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
+    if run_real_bridge_e2e:
+        test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "1"
+        test_env["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "distributed"
+        test_env["TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"] = "0"
+        test_env["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = E2E_BASE_URL
+    else:
+        test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
 
     # Start the relay server with the --use_mock_llm flag
     relay_command = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -511,23 +511,27 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         stream_mode = latest_headers.get("x-tokenplace-api-v1-stream-mode")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
+        execution_backend_path = latest_headers.get("x-tokenplace-api-v1-execution-backend-path")
         provider_diagnostics = (
-            "landing-page real-provider guardrail diagnostics: "
+            "landing-page real desktop-bridge guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"execution_backend_path={execution_backend_path!r}, stream_mode={stream_mode!r}; "
+            "expected distributed provider path with desktop-bridge execution and non-streaming mode"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
-            "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+        assert provider_class in {"DistributedApiV1ComputeProvider", "FallbackApiV1ComputeProvider"}, (
+            "landing-page real desktop-bridge guardrail requires distributed provider selection. "
+            f"{provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
-            assert assistant_text.strip().lower() != "stub", (
-                "assistant response must not be stub when runtime reports real inference support "
-                f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"
-            )
+        assert resolved_provider_path == "distributed", (
+            "landing-page real desktop-bridge guardrail must fail on local/fallback provider resolution. "
+            f"{provider_diagnostics}"
+        )
+        assert execution_backend_path == "registered_desktop_compute_node", (
+            "landing-page real desktop-bridge guardrail requires desktop bridge processing path. "
+            f"{provider_diagnostics}"
+        )
+        assert assistant_text.strip().lower() != "stub"
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(
@@ -589,6 +593,16 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
+
+        stderr_output = "".join(stderr_lines)
+        assert "desktop.compute_node_bridge.process_request.ok" in stderr_output, (
+            "desktop bridge must process at least one real relay request; heartbeat-only registration "
+            "must fail this guardrail"
+        )
+        assert "desktop.compute_node_bridge.process_request.start stream=True" not in stderr_output
+        assert "api_v1_payload=False" not in stderr_output, (
+            "desktop bridge request processing must stay on API v1 payload path and exclude legacy payload handling"
+        )
     finally:
         if bridge_process.stdin:
             try:

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -316,3 +316,57 @@ def test_legacy_completion_encrypted_response_sets_provider_headers(client, monk
     assert response.headers["X-Tokenplace-API-V1-Provider"] == "_LocalProvider"
     assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "local"
     assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
+
+
+def test_chat_completions_rejects_streaming_contract_and_skips_provider(client, monkeypatch):
+    provider_called = False
+
+    def _provider():
+        nonlocal provider_called
+        provider_called = True
+        raise AssertionError("provider should not be called for stream=true")
+
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", _provider)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    assert provider_called is False
+    error = response.get_json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "stream"
+    assert "Streaming is not supported for API v1 chat completions" in error["message"]
+
+
+def test_legacy_completions_rejects_streaming_contract_and_skips_provider(client, monkeypatch):
+    provider_called = False
+
+    def _provider():
+        nonlocal provider_called
+        provider_called = True
+        raise AssertionError("provider should not be called for stream=true")
+
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", _provider)
+
+    response = client.post(
+        "/api/v1/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "prompt": "hi",
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    assert provider_called is False
+    error = response.get_json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "stream"
+    assert "Streaming is not supported for API v1 completions" in error["message"]

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -46,3 +46,14 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "The LLM server returned an invalid response. Please try again." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
+
+
+def test_landing_chat_js_targets_relay_api_v1_chat_endpoint_only():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "fetch('/api/v1/chat/completions'" in chat_js
+    assert "/api/v1/completions" not in chat_js, (
+        "landing chat must not call the legacy API v1 completions endpoint"
+    )
+    assert "/relay/api/v1/chat/completions" not in chat_js, (
+        "landing chat must not bypass relay API routing via relay-internal endpoints"
+    )


### PR DESCRIPTION
### Motivation
- The existing real desktop-bridge guardrail treated local provider resolution as an acceptable success and could pass without proving the intended browser -> relay API v1 -> desktop compute-node -> relay -> browser path. 
- Tests must fail loudly on local/fallback resolution, streaming or API v2 usage, or legacy bypass behavior to protect the v0.1.0 non-streaming API v1 relay contract.

### Description
- Update `tests/conftest.py` to set `TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed`, disable fallback (`TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK=0`) and point `TOKENPLACE_DISTRIBUTED_COMPUTE_URL` at the relay when the real desktop-bridge e2e node is being run.  This ensures the real-bridge harness enforces distributed API v1 routing. 
- Harden `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1` to assert: observed API v1 requests, zero API v2 calls, `X-Tokenplace-API-V1-Stream-Mode` is `non-streaming`, resolved provider path equals `distributed`, `X-Tokenplace-API-V1-Execution-Backend-Path` equals `registered_desktop_compute_node`, and the desktop bridge emitted a real `desktop.compute_node_bridge.process_request.ok` event (failing heartbeat-only registration). 
- Add unit tests in `tests/unit/test_api_v1_routes_additional.py` that verify API v1 endpoints reject `stream=true` (for both chat completions and legacy completions) and that the provider resolution is not invoked for invalid streaming requests. 
- Add a JS-target guard in `tests/unit/test_touch_ui.py` that asserts the landing UI targets `fetch('/api/v1/chat/completions')` only and does not reference legacy or relay-internal bypass endpoints. 

### Testing
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` and all tests passed (17 passed). 
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (25 passed). 
- Ran `python -m pytest -q tests/unit/test_touch_ui.py` and all tests passed (6 passed). 
- Ran the new streaming-contract unit checks with `python -m pytest -q tests/unit/test_api_v1_routes_additional.py -k 'streaming_contract'` and they passed (2 passed). 
- `pre-commit run --all-files` executed successfully. 
- Attempted the focused E2E verification (`RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' -s`), but Playwright browsers were not installed in this environment (Playwright reported `playwright install` is required), so the full e2e run could not complete here; the test harness and assertions are in place and will run when browsers are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8885e67c832faccfb203ba7e0219)