### PR TITLE
🚨 Fail closed distributed API v1 relay plaintext dispatch

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -13,8 +13,6 @@ from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
-import requests
-
 from api.v1.models import generate_response
 
 logger = logging.getLogger("api.v1.compute_provider")
@@ -44,6 +42,14 @@ class ComputeProviderError(Exception):
 
 
 _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
+    "relay_api_v1_plaintext_disabled": {
+        "error_type": "service_unavailable_error",
+        "public_message": (
+            "Distributed API v1 relay is temporarily disabled while encrypted transport "
+            "is restored."
+        ),
+        "status_code": 503,
+    },
     "no_registered_compute_nodes": {
         "error_type": "service_unavailable_error",
         "public_message": "No LLM servers are available right now.",
@@ -124,7 +130,7 @@ class LocalApiV1ComputeProvider:
 
 @dataclass(frozen=True)
 class DistributedApiV1ComputeProvider:
-    """Provider that forwards API v1 chat payloads to a remote compute endpoint."""
+    """Provider that fails closed while distributed API v1 relay is plaintext."""
 
     base_url: str
     timeout_seconds: float = 30.0
@@ -136,87 +142,14 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        payload: Dict[str, Any] = {
-            "model": model_id,
-            "messages": messages,
-            "stream": False,
-        }
-        for key, value in (options or {}).items():
-            if key == "stream":
-                continue
-            payload[key] = value
-
-        try:
-            response = requests.post(
-                f"{self.base_url.rstrip('/')}/relay/api/v1/chat/completions",
-                json=payload,
-                timeout=self.timeout_seconds,
-            )
-        except requests.Timeout as exc:
-            raise _error_from_code(
-                "compute_node_bridge_timeout",
-                message=f"distributed provider timed out contacting relay bridge: {exc}",
-            ) from exc
-        except requests.RequestException as exc:
-            raise _error_from_code(
-                "compute_node_unreachable",
-                message=f"distributed provider request failed: {exc}",
-            ) from exc
-        except Exception as exc:
-            raise _error_from_code(
-                "compute_node_bridge_error",
-                message=f"distributed provider request failed: {exc}",
-            ) from exc
-
-        if response.status_code != 200:
-            error_code = "compute_node_bridge_error"
-            error_message = f"distributed provider returned status {response.status_code}"
-            try:
-                parsed = response.json()
-                if isinstance(parsed, dict):
-                    error_payload = parsed.get("error", {})
-                    if isinstance(error_payload, dict):
-                        candidate_code = error_payload.get("code")
-                        candidate_message = error_payload.get("message")
-                        if isinstance(candidate_code, str) and candidate_code.strip():
-                            error_code = candidate_code.strip()
-                        if isinstance(candidate_message, str) and candidate_message.strip():
-                            error_message = candidate_message.strip()
-            except ValueError:
-                pass
-            raise _error_from_code(error_code, message=error_message)
-
-        try:
-            body = response.json()
-        except ValueError as exc:
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider returned non-JSON response",
-            ) from exc
-
-        choices = body.get("choices")
-        if not isinstance(choices, list) or not choices:
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider returned no choices",
-            )
-
-        first_choice = choices[0]
-        if not isinstance(first_choice, dict):
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider choice payload is invalid",
-            )
-
-        message = first_choice.get("message")
-        if not isinstance(message, dict):
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="distributed provider response missing message",
-            )
-
-        _last_backend_path.set("registered_desktop_compute_node")
-        return message
+        del model_id, messages, options
+        raise _error_from_code(
+            "relay_api_v1_plaintext_disabled",
+            message=(
+                "distributed API v1 relay has been disabled because it forwards plaintext "
+                "messages through relay dispatch"
+            ),
+        )
 
 
 @dataclass(frozen=True)

--- a/relay.py
+++ b/relay.py
@@ -693,152 +693,38 @@ def relay_diagnostics():
 
 @app.route('/relay/api/v1/chat/completions', methods=['POST'])
 def relay_api_v1_chat_completions():
