### PR TITLE
Require registration tokens for API v1 relay dispatch

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -695,6 +695,19 @@ def relay_diagnostics():
 def relay_api_v1_chat_completions():
     """Queue API v1 chat requests for registered compute nodes and wait for completion."""
 
+    if not SERVER_REGISTRATION_TOKENS:
+        return jsonify(
+            {
+                'error': {
+                    'type': 'service_unavailable_error',
+                    'code': 'relay_registration_tokens_required',
+                    'message': (
+                        'API v1 relay dispatch requires relay server registration tokens'
+                    ),
+                }
+            }
+        ), 503
+
     _evict_stale_servers()
     payload = request.get_json(silent=True)
     if payload is None:

--- a/tests/unit/test_relay_registration_token.py
+++ b/tests/unit/test_relay_registration_token.py
@@ -231,3 +231,37 @@ def test_evict_stale_servers_cleans_up_queue_and_stream_state(relay_module) -> N
     assert "stale-server" not in relay_module.client_inference_requests
     assert "session-stale" not in relay_module.streaming_sessions
     assert "client-stale" not in relay_module.streaming_sessions_by_client
+
+
+def test_api_v1_relay_dispatch_requires_registration_tokens_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API v1 relay dispatch should fail closed when registration tokens are unset."""
+
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "testing")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_SERVER_TOKEN", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_SERVER_TOKENS", raising=False)
+
+    for name in MODULES_TO_CLEAR:
+        sys.modules.pop(name, None)
+
+    try:
+        relay = importlib.import_module("relay")
+        relay.app.config["TESTING"] = True
+        client = relay.app.test_client()
+
+        response = client.post(
+            "/relay/api/v1/chat/completions",
+            json={"model": "llama", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert response.status_code == 503
+        assert response.get_json() == {
+            "error": {
+                "type": "service_unavailable_error",
+                "code": "relay_registration_tokens_required",
+                "message": "API v1 relay dispatch requires relay server registration tokens",
+            }
+        }
+    finally:
+        for name in MODULES_TO_CLEAR:
+            sys.modules.pop(name, None)


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated compute nodes from receiving plaintext API v1 chat traffic when no registration tokens are configured, closing an interception/tampering attack path introduced by the new relay path.

### Description
- Add a fail-closed guard in `relay_api_v1_chat_completions` that returns `503` with a structured `error` object when `SERVER_REGISTRATION_TOKENS` is empty.
- Preserve existing API v1 request validation and queueing behavior when tokens are present, only blocking dispatch when token configuration is missing.
- Add a regression test `test_api_v1_relay_dispatch_requires_registration_tokens_configuration` in `tests/unit/test_relay_registration_token.py` which clears token env vars and asserts the `503` error payload.

### Testing
- Ran `pytest -q tests/unit/test_relay_registration_token.py`, which failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'requests'`).
- Ran `pre-commit run --all-files`, which could not execute here because `pre-commit` is not installed in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaea401de8832fb86bcae80f5f0814)