### PR TITLE
Add relay-blind E2EE anti-regression safeguards (tests + docs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
   sidecar launch, include regression coverage that asserts GPU mode does not
   silently fall back to CPU when GPU runtime support is expected.
 
+
+## Relay-blind E2EE invariant (must-follow)
+- Distributed inference relay traffic is ciphertext-only; relay-visible plaintext model payload content is forbidden.
+- Never queue, log, diagnose, forward, or echo OpenAI `messages`/`prompt` plaintext through relay-owned state or relay-targeted network calls.
+- If distributed relay cannot satisfy relay-blind E2EE, fail closed.
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/docs/security/e2ee_relay_invariant.md
+++ b/docs/security/e2ee_relay_invariant.md
@@ -1,0 +1,25 @@
+# relay-blind E2EE invariant
+
+Distributed inference through relay paths must be relay-blind end-to-end encryption.
+
+## Rules
+
+- Relay-visible distributed payloads must be ciphertext-only plus safe routing metadata.
+- Never put OpenAI-style plaintext `messages`, legacy `prompt`, tool-call arguments, or model output text in relay-owned queue state (`client_inference_requests`) or relay diagnostics/logging.
+- Never POST raw model payloads to relay-dispatch endpoints; distributed API relay paths must fail closed unless an approved encrypted envelope is used.
+- If a feature requires plaintext processing, run it in local/non-distributed mode or fail closed.
+
+## Safeguard tests
+
+- `tests/unit/test_e2ee_relay_invariant.py` includes static forbidden-pattern checks and plaintext sentinel checks for relay state, network egress, logs/diagnostics, and local-vs-distributed API contracts.
+- `tests/test_relay.py` and `tests/unit/test_api_v1_compute_provider.py` cover relay queue contracts and encrypted envelope behavior.
+
+## For coding agents
+
+Before changing relay/API code:
+
+1. Do not route `messages`/`prompt` plaintext through relay.
+2. Do not add relay queue fields containing plaintext model content.
+3. Do not send raw model payloads to relay endpoints.
+4. Do not log/diagnose/echo distributed plaintext payload content.
+5. If uncertain, add sentinel checks across relay state, outbound requests, logs, diagnostics, and API responses.

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+import relay as relay_module
+from relay import app, client_inference_requests, client_responses, streaming_sessions, streaming_sessions_by_client
+
+RELAY_STATE_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT"
+NETWORK_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT"
+LOG_SENTINEL = "E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS"
+
+
+def _flatten(value):
+    if isinstance(value, dict):
+        return " ".join(f"{k} {_flatten(v)}" for k, v in value.items())
+    if isinstance(value, (list, tuple, set)):
+        return " ".join(_flatten(v) for v in value)
+    return repr(value)
+
+
+@pytest.fixture
+def relay_client():
+    app.config["TESTING"] = True
+    relay_module.known_servers.clear()
+    client_inference_requests.clear()
+    client_responses.clear()
+    streaming_sessions.clear()
+    streaming_sessions_by_client.clear()
+    with app.test_client() as client:
+        yield client
+
+
+def test_static_forbidden_plaintext_patterns_absent():
+    forbidden_regexes = [
+        ("relay.py", r"client_inference_requests\.setdefault\([^\n]*\)\.append\(\{[^}]*api_v1_request[^}]*messages"),
+        ("api/v1/compute_provider.py", r"requests\.(post|request)\([^\n]*relay/api/v1/chat/completions[^\n]*messages"),
+    ]
+    for relpath, pattern in forbidden_regexes:
+        text = Path(relpath).read_text(encoding="utf-8")
+        if __import__("re").search(pattern, text, __import__("re").DOTALL):
+            pytest.fail(f"forbidden plaintext relay pattern found in {relpath}: {pattern}")
+
+
+def test_runtime_relay_state_and_logs_do_not_include_plaintext_sentinel(relay_client, caplog):
+    caplog.set_level("INFO")
+    response = relay_client.post(
+        "/relay/api/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": RELAY_STATE_SENTINEL}]},
+    )
+    assert response.status_code == 503
+    body = response.get_json()
+    assert body["error"]["code"] == "distributed_api_v1_relay_disabled"
+    state_blob = _flatten(
+        {
+            "client_inference_requests": client_inference_requests,
+            "client_responses": client_responses,
+            "streaming_sessions": streaming_sessions,
+            "streaming_sessions_by_client": streaming_sessions_by_client,
+            "diagnostics": relay_client.get("/relay/diagnostics").get_json(),
+        }
+    )
+    assert RELAY_STATE_SENTINEL not in state_blob
+    assert RELAY_STATE_SENTINEL not in response.get_data(as_text=True)
+    assert RELAY_STATE_SENTINEL not in " ".join(r.getMessage() for r in caplog.records)
+
+
+def test_network_egress_never_sends_plaintext_sentinel(monkeypatch, relay_client):
+    calls = []
+
+    def _capture(method):
+        def _inner(*args, **kwargs):
+            calls.append({"method": method, "args": args, "kwargs": kwargs})
+            raise AssertionError("network should not be used by fail-closed relay endpoint")
+
+        return _inner
+
+    monkeypatch.setattr(requests, "post", _capture("post"))
+    monkeypatch.setattr(requests, "get", _capture("get"))
+    monkeypatch.setattr(requests, "request", _capture("request"))
+    monkeypatch.setattr(requests.sessions.Session, "request", _capture("session.request"))
+
+    response = relay_client.post(
+        "/relay/api/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": NETWORK_SENTINEL}]},
+    )
+    assert response.status_code == 503
+    for call in calls:
+        assert NETWORK_SENTINEL not in _flatten(call)
+
+
+def test_contract_local_plaintext_allowed_but_relay_plaintext_forbidden(monkeypatch):
+    from api.v1 import routes
+
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        monkeypatch.setattr(
+            routes,
+            "generate_response",
+            lambda _model, messages, **_opts: messages + [{"role": "assistant", "content": "ok"}],
+        )
+        local = client.post(
+            "/api/v1/chat/completions",
+            json={"model": "llama-3-8b-instruct", "messages": [{"role": "user", "content": "local plaintext ok"}]},
+        )
+        assert local.status_code == 200
+
+        relay_resp = client.post(
+            "/relay/api/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "forbidden distributed plaintext"}]},
+        )
+        assert relay_resp.status_code == 503
+
+
+def test_legacy_faucet_sink_ciphertext_contract(relay_client):
+    server_key = "server-key"
+    relay_client.post("/sink", json={"server_public_key": server_key})
+    payload = {
+        "client_public_key": "client-key",
+        "server_public_key": server_key,
+        "chat_history": "ciphertext",
+        "cipherkey": "cipherkey",
+        "iv": "iv",
+    }
+    posted = relay_client.post("/faucet", json=payload)
+    assert posted.status_code == 200
+    sink = relay_client.post("/sink", json={"server_public_key": server_key}).get_json()
+    assert sink["chat_history"] == "ciphertext"
+    assert "messages" not in json.dumps(sink)


