### PR TITLE
🛠️ fix: repair desktop release action pin and add outage record

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -115,7 +115,7 @@ jobs:
           path: release-assets/macos
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88 # v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -316,7 +316,7 @@ jobs:
           path: release-assets/windows
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@153bb8e36b35d4f28c473603ceb4af68578f6b88
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/outages/2026-04-29-desktop-tauri-release-publish-action-pin-invalid.json
+++ b/outages/2026-04-29-desktop-tauri-release-publish-action-pin-invalid.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-04-29",
+  "slug": "desktop-tauri-release-publish-action-pin-invalid",
+  "summary": "Desktop Tauri release publishing failed because workflow files pinned softprops/action-gh-release to a non-existent commit SHA, causing immediate action resolution failure.",
+  "impact": "Medium release automation outage: desktop artifacts were built but the Publish GitHub Release stage failed before release creation/upload.",
+  "fix": "Updated desktop release workflows to use a valid softprops/action-gh-release v2.6.1 commit pin (153bb8e04406b158c6c84fc1615b65b24149a1fe) instead of the invalid SHA.",
+  "lessons": "Treat GitHub Action pin updates as release-critical changes and verify pinned SHAs resolve upstream; add automated pin-validity checks in CI."
+}

--- a/outages/2026-04-29-desktop-tauri-release-publish-action-pin-invalid.md
+++ b/outages/2026-04-29-desktop-tauri-release-publish-action-pin-invalid.md
@@ -1,0 +1,52 @@
+# Outage: Desktop Tauri release publish stage failed due to invalid action pin
+
+- **Date:** 2026-04-29
+- **Slug:** `desktop-tauri-release-publish-action-pin-invalid`
+- **Affected area:** GitHub Actions Desktop release publishing jobs
+- **Introduction point:** GitHub Actions workflow pin update that referenced a non-existent commit SHA for `softprops/action-gh-release`
+
+## Summary
+The **Publish GitHub Release** stage in the Desktop Tauri release workflow failed before any release
+logic executed because the workflow referenced an invalid commit SHA for
+`softprops/action-gh-release`.
+
+GitHub Actions could not resolve the pinned ref and aborted with:
+`unable to find version 153bb8e36b35d4f28c473603ceb4af68578f6b88`.
+
+## Severity / impact
+- **Severity:** Medium (release automation outage)
+- **User impact:** Desktop release artifacts were built but not published to GitHub Releases by the
+  automated publish stage.
+- **Scope:** Affected publish stages using the same invalid `action-gh-release` SHA pin.
+
+## Root cause
+- The workflow pinned `softprops/action-gh-release` to a SHA that does not exist upstream:
+  `153bb8e36b35d4f28c473603ceb4af68578f6b88`.
+- Because action resolution happens in the runner setup phase, the job failed immediately during
+  action download metadata resolution.
+
+## What failed technically
+- Job: Desktop Tauri Release → Publish GitHub Release
+- Failure point: "Getting action download info"
+- Error: `Unable to resolve action ... unable to find version ...`
+
+This prevented execution of all subsequent release-publish steps.
+
+## Fix implemented
+- Replaced the invalid SHA with the valid `v2.6.1` pinned commit for
+  `softprops/action-gh-release`:
+  - from `153bb8e36b35d4f28c473603ceb4af68578f6b88`
+  - to `153bb8e04406b158c6c84fc1615b65b24149a1fe`
+- Applied this correction consistently in both workflows that publish desktop releases:
+  - `.github/workflows/desktop-release.yml`
+  - `.github/workflows/desktop-build.yml`
+
+## Verification
+- Confirmed the invalid SHA no longer appears in repository workflow files.
+- Confirmed the corrected SHA is present in both desktop release publish workflows.
+
+## Prevention / follow-up
+- Keep action pins sourced from upstream release tags and verify pinned SHA existence when updating
+  workflow actions.
+- Add a workflow lint/check step for action pin validity to catch unresolved action refs before
+  release day.


### PR DESCRIPTION
### Motivation
- The Desktop Tauri release publish stage failed during action resolution because workflows pinned `softprops/action-gh-release` to a non-existent commit SHA, preventing automated creation/upload of GitHub Releases.

### Description
- Replace the invalid `softprops/action-gh-release` pin with the valid `v2.6.1` commit `153bb8e04406b158c6c84fc1615b65b24149a1fe` in `/.github/workflows/desktop-release.yml` and `/.github/workflows/desktop-build.yml`, and add a human-readable outage report `outages/2026-04-29-desktop-tauri-release-publish-action-pin-invalid.md` plus a machine-readable sidecar `outages/2026-04-29-desktop-tauri-release-publish-action-pin-invalid.json` documenting root cause and remediation.

### Testing
- Attempted `pre-commit run --all-files` which failed in this environment because `pre-commit` is not installed, and attempted `git diff --cached | ./scripts/scan-secrets.py` which failed because the repository script is not present; the workflow files were inspected to confirm the corrected action SHA is present in both publish steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f196ba1768832f976f60b61e1fa090)