### PR TITLE
Fail-closed plaintext distributed API v1 relay dispatch

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -13,8 +13,6 @@ from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
-import requests
-
 from api.v1.models import generate_response
 
 logger = logging.getLogger("api.v1.compute_provider")
@@ -74,6 +72,11 @@ _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
         "public_message": "The LLM server returned an invalid response. Please try again.",
         "status_code": 502,
     },
+    "api_v1_relay_disabled": {
+        "error_type": "service_unavailable_error",
+        "public_message": "Distributed API v1 relay is disabled pending E2EE support.",
+        "status_code": 503,
+    },
 }
 
 
@@ -124,7 +127,7 @@ class LocalApiV1ComputeProvider:
 
 @dataclass(frozen=True)
 class DistributedApiV1ComputeProvider:
-    """Provider that forwards API v1 chat payloads to a remote compute endpoint."""
+    """Disabled provider kept for compatibility with existing configuration parsing."""
 
     base_url: str
     timeout_seconds: float = 30.0
@@ -136,87 +139,13 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        payload: Dict[str, Any] = {
-            "model": model_id,
-            "messages": messages,
-            "stream": False,
-        }
-        for key, value in (options or {}).items():
-            if key == "stream":
-                continue
-            payload[key] = value
-
-        try:
-            response = requests.post(
-                f"{self.base_url.rstrip('/')}/relay/api/v1/chat/completions",
-                json=payload,
-                timeout=self.timeout_seconds,
-            )
-        except requests.Timeout as exc:
-            raise _error_from_code(
-                "compute_node_bridge_timeout",
-                message=f"distributed provider timed out contacting relay bridge: {exc}",
-            ) from exc
-        except requests.RequestException as exc:
-            raise _error_from_code(
-                "compute_node_unreachable",
-                message=f"distributed provider request failed: {exc}",
-            ) from exc
-        except Exception as exc:
-            raise _error_from_code(
-                "compute_node_bridge_error",
-                message=f"distributed provider request failed: {exc}",
-            ) from exc
-
-        if response.status_code != 200:
-            error_code = "compute_node_bridge_error"
-            error_message = f"distributed provider returned status {response.status_code}"
-            try:
-                parsed = response.json()
-                if isinstance(parsed, dict):
-                    error_payload = parsed.get("error", {})
-                    if isinstance(error_payload, dict):
-                        candidate_code = error_payload.get("code")
-                        candidate_message = error_payload.get("message")
-                        if isinstance(candidate_code, str) and candidate_code.strip():
-                            error_code = candidate_code.strip()
-                        if isinstance(candidate_message, str) and candidate_message.strip():
-                            error_message = candidate_message.strip()
-            except ValueError:
-                pass
-            raise _error_from_code(error_code, message=error_message)
-
-        try:
-            body = response.json()
-        except ValueError as exc:
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider returned non-JSON response",
-            ) from exc
-
-        choices = body.get("choices")
-        if not isinstance(choices, list) or not choices:
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider returned no choices",
-            )
-
-        first_choice = choices[0]
-        if not isinstance(first_choice, dict):
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider choice payload is invalid",
-            )
-
-        message = first_choice.get("message")
-        if not isinstance(message, dict):
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider response missing message",
-            )
-
-        _last_backend_path.set("registered_desktop_compute_node")
-        return message
+        raise _error_from_code(
+            "api_v1_relay_disabled",
+            message=(
+                "distributed API v1 relay provider is disabled pending an E2EE-compatible "
+                "relay design"
+            ),
+        )
 
 
 @dataclass(frozen=True)

--- a/relay.py
+++ b/relay.py
@@ -693,152 +693,32 @@ def relay_diagnostics():
 
 @app.route('/relay/api/v1/chat/completions', methods=['POST'])
 def relay_api_v1_chat_completions():
