### PR TITLE
📝 docs: lock API v1-only E2EE architecture baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,23 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Never queue, forward, log, diagnose, or expose plaintext model payload content in relay-owned state.
 - Any distributed plaintext path must fail closed unless replaced by an approved E2EE envelope path.
 
+
+## API v1-only runtime guardrails (v0.1.0 release baseline)
+- API v1 is the active API for `v0.1.0` and the only active runtime integration target.
+- API v1 is non-streaming; return responses only after full generation.
+- Do not add streaming behavior to API v1 routes.
+- API v2 exists but is incomplete; do not route runtime traffic through API v2 yet.
+- Do not migrate `server.py`, `relay.py`, `client.py`, desktop Tauri runtime, or relay HTML chat UI
+  to API v2 until API v1 is fully launched and `v0.1.0` is finalized.
+- `/sink`, `/faucet`, `/source`, `/retrieve`, and `/next_server` are deprecated legacy relay
+  endpoints. Do not use or extend them for active production paths; do not reintroduce them as
+  compatibility fallbacks.
+- Required direction for active inference paths: use API v1 E2EE relay routes across server, relay,
+  client, desktop, and landing-page chat UI.
+- If a path cannot preserve relay-blind E2EE, fail closed rather than routing plaintext.
+
+Reference architecture note: [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,10 @@
+
+> **API baseline (v0.1.0):** API v1 is the only active runtime target, non-streaming, and E2EE
+> relay-blind (ciphertext + routing metadata only). API v2 is incomplete and must not carry active
+> runtime traffic yet. Deprecated legacy relay routes (`/sink`, `/faucet`, `/source`, `/retrieve`,
+> `/next_server`) must not be used or extended for active production flows.
+> See `docs/architecture/api_v1_e2ee_relay.md`.
+
 # Claude Integration
 
 This file summarizes best practices from [Anthropic's "Claude Code Best Practices"](https://www.anthropic.com/engineering/claude-code-best-practices).

--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ There are tons of personal computers and homelabs out there with lots of compute
 For a quick orientation to the repository layout and key docs, see [docs/ONBOARDING.md](docs/ONBOARDING.md).
 For a directory-by-directory atlas, visit [docs/REPO_MAP.md](docs/REPO_MAP.md).
 
+
+## API v1-only architecture baseline (v0.1.0)
+
+For `v0.1.0`, **API v1 is the only active runtime integration target**.
+
+- **API v1 is the active API for v0.1.0.**
+- **API v1 is non-streaming.** Return responses only after the full model response is generated.
+- **Do not add streaming to API v1.**
+- **API v2 exists but is incomplete.** Do not route runtime traffic through API v2 yet.
+- Do not migrate UI/desktop/server flows to API v2 until API v1 launches and `v0.1.0` is finalized.
+- Legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, and `/next_server` are
+  deprecated and must not be used for active production inference paths.
+- Do not extend deprecated legacy routes for new features or reintroduce them as compatibility
+  fallbacks.
+- Active inference alignment target: `server.py`, `relay.py`, `client.py`, desktop Tauri app, and
+  relay HTML chat UI all use API v1 E2EE routes.
+- Relay-path E2EE is fail-closed: relay sees ciphertext + safe routing metadata only; plaintext
+  prompts/messages/responses/tool arguments must never appear in relay-owned state, logs, diagnostics,
+  or relay-visible HTTP payloads.
+
+See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md) for the
+detailed baseline that Prompts 1-4 implement.
+
 ## Desktop direction
 
 The `desktop-tauri/` app is the forward-looking desktop path, but it is currently an MVP and does
@@ -168,7 +191,7 @@ See also:
 - `relay.py` is the canonical relay entrypoint.
 - `server/server_app.py` is retained only as a legacy compatibility shim that delegates to `server.py`.
 
-## Deployment topology
+## Deployment topology (legacy notes below are historical/deprecated during migration)
 
 - **Current / legacy local flow (today):** local or self-hosted `relay.py` + `server.py` on the
   legacy sink/source contract.

--- a/docs/LLM_ASSISTANT_GUIDE.md
+++ b/docs/LLM_ASSISTANT_GUIDE.md
@@ -1,3 +1,10 @@
+
+> **API baseline (v0.1.0):** API v1 is the only active runtime target, non-streaming, and E2EE
+> relay-blind (ciphertext + routing metadata only). API v2 is incomplete and must not carry active
+> runtime traffic yet. Deprecated legacy relay routes (`/sink`, `/faucet`, `/source`, `/retrieve`,
+> `/next_server`) must not be used or extended for active production flows.
+> See `docs/architecture/api_v1_e2ee_relay.md`.
+
 # Guide for LLM Assistants Working with token.place
 
 This document provides guidance specifically for LLM assistants (like Claude) to help navigate and work with the token.place codebase more effectively.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,3 +1,10 @@
+
+> **API baseline (v0.1.0):** API v1 is the only active runtime target, non-streaming, and E2EE
+> relay-blind (ciphertext + routing metadata only). API v2 is incomplete and must not carry active
+> runtime traffic yet. Deprecated legacy relay routes (`/sink`, `/faucet`, `/source`, `/retrieve`,
+> `/next_server`) must not be used or extended for active production flows.
+> See `docs/architecture/api_v1_e2ee_relay.md`.
+
 # `token.place` Onboarding Guide
 
 Welcome to `token.place`! This document provides a high-level overview of the project structure and pointers for where to learn more.

--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -1,0 +1,50 @@
+# API v1-only E2EE relay architecture (v0.1.0 baseline)
+
+## Status baseline for Prompt 0
+
+This document is the evergreen architecture baseline for the API v1-only relay repair
+sequence (Prompts 1-4).
+
+- **API v1 is the active API for v0.1.0.**
+- **API v1 is non-streaming.** Responses must be returned only after the full model response is
+  generated.
+- **Do not add streaming to API v1.**
+- **API v2 exists but is incomplete.** Do not route active runtime traffic through API v2 yet.
+- Do not migrate UI, desktop, relay, or server runtime paths to API v2 until API v1 is fully
+  launched and `v0.1.0` is finalized.
+
+## Required runtime alignment
+
+Active inference paths for `v0.1.0` must align on API v1 E2EE routes:
+
+- `server.py`
+- `relay.py`
+- `client.py`
+- desktop Tauri app
+- relay.py landing-page HTML chat UI
+
+Legacy relay routes (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`) are
+**deprecated legacy endpoints**. They may remain temporarily for migration compatibility, but:
+
+- do not use them for active production inference paths,
+- do not extend them for new features,
+- do not reintroduce them as fallback behavior.
+
+## E2EE invariant (fail-closed)
+
+Relay-owned systems are relay-blind by design. Relay-visible data may include only ciphertext and
+safe routing metadata.
+
+The relay must never store, log, inspect, diagnose, or forward plaintext model payload content,
+including prompts, OpenAI `messages`, legacy `prompt`, assistant responses, tool arguments, or
+model output text.
+
+If any path cannot preserve this E2EE invariant, that path must fail closed.
+
+## Migration context
+
+There is a known gap between `relay.py`, the desktop Tauri app, and the relay landing-page chat UI:
+some E2E flow segments still use deprecated legacy routes.
+
+Prompts 1-4 repair this by restoring and aligning active runtime paths on API v1 E2EE routes
+without prematurely migrating to API v2.

--- a/llms.txt
+++ b/llms.txt
@@ -1,3 +1,10 @@
+
+> **API baseline (v0.1.0):** API v1 is the only active runtime target, non-streaming, and E2EE
+> relay-blind (ciphertext + routing metadata only). API v2 is incomplete and must not carry active
+> runtime traffic yet. Deprecated legacy relay routes (`/sink`, `/faucet`, `/source`, `/retrieve`,
+> `/next_server`) must not be used or extended for active production flows.
+> See `docs/architecture/api_v1_e2ee_relay.md`.
+
 # token.place llms.txt
 
 Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python servers host local LLMs; a relay obfuscates IPs. JavaScript clients handle browser-side crypto.


### PR DESCRIPTION
### Motivation
- Establish an evergreen documentation baseline so all future contributors and coding agents target API v1 (v0.1.0) and do not reintroduce legacy relay flows or prematurely use API v2. 
- Make the relay E2EE invariant and the non-streaming, API v1-only launch target unambiguous before follow-up migration work (Prompts 1–4).
- Call out deprecated legacy endpoints so teams know not to use `/sink`, `/faucet`, `/source`, `/retrieve`, or `/next_server` in active production paths.

### Description
- Add `docs/architecture/api_v1_e2ee_relay.md` describing the API v1-only E2EE baseline, required component alignment, deprecated legacy routes, and the fail-closed E2EE invariant. 
- Add a high-signal `API v1-only architecture baseline (v0.1.0)` section to `README.md` linking to the new architecture note and marking legacy topology text as historical/deprecated for the migration period. 
- Insert explicit runtime guardrails into `AGENTS.md` that instruct coding agents to use API v1 E2EE routes, avoid streaming on v1, defer API v2, and not extend or reuse legacy relay endpoints. 
- Propagate a concise API-baseline callout to `llms.txt`, `CLAUDE.md`, `docs/ONBOARDING.md`, and `docs/LLM_ASSISTANT_GUIDE.md` so machine and human readers see the same constraints immediately.

### Testing
- Ran repository grep-based verifications with `rg` to locate legacy endpoint names and baseline keywords, and the expected references now appear in the updated docs (searches succeeded). 
- Ran `git diff --stat` and targeted `git diff` of the modified docs to verify the intended file-level changes (diff inspection succeeded). 
- Attempted to run `pre-commit run --all-files` but the `pre-commit` tool was not available in this execution environment (`pre-commit: command not found`). 
- Note: CI will run the full `pre-commit` and test suite on the PR in GitHub Actions; this change is docs-only and does not modify production code or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a42a3adc832f9eb345baec945c4f)