### PR TITLE
Add permanent multi-layer anti-regression safeguards for relay-blind E2EE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,11 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
   sidecar launch, include regression coverage that asserts GPU mode does not
   silently fall back to CPU when GPU runtime support is expected.
 
+## Relay-blind E2EE invariant (must-follow)
+- Distributed relay inference must be relay-blind E2EE (ciphertext only + routing metadata).
+- Never queue, forward, log, diagnose, or expose plaintext model payload content in relay-owned state.
+- Any distributed plaintext path must fail closed unless replaced by an approved E2EE envelope path.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/docs/security/e2ee_relay_invariant.md
+++ b/docs/security/e2ee_relay_invariant.md
@@ -1,0 +1,37 @@
+# Relay-blind E2EE invariant (distributed inference)
+
+## Core rule
+
+For distributed inference, relay-visible traffic is **ciphertext only** plus safe routing metadata.
+Relay-owned systems must never receive or expose plaintext model payloads.
+
+Forbidden plaintext examples:
+- OpenAI-style `messages`
+- legacy `prompt`
+- assistant response text
+- tool-call arguments/content
+- equivalent future model payload fields
+
+## Guardrails in tests
+
+`tests/unit/test_e2ee_relay_invariant.py` enforces anti-regression safeguards:
+- static forbidden source-pattern scanning for PR #813-style relay plaintext paths;
+- runtime relay-state sentinel checks (queue/session/diagnostics);
+- outbound network egress sentinel checks (`requests.post/get/request` and
+  `requests.Session.request`);
+- log + diagnostics sentinel checks.
+
+Contract expectations retained:
+- Local/non-distributed API paths may process plaintext locally.
+- Distributed relay API v1 plaintext path must stay fail-closed unless using approved E2EE envelope.
+- Legacy `/sink` + `/faucet` flow remains ciphertext-envelope-based.
+
+## For coding agents
+
+- Never route OpenAI `messages` or legacy `prompt` through relay in plaintext.
+- Never add relay queue fields containing plaintext model content.
+- Never POST raw model payloads to relay endpoints.
+- Never log, diagnose, or echo distributed plaintext payload content.
+- If a feature requires plaintext, keep it outside relay-blind distributed mode or fail closed.
+- When in doubt, add sentinel tests for relay state, outbound network calls, logs,
+  diagnostics, and API responses.

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -626,6 +626,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             if "desktop.compute_node_bridge.process_request" in line
         ]
         assert process_request_lines, "desktop bridge should process encrypted relay requests"
+        bridge_stderr_text = "".join(stderr_lines)
+        assert "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT" not in bridge_stderr_text
+        assert "E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT" not in bridge_stderr_text
+        assert "E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS" not in bridge_stderr_text
     finally:
         if bridge_process.stdin:
             try:

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -79,6 +79,67 @@ def test_runtime_relay_state_never_stores_plaintext_sentinel_when_distributed_di
     assert E2EE_SENTINEL_RELAY_STATE not in diag_text
 
 
+def test_legacy_sink_and_faucet_contract_remains_ciphertext_only(relay_client):
+    relay.known_servers["server-key"] = {
+        "public_key": "server-key",
+        "last_ping": relay.datetime.now(),
+        "last_ping_duration": 10,
+    }
+    ciphertext_envelope = {
+        "chat_history": "abc",
+        "cipherkey": "def",
+        "iv": "ghi",
+        "client_public_key": "client-key",
+    }
+    relay.client_inference_requests["server-key"] = [ciphertext_envelope]
+
+    sink_response = relay_client.post("/sink", json={"server_public_key": "server-key"})
+    assert sink_response.status_code == 200
+    sink_payload = sink_response.get_json()
+    assert sink_payload["chat_history"] == ciphertext_envelope["chat_history"]
+    assert sink_payload["client_public_key"] == ciphertext_envelope["client_public_key"]
+    assert "messages" not in _to_text(sink_payload)
+
+    faucet_response = relay_client.post(
+        "/faucet",
+        json={
+            "chat_history": "rsp",
+            "cipherkey": "k",
+            "iv": "v",
+            "server_public_key": "server-key",
+            "client_public_key": "client-key",
+        },
+    )
+    assert faucet_response.status_code == 200
+    faucet_payload = faucet_response.get_json()
+    assert faucet_payload["message"] == "Request received"
+    assert E2EE_SENTINEL_RELAY_STATE not in _to_text(relay.client_responses)
+
+
+def test_local_api_v1_v2_plaintext_remains_allowed_when_not_distributed():
+    provider = compute_provider.LocalApiV1ComputeProvider()
+
+    def _fake_response(model, history, **_kwargs):
+        return history + [{"role": "assistant", "content": f"{model}-ok"}]
+
+    original = compute_provider.generate_response
+    compute_provider.generate_response = _fake_response
+    try:
+        result = provider.complete_chat(
+            model_id="llama-3",
+            messages=[{"role": "user", "content": "local-v1-plaintext-ok"}],
+            options={"temperature": 0.1},
+        )
+    finally:
+        compute_provider.generate_response = original
+
+    assert result["content"] == "llama-3-ok"
+    v2_routes_source = (Path(__file__).resolve().parents[2] / "api" / "v2" / "routes.py").read_text(
+        encoding="utf-8"
+    )
+    assert "distributed_api_v1_relay_disabled" not in v2_routes_source
+
+
 def test_network_egress_never_leaks_plaintext_sentinel_to_relay(monkeypatch):
     outbound = []
     crypto_manager = compute_provider.CryptoManager()