-    """Queue API v1 chat requests for registered compute nodes and wait for completion."""
-
-    _evict_stale_servers()
-    payload = request.get_json(silent=True)
-    if payload is None:
-        return jsonify(
-            {
-                'error': {
-                    'type': 'invalid_request_error',
-                    'code': 'invalid_request_payload',
-                    'message': 'Invalid request data',
-                }
-            }
-        ), 400
-    if not isinstance(payload, dict):
-        return jsonify(
-            {
-                'error': {
-                    'type': 'invalid_request_error',
-                    'code': 'invalid_request_payload',
-                    'message': 'Invalid request data',
-                }
-            }
-        ), 400
-
-    model = payload.get('model')
-    messages = payload.get('messages')
-    if not isinstance(model, str) or not model.strip() or not isinstance(messages, list):
-        return jsonify(
-            {
-                'error': {
-                    'type': 'invalid_request_error',
-                    'code': 'invalid_api_v1_payload',
-                    'message': 'Invalid API v1 payload',
-                }
-            }
-        ), 400
-
-    available_servers = list(known_servers.keys())
-    if not available_servers:
-        return jsonify(
-            {
-                'error': {
-                    'type': 'service_unavailable_error',
-                    'code': 'no_registered_compute_nodes',
-                    'message': 'No registered compute nodes available',
-                }
-            }
-        ), 503
-
-    selected_server = secrets.choice(available_servers)
-    request_id = secrets.token_urlsafe(16)
-    with api_v1_response_lock:
-        api_v1_pending_request_ids.add(request_id)
-    queue_item = {
-        'api_v1_request': {
-            'request_id': request_id,
-            'model': model,
-            'messages': messages,
-            'options': {
-                key: value
-                for key, value in payload.items()
-                if key not in {'model', 'messages', 'stream'}
-            },
-        }
-    }
-    client_inference_requests.setdefault(selected_server, []).append(queue_item)
-
-    timeout_seconds = float(os.environ.get('TOKENPLACE_RELAY_API_V1_TIMEOUT_SECONDS', '45'))
-    response_payload = _await_api_v1_response(request_id, timeout_seconds)
-    if response_payload is None:
-        return jsonify(
-            {
-                'error': {
-                    'type': 'timeout_error',
-                    'code': 'compute_node_timeout',
-                    'message': 'Timed out waiting for registered compute node',
-                }
-            }
-        ), 504
-
-    if response_payload.get('error'):
-        logging.warning(
-            "Compute node bridge error for request_id=%s: %r",
-            request_id,
-            response_payload.get('error'),
-        )
-        return jsonify(
-            {
-                'error': {
-                    'type': 'upstream_error',
-                    'code': 'compute_node_bridge_error',
-                    'message': 'Compute node returned an error',
-                }
-            }
-        ), 502
-
-    message = response_payload.get('message')
-    if not isinstance(message, dict):
-        return jsonify(
-            {
-                'error': {
-                    'type': 'server_error',
-                    'code': 'compute_node_invalid_payload',
-                    'message': 'Compute node returned invalid response',
-                }
-            }
-        ), 502
+    """Fail closed until API v1 relay dispatch is redesigned for E2EE compatibility."""
 
     return jsonify(
         {
-            'id': f"chatcmpl-{request_id}",
-            'object': 'chat.completion',
-            'created': int(time.time()),
-            'model': model,
-            'choices': [{'index': 0, 'message': message, 'finish_reason': 'stop'}],
+            'error': {
+                'type': 'service_unavailable_error',
+                'code': 'api_v1_relay_disabled',
+                'message': 'Distributed API v1 relay is disabled pending E2EE support',
+            }
         }
-    )
+    ), 503
 
 
 @app.route('/relay/api/v1/source', methods=['POST'])
 def relay_api_v1_source():
-    """Accept API v1 completion results from registered compute nodes."""
+    """Fail closed until API v1 relay dispatch is redesigned for E2EE compatibility."""
 
-    auth_error = _validate_server_registration()
-    if auth_error:
-        return auth_error
-
-    payload = request.get_json() or {}
-    if not isinstance(payload, dict):
-        return jsonify({'error': 'Invalid request data'}), 400
-
-    request_id = payload.get('request_id')
-    if not isinstance(request_id, str) or not request_id.strip():
-        return jsonify({'error': 'Missing request_id'}), 400
-
-    response_payload: Dict[str, Any] = {}
-    message = payload.get('message')
-    if isinstance(message, dict):
-        response_payload['message'] = message
-    error = payload.get('error')
-    if isinstance(error, str) and error.strip():
-        response_payload['error'] = error.strip()
-
-    _enqueue_api_v1_response(request_id, response_payload)
-    return jsonify({'message': 'API v1 response queued'}), 200
+    return jsonify(
+        {
+            'error': {
+                'type': 'service_unavailable_error',
+                'code': 'api_v1_relay_disabled',
+                'message': 'Distributed API v1 relay is disabled pending E2EE support',
+            }
+        }
+    ), 503
 
 @app.route('/faucet', methods=['POST'])
 def faucet():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -226,30 +226,10 @@ def test_unencrypted_chat_completion(client, client_keys, mock_llama):
     assert 'Mock response' in data['choices'][0]['message']['content']
 
 
