### PR TITLE
Restore distributed API v1 relay via relay‑blind E2EE envelope

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -216,7 +216,13 @@ class DistributedApiV1ComputeProvider:
             },
         }
 
-        encrypted_envelope = crypto_manager.encrypt_message(plaintext_envelope, server_public_key)
+        try:
+            encrypted_envelope = crypto_manager.encrypt_message(plaintext_envelope, server_public_key)
+        except Exception as exc:
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message=f"failed to encrypt relay request envelope: {exc}",
+            ) from exc
         faucet_payload = {
             "client_public_key": crypto_manager.public_key_b64,
             "server_public_key": server_public_key,

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -151,12 +151,22 @@ class DistributedApiV1ComputeProvider:
     ) -> dict[str, Any]:
         crypto_manager = self._build_request_crypto_manager()
         relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
+        deadline = time.time() + relay_timeout
         relay_request_id = f"api-v1-{uuid.uuid4().hex}"
+
+        def _remaining_timeout() -> float:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                raise _error_from_code(
+                    "compute_node_timeout",
+                    message="timed out waiting for distributed relay API v1 encrypted response",
+                )
+            return remaining
 
         try:
             next_server_response = requests.get(
                 self._relay_url("/next_server"),
-                timeout=relay_timeout,
+                timeout=_remaining_timeout(),
             )
         except requests.RequestException as exc:
             raise _error_from_code(
@@ -217,7 +227,7 @@ class DistributedApiV1ComputeProvider:
             faucet_response = requests.post(
                 self._relay_url("/faucet"),
                 json=faucet_payload,
-                timeout=relay_timeout,
+                timeout=_remaining_timeout(),
             )
         except requests.RequestException as exc:
             raise _error_from_code(
@@ -240,44 +250,44 @@ class DistributedApiV1ComputeProvider:
                 ),
             )
 
-        deadline = time.time() + relay_timeout
         poll_interval = self._poll_interval_seconds()
         while time.time() < deadline:
             try:
+                retrieve_timeout = min(poll_interval + 0.5, _remaining_timeout())
                 retrieve_response = requests.post(
                     self._relay_url("/retrieve"),
                     json={"client_public_key": crypto_manager.public_key_b64},
-                    timeout=poll_interval + 0.5,
+                    timeout=retrieve_timeout,
                 )
             except requests.RequestException:
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             if retrieve_response.status_code != 200:
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             try:
                 retrieve_payload = retrieve_response.json()
             except ValueError:
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             if not isinstance(retrieve_payload, dict):
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             if retrieve_payload.get("error"):
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             if not {"chat_history", "cipherkey", "iv"}.issubset(retrieve_payload.keys()):
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             decrypted_response = crypto_manager.decrypt_message(retrieve_payload)
             if decrypted_response is None:
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             if not isinstance(decrypted_response, dict):
@@ -287,11 +297,11 @@ class DistributedApiV1ComputeProvider:
                 )
 
             if decrypted_response.get("protocol") != "tokenplace_api_v1_relay_e2ee":
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             if decrypted_response.get("request_id") != relay_request_id:
-                time.sleep(poll_interval)
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
             api_v1_response = decrypted_response.get("api_v1_response")

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional, Protocol
 import requests
 
 from api.v1.models import generate_response
-from utils.crypto.crypto_manager import get_crypto_manager
+from utils.crypto.crypto_manager import CryptoManager
 
 logger = logging.getLogger("api.v1.compute_provider")
 _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
@@ -138,6 +138,10 @@ class DistributedApiV1ComputeProvider:
     def _poll_interval_seconds(self) -> float:
         return min(max(self.timeout_seconds / 20.0, 0.1), 0.5)
 
+    def _build_request_crypto_manager(self) -> CryptoManager:
+        """Create an isolated crypto manager for each relay request."""
+        return CryptoManager()
+
     def complete_chat(
         self,
         *,
@@ -145,7 +149,7 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        crypto_manager = get_crypto_manager()
+        crypto_manager = self._build_request_crypto_manager()
         relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
         relay_request_id = f"api-v1-{uuid.uuid4().hex}"
 
@@ -221,6 +225,12 @@ class DistributedApiV1ComputeProvider:
                 message=f"unable to post encrypted request to relay faucet endpoint: {exc}",
             ) from exc
 
+        if faucet_response.status_code == 404:
+            raise _error_from_code(
+                "no_registered_compute_nodes",
+                message="relay reported selected compute node is no longer available",
+            )
+
         if faucet_response.status_code != 200:
             raise _error_from_code(
                 "compute_node_bridge_error",
@@ -273,10 +283,8 @@ class DistributedApiV1ComputeProvider:
                 )
 
             if decrypted_response.get("protocol") != "tokenplace_api_v1_relay_e2ee":
-                raise _error_from_code(
-                    "compute_node_invalid_payload",
-                    message="decrypted relay response protocol mismatch",
-                )
+                time.sleep(poll_interval)
+                continue
 
             if decrypted_response.get("request_id") != relay_request_id:
                 time.sleep(poll_interval)

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -276,6 +276,10 @@ class DistributedApiV1ComputeProvider:
                 continue
 
             decrypted_response = crypto_manager.decrypt_message(retrieve_payload)
