### PR TITLE
Add E2EE relay anti-regression safeguards: tests, docs, and agent guidance

### DIFF
--- a/.github/instructions/e2ee_relay_invariant.instructions.md
+++ b/.github/instructions/e2ee_relay_invariant.instructions.md
@@ -1,0 +1,11 @@
+# E2EE relay invariant for coding agents
+
+When editing relay/API v1 distributed paths, preserve this invariant:
+
+- relay path traffic must be relay-blind E2EE,
+- no plaintext `messages`/`prompt`/tool content/model text in relay queues,
+- no plaintext in relay-targeted network payloads,
+- no plaintext in logs, diagnostics, or error echoes.
+
+If a change needs plaintext, keep it out of distributed relay mode or fail closed.
+Update sentinel tests in `tests/unit/test_e2ee_relay_invariant.py` with any relay/API changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,8 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 ### Prompt Agent
 - **When:** you run `flywheel prompt`
 - **Does:** generate context-aware prompts for Codex or other LLM assistants
+
+## Relay-blind E2EE invariant (must not regress)
+- Distributed relay inference must remain relay-blind E2EE (ciphertext + routing metadata only).
+- Never enqueue, forward, log, diagnose, or expose plaintext model payload content on relay paths.
+- If distributed plaintext would otherwise occur, fail closed and add sentinel tests.

--- a/docs/security/e2ee_relay_invariant.md
+++ b/docs/security/e2ee_relay_invariant.md
@@ -1,0 +1,22 @@
+# Relay-blind E2EE invariant
+
+Distributed inference over relay paths must be relay-blind end-to-end encryption.
+
+## Core rules
+- Relay-visible data must be ciphertext plus safe routing metadata only.
+- Never queue plaintext model content in relay-owned state (`client_inference_requests`,
+  response queues, or stream session state).
+- Never send OpenAI-style plaintext (`messages`, `prompt`, tool arguments, model output text)
+  to relay endpoints.
+- Never log, diagnose, or echo distributed plaintext payloads.
+
+## For coding agents
+- Do not route `messages`/`prompt` through relay in plaintext.
+- Do not add relay queue fields containing plaintext model content.
+- Do not POST raw model payloads to relay endpoints.
+- Do not include plaintext distributed payload content in logs/diagnostics/errors.
+- If plaintext is required, run outside relay-blind distributed mode or fail closed.
+- Add/update sentinel tests for relay state, network egress, logs, diagnostics, and API responses.
+
+## Guardrails in tests
+- `tests/unit/test_e2ee_relay_invariant.py` contains static and runtime anti-regression sentinels.

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -1,0 +1,132 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import relay as relay_module
+from api.v1 import compute_provider
+from relay import app, client_inference_requests, client_responses, known_servers, streaming_sessions
+
+RELAY_STATE_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT"
+NETWORK_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT"
+LOG_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS"
+
+
+def _scan_text(value):
+    try:
+        return json.dumps(value, sort_keys=True, default=repr)
+    except Exception:
+        return repr(value)
+
+
+@pytest.fixture
+def relay_client():
+    app.config["TESTING"] = True
+    known_servers.clear()
+    client_inference_requests.clear()
+    client_responses.clear()
+    streaming_sessions.clear()
+    with app.test_client() as client:
+        yield client
+
+
+def test_static_forbidden_plaintext_patterns_absent():
+    files = [Path("relay.py"), Path("api/v1/compute_provider.py"), Path("server.py")]
+    disallowed = [
+        "client_inference_requests.setdefault(server_public_key, []).append({'api_v1_request'",
+        '/relay/api/v1/chat/completions", json={"messages"',
+        "api_v1_request.messages",
+    ]
+    for file in files:
+        content = file.read_text(encoding="utf-8")
+        for token in disallowed:
+            assert token not in content, f"{token} unexpectedly present in {file}"
+
+
+def test_runtime_relay_state_sentinel_not_queued_when_distributed_plaintext_path_called(relay_client):
+    response = relay_client.post(
+        "/relay/api/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": RELAY_STATE_SENTINEL}]},
+    )
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["code"] == "distributed_api_v1_relay_disabled"
+    assert RELAY_STATE_SENTINEL not in _scan_text(client_inference_requests)
+    assert RELAY_STATE_SENTINEL not in _scan_text(client_responses)
+    assert RELAY_STATE_SENTINEL not in _scan_text(streaming_sessions)
+
+
+def test_network_egress_plaintext_sentinel_never_leaves_process(monkeypatch):
+    captured = []
+
+    def _capture(method, url, **kwargs):
+        captured.append({"method": method, "url": url, "kwargs": kwargs})
+        raise AssertionError("network should not be called in fail-closed mode")
+
+    monkeypatch.setattr(compute_provider.requests, "post", lambda url, **kwargs: _capture("post", url, **kwargs))
+    monkeypatch.setattr(compute_provider.requests, "get", lambda url, **kwargs: _capture("get", url, **kwargs))
+    monkeypatch.setattr(compute_provider.requests, "request", lambda method, url, **kwargs: _capture(method, url, **kwargs))
+    monkeypatch.setattr(
+        compute_provider.requests.sessions.Session,
+        "request",
+        lambda self, method, url, **kwargs: _capture(method, url, **kwargs),
+    )
+
+    with app.test_client() as client:
+        resp = client.post(
+            "/relay/api/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": NETWORK_SENTINEL}]},
+        )
+    assert resp.status_code == 503
+    for outbound in captured:
+        assert NETWORK_SENTINEL not in _scan_text(outbound)
+
+
+def test_logs_and_diagnostics_never_echo_plaintext_sentinel(relay_client, caplog):
+    caplog.set_level("INFO")
+    relay_client.post(
+        "/relay/api/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": LOG_SENTINEL}]},
+    )
+    diagnostics = relay_client.get("/relay/diagnostics").get_json()
+    assert LOG_SENTINEL not in diagnostics.__repr__()
+    for record in caplog.records:
+        assert LOG_SENTINEL not in record.getMessage()
+        assert LOG_SENTINEL not in repr(record.__dict__)
+
+
+def test_local_plaintext_allowed_but_relay_plaintext_forbidden(monkeypatch):
+    provider = compute_provider.LocalApiV1ComputeProvider()
+    monkeypatch.setattr(
+        compute_provider,
+        "generate_response",
+        lambda _model, messages, **_opts: [*messages, {"role": "assistant", "content": "ok"}],
+    )
+    response = provider.complete_chat(
+        model_id="model",
+        messages=[{"role": "user", "content": "local plaintext is allowed"}],
+    )
+    assert response["content"] == "ok"
+
+    with app.test_client() as client:
+        relay_resp = client.post(
+            "/relay/api/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "forbidden distributed plaintext"}]},
+        )
+    assert relay_resp.status_code == 503
+
+
+def test_sink_and_faucet_ciphertext_contract_preserved(relay_client):
+    server_key = "server-key"
+    relay_client.post("/sink", json={"server_public_key": server_key})
+    faucet_payload = {
+        "client_public_key": "client-key",
+        "server_public_key": server_key,
+        "chat_history": "ciphertext",
+        "cipherkey": "cipherkey",
+        "iv": "iv",
+    }
+    faucet_response = relay_client.post("/faucet", json=faucet_payload)
+    assert faucet_response.status_code == 200
+    sink_response = relay_client.post("/sink", json={"server_public_key": server_key}).get_json()
+    assert sink_response["chat_history"] == "ciphertext"