-def test_api_v1_chat_completion_supports_distributed_provider_contract(client, monkeypatch):
-    captured = {}
-
-    def fake_post(url, json=None, timeout=None):
-        captured['url'] = url
-        captured['json'] = json
-        captured['timeout'] = timeout
-        return MagicMock(
-            status_code=200,
-            json=lambda: {
-                'choices': [
-                    {
-                        'message': {
-                            'role': 'assistant',
-                            'content': 'distributed-path response',
-                        }
-                    }
-                ]
-            },
-        )
-
-    monkeypatch.setattr('api.v1.compute_provider.requests.post', fake_post)
+def test_api_v1_chat_completion_distributed_provider_fails_closed(client, monkeypatch):
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')
+    monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
 
     payload = {
         'model': 'remote-only-model',
@@ -258,23 +238,12 @@ def test_api_v1_chat_completion_supports_distributed_provider_contract(client, m
         'stop': ['END'],
     }
     response = client.post('/api/v1/chat/completions', json=payload)
-    assert response.status_code == 200
+    assert response.status_code == 503
     data = response.get_json()
-    assert data['choices'][0]['message']['content'] == 'distributed-path response'
-
-    assert captured['url'] == 'https://compute.example/relay/api/v1/chat/completions'
-    assert captured['json']['model'] == 'remote-only-model'
-    assert captured['json']['messages'][0]['content'] == 'Ping distributed runtime'
-    assert captured['json']['stream'] is False
-    assert captured['json']['stop'] == ['END']
+    assert data['error']['code'] == 'api_v1_relay_disabled'
 
 
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):
-    monkeypatch.setattr(
-        'api.v1.compute_provider.requests.post',
-        lambda _url, json=None, timeout=None: MagicMock(status_code=503, json=lambda: {'error': 'down'}),
-    )
-
     fallback_message = {
         'role': 'assistant',
         'content': 'local fallback response',
@@ -300,22 +269,10 @@ def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client,
     assert response.get_json()['choices'][0]['message']['content'] == 'local fallback response'
 
 
-def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monkeypatch):
+def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monkeypatch):
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')
     monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
-
-    monkeypatch.setattr(
-        'api.v1.routes.get_api_v1_compute_provider',
-        lambda: importlib.import_module('api.v1.compute_provider').DistributedApiV1ComputeProvider(
-            base_url='https://compute.example'
-        ),
-    )
-
-    monkeypatch.setattr(
-        'api.v1.compute_provider.requests.post',
-        lambda _url, json=None, timeout=None: MagicMock(status_code=503, json=lambda: {'error': 'down'}),
-    )
 
     local_generate = MagicMock(side_effect=AssertionError('local generation should not run'))
     monkeypatch.setattr('api.v1.compute_provider.generate_response', local_generate)
@@ -328,7 +285,7 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monk
         },
     )
 
-    assert response.status_code == 502
+    assert response.status_code == 503
     local_generate.assert_not_called()
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -212,45 +212,28 @@ def test_two_servers_receive_only_addressed_work(client):
     assert server_one_work.get_json()["chat_history"] == "work-for-server-one"
 
 