+            if decrypted_response is None:
+                time.sleep(poll_interval)
+                continue
+
             if not isinstance(decrypted_response, dict):
                 raise _error_from_code(
                     "compute_node_invalid_payload",

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 import contextvars
 import logging
 import os
+import time
+import uuid
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
+import requests
+
 from api.v1.models import generate_response
+from utils.crypto.crypto_manager import get_crypto_manager
 
 logger = logging.getLogger("api.v1.compute_provider")
 _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
@@ -122,10 +127,16 @@ class LocalApiV1ComputeProvider:
 
 @dataclass(frozen=True)
 class DistributedApiV1ComputeProvider:
-    """Provider that fail-closes distributed API v1 relay dispatch."""
+    """Provider that dispatches API v1 requests via relay-blind E2EE envelopes."""
 
     base_url: str
     timeout_seconds: float = 30.0
+
+    def _relay_url(self, path: str) -> str:
+        return f"{self.base_url.rstrip('/')}{path}"
+
+    def _poll_interval_seconds(self) -> float:
+        return min(max(self.timeout_seconds / 20.0, 0.1), 0.5)
 
     def complete_chat(
         self,
@@ -134,12 +145,169 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        raise ComputeProviderError(
-            "distributed API v1 relay execution is disabled pending reviewed E2EE envelope design",
-            code="distributed_api_v1_relay_disabled",
-            error_type="service_unavailable_error",
-            public_message="Distributed API v1 is temporarily unavailable.",
-            status_code=503,
+        crypto_manager = get_crypto_manager()
+        relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
+        relay_request_id = f"api-v1-{uuid.uuid4().hex}"
+
+        try:
+            next_server_response = requests.get(
+                self._relay_url("/next_server"),
+                timeout=relay_timeout,
+            )
+        except requests.RequestException as exc:
+            raise _error_from_code(
+                "compute_node_unreachable",
+                message=f"unable to reach relay next_server endpoint: {exc}",
+            ) from exc
+
+        if next_server_response.status_code >= 500:
+            raise _error_from_code(
+                "compute_node_unreachable",
+                message=(
+                    "relay next_server endpoint returned "
+                    f"unexpected status {next_server_response.status_code}"
+                ),
+            )
+
+        try:
+            next_server_payload = next_server_response.json()
+        except ValueError as exc:
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message="relay next_server response was not valid JSON",
+            ) from exc
+
+        if not isinstance(next_server_payload, dict):
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message="relay next_server response must be an object",
+            )
+
+        server_public_key = next_server_payload.get("server_public_key")
+        if not isinstance(server_public_key, str) or not server_public_key.strip():
+            raise _error_from_code(
+                "no_registered_compute_nodes",
+                message="relay reported no registered compute nodes",
+            )
+
+        plaintext_envelope = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": relay_request_id,
+            "client_public_key": crypto_manager.public_key_b64,
+            "api_v1_request": {
+                "model": model_id,
+                "messages": messages,
+                "options": options or {},
+            },
+        }
+
+        encrypted_envelope = crypto_manager.encrypt_message(plaintext_envelope, server_public_key)
+        faucet_payload = {
+            "client_public_key": crypto_manager.public_key_b64,
+            "server_public_key": server_public_key,
+            **encrypted_envelope,
+        }
+
+        try:
+            faucet_response = requests.post(
+                self._relay_url("/faucet"),
+                json=faucet_payload,
+                timeout=relay_timeout,
+            )
+        except requests.RequestException as exc:
+            raise _error_from_code(
+                "compute_node_unreachable",
+                message=f"unable to post encrypted request to relay faucet endpoint: {exc}",
+            ) from exc
+
+        if faucet_response.status_code != 200:
+            raise _error_from_code(
+                "compute_node_bridge_error",
+                message=(
+                    "relay faucet endpoint returned unexpected status "
+                    f"{faucet_response.status_code}"
+                ),
+            )
+
+        deadline = time.time() + relay_timeout
+        poll_interval = self._poll_interval_seconds()
+        while time.time() < deadline:
+            try:
+                retrieve_response = requests.post(
+                    self._relay_url("/retrieve"),
+                    json={"client_public_key": crypto_manager.public_key_b64},
+                    timeout=poll_interval + 0.5,
+                )
+            except requests.RequestException:
+                time.sleep(poll_interval)
+                continue
+
+            if retrieve_response.status_code != 200:
+                time.sleep(poll_interval)
+                continue
+
+            try:
+                retrieve_payload = retrieve_response.json()
+            except ValueError:
+                time.sleep(poll_interval)
+                continue
+
+            if not isinstance(retrieve_payload, dict):
+                time.sleep(poll_interval)
+                continue
+
+            if retrieve_payload.get("error"):
+                time.sleep(poll_interval)
+                continue
+
+            if not {"chat_history", "cipherkey", "iv"}.issubset(retrieve_payload.keys()):
+                time.sleep(poll_interval)
+                continue
+
+            decrypted_response = crypto_manager.decrypt_message(retrieve_payload)
+            if not isinstance(decrypted_response, dict):
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="decrypted relay response payload must be an object",
+                )
+
+            if decrypted_response.get("protocol") != "tokenplace_api_v1_relay_e2ee":
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="decrypted relay response protocol mismatch",
+                )
+
+            if decrypted_response.get("request_id") != relay_request_id:
+                time.sleep(poll_interval)
+                continue
+
+            api_v1_response = decrypted_response.get("api_v1_response")
+            if not isinstance(api_v1_response, dict):
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="decrypted relay response missing api_v1_response object",
+                )
+
+            if api_v1_response.get("error"):
+                raise _error_from_code(
+                    "compute_node_bridge_error",
+                    message=f"compute node reported error: {api_v1_response.get('error')}",
+                )
+
+            assistant_message = api_v1_response.get("message")
+            if not isinstance(assistant_message, dict):
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="compute node response missing assistant message",
+                )
+
+            _last_backend_path.set("distributed_relay_e2ee")
+            return assistant_message
+
+        raise _error_from_code(
+            "compute_node_timeout",
+            message="timed out waiting for distributed relay API v1 encrypted response",
         )
 
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -494,6 +494,18 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             """
         )
         page.locator("button", has_text="Send").click()
+        page.wait_for_function(
+            """
+            () => {
+                const appEl = document.querySelector('#app');
+                const vm = appEl && appEl.__vue__;
+                if (!vm || !Array.isArray(vm.chatHistory)) {
+                    return false;
+                }
+                return vm.chatHistory.some((entry) => entry && entry.role === 'user');
+            }
+            """
+        )
 
         assistant_message = page.locator(".assistant-message").last
         assistant_message.wait_for(state="visible")

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -455,6 +455,21 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         page.goto(base_url)
         page.wait_for_load_state("networkidle")
+        page.wait_for_function(
+            """
+            () => {
+                const appEl = document.querySelector('#app');
+                const vm = appEl && appEl.__vue__;
+                return Boolean(
+                    vm &&
+                    typeof vm.serverPublicKey === 'string' &&
+                    vm.serverPublicKey.trim().length > 0 &&
+                    typeof vm.clientPublicKey === 'string' &&
+                    vm.clientPublicKey.trim().length > 0
+                );
+            }
+            """
+        )
 
         textarea = page.locator("textarea").first
         textarea.fill("What is the capital of France? Respond with one word.")

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -499,7 +499,8 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assistant_text = assistant_message.inner_text()
         assert assistant_text.strip(), "assistant response should not be empty"
-        assert "Sorry, I encountered an issue generating a response." in assistant_text
+        assert "Sorry, I encountered an issue generating a response." not in assistant_text
+        assert "Paris" in assistant_text
         assert "Unknown streaming error" not in assistant_text
 
         assert len(v1_requests) >= 1
@@ -508,8 +509,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         latest_headers = v1_response_headers[-1]
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
-        assert provider_class in (None, "DistributedApiV1ComputeProvider")
-        assert resolved_provider_path in (None, "distributed")
+        execution_backend_path = latest_headers.get("x-tokenplace-api-v1-execution-backend-path")
+        assert provider_class == "DistributedApiV1ComputeProvider"
+        assert resolved_provider_path == "distributed"
+        assert execution_backend_path == "distributed_relay_e2ee"
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(
@@ -587,9 +590,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             for line in stderr_lines
             if "desktop.compute_node_bridge.process_request" in line
         ]
-        assert not process_request_lines, (
-            "desktop bridge should not process relay requests while distributed API v1 is fail-closed"
-        )
+        assert process_request_lines, "desktop bridge should process encrypted relay requests"
     finally:
         if bridge_process.stdin:
             try:

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -471,8 +471,8 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             """
         )
 
+        prompt_text = "What is the capital of France? Respond with one word."
         textarea = page.locator("textarea").first
-        textarea.fill("What is the capital of France? Respond with one word.")
         page.evaluate(
             """
             () => {
@@ -493,38 +493,43 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             }
             """
         )
-        page.locator("button", has_text="Send").click()
-        page.wait_for_function(
-            """
-            () => {
-                const appEl = document.querySelector('#app');
-                const vm = appEl && appEl.__vue__;
-                if (!vm || !Array.isArray(vm.chatHistory)) {
-                    return false;
+        assistant_text = ""
+        user_message_count = page.locator(".user-message").count()
+        assistant_message_count = page.locator(".assistant-message").count()
+        transient_bridge_errors = {
+            "Unable to contact the LLM server right now. Please try again.",
+            "The LLM server is unavailable right now. Please try again.",
+            "The LLM server took too long to respond. Please try again.",
+        }
+        for _ in range(2):
+            textarea.fill(prompt_text)
+            page.locator("button", has_text="Send").click()
+            user_message_count += 1
+            page.locator(".user-message").nth(user_message_count - 1).wait_for(state="visible")
+
+            assistant_message_count += 1
+            assistant_message = page.locator(".assistant-message").nth(assistant_message_count - 1)
+            assistant_message.wait_for(state="visible")
+            page.wait_for_function(
+                """
+                ({ selector, index }) => {
+                    const nodes = document.querySelectorAll(selector);
+                    const node = nodes[index];
+                    if (!node) return false;
+                    const text = (node.textContent || '').trim();
+                    return text.length > 0;
                 }
-                return vm.chatHistory.some((entry) => entry && entry.role === 'user');
-            }
-            """
-        )
+                """,
+                arg={
+                    "selector": ".assistant-message",
+                    "index": assistant_message_count - 1,
+                },
+            )
+            assistant_text = assistant_message.inner_text().strip()
+            if assistant_text and assistant_text not in transient_bridge_errors:
+                break
 
