### PR TITLE
Restore API v1 distributed relay via relay-blind E2EE envelope

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -7,12 +7,19 @@ remote distributed compute-node endpoint while preserving a local fallback.
 from __future__ import annotations
 
 import contextvars
+import base64
+import json
 import logging
 import os
+import time
+import uuid
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
+import requests
+
+from api.v1.encryption import encryption_manager
 from api.v1.models import generate_response
 
 logger = logging.getLogger("api.v1.compute_provider")
@@ -122,7 +129,7 @@ class LocalApiV1ComputeProvider:
 
 @dataclass(frozen=True)
 class DistributedApiV1ComputeProvider:
-    """Provider that fail-closes distributed API v1 relay dispatch."""
+    """Provider that dispatches API v1 requests through the relay E2EE envelope."""
 
     base_url: str
     timeout_seconds: float = 30.0
@@ -134,12 +141,125 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        raise ComputeProviderError(
-            "distributed API v1 relay execution is disabled pending reviewed E2EE envelope design",
-            code="distributed_api_v1_relay_disabled",
-            error_type="service_unavailable_error",
-            public_message="Distributed API v1 is temporarily unavailable.",
-            status_code=503,
+        request_id = f"api-v1-{uuid.uuid4().hex}"
+        request_payload = {
+            "protocol": "api_v1_e2ee",
+            "version": 1,
+            "request_id": request_id,
+            "api_v1_request": {
+                "request_id": request_id,
+                "model": model_id,
+                "messages": messages,
+                "options": options or {},
+            },
+        }
+
+        relay_url = self.base_url.rstrip("/")
+        timeout = self.timeout_seconds
+        try:
+            next_server_response = requests.get(
+                f"{relay_url}/next_server",
+                timeout=timeout,
+            )
+            next_server_response.raise_for_status()
+            next_server_data = next_server_response.json()
+        except requests.Timeout as exc:
+            raise _error_from_code("compute_node_timeout", message=str(exc)) from exc
+        except requests.RequestException as exc:
+            raise _error_from_code("compute_node_unreachable", message=str(exc)) from exc
+        except json.JSONDecodeError as exc:
+            raise _error_from_code("compute_node_invalid_payload", message=str(exc)) from exc
+
+        server_public_key = next_server_data.get("server_public_key")
+        if not isinstance(server_public_key, str) or not server_public_key:
+            raise _error_from_code(
+                "no_registered_compute_nodes",
+                message="relay returned no compute node public key",
+            )
+
+        encrypted_request = encryption_manager.encrypt_message(request_payload, server_public_key)
+        if not encrypted_request:
+            raise _error_from_code(
+                "compute_node_bridge_error",
+                message="failed to encrypt distributed API v1 relay envelope",
+            )
+
+        faucet_payload = {
+            "client_public_key": encryption_manager.public_key_b64,
+            "server_public_key": server_public_key,
+            "chat_history": encrypted_request["ciphertext"],
+            "cipherkey": encrypted_request["cipherkey"],
+            "iv": encrypted_request["iv"],
+        }
+
+        try:
+            faucet_response = requests.post(
+                f"{relay_url}/faucet",
+                json=faucet_payload,
+                timeout=timeout,
+            )
+            faucet_response.raise_for_status()
+        except requests.Timeout as exc:
+            raise _error_from_code("compute_node_timeout", message=str(exc)) from exc
+        except requests.RequestException as exc:
+            raise _error_from_code("compute_node_unreachable", message=str(exc)) from exc
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                retrieve_response = requests.post(
+                    f"{relay_url}/retrieve",
+                    json={"client_public_key": encryption_manager.public_key_b64},
+                    timeout=min(2.0, timeout),
+                )
+                retrieve_response.raise_for_status()
+                retrieve_data = retrieve_response.json()
+            except requests.Timeout:
+                continue
+            except requests.RequestException as exc:
+                raise _error_from_code("compute_node_unreachable", message=str(exc)) from exc
+            except json.JSONDecodeError as exc:
+                raise _error_from_code("compute_node_invalid_payload", message=str(exc)) from exc
+
+            if retrieve_data.get("error"):
+                time.sleep(0.2)
+                continue
+
+            try:
+                decrypted = encryption_manager.decrypt_message(
+                    {
+                        "ciphertext": base64.b64decode(retrieve_data["chat_history"]),
+                        "iv": base64.b64decode(retrieve_data["iv"]),
+                    },
+                    base64.b64decode(retrieve_data["cipherkey"]),
+                )
+                if decrypted is None:
+                    raise ValueError("empty decrypted payload")
+                response_payload = json.loads(decrypted.decode("utf-8"))
+            except Exception as exc:
+                raise _error_from_code("compute_node_invalid_payload", message=str(exc)) from exc
+
+            if isinstance(response_payload, dict):
+                api_v1_error = response_payload.get("api_v1_error")
+                if isinstance(api_v1_error, dict):
+                    error_code = api_v1_error.get("code", "compute_node_bridge_error")
+                    raise _error_from_code(
+                        str(error_code),
+                        message=str(api_v1_error.get("message", "distributed API v1 relay error")),
+                    )
+                api_v1_response = response_payload.get("api_v1_response")
+                if isinstance(api_v1_response, dict) and isinstance(api_v1_response.get("message"), dict):
+                    _last_backend_path.set("distributed_relay_e2ee")
+                    return api_v1_response["message"]
+
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message="distributed API v1 relay response had unexpected shape",
+            )
+
+        raise _error_from_code(
+            "compute_node_timeout",
+            message="timed out while waiting for distributed API v1 relay response",
         )
 
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -499,7 +499,8 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assistant_text = assistant_message.inner_text()
         assert assistant_text.strip(), "assistant response should not be empty"