-    """Queue API v1 chat requests for registered compute nodes and wait for completion."""
-
-    _evict_stale_servers()
-    payload = request.get_json(silent=True)
-    if payload is None:
-        return jsonify(
-            {
-                'error': {
-                    'type': 'invalid_request_error',
-                    'code': 'invalid_request_payload',
-                    'message': 'Invalid request data',
-                }
-            }
-        ), 400
-    if not isinstance(payload, dict):
-        return jsonify(
-            {
-                'error': {
-                    'type': 'invalid_request_error',
-                    'code': 'invalid_request_payload',
-                    'message': 'Invalid request data',
-                }
-            }
-        ), 400
-
-    model = payload.get('model')
-    messages = payload.get('messages')
-    if not isinstance(model, str) or not model.strip() or not isinstance(messages, list):
-        return jsonify(
-            {
-                'error': {
-                    'type': 'invalid_request_error',
-                    'code': 'invalid_api_v1_payload',
-                    'message': 'Invalid API v1 payload',
-                }
-            }
-        ), 400
-
-    available_servers = list(known_servers.keys())
-    if not available_servers:
-        return jsonify(
-            {
-                'error': {
-                    'type': 'service_unavailable_error',
-                    'code': 'no_registered_compute_nodes',
-                    'message': 'No registered compute nodes available',
-                }
-            }
-        ), 503
-
-    selected_server = secrets.choice(available_servers)
-    request_id = secrets.token_urlsafe(16)
-    with api_v1_response_lock:
-        api_v1_pending_request_ids.add(request_id)
-    queue_item = {
-        'api_v1_request': {
-            'request_id': request_id,
-            'model': model,
-            'messages': messages,
-            'options': {
-                key: value
-                for key, value in payload.items()
-                if key not in {'model', 'messages', 'stream'}
-            },
-        }
-    }
-    client_inference_requests.setdefault(selected_server, []).append(queue_item)
-
-    timeout_seconds = float(os.environ.get('TOKENPLACE_RELAY_API_V1_TIMEOUT_SECONDS', '45'))
-    response_payload = _await_api_v1_response(request_id, timeout_seconds)
-    if response_payload is None:
-        return jsonify(
-            {
-                'error': {
-                    'type': 'timeout_error',
-                    'code': 'compute_node_timeout',
-                    'message': 'Timed out waiting for registered compute node',
-                }
-            }
-        ), 504
-
-    if response_payload.get('error'):
-        logging.warning(
-            "Compute node bridge error for request_id=%s: %r",
-            request_id,
-            response_payload.get('error'),
-        )
-        return jsonify(
-            {
-                'error': {
-                    'type': 'upstream_error',
-                    'code': 'compute_node_bridge_error',
-                    'message': 'Compute node returned an error',
-                }
-            }
-        ), 502
-
-    message = response_payload.get('message')
-    if not isinstance(message, dict):
-        return jsonify(
-            {
-                'error': {
-                    'type': 'server_error',
-                    'code': 'compute_node_invalid_payload',
-                    'message': 'Compute node returned invalid response',
-                }
-            }
-        ), 502
+    """Fail closed until API v1 relay traffic has an E2EE-compatible transport."""
 
     return jsonify(
         {
-            'id': f"chatcmpl-{request_id}",
-            'object': 'chat.completion',
-            'created': int(time.time()),
-            'model': model,
-            'choices': [{'index': 0, 'message': message, 'finish_reason': 'stop'}],
+            'error': {
+                'type': 'service_unavailable_error',
+                'code': 'relay_api_v1_plaintext_disabled',
+                'message': (
+                    'Distributed API v1 relay is temporarily disabled until an '
+                    'end-to-end encrypted transport is available.'
+                ),
+            }
         }
-    )
+    ), 503
 
 
 @app.route('/relay/api/v1/source', methods=['POST'])
 def relay_api_v1_source():
-    """Accept API v1 completion results from registered compute nodes."""
+    """Fail closed until API v1 relay traffic has an E2EE-compatible transport."""
 