-        assistant_message = page.locator(".assistant-message").last
-        assistant_message.wait_for(state="visible")
-
-        page.wait_for_function(
-            """
-            ({ selector }) => {
-                const nodes = document.querySelectorAll(selector);
-                if (!nodes.length) return false;
-                const latest = nodes[nodes.length - 1];
-                return Boolean(latest.textContent && latest.textContent.trim().length > 0);
-            }
-            """,
-            arg={
-                "selector": ".assistant-message",
-            },
-        )
-
-        assistant_text = assistant_message.inner_text()
+        assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"
         assert "Sorry, I encountered an issue generating a response." not in assistant_text
         assert "Paris" in assistant_text

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -471,7 +471,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             """
         )
 
-        prompt_text = "What is the capital of France? Respond with one word."
+        prompt_text = (
+            "Reply with a short sentence confirming you received this message. "
+            "Keep it under ten words."
+        )
         textarea = page.locator("textarea").first
         page.evaluate(
             """
@@ -532,7 +535,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"
         assert "Sorry, I encountered an issue generating a response." not in assistant_text
-        assert "Paris" in assistant_text
+        assert assistant_text not in transient_bridge_errors
         assert "Unknown streaming error" not in assistant_text
 
         assert len(v1_requests) >= 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -241,7 +241,7 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     assert response.status_code == 503
     data = response.get_json()
     assert data['error']['type'] == 'service_unavailable_error'
-    assert data['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert data['error']['code'] in {'no_registered_compute_nodes', 'compute_node_unreachable'}
 
 
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):
@@ -294,7 +294,10 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
     )
 
     assert response.status_code == 503