-        assert "Sorry, I encountered an issue generating a response." in assistant_text
+        assert "Sorry, I encountered an issue generating a response." not in assistant_text
+        assert "No LLM servers are available right now." not in assistant_text
         assert "Unknown streaming error" not in assistant_text
 
         assert len(v1_requests) >= 1
@@ -508,8 +509,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         latest_headers = v1_response_headers[-1]
         provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
         resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
+        execution_backend_path = latest_headers.get("x-tokenplace-api-v1-execution-backend-path")
         assert provider_class in (None, "DistributedApiV1ComputeProvider")
         assert resolved_provider_path in (None, "distributed")
+        assert execution_backend_path in (None, "distributed_relay_e2ee")
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(
@@ -587,9 +590,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             for line in stderr_lines
             if "desktop.compute_node_bridge.process_request" in line
         ]
-        assert not process_request_lines, (
-            "desktop bridge should not process relay requests while distributed API v1 is fail-closed"
-        )
+        assert process_request_lines, "desktop bridge should process relay requests for API v1 E2EE mode"
     finally:
         if bridge_process.stdin:
             try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -241,7 +241,10 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     assert response.status_code == 503
     data = response.get_json()
     assert data['error']['type'] == 'service_unavailable_error'
-    assert data['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert data['error']['code'] in {
+        'compute_node_unreachable',
+        'no_registered_compute_nodes',
+    }
 
 
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):
@@ -275,12 +278,17 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')
     monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
 
-    monkeypatch.setattr(
-        'api.v1.routes.get_api_v1_compute_provider',
-        lambda: importlib.import_module('api.v1.compute_provider').DistributedApiV1ComputeProvider(
-            base_url='https://compute.example'
-        ),
-    )
+    class _FailingDistributedProvider:
+        def complete_chat(self, **_kwargs):
+            raise importlib.import_module('api.v1.compute_provider').ComputeProviderError(
+                "No LLM servers are available right now.",
+                code="no_registered_compute_nodes",
+                error_type="service_unavailable_error",
+                public_message="No LLM servers are available right now.",
+                status_code=503,
+            )
+
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: _FailingDistributedProvider())
 
     local_generate = MagicMock(side_effect=AssertionError('local generation should not run'))
     monkeypatch.setattr('api.v1.compute_provider.generate_response', local_generate)
@@ -294,7 +302,7 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
     )
 
     assert response.status_code == 503