-    auth_error = _validate_server_registration()
-    if auth_error:
-        return auth_error
-
-    payload = request.get_json() or {}
-    if not isinstance(payload, dict):
-        return jsonify({'error': 'Invalid request data'}), 400
-
-    request_id = payload.get('request_id')
-    if not isinstance(request_id, str) or not request_id.strip():
-        return jsonify({'error': 'Missing request_id'}), 400
-
-    response_payload: Dict[str, Any] = {}
-    message = payload.get('message')
-    if isinstance(message, dict):
-        response_payload['message'] = message
-    error = payload.get('error')
-    if isinstance(error, str) and error.strip():
-        response_payload['error'] = error.strip()
-
-    _enqueue_api_v1_response(request_id, response_payload)
-    return jsonify({'message': 'API v1 response queued'}), 200
+    return jsonify(
+        {
+            'error': {
+                'type': 'service_unavailable_error',
+                'code': 'relay_api_v1_plaintext_disabled',
+                'message': (
+                    'Distributed API v1 relay is temporarily disabled until an '
+                    'end-to-end encrypted transport is available.'
+                ),
+            }
+        }
+    ), 503
 
 @app.route('/faucet', methods=['POST'])
 def faucet():
@@ -992,7 +878,11 @@ def sink():
 
         first_request = batch[0]
         if 'api_v1_request' in first_request:
-            response_data['api_v1_request'] = first_request['api_v1_request']
+            logging.warning(
+                "Dropping deprecated plaintext api_v1_request relay payload for server=%s",
+                public_key,
+            )
+            return jsonify(response_data)
         else:
             response_data.update({
                 'client_public_key': first_request['client_public_key'],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -227,29 +227,13 @@ def test_unencrypted_chat_completion(client, client_keys, mock_llama):
 
 
 def test_api_v1_chat_completion_supports_distributed_provider_contract(client, monkeypatch):
-    captured = {}
-
-    def fake_post(url, json=None, timeout=None):
-        captured['url'] = url
-        captured['json'] = json
-        captured['timeout'] = timeout
-        return MagicMock(
-            status_code=200,
-            json=lambda: {
-                'choices': [
-                    {
-                        'message': {
-                            'role': 'assistant',
-                            'content': 'distributed-path response',
-                        }
-                    }
-                ]
-            },
-        )
-
-    monkeypatch.setattr('api.v1.compute_provider.requests.post', fake_post)
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')
+    monkeypatch.setattr(
+        'api.v1.compute_provider.generate_response',
+        lambda _model, messages, **_options: messages
+        + [{'role': 'assistant', 'content': 'fallback local response'}],
+    )
 
     payload = {
         'model': 'remote-only-model',
@@ -260,21 +244,10 @@ def test_api_v1_chat_completion_supports_distributed_provider_contract(client, m
     response = client.post('/api/v1/chat/completions', json=payload)
     assert response.status_code == 200
     data = response.get_json()
-    assert data['choices'][0]['message']['content'] == 'distributed-path response'
-
-    assert captured['url'] == 'https://compute.example/relay/api/v1/chat/completions'
-    assert captured['json']['model'] == 'remote-only-model'
-    assert captured['json']['messages'][0]['content'] == 'Ping distributed runtime'
-    assert captured['json']['stream'] is False
-    assert captured['json']['stop'] == ['END']
+    assert data['choices'][0]['message']['content'] == 'fallback local response'
 
 
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):
-    monkeypatch.setattr(
-        'api.v1.compute_provider.requests.post',
-        lambda _url, json=None, timeout=None: MagicMock(status_code=503, json=lambda: {'error': 'down'}),
-    )
-
     fallback_message = {
         'role': 'assistant',
         'content': 'local fallback response',
@@ -312,11 +285,6 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monk
         ),
     )
 
-    monkeypatch.setattr(
-        'api.v1.compute_provider.requests.post',
-        lambda _url, json=None, timeout=None: MagicMock(status_code=503, json=lambda: {'error': 'down'}),
-    )
-
     local_generate = MagicMock(side_effect=AssertionError('local generation should not run'))
     monkeypatch.setattr('api.v1.compute_provider.generate_response', local_generate)
 
@@ -328,7 +296,7 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_502(client, monk
         },
     )
 
-    assert response.status_code == 502
+    assert response.status_code == 503
     local_generate.assert_not_called()
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -212,45 +212,27 @@ def test_two_servers_receive_only_addressed_work(client):
     assert server_one_work.get_json()["chat_history"] == "work-for-server-one"
 
 
-def test_relay_api_v1_returns_structured_error_for_invalid_json(client):
+def test_relay_api_v1_chat_completions_fail_closed(client):
     response = client.post(
         "/relay/api/v1/chat/completions",
         data="[",
         content_type="application/json",
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 503
     data = response.get_json()
-    assert data["error"]["type"] == "invalid_request_error"
-    assert data["error"]["code"] == "invalid_request_payload"
-    assert data["error"]["message"] == "Invalid request data"
+    assert data["error"]["type"] == "service_unavailable_error"
+    assert data["error"]["code"] == "relay_api_v1_plaintext_disabled"
+    assert "temporarily disabled" in data["error"]["message"]
 
 
-def test_relay_api_v1_masks_upstream_bridge_error_message(client, monkeypatch):
-    known_servers[DUMMY_SERVER_PUB_KEY] = {
-        "public_key": DUMMY_SERVER_PUB_KEY,
-        "last_ping": datetime.now(),
-        "last_ping_duration": 10,
-    }
-    monkeypatch.setattr(
-        relay_module,
-        "_await_api_v1_response",
-        lambda request_id, timeout_seconds: {"error": "stacktrace/token"},
-    )
+def test_relay_api_v1_source_fail_closed(client):
+    response = client.post("/relay/api/v1/source", json={"request_id": "req-1"})
 
-    response = client.post(
-        "/relay/api/v1/chat/completions",
-        json={
-            "model": "llama-3-8b-instruct",
-            "messages": [{"role": "user", "content": "hello"}],
-        },
-    )
-
-    assert response.status_code == 502
+    assert response.status_code == 503
     data = response.get_json()
-    assert data["error"]["type"] == "upstream_error"
-    assert data["error"]["code"] == "compute_node_bridge_error"
-    assert data["error"]["message"] == "Compute node returned an error"
+    assert data["error"]["type"] == "service_unavailable_error"
+    assert data["error"]["code"] == "relay_api_v1_plaintext_disabled"
 
 # --- Test /faucet ---
 
@@ -373,13 +355,11 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client):
 
 def test_healthz_returns_draining_when_shutdown_flag_set(client):
     """healthz should switch to draining status and 503 during shutdown."""
-    from relay import DRAINING
-
-    DRAINING.set()
+    relay_module.DRAINING.set()
     try:
         response = client.get("/healthz")
     finally:
-        DRAINING.clear()
+        relay_module.DRAINING.clear()
 
     assert response.status_code == 503
     assert response.headers["Retry-After"] == "0"
@@ -390,13 +370,11 @@ def test_healthz_returns_draining_when_shutdown_flag_set(client):
 
 def test_livez_remains_alive_when_draining(client):
     """livez should stay green so orchestrators can distinguish readiness from liveness."""
-    from relay import DRAINING
-
-    DRAINING.set()
+    relay_module.DRAINING.set()
     try:
         response = client.get("/livez")
     finally:
-        DRAINING.clear()
+        relay_module.DRAINING.clear()
 
     assert response.status_code == 200
     assert response.get_json()["status"] == "alive"

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 
 from api.v1 import compute_provider
@@ -13,56 +11,27 @@ from api.v1.compute_provider import (
 from relay import app
 
 
-def test_distributed_compute_provider_posts_api_v1_contract(monkeypatch):
-    captured = {}
+def test_distributed_compute_provider_fails_closed_with_plaintext_disabled_error():
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
 
-    def fake_post(url, json=None, timeout=None):
-        captured["url"] = url
-        captured["json"] = json
-        captured["timeout"] = timeout
-        return SimpleNamespace(
-            status_code=200,
-            json=lambda: {
-                "choices": [
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "content": "distributed response",
-                        }
-                    }
-                ]
-            },
+    with pytest.raises(ComputeProviderError) as exc_info:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+            options={"temperature": 0.2},
         )
 
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
-
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
-    message = provider.complete_chat(
-        model_id="llama-3-8b-instruct",
-        messages=[{"role": "user", "content": "hi"}],
-        options={"temperature": 0.2, "stream": True},
-    )
-
-    assert captured["url"] == "https://node-a.example/relay/api/v1/chat/completions"
-    assert captured["timeout"] == 5
-    assert captured["json"]["model"] == "llama-3-8b-instruct"
-    assert captured["json"]["messages"] == [{"role": "user", "content": "hi"}]
-    assert captured["json"]["stream"] is False
-    assert captured["json"]["temperature"] == 0.2
-    assert "stream" not in captured["json"] or captured["json"]["stream"] is False
-    assert message["content"] == "distributed response"
+    assert exc_info.value.code == "relay_api_v1_plaintext_disabled"
+    assert exc_info.value.error_type == "service_unavailable_error"
+    assert exc_info.value.status_code == 503
 
 
-def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):
-    def failing_post(_url, json=None, timeout=None):
-        return SimpleNamespace(status_code=503, json=lambda: {"error": "down"})
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", failing_post)
-
+def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails_closed(monkeypatch):
     fallback_message = {"role": "assistant", "content": "local fallback"}
 
     monkeypatch.setattr(
-        "api.v1.compute_provider.generate_response",
+        compute_provider,
+        "generate_response",
         lambda _model, messages, **_options: messages + [fallback_message],
     )
 
