### PR TITLE
Add permanent anti-regression safeguards for relay-blind E2EE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,10 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 ### Prompt Agent
 - **When:** you run `flywheel prompt`
 - **Does:** generate context-aware prompts for Codex or other LLM assistants
+
+## Security invariant: relay-blind E2EE (must-follow)
+- Distributed relay inference must be ciphertext-only for relay-visible payloads.
+- Never queue or forward plaintext `messages`/`prompt`/tool args/model output through relay state.
+- Never POST raw model payloads to relay endpoints; use approved encrypted envelopes only.
+- Never log or expose distributed plaintext in diagnostics/errors.
+- If plaintext is needed, keep it local/non-distributed or fail closed.

--- a/docs/security/e2ee_relay_invariant.md
+++ b/docs/security/e2ee_relay_invariant.md
@@ -1,0 +1,28 @@
+# Relay-blind E2EE invariant
+
+Distributed relay inference must remain relay-blind end-to-end encrypted (E2EE).
+
+## Rules
+
+- Relay-visible request/response payloads must be ciphertext plus safe routing metadata only.
+- Never route OpenAI-style `messages`, legacy `prompt`, tool args, or model output plaintext through relay queues.
+- Never queue plaintext in `client_inference_requests` or relay-owned response/streaming state.
+- Never POST raw model payloads to relay endpoints.
+- Never log, diagnose, or echo distributed plaintext payloads.
+- If plaintext handling is required for a feature, run it outside distributed relay mode or fail closed.
+
+## For coding agents
+
+Before editing relay/API/compute-node bridge code:
+
+1. Add/update sentinel tests for relay state, outbound network calls, logs, diagnostics, and API responses.
+2. Ensure distributed mode either:
+   - uses an approved encrypted envelope, or
+   - fails closed before queue/network dispatch.
+3. Preserve local plaintext behavior for non-distributed API routes without allowing relay plaintext paths.
+
+Sentinel strings used by regression tests:
+
+- `E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT`
+- `E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT`
+- `E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS`

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -306,6 +306,10 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
 
 @pytest.mark.e2e
+RELAY_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT"
+
+
+@pytest.mark.e2e
 def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
     page: Page,
     base_url: str,
@@ -471,10 +475,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             """
         )
 
-        prompt_text = (
-            "Reply with a short sentence confirming you received this message. "
-            "Keep it under ten words."
-        )
+        prompt_text = RELAY_SENTINEL
         textarea = page.locator("textarea").first
         page.evaluate(
             """
