### PR TITLE
Document relay landing-page desktop-bridge/API v1 mismatch outage

### DIFF
--- a/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.json
+++ b/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-04-20",
   "slug": "relay-landing-page-desktop-bridge-api-v1-mismatch",
-  "summary": "The relay landing-page used API v1 chat completions while desktop-bridge servicing validation remained effectively aligned to legacy relay behavior, allowing desktop registration/health to appear green without proving real API v1 request handling.",
+  "summary": "The relay landing-page used API v1 chat completions while desktop-bridge servicing checks remained aligned to legacy relay behavior, allowing desktop registration/health to appear green without proving real API v1 request handling.",
   "impact": "Users could see a healthy desktop operator but still receive fake/stub-style or poor failure experiences on landing-page requests, especially when no nodes were available.",
   "fix": "Added an unmocked landing-page browser->relay->desktop-bridge API v1 e2e guardrail, wired CI to run it always-on with a tiny real GGUF model, and tightened user-facing failure messaging for no-node/bridge-error conditions.",
   "lessons": "Registration heartbeat signals are not sufficient readiness checks; CI must validate full request-processing semantics and provider-path diagnostics for relay landing-page API v1 traffic."

--- a/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.json
+++ b/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-20",
+  "slug": "relay-landing-page-desktop-bridge-api-v1-mismatch",
+  "summary": "The relay landing-page used API v1 chat completions while desktop-bridge servicing validation remained effectively aligned to legacy relay behavior, allowing desktop registration/health to appear green without proving real API v1 request handling.",
+  "impact": "Users could see a healthy desktop operator but still receive fake/stub-style or poor failure experiences on landing-page requests, especially when no nodes were available.",
+  "fix": "Added an unmocked landing-page browser->relay->desktop-bridge API v1 e2e guardrail, wired CI to run it always-on with a tiny real GGUF model, and tightened user-facing failure messaging for no-node/bridge-error conditions.",
+  "lessons": "Registration heartbeat signals are not sufficient readiness checks; CI must validate full request-processing semantics and provider-path diagnostics for relay landing-page API v1 traffic."
+}

--- a/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md
+++ b/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md
@@ -6,7 +6,7 @@
 
 ## Summary
 The landing-page chat path used `POST /api/v1/chat/completions`, but the desktop bridge was only
-participating in legacy relay polling/response semantics for request handling. That mismatch let the
+participating in legacy relay polling semantics for request handling. That mismatch let the
 desktop app appear healthy (`Running`/`Registered`) while not actually servicing landing-page API v1
 requests end-to-end.
 
@@ -35,7 +35,7 @@ requests end-to-end.
 
 ## Why CI/tests missed it
 CI initially validated a local-provider/mocked-path bypass instead of enforcing the full browser →
-relay API v1 → relay sink/source → desktop bridge runtime contract. As a result, checks could pass
+relay API v1 → relay sink/source → desktop bridge contract. As a result, checks could pass
 while the desktop bridge never handled the landing-page request payload that users depend on.
 
 ## Remediation

--- a/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md
+++ b/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md
@@ -8,15 +8,17 @@
 The landing-page chat path used `POST /api/v1/chat/completions`, but the desktop bridge was only
 participating in legacy relay polling/response semantics for request handling. That mismatch let the
 desktop app appear healthy (`Running`/`Registered`) while not actually servicing landing-page API v1
-requests end to end.
+requests end-to-end.
 
-## Impact / user-visible symptoms
+## Symptoms
 - Users could see desktop operator status as healthy while landing-page requests were not processed
   by the registered desktop bridge.
-- Landing-page responses could fall back to a fake/stub-style result instead of real desktop
-  inference in scenarios where real-provider path assumptions were bypassed.
 - Failure messaging was weak for degraded relay availability, including poor UX when no compute
   nodes were available.
+
+## Impact
+- Landing-page responses could fall back to a fake/stub-style result instead of real desktop
+  inference in scenarios where real-provider path assumptions were bypassed.
 
 ## Root cause
 1. Contract drift across boundaries: landing-page traffic was pinned to API v1, while bridge-side
@@ -36,7 +38,7 @@ CI initially validated a local-provider/mocked-path bypass instead of enforcing 
 relay API v1 → relay sink/source → desktop bridge runtime contract. As a result, checks could pass
 while the desktop bridge never handled the landing-page request payload that users depend on.
 
-## Resolution (final fixed state)
+## Remediation
 - Added an unmocked e2e guardrail in `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1`
   that requires:
   - API v1 route usage and non-streaming behavior,
@@ -48,7 +50,7 @@ while the desktop bridge never handled the landing-page request payload that use
 - Tightened landing-page failure handling so no-node and bridge-error states surface actionable user
   messages instead of generic failures.
 