-def test_relay_api_v1_returns_structured_error_for_invalid_json(client):
+def test_relay_api_v1_chat_completions_fails_closed(client):
     response = client.post(
         "/relay/api/v1/chat/completions",
         data="[",
         content_type="application/json",
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 503
     data = response.get_json()
-    assert data["error"]["type"] == "invalid_request_error"
-    assert data["error"]["code"] == "invalid_request_payload"
-    assert data["error"]["message"] == "Invalid request data"
+    assert data["error"]["type"] == "service_unavailable_error"
+    assert data["error"]["code"] == "api_v1_relay_disabled"
+    assert "disabled" in data["error"]["message"].lower()
 
 
-def test_relay_api_v1_masks_upstream_bridge_error_message(client, monkeypatch):
-    known_servers[DUMMY_SERVER_PUB_KEY] = {
-        "public_key": DUMMY_SERVER_PUB_KEY,
-        "last_ping": datetime.now(),
-        "last_ping_duration": 10,
-    }
-    monkeypatch.setattr(
-        relay_module,
-        "_await_api_v1_response",
-        lambda request_id, timeout_seconds: {"error": "stacktrace/token"},
-    )
+def test_relay_api_v1_source_fails_closed(client):
+    response = client.post("/relay/api/v1/source", json={"request_id": "req-1"})
 
-    response = client.post(
-        "/relay/api/v1/chat/completions",
-        json={
-            "model": "llama-3-8b-instruct",
-            "messages": [{"role": "user", "content": "hello"}],
-        },
-    )
-
-    assert response.status_code == 502
+    assert response.status_code == 503
     data = response.get_json()
-    assert data["error"]["type"] == "upstream_error"
-    assert data["error"]["code"] == "compute_node_bridge_error"
-    assert data["error"]["message"] == "Compute node returned an error"
+    assert data["error"]["type"] == "service_unavailable_error"
+    assert data["error"]["code"] == "api_v1_relay_disabled"
+    assert "disabled" in data["error"]["message"].lower()
 
 # --- Test /faucet ---
 
@@ -373,13 +356,11 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client):
 
 def test_healthz_returns_draining_when_shutdown_flag_set(client):
     """healthz should switch to draining status and 503 during shutdown."""
-    from relay import DRAINING
-
-    DRAINING.set()
+    relay_module.DRAINING.set()
     try:
         response = client.get("/healthz")
     finally:
-        DRAINING.clear()
+        relay_module.DRAINING.clear()
 
     assert response.status_code == 503
     assert response.headers["Retry-After"] == "0"

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 
 from api.v1 import compute_provider
@@ -13,56 +11,26 @@ from api.v1.compute_provider import (
 from relay import app
 
 
-def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
-    captured = {}
+def test_distributed_compute_provider_fails_closed_without_network_calls():
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
 
-    def fake_post(url, json=None, timeout=None):
-        captured["url"] = url
-        captured["json"] = json
-        captured["timeout"] = timeout
-        return SimpleNamespace(
-            status_code=200,
-            json=lambda: {
-                "choices": [
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "content": "distributed response",
-                        }
-                    }
-                ]
-            },
+    with pytest.raises(ComputeProviderError) as exc_info:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+            options={"temperature": 0.2},
         )
 
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
-
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
-    message = provider.complete_chat(
-        model_id="llama-3-8b-instruct",
-        messages=[{"role": "user", "content": "hi"}],
-        options={"temperature": 0.2, "stream": True},
-    )
-
-    assert captured["url"] == "https://node-a.example/relay/api/v1/chat/completions"
-    assert captured["timeout"] == 5
-    assert captured["json"]["model"] == "llama-3-8b-instruct"
-    assert captured["json"]["messages"] == [{"role": "user", "content": "hi"}]
-    assert captured["json"]["stream"] is False
-    assert captured["json"]["temperature"] == 0.2
-    assert "stream" not in captured["json"] or captured["json"]["stream"] is False
-    assert message["content"] == "distributed response"
+    assert exc_info.value.code == "api_v1_relay_disabled"
+    assert exc_info.value.status_code == 503
 
 
-def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):
-    def failing_post(_url, json=None, timeout=None):
-        return SimpleNamespace(status_code=503, json=lambda: {"error": "down"})
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", failing_post)
-
+def test_fallback_compute_provider_uses_local_adapter_when_distributed_disabled(monkeypatch):
     fallback_message = {"role": "assistant", "content": "local fallback"}
 
     monkeypatch.setattr(
-        "api.v1.compute_provider.generate_response",
+        compute_provider,
+        "generate_response",
         lambda _model, messages, **_options: messages + [fallback_message],
     )
 
@@ -77,174 +45,6 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(mon
     )
 
     assert result == fallback_message