@@ -619,6 +620,9 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
+
+        combined_bridge_output = "".join(stderr_lines)
+        assert RELAY_SENTINEL not in combined_bridge_output
 
         process_request_lines = [
             line

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -1,0 +1,180 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import relay
+from api.v1 import compute_provider
+from relay import app, client_inference_requests, client_responses, streaming_sessions
+
+RELAY_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT"
+NETWORK_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT"
+LOG_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS"
+
+
+@pytest.fixture
+def relay_client():
+    app.config["TESTING"] = True
+    relay.known_servers.clear()
+    client_inference_requests.clear()
+    client_responses.clear()
+    streaming_sessions.clear()
+    with app.test_client() as client:
+        yield client
+
+
+def _flatten(value):
+    try:
+        return json.dumps(value, sort_keys=True, default=str)
+    except Exception:
+        return repr(value)
+
+
+def test_static_forbidden_plaintext_patterns_regression_guard():
+    repo_root = Path(__file__).resolve().parents[2]
+    targets = [
+        repo_root / "relay.py",
+        repo_root / "api/v1/compute_provider.py",
+        repo_root / "api/v1/routes.py",
+        repo_root / "desktop-tauri/src-tauri/python/compute_node_bridge.py",
+    ]
+
+    forbidden = [
+        "client_inference_requests.setdefault(server_public_key, []).append({\"api_v1_request\"",
+        '"api_v1_request": {"messages"',
+        '"/relay/api/v1/chat/completions"',
+        "api_v1_request.messages",
+    ]
+    allowed_exceptions = {
+        "api/v1/compute_provider.py": ["\"api_v1_request\": {"],
+        "relay.py": ["if 'api_v1_request' in request_payload:"],
+    }
+
+    for marker in forbidden:
+        for path in targets:
+            content = path.read_text(encoding="utf-8")
+            if marker in content:
+                exception_hits = any(
+                    marker in allowed for allowed in allowed_exceptions.get(path.relative_to(repo_root).as_posix(), [])
+                )
+                assert exception_hits, f"Forbidden plaintext relay pattern in {path}: {marker}"
+
+
+def test_runtime_relay_state_never_contains_plaintext_sentinel(relay_client):
+    response = relay_client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": RELAY_SENTINEL}],
+            "distributed": True,
+        },
+    )
+    assert response.status_code == 503
+
+    state_dump = _flatten(
+        {
+            "client_inference_requests": client_inference_requests,
+            "client_responses": client_responses,
+            "streaming_sessions": streaming_sessions,
+            "diagnostics": relay_client.get("/relay/diagnostics").get_json(),
+        }
+    )
+    assert RELAY_SENTINEL not in state_dump
+    assert all(not queued for queued in client_inference_requests.values())
+
+
+def test_network_egress_guard_no_plaintext_sentinel_to_relay(monkeypatch):
+    outbound = []
+
+    def _record(method_name):
+        def _inner(url, **kwargs):
+            outbound.append({"method": method_name, "url": url, "kwargs": kwargs})
+            class _Resp:
+                status_code = 503
+
+                @staticmethod
+                def json():
+                    return {"error": {"code": "distributed_api_v1_relay_disabled"}}
+
+            return _Resp()
+
+        return _inner
+
+    monkeypatch.setattr(compute_provider.requests, "post", _record("post"))
+    monkeypatch.setattr(compute_provider.requests, "get", _record("get"))
+    monkeypatch.setattr(compute_provider.requests, "request", lambda *a, **k: _record("request")(a[1], **k))
+    monkeypatch.setattr(compute_provider.requests.Session, "request", lambda *a, **k: _record("session")(a[2], **k))
+
+    provider = compute_provider.DistributedApiV1ComputeProvider(
+        base_url="https://relay.example",
+        timeout_seconds=0.01,
+    )
+    with pytest.raises(compute_provider.ComputeProviderError):
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": NETWORK_SENTINEL}],
+        )
+
+    for call in outbound:
+        assert NETWORK_SENTINEL not in _flatten(call)
+
+
+def test_log_and_diagnostics_never_echo_plaintext(caplog, relay_client):
+    caplog.set_level("INFO")
+    response = relay_client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": LOG_SENTINEL}],
+            "distributed": True,
+        },
+    )
+    assert response.status_code == 503
+
+    logs_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert LOG_SENTINEL not in logs_text
+    assert LOG_SENTINEL not in _flatten(response.get_json())
+    assert LOG_SENTINEL not in _flatten(relay_client.get("/relay/diagnostics").get_json())
+
+
+def test_contract_local_plaintext_allowed_distributed_plaintext_forbidden(relay_client):
+    local_response = relay_client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "local-plaintext-ok"}],
+            "distributed": False,
+        },
+    )
+    assert local_response.status_code in {200, 500, 503}
+
+    distributed_response = relay_client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "distributed-plaintext-forbidden"}],
+            "distributed": True,
+        },
+    )
+    assert distributed_response.status_code == 503
+    payload = distributed_response.get_json()
+    assert payload and payload.get("error", {}).get("code") == "distributed_api_v1_relay_disabled"
+
+
+def test_contract_legacy_sink_faucet_ciphertext_only(relay_client):
+    sink_registration = relay_client.post("/sink", json={"server_public_key": "server-key"})
+    assert sink_registration.status_code == 200
+
+    faucet_payload = {
+        "client_public_key": "client-key",
+        "server_public_key": "server-key",
+        "chat_history": "ciphertext",
+        "cipherkey": "encrypted-key",
+        "iv": "encrypted-iv",
+    }
+    faucet_response = relay_client.post("/faucet", json=faucet_payload)
+    assert faucet_response.status_code == 200
+
+    work = relay_client.post("/sink", json={"server_public_key": "server-key", "max_batch_size": 1}).get_json()
+    assert work["chat_history"] == "ciphertext"
+    assert "messages" not in _flatten(work)


### PR DESCRIPTION
### Motivation
- Prevent reintroduction of PR #813–style plaintext relay dispatch by adding durable multi-layer guardrails. 
- Ensure the relay can only see ciphertext and safe routing metadata across static, runtime, network, log/diagnostic, and contract surfaces. 
- Make the invariant discoverable to future maintainers and coding agents so changes touching relay/API/compute-node code must respect relay-blind E2EE.

### Description
- Add `tests/unit/test_e2ee_relay_invariant.py` containing a static forbidden-pattern scan, a runtime relay-state sentinel (`E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT`), network egress monkeypatch sentinels (`E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT`), log/diagnostics assertions (`E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS`), and contract checks that distinguish local plaintext from forbidden distributed plaintext. 
- Harden the landing-page desktop-bridge guardrail in `tests/e2e/test_ui.py` by using the relay plaintext sentinel as the prompt and asserting the bridge stderr/log output never contains the sentinel while preserving existing E2EE / non-streaming assertions. 
- Add agent-facing documentation `docs/security/e2ee_relay_invariant.md` that codifies the must-follow relay-blind E2EE rules and required sentinel strings for future tests. 
- Update `AGENTS.md` with a compact, must-follow invariant note so coding agents see the invariant before editing relay/API code.

### Testing
- Attempted the verification command `python -m pytest -q tests/unit/test_e2ee_relay_invariant.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py`, but local runs were blocked by missing test/runtime deps initially (`requests`) and then by `playwright` required by the test harness, so the full pytest suite did not complete locally. 
- Ran `python -m pytest -q tests/unit/test_e2ee_relay_invariant.py` which failed to load test fixtures due to missing `playwright` in the environment (expected in CI). 
- Executed repository searches (`rg`) to confirm sentinel strings and invariant references were added and discovered in `tests`, `docs`, and `AGENTS.md`; those pattern checks succeeded. 
- `pre-commit` was not available in the local environment so `pre-commit run --all-files` was not executed locally; CI will run the full test matrix where the new guards should fail if a PR #813–style plaintext relay regression is reintroduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16308c454832fb7fac9a7cc212002)