### PR TITLE
🧪 test: harden desktop bridge landing-page guardrails

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,10 +222,15 @@ def setup_servers(
     test_env = os.environ.copy()
     test_env["TOKEN_PLACE_ENV"] = "testing"
     test_env["USE_MOCK_LLM"] = "0" if run_real_bridge_e2e else "1"
-    # NOTE: keep API v1 provider selection local for the desktop-bridge landing-page
-    # guardrail. Pointing TOKENPLACE_DISTRIBUTED_COMPUTE_URL at the relay causes
-    # recursive /api/v1/chat/completions self-calls and deterministic failures.
-    test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
+    if run_real_bridge_e2e:
+        # Real desktop-bridge landing-chat guardrail must exercise relay API v1
+        # distributed routing (no local provider fallback).
+        test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "1"
+        test_env["TOKENPLACE_API_V1_COMPUTE_PROVIDER"] = "distributed"
+        test_env["TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK"] = "0"
+        test_env["TOKENPLACE_DISTRIBUTED_COMPUTE_URL"] = E2E_BASE_URL
+    else:
+        test_env["TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED"] = "0"
 
     # Start the relay server with the --use_mock_llm flag
     relay_command = [sys.executable, "relay.py", "--port", str(E2E_RELAY_PORT)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,8 +273,11 @@ def setup_servers(
         print(f"Relay stderr: {stderr}")
         pytest.skip("Relay server failed to start")
 
-    if focused_e2e_only:
-        print("Focused relay e2e mode enabled: skipping server registration bootstrap")
+    if focused_e2e_only or run_real_bridge_e2e:
+        if run_real_bridge_e2e:
+            print("Real desktop-bridge guardrail mode: skipping server.py registration bootstrap to avoid non-bridge node selection")
+        else:
+            print("Focused relay e2e mode enabled: skipping server registration bootstrap")
         yield relay_process, None
         relay_process.terminate()
         relay_process.wait(timeout=5)

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -531,10 +531,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "landing-page real-provider guardrail requires execution backend path "
             f"'registered_desktop_compute_node'. {provider_diagnostics}"
         )
-        forbidden_provider_paths = {"local", "distributed_with_local_fallback"}
-        forbidden_execution_paths = {"local_in_process", "fallback_local_in_process"}
-        assert resolved_provider_path not in forbidden_provider_paths, provider_diagnostics
-        assert execution_backend_path not in forbidden_execution_paths, provider_diagnostics
         if runtime_supports_real_inference:
             assert assistant_text.strip().lower() != "stub", (
                 "assistant response must not be stub when runtime reports real inference support. "

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -511,22 +511,34 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         stream_mode = latest_headers.get("x-tokenplace-api-v1-stream-mode")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
+        execution_backend_path = latest_headers.get("x-tokenplace-api-v1-execution-backend-path")
         provider_diagnostics = (
             "landing-page real-provider guardrail diagnostics: "
             f"provider_class={provider_class!r}, resolved_provider_path={resolved_provider_path!r}, "
-            f"stream_mode={stream_mode!r}; expected provider_class='LocalApiV1ComputeProvider', "
-            "resolved_provider_path='local', stream_mode='non-streaming'"
+            f"execution_backend_path={execution_backend_path!r}, stream_mode={stream_mode!r}; "
+            "expected provider_class='DistributedApiV1ComputeProvider', "
+            "resolved_provider_path='distributed', "
+            "execution_backend_path='registered_desktop_compute_node', "
+            "stream_mode='non-streaming'"
         )
-        assert provider_class == "LocalApiV1ComputeProvider", provider_diagnostics
+        assert provider_class == "DistributedApiV1ComputeProvider", provider_diagnostics
         assert stream_mode == "non-streaming", provider_diagnostics
-        assert resolved_provider_path == "local", (
+        assert resolved_provider_path == "distributed", (
             "landing-page real-provider guardrail requires resolved provider path "
-            f"'local'. {provider_diagnostics}"
+            f"'distributed'. {provider_diagnostics}"
         )
-        if runtime_supports_real_inference and resolved_provider_path != "local":
+        assert execution_backend_path == "registered_desktop_compute_node", (
+            "landing-page real-provider guardrail requires execution backend path "
+            f"'registered_desktop_compute_node'. {provider_diagnostics}"
+        )
+        forbidden_provider_paths = {"local", "distributed_with_local_fallback"}
+        forbidden_execution_paths = {"local_in_process", "fallback_local_in_process"}
+        assert resolved_provider_path not in forbidden_provider_paths, provider_diagnostics
+        assert execution_backend_path not in forbidden_execution_paths, provider_diagnostics
+        if runtime_supports_real_inference:
             assert assistant_text.strip().lower() != "stub", (
-                "assistant response must not be stub when runtime reports real inference support "
-                f"and provider path is {resolved_provider_path!r}. {provider_diagnostics}"
+                "assistant response must not be stub when runtime reports real inference support. "
+                f"{provider_diagnostics}"
             )
 
         page.wait_for_timeout(300)
@@ -585,10 +597,35 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         encrypted_request = v1_requests[0].post_data_json
         assert encrypted_request.get("encrypted") is True
+        assert encrypted_request.get("stream") in (None, False)
         client_public_key = encrypted_request.get("client_public_key")
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
+
+        process_request_ok_lines = [
+            line
+            for line in stderr_lines
+            if "desktop.compute_node_bridge.process_request.ok" in line
+        ]
+        process_request_start_lines = [
+            line
+            for line in stderr_lines
+            if "desktop.compute_node_bridge.process_request.start" in line
+        ]
+        assert process_request_ok_lines, (
+            "desktop bridge did not process any relay request; only heartbeat registration "
+            "would indicate a bypassed landing-page path"
+        )
+        assert any("api_v1_payload=True" in line for line in process_request_start_lines), (
+            "desktop bridge never processed an API v1 relay payload"
+        )
+        assert not any("api_v1_payload=False" in line for line in process_request_start_lines), (
+            "desktop bridge processed a non-API-v1 relay payload (legacy bypass detected)"
+        )
+        assert not any("stream=True" in line for line in process_request_start_lines), (
+            "desktop bridge processed a streaming relay request; landing-page flow must stay non-streaming"
+        )
     finally:
         if bridge_process.stdin:
             try:

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -320,6 +320,32 @@ def test_legacy_completion_sets_provider_headers(client, monkeypatch):
     assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
 
 
+def test_legacy_completion_rejects_streaming_for_api_v1(client, monkeypatch):
+    provider_called = {"value": False}
+
+    class _GuardrailProvider:
+        def complete_chat(self, model_id, messages, options):
+            provider_called["value"] = True
+            return {"role": "assistant", "content": "hello"}
+
+    payload = {
+        "model": "llama-3-8b-instruct",
+        "prompt": "hi",
+        "stream": True,
+    }
+
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _GuardrailProvider())
+
+    response = client.post("/api/v1/completions", json=payload)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"]["param"] == "stream"
+    assert "Streaming is not supported for API v1 completions" in body["error"]["message"]
+    assert provider_called["value"] is False
+
+
 def test_legacy_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -203,7 +203,11 @@ def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monk
     monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _DistributedProvider())
     monkeypatch.setattr(routes, "get_api_v1_resolved_provider_path", lambda _provider: "distributed")
 
-    response = client.post("/api/v1/chat/completions", json=payload)
+    backend_path_token = compute_provider._last_backend_path.set("unknown")
+    try:
+        response = client.post("/api/v1/chat/completions", json=payload)
+    finally:
+        compute_provider._last_backend_path.reset(backend_path_token)
 
     assert response.status_code == 200
     assert response.headers["X-Tokenplace-API-V1-Provider"] == "_DistributedProvider"
@@ -232,7 +236,6 @@ def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
     monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
     monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
     monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
-    monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _GuardrailProvider())
 
     response = client.post("/api/v1/chat/completions", json=payload)
 

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -206,8 +206,41 @@ def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monk
     response = client.post("/api/v1/chat/completions", json=payload)
 
     assert response.status_code == 200
+    assert response.headers["X-Tokenplace-API-V1-Provider"] == "_DistributedProvider"
     assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
+    assert (
+        response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"]
+        == "unknown"
+    )
     assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
+
+
+def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
+    provider_called = {"value": False}
+
+    class _GuardrailProvider:
+        def complete_chat(self, model_id, messages, options):
+            provider_called["value"] = True
+            return {"role": "assistant", "content": "Paris"}
+
+    payload = {
+        "model": "llama-3-8b-instruct",
+        "messages": [{"role": "user", "content": "Capital of France?"}],
+        "stream": True,
+    }
+
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _GuardrailProvider())
+
+    response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"]["param"] == "stream"
+    assert "Streaming is not supported for API v1 chat completions" in body["error"]["message"]
+    assert provider_called["value"] is False
 
 
 def test_chat_completion_encrypted_response_sets_provider_headers(client, monkeypatch):

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -18,11 +18,17 @@ def test_chat_js_defines_touch_detection_hook():
 
 def test_landing_chat_js_avoids_relay_v2_streaming_path():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "/api/v1/chat/completions" in chat_js, (
+        "landing chat must call relay API v1 chat completions endpoint"
+    )
     assert "/api/v2/chat/completions" not in chat_js, (
         "landing chat must not call relay v2 chat completions endpoint"
     )
     assert "sendStreamingMessage(" not in chat_js, (
         "landing chat must not include streaming relay send helper call chain"
+    )
+    assert "stream: true" not in chat_js, (
+        "landing chat request payload must not opt into streaming for relay API v1"
     )
 
 

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -27,7 +27,7 @@ def test_landing_chat_js_avoids_relay_v2_streaming_path():
     assert "sendStreamingMessage(" not in chat_js, (
         "landing chat must not include streaming relay send helper call chain"
     )