### PR DESCRIPTION
### Motivation
- Prevent accidental reintroduction of plaintext relay dispatch by adding durable, multi-layer guardrails that catch the PR #813 regression shape.
- Make the relay-blind E2EE invariant explicit and discoverable to future maintainers and coding agents so relay/API edits are performed with the invariant top-of-mind.

### Description
- Add `tests/unit/test_e2ee_relay_invariant.py` which implements static forbidden-pattern checks and runtime sentinel tests, including the sentinels `E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT`, `E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT`, and `E2EE_SENTINEL_SHOULD_NEVER_APPEAR_IN_LOGS_OR_DIAGNOSTICS`, plus local-vs-distributed contract assertions and legacy `/faucet`+`/sink` ciphertext contract coverage.
- Add `docs/security/e2ee_relay_invariant.md` documenting the relay-blind E2EE invariant, concrete rules, the safeguard tests, and an explicit “For coding agents” checklist.
- Add a compact “Relay-blind E2EE invariant (must-follow)” section to the root `AGENTS.md` so automated agents and contributors see the invariant before editing relay/API code.
- Tests and docs intentionally guard the existing Prompt-2 final state and do not implement any new distributed API behavior.

### Testing
- Ran `python -m pytest -q tests/unit/test_e2ee_relay_invariant.py` and the new invariant tests passed.
- Ran `python -m pytest -q tests/unit/test_e2ee_relay_invariant.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py` and the combined test set passed.
- Ran `pre-commit run --all-files` and the repository checks passed.
- Ran repository grep checks for the sentinel/invariant strings and forbidden-patterns (the new tests and docs are discoverable by `rg`) and results matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16308c454832fb7fac9a7cc212002)