@@ -77,174 +46,6 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(mon
     )
 
     assert result == fallback_message
-
-
-def test_distributed_compute_provider_raises_when_contract_is_invalid(monkeypatch):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=200, json=lambda: {"choices": []}),
-    )
-
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError):
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-
-def test_distributed_compute_provider_handles_non_object_error_json(monkeypatch):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=503, json=lambda: []),
-    )
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert exc_info.value.status_code == 502
-
-
-def test_distributed_compute_provider_handles_non_json_error_response(monkeypatch):
-    def invalid_json(_url, json=None, timeout=None):
-        return SimpleNamespace(status_code=502, json=lambda: (_ for _ in ()).throw(ValueError("invalid json")))
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", invalid_json)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert str(exc_info.value) == "distributed provider returned status 502"
-
-
-def test_distributed_compute_provider_handles_non_object_error_field(monkeypatch):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(
-            status_code=503, json=lambda: {"error": "bridge down"}
-        ),
-    )
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert str(exc_info.value) == "distributed provider returned status 503"
-
-
-def test_distributed_compute_provider_timeout_maps_to_timeout_metadata(monkeypatch):
-    def timeout_post(_url, json=None, timeout=None):
-        raise compute_provider.requests.Timeout("timed out")
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", timeout_post)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_timeout"
-    assert exc_info.value.error_type == "timeout_error"
-    assert exc_info.value.status_code == 504
-    assert exc_info.value.public_message == "The LLM server took too long to respond. Please try again."
-
-
-def test_distributed_compute_provider_unexpected_exception_maps_to_bridge_error(monkeypatch):
-    def boom(_url, json=None, timeout=None):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", boom)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_bridge_error"
-    assert exc_info.value.status_code == 502
-
-
-def test_distributed_compute_provider_request_exception_maps_to_unreachable(monkeypatch):
-    def failing_post(_url, json=None, timeout=None):
-        raise compute_provider.requests.RequestException("connection reset by peer")
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", failing_post)
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == "compute_node_unreachable"
-    assert exc_info.value.error_type == "service_unavailable_error"
-    assert exc_info.value.status_code == 503
-    assert exc_info.value.public_message == "The LLM server is unavailable right now. Please try again."
-
-
-@pytest.mark.parametrize(
-    ("status_code", "payload", "expected_error_code"),
-    [
-        (
-            503,
-            {
-                "error": {
-                    "type": "service_unavailable_error",
-                    "code": "no_registered_compute_nodes",
-                    "message": "No registered compute nodes available",
-                }
-            },
-            "no_registered_compute_nodes",
-        ),
-        (
-            504,
-            {
-                "error": {
-                    "type": "timeout_error",
-                    "code": "compute_node_timeout",
-                    "message": "Timed out waiting for registered compute node",
-                }
-            },
-            "compute_node_timeout",
-        ),
-    ],
-)
-def test_distributed_compute_provider_raises_structured_errors(
-    monkeypatch, status_code, payload, expected_error_code
-):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(status_code=status_code, json=lambda: payload),
-    )
-    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example")
-
-    with pytest.raises(ComputeProviderError) as exc_info:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hello"}],
-        )
-
-    assert exc_info.value.code == expected_error_code
 
 
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
@@ -285,36 +86,12 @@ def test_get_api_v1_resolved_provider_path_labels_instance_types():
     assert get_api_v1_resolved_provider_path(object()) == "unknown"
 
 