### PR DESCRIPTION
### Motivation
- Prevent reintroduction of plaintext relay dispatch by adding durable, multi-layer guardrails around the relay/API v1 distributed path. 
- Lock the current Prompt‑2 state for distributed API v1 (fail‑closed or relay‑blind E2EE as already established) and make it obvious to future maintainers and coding agents. 

### Description
- Add a new test module `tests/unit/test_e2ee_relay_invariant.py` which implements: a static source-pattern scanner for forbidden plaintext relay shapes, runtime relay-state sentinel checks (`E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT`), network egress monkeypatch captures (`E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT`), and log/diagnostics assertions (`E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS`), plus contract checks distinguishing local plaintext from forbidden distributed plaintext. 
- Preserve legacy ciphertext `/faucet` + `/sink` behavior via tests that assert ciphertext is queued and returned while plaintext relay paths fail closed. 
- Add documentation `docs/security/e2ee_relay_invariant.md` that codifies the relay‑blind E2EE invariant and provides explicit “For coding agents” rules. 
- Add a concise invariant reminder to `AGENTS.md` and a short instruction file at `.github/instructions/e2ee_relay_invariant.instructions.md` so agents and maintainers see the invariant before editing relay/API code. 

### Testing
- Ran the focused verification commands used during the rollout: `python -m pytest -q tests/unit/test_e2ee_relay_invariant.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py`, `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'`, and `python -m pytest -q`, which were blocked in the current environment due to missing test dependencies (`ModuleNotFoundError: No module named 'requests'`), so full pytest runs could not complete here. 
- Performed repository searches that verify sentinel strings and invariant text are present; `rg` checks for the three sentinel constants and invariant keywords succeeded. 
- `pre-commit` could not be executed in this environment (`pre-commit` not installed), but the new tests and docs are included so CI (where dependencies are present) will run the full suite and enforce these safeguards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16308c454832fb7fac9a7cc212002)