### PR TITLE
fix: restore desktop release publish action (softprops/action-gh-release@v2)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -115,7 +115,7 @@ jobs:
           path: release-assets/macos
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88 # v2.6.1
+        uses: softprops/action-gh-release@v2 # pin to maintained major tag; prior SHA no longer resolvable
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -316,7 +316,7 @@ jobs:
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88
+        uses: softprops/action-gh-release@v2
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/outages/2026-04-29-desktop-release-gh-release-action-ref-not-found.json
+++ b/outages/2026-04-29-desktop-release-gh-release-action-ref-not-found.json
@@ -1,0 +1,18 @@
+{
+  "date": "2026-04-29",
+  "slug": "desktop-release-gh-release-action-ref-not-found",
+  "summary": "The Desktop Tauri Release workflow failed before publish execution because GitHub Actions could not resolve the exact commit SHA pinned for softprops/action-gh-release.",
+  "impact": "Desktop artifacts were built, but the workflow could not create/update the GitHub Release, blocking installer publication from CI.",
+  "fix": "Updated .github/workflows/desktop-release.yml and .github/workflows/desktop-build.yml to use softprops/action-gh-release@v2 instead of the non-resolvable commit SHA 153bb8e36b35d4f28c473603ceb4af68578f6b88.",
+  "lessons": "Monitor third-party action references, validate pinned SHAs on a schedule, and centralize critical release dependency versions.",
+  "workflowRun": "actions/runs/25091837962",
+  "affectedJobs": [
+    "Publish GitHub Release (ubuntu-24.04)"
+  ],
+  "detection": {
+    "errors": [
+      "Unable to resolve action softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88, unable to find version 153bb8e36b35d4f28c473603ceb4af68578f6b88"
+    ]
+  },
+  "rootCause": "Release workflows pinned softprops/action-gh-release to commit 153bb8e36b35d4f28c473603ceb4af68578f6b88. GitHub Actions could not resolve that action ref, so workflow initialization failed before publish steps executed."
+}

--- a/outages/2026-04-29-desktop-release-gh-release-action-ref-not-found.md
+++ b/outages/2026-04-29-desktop-release-gh-release-action-ref-not-found.md
@@ -1,0 +1,30 @@
+# Outage: Desktop release publish stage failed resolving pinned `action-gh-release` SHA
+
+- **Date:** 2026-04-29
+- **Slug:** `desktop-release-gh-release-action-ref-not-found`
+- **Workflow run:** `actions/runs/25091837962`
+- **Affected jobs:**
+  - Publish GitHub Release (ubuntu-24.04)
+
+## Summary
+The Desktop Tauri Release workflow failed before the publish step executed because GitHub Actions could not resolve the exact commit SHA pinned for `softprops/action-gh-release`.
+
+## Impact
+Desktop artifacts were built, but the workflow could not create/update the GitHub Release. This blocked publishing installers from the release pipeline.
+
+## Detection
+Observed CI error:
+- `Unable to resolve action 'softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88', unable to find version '153bb8e36b35d4f28c473603ceb4af68578f6b88'`
+
+## Root cause
+Both `.github/workflows/desktop-release.yml` and `.github/workflows/desktop-build.yml` pinned `softprops/action-gh-release` to commit `153bb8e36b35d4f28c473603ceb4af68578f6b88`. That ref is no longer resolvable by GitHub Actions for action download, causing setup to fail before workflow steps run.
+
+**Unambiguous root cause statement (acceptance criteria):** release workflows depended on an action reference that GitHub could not fetch, so release publishing aborted during action resolution.
+
+## Resolution
+Updated both release workflows to use `softprops/action-gh-release@v2` (maintained major tag) instead of the non-resolvable commit SHA. This restores action resolution and unblocks release publishing.
+
+## Lessons / follow-up
+- Keep third-party action pins monitored and periodically validated.
+- If strict commit pinning is required, add a scheduled check that validates all pinned action SHAs still resolve.
+- Mirror critical release dependencies in a reusable workflow with centralized version management.


### PR DESCRIPTION
### Motivation
- The Desktop Tauri Release publish job failed during workflow initialization because GitHub Actions could not resolve a hard-pinned commit SHA for `softprops/action-gh-release`, preventing the release from being created. 
- The change aims to restore release publishing quickly by pointing to a maintained, resolvable action reference and to document the incident for postmortem tracking.

### Description
- Replaced the non-resolvable `softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88` pin with `softprops/action-gh-release@v2` in `.github/workflows/desktop-release.yml` and `.github/workflows/desktop-build.yml` to use a maintained major tag that resolves. 
- Added an outage report at `outages/2026-04-29-desktop-release-gh-release-action-ref-not-found.md` describing detection, impact, root cause, resolution, and follow-up. 
- Added the matching structured outage record `outages/2026-04-29-desktop-release-gh-release-action-ref-not-found.json` for automation and reporting consistency. 
- Changes are limited to CI workflow references and outage documentation to minimize risk.

### Testing
- Attempted `pre-commit run --all-files`, which failed because `pre-commit` is not installed in this runner environment. 
- Attempted `git diff --cached | ./scripts/scan-secrets.py`, which failed because `./scripts/scan-secrets.py` is not present in this repository environment. 
- No other automated tests were run in this environment; CI will validate the workflow resolution and release job on the next run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f196ba1768832f976f60b61e1fa090)