-
-
-def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatch):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=200, json=lambda: {"choices": []}),
-    )
-
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError):
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-
-def test_distributed_compute_provider_handles_non_object_error_json(monkeypatch):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=503, json=lambda: []),
-    )
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert exc_info.value.status_code == 502
-
-
-def test_distributed_compute_provider_handles_non_json_error_response(monkeypatch):
-    def invalid_json(_url, json=None, timeout=None):
-        return SimpleNamespace(status_code=502, json=lambda: (_ for _ in ()).throw(ValueError("invalid json")))
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", invalid_json)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert str(exc_info.value) == "distributed provider returned status 502"
-
-
-def test_distributed_compute_provider_handles_non_object_error_field(monkeypatch):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(
-            status_code=503, json=lambda: {"error": "bridge down"}
-        ),
-    )
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert str(exc_info.value) == "distributed provider returned status 503"
-
-
-def test_distributed_compute_provider_timeout_maps_to_timeout_metadata(monkeypatch):
-    def timeout_post(_url, json=None, timeout=None):
-        raise compute_provider.requests.Timeout("timed out")
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", timeout_post)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_timeout"
-    assert exc_info.value.error_type == "timeout_error"
-    assert exc_info.value.status_code == 504
-    assert exc_info.value.public_message == "The LLM server took too long to respond. Please try again."
-
-
-def test_distributed_compute_provider_unexpected_exception_maps_to_bridge_error(monkeypatch):
-    def boom(_url, json=None, timeout=None):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", boom)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert exc_info.value.status_code == 502
-
-
-def test_distributed_compute_provider_request_exception_maps_to_unreachable(monkeypatch):
-    def failing_post(_url, json=None, timeout=None):
-        raise compute_provider.requests.RequestException("connection reset by peer")
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", failing_post)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_unreachable"
-    assert exc_info.value.error_type == "service_unavailable_error"
-    assert exc_info.value.status_code == 503
-    assert exc_info.value.public_message == "The LLM server is unavailable right now. Please try again."
-
-
-@pytest.mark.parametrize(
-    ("status_code", "payload", "expected_error_code"),
-    [
-        (
-            503,
-            {
-                "error": {
-                    "type": "service_unavailable_error",
-                    "code": "no_registered_compute_nodes",
-                    "message": "No registered compute nodes available",
-                }
-            },
-            "no_registered_compute_nodes",
-        ),
-        (
-            504,
-            {
-                "error": {
-                    "type": "timeout_error",
-                    "code": "compute_node_timeout",
-                    "message": "Timed out waiting for registered compute node",
-                }
-            },
-            "compute_node_timeout",
-        ),
-    ],
-)
-def test_distributed_compute_provider_raises_structured_errors(
-    monkeypatch, status_code, payload, expected_error_code
-):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=status_code, json=lambda: payload),
-    )
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == expected_error_code
 
 
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
@@ -285,36 +85,10 @@ def test_get_api_v1_resolved_provider_path_labels_instance_types():
     assert get_api_v1_resolved_provider_path(object()) == "unknown"
 
 
-@pytest.mark.parametrize(
-    ("post_status", "expected_backend_path"),
-    [
-        (200, "registered_desktop_compute_node"),
-        (503, "fallback_local_in_process"),
-    ],
-)
-def test_api_v1_chat_completion_emits_execution_backend_path_header(
-    monkeypatch, post_status, expected_backend_path
-):
-    def fake_post(_url, json=None, timeout=None):
-        if post_status == 200:
-            return SimpleNamespace(
-                status_code=200,
-                json=lambda: {
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": "distributed response",
-                            }
-                        }
-                    ]
-                },
-            )
-        return SimpleNamespace(status_code=503, json=lambda: {"error": "down"})
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
+def test_api_v1_chat_completion_emits_execution_backend_path_header_with_fallback(monkeypatch):
     monkeypatch.setattr(
-        "api.v1.compute_provider.generate_response",
+        compute_provider,
+        "generate_response",
         lambda _model, messages, **_options: messages
         + [{"role": "assistant", "content": "fallback response"}],
     )