@@ -134,6 +195,9 @@ def test_logs_and_diagnostics_do_not_echo_plaintext_sentinel(caplog, relay_clien
         {"api_v1_request": {"messages": [{"role": "user", "content": E2EE_SENTINEL_LOGS}]}}
     ]
 
+    diagnostics_before_sink = _to_text(relay_client.get("/relay/diagnostics").get_json())
+    assert E2EE_SENTINEL_LOGS not in diagnostics_before_sink
+
     relay_logger = logging.getLogger("tokenplace.relay")
     relay_logger.addHandler(caplog.handler)
     try:
@@ -143,7 +207,7 @@ def test_logs_and_diagnostics_do_not_echo_plaintext_sentinel(caplog, relay_clien
     finally:
         relay_logger.removeHandler(caplog.handler)
 
-    logs_text = "\n".join(record.getMessage() for record in caplog.records)
+    logs_text = "\n".join(caplog.handler.format(record) for record in caplog.records)
     assert logs_text, "Expected relay logs to be captured during /sink request"
     assert E2EE_SENTINEL_LOGS not in logs_text
 

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -1,5 +1,7 @@
 import copy
 import json
+import logging
+import re
 from pathlib import Path
 
 import pytest
@@ -45,17 +47,13 @@ def test_static_forbidden_plaintext_patterns_regression_guard():
         root / "server.py",
     ]
     forbidden_patterns = [
-        "client_inference_requests.setdefault(server_public_key, []).append({\"api_v1_request\"",
-        "client_inference_requests.setdefault(server_public_key, []).append({'api_v1_request'",
-        "\"api_v1_request\": {\"messages\"",
-        "'api_v1_request': {'messages'",
-        "requests.post(self._relay_url('/relay/api/v1/chat/completions')",
-        "requests.post(self._relay_url(\"/relay/api/v1/chat/completions\")",
+        r"client_inference_requests\.setdefault\(server_public_key,\s*\[\]\)\.append\(\s*\{[^}]*api_v1_request[^}]*messages",
+        r"requests\.post\(self\._relay_url\((?:'|\")/relay/api/v1/chat/completions(?:'|\")\)",
     ]
 
     scanned = "\n\n".join(f.read_text(encoding="utf-8") for f in targets if f.exists())
 
-    matched = [pattern for pattern in forbidden_patterns if pattern in scanned]
+    matched = [pattern for pattern in forbidden_patterns if re.search(pattern, scanned, flags=re.DOTALL)]
     assert matched == [], (
         "Found forbidden plaintext relay-dispatch pattern(s): "
         f"{matched}. These patterns indicate PR #813-style regression risk."
@@ -83,6 +81,7 @@ def test_runtime_relay_state_never_stores_plaintext_sentinel_when_distributed_di
 
 def test_network_egress_never_leaks_plaintext_sentinel_to_relay(monkeypatch):
     outbound = []
+    crypto_manager = compute_provider.CryptoManager()
 
     class _Resp:
         def __init__(self, status_code, payload):
@@ -96,7 +95,9 @@ def test_network_egress_never_leaks_plaintext_sentinel_to_relay(monkeypatch):
         def _inner(url, **kwargs):
             outbound.append({"method": method, "url": url, "kwargs": copy.deepcopy(kwargs)})
             if str(url).endswith("/next_server"):
-                return _Resp(200, {"error": {"code": 503, "message": "No servers available"}})
+                return _Resp(200, {"server_public_key": crypto_manager.public_key_b64})
+            if str(url).endswith("/faucet"):
+                return _Resp(500, {"error": "forced faucet failure for test coverage"})
             return _Resp(500, {"error": "unexpected"})
 
         return _inner
@@ -117,9 +118,9 @@ def test_network_egress_never_leaks_plaintext_sentinel_to_relay(monkeypatch):
             options={"temperature": 0.1},
         )
 