-@pytest.mark.parametrize(
-    ("post_status", "expected_backend_path"),
-    [
-        (200, "registered_desktop_compute_node"),
-        (503, "fallback_local_in_process"),
-    ],
-)
-def test_api_v1_chat_completion_emits_execution_backend_path_header(
-    monkeypatch, post_status, expected_backend_path
+def test_api_v1_chat_completion_emits_fallback_backend_path_header_when_distributed_disabled(
+    monkeypatch,
 ):
-    def fake_post(_url, json=None, timeout=None):
-        if post_status == 200:
-            return SimpleNamespace(
-                status_code=200,
-                json=lambda: {
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": "distributed response",
-                            }
-                        }
-                    ]
-                },
-            )
-        return SimpleNamespace(status_code=503, json=lambda: {"error": "down"})
-
-    monkeypatch.setattr("api.v1.compute_provider.requests.post", fake_post)
     monkeypatch.setattr(
-        "api.v1.compute_provider.generate_response",
+        compute_provider,
+        "generate_response",
         lambda _model, messages, **_options: messages
         + [{"role": "assistant", "content": "fallback response"}],
     )
@@ -337,28 +114,15 @@ def test_api_v1_chat_completion_emits_execution_backend_path_header(
         assert response.status_code == 200
         assert (
             response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"]
-            == expected_backend_path
+            == "fallback_local_in_process"
         )
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
-def test_api_v1_chat_completion_returns_structured_error_for_no_registered_nodes(
+def test_api_v1_chat_completion_returns_structured_error_when_distributed_disabled_without_fallback(
     monkeypatch,
 ):
-    monkeypatch.setattr(
-        "api.v1.compute_provider.requests.post",
-        lambda _url, json=None, timeout=None: SimpleNamespace(
-            status_code=503,
-            json=lambda: {
-                "error": {
-                    "type": "service_unavailable_error",
-                    "code": "no_registered_compute_nodes",
-                    "message": "No registered compute nodes available",
-                }
-            },
-        ),
-    )
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
@@ -378,7 +142,6 @@ def test_api_v1_chat_completion_returns_structured_error_for_no_registered_nodes
         assert response.status_code == 503
         error = response.get_json()["error"]
         assert error["type"] == "service_unavailable_error"
-        assert error["code"] == "no_registered_compute_nodes"
-        assert error["message"] == "No LLM servers are available right now."
+        assert error["code"] == "relay_api_v1_plaintext_disabled"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -51,7 +51,6 @@ class ComputeNodeRuntimeConfig:
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
-API_V1_RELAY_REQUIRED_FIELDS = frozenset({"api_v1_request"})
 
 
 def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
@@ -65,9 +64,8 @@ def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
 def is_api_v1_relay_payload(payload: Dict[str, Any]) -> bool:
     """Return whether ``payload`` carries relay API v1 request work."""
 
-    if not isinstance(payload, dict):
-        return False
-    return API_V1_RELAY_REQUIRED_FIELDS.issubset(payload.keys())
+    del payload
+    return False
 
 
 class RelayRequestAdapter(Protocol):
@@ -100,10 +98,12 @@ class ApiV1RelayRequestAdapter:
         self._relay_client = relay_client
 
     def can_process(self, request_data: Dict[str, Any]) -> bool:
-        return is_api_v1_relay_payload(request_data)
+        del request_data
+        return False
 
     def process(self, request_data: Dict[str, Any]) -> bool:
-        return self._relay_client.process_api_v1_chat_request(request_data)
+        del request_data
+        return False
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -266,7 +266,6 @@ class ComputeNodeRuntime:
         )
         if request_adapters is None:
             self.request_adapters = [
-                ApiV1RelayRequestAdapter(self.relay_client),
                 LegacyRelayRequestAdapter(self.relay_client),
             ]
         else:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import base64
-import inspect
 import ipaddress
 import json
 import jsonschema
@@ -44,7 +43,6 @@ RELAY_RESPONSE_SCHEMA = {
         "chat_history": {"type": "string"},
         "cipherkey": {"type": "string"},
         "iv": {"type": "string"},
-        "api_v1_request": {"type": "object"},
         "error": {"type": "string"}
     }
 }
