### PR TITLE
Restore API v1 distributed relay with relay-blind E2EE envelopes

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -7,13 +7,19 @@ remote distributed compute-node endpoint while preserving a local fallback.
 from __future__ import annotations
 
 import contextvars
+import base64
+import json
 import logging
 import os
+import time
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
+import requests
+
 from api.v1.models import generate_response
+from encrypt import decrypt, encrypt, generate_keys
 
 logger = logging.getLogger("api.v1.compute_provider")
 _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
@@ -122,10 +128,77 @@ class LocalApiV1ComputeProvider:
 
 @dataclass(frozen=True)
 class DistributedApiV1ComputeProvider:
-    """Provider that fail-closes distributed API v1 relay dispatch."""
+    """Provider that relays API v1 requests through relay-blind E2EE envelopes."""
 
     base_url: str
     timeout_seconds: float = 30.0
+    poll_interval_seconds: float = 0.25
+    response_timeout_seconds: float = 30.0
+
+    _PROTOCOL = "api_v1_relay_e2ee"
+    _VERSION = 1
+
+    def _request_url(self, path: str) -> str:
+        return f"{self.base_url.rstrip('/')}{path}"
+
+    def _post_json(self, path: str, payload: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+        try:
+            response = requests.post(
+                self._request_url(path),
+                json=payload,
+                timeout=timeout or self.timeout_seconds,
+            )
+        except requests.Timeout as exc:
+            raise _error_from_code("compute_node_timeout", message=str(exc)) from exc
+        except requests.RequestException as exc:
+            raise _error_from_code("compute_node_unreachable", message=str(exc)) from exc
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise _error_from_code("compute_node_invalid_payload", message="relay returned non-JSON payload") from exc
+
+        if response.status_code >= 400:
+            relay_error = body.get("error") if isinstance(body, dict) else None
+            if isinstance(relay_error, dict):
+                relay_code = relay_error.get("code")
+                relay_message = relay_error.get("message") or "relay error"
+                if isinstance(relay_code, str):
+                    raise _error_from_code(relay_code, message=str(relay_message))
+                raise ComputeProviderError(str(relay_message))
+            raise ComputeProviderError(f"relay returned HTTP {response.status_code}")
+
+        if not isinstance(body, dict):
+            raise _error_from_code("compute_node_invalid_payload", message="relay returned invalid JSON payload")
+        return body
+
+    def _get_json(self, path: str, *, timeout: float | None = None) -> dict[str, Any]:
+        try:
+            response = requests.get(
+                self._request_url(path),
+                timeout=timeout or self.timeout_seconds,
+            )
+        except requests.Timeout as exc:
+            raise _error_from_code("compute_node_timeout", message=str(exc)) from exc
+        except requests.RequestException as exc:
+            raise _error_from_code("compute_node_unreachable", message=str(exc)) from exc
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message="relay returned non-JSON payload",
+            ) from exc
+
+        if response.status_code >= 400:
+            raise ComputeProviderError(f"relay returned HTTP {response.status_code}")
+        if not isinstance(body, dict):
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message="relay returned invalid JSON payload",
+            )
+        return body
 
     def complete_chat(
         self,
@@ -134,12 +207,89 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        raise ComputeProviderError(
-            "distributed API v1 relay execution is disabled pending reviewed E2EE envelope design",
-            code="distributed_api_v1_relay_disabled",
-            error_type="service_unavailable_error",
-            public_message="Distributed API v1 is temporarily unavailable.",
-            status_code=503,
+        next_server = self._get_json("/next_server", timeout=self.timeout_seconds)
+        server_public_key_b64 = next_server.get("server_public_key")
+        if not isinstance(server_public_key_b64, str) or not server_public_key_b64.strip():
+            raise _error_from_code(
+                "no_registered_compute_nodes",
+                message="No registered compute nodes available",
+            )
+
+        try:
+            client_private_key, client_public_key = generate_keys()
+            envelope_payload = {
+                "protocol": self._PROTOCOL,
+                "version": self._VERSION,
+                "request": {
+                    "model": model_id,
+                    "messages": messages,
+                    "options": options or {},
+                },
+            }
+            ciphertext_dict, cipherkey, iv = encrypt(
+                json.dumps(envelope_payload).encode("utf-8"),
+                base64.b64decode(server_public_key_b64),
+                use_pkcs1v15=True,
+            )
+            faucet_payload = {
+                "client_public_key": base64.b64encode(client_public_key).decode("utf-8"),
+                "server_public_key": server_public_key_b64,
+                "chat_history": base64.b64encode(ciphertext_dict["ciphertext"]).decode("utf-8"),
+                "cipherkey": base64.b64encode(cipherkey).decode("utf-8"),
+                "iv": base64.b64encode(iv).decode("utf-8"),
+            }
+        except Exception as exc:
+            raise _error_from_code("compute_node_invalid_payload", message=f"unable to build encrypted relay payload: {exc}") from exc
+
+        self._post_json("/faucet", faucet_payload, timeout=self.timeout_seconds)
+
+        deadline = time.monotonic() + max(self.response_timeout_seconds, 0.1)
+        while time.monotonic() < deadline:
+            retrieve_response = self._post_json(
+                "/retrieve",
+                {"client_public_key": faucet_payload["client_public_key"]},
+                timeout=self.timeout_seconds,
+            )
+            if retrieve_response.get("error") == "No response available for the given public key":
+                time.sleep(self.poll_interval_seconds)
+                continue
+
+            try:
+                decrypted = decrypt(
+                    {
+                        "ciphertext": base64.b64decode(retrieve_response["chat_history"]),
+                        "iv": base64.b64decode(retrieve_response["iv"]),
+                    },
+                    base64.b64decode(retrieve_response["cipherkey"]),
+                    client_private_key,
+                )
+                decoded = json.loads(decrypted.decode("utf-8"))
+            except Exception as exc:
+                raise _error_from_code("compute_node_invalid_payload", message=str(exc)) from exc
+
+            if not isinstance(decoded, dict):
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="compute node returned non-object response envelope",
+                )
+            if decoded.get("ok") is not True:
+                relay_error = decoded.get("error") or {}
+                if isinstance(relay_error, dict) and isinstance(relay_error.get("code"), str):
+                    raise _error_from_code(relay_error["code"], message=str(relay_error.get("message", "distributed inference failed")))
+                raise ComputeProviderError("distributed inference failed")
+
+            assistant_message = decoded.get("assistant_message")
+            if not isinstance(assistant_message, dict):
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="compute node response missing assistant_message",
+                )
+            _last_backend_path.set("distributed_relay_e2ee")
+            return assistant_message
+
+        raise _error_from_code(
+            "compute_node_timeout",
+            message="timed out waiting for distributed relay API v1 response",
         )
 
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -499,7 +499,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assistant_text = assistant_message.inner_text()
         assert assistant_text.strip(), "assistant response should not be empty"