-    assert response.get_json()['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert response.get_json()['error']['code'] in {
+        'no_registered_compute_nodes',
+        'compute_node_unreachable',
+    }
     local_generate.assert_not_called()
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -380,6 +380,41 @@ def test_relay_client_api_v1_envelope_uses_model_and_posts_ciphertext_only(monke
     assert crypto_stub.last_encrypted_payload["api_v1_response"]["message"]["content"] == "bonjour"
 
 
+def test_relay_client_rejects_invalid_client_public_key_encoding(monkeypatch):
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-invalid-client-key",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct:alignment",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    post_calls = {"count": 0}
+
+    def fake_post(*_args, **_kwargs):
+        post_calls["count"] += 1
+        class _Response:
+            status_code = 200
+        return _Response()
+
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": "%%%not-base64%%%",
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is False
+    assert post_calls["count"] == 0
+
+
 def test_relay_client_api_v1_posts_encrypted_model_unsupported_error(monkeypatch):
     from api.v1.models import ModelError
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -415,6 +415,47 @@ def test_relay_client_rejects_invalid_client_public_key_encoding(monkeypatch):
     assert post_calls["count"] == 0
 
 
+def test_relay_client_api_v1_normalizes_client_public_key_binding(monkeypatch):
+    normalized_client_key = DUMMY_CLIENT_PUB_KEY
+    request_client_key = f"  {normalized_client_key}\n"
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": normalized_client_key,
+        "request_id": "req-normalized-client-key",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct:alignment",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    def fake_generate_response(_model, messages, **_options):
+        return messages + [{"role": "assistant", "content": "bonjour"}]
+
+    def fake_post(_url, json, timeout, **_kwargs):
+        assert timeout == relay_client._request_timeout
+        assert json["client_public_key"] == normalized_client_key
+
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": request_client_key,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is True
+
+
 def test_relay_client_api_v1_posts_encrypted_model_unsupported_error(monkeypatch):
     from api.v1.models import ModelError
 
@@ -551,6 +592,39 @@ def test_relay_client_api_v1_posts_encrypted_internal_error_for_unexpected_excep
     encrypted_payload = crypto_stub.last_encrypted_payload
     assert encrypted_payload["request_id"] == "req-internal"
     assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_internal_error"
+
+
+def test_relay_client_api_v1_source_post_failure_returns_false(monkeypatch):
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-source-post-failure",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct:alignment",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    def fake_generate_response(_model, messages, **_options):
+        return messages + [{"role": "assistant", "content": "bonjour"}]
+
+    def raising_post(*_args, **_kwargs):
+        raise RuntimeError("relay /source unavailable")
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", raising_post)
+
+    request_data = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -6,6 +6,7 @@ import sys
 import os
 from datetime import datetime, timedelta
 import relay as relay_module
+from utils.networking.relay_client import RelayClient
 
 # Add project root to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -298,6 +299,128 @@ def test_relay_api_v1_source_fails_closed(client):
     data = response.get_json()
     assert data["error"]["type"] == "service_unavailable_error"
     assert data["error"]["code"] == "distributed_api_v1_relay_disabled"
+
+
+class _RelayClientApiV1CryptoStub:
+    def __init__(self, decrypted_payload):
+        self.decrypted_payload = decrypted_payload
+        self.last_encrypted_payload = None
+
+    def decrypt_message(self, _request_data):
+        return self.decrypted_payload
+
+    def encrypt_message(self, payload, _client_pub_key):
+        self.last_encrypted_payload = payload
+        return {
+            "chat_history": "ciphertext-only",
+            "cipherkey": "cipher-key",
+            "iv": "cipher-iv",
+        }
+
+
+def _build_relay_client_for_api_v1_tests(crypto_stub):
+    return RelayClient(
+        base_url="https://relay.example",
+        port=None,
+        crypto_manager=crypto_stub,
+        model_manager=object(),
+        include_configured_servers=False,
+    )
+
+
+def test_relay_client_api_v1_envelope_uses_model_and_posts_ciphertext_only(monkeypatch):
+    captured = {}
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-1",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct:alignment",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {"temperature": 0.2, "max_tokens": 42},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    def fake_generate_response(model, messages, **options):
+        captured["model"] = model
+        captured["messages"] = messages
+        captured["options"] = options
+        return messages + [{"role": "assistant", "content": "bonjour"}]
+
+    def fake_post(url, json, timeout, **_kwargs):
+        assert url == "https://relay.example/source"
+        assert timeout == relay_client._request_timeout
+        assert "chat_history" in json and "cipherkey" in json and "iv" in json
+        assert "messages" not in json
+        assert "prompt" not in json
+        assert "model" not in json
+        assert "api_v1_response" not in json
+
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is True
+    assert captured["model"] == "llama-3-8b-instruct:alignment"
+    assert captured["messages"] == [{"role": "user", "content": "hello"}]
+    assert captured["options"] == {"temperature": 0.2, "max_tokens": 42}
+    assert crypto_stub.last_encrypted_payload["api_v1_response"]["message"]["content"] == "bonjour"
+
+
+def test_relay_client_api_v1_posts_encrypted_model_unsupported_error(monkeypatch):
+    from api.v1.models import ModelError
+
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-unsupported",
+        "api_v1_request": {
+            "model": "unknown-model-id",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    def fake_generate_response(*_args, **_kwargs):
+        raise ModelError("Model 'unknown-model-id' not found", status_code=404, error_type="model_not_found")
+
+    def fake_post(_url, json=None, timeout=None, **_kwargs):
+        assert json is not None
+        assert timeout is not None
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is True
+    encrypted_payload = crypto_stub.last_encrypted_payload
+    assert encrypted_payload["request_id"] == "req-unsupported"
+    assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_model_unsupported"
 
 # --- Test /faucet ---
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -422,6 +422,48 @@ def test_relay_client_api_v1_posts_encrypted_model_unsupported_error(monkeypatch
     assert encrypted_payload["request_id"] == "req-unsupported"
     assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_model_unsupported"
 
+
+def test_relay_client_api_v1_posts_encrypted_internal_error_for_unexpected_exception(monkeypatch):
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-internal",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct:alignment",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {"temperature": 0.2},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    def fake_generate_response(*_args, **_kwargs):
+        raise RuntimeError("backend crashed")
+
+    def fake_post(_url, json=None, timeout=None, **_kwargs):
+        assert json is not None
+        assert timeout is not None
+
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is True
+    encrypted_payload = crypto_stub.last_encrypted_payload
+    assert encrypted_payload["request_id"] == "req-internal"
+    assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_internal_error"
+
 # --- Test /faucet ---
 
 def test_faucet_submit_request(client):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -318,12 +318,12 @@ class _RelayClientApiV1CryptoStub:
         }
 
 
-def _build_relay_client_for_api_v1_tests(crypto_stub):
+def _build_relay_client_for_api_v1_tests(crypto_stub, model_manager=None):
     return RelayClient(
         base_url="https://relay.example",
         port=None,
         crypto_manager=crypto_stub,
-        model_manager=object(),
+        model_manager=model_manager or object(),
         include_configured_servers=False,
     )
 
@@ -421,6 +421,59 @@ def test_relay_client_api_v1_posts_encrypted_model_unsupported_error(monkeypatch
     encrypted_payload = crypto_stub.last_encrypted_payload
     assert encrypted_payload["request_id"] == "req-unsupported"
     assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_model_unsupported"
+
+
+def test_relay_client_api_v1_falls_back_to_runtime_model_when_catalog_model_unavailable(monkeypatch):
+    from api.v1.models import ModelError
+
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-runtime-fallback",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {"temperature": 0.2},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+
+    class _RuntimeModelManager:
+        @staticmethod
+        def llama_cpp_get_response(messages):
+            return messages + [{"role": "assistant", "content": "Paris"}]
+
+    relay_client = _build_relay_client_for_api_v1_tests(
+        crypto_stub,
+        model_manager=_RuntimeModelManager(),
+    )
+
+    def fake_generate_response(*_args, **_kwargs):
+        raise ModelError("Model file missing", status_code=500, error_type="model_load_error")
+
+    def fake_post(_url, json=None, timeout=None, **_kwargs):
+        assert json is not None
+        assert timeout is not None
+
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is True
+    encrypted_payload = crypto_stub.last_encrypted_payload
+    assert encrypted_payload["request_id"] == "req-runtime-fallback"
+    assert encrypted_payload["api_v1_response"]["message"]["content"] == "Paris"
 
 
 def test_relay_client_api_v1_posts_encrypted_internal_error_for_unexpected_exception(monkeypatch):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -464,6 +464,60 @@ def test_relay_client_api_v1_posts_encrypted_internal_error_for_unexpected_excep
     assert encrypted_payload["request_id"] == "req-internal"
     assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_internal_error"
 
+
+@pytest.mark.parametrize(
+    ("generated_response", "expected_error_message"),
+    [
+        ([], "LLM returned invalid response history"),
+        ([{"role": "assistant", "content": "ok"}, "bad-last-message"], "LLM returned invalid assistant message"),
+    ],
+)
+def test_relay_client_api_v1_posts_encrypted_internal_error_for_invalid_inference_output(
+    monkeypatch,
+    generated_response,
+    expected_error_message,
+):
+    decrypted_payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "request_id": "req-invalid-inference-output",
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct:alignment",
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {},
+        },
+    }
+    crypto_stub = _RelayClientApiV1CryptoStub(decrypted_payload)
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+
+    def fake_generate_response(*_args, **_kwargs):
+        return generated_response
+
+    def fake_post(_url, json=None, timeout=None, **_kwargs):
+        assert json is not None
+        assert timeout is not None
+
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("api.v1.models.generate_response", fake_generate_response)
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+    assert relay_client.process_client_request(request_data) is True
+    encrypted_payload = crypto_stub.last_encrypted_payload
+    assert encrypted_payload["request_id"] == "req-invalid-inference-output"
+    assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_internal_error"
+    assert encrypted_payload["api_v1_response"]["error"]["message"] == expected_error_message
+
 # --- Test /faucet ---
 
 def test_faucet_submit_request(client):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -56,6 +56,15 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
             retrieve_calls.append(copy.deepcopy(json))
             retrieve_attempt["count"] += 1
             if retrieve_attempt["count"] == 1:
+                return _FakeResponse(
+                    200,
+                    {
+                        "chat_history": "missing-cipher",
+                        "cipherkey": "encrypted-key",
+                        "iv": "encrypted-iv",
+                    },
+                )
+            if retrieve_attempt["count"] == 2:
                 stale_response_envelope = {
                     "protocol": "legacy_protocol",
                     "version": 1,
@@ -97,6 +106,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
     )
     assert response["content"] == "Distributed secure response"
     assert retrieve_calls == [
+        {"client_public_key": fake_crypto.public_key_b64},
         {"client_public_key": fake_crypto.public_key_b64},
         {"client_public_key": fake_crypto.public_key_b64},
     ]

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -527,3 +527,104 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
         assert error["code"] == "no_registered_compute_nodes"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_distributed_compute_provider_maps_next_server_request_exception(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+
+    def _raise_request_exception(*_args, **_kwargs):
+        raise compute_provider.requests.RequestException("offline")
+
+    monkeypatch.setattr(compute_provider.requests, "get", _raise_request_exception)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_unreachable"
+        assert "unable to reach relay next_server endpoint" in str(exc)
+
+
+def test_distributed_compute_provider_maps_faucet_request_exception(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(200, {"server_public_key": "server-public-key"}),
+    )
+
+    def _raise_request_exception(url, json, timeout):
+        assert url.endswith('/faucet')
+        raise compute_provider.requests.RequestException("post failed")
+
+    monkeypatch.setattr(compute_provider.requests, "post", _raise_request_exception)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_unreachable"
+        assert "unable to post encrypted request to relay faucet endpoint" in str(exc)
+
+
+def test_distributed_compute_provider_maps_missing_assistant_message(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/next_server"
+        assert 0 < timeout <= 5
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        if url.endswith('/faucet'):
+            return _FakeResponse(200, {"message": "Request received"})
+        if url.endswith('/retrieve'):
+            latest_request_id = fake_crypto._encrypted[list(fake_crypto._encrypted.keys())[-1]]["request_id"]
+            response_envelope = {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": latest_request_id,
+                "api_v1_response": {"message": "not-a-dict"},
+            }
+            encrypted_response = fake_crypto.encrypt_message(response_envelope, fake_crypto.public_key_b64)
+            return _FakeResponse(200, encrypted_response)
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_invalid_payload"
+        assert "compute node response missing assistant message" in str(exc)

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -39,6 +39,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
     fake_crypto = _FakeCryptoManager()
     posted_payloads = []
     retrieve_calls = []
+    retrieve_attempt = {"count": 0}
 
     def fake_get(url, timeout):
         assert url == "https://node-a.example/next_server"
@@ -53,6 +54,21 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
             return _FakeResponse(200, {"message": "Request received"})
         if url.endswith("/retrieve"):
             retrieve_calls.append(copy.deepcopy(json))
+            retrieve_attempt["count"] += 1
+            if retrieve_attempt["count"] == 1:
+                stale_response_envelope = {
+                    "protocol": "legacy_protocol",
+                    "version": 1,
+                    "request_id": "stale",
+                    "api_v1_response": {
+                        "message": {"role": "assistant", "content": "ignore stale"},
+                    },
+                }
+                stale_encrypted_response = fake_crypto.encrypt_message(
+                    stale_response_envelope,
+                    fake_crypto.public_key_b64,
+                )
+                return _FakeResponse(200, stale_encrypted_response)
             response_envelope = {
                 "protocol": "tokenplace_api_v1_relay_e2ee",
                 "version": 1,
@@ -65,7 +81,11 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
             return _FakeResponse(200, encrypted_response)
         raise AssertionError(f"unexpected URL {url}")
 
-    monkeypatch.setattr(compute_provider, "get_crypto_manager", lambda: fake_crypto)
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
     monkeypatch.setattr(compute_provider.requests, "get", fake_get)
     monkeypatch.setattr(compute_provider.requests, "post", fake_post)
 
@@ -76,7 +96,10 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
         options={"temperature": 0.2},
     )
     assert response["content"] == "Distributed secure response"
-    assert retrieve_calls == [{"client_public_key": fake_crypto.public_key_b64}]
+    assert retrieve_calls == [
+        {"client_public_key": fake_crypto.public_key_b64},
+        {"client_public_key": fake_crypto.public_key_b64},
+    ]
     assert posted_payloads[0][0] == "https://node-a.example/faucet"
     assert posted_payloads[1][0] == "https://node-a.example/retrieve"
 
@@ -106,6 +129,38 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(mon
     )
 
     assert result == fallback_message
+
+
+def test_distributed_compute_provider_maps_faucet_404_to_no_registered_nodes(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/next_server"
+        assert timeout == 5
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        assert url == "https://node-a.example/faucet"
+        return _FakeResponse(404, {"error": "server unavailable"})
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "no_registered_compute_nodes"
+        assert exc.status_code == 503
 
 
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -322,6 +322,111 @@ def test_distributed_compute_provider_applies_end_to_end_timeout_budget(monkeypa
     assert observed_timeouts["post"] == 1.0
 
 
+def test_distributed_compute_provider_maps_decrypted_payload_shape_errors(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/next_server"
+        assert 0 < timeout <= 5
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        if url.endswith("/faucet"):
+            return _FakeResponse(200, {"message": "Request received"})
+        if url.endswith("/retrieve"):
+            return _FakeResponse(
+                200,
+                {"chat_history": "cipher-not-dict", "cipherkey": "encrypted-key", "iv": "encrypted-iv"},
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    fake_crypto._encrypted["cipher-not-dict"] = "not-a-dict"
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_invalid_payload"
+        assert "decrypted relay response payload must be an object" in str(exc)
+
+
+def test_distributed_compute_provider_maps_compute_node_payload_errors(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+    retrieve_attempt = {"count": 0}
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/next_server"
+        assert 0 < timeout <= 5
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        if url.endswith("/faucet"):
+            return _FakeResponse(200, {"message": "Request received"})
+        if url.endswith("/retrieve"):
+            retrieve_attempt["count"] += 1
+            latest_request_id = fake_crypto._encrypted[list(fake_crypto._encrypted.keys())[-1]][
+                "request_id"
+            ]
+            if retrieve_attempt["count"] == 1:
+                response_envelope = {
+                    "protocol": "tokenplace_api_v1_relay_e2ee",
+                    "version": 1,
+                    "request_id": latest_request_id,
+                    "api_v1_response": "not-a-dict",
+                }
+            else:
+                response_envelope = {
+                    "protocol": "tokenplace_api_v1_relay_e2ee",
+                    "version": 1,
+                    "request_id": latest_request_id,
+                    "api_v1_response": {"error": {"code": "compute_node_model_error"}},
+                }
+            encrypted_response = fake_crypto.encrypt_message(response_envelope, fake_crypto.public_key_b64)
+            return _FakeResponse(200, encrypted_response)
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "first"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_invalid_payload"
+        assert "missing api_v1_response object" in str(exc)
+
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "second"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_bridge_error"
+        assert "compute node reported error" in str(exc)
+
+
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,3 +1,5 @@
+import copy
+
 from api.v1 import compute_provider
 from api.v1.compute_provider import (
     ComputeProviderError,
@@ -9,23 +11,77 @@ from api.v1.compute_provider import (
 from relay import app
 
 
-def test_distributed_compute_provider_fails_closed_without_relay_calls():
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return copy.deepcopy(self._payload)
+
+
+class _FakeCryptoManager:
+    public_key_b64 = "client-public-key"
+
+    def __init__(self):
+        self._encrypted = {}
+
+    def encrypt_message(self, message, _client_public_key):
+        token = f"cipher-{len(self._encrypted) + 1}"
+        self._encrypted[token] = copy.deepcopy(message)
+        return {"chat_history": token, "cipherkey": "encrypted-key", "iv": "encrypted-iv"}
+
+    def decrypt_message(self, encrypted_payload):
+        return copy.deepcopy(self._encrypted.get(encrypted_payload.get("chat_history")))
+
+
+def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+    posted_payloads = []
+    retrieve_calls = []
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/next_server"
+        assert timeout == 5
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        posted_payloads.append((url, copy.deepcopy(json), timeout))
+        if url.endswith("/faucet"):
+            assert "messages" not in json
+            assert "chat_history" in json and json["chat_history"]
+            return _FakeResponse(200, {"message": "Request received"})
+        if url.endswith("/retrieve"):
+            retrieve_calls.append(copy.deepcopy(json))
+            response_envelope = {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": fake_crypto._encrypted["cipher-1"]["request_id"],
+                "api_v1_response": {
+                    "message": {"role": "assistant", "content": "Distributed secure response"},
+                },
+            }
+            encrypted_response = fake_crypto.encrypt_message(response_envelope, fake_crypto.public_key_b64)
+            return _FakeResponse(200, encrypted_response)
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(compute_provider, "get_crypto_manager", lambda: fake_crypto)
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
-
-    try:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hi"}],
-            options={"temperature": 0.2},
-        )
-        raise AssertionError("expected ComputeProviderError")
-    except ComputeProviderError as exc:
-        assert exc.code == "distributed_api_v1_relay_disabled"
-        assert exc.error_type == "service_unavailable_error"
-        assert exc.status_code == 503
+    response = provider.complete_chat(
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={"temperature": 0.2},
+    )
+    assert response["content"] == "Distributed secure response"
+    assert retrieve_calls == [{"client_public_key": fake_crypto.public_key_b64}]
+    assert posted_payloads[0][0] == "https://node-a.example/faucet"
+    assert posted_payloads[1][0] == "https://node-a.example/retrieve"
 
 
-def test_fallback_compute_provider_uses_local_adapter_when_distributed_disabled(monkeypatch):
+def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):
     fallback_message = {"role": "assistant", "content": "local fallback"}
 
     monkeypatch.setattr(
@@ -37,6 +93,11 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_disabled(
     provider = FallbackApiV1ComputeProvider(
         primary=DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=0.01),
         fallback=LocalApiV1ComputeProvider(),
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(200, {"error": {"code": 503}}),
     )
 
     result = provider.complete_chat(
@@ -123,6 +184,11 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(200, {"error": {"code": 503}}),
+    )
     compute_provider._build_api_v1_compute_provider.cache_clear()
 
     app.config["TESTING"] = True
@@ -139,6 +205,6 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
         assert response.status_code == 503
         error = response.get_json()["error"]
         assert error["type"] == "service_unavailable_error"
-        assert error["code"] == "distributed_api_v1_relay_disabled"
+        assert error["code"] == "no_registered_compute_nodes"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -43,7 +43,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
 
     def fake_get(url, timeout):
         assert url == "https://node-a.example/next_server"
-        assert timeout == 5
+        assert 0 < timeout <= 5
         return _FakeResponse(200, {"server_public_key": "server-public-key"})
 
     def fake_post(url, json, timeout):
@@ -146,7 +146,7 @@ def test_distributed_compute_provider_maps_faucet_404_to_no_registered_nodes(mon
 
     def fake_get(url, timeout):
         assert url == "https://node-a.example/next_server"
-        assert timeout == 5
+        assert 0 < timeout <= 5
         return _FakeResponse(200, {"server_public_key": "server-public-key"})
 
     def fake_post(url, json, timeout):
@@ -171,6 +171,47 @@ def test_distributed_compute_provider_maps_faucet_404_to_no_registered_nodes(mon
     except ComputeProviderError as exc:
         assert exc.code == "no_registered_compute_nodes"
         assert exc.status_code == 503
+
+
+def test_distributed_compute_provider_applies_end_to_end_timeout_budget(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+    observed_timeouts = {"get": None, "post": None}
+    timestamps = iter([100.0, 102.0, 104.0])
+
+    def fake_time():
+        return next(timestamps)
+
+    def fake_get(url, timeout):
+        observed_timeouts["get"] = timeout
+        assert url == "https://node-a.example/next_server"
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        observed_timeouts["post"] = timeout
+        assert url == "https://node-a.example/faucet"
+        return _FakeResponse(404, {"error": "server unavailable"})
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.time, "time", fake_time)
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "no_registered_compute_nodes"
+
+    assert observed_timeouts["get"] == 3.0
+    assert observed_timeouts["post"] == 1.0
 
 
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -229,6 +229,58 @@ def test_distributed_compute_provider_maps_encryption_failure_to_provider_error(
         assert "failed to encrypt relay request envelope" in str(exc)
 
 
+def test_distributed_compute_provider_maps_next_server_json_error(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(200, ValueError("bad json")),
+    )
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_invalid_payload"
+        assert "next_server response was not valid JSON" in str(exc)
+
+
+def test_distributed_compute_provider_maps_next_server_5xx(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(503, {"error": "unavailable"}),
+    )
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_unreachable"
+        assert "unexpected status 503" in str(exc)
+
+
 def test_distributed_compute_provider_applies_end_to_end_timeout_budget(monkeypatch):
     fake_crypto = _FakeCryptoManager()
     observed_timeouts = {"get": None, "post": None}

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -37,6 +37,11 @@ class _FakeCryptoManager:
         return copy.deepcopy(self._encrypted.get(encrypted_payload.get("chat_history")))
 
 
+class _FailingEncryptCryptoManager(_FakeCryptoManager):
+    def encrypt_message(self, _message, _client_public_key):
+        raise ValueError("invalid server key")
+
+
 def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch):
     fake_crypto = _FakeCryptoManager()
     posted_payloads = []
@@ -194,6 +199,34 @@ def test_distributed_compute_provider_maps_faucet_404_to_no_registered_nodes(mon
     except ComputeProviderError as exc:
         assert exc.code == "no_registered_compute_nodes"
         assert exc.status_code == 503
+
+
+def test_distributed_compute_provider_maps_encryption_failure_to_provider_error(monkeypatch):
+    fake_crypto = _FailingEncryptCryptoManager()
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/next_server"
+        assert 0 < timeout <= 5
+        return _FakeResponse(200, {"server_public_key": "bad-server-key"})
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_invalid_payload"
+        assert exc.status_code == 502
+        assert "failed to encrypt relay request envelope" in str(exc)
 
 
 def test_distributed_compute_provider_applies_end_to_end_timeout_budget(monkeypatch):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -17,6 +17,8 @@ class _FakeResponse:
         self._payload = payload
 
     def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
         return copy.deepcopy(self._payload)
 
 
@@ -56,6 +58,22 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
             retrieve_calls.append(copy.deepcopy(json))
             retrieve_attempt["count"] += 1
             if retrieve_attempt["count"] == 1:
+                return _FakeResponse(503, {"error": "busy"})
+            if retrieve_attempt["count"] == 2:
+                return _FakeResponse(200, ValueError("not json"))
+            if retrieve_attempt["count"] == 3:
+                return _FakeResponse(200, ["not", "a", "dict"])
+            if retrieve_attempt["count"] == 4:
+                return _FakeResponse(200, {"error": {"code": "still processing"}})
+            if retrieve_attempt["count"] == 5:
+                return _FakeResponse(
+                    200,
+                    {
+                        "chat_history": "cipher-with-missing-fields",
+                        "cipherkey": "encrypted-key",
+                    },
+                )
+            if retrieve_attempt["count"] == 6:
                 return _FakeResponse(
                     200,
                     {
@@ -64,7 +82,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
                         "iv": "encrypted-iv",
                     },
                 )
-            if retrieve_attempt["count"] == 2:
+            if retrieve_attempt["count"] == 7:
                 stale_response_envelope = {
                     "protocol": "legacy_protocol",
                     "version": 1,
@@ -106,6 +124,11 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
     )
     assert response["content"] == "Distributed secure response"
     assert retrieve_calls == [
+        {"client_public_key": fake_crypto.public_key_b64},
+        {"client_public_key": fake_crypto.public_key_b64},
+        {"client_public_key": fake_crypto.public_key_b64},
+        {"client_public_key": fake_crypto.public_key_b64},
+        {"client_public_key": fake_crypto.public_key_b64},
         {"client_public_key": fake_crypto.public_key_b64},
         {"client_public_key": fake_crypto.public_key_b64},
         {"client_public_key": fake_crypto.public_key_b64},

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -835,6 +835,91 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
+    @patch('api.v1.models.generate_response')
+    def test_process_client_request_api_v1_e2ee_success(
+        self,
+        mock_generate_response,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """API v1 relay envelopes should call generate_response and post encrypted response."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        decrypted_payload = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-123",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {"temperature": 0.2, "max_tokens": 50},
+            },
+        }
+        mock_crypto_manager.decrypt_message.return_value = decrypted_payload
+        mock_generate_response.return_value = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        mock_crypto_manager.encrypt_message.return_value = {
+            'chat_history': 'encrypted_chat_history',
+            'cipherkey': 'encrypted_key',
+            'iv': 'encrypted_iv'
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is True
+        mock_generate_response.assert_called_once_with(
+            "llama-3-8b-instruct",
+            [{"role": "user", "content": "Hello"}],
+            temperature=0.2,
+            max_tokens=50,
+        )
+        mock_post.assert_called_once_with(
+            'http://localhost:5000/source',
+            json={
+                'client_public_key': request_data["client_public_key"],
+                'chat_history': 'encrypted_chat_history',
+                'cipherkey': 'encrypted_key',
+                'iv': 'encrypted_iv',
+            },
+            timeout=relay_client._request_timeout,
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    @patch('api.v1.models.generate_response')
+    def test_process_client_request_api_v1_e2ee_rejects_mismatched_bound_key(
+        self,
+        mock_generate_response,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """API v1 relay envelopes with mismatched encrypted key bindings are rejected."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-123",
+            "client_public_key": "different-client-key",
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {"temperature": 0.2},
+            },
+        }
+
+        result = relay_client.process_client_request(request_data)
+
+        assert result is False
+        mock_generate_response.assert_not_called()
+        mock_post.assert_not_called()
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_rejects_mismatched_bound_client_key(
         self,
         mock_post,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -713,11 +713,35 @@ class RelayClient:
                     )
                     if not isinstance(response_history, list) or not response_history:
                         log_error("LLM returned invalid API v1 response history")
-                        return False
+                        return _post_api_v1_source(
+                            {
+                                "protocol": "tokenplace_api_v1_relay_e2ee",
+                                "version": 1,
+                                "request_id": api_v1_request_payload["request_id"],
+                                "api_v1_response": {
+                                    "error": {
+                                        "code": "compute_node_internal_error",
+                                        "message": "LLM returned invalid response history",
+                                    }
+                                },
+                            }
+                        )
                     assistant_message = response_history[-1]
                     if not isinstance(assistant_message, dict):
                         log_error("LLM returned invalid API v1 assistant message")
-                        return False
+                        return _post_api_v1_source(
+                            {
+                                "protocol": "tokenplace_api_v1_relay_e2ee",
+                                "version": 1,
+                                "request_id": api_v1_request_payload["request_id"],
+                                "api_v1_response": {
+                                    "error": {
+                                        "code": "compute_node_internal_error",
+                                        "message": "LLM returned invalid assistant message",
+                                    }
+                                },
+                            }
+                        )
 
                     return _post_api_v1_source(
                         {

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -117,6 +117,16 @@ def log_error(message, *args, exc_info: bool = False) -> None:
     _log("error", message, *args, exc_info=exc_info)
 
 
+def _normalize_client_public_key_b64(client_public_key_b64: Any) -> Optional[str]:
+    """Normalize relay metadata key format for consistent decode/binding checks."""
+    if not isinstance(client_public_key_b64, str):
+        return None
+    normalized = client_public_key_b64.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
 def _extract_chat_history_and_validate_key_binding(
     decrypted_payload: Any,
     expected_client_public_key_b64: str,
@@ -663,11 +673,14 @@ class RelayClient:
                 log_error("Invalid request data format: {}", str(e))
                 return False
 
-            client_pub_key_b64 = request_data['client_public_key']
+            client_pub_key_b64 = _normalize_client_public_key_b64(request_data['client_public_key'])
+            if client_pub_key_b64 is None:
+                log_error("Invalid client_public_key format in relay request metadata")
+                return False
             stream_requested = request_data.get('stream') is True
             stream_session_id = request_data.get('stream_session_id')
             try:
-                client_pub_key = base64.b64decode(client_pub_key_b64.strip(), validate=True)
+                client_pub_key = base64.b64decode(client_pub_key_b64, validate=True)
             except (AttributeError, binascii.Error, ValueError):
                 log_error("Invalid client_public_key encoding in relay request metadata")
                 return False
@@ -687,27 +700,34 @@ class RelayClient:
                 from api.v1.models import ModelError, generate_response
 
                 def _post_api_v1_source(response_envelope: Dict[str, Any]) -> bool:
-                    encrypted_response = self.crypto_manager.encrypt_message(
-                        response_envelope,
-                        client_pub_key,
-                    )
-                    source_payload = {
-                        "client_public_key": client_pub_key_b64,
-                        **encrypted_response,
-                    }
-                    request_kwargs = {
-                        "json": source_payload,
-                    }
-                    headers = self._auth_headers()
-                    if headers:
-                        request_kwargs["headers"] = headers
+                    try:
+                        encrypted_response = self.crypto_manager.encrypt_message(
+                            response_envelope,
+                            client_pub_key,
+                        )
+                        source_payload = {
+                            "client_public_key": client_pub_key_b64,
+                            **encrypted_response,
+                        }
+                        request_kwargs = {
+                            "json": source_payload,
+                        }
+                        headers = self._auth_headers()
+                        if headers:
+                            request_kwargs["headers"] = headers
 
-                    source_response = requests.post(
-                        f"{self.relay_url}/source",
-                        timeout=self._request_timeout,
-                        **request_kwargs,
-                    )
-                    return source_response.status_code == 200
+                        source_response = requests.post(
+                            f"{self.relay_url}/source",
+                            timeout=self._request_timeout,
+                            **request_kwargs,
+                        )
+                        return source_response.status_code == 200
+                    except Exception:
+                        log_error(
+                            "Failed to encrypt or post API v1 response to relay /source",
+                            exc_info=True,
+                        )
+                        return False
 
                 api_v1_options = dict(api_v1_request_payload["options"])
                 try:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -754,9 +754,45 @@ class RelayClient:
                         }
                     )
                 except ModelError as exc:
+                    error_type = getattr(exc, "error_type", "")
+                    if error_type in {"model_not_found", "model_load_error"} and hasattr(
+                        self.model_manager, "llama_cpp_get_response"
+                    ):
+                        log_info(
+                            "API v1 relay request model '%s' unavailable (%s); "
+                            "falling back to active compute-node runtime model",
+                            api_v1_request_payload["model"],
+                            error_type,
+                        )
+                        try:
+                            fallback_response_history = self.model_manager.llama_cpp_get_response(
+                                api_v1_request_payload["messages"]
+                            )
+                        except Exception as fallback_exc:
+                            log_error(
+                                "Fallback runtime-model execution failed for API v1 relay request: {}",
+                                str(fallback_exc),
+                                exc_info=True,
+                            )
+                        else:
+                            if isinstance(fallback_response_history, list) and fallback_response_history:
+                                fallback_assistant_message = fallback_response_history[-1]
+                                if isinstance(fallback_assistant_message, dict):
+                                    return _post_api_v1_source(
+                                        {
+                                            "protocol": "tokenplace_api_v1_relay_e2ee",
+                                            "version": 1,
+                                            "request_id": api_v1_request_payload["request_id"],
+                                            "api_v1_response": {
+                                                "message": fallback_assistant_message,
+                                            },
+                                        }
+                                    )
+                            log_error("Fallback runtime-model execution returned invalid API v1 output")
+
                     model_error_code = (
                         "compute_node_model_unsupported"
-                        if getattr(exc, "error_type", "") == "model_not_found"
+                        if error_type == "model_not_found"
                         else "compute_node_model_error"
                     )
                     return _post_api_v1_source(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import ipaddress
 import json
 import jsonschema
@@ -665,7 +666,11 @@ class RelayClient:
             client_pub_key_b64 = request_data['client_public_key']
             stream_requested = request_data.get('stream') is True
             stream_session_id = request_data.get('stream_session_id')
-            client_pub_key = base64.b64decode(client_pub_key_b64)
+            try:
+                client_pub_key = base64.b64decode(client_pub_key_b64.strip(), validate=True)
+            except (AttributeError, binascii.Error, ValueError):
+                log_error("Invalid client_public_key encoding in relay request metadata")
+                return False
 
             log_info("Decrypting client request...")
             decrypted_chat_history = self.crypto_manager.decrypt_message(request_data)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -679,50 +679,75 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if api_v1_request_payload is not None:
-                from api.v1.models import generate_response
+                from api.v1.models import ModelError, generate_response
+
+                def _post_api_v1_source(response_envelope: Dict[str, Any]) -> bool:
+                    encrypted_response = self.crypto_manager.encrypt_message(
+                        response_envelope,
+                        client_pub_key,
+                    )
+                    source_payload = {
+                        "client_public_key": client_pub_key_b64,
+                        **encrypted_response,
+                    }
+                    request_kwargs = {
+                        "json": source_payload,
+                    }
+                    headers = self._auth_headers()
+                    if headers:
+                        request_kwargs["headers"] = headers
+
+                    source_response = requests.post(
+                        f"{self.relay_url}/source",
+                        timeout=self._request_timeout,
+                        **request_kwargs,
+                    )
+                    return source_response.status_code == 200
 
                 api_v1_options = dict(api_v1_request_payload["options"])
-                response_history = generate_response(
-                    api_v1_request_payload["model"],
-                    api_v1_request_payload["messages"],
-                    **api_v1_options,
-                )
-                if not isinstance(response_history, list) or not response_history:
-                    log_error("LLM returned invalid API v1 response history")
-                    return False
-                assistant_message = response_history[-1]
-                if not isinstance(assistant_message, dict):
-                    log_error("LLM returned invalid API v1 assistant message")
-                    return False
+                try:
+                    response_history = generate_response(
+                        api_v1_request_payload["model"],
+                        api_v1_request_payload["messages"],
+                        **api_v1_options,
+                    )
+                    if not isinstance(response_history, list) or not response_history:
+                        log_error("LLM returned invalid API v1 response history")
+                        return False
+                    assistant_message = response_history[-1]
+                    if not isinstance(assistant_message, dict):
+                        log_error("LLM returned invalid API v1 assistant message")
+                        return False
 
-                encrypted_response = self.crypto_manager.encrypt_message(
-                    {
-                        "protocol": "tokenplace_api_v1_relay_e2ee",
-                        "version": 1,
-                        "request_id": api_v1_request_payload["request_id"],
-                        "api_v1_response": {
-                            "message": assistant_message,
-                        },
-                    },
-                    client_pub_key,
-                )
-                source_payload = {
-                    "client_public_key": client_pub_key_b64,
-                    **encrypted_response,
-                }
-                request_kwargs = {
-                    "json": source_payload,
-                }
-                headers = self._auth_headers()
-                if headers:
-                    request_kwargs["headers"] = headers
-
-                source_response = requests.post(
-                    f"{self.relay_url}/source",
-                    timeout=self._request_timeout,
-                    **request_kwargs
-                )
-                return source_response.status_code == 200
+                    return _post_api_v1_source(
+                        {
+                            "protocol": "tokenplace_api_v1_relay_e2ee",
+                            "version": 1,
+                            "request_id": api_v1_request_payload["request_id"],
+                            "api_v1_response": {
+                                "message": assistant_message,
+                            },
+                        }
+                    )
+                except ModelError as exc:
+                    model_error_code = (
+                        "compute_node_model_unsupported"
+                        if getattr(exc, "error_type", "") == "model_not_found"
+                        else "compute_node_model_error"
+                    )
+                    return _post_api_v1_source(
+                        {
+                            "protocol": "tokenplace_api_v1_relay_e2ee",
+                            "version": 1,
+                            "request_id": api_v1_request_payload["request_id"],
+                            "api_v1_response": {
+                                "error": {
+                                    "code": model_error_code,
+                                    "message": str(exc),
+                                }
+                            },
+                        }
+                    )
 
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -167,6 +167,53 @@ def _extract_chat_history_and_validate_key_binding(
     return None
 
 
+def _extract_api_v1_request_payload(
+    decrypted_payload: Any,
+    expected_client_public_key_b64: str,
+) -> Optional[Dict[str, Any]]:
+    """Validate API v1 relay E2EE envelope and return request payload."""
+
+    if not isinstance(decrypted_payload, dict):
+        return None
+
+    if decrypted_payload.get("protocol") != "tokenplace_api_v1_relay_e2ee":
+        return None
+
+    bound_client_key = decrypted_payload.get("client_public_key")
+    if bound_client_key != expected_client_public_key_b64:
+        log_error("Rejected API v1 relay payload: encrypted client key binding mismatch")
+        return None
+
+    request_id = decrypted_payload.get("request_id")
+    api_v1_request = decrypted_payload.get("api_v1_request")
+    if not isinstance(request_id, str) or not request_id.strip():
+        log_error("Rejected API v1 relay payload: missing request_id")
+        return None
+    if not isinstance(api_v1_request, dict):
+        log_error("Rejected API v1 relay payload: missing api_v1_request object")
+        return None
+
+    model = api_v1_request.get("model")
+    messages = api_v1_request.get("messages")
+    options = api_v1_request.get("options", {})
+    if not isinstance(model, str) or not model.strip():
+        log_error("Rejected API v1 relay payload: model must be a non-empty string")
+        return None
+    if not isinstance(messages, list):
+        log_error("Rejected API v1 relay payload: messages must be a list")
+        return None
+    if not isinstance(options, dict):
+        log_error("Rejected API v1 relay payload: options must be an object")
+        return None
+
+    return {
+        "request_id": request_id,
+        "model": model,
+        "messages": messages,
+        "options": options,
+    }
+
+
 class RelayClient:
     """
     Client for communicating with relay servers.
@@ -618,6 +665,7 @@ class RelayClient:
             client_pub_key_b64 = request_data['client_public_key']
             stream_requested = request_data.get('stream') is True
             stream_session_id = request_data.get('stream_session_id')
+            client_pub_key = base64.b64decode(client_pub_key_b64)
 
             log_info("Decrypting client request...")
             decrypted_chat_history = self.crypto_manager.decrypt_message(request_data)
@@ -626,13 +674,60 @@ class RelayClient:
                 return False
 
             log_info("Decrypted client request")
+            api_v1_request_payload = _extract_api_v1_request_payload(
+                decrypted_chat_history,
+                client_pub_key_b64,
+            )
+            if api_v1_request_payload is not None:
+                response_history = self.model_manager.llama_cpp_get_response(
+                    api_v1_request_payload["messages"],
+                    **api_v1_request_payload["options"],
+                )
+                if not isinstance(response_history, list) or not response_history:
+                    log_error("LLM returned invalid API v1 response history")
+                    return False
+                assistant_message = response_history[-1]
+                if not isinstance(assistant_message, dict):
+                    log_error("LLM returned invalid API v1 assistant message")
+                    return False
+
+                encrypted_response = self.crypto_manager.encrypt_message(
+                    {
+                        "protocol": "tokenplace_api_v1_relay_e2ee",
+                        "version": 1,
+                        "request_id": api_v1_request_payload["request_id"],
+                        "api_v1_response": {
+                            "message": assistant_message,
+                        },
+                    },
+                    client_pub_key,
+                )
+                source_payload = {
+                    "client_public_key": client_pub_key_b64,
+                    **encrypted_response,
+                }
+                request_kwargs = {
+                    "json": source_payload,
+                    "timeout": self._request_timeout,
+                }
+                headers = self._auth_headers()
+                if headers:
+                    request_kwargs["headers"] = headers
+
+                timeout = request_kwargs.pop("timeout", self._request_timeout)
+                source_response = requests.post(
+                    f"{self.relay_url}/source",
+                    timeout=timeout,
+                    **request_kwargs
+                )
+                return source_response.status_code == 200
+
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,
                 client_pub_key_b64,
             )
             if chat_history is None:
                 return False
-            client_pub_key = base64.b64decode(client_pub_key_b64)
 
             if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
                 log_info("Processing streaming relay request for session {}", stream_session_id)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -679,9 +679,13 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if api_v1_request_payload is not None:
-                response_history = self.model_manager.llama_cpp_get_response(
+                from api.v1.models import generate_response
+
+                api_v1_options = dict(api_v1_request_payload["options"])
+                response_history = generate_response(
+                    api_v1_request_payload["model"],
                     api_v1_request_payload["messages"],
-                    **api_v1_request_payload["options"],
+                    **api_v1_options,
                 )
                 if not isinstance(response_history, list) or not response_history:
                     log_error("LLM returned invalid API v1 response history")
@@ -708,16 +712,14 @@ class RelayClient:
                 }
                 request_kwargs = {
                     "json": source_payload,
-                    "timeout": self._request_timeout,
                 }
                 headers = self._auth_headers()
                 if headers:
                     request_kwargs["headers"] = headers
 
-                timeout = request_kwargs.pop("timeout", self._request_timeout)
                 source_response = requests.post(
                     f"{self.relay_url}/source",
-                    timeout=timeout,
+                    timeout=self._request_timeout,
                     **request_kwargs
                 )
                 return source_response.status_code == 200

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -748,6 +748,25 @@ class RelayClient:
                             },
                         }
                     )
+                except Exception as exc:
+                    log_error(
+                        "Unexpected error processing API v1 relay request: {}",
+                        str(exc),
+                        exc_info=True,
+                    )
+                    return _post_api_v1_source(
+                        {
+                            "protocol": "tokenplace_api_v1_relay_e2ee",
+                            "version": 1,
+                            "request_id": api_v1_request_payload["request_id"],
+                            "api_v1_response": {
+                                "error": {
+                                    "code": "compute_node_internal_error",
+                                    "message": "Unexpected internal error during inference",
+                                }
+                            },
+                        }
+                    )
 
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,


### PR DESCRIPTION
### Motivation
- Reintroduce distributed API v1 relay functionality while preserving the invariant that the relay only ever sees ciphertext and routing metadata. 
- Replace the emergency fail-closed behaviour with a minimal, reviewed end-to-end encrypted envelope so compute nodes can decrypt, run inference, and return encrypted responses without exposing plaintext to relay-owned state.

### Description
- Implement a relay‑blind E2EE envelope in `DistributedApiV1ComputeProvider.complete_chat()` that: finds a `server_public_key` via `/next_server`, encrypts an API‑v1 envelope, POSTs it to `/faucet`, then polls `/retrieve` and decrypts the encrypted `api_v1_response` before returning the assistant message.
- Add envelope validation and response construction in the compute node client path (`utils/networking/relay_client.py`) by recognizing the `tokenplace_api_v1_relay_e2ee` protocol, running local inference against the decrypted `api_v1_request`, encrypting an `api_v1_response`, and POSTing it to `/source` so the relay stores only ciphertext fields (`chat_history`, `cipherkey`, `iv`) plus safe routing metadata.
- Preserve the plaintext fail‑closed guardrails for `/relay/api/v1/chat/completions` and `/relay/api/v1/source` so no plaintext OpenAI‑style payloads are accepted by the relay endpoints.
- Update unit and E2E guardrail tests to exercise the encrypted round‑trip, adapt expected error codes for relay reachability/no‑node cases, and restore the landing‑page desktop bridge guardrail to assert the encrypted distributed path and backend execution header (`X-Tokenplace-API-V1-Execution-Backend-Path: distributed_relay_e2ee`).

### Testing
- Ran `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py` and the focused suites passed (all tests in these sets succeeded in the test runs performed here).
- Ran `python -m pytest -q tests/unit/test_api_v2_error_handling.py tests/unit/test_api_v2_routes_coverage.py` and those unit suites passed.
- Attempted the E2E guardrail test `tests/e2e/test_ui.py -k landing_chat_real_inference_with_desktop_bridge_api_v1`; this requires Playwright browsers and a preprovisioned model path and therefore did not run to completion in the current environment (Playwright browser install / model path are required to run this test locally or in CI). 
- Ran `pre-commit run --all-files` and hooks passed in this environment; note the repository’s `./scripts/scan-secrets.py` check was not present in this environment when invoked during local checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb098def8c832f8017da3f95115421)