@@ -736,84 +734,11 @@ class RelayClient:
             return False
 
     def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
-        """Process relay API v1 chat request payload and post result back to relay."""
+        """Fail closed for relay API v1 plaintext payloads."""
 
-        api_v1_request = request_data.get('api_v1_request') if isinstance(request_data, dict) else None
-        if not isinstance(api_v1_request, dict):
-            return False
-
-        request_id = api_v1_request.get('request_id')
-        messages = api_v1_request.get('messages')
-        options = api_v1_request.get('options')
-        if not isinstance(request_id, str) or not request_id.strip() or not isinstance(messages, list):
-            log_error("Invalid api_v1_request payload for compute node bridge")
-            return False
-
-        source_payload: Dict[str, Any] = {'request_id': request_id}
-
-        try:
-            llama_kwargs: Dict[str, Any] = {}
-            if isinstance(options, dict):
-                try:
-                    signature = inspect.signature(self.model_manager.llama_cpp_get_response)
-                    accepts_kwargs = any(
-                        parameter.kind == inspect.Parameter.VAR_KEYWORD
-                        for parameter in signature.parameters.values()
-                    )
-                    if accepts_kwargs:
-                        llama_kwargs = options
-                    else:
-                        llama_kwargs = {
-                            key: value
-                            for key, value in options.items()
-                            if key in signature.parameters and key != 'chat_history'
-                        }
-                except (TypeError, ValueError):
-                    llama_kwargs = {}
-
-            response_history = self.model_manager.llama_cpp_get_response(messages, **llama_kwargs)
-            assistant_message = response_history[-1] if isinstance(response_history, list) else None
-            if not isinstance(assistant_message, dict):
-                source_payload['error'] = 'invalid assistant message payload'
-            else:
-                source_payload['message'] = {
-                    'role': assistant_message.get('role', 'assistant'),
-                    'content': assistant_message.get('content', ''),
-                }
-                if isinstance(assistant_message.get('tool_calls'), list):
-                    source_payload['message']['tool_calls'] = assistant_message['tool_calls']
-        except Exception as exc:  # pragma: no cover - model runtime edge case
-            source_payload['error'] = str(exc)
-
-        request_kwargs = {
-            'json': source_payload,
-        }
-        headers = self._auth_headers()
-        if headers:
-            request_kwargs['headers'] = headers
-
-        try:
-            response = requests.post(
-                f'{self.relay_url}/relay/api/v1/source',
-                timeout=self._request_timeout,
-                **request_kwargs,
-            )
-            if response.status_code != 200:
-                log_error("Error status from /relay/api/v1/source: {}", response.status_code)
-                return False
-            return True
-        except requests.ConnectionError as exc:
-            log_error("Connection error posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
-        except requests.Timeout as exc:
-            log_error("Timeout posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
-        except requests.RequestException as exc:
-            log_error("Request error posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
-        except Exception as exc:
-            log_error("Unexpected error posting to /relay/api/v1/source: {}", str(exc), exc_info=True)
-            return False
+        if isinstance(request_data, dict) and isinstance(request_data.get('api_v1_request'), dict):
+            log_error("Rejected deprecated plaintext api_v1_request relay payload")
+        return False
 
     def poll_relay_continuously(self):  # pragma: no cover
         """
@@ -872,10 +797,7 @@ class RelayClient:
 
                     # Check if there's a client request to process
                     required_fields = ['client_public_key', 'chat_history', 'cipherkey', 'iv']
-                    if isinstance(relay_response.get('api_v1_request'), dict):
-                        log_info("Processing API v1 relay request...")
-                        self.process_api_v1_chat_request(relay_response)
-                    elif all(field in relay_response for field in required_fields):
+                    if all(field in relay_response for field in required_fields):
                         log_info("Processing client request...")
                         self.process_client_request(relay_response)
                     else:


### PR DESCRIPTION
### Motivation
- Close the regression that allowed plaintext OpenAI-style `messages` to be dispatched through the relay, preserving the invariant that the relay only sees ciphertext.
- Prevent compute nodes or distributed providers from processing or forwarding plaintext `api_v1_request` work until an E2EE-compatible transport is available.
- Minimize blast radius by keeping local in-process API v1 execution working while disabling the distributed plaintext paths.

### Description
- Fail-closed the relay endpoints `POST /relay/api/v1/chat/completions` and `POST /relay/api/v1/source` to return a structured 503 `relay_api_v1_plaintext_disabled` error. (changes in `relay.py`)
- Drop any queued legacy `api_v1_request` items in `/sink` instead of returning them to compute nodes and log a warning. (changes in `relay.py`)
- Disable the distributed API v1 provider so `DistributedApiV1ComputeProvider.complete_chat` raises a structured `ComputeProviderError` with code `relay_api_v1_plaintext_disabled`. (changes in `api/v1/compute_provider.py`)
- Remove/disable compute-node plaintext processing: `RelayClient.process_api_v1_chat_request` now rejects plaintext API v1 payloads and the polling loop no longer dispatches `api_v1_request` work; the runtime no longer registers the API v1 adapter by default. (changes in `utils/networking/relay_client.py` and `utils/compute_node_runtime.py`)
- Tests updated to assert fail-closed behavior and to preserve local fallback semantics for API v1. (changes in `tests/test_relay.py`, `tests/test_api.py`, `tests/unit/test_api_v1_compute_provider.py`)

### Testing
- Ran targeted suites: `python -m pytest -q tests/unit/test_relay_registration_token.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py` and `python -m pytest -q tests/test_api.py tests/unit`; these passed (targeted unit and API tests succeeded).
- Ran full test run `python -m pytest -q`; the run shows the repository test suite largely passing but 4 integration tests errored due to environment subprocess registration timeouts in this execution environment (these errors are unrelated to the containment changes and stem from test harness process orchestration in the container).
- Ran `pre-commit run --all-files` which passed.
- Verification searches performed: `rg "api_v1_request|process_api_v1_chat_request|ApiV1RelayRequestAdapter|is_api_v1_relay_payload" .` and `rg "client_inference_requests.*messages|['\"]messages['\"].*client_inference_requests|api_v1_request.*messages" .` confirm there are no code paths queuing plaintext `api_v1_request.messages` through `client_inference_requests`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaecf9099c832f9a9789fb43598393)