### PR TITLE
🛠️ Fix Desktop release gh-release action resolution outage

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -115,7 +115,7 @@ jobs:
           path: release-assets/macos
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88 # v2.6.1
+        uses: softprops/action-gh-release@v2 # pin moved; use maintained major tag
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -316,7 +316,7 @@ jobs:
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88
+        uses: softprops/action-gh-release@v2
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/outages/2026-04-29-desktop-release-gh-release-action-resolution-failure.json
+++ b/outages/2026-04-29-desktop-release-gh-release-action-resolution-failure.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-29",
+  "slug": "desktop-release-gh-release-action-resolution-failure",
+  "summary": "Desktop Tauri Release publish stage failed because the workflow pinned softprops/action-gh-release to an unavailable commit SHA.",
+  "impact": "Release artifacts were produced but GitHub Release publication failed to start for the affected run.",
+  "fix": "Replaced the unavailable SHA pin with softprops/action-gh-release@v2 in desktop release workflows.",
+  "lessons": "Pinned third-party action revisions can become unresolvable; dependency audits and coordinated workflow updates reduce release pipeline outages."
+}

--- a/outages/2026-04-29-desktop-release-gh-release-action-resolution-failure.md
+++ b/outages/2026-04-29-desktop-release-gh-release-action-resolution-failure.md
@@ -1,0 +1,37 @@
+# Outage: Desktop release publish stage failed to resolve gh-release action
+
+- **Date:** 2026-04-29
+- **Slug:** `desktop-release-gh-release-action-resolution-failure`
+- **Workflow run:** `actions/runs/25091837962`
+- **Affected job:** `Publish GitHub Release` in `Desktop Tauri Release`
+
+## Summary
+The desktop release workflow failed before execution of release logic because GitHub Actions could not resolve the pinned commit SHA for `softprops/action-gh-release`.
+
+## Impact
+Desktop release artifacts were built, but release publication was blocked. This prevented automatic creation/update of the GitHub Release for that run.
+
+## Detection
+The job failed at action resolution time with:
+- `Unable to resolve action softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88`
+- `unable to find version 153bb8e36b35d4f28c473603ceb4af68578f6b88`
+
+## Root cause
+The workflows pinned `softprops/action-gh-release` to a specific commit SHA that was no longer resolvable by GitHub Actions at runtime.
+
+**Unambiguous root cause statement (acceptance criteria):** release publish jobs referenced an unavailable action revision (`153bb8e36b35d4f28c473603ceb4af68578f6b88`), causing workflow startup failure before any release-publish steps ran.
+
+## Resolution
+Updated all desktop release publish workflow references from the unavailable commit pin to the maintained major tag `softprops/action-gh-release@v2`:
+- `.github/workflows/desktop-release.yml`
+- `.github/workflows/desktop-build.yml`
+
+This restores action resolution and unblocks the publish stage.
+
+## Why this fix works
+`@v2` tracks a maintained release line in the upstream action repository rather than a single potentially unavailable revision. GitHub can resolve the major tag to a valid current v2 release, allowing workflow startup and release publication to proceed.
+
+## Follow-up and prevention
+- Add a periodic workflow dependency audit to detect unresolved or deprecated action pins before release runs.
+- When pinning to SHAs, verify long-term availability strategy (e.g., vendor mirror or automation to refresh pins).
+- Keep desktop release and desktop build workflows aligned so publish-action upgrades happen consistently.


### PR DESCRIPTION
### Motivation
- The Desktop Tauri Release publish job failed to start because workflows pinned `softprops/action-gh-release` to an unavailable commit SHA, blocking release publication. 
- An outage record was added to capture the failure mode, root cause, remediation, and follow-up prevention steps.

### Description
- Replaced the unavailable SHA pin `softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88` with the maintained major tag `softprops/action-gh-release@v2` in `/.github/workflows/desktop-release.yml` and `/.github/workflows/desktop-build.yml`.
- Added an outage report `outages/2026-04-29-desktop-release-gh-release-action-resolution-failure.md` describing the incident and remediation.
- Added structured outage sidecar `outages/2026-04-29-desktop-release-gh-release-action-resolution-failure.json` for automation/indexing.
- Changes were committed and a PR created titled: "🛠️ Fix Desktop release gh-release action resolution outage".

### Testing
- Ran `rg -n "softprops/action-gh-release@" .github/workflows` to verify the workflows now reference `@v2`, which succeeded. 
- Attempted to run `pre-commit run --all-files`, but the command was not available in this environment (`pre-commit: command not found`).
- Attempted to run `./scripts/scan-secrets.py` via the commit pre-check path, but the script does not exist in this repository, so that check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f196ba1768832f976f60b61e1fa090)