### PR TITLE
Fix invalid softprops/action-gh-release SHA in desktop release workflows and add outage record

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -115,7 +115,7 @@ jobs:
           path: release-assets/macos
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88 # v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -316,7 +316,7 @@ jobs:
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -316,7 +316,7 @@ jobs:
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/outages/2026-04-29-desktop-release-publish-action-pin-invalid.json
+++ b/outages/2026-04-29-desktop-release-publish-action-pin-invalid.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-29",
+  "slug": "desktop-release-publish-action-pin-invalid",
+  "summary": "Desktop Tauri release publishing failed because the workflow referenced a non-existent pinned SHA for softprops/action-gh-release.",
+  "impact": "GitHub Release publication was blocked at action-resolution time, preventing release asset publishing despite successful upstream build steps.",
+  "fix": "Replaced the invalid action pin with the valid softprops/action-gh-release v2.6.1 commit SHA (153bb8e04406b158c6c84fc1615b65b24149a1fe) in desktop release workflows.",
+  "lessons": "Pinned GitHub Actions SHAs must be verified against upstream refs before merge; use deterministic SHA validation in CI maintenance changes."
+}

--- a/outages/2026-04-29-desktop-release-publish-action-pin-invalid.md
+++ b/outages/2026-04-29-desktop-release-publish-action-pin-invalid.md
@@ -5,7 +5,7 @@
 - **Affected area:** GitHub Actions desktop release pipeline (`.github/workflows/desktop-release.yml`)
 
 ## Summary
-The **Publish Github Release** stage in the desktop Tauri release workflow failed
+The **Publish GitHub Release** stage in the desktop Tauri release workflow failed
 before execution because it referenced a non-existent commit SHA for
 `softprops/action-gh-release`.
 

--- a/outages/2026-04-29-desktop-release-publish-action-pin-invalid.md
+++ b/outages/2026-04-29-desktop-release-publish-action-pin-invalid.md
@@ -1,0 +1,39 @@
+# Outage: desktop release publish job failed on invalid action pin
+
+- **Date:** 2026-04-29
+- **Slug:** `desktop-release-publish-action-pin-invalid`
+- **Affected area:** GitHub Actions desktop release pipeline (`.github/workflows/desktop-release.yml`)
+
+## Summary
+The **Publish Github Release** stage in the desktop Tauri release workflow failed
+before execution because it referenced a non-existent commit SHA for
+`softprops/action-gh-release`.
+
+## Symptoms
+- The job stopped during action resolution, before any release upload logic ran.
+- GitHub Actions reported:
+  - `Unable to resolve action softprops/action-gh-release@...`
+  - `unable to find version ...`
+
+## Impact
+- Desktop release artifacts were not published to GitHub Releases.
+- Release automation was blocked even though prior build/sign stages could
+  succeed.
+
+## Root cause
+1. The workflow pinned `softprops/action-gh-release` to
+   `153bb8e36b35d4f28c473603ceb4af68578f6b88`.
+2. That SHA does not exist in the upstream action repository.
+3. GitHub Actions fails closed when a pinned SHA cannot be resolved.
+
+## Remediation
+- Updated the action pin to the valid `v2.6.1` tag commit:
+  `153bb8e04406b158c6c84fc1615b65b24149a1fe`.
+- Applied the same correction in both release-related workflows to prevent
+  recurrence in sibling pipelines.
+
+## Follow-up / prevention
+- For pinned actions, validate SHAs with `git ls-remote` against the action
+  repository before merging.
+- Keep action tag comments aligned with the pinned commit and periodically
+  re-verify when workflow files are touched.


### PR DESCRIPTION
### Motivation
- The desktop Tauri release pipeline failed at action resolution because the workflow pinned `softprops/action-gh-release` to a non-existent commit SHA, preventing GitHub Releases from being created.
- Ensure both release-related workflows reference a resolvable action revision to avoid blocking automated publish stages.

### Description
- Replaced the invalid `softprops/action-gh-release` SHA with the valid `v2.6.1` commit SHA `153bb8e04406b158c6c84fc1615b65b24149a1fe` in `.github/workflows/desktop-release.yml` and `.github/workflows/desktop-build.yml`.
- Added a human-readable outage report `outages/2026-04-29-desktop-release-publish-action-pin-invalid.md` documenting symptoms, root cause, remediation, and prevention guidance.
- Added a machine-readable outage record `outages/2026-04-29-desktop-release-publish-action-pin-invalid.json` summarizing the incident and the applied fix.

### Testing
- Verified the upstream action refs with `git ls-remote https://github.com/softprops/action-gh-release.git refs/tags/v2.6.1 refs/tags/v2`, which confirmed the valid `v2.6.1` tag commit SHA (success).
- Attempted `pre-commit run --all-files` but it could not run in this environment because `pre-commit` is not installed (not executed).
- Attempted the repository secrets scan via `git diff --cached | ./scripts/scan-secrets.py` but the repository contains no `./scripts/scan-secrets.py` helper in this environment (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f196ba1768832f976f60b61e1fa090)