### PR TITLE
🛠️ chore(ci): clarify relay landing-page API v1 desktop-bridge guardrail and model cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,10 @@ on:
 
 jobs:
   test:
-    name: Run tests and collect coverage
+    name: Test suite + relay landing-page real desktop-bridge API v1 guardrail
     runs-on: ubuntu-latest
+    env:
+      CI_REAL_DESKTOP_BRIDGE_MODEL_PATH: .ci-models/tinygemma3-Q8_0.gguf
     permissions:
       actions: read
       contents: read
@@ -50,32 +52,35 @@ jobs:
       - name: Install Node.js dependencies
         if: steps.prep.outputs.rc != '2'
         run: npm ci
-      - name: Restore cached real desktop-bridge model artifact
+      - name: Restore relay landing-page desktop-bridge API v1 guardrail model cache
         if: steps.prep.outputs.rc != '2'
         uses: actions/cache@v4
         with:
-          path: .ci-models/tinygemma3-Q8_0.gguf
-          key: ci-real-desktop-bridge-model-tinygemma3-q8-20260422
-      - name: Provision real desktop-bridge model artifact
+          path: ${{ env.CI_REAL_DESKTOP_BRIDGE_MODEL_PATH }}
+          key: ci-relay-landing-page-real-desktop-bridge-api-v1-model-tinygemma3-q8_0-v1
+      - name: Provision relay landing-page desktop-bridge API v1 guardrail model artifact
         if: steps.prep.outputs.rc != '2'
         run: |
           set -euo pipefail
-          mkdir -p .ci-models
-          MODEL_PATH=".ci-models/tinygemma3-Q8_0.gguf"
+          mkdir -p "$(dirname "${CI_REAL_DESKTOP_BRIDGE_MODEL_PATH}")"
+          MODEL_PATH="${CI_REAL_DESKTOP_BRIDGE_MODEL_PATH}"
           if [ ! -s "$MODEL_PATH" ]; then
+            # Keep this as a tiny real GGUF (about 45 MB) so CI still exercises
+            # actual llama.cpp inference and desktop bridge wiring (not a fake).
             curl -fL \
               "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/c287502cd9e278dac8eed805c112cce5d0081e0b/tinygemma3-Q8_0.gguf" \
               -o "$MODEL_PATH.tmp"
             mv "$MODEL_PATH.tmp" "$MODEL_PATH"
           fi
           test -s "$MODEL_PATH"
-      - name: Run tests
+          test "$(wc -c < "$MODEL_PATH")" -ge 40000000
+      - name: Run tests (includes relay landing-page real desktop-bridge API v1 guardrail)
         if: steps.prep.outputs.rc != '2'
         run: ./run_all_tests.sh
         env:
           TEST_COVERAGE: '1'
-          # Keep the real landing-page desktop-bridge guardrail always-on in CI.
-          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/tinygemma3-Q8_0.gguf
+          # Keep this guardrail always-on when the real tiny GGUF is provisioned.
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/${{ env.CI_REAL_DESKTOP_BRIDGE_MODEL_PATH }}
       - name: Upload coverage reports to Codecov
         if: steps.prep.outputs.rc != '2'
         uses: codecov/codecov-action@v5

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -164,11 +164,13 @@ else
     echo "Skipping End-to-End Tests (set RUN_E2E=1 to enable)"
 fi
 
-# 8b. Relay landing-page real desktop bridge guardrail (requires local GGUF model path)
+# 8b. Relay landing-page real desktop bridge API v1 guardrail.
+# This intentionally uses a tiny *real* GGUF model in CI so the test still proves
+# true inference + bridge wiring instead of a synthetic fake response path.
 if [ -n "${TOKENPLACE_REAL_E2E_MODEL_PATH:-}" ] && [ -f "${TOKENPLACE_REAL_E2E_MODEL_PATH}" ]; then
-    run_test "Relay Landing Page Real Desktop Bridge Guardrail"   "RUN_RELAY_REGISTRATION_TESTS=1 $PYTHON_CMD -m pytest tests/e2e/test_ui.py -v -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' $COVERAGE_ARGS"   "Verifying browser -> relay/API v1 -> desktop bridge runtime with non-streaming guardrails"
+    run_test "Relay Landing Page Real Desktop Bridge API v1 Guardrail"   "RUN_RELAY_REGISTRATION_TESTS=1 $PYTHON_CMD -m pytest tests/e2e/test_ui.py -v -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' $COVERAGE_ARGS"   "Verifying browser -> relay/API v1 -> desktop bridge runtime with non-streaming guardrails"
 else
-    echo "Skipping Relay Landing Page Real Desktop Bridge Guardrail (set TOKENPLACE_REAL_E2E_MODEL_PATH to a local GGUF file to enable)"
+    echo "Skipping Relay Landing Page Real Desktop Bridge API v1 Guardrail (set TOKENPLACE_REAL_E2E_MODEL_PATH to a local GGUF file to enable)"
 fi
 
 # 9. Run failure recovery tests


### PR DESCRIPTION
### Motivation
- Make the CI guardrail intent explicit by naming the workflow/check to clearly indicate it validates the relay landing-page real desktop-bridge API v1 path.
- Reduce fragility and cost by ensuring CI uses the smallest viable *real* GGUF artifact that still proves end-to-end inference and bridge wiring rather than a synthetic fake.
- Keep cache behavior and model path plumbing explicit and maintainable so the guardrail remains automatic when the artifact is available.

### Description
- Renamed the CI job to `Test suite + relay landing-page real desktop-bridge API v1 guardrail` and introduced a job-level env var `CI_REAL_DESKTOP_BRIDGE_MODEL_PATH` to centralize the artifact path in `/.github/workflows/ci.yml`.
- Replaced generic cache/step names with guardrail-specific labels and a purposeful cache key `ci-relay-landing-page-real-desktop-bridge-api-v1-model-tinygemma3-q8_0-v1` in `/.github/workflows/ci.yml`.
- Kept the tiny real model `tinygemma3-Q8_0.gguf` as the provisioned artifact, made the download path explicit, and added a lightweight sanity check (`test "$(wc -c < "$MODEL_PATH")" -ge 40000000`) to assert the artifact is the expected small real file.
- Updated `run_all_tests.sh` guardrail messaging and added comments explaining the choice to use a tiny *real* GGUF so the test exercises actual llama.cpp inference + desktop bridge wiring, and renamed the test label to `Relay Landing Page Real Desktop Bridge API v1 Guardrail`.

### Testing
- Ran `TEST_COVERAGE=1 ./run_all_tests.sh`, which exercised the JS test suite and multiple steps but failed Python test stages due to the environment missing Python dependencies (`requests`, `cryptography`) and the `coverage` binary; the JS tests passed.
- Ran `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'`, which failed in this environment because `requests` is not installed so the test could not initialize.
- Verified the workflow changes by running the modified CI provisioning logic locally to confirm the model download URL and the added file-size assertion are reachable and parse correctly (artifact head checks performed during development).
- No other functional/test logic was changed; the guardrail remains conditional on `TOKENPLACE_REAL_E2E_MODEL_PATH` and will run automatically in CI when the model artifact is provisioned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabddbb530832f8cb38185c9d80ca0)