### PR TITLE
🛠️ Clarify relay landing-page real desktop-bridge API v1 CI guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run tests and collect coverage
+    name: Run tests + relay landing-page real desktop-bridge API v1 guardrail
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -54,14 +54,20 @@ jobs:
         if: steps.prep.outputs.rc != '2'
         uses: actions/cache@v4
         with:
-          path: .ci-models/tinygemma3-Q8_0.gguf
-          key: ci-real-desktop-bridge-model-tinygemma3-q8-20260422
-      - name: Provision real desktop-bridge model artifact
+          path: .ci-models/relay-landing-desktop-bridge-api-v1/tinygemma3-Q8_0.gguf
+          key: ci-relay-landing-desktop-bridge-api-v1-real-model-tinygemma3-q8-c287502
+      - name: Provision relay landing-page real desktop-bridge API v1 model artifact
         if: steps.prep.outputs.rc != '2'
         run: |
           set -euo pipefail
-          mkdir -p .ci-models
-          MODEL_PATH=".ci-models/tinygemma3-Q8_0.gguf"
+          MODEL_DIR=".ci-models/relay-landing-desktop-bridge-api-v1"
+          MODEL_PATH="$MODEL_DIR/tinygemma3-Q8_0.gguf"
+          mkdir -p "$MODEL_DIR"
+
+          # Keep this a tiny *real* GGUF (not a fake artifact): this guardrail
+          # must exercise real llama.cpp inference for browser -> relay/API v1
+          # -> desktop bridge wiring. tinygemma3-Q8_0 is currently ~47 MB and
+          # the smallest practical option we can pin from the existing source.
           if [ ! -s "$MODEL_PATH" ]; then
             curl -fL \
               "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/c287502cd9e278dac8eed805c112cce5d0081e0b/tinygemma3-Q8_0.gguf" \
@@ -74,8 +80,9 @@ jobs:
         run: ./run_all_tests.sh
         env:
           TEST_COVERAGE: '1'
-          # Keep the real landing-page desktop-bridge guardrail always-on in CI.
-          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/tinygemma3-Q8_0.gguf
+          # Keep the relay landing-page desktop-bridge API v1 real-inference
+          # guardrail always-on in CI when the tiny GGUF artifact is present.
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/relay-landing-desktop-bridge-api-v1/tinygemma3-Q8_0.gguf
       - name: Upload coverage reports to Codecov
         if: steps.prep.outputs.rc != '2'
         uses: codecov/codecov-action@v5

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -164,11 +164,15 @@ else
     echo "Skipping End-to-End Tests (set RUN_E2E=1 to enable)"
 fi
 
-# 8b. Relay landing-page real desktop bridge guardrail (requires local GGUF model path)
+# 8b. Relay landing-page real desktop-bridge API v1 guardrail
+# Uses a tiny real GGUF model (never a fake artifact) so CI still validates
+# end-to-end llama.cpp inference wiring without a heavyweight download.
 if [ -n "${TOKENPLACE_REAL_E2E_MODEL_PATH:-}" ] && [ -f "${TOKENPLACE_REAL_E2E_MODEL_PATH}" ]; then
-    run_test "Relay Landing Page Real Desktop Bridge Guardrail"   "RUN_RELAY_REGISTRATION_TESTS=1 $PYTHON_CMD -m pytest tests/e2e/test_ui.py -v -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' $COVERAGE_ARGS"   "Verifying browser -> relay/API v1 -> desktop bridge runtime with non-streaming guardrails"
+    run_test "Relay Landing Page Real Desktop-Bridge API v1 Guardrail" \
+        "RUN_RELAY_REGISTRATION_TESTS=1 $PYTHON_CMD -m pytest tests/e2e/test_ui.py -v -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' $COVERAGE_ARGS" \
+        "Verifying browser -> relay/API v1 -> desktop bridge runtime with non-streaming guardrails"
 else
-    echo "Skipping Relay Landing Page Real Desktop Bridge Guardrail (set TOKENPLACE_REAL_E2E_MODEL_PATH to a local GGUF file to enable)"
+    echo "Skipping Relay Landing Page Real Desktop-Bridge API v1 Guardrail (set TOKENPLACE_REAL_E2E_MODEL_PATH to a local GGUF file to enable)"
 fi
 
 # 9. Run failure recovery tests


### PR DESCRIPTION
### Motivation

- Make the CI guardrail name and behavior explicitly reflect that it validates the relay landing-page -> desktop-bridge API v1 path rather than a generic test. 
- Keep a small, real GGUF model in CI so the guardrail exercises real llama.cpp inference without requiring a heavyweight artifact or using a fake/stub. 

### Description

- Renamed the CI job display name to `Run tests + relay landing-page real desktop-bridge API v1 guardrail` in `.github/workflows/ci.yml` for clarity. 
- Scoped the model cache and provisioning to an explicit folder ` .ci-models/relay-landing-desktop-bridge-api-v1/tinygemma3-Q8_0.gguf` and updated the cache `key` to `ci-relay-landing-desktop-bridge-api-v1-real-model-tinygemma3-q8-c287502`. 
- Updated the provisioning step to create `MODEL_DIR` and pin a tiny real GGUF (`tinygemma3-Q8_0.gguf`) with concise comments explaining the choice of a small real model (approx ~47 MB) rather than a fake artifact. 
- Updated `run_all_tests.sh` to rename the guardrail runner to `Relay Landing Page Real Desktop-Bridge API v1 Guardrail`, add the explanatory comment about using a tiny real GGUF, and to print a matching skip message when `TOKENPLACE_REAL_E2E_MODEL_PATH` is not present. 
- CI wiring preserved: test step continues to set `TOKENPLACE_REAL_E2E_MODEL_PATH` to the new guarded model path so the guardrail runs automatically when the artifact is present. 

### Testing

- Ran `TEST_COVERAGE=1 ./run_all_tests.sh`, which executed the JS tests and cgroup checks successfully but failed Python test runs due to missing runtime test deps (`requests`, `cryptography`, and `coverage`) in this environment, causing an overall non-zero result. 
- The targeted command `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'` failed locally due to missing `requests` import from `tests/conftest.py`. 
- `pre-commit` was not available in the execution environment so `pre-commit run --all-files` could not be run here. 
- The CI changes are minimal and the guardrail remains enabled in the workflow and will run automatically on GitHub Actions when the pinned tiny GGUF artifact is provisioned (i.e., when `TOKENPLACE_REAL_E2E_MODEL_PATH` points to the cached `.ci-models/relay-landing-desktop-bridge-api-v1/tinygemma3-Q8_0.gguf`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabddbb530832f8cb38185c9d80ca0)