@@ -337,28 +111,13 @@ def test_api_v1_chat_completion_emits_execution_backend_path_header(
         assert response.status_code == 200
         assert (
             response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"]
-            == expected_backend_path
+            == "fallback_local_in_process"
         )
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
-def test_api_v1_chat_completion_returns_structured_error_for_no_registered_nodes(
-    monkeypatch,
-):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(
-            status_code=503,
-            json=lambda: {
-                "error": {
-                    "type": "service_unavailable_error",
-                    "code": "no_registered_compute_nodes",
-                    "message": "No registered compute nodes available",
-                }
-            },
-        ),
-    )
+def test_api_v1_chat_completion_returns_structured_error_when_fallback_disabled(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
@@ -378,7 +137,6 @@ def test_api_v1_chat_completion_returns_structured_error_for_no_registered_nodes
         assert response.status_code == 503
         error = response.get_json()["error"]
         assert error["type"] == "service_unavailable_error"
-        assert error["code"] == "no_registered_compute_nodes"
-        assert error["message"] == "No LLM servers are available right now."
+        assert error["code"] == "api_v1_relay_disabled"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -51,7 +51,6 @@ class ComputeNodeRuntimeConfig:
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
-API_V1_RELAY_REQUIRED_FIELDS = frozenset({"api_v1_request"})
 
 
 def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
@@ -63,11 +62,8 @@ def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
 
 
 def is_api_v1_relay_payload(payload: Dict[str, Any]) -> bool:
-    """Return whether ``payload`` carries relay API v1 request work."""
-
-    if not isinstance(payload, dict):
-        return False
-    return API_V1_RELAY_REQUIRED_FIELDS.issubset(payload.keys())
+    """API v1 relay payloads are intentionally disabled until E2EE support exists."""
+    return False
 
 
 class RelayRequestAdapter(Protocol):
@@ -94,16 +90,17 @@ class LegacyRelayRequestAdapter:
 
 
 class ApiV1RelayRequestAdapter:
-    """Adapter for relay-dispatched API v1 chat-completions payloads."""
+    """Disabled adapter retained for compatibility in tests/integration wiring."""
 
     def __init__(self, relay_client: "RelayClient"):
         self._relay_client = relay_client
 
     def can_process(self, request_data: Dict[str, Any]) -> bool:
-        return is_api_v1_relay_payload(request_data)
+        return False
 
     def process(self, request_data: Dict[str, Any]) -> bool:
-        return self._relay_client.process_api_v1_chat_request(request_data)
+        _ = request_data
+        return False
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -266,7 +263,6 @@ class ComputeNodeRuntime:
         )
         if request_adapters is None:
             self.request_adapters = [
-                ApiV1RelayRequestAdapter(self.relay_client),
                 LegacyRelayRequestAdapter(self.relay_client),
             ]
         else:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import base64
-import inspect
 import ipaddress
 import json
 import jsonschema
@@ -44,7 +43,6 @@ RELAY_RESPONSE_SCHEMA = {
         "chat_history": {"type": "string"},
         "cipherkey": {"type": "string"},
         "iv": {"type": "string"},
-        "api_v1_request": {"type": "object"},
         "error": {"type": "string"}
     }
 }
@@ -736,84 +734,10 @@ class RelayClient:
             return False
 
     def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
