### PR TITLE
📝 Add outage record for relay landing-page desktop-bridge/API v1 mismatch

### DIFF
--- a/outages/2026-04-24-relay-landing-page-desktop-bridge-api-v1-mismatch.json
+++ b/outages/2026-04-24-relay-landing-page-desktop-bridge-api-v1-mismatch.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-24",
+  "slug": "relay-landing-page-desktop-bridge-api-v1-mismatch",
+  "summary": "Relay landing-page chat used API v1 while desktop bridge servicing remained aligned to legacy relay request handling, allowing operators to appear registered while real landing-page requests were not processed through the intended desktop-bridge path.",
+  "impact": "Users could see healthy desktop operator status but still receive stub/fake responses or weak failure messaging when no relay compute nodes were available.",
+  "fix": "Aligned guardrails to enforce distributed API v1 landing-page routing through registered desktop bridge execution, added unmocked e2e assertions for API v1 non-streaming bridge request processing, and made this real-model guardrail always-on in CI.",
+  "lessons": "Registration heartbeat checks are not sufficient service health signals; CI guardrails must assert real end-to-end request processing on the exact API/protocol path users rely on and must fail on local-provider bypasses."
+}

--- a/outages/2026-04-24-relay-landing-page-desktop-bridge-api-v1-mismatch.md
+++ b/outages/2026-04-24-relay-landing-page-desktop-bridge-api-v1-mismatch.md
@@ -1,0 +1,54 @@
+# Outage: relay landing-page desktop-bridge/API v1 mismatch
+
+- **Date:** 2026-04-24
+- **Slug:** `relay-landing-page-desktop-bridge-api-v1-mismatch`
+- **Affected area:** relay-served landing-page chat (`/`) routed through API v1 and desktop bridge
+
+## Summary
+The landing-page UI sent requests to `/api/v1/chat/completions`, but the desktop bridge only
+participated in legacy relay polling/response handling. This made operator status look healthy while
+real landing-page API v1 requests were not actually serviced by the registered desktop node.
+
+## Impact / user-visible symptoms
+- Desktop operator could show healthy registration/heartbeat while landing-page requests were not
+  handled by the bridge.
+- Users could receive a fake/stub assistant response instead of real desktop inference.
+- Failure messaging remained weak when no relay compute nodes were available.
+
+## Root cause
+1. Protocol-path mismatch: landing-page traffic used API v1 while desktop bridge request handling
+   still accepted legacy/non-API-v1 relay payload paths.
+2. Registration health and request-processing health were treated as equivalent, so heartbeat success
+   masked request-path incompatibility.
+
+## Contributing factors
+- Existing smoke coverage allowed mocked `/api/v1/chat/completions` flows that validated rendering
+  but not relay queue/sink/source behavior through `compute_node_bridge.py`.
+- Guardrail setup allowed provider-path outcomes that could pass while effectively validating local
+  provider bypass instead of enforced distributed desktop-bridge execution.
+
+## Why CI/tests missed it
+CI validated the old guardrail surface, which proved the local-provider bypass path could succeed
+without proving that a registered desktop bridge processed API v1, non-streaming relay payloads.
+As a result, the test signal showed green while real landing-page bridge servicing was still broken.
+
+## Resolution
+Following the preceding fixes, guardrails now enforce and verify the intended final path:
+- API v1 distributed routing is forced for the real landing-page bridge e2e fixture in
+  `tests/conftest.py` (`TOKENPLACE_API_V1_ENFORCE_RELAY_DISTRIBUTED=1`, distributed fallback off).
+- The unmocked e2e in `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1`
+  now requires:
+  - API v1 only (no API v2),
+  - non-streaming responses,
+  - distributed provider + `registered_desktop_compute_node` execution backend,
+  - desktop-bridge `process_request` evidence for API v1 payload handling,
+  - non-stub assistant output when runtime reports real inference support.
+- CI (`.github/workflows/ci.yml`) now runs this guardrail with a tiny real GGUF model before the
+  full suite and keeps the same model path during `./run_all_tests.sh`.
+
+## Preventive follow-ups / guardrails added
+- Keep the always-on CI relay landing-page desktop-bridge API v1 guardrail workflow step mandatory.
+- Preserve assertions that fail if bridge processing falls back to legacy/non-API-v1 or streaming
+  relay request handling.
+- Continue requiring explicit distributed-provider diagnostics in landing-page e2e headers so
+  local-provider bypass cannot silently satisfy the guardrail.


### PR DESCRIPTION
### Motivation
- Record a production incident where the landing-page used `/api/v1/chat/completions` while the desktop bridge only participated in legacy relay polling, causing requests to be bypassed. 
- Explain why operator heartbeats hid the functional failure and why CI coverage missed the mismatch. 
- Capture the final resolved state and the guardrails/tests established to prevent recurrence.

### Description
- Added a new outage entry `outages/2026-04-24-relay-landing-page-desktop-bridge-api-v1-mismatch.md` following the repo incident template with summary, impact, root cause, contributing factors, resolution, and preventive follow-ups. 
- Added matching JSON metadata `outages/2026-04-24-relay-landing-page-desktop-bridge-api-v1-mismatch.json` that conforms to `outages/schema.json` fields (`date`, `slug`, `summary`, `impact`, `fix`, `lessons`). 
- The writeup references the relevant guardrails and tests updated as part of the prior fixes, specifically the focused relay e2e enforcement in `tests/conftest.py`, the unmocked E2E in `tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1`, and the CI step in `.github/workflows/ci.yml` that runs the tiny real GGUF guardrail.

### Testing
- Ran `pre-commit run --all-files`; linter/hooks initialized and many checks passed, but the run failed overall because Python test dependencies are not available in this environment (`ModuleNotFoundError` for `requests` and `cryptography`), causing the Python test suites to fail in the pre-commit check. 
- From the pre-commit output: JavaScript test hooks and client smoke tests passed, cgroup setup checks passed, and multiple Python test suites failed (Python unit, integration, API, security audit, and crypto compatibility tests) due to missing local Python dependencies. 
- The repo CI workflow (`.github/workflows/ci.yml`) includes the always-on relay landing-page desktop-bridge API v1 guardrail that exercises a tiny real GGUF model before the full test suite; the outage entry documents that guardrail as the prevention/remediation path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae406d51c832f8bff76c5fd731770)