### PR TITLE
📝 docs: lock API v1-only E2EE architecture baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,17 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Never queue, forward, log, diagnose, or expose plaintext model payload content in relay-owned state.
 - Any distributed plaintext path must fail closed unless replaced by an approved E2EE envelope path.
 
+
+## API v1-only runtime guardrails for v0.1.0 (must-follow)
+- API v1 is the active API for v0.1.0 and is non-streaming; return responses only after full generation.
+- Do not add streaming to API v1.
+- API v2 exists but is incomplete; do not route runtime traffic to API v2 until API v1 launch and v0.1.0 finalization.
+- Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, and `/next_server` must not be used in active production paths.
+- Do not extend legacy relay routes for new features and do not reintroduce them as compatibility fallbacks.
+- Required active-path alignment on API v1 E2EE: `server.py`, `relay.py`, `client.py`, desktop Tauri, and relay landing-page HTML chat UI.
+- If a path cannot preserve relay-blind E2EE (ciphertext only + safe routing metadata), fail closed rather than sending plaintext through relay.
+- Architecture baseline doc: [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,13 @@ It complements [AGENTS.md](AGENTS.md) and [llms.txt](llms.txt) by focusing on gu
 - Validate model output before acting on it.
 
 For broader assistant behavior, see [docs/AGENTS.md](docs/AGENTS.md).
+
+
+## token.place API v1 architecture constraints (current)
+- API v1 is the active API for v0.1.0 and is non-streaming. Return outputs after full generation.
+- Do not add streaming behavior to API v1.
+- API v2 exists but is incomplete; do not migrate active runtime paths to API v2 yet.
+- Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server` are historical only and must not be used in active production paths.
+- Required active-path alignment on API v1 E2EE: `server.py`, `relay.py`, `client.py`, desktop Tauri, and relay landing-page HTML chat UI.
+- Relay must remain blind to plaintext model payload content; if E2EE cannot be preserved, fail closed.
+- Reference: [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).

--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ See also:
 - [`docs/design/tauri_desktop_client.md`](docs/design/tauri_desktop_client.md)
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
+## API v1 launch architecture guardrails (v0.1.0)
+
+- **API v1 is the active API for `v0.1.0` and the only active runtime integration target.**
+- **API v1 is non-streaming.** Return responses only after full model generation is complete.
+- **Do not add streaming to API v1.**
+- **API v2 exists but is incomplete and must not carry runtime traffic yet.**
+- **Do not migrate active UI/desktop/server/relay flows to API v2** until API v1 is launched and
+  `v0.1.0` is finalized.
+- **Deprecated legacy relay endpoints** `/sink`, `/faucet`, `/source`, `/retrieve`, and
+  `/next_server` must not be used in active production paths, extended for new features, or
+  reintroduced as fallbacks.
+- Active inference alignment target: `server.py`, `relay.py`, `client.py`, desktop Tauri, and
+  relay landing-page chat UI all use API v1 E2EE relay routes.
+- E2EE invariant: relay sees ciphertext + safe routing metadata only; if E2EE cannot be preserved,
+  fail closed.
+
+See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md) for the
+canonical migration baseline and Prompt 0-4 context.
+
 ## Canonical entrypoints
 
 - `server.py` is the canonical compute-node server entrypoint.

--- a/docs/LLM_ASSISTANT_GUIDE.md
+++ b/docs/LLM_ASSISTANT_GUIDE.md
@@ -68,6 +68,19 @@ When helping users in a Linux/Unix environment:
    kill -9 <pid>
    ```
 
+
+## API v1-only relay guidance (must-follow for active runtime work)
+
+- API v1 is the active API for v0.1.0 and the only active runtime integration target.
+- API v1 is non-streaming. Return responses only after full generation; do not add streaming.
+- API v2 exists but is incomplete. Do not route runtime traffic to API v2 yet.
+- Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, and `/next_server` are historical only. Do not use, extend, or revive them for active production paths.
+- Required component alignment on API v1 E2EE: `server.py`, `relay.py`, `client.py`, desktop Tauri, and relay landing-page HTML chat UI.
+- E2EE invariant: relay sees ciphertext + safe routing metadata only. Never permit plaintext prompts/messages/responses/tool arguments/model output in relay-owned state/logs/diagnostics/payloads.
+- If E2EE cannot be preserved on a path, fail closed.
+- Migration context: a known gap still exists between relay.py, desktop Tauri, and relay HTML chat UI; Prompts 1-4 are intended to close that gap.
+- Reference: [architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).
+
 ## Common Tasks and Solutions
 
 ### Running Tests

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -12,6 +12,21 @@ Welcome to `token.place`! This document provides a high-level overview of the pr
 - **`static/`** – frontend assets including `chat.js`, a browser-based chat client that performs client-side encryption.
 - **`tests/`** – unit, integration and end-to-end tests. See [tests/README.md](../tests/README.md).
 
+
+## API v1-only launch baseline (v0.1.0)
+
+- API v1 is the active API for v0.1.0 and the only active runtime target.
+- API v1 is non-streaming: return responses only after full model generation.
+- Do not add streaming to API v1.
+- API v2 exists but is incomplete; do not route runtime traffic through API v2 yet.
+- Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server` must not be used in active production paths, extended for new features, or revived as fallbacks.
+- Required active-path alignment on API v1 E2EE: `server.py`, `relay.py`, `client.py`, desktop Tauri, and relay landing-page HTML chat UI.
+- Relay sees ciphertext only (plus safe routing metadata). If E2EE cannot be preserved, fail closed.
+
+Known migration gap: some end-to-end path segments still use legacy routes. Prompts 1-4 address
+that gap after this Prompt 0 docs baseline. See
+[architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).
+
 ## Encryption Workflow
 
 1. Clients generate an RSA key pair and fetch the server's public key.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ testing, and deploying token.place. For an expanded overview of every directory,
   - Start here: [README.md](../README.md#quickstart)
   - Also see: [ONBOARDING.md](ONBOARDING.md), [DEVELOPMENT.md](DEVELOPMENT.md)
 - **Understand architecture choices**
-  - Start here: [ARCHITECTURE.md](ARCHITECTURE.md)
+  - Start here: [ARCHITECTURE.md](ARCHITECTURE.md),
+    [architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md)
   - Also see: [STREAMING_IMPLEMENTATION_GUIDE.md](STREAMING_IMPLEMENTATION_GUIDE.md),
     [CROSS_PLATFORM.md](CROSS_PLATFORM.md),
     [roadmap/desktop_compute_node_migration.md](roadmap/desktop_compute_node_migration.md),

--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -1,0 +1,68 @@
+# API v1-only E2EE relay architecture (v0.1.0)
+
+This note is the canonical architecture baseline for the API v1-only relay repair sequence
+(Prompts 0-4).
+
+## Launch target and active runtime contract
+
+- **API v1 is the active API for `v0.1.0`.**
+- **API v1 is non-streaming.** Responses are returned only after the full model response is
+  generated.
+- **Do not add streaming to API v1.**
+- All active runtime inference paths must target API v1 routes:
+  - `server.py`
+  - `relay.py`
+  - `client.py`
+  - desktop Tauri app (`desktop-tauri/`)
+  - relay landing-page HTML chat UI served by `relay.py`
+
+## API v2 status (do not use yet)
+
+- API v2 exists in-repo but is currently incomplete for launch.
+- Do **not** route active runtime traffic through API v2 yet.
+- Do **not** migrate UI, desktop, relay, or server active inference flows to API v2 until API v1
+  is launched and the `v0.1.0` tag is finalized.
+
+## Legacy relay route deprecation (must not be active)
+
+The following endpoints are deprecated legacy relay routes:
+
+- `/sink`
+- `/faucet`
+- `/source`
+- `/retrieve`
+- `/next_server`
+
+Rules:
+
+- Do not use them in active production paths.
+- Do not extend them for new features.
+- Do not reintroduce them as compatibility fallbacks.
+- Use API v1 E2EE relay routes instead.
+
+Legacy endpoints may remain temporarily for migration compatibility and historical context only,
+with explicit deprecated/legacy labeling.
+
+## E2EE relay invariant (fail closed)
+
+All client/server communication through relay must remain relay-blind E2EE:
+
+- Relay sees ciphertext plus safe routing metadata only.
+- Plaintext prompts/messages/responses/tool arguments/model output must never appear in
+  relay-owned state, relay logs, relay diagnostics, or relay-visible HTTP payloads.
+- If a path cannot preserve E2EE, it must fail closed.
+
+## Migration context for Prompts 1-4
+
+Known current gap: `relay.py`, desktop Tauri, and the relay HTML chat UI are not fully aligned on
+API v1 E2EE. Some end-to-end path segments still mistakenly use legacy routes.
+
+Prompt sequence intent:
+
+1. Prompt 0 (this docs baseline): lock architecture direction.
+2. Prompt 1: restore API v1 relay/server route contract.
+3. Prompt 2: migrate desktop/Tauri off legacy polling to API v1.
+4. Prompt 3: migrate relay landing-page UI path to API v1 E2EE and remove plaintext/bypass
+   behavior.
+5. Prompt 4: add final guardrails/tests/docs proving active production paths no longer touch
+   deprecated legacy routes.

--- a/llms.txt
+++ b/llms.txt
@@ -27,3 +27,13 @@ Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python
 - Tests live in `tests/` and cover Python, JS, and Playwright
 - Docs in `docs/` with onboarding and style guides
 - See AGENTS.md for the Markdown version of this file
+
+
+## API architecture baseline (v0.1.0)
+- API v1 is the active API for v0.1.0 and the only active runtime target.
+- API v1 is non-streaming; return responses after full generation (no streaming additions).
+- API v2 exists but is incomplete; do not route runtime traffic to API v2 yet.
+- Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server` must not be used in active production paths, extended, or reintroduced as fallbacks.
+- Required API v1 E2EE alignment: `server.py`, `relay.py`, `client.py`, desktop Tauri, and relay landing-page chat UI.
+- Relay-blind E2EE invariant: relay sees ciphertext plus safe metadata only; fail closed if E2EE cannot be preserved.
+- See `docs/architecture/api_v1_e2ee_relay.md`.


### PR DESCRIPTION
### Motivation
- Provide a clear, machine- and human-readable baseline so all future coding agents and contributors treat API v1 as the v0.1.0 launch target and avoid reintroducing legacy relay flows. 
- Prevent accidental runtime drift to incomplete API v2 or legacy relay endpoints (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`) before the planned migration sequence (Prompts 1–4). 
- Codify the relay-blind E2EE invariant and fail-closed requirement so documentation enforces the security boundary for distributed inference. 

### Description
- Added a canonical architecture baseline at `docs/architecture/api_v1_e2ee_relay.md` that declares: API v1-only for `v0.1.0`, non-streaming behavior, API v2 deferment, legacy route deprecation, component alignment, and the Prompt 0–4 migration context. 
- Updated high-signal evergreen docs (`README.md`, `AGENTS.md`, `llms.txt`, `CLAUDE.md`, `docs/ONBOARDING.md`, `docs/LLM_ASSISTANT_GUIDE.md`, and `docs/README.md`) to reference and reflect the API v1-only, non-streaming, E2EE constraints and to mark legacy relay endpoints as deprecated/historical. 
- Made documentation-only changes; no production code, tests, or runtime paths were modified. 

### Testing
- Ran targeted text searches with `rg` to confirm the legacy endpoints and API v1/v2/E2EE language appear in the updated docs and that deprecated routes are explicitly labeled, and those `rg` checks succeeded. 
- Ran `git diff --stat` and `git diff -- <files>` to verify the intended docs-only diff showing the new `docs/architecture/api_v1_e2ee_relay.md` and updates to `README.md`, `AGENTS.md`, `llms.txt`, `CLAUDE.md`, `docs/ONBOARDING.md`, `docs/LLM_ASSISTANT_GUIDE.md`, and `docs/README.md`. 
- Attempted to run `pre-commit run --all-files` but `pre-commit` is not installed in this environment so it was not executed here. 
- Attempted a repository secret scan via `./scripts/scan-secrets.py` but the script was not present in the execution environment, so that check was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a42a3adc832f9eb345baec945c4f)