-    assert "stream: true" not in chat_js, (
+    assert not re.search(r"""(['\"]?)stream\1\s*:\s*true\b""", chat_js), (
         "landing chat request payload must not opt into streaming for relay API v1"
     )
 

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -21,6 +21,12 @@ def test_landing_chat_js_avoids_relay_v2_streaming_path():
     assert "/api/v1/chat/completions" in chat_js, (
         "landing chat must call relay API v1 chat completions endpoint"
     )
+    assert "/api/v1/completions" not in chat_js, (
+        "landing chat must not call legacy API v1 text completions endpoint"
+    )
+    assert "/relay/api/v1/chat/completions" not in chat_js, (
+        "landing chat must not use relay-prefixed API v1 bypass path"
+    )
     assert "/api/v2/chat/completions" not in chat_js, (
         "landing chat must not call relay v2 chat completions endpoint"
     )


### PR DESCRIPTION
### Motivation
- The existing real desktop-bridge guardrail could pass while the request was handled by a local/fallback provider or legacy/streaming paths instead of the intended relay→desktop bridge API v1 flow. 
- Tests must enforce API v1 non-streaming relay path, disallow API v2/streaming/legacy bypass, and require proof that the desktop bridge actually processed a real request.

### Description
- Aligned the E2E harness in `tests/conftest.py` so the real desktop-bridge guardrail runs with distributed API v1 routing and no local fallback by setting `TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED=1`, `TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed`, `TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK=0`, and `TOKENPLACE_DISTRIBUTED_COMPUTE_URL=E2E_BASE_URL` for the targeted nodeid.
- Tightened `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1` to assert the real path by checking: at least one `/api/v1/chat/completions` request was made, no `/api/v2` calls, response headers report `X-Tokenplace-API-V1-Provider == DistributedApiV1ComputeProvider`, `X-Tokenplace-API-V1-Resolved-Provider-Path == distributed`, `X-Tokenplace-API-V1-Execution-Backend-Path == registered_desktop_compute_node`, `X-Tokenplace-API-V1-Stream-Mode == non-streaming`, and that the desktop bridge emitted `process_request` log lines proving it processed an API v1 payload (not only heartbeats or legacy payloads) and did not process streaming requests.
- Added unit-level checks in `tests/unit/test_api_v1_routes_additional.py` to assert provider diagnostics headers are present and stable (`X-Tokenplace-API-V1-Provider`, `X-Tokenplace-API-V1-Resolved-Provider-Path`, `X-Tokenplace-API-V1-Execution-Backend-Path`, `X-Tokenplace-API-V1-Stream-Mode`) and a new guardrail test `test_chat_completion_rejects_streaming_for_api_v1` that verifies API v1 rejects `stream: true` with a `400` before provider invocation.
- Strengthened landing-page UI expectations in `tests/unit/test_touch_ui.py` to explicitly require use of `/api/v1/chat/completions`, forbid `/api/v2/chat/completions`, disallow `sendStreamingMessage(` and `stream: true` usage in the landing flow to prevent accidental reintroduction of streaming behavior.

### Testing
- I attempted the unit and focused E2E runs locally using the repository test commands; the test environment in this run lacked several test dependencies so the automated runs aborted with import errors before reaching the modified assertions (missing packages observed: `requests`, `playwright`, `psutil`, `jsonschema`, etc.).
- Commands attempted (environment-dependent): `python -m pytest -q tests/unit/test_api_v1_compute_provider.py`, `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py`, `python -m pytest -q tests/unit/test_touch_ui.py`, and `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' -s` — all aborted in this environment due to missing test runtime dependencies; installation of some deps (`requests`, `playwright`, `psutil`, `cryptography`, `flask`) was attempted but a full `requirements.txt` install could not complete in this environment.
- These test changes are narrowly scoped to tests/harness files and will run in CI (or a developer environment with the full test deps installed); CI should validate the intended guardrail: failures when provider resolution is local/fallback, when only heartbeats occur, or when API v2/streaming/legacy paths are used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8885e67c832faccfb203ba7e0219)