-        """Process relay API v1 chat request payload and post result back to relay."""
-
-        api_v1_request = request_data.get('api_v1_request') if isinstance(request_data, dict) else None
-        if not isinstance(api_v1_request, dict):
-            return False
-
-        request_id = api_v1_request.get('request_id')
-        messages = api_v1_request.get('messages')
-        options = api_v1_request.get('options')
-        if not isinstance(request_id, str) or not request_id.strip() or not isinstance(messages, list):
-            log_error("Invalid api_v1_request payload for compute node bridge")
-            return False
-
-        source_payload: Dict[str, Any] = {'request_id': request_id}
-
-        try:
-            llama_kwargs: Dict[str, Any] = {}
-            if isinstance(options, dict):
-                try:
-                    signature = inspect.signature(self.model_manager.llama_cpp_get_response)
-                    accepts_kwargs = any(
-                        parameter.kind == inspect.Parameter.VAR_KEYWORD
-                        for parameter in signature.parameters.values()
-                    )
-                    if accepts_kwargs:
-                        llama_kwargs = options
-                    else:
-                        llama_kwargs = {
-                            key: value
-                            for key, value in options.items()
-                            if key in signature.parameters and key != 'chat_history'
-                        }
-                except (TypeError, ValueError):
-                    llama_kwargs = {}
-
-            response_history = self.model_manager.llama_cpp_get_response(messages, **llama_kwargs)
-            assistant_message = response_history[-1] if isinstance(response_history, list) else None
-            if not isinstance(assistant_message, dict):
-                source_payload['error'] = 'invalid assistant message payload'
-            else:
-                source_payload['message'] = {
-                    'role': assistant_message.get('role', 'assistant'),
-                    'content': assistant_message.get('content', ''),
-                }
-                if isinstance(assistant_message.get('tool_calls'), list):
-                    source_payload['message']['tool_calls'] = assistant_message['tool_calls']
-        except Exception as exc:  # pragma: no cover - model runtime edge case
-            source_payload['error'] = str(exc)
-
-        request_kwargs = {
-            'json': source_payload,
-        }
-        headers = self._auth_headers()
-        if headers:
-            request_kwargs['headers'] = headers
-
-        try:
-            response = requests.post(
-                f'{self.relay_url}/relay/api/v1/source',
-                timeout=self._request_timeout,
-                **request_kwargs,
-            )
-            if response.status_code != 200:
-                log_error("Error status from /relay/api/v1/source: {}", response.status_code)
-                return False
-            return True
-        except requests.ConnectionError as exc:
-            log_error("Connection error posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
-        except requests.Timeout as exc:
-            log_error("Timeout posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
-        except requests.RequestException as exc:
-            log_error("Request error posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
-        except Exception as exc:
-            log_error("Unexpected error posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
+        """Plaintext API v1 relay dispatch is disabled pending E2EE-compatible design."""
+        _ = request_data
+        log_error("API v1 relay request handling is disabled pending E2EE-compatible design")
+        return False
 
     def poll_relay_continuously(self):  # pragma: no cover
         """
@@ -872,10 +796,7 @@ class RelayClient:
 
                     # Check if there's a client request to process
                     required_fields = ['client_public_key', 'chat_history', 'cipherkey', 'iv']
-                    if isinstance(relay_response.get('api_v1_request'), dict):
-                        log_info("Processing API v1 relay request...")
-                        self.process_api_v1_chat_request(relay_response)
-                    elif all(field in relay_response for field in required_fields):
+                    if all(field in relay_response for field in required_fields):
                         log_info("Processing client request...")
                         self.process_client_request(relay_response)
                     else:


### PR DESCRIPTION
### Motivation
- Close the regression that allowed plaintext OpenAI-style `messages` to traverse the distributed relay work queue and violate the relay E2EE invariant.
- Ensure the relay and compute-node runtime never queue or post raw `api_v1_request.messages` to `client_inference_requests` or relay endpoints until an E2EE-compatible design is implemented.

### Description
- Fail-closed the distributed API v1 relay endpoints so `POST /relay/api/v1/chat/completions` and `POST /relay/api/v1/source` immediately return a structured `api_v1_relay_disabled` service-unavailable error (changes in `relay.py`).
- Disable the distributed API v1 compute provider dispatch by making `DistributedApiV1ComputeProvider.complete_chat()` raise a `ComputeProviderError` mapped to `api_v1_relay_disabled`, and add the `api_v1_relay_disabled` entry to `_RELAY_ERROR_MAP` (changes in `api/v1/compute_provider.py`).
- Remove/disable plaintext API v1 processing from compute-node runtime and relay client by making `is_api_v1_relay_payload()` return `False`, disabling `ApiV1RelayRequestAdapter`, and making `RelayClient.process_api_v1_chat_request()` a no-op that logs and returns `False` (changes in `utils/compute_node_runtime.py` and `utils/networking/relay_client.py`).
- Preserve the legacy E2EE `/sink` + `/faucet` flow and local in-process API v1 behavior; update tests to assert the new fail-closed behavior and fallback semantics (tests updated under `tests/`).

### Testing
- Ran targeted verification: `python -m pytest -q tests/unit/test_relay_registration_token.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py`, which passed.
- Ran API/unit smoke: `python -m pytest -q tests/test_api.py tests/unit`, which passed.
- Ran `pre-commit run --all-files`, which passed the configured hooks.
- Ran repository-wide test command `python -m pytest -q`; in this environment some integration subprocess tests (server/relay registration) may time out; targeted and unit suites that validate the fail-closed behavior passed.
- Searched the codebase for API v1 relay handling to confirm no code path queues plaintext `api_v1_request.messages` via `client_inference_requests` using repository search commands included in the verification notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaecf9099c832f9a9789fb43598393)