-    relay_calls = [call for call in outbound if "relay" in call["url"]]
-    assert relay_calls, "Expected at least one relay-targeted outbound call"
-    serialized = _to_text(relay_calls)
+    faucet_calls = [call for call in outbound if str(call["url"]).endswith("/faucet")]
+    assert faucet_calls, "Expected an outbound /faucet relay request"
+    serialized = _to_text(faucet_calls)
     assert E2EE_SENTINEL_NETWORK not in serialized
 
 
@@ -133,10 +134,17 @@ def test_logs_and_diagnostics_do_not_echo_plaintext_sentinel(caplog, relay_clien
         {"api_v1_request": {"messages": [{"role": "user", "content": E2EE_SENTINEL_LOGS}]}}
     ]
 
-    sink_response = relay_client.post("/sink", json={"server_public_key": "server-key"})
-    assert sink_response.status_code == 200
+    relay_logger = logging.getLogger("tokenplace.relay")
+    relay_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="tokenplace.relay"):
+            sink_response = relay_client.post("/sink", json={"server_public_key": "server-key"})
+        assert sink_response.status_code == 200
+    finally:
+        relay_logger.removeHandler(caplog.handler)
 
     logs_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert logs_text, "Expected relay logs to be captured during /sink request"
     assert E2EE_SENTINEL_LOGS not in logs_text
 
     diagnostics_text = _to_text(relay_client.get("/relay/diagnostics").get_json())

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -1,0 +1,144 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+import relay
+from api.v1 import compute_provider
+
+E2EE_SENTINEL_RELAY_STATE = "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT"
+E2EE_SENTINEL_NETWORK = "E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT"
+E2EE_SENTINEL_LOGS = "E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS"
+
+
+@pytest.fixture
+def relay_client():
+    relay.app.config["TESTING"] = True
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    relay.streaming_sessions.clear()
+    relay.streaming_sessions_by_client.clear()
+    with relay.app.test_client() as client:
+        yield client
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    relay.streaming_sessions.clear()
+    relay.streaming_sessions_by_client.clear()
+
+
+def _to_text(value):
+    try:
+        return json.dumps(value, sort_keys=True, default=repr)
+    except TypeError:
+        return repr(value)
+
+
+def test_static_forbidden_plaintext_patterns_regression_guard():
+    root = Path(__file__).resolve().parents[2]
+    targets = [
+        root / "relay.py",
+        root / "api" / "v1" / "compute_provider.py",
+        root / "api" / "v1" / "routes.py",
+        root / "server.py",
+    ]
+    forbidden_patterns = [
+        "client_inference_requests.setdefault(server_public_key, []).append({\"api_v1_request\"",
+        "client_inference_requests.setdefault(server_public_key, []).append({'api_v1_request'",
+        "\"api_v1_request\": {\"messages\"",
+        "'api_v1_request': {'messages'",
+        "requests.post(self._relay_url('/relay/api/v1/chat/completions')",
+        "requests.post(self._relay_url(\"/relay/api/v1/chat/completions\")",
+    ]
+
+    scanned = "\n\n".join(f.read_text(encoding="utf-8") for f in targets if f.exists())
+
+    matched = [pattern for pattern in forbidden_patterns if pattern in scanned]
+    assert matched == [], (
+        "Found forbidden plaintext relay-dispatch pattern(s): "
+        f"{matched}. These patterns indicate PR #813-style regression risk."
+    )
+
+
+def test_runtime_relay_state_never_stores_plaintext_sentinel_when_distributed_disabled(relay_client):
+    payload = {
+        "model": "llama-3",
+        "messages": [{"role": "user", "content": E2EE_SENTINEL_RELAY_STATE}],
+    }
+    response = relay_client.post("/relay/api/v1/chat/completions", json=payload)
+    assert response.status_code == 503
+    assert response.get_json()["error"]["code"] == "distributed_api_v1_relay_disabled"
+
+    assert relay.client_inference_requests == {}
+    assert relay.client_responses == {}
+    assert relay.streaming_sessions == {}
+    assert relay.streaming_sessions_by_client == {}
+
+    diagnostics = relay_client.get("/relay/diagnostics")
+    diag_text = _to_text(diagnostics.get_json())
+    assert E2EE_SENTINEL_RELAY_STATE not in diag_text
+
+
+def test_network_egress_never_leaks_plaintext_sentinel_to_relay(monkeypatch):
+    outbound = []
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return copy.deepcopy(self._payload)
+
+    def _capture(method):
+        def _inner(url, **kwargs):
+            outbound.append({"method": method, "url": url, "kwargs": copy.deepcopy(kwargs)})
+            if str(url).endswith("/next_server"):
+                return _Resp(200, {"error": {"code": 503, "message": "No servers available"}})
+            return _Resp(500, {"error": "unexpected"})
+
+        return _inner
+
+    monkeypatch.setattr(compute_provider.requests, "post", _capture("post"))
+    monkeypatch.setattr(compute_provider.requests, "get", _capture("get"))
+    monkeypatch.setattr(compute_provider.requests, "request", _capture("request"))
+    monkeypatch.setattr(compute_provider.requests.Session, "request", lambda *_a, **_k: _Resp(599, {}))
+
+    provider = compute_provider.DistributedApiV1ComputeProvider(
+        base_url="https://relay.example",
+        timeout_seconds=0.1,
+    )
+    with pytest.raises(compute_provider.ComputeProviderError):
+        provider.complete_chat(
+            model_id="llama-3",
+            messages=[{"role": "user", "content": E2EE_SENTINEL_NETWORK}],
+            options={"temperature": 0.1},
+        )
+
+    relay_calls = [call for call in outbound if "relay" in call["url"]]
+    assert relay_calls, "Expected at least one relay-targeted outbound call"
+    serialized = _to_text(relay_calls)
+    assert E2EE_SENTINEL_NETWORK not in serialized
+
+
+def test_logs_and_diagnostics_do_not_echo_plaintext_sentinel(caplog, relay_client):
+    relay.known_servers["server-key"] = {
+        "public_key": "server-key",
+        "last_ping": relay.datetime.now(),
+        "last_ping_duration": 10,
+    }
+    relay.client_inference_requests["server-key"] = [
+        {"api_v1_request": {"messages": [{"role": "user", "content": E2EE_SENTINEL_LOGS}]}}
+    ]
+
+    sink_response = relay_client.post("/sink", json={"server_public_key": "server-key"})
+    assert sink_response.status_code == 200
+
+    logs_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert E2EE_SENTINEL_LOGS not in logs_text
+
+    diagnostics_text = _to_text(relay_client.get("/relay/diagnostics").get_json())
+    assert E2EE_SENTINEL_LOGS not in diagnostics_text
+    assert _to_text(sink_response.get_json()).find(E2EE_SENTINEL_LOGS) == -1


