### PR TITLE
🔧 ci: harden desktop release action runtime

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -23,6 +23,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build desktop artifacts (${{ matrix.os }})
@@ -290,19 +293,19 @@ jobs:
           fi
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: macos-arm64-bundles
           path: release-assets/macos
 
       - name: Download Windows artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: windows-x64-bundles
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
### Motivation
- Reduce release asset churn and silence upcoming Node.js 20 deprecation warnings by forcing JavaScript-based actions to run on Node.js 24 and updating a few workflow action versions.

### Description
- In `.github/workflows/desktop-release.yml` set `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, bump `actions/download-artifact` from `@v4` to `@v5`, and move `softprops/action-gh-release` from a pinned SHA to `softprops/action-gh-release@v2`.

### Testing
- Ran `pre-commit run --all-files` (which executes the repository test suite); JavaScript tests passed, but the overall pre-commit check failed because several Python tests failed due to missing environment dependencies (`requests`, `cryptography`), resulting in 7 failing test targets (Python unit, integration, API, Bandit, and crypto tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1878f0fb4832fbb6bd3936bb270c8)