-## Preventive follow-ups / guardrails added
+## Follow-up / prevention
 - Keep relay landing-page desktop-bridge API v1 guardrail mandatory in CI.
 - Keep assertions that reject v2/streaming drift on relay landing-page traffic.
 - Preserve user-facing error-code mapping coverage for no-node and bridge-failure conditions.

--- a/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md
+++ b/outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md
@@ -1,0 +1,54 @@
+# Outage: relay landing-page desktop-bridge/API v1 mismatch
+
+- **Date:** 2026-04-20
+- **Slug:** `relay-landing-page-desktop-bridge-api-v1-mismatch`
+- **Affected area:** relay-served landing-page chat (`/`) with desktop operator connected
+
+## Summary
+The landing-page chat path used `POST /api/v1/chat/completions`, but the desktop bridge was only
+participating in legacy relay polling/response semantics for request handling. That mismatch let the
+desktop app appear healthy (`Running`/`Registered`) while not actually servicing landing-page API v1
+requests end to end.
+
+## Impact / user-visible symptoms
+- Users could see desktop operator status as healthy while landing-page requests were not processed
+  by the registered desktop bridge.
+- Landing-page responses could fall back to a fake/stub-style result instead of real desktop
+  inference in scenarios where real-provider path assumptions were bypassed.
+- Failure messaging was weak for degraded relay availability, including poor UX when no compute
+  nodes were available.
+
+## Root cause
+1. Contract drift across boundaries: landing-page traffic was pinned to API v1, while bridge-side
+   execution validation was effectively aligned with legacy relay behavior rather than strict API v1
+   request servicing.
+2. Health/registration signals were treated as sufficient evidence of readiness, even though they did
+   not prove that the bridge processed real landing-page API v1 requests.
+
+## Contributing factors
+- Existing UI smoke coverage relied on mocked `/api/v1/chat/completions`, which validated endpoint
+  selection/rendering but not the real relay queue + bridge execution path.
+- Guardrails focused on startup and registration success before adding assertions for bridge request
+  processing semantics (`api_v1_payload`, non-streaming, and provider-path headers).
+
+## Why CI/tests missed it
+CI initially validated a local-provider/mocked-path bypass instead of enforcing the full browser →
+relay API v1 → relay sink/source → desktop bridge runtime contract. As a result, checks could pass
+while the desktop bridge never handled the landing-page request payload that users depend on.
+
+## Resolution (final fixed state)
+- Added an unmocked e2e guardrail in `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1`
+  that requires:
+  - API v1 route usage and non-streaming behavior,
+  - distributed provider/header diagnostics for registered desktop execution,
+  - desktop bridge processing evidence in stderr (`process_request.start/ok` with `api_v1_payload=True`),
+  - and non-stub assistant output when runtime reports real inference support.
+- Updated CI (`.github/workflows/ci.yml`) to run this guardrail explicitly with a tiny real GGUF
+  model and keep it always-on via `TOKENPLACE_REAL_E2E_MODEL_PATH`.
+- Tightened landing-page failure handling so no-node and bridge-error states surface actionable user
+  messages instead of generic failures.
+
+## Preventive follow-ups / guardrails added
+- Keep relay landing-page desktop-bridge API v1 guardrail mandatory in CI.
+- Keep assertions that reject v2/streaming drift on relay landing-page traffic.
+- Preserve user-facing error-code mapping coverage for no-node and bridge-failure conditions.


### PR DESCRIPTION
### Motivation
- Capture a canonical outage writeup for a protocol mismatch where the landing-page UI used `POST /api/v1/chat/completions` while the desktop bridge remained aligned with legacy relay polling, causing the desktop app to appear healthy without actually servicing landing-page API v1 requests.
- Explain user-visible symptoms (fake/stub responses and weak no-node failure messaging), the root cause (contract drift + readiness signal misuse), and why CI initially missed the regression.
- Record the final fixed state and the guardrails added so future changes must validate full browser → relay API v1 → relay sink/source → desktop bridge semantics.

### Description
- Added a Markdown outage report at `outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.md` following the repo's existing outage format with date/slug/summary, impact, root cause, contributing factors, CI miss analysis, resolution, and preventive follow-ups.
- Added a matching structured JSON entry at `outages/2026-04-20-relay-landing-page-desktop-bridge-api-v1-mismatch.json` that conforms to `outages/schema.json` with `date`, `slug`, `summary`, `impact`, `fix`, and `lessons` fields.
- Documented the relevant guardrail artifacts added in the preceding fixes, including `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1` and the CI guardrail configuration in `.github/workflows/ci.yml` that runs a tiny real GGUF model for the landing-page desktop-bridge API v1 path.

### Testing
- Ran repository checks `git diff --stat` and `git diff -- outages` to verify the change set touched only the new `outages/` files.
- Attempted `pre-commit run --all-files` but it failed in this environment because `pre-commit` is not installed.
- Attempted the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` but the helper script was not present in this environment, so no local secret-scan was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae406d51c832f8bff76c5fd731770)