### PR DESCRIPTION
### Motivation
- Prevent reintroduction of PR #813-style plaintext relay dispatch by adding durable, multi-layer safeguards across source, runtime, network, and logs. 
- Ensure relay-owned state, relay-targeted network egress, and diagnostics never include plaintext model payloads while preserving the existing Prompt-2 final behavior (fail-closed or approved E2EE envelope). 
- Provide a short, high-visibility invariant for coding agents so future edits hit the constraint before changing relay/API code.

### Description
- Add `tests/unit/test_e2ee_relay_invariant.py` implementing: a static forbidden-pattern scanner for risky source shapes, runtime relay-state sentinel checks (`E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT`), network egress sentinel checks (`E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT`) that monkeypatch `requests` calls including `Session.request`, and log/diagnostics sentinel checks (`E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS`).
- Add documentation at `docs/security/e2ee_relay_invariant.md` describing the ciphertext-only invariant, forbidden fields, test guardrails, and explicit “For coding agents” rules. 
- Insert a compact relay-blind E2EE invariant note into root `AGENTS.md` to surface the rule to automated agents and maintainers. 
- No changes to distributed relay implementation were made (only tests/docs and small testability hooks via test scaffolding), and legacy `/sink`+`/faucet` ciphertext behavior and local API v1/v2 behavior were preserved.

### Testing
- Ran `python -m pytest -q tests/unit/test_e2ee_relay_invariant.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py` and the invoked suites completed successfully (unit invariant + relay + compute provider checks passed; `57 passed`).
- Attempted `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'` which errored in this environment due to missing Playwright browser binaries (environment limitation), not a code regression. 
- Ran `pre-commit run --all-files` which completed successfully, and ran repository `rg` checks for sentinel strings and invariant keywords which all reported expected matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16308c454832fb7fac9a7cc212002)