### PR TITLE
Clarify relay landing-page real desktop-bridge API v1 CI guardrail and tiny model artifact naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (relay landing-page real desktop-bridge API v1 guardrail)
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run tests and collect coverage
+    name: Run tests + relay landing-page real desktop-bridge API v1 guardrail
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -50,18 +50,20 @@ jobs:
       - name: Install Node.js dependencies
         if: steps.prep.outputs.rc != '2'
         run: npm ci
-      - name: Restore cached real desktop-bridge model artifact
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
         if: steps.prep.outputs.rc != '2'
         uses: actions/cache@v4
         with:
-          path: .ci-models/tinygemma3-Q8_0.gguf
-          key: ci-real-desktop-bridge-model-tinygemma3-q8-20260422
-      - name: Provision real desktop-bridge model artifact
+          path: .ci-models/relay-landing-api-v1-tinygemma3-Q8_0.gguf
+          key: ci-relay-landing-api-v1-real-model-tinygemma3-q8-20260424
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
         if: steps.prep.outputs.rc != '2'
         run: |
           set -euo pipefail
           mkdir -p .ci-models
-          MODEL_PATH=".ci-models/tinygemma3-Q8_0.gguf"
+          # Keep this guardrail on a tiny *real* GGUF to verify real llama.cpp inference
+          # end-to-end without paying the CI cost/fragility of large checkpoint downloads.
+          MODEL_PATH=".ci-models/relay-landing-api-v1-tinygemma3-Q8_0.gguf"
           if [ ! -s "$MODEL_PATH" ]; then
             curl -fL \
               "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/c287502cd9e278dac8eed805c112cce5d0081e0b/tinygemma3-Q8_0.gguf" \
@@ -74,8 +76,9 @@ jobs:
         run: ./run_all_tests.sh
         env:
           TEST_COVERAGE: '1'
-          # Keep the real landing-page desktop-bridge guardrail always-on in CI.
-          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/tinygemma3-Q8_0.gguf
+          # Keep the relay landing-page desktop-bridge API v1 guardrail always-on with
+          # a tiny real model (not a fake) so CI still proves real runtime behavior.
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/relay-landing-api-v1-tinygemma3-Q8_0.gguf
       - name: Upload coverage reports to Codecov
         if: steps.prep.outputs.rc != '2'
         uses: codecov/codecov-action@v5

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -164,11 +164,13 @@ else
     echo "Skipping End-to-End Tests (set RUN_E2E=1 to enable)"
 fi
 
-# 8b. Relay landing-page real desktop bridge guardrail (requires local GGUF model path)
+# 8b. Relay landing-page real desktop bridge API v1 guardrail.
+# Uses a tiny *real* GGUF (when provisioned) so this remains an end-to-end real
+# inference check instead of a brittle/heavy large-model CI dependency.
 if [ -n "${TOKENPLACE_REAL_E2E_MODEL_PATH:-}" ] && [ -f "${TOKENPLACE_REAL_E2E_MODEL_PATH}" ]; then
-    run_test "Relay Landing Page Real Desktop Bridge Guardrail"   "RUN_RELAY_REGISTRATION_TESTS=1 $PYTHON_CMD -m pytest tests/e2e/test_ui.py -v -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' $COVERAGE_ARGS"   "Verifying browser -> relay/API v1 -> desktop bridge runtime with non-streaming guardrails"
+    run_test "Relay Landing Page Real Desktop Bridge API v1 Guardrail"   "RUN_RELAY_REGISTRATION_TESTS=1 $PYTHON_CMD -m pytest tests/e2e/test_ui.py -v -k 'landing_chat_real_inference_with_desktop_bridge_api_v1' $COVERAGE_ARGS"   "Verifying browser -> relay/API v1 -> desktop bridge runtime with non-streaming guardrails"
 else
-    echo "Skipping Relay Landing Page Real Desktop Bridge Guardrail (set TOKENPLACE_REAL_E2E_MODEL_PATH to a local GGUF file to enable)"
+    echo "Skipping Relay Landing Page Real Desktop Bridge API v1 Guardrail (set TOKENPLACE_REAL_E2E_MODEL_PATH to a local GGUF file to enable)"
 fi
 
 # 9. Run failure recovery tests


### PR DESCRIPTION
### Motivation
- Right-size the real-model CI guardrail so it continues to validate the relay landing-page -> desktop-bridge path end-to-end without becoming an expensive or fragile large-checkpoint download.
- Prefer a tiny, fast real GGUF over a fake so CI proves real inference behavior while remaining cache-friendly and explicit.
- Make the workflow and check names clearly communicate that this is the relay landing-page real desktop-bridge API v1 guardrail.

### Description
- Renamed the workflow and job labels to surface the guardrail intent (`CI (relay landing-page real desktop-bridge API v1 guardrail)` and `Run tests + relay landing-page real desktop-bridge API v1 guardrail`).
- Switched the model cache/artifact path and key to an explicit guardrail-specific name (`.ci-models/relay-landing-api-v1-tinygemma3-Q8_0.gguf` / `ci-relay-landing-api-v1-real-model-tinygemma3-q8-20260424`) and wired `TOKENPLACE_REAL_E2E_MODEL_PATH` to that path so the guardrail runs automatically when provisioned.
- Kept the real model choice as the tiny `tinygemma3-Q8_0.gguf` (small real GGUF) and added concise inline comments explaining the rationale: keep a tiny real model (not a fake) to validate real `llama.cpp` inference end-to-end while avoiding large-model CI antipatterns.
- Updated `run_all_tests.sh` display name and skip message for the guardrail and added a short explanatory comment describing why this uses a tiny real GGUF for the API v1 desktop-bridge guardrail.

### Testing
- Ran `TEST_COVERAGE=1 ./run_all_tests.sh`; JavaScript tests and the cgroup script test passed, but the overall script failed in this environment due to missing Python test dependencies (`requests`, `cryptography`) and missing `coverage` binary, so the full run did not complete.
- Ran `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'`; the test run failed here due to missing `requests` in the test environment, so the guardrail itself could not be executed locally in this sandbox.
- `pre-commit run --all-files` could not be executed in this environment because `pre-commit` is not installed; CI will still run `pre-commit`/`./run_all_tests.sh` on push/PR where the environment provides the required deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabddbb530832f8cb38185c9d80ca0)