-    assert response.get_json()['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert response.get_json()['error']['code'] == 'no_registered_compute_nodes'
     local_generate.assert_not_called()
 
 

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -9,20 +9,71 @@ from api.v1.compute_provider import (
 from relay import app
 
 
-def test_distributed_compute_provider_fails_closed_without_relay_calls():
+def test_distributed_compute_provider_uses_e2ee_relay_envelope(monkeypatch):
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+    captured_faucet_payload = {}
 
-    try:
-        provider.complete_chat(
-            model_id="llama-3-8b-instruct",
-            messages=[{"role": "user", "content": "hi"}],
-            options={"temperature": 0.2},
-        )
-        raise AssertionError("expected ComputeProviderError")
-    except ComputeProviderError as exc:
-        assert exc.code == "distributed_api_v1_relay_disabled"
-        assert exc.error_type == "service_unavailable_error"
-        assert exc.status_code == 503
+    monkeypatch.setattr(
+        compute_provider.encryption_manager,
+        "encrypt_message",
+        lambda payload, _server_key: {
+            "encrypted": True,
+            "ciphertext": "ciphertext-envelope",
+            "cipherkey": "cipherkey-envelope",
+            "iv": "iv-envelope",
+        },
+    )
+    monkeypatch.setattr(
+        compute_provider.encryption_manager,
+        "decrypt_message",
+        lambda _ciphertext_dict, _cipherkey: b'{"api_v1_response":{"message":{"role":"assistant","content":"hi"}}}',
+    )
+
+    class DummyResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: DummyResponse({"server_public_key": "server-key-b64"}),
+    )
+
+    retrieve_calls = {"count": 0}
+
+    def fake_post(url, **kwargs):
+        if url.endswith("/faucet"):
+            captured_faucet_payload.update(kwargs["json"])
+            return DummyResponse({"message": "ok"})
+        if url.endswith("/retrieve"):
+            retrieve_calls["count"] += 1
+            return DummyResponse(
+                {
+                    "chat_history": "cmVzcG9uc2UtY2lwaGVydGV4dA==",
+                    "cipherkey": "Y2lwaGVya2V5",
+                    "iv": "aXY=",
+                }
+            )
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    message = provider.complete_chat(
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={"temperature": 0.2},
+    )
+
+    assert message == {"role": "assistant", "content": "hi"}
+    assert "messages" not in captured_faucet_payload
+    assert captured_faucet_payload["chat_history"] == "ciphertext-envelope"
+    assert retrieve_calls["count"] == 1
 
 
 def test_fallback_compute_provider_uses_local_adapter_when_distributed_disabled(monkeypatch):
@@ -124,6 +175,20 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://node-a.example")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
     compute_provider._build_api_v1_compute_provider.cache_clear()
+    class _FailingDistributedProvider:
+        def complete_chat(self, **_kwargs):
+            raise ComputeProviderError(
+                "No LLM servers are available right now.",
+                code="no_registered_compute_nodes",
+                error_type="service_unavailable_error",
+                public_message="No LLM servers are available right now.",
+                status_code=503,
+            )
+
+    monkeypatch.setattr(
+        "api.v1.routes.get_api_v1_compute_provider",
+        lambda: _FailingDistributedProvider(),
+    )
 
     app.config["TESTING"] = True
     with app.test_client() as client:
@@ -139,6 +204,6 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
         assert response.status_code == 503
         error = response.get_json()["error"]
         assert error["type"] == "service_unavailable_error"
-        assert error["code"] == "distributed_api_v1_relay_disabled"
+        assert error["code"] == "no_registered_compute_nodes"
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -167,6 +167,17 @@ def _extract_chat_history_and_validate_key_binding(
     return None
 
 
+def _is_api_v1_e2ee_envelope(payload: Any) -> bool:
+    """Return True when the decrypted payload matches the API v1 E2EE envelope shape."""
+
+    if not isinstance(payload, dict):
+        return False
+    return (
+        payload.get("protocol") == "api_v1_e2ee"
+        and isinstance(payload.get("api_v1_request"), dict)
+    )
+
+
 class RelayClient:
     """
     Client for communicating with relay servers.
@@ -626,13 +637,20 @@ class RelayClient:
                 return False
 
             log_info("Decrypted client request")
+            client_pub_key = base64.b64decode(client_pub_key_b64)
+            if _is_api_v1_e2ee_envelope(decrypted_chat_history):
+                return self.process_api_v1_chat_request(
+                    decrypted_chat_history,
+                    client_pub_key_b64=client_pub_key_b64,
+                    client_pub_key=client_pub_key,
+                )
+
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,
                 client_pub_key_b64,
             )
             if chat_history is None:
                 return False
-            client_pub_key = base64.b64decode(client_pub_key_b64)
 
             if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
                 log_info("Processing streaming relay request for session {}", stream_session_id)
@@ -734,11 +752,96 @@ class RelayClient:
             log_error("Exception during request processing: {}", str(e), exc_info=True)
             return False
 
-    def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
-        """Relay API v1 plaintext dispatch is disabled pending an E2EE-compatible design."""
+    def process_api_v1_chat_request(
+        self,
+        request_data: Dict[str, Any],
+        *,
+        client_pub_key_b64: str,
+        client_pub_key: bytes,
+    ) -> bool:
+        """Process an API v1 E2EE relay request and return an encrypted API v1 response envelope."""
 
-        log_error("Rejected disabled relay API v1 payload dispatch")
-        return False
+        api_v1_request = request_data.get("api_v1_request")
+        if not isinstance(api_v1_request, dict):
+            log_error("Invalid API v1 relay payload: missing api_v1_request object")
+            return False
+
+        model_id = api_v1_request.get("model")
+        messages = api_v1_request.get("messages")
+        options = api_v1_request.get("options", {})
+        request_id = api_v1_request.get("request_id")
+        if not isinstance(model_id, str) or not isinstance(messages, list):
+            log_error("Invalid API v1 relay payload: model/messages types are invalid")
+            return False
+        if options is None:
+            options = {}
+        if not isinstance(options, dict):
+            log_error("Invalid API v1 relay payload: options must be an object")
+            return False
+
+        response_payload: Dict[str, Any]
+        try:
+            from api.v1.models import generate_response
+
+            response_messages = generate_response(model_id, messages, **options)
+            if not response_messages or not isinstance(response_messages[-1], dict):
+                raise ValueError("API v1 compute node returned invalid response history")
+            response_payload = {
+                "protocol": "api_v1_e2ee",
+                "version": 1,
+                "request_id": request_id,
+                "api_v1_response": {
+                    "message": response_messages[-1],
+                },
+            }
+        except Exception as exc:
+            log_error("API v1 relay compute failed: {}", str(exc), exc_info=True)
+            response_payload = {
+                "protocol": "api_v1_e2ee",
+                "version": 1,
+                "request_id": request_id,
+                "api_v1_error": {
+                    "code": "compute_node_bridge_error",
+                    "message": "Unable to generate a distributed API v1 response.",
+                },
+            }
+
+        encrypted_response = self.crypto_manager.encrypt_message(response_payload, client_pub_key)
+        if not isinstance(encrypted_response, dict):
+            log_error("Failed to encrypt API v1 relay response payload")
+            return False
+        source_payload = {
+            'client_public_key': client_pub_key_b64,
+            **encrypted_response
+        }
+        try:
+            jsonschema.validate(instance=source_payload, schema=MESSAGE_SCHEMA)
+        except jsonschema.exceptions.ValidationError as e:
+            log_error("Invalid response payload format: {}", str(e))
+            return False
+
+        request_kwargs = {
+            'json': source_payload,
+            'timeout': self._request_timeout,
+        }
+        headers = self._auth_headers()
+        if headers:
+            request_kwargs['headers'] = headers
+
+        timeout = request_kwargs.pop('timeout', self._request_timeout)
+        try:
+            source_response = requests.post(
+                f'{self.relay_url}/source',
+                timeout=timeout,
+                **request_kwargs
+            )
+        except requests.RequestException as exc:
+            log_error("API v1 relay failed posting response: {}", str(exc), exc_info=True)
+            return False
+        if source_response.status_code != 200:
+            log_error("Error status from /source: {}", source_response.status_code)
+            return False
+        return True
 
     def poll_relay_continuously(self):  # pragma: no cover
         """


### PR DESCRIPTION
### Motivation
- Re-enable distributed API v1 compute while preserving the invariant that the relay sees ciphertext only, by implementing a minimal reviewed E2EE envelope for relay dispatch. 
- Preserve local in-process API v1/v2 behavior and legacy ciphertext `/sink` + `/faucet` routing while avoiding any relay-visible plaintext payloads.

### Description
- Implement a minimal API v1 E2EE envelope in `DistributedApiV1ComputeProvider.complete_chat()` that builds an `api_v1_e2ee` payload, encrypts it with the target compute node public key, posts only ciphertext fields to the relay `/faucet`, polls `/retrieve`, decrypts the returned envelope, and returns the assistant message or mapped structured errors. (`api/v1/compute_provider.py`)
- Extend the compute-node relay client so decrypted relay payloads are recognized as `api_v1_e2ee` envelopes (`_is_api_v1_e2ee_envelope`) and handled by `process_api_v1_chat_request`, which runs `api.v1.models.generate_response`, wraps the assistant message in an encrypted `api_v1_response` envelope, and posts it back to the relay `/source` using ciphertext-only fields. (`utils/networking/relay_client.py`)
- Keep relay-visible transport shape unchanged: relay state and endpoints continue to exchange only `chat_history`/`cipherkey`/`iv` plus safe routing metadata and public keys; no plaintext `messages` are queued or posted to relay endpoints.
- Update tests and landing-page guardrail expectations to reflect restored E2EE behavior: unit tests assert the provider uses ciphertext envelopes and that the landing-page desktop-bridge E2E guardrail expects successful E2EE processing (or explicit distributed failures when no nodes are available). (tests under `tests/test_api.py`, `tests/unit/test_api_v1_compute_provider.py`, `tests/e2e/test_ui.py`)

### Testing
- Ran `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py` and the targeted suites covering relay and API v1 changes passed.
- Ran `python -m pytest -q tests/unit/test_api_v2_error_handling.py tests/unit/test_api_v2_routes_coverage.py` and those v2/unit suites passed.
- Ran `pre-commit run --all-files` and the configured checks completed successfully in this environment.
- Attempting a full `python -m pytest -q` in this CI-like environment hit unrelated integration/E2E issues: a small number of integration tests timed out waiting for external relay/server registration and Playwright browser binaries are not installed here (the E2E guardrail run requires `playwright install`), both of which are environment-specific and not caused by these code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb098def8c832f8017da3f95115421)