-        assert "Sorry, I encountered an issue generating a response." in assistant_text
+        assert "Sorry, I encountered an issue generating a response." not in assistant_text
         assert "Unknown streaming error" not in assistant_text
 
         assert len(v1_requests) >= 1
@@ -583,13 +583,9 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
 
         process_request_lines = [
-            line
-            for line in stderr_lines
-            if "desktop.compute_node_bridge.process_request" in line
+            line for line in stderr_lines if "desktop.compute_node_bridge.process_request" in line
         ]
-        assert not process_request_lines, (
-            "desktop bridge should not process relay requests while distributed API v1 is fail-closed"
-        )
+        assert process_request_lines, "desktop bridge should process relay E2EE request payloads"
     finally:
         if bridge_process.stdin:
             try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,6 +230,14 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')
     monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
+    monkeypatch.setattr(
+        'api.v1.compute_provider.requests.get',
+        lambda *args, **kwargs: type(
+            'Resp',
+            (),
+            {'status_code': 200, 'json': staticmethod(lambda: {'error': {'message': 'No servers', 'code': 503}})},
+        )(),
+    )
 
     payload = {
         'model': 'remote-only-model',
@@ -241,7 +249,7 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     assert response.status_code == 503
     data = response.get_json()
     assert data['error']['type'] == 'service_unavailable_error'
-    assert data['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert data['error']['code'] == 'no_registered_compute_nodes'
 
 
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):
@@ -284,6 +292,14 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
 
     local_generate = MagicMock(side_effect=AssertionError('local generation should not run'))
     monkeypatch.setattr('api.v1.compute_provider.generate_response', local_generate)
+    monkeypatch.setattr(
+        'api.v1.compute_provider.requests.get',
+        lambda *args, **kwargs: type(
+            'Resp',
+            (),
+            {'status_code': 200, 'json': staticmethod(lambda: {'error': {'message': 'No servers', 'code': 503}})},
+        )(),
+    )
 
     response = client.post(
         '/api/v1/chat/completions',
@@ -294,7 +310,7 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
     )
 
     assert response.status_code == 503
-    assert response.get_json()['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert response.get_json()['error']['code'] == 'no_registered_compute_nodes'
     local_generate.assert_not_called()
 
 

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,3 +1,6 @@
+import base64
+import json
+
 from api.v1 import compute_provider
 from api.v1.compute_provider import (
     ComputeProviderError,
@@ -9,8 +12,26 @@ from api.v1.compute_provider import (
 from relay import app
 
 
-def test_distributed_compute_provider_fails_closed_without_relay_calls():
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def test_distributed_compute_provider_returns_no_nodes_when_relay_has_no_server(monkeypatch):
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(
+            {"error": {"message": "No servers available", "code": 503}},
+            status_code=200,
+        ),
+    )
 
     try:
         provider.complete_chat(
@@ -20,12 +41,12 @@ def test_distributed_compute_provider_fails_closed_without_relay_calls():
         )
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
-        assert exc.code == "distributed_api_v1_relay_disabled"
+        assert exc.code == "no_registered_compute_nodes"
         assert exc.error_type == "service_unavailable_error"
         assert exc.status_code == 503
 
 
-def test_fallback_compute_provider_uses_local_adapter_when_distributed_disabled(monkeypatch):
+def test_fallback_compute_provider_uses_local_adapter_when_distributed_unavailable(monkeypatch):
     fallback_message = {"role": "assistant", "content": "local fallback"}
 
     monkeypatch.setattr(
@@ -37,6 +58,14 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_disabled(
     provider = FallbackApiV1ComputeProvider(
         primary=DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=0.01),
         fallback=LocalApiV1ComputeProvider(),
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(
+            {"error": {"message": "No servers available", "code": 503}},
+            status_code=200,
+        ),
     )
 
     result = provider.complete_chat(
@@ -124,6 +153,14 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
     compute_provider._build_api_v1_compute_provider.cache_clear()
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(
+            {"error": {"message": "No servers available", "code": 503}},
+            status_code=200,
+        ),
+    )
 
     app.config["TESTING"] = True
     with app.test_client() as client:
@@ -139,6 +176,78 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
         assert response.status_code == 503
         error = response.get_json()["error"]
         assert error["type"] == "service_unavailable_error"
-        assert error["code"] == "distributed_api_v1_relay_disabled"
+        assert error["code"] == "no_registered_compute_nodes"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_distributed_compute_provider_uses_relay_blind_encrypted_envelope(monkeypatch):
+    provider = DistributedApiV1ComputeProvider(
+        base_url="https://node-a.example",
+        timeout_seconds=5,
+        poll_interval_seconds=0.0,
+        response_timeout_seconds=1.0,
+    )
+    server_private_key, server_public_key = compute_provider.generate_keys()
+    _client_private_key, client_public_key = compute_provider.generate_keys()
+    assistant_message = {"role": "assistant", "content": "encrypted relay response"}
+    network_calls = {"faucet": [], "retrieve": 0}
+
+    def fake_generate_keys():
+        return _client_private_key, client_public_key
+
+    def fake_get(url, timeout):
+        assert url.endswith("/next_server")
+        return _FakeResponse(
+            {"server_public_key": base64.b64encode(server_public_key).decode("utf-8")},
+            status_code=200,
+        )
+
+    def fake_post(url, json, timeout):
+        if url.endswith("/faucet"):
+            network_calls["faucet"].append(json)
+            assert "messages" not in json
+            decrypted = compute_provider.decrypt(
+                {
+                    "ciphertext": base64.b64decode(json["chat_history"]),
+                    "iv": base64.b64decode(json["iv"]),
+                },
+                base64.b64decode(json["cipherkey"]),
+                server_private_key,
+            )
+            payload = json_module.loads(decrypted.decode("utf-8"))
+            assert payload["protocol"] == "api_v1_relay_e2ee"
+            assert payload["request"]["messages"][0]["content"] == "hello"
+            return _FakeResponse({"message": "ok"}, status_code=200)
+
+        if url.endswith("/retrieve"):
+            network_calls["retrieve"] += 1
+            encrypted_data, encrypted_key, iv = compute_provider.encrypt(
+                json_module.dumps({"ok": True, "assistant_message": assistant_message}).encode("utf-8"),
+                base64.b64decode(json["client_public_key"]),
+                use_pkcs1v15=True,
+            )
+            return _FakeResponse(
+                {
+                    "chat_history": base64.b64encode(encrypted_data["ciphertext"]).decode("utf-8"),
+                    "cipherkey": base64.b64encode(encrypted_key).decode("utf-8"),
+                    "iv": base64.b64encode(iv).decode("utf-8"),
+                },
+                status_code=200,
+            )
+        raise AssertionError(f"unexpected url {url}")
+
+    json_module = json
+    monkeypatch.setattr(compute_provider, "generate_keys", fake_generate_keys)
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    result = provider.complete_chat(
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"temperature": 0.2},
+    )
+
+    assert result == assistant_message
+    assert network_calls["faucet"]
+    assert network_calls["retrieve"] >= 1

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -116,11 +116,11 @@ def log_error(message, *args, exc_info: bool = False) -> None:
     _log("error", message, *args, exc_info=exc_info)
 
 
-def _extract_chat_history_and_validate_key_binding(
+def _extract_decrypted_request_payload_and_validate_key_binding(
     decrypted_payload: Any,
     expected_client_public_key_b64: str,
 ) -> Optional[Any]:
-    """Validate optional encrypted key-binding metadata and return chat history."""
+    """Validate optional encrypted key-binding metadata and return decrypted payload."""
 
     def _is_valid_chat_history(chat_history: Any) -> bool:
         if not isinstance(chat_history, list):
@@ -148,6 +148,10 @@ def _extract_chat_history_and_validate_key_binding(
         else:
             # Legacy clients may still send unbound payloads; continue to accept for compatibility.
             pass
+
+        protocol = decrypted_payload.get("protocol")
+        if protocol == "api_v1_relay_e2ee":
+            return decrypted_payload
 
         if "chat_history" not in decrypted_payload:
             log_error("Invalid encrypted payload: missing chat_history")
@@ -626,13 +630,26 @@ class RelayClient:
                 return False
 
             log_info("Decrypted client request")
-            chat_history = _extract_chat_history_and_validate_key_binding(
+            decrypted_payload = _extract_decrypted_request_payload_and_validate_key_binding(
                 decrypted_chat_history,
                 client_pub_key_b64,
             )
-            if chat_history is None:
+            if decrypted_payload is None:
                 return False
             client_pub_key = base64.b64decode(client_pub_key_b64)
+            is_api_v1_e2ee_request = (
+                isinstance(decrypted_payload, dict)
+                and decrypted_payload.get("protocol") == "api_v1_relay_e2ee"
+            )
+            if is_api_v1_e2ee_request:
+                return self.process_api_v1_chat_request(
+                    request_data,
+                    client_pub_key_b64=client_pub_key_b64,
+                    client_pub_key=client_pub_key,
+                    decrypted_payload=decrypted_payload,
+                )
+
+            chat_history = decrypted_payload
 
             if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
                 log_info("Processing streaming relay request for session {}", stream_session_id)
@@ -734,11 +751,86 @@ class RelayClient:
             log_error("Exception during request processing: {}", str(e), exc_info=True)
             return False
 
-    def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
-        """Relay API v1 plaintext dispatch is disabled pending an E2EE-compatible design."""
+    def process_api_v1_chat_request(
+        self,
+        request_data: Dict[str, Any],
+        *,
+        client_pub_key_b64: str,
+        client_pub_key: bytes,
+        decrypted_payload: Dict[str, Any],
+    ) -> bool:
+        """Process an API v1 relay-blind E2EE chat payload through the legacy relay channel."""
 
-        log_error("Rejected disabled relay API v1 payload dispatch")
-        return False
+        request_envelope = decrypted_payload.get("request")
+        if not isinstance(request_envelope, dict):
+            log_error("Invalid API v1 relay envelope: missing request object")
+            return False
+
+        model_id = request_envelope.get("model")
+        messages = request_envelope.get("messages")
+        options = request_envelope.get("options") or {}
+
+        if not isinstance(model_id, str) or not model_id.strip():
+            log_error("Invalid API v1 relay envelope: missing model")
+            return False
+        if not isinstance(messages, list):
+            log_error("Invalid API v1 relay envelope: messages must be a list")
+            return False
+        if not isinstance(options, dict):
+            log_error("Invalid API v1 relay envelope: options must be an object")
+            return False
+
+        try:
+            from api.v1.models import generate_response
+
+            updated_messages = generate_response(model_id, messages, **options)
+            if not updated_messages or not isinstance(updated_messages[-1], dict):
+                response_envelope = {
+                    "ok": False,
+                    "error": {
+                        "code": "compute_node_invalid_payload",
+                        "message": "API v1 compute node produced invalid assistant message",
+                    },
+                }
+            else:
+                response_envelope = {
+                    "ok": True,
+                    "assistant_message": updated_messages[-1],
+                }
+        except Exception as exc:
+            log_error("API v1 relay envelope generation failed: {}", str(exc), exc_info=True)
+            response_envelope = {
+                "ok": False,
+                "error": {
+                    "code": "compute_node_bridge_error",
+                    "message": "API v1 distributed execution failed on compute node",
+                },
+            }
+
+        encrypted_response = self.crypto_manager.encrypt_message(response_envelope, client_pub_key)
+        source_payload = {
+            "client_public_key": client_pub_key_b64,
+            **encrypted_response,
+        }
+
+        request_kwargs = {
+            "json": source_payload,
+            "timeout": self._request_timeout,
+        }
+        headers = self._auth_headers()
+        if headers:
+            request_kwargs["headers"] = headers
+
+        timeout = request_kwargs.pop("timeout", self._request_timeout)
+        source_response = requests.post(
+            f"{self.relay_url}/source",
+            timeout=timeout,
+            **request_kwargs,
+        )
+        if source_response.status_code != 200:
+            log_error("Error status from /source for API v1 relay envelope: {}", source_response.status_code)
+            return False
+        return True
 
     def poll_relay_continuously(self):  # pragma: no cover
         """


### PR DESCRIPTION
### Motivation
- Restore safe distributed API v1 relay paths by sending only ciphertext through relay-owned state and network calls, preserving the relay-sees-ciphertext-only invariant. 
- Replace the temporary fail-closed behavior with a minimal, reviewed E2EE envelope that compute nodes can decrypt and honor, or keep fail-closed where unavailable. 
- Ensure the landing-page desktop-bridge guardrail reflects the restored E2EE distributed path (or remains explicit if deferred).

### Description
- Implement `DistributedApiV1ComputeProvider` to discover a compute node via `/next_server`, build a small encrypted envelope containing `model`, `messages`, and `options`, submit it via the relay legacy `/faucet` endpoint, poll `/retrieve` for the encrypted reply, decrypt and return the assistant message, and map relay/compute errors to structured provider errors (`no_registered_compute_nodes`, `compute_node_timeout`, etc.).
- Add safe HTTP helpers (`_get_json`, `_post_json`) and timeout/error handling in `api/v1/compute_provider.py`, and use existing `encrypt`/`decrypt`/`generate_keys` helpers to produce relay‑blind ciphertext payloads. 
- Extend `utils/networking/relay_client.py` to recognize and validate the decrypted API v1 E2EE envelope protocol (`protocol: api_v1_relay_e2ee`), run `generate_response()` on the compute node, and return only encrypted response envelopes to the relay via `/source` (no plaintext forwarded or logged). 
- Update tests and the landing-page guardrail: adjust unit and API tests to expect `no_registered_compute_nodes` for the no-node path, add a unit test that asserts the provider emits a relay-blind encrypted request and correctly decodes an encrypted reply, and change the E2E landing-page assertions to expect the desktop bridge to process E2EE relay payloads.

### Testing
- Ran `python -m py_compile` checks against modified modules and test files which succeeded. 
- Ran `python -m pytest -q tests/unit/test_api_v1_compute_provider.py` which passed (all provider unit tests succeeded). 
- Ran `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py` which passed (targeted relay + API suites succeeded). 
- Ran `python -m pytest -q tests/unit/test_api_v2_error_handling.py tests/unit/test_api_v2_routes_coverage.py` which passed; the focused E2E guardrail test `tests/e2e/test_ui.py -k landing_chat_real_inference_with_desktop_bridge_api_v1` could not be completed in this environment because Playwright Chromium is not installed (Playwright reported the browser executable is missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb098def8c832f8017da3f95115421)