### PR TITLE
📝 docs: lock API v1-only E2EE architecture baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,25 @@ with the repo. A plain-text mirror lives in [llms.txt](llms.txt).
 - Never queue, forward, log, diagnose, or expose plaintext model payload content in relay-owned state.
 - Any distributed plaintext path must fail closed unless replaced by an approved E2EE envelope path.
 
+
+## API v1-only relay architecture guardrails (Prompt 0 baseline)
+- API v1 is the active API for `v0.1.0` and the only active runtime target.
+- API v1 is non-streaming; responses are returned only after full model output generation.
+- Do not add streaming to API v1 relay/client-server inference paths.
+- API v2 exists but is incomplete; do not route runtime traffic through API v2 until API v1 is
+  launched and `v0.1.0` is finalized.
+- Deprecated legacy relay endpoints: `/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`.
+  Do not use them in active production code, do not extend them, and do not reintroduce them as
+  compatibility fallbacks.
+- Active runtime inference paths for `server.py`, `relay.py`, `client.py`, desktop Tauri flows,
+  and relay landing-page HTML chat UI must align on API v1 E2EE routes.
+- Relay-owned state/logs/diagnostics/payloads must stay ciphertext-only (+ safe routing metadata).
+  Never expose plaintext prompts/messages/responses/tool arguments/model output text.
+- If E2EE cannot be preserved for a path, fail closed.
+- Context for Prompts 1-4: there is a known alignment gap where some E2E pieces still touch legacy
+  routes; migrations are intentional follow-up work, not behavior to preserve.
+- Architecture note: [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).
+
 ## Coding Conventions
 - New JavaScript should be written in **TypeScript** using functional React
   components and hooks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,17 @@ It complements [AGENTS.md](AGENTS.md) and [llms.txt](llms.txt) by focusing on gu
 - Validate model output before acting on it.
 
 For broader assistant behavior, see [docs/AGENTS.md](docs/AGENTS.md).
+
+
+## token.place API v1 relay guardrails
+- Treat API v1 as the only active runtime target for v0.1.0.
+- API v1 is non-streaming for relay/client-server paths; do not introduce streaming.
+- API v2 is present but incomplete; do not route runtime traffic through it yet.
+- Deprecated legacy routes (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`) must not be
+  used or extended for active production paths.
+- Preserve relay-blind E2EE: relay surfaces may see ciphertext + safe metadata only; plaintext
+  model payload content must never appear in relay-owned state/logs/diagnostics/payloads.
+- If a path cannot preserve E2EE, fail closed.
+- For migration context and required component alignment (`server.py`, `relay.py`, `client.py`,
+  desktop Tauri, relay HTML chat UI), see
+  [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).

--- a/README.md
+++ b/README.md
@@ -165,20 +165,23 @@ See also:
 
 ## API v1 E2EE architecture baseline (v0.1.0)
 
-- **API v1 is the active API for v0.1.0** and the only active runtime integration target.
+- **This baseline applies to the active v0.1.0 relay/client-server runtime path** (including distributed relay and desktop integration paths being finalized for v0.1.0).
+- **API v1 is the active API for v0.1.0** and the only approved runtime integration target.
 - **API v1 is non-streaming** for relay/client-server inference paths; return responses only after
   full model generation is complete.
 - **Do not add streaming to API v1** for active relay/client-server paths.
 - **API v2 exists but is incomplete**; do not route runtime traffic through API v2 until API v1 is
   launched and v0.1.0 is finalized.
+- **If later sections of this README show API v2 streaming or `/api/v2/chat/completions` examples,
+  treat them as experimental/reference-only** and not as approved runtime integration guidance for v0.1.0.
 - **Deprecated legacy relay endpoints**: `/sink`, `/faucet`, `/source`, `/retrieve`,
   `/next_server`. Do not use, extend, or reintroduce these as active production fallbacks.
 - Relay-blind E2EE remains mandatory: relay surfaces may see ciphertext + safe routing metadata
   only, and must never store or expose plaintext model payload content.
 
 Known migration gap: `relay.py`, desktop-tauri paths, and relay landing-page HTML chat flow are
-not fully aligned yet; some E2E pieces still hit legacy routes. Prompts 1-4 handle that migration
-work. Prompt 0 is docs-only.
+not fully aligned yet; some E2E pieces still hit legacy routes. This migration is tracked as
+follow-up implementation work.
 
 See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ See also:
 - [`docs/design/tauri_desktop_client.md`](docs/design/tauri_desktop_client.md)
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
+
+## API v1 E2EE architecture baseline (v0.1.0)
+
+- **API v1 is the active API for v0.1.0** and the only active runtime integration target.
+- **API v1 is non-streaming** for relay/client-server inference paths; return responses only after
+  full model generation is complete.
+- **Do not add streaming to API v1** for active relay/client-server paths.
+- **API v2 exists but is incomplete**; do not route runtime traffic through API v2 until API v1 is
+  launched and v0.1.0 is finalized.
+- **Deprecated legacy relay endpoints**: `/sink`, `/faucet`, `/source`, `/retrieve`,
+  `/next_server`. Do not use, extend, or reintroduce these as active production fallbacks.
+- Relay-blind E2EE remains mandatory: relay surfaces may see ciphertext + safe routing metadata
+  only, and must never store or expose plaintext model payload content.
+
+Known migration gap: `relay.py`, desktop-tauri paths, and relay landing-page HTML chat flow are
+not fully aligned yet; some E2E pieces still hit legacy routes. Prompts 1-4 handle that migration
+work. Prompt 0 is docs-only.
+
+See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).
+
 ## Canonical entrypoints
 
 - `server.py` is the canonical compute-node server entrypoint.
@@ -171,7 +191,7 @@ See also:
 ## Deployment topology
 
 - **Current / legacy local flow (today):** local or self-hosted `relay.py` + `server.py` on the
-  legacy sink/source contract.
+  deprecated legacy sink/source contract (historical compatibility only; not for active production paths).
 - **Near-term multi-node legacy flow:** multiple compute nodes (including desktop-tauri after
   parity) register through `relay.py` using the same legacy contract.
 - **Future distributed API v1 flow (post-parity):** distributed compute migrates to API v1-aligned
@@ -256,7 +276,7 @@ In the short-to-medium term architecture, sugarkube scope remains relay-only.
   - [x] server.py stays on personal gaming PC
   - [x] potential cloud fallback node via Cloudflare
 - [x] allow participation from other server.pys
-  - [x] Relay enforces invitation tokens so community-run `server.py` nodes can authenticate `/sink` and `/source`
+  - [x] (Historical legacy) Relay invitation tokens for deprecated `/sink` and `/source` compatibility flows
   - [x] split relay/server python dependencies to reduce installation toil for relay-only nodes
 - [x] API v2 with at least 10 models supported and available
   - [x] Catalogue exposes Llama 3, Mixtral, Phi-3, Mistral Nemo, and Qwen2.5 variants
@@ -588,7 +608,7 @@ list.
 
 `token.place` now ships with an opt-in challenge/response layer for compute
 nodes. Set `TOKEN_PLACE_RELAY_SERVER_TOKEN` before launching the relay and
-every `/sink` or `/source` call must include an `X-Relay-Server-Token`
+for deprecated legacy `/sink` or `/source` compatibility flows only, include an `X-Relay-Server-Token`
 header that matches the configured value. Requests missing the header are
 rejected with an HTTP 401 so unknown machines can no longer impersonate
 trusted servers. Sensitive tokens are stripped when saving config files, so
@@ -629,7 +649,7 @@ python client.py
 
 #### Relay batching
 
-Operators running `server.py` can include a `max_batch_size` integer in their `/sink` polls to
+For deprecated legacy compatibility only, operators running `server.py` can include a `max_batch_size` integer in `/sink` polls to
 retrieve multiple pending jobs at once. The relay removes up to that many queued faucet requests,
 returns the first item via the legacy `client_public_key`/`chat_history` fields, and exposes the full
 batch under a `batch` array for upgraded workers. Leaving `max_batch_size` unset preserves the
@@ -986,7 +1006,7 @@ For deployments that need to relocate the queue file, set `TOKEN_PLACE_CONTRIBUT
 Once an operator is ready to host `server.py`, generate an invitation token and expose it to the relay by
 setting `TOKEN_PLACE_RELAY_SERVER_TOKENS` (comma or newline delimited) before launching `relay.py`.
 Each joined node must supply the matching token via the `TOKEN_PLACE_RELAY_SERVER_TOKEN` environment
-variable, which the relay client automatically forwards to the `/sink` and `/source` endpoints as the
+variable, which the legacy relay client forwards to deprecated `/sink` and `/source` endpoints as the
 `X-Relay-Server-Token` header. Requests without a valid token are rejected, preventing uninvited nodes
 from queueing or retrieving encrypted workloads while still keeping the workflow simple for approved
 operators.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay
 
 - **Current / legacy local flow (today):** local or self-hosted `relay.py` + `server.py` on the
   deprecated legacy sink/source contract (historical compatibility only; not for active production paths).
-- **Near-term multi-node legacy flow:** multiple compute nodes (including desktop-tauri after
-  parity) register through `relay.py` using the same legacy contract.
+- **Near-term multi-node legacy flow (deprecated/historical migration context only):** multiple
+  compute nodes (including desktop-tauri after parity) register through `relay.py` using the same
+  legacy contract until API v1 distributed migration is complete.
 - **Future distributed API v1 flow (post-parity):** distributed compute migrates to API v1-aligned
   contracts after parity and operational readiness gates are complete.
 - **Operator platform targets:** Windows 11 + NVIDIA/CUDA and macOS Apple Silicon + Metal first,

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -36,7 +36,14 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 
 ### API boundary for `v0.1.0` (must-follow)
 
-- API v2 is deferred until **after** API v1 is fully launched on sugarkube.
+- API v1 is the active API for `v0.1.0` and the only active runtime integration target.
+- API v1 relay/client-server inference is **non-streaming by design**: return responses only
+  after full model generation is complete. Do not add streaming to API v1.
+- API v2 exists but is incomplete and is deferred until **after** API v1 is fully launched on
+  sugarkube and `v0.1.0` is finalized.
+- Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, and
+  `/next_server` are historical compatibility only. Do not use them in active production paths, do
+  not extend them for new features, and do not reintroduce them as fallbacks.
 - Until that launch happens, the following traffic must be **API v1-only**:
   - desktop-tauri network/API calls,
   - `relay.py`,
@@ -46,6 +53,7 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
   the landing-page relay chat flow.
 - Desktop prompt smoke tests may still use local `llama_cpp_python` streaming because that path is
   local-only and not relay/API traffic.
+- Architecture reference: [architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).
 
 ## Documentation
 

--- a/docs/LLM_ASSISTANT_GUIDE.md
+++ b/docs/LLM_ASSISTANT_GUIDE.md
@@ -15,6 +15,28 @@ This document provides guidance specifically for LLM assistants (like Claude) to
 - `/tests/`: Test suites for unit and integration testing
 - `/docs/`: Documentation for contributors
 
+
+## API v1 relay rules for assistants (must-follow)
+
+- API v1 is the active API for `v0.1.0` and the only active runtime target.
+- API v1 is non-streaming for relay/client-server inference; return full responses only.
+- Do not add streaming to API v1.
+- API v2 is incomplete; do not route runtime traffic through API v2 until API v1 launch and
+  `v0.1.0` finalization.
+- Deprecated legacy relay endpoints (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`)
+  are historical compatibility only. Do not use or extend them for active production paths, and do
+  not reintroduce them as fallbacks.
+- Keep active inference paths aligned on API v1 E2EE routes for `server.py`, `relay.py`,
+  `client.py`, desktop Tauri flows, and relay HTML chat UI.
+- Relay-visible surfaces must stay ciphertext-only (+ safe routing metadata). Plaintext prompts,
+  messages, responses, tool arguments, or model output text must never appear in relay-owned
+  state/logs/diagnostics/payloads.
+- If a path cannot preserve E2EE, fail closed.
+
+Migration context: there is a known gap between `relay.py`, desktop Tauri, and relay HTML chat UI
+where some E2E segments still use legacy routes. Prompts 1-4 own the migration repairs.
+Reference: [docs/architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).
+
 ## Environment-Specific Considerations
 
 ### Windows/PowerShell Environment

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -38,7 +38,7 @@ This ensures that plaintext prompts and responses never reach the relay or any i
   it must fail closed.
 
 Known migration context: `relay.py`, desktop Tauri, and relay HTML chat UI are not fully aligned
-yet and some E2E pieces still touch legacy routes. Prompts 1-4 own that migration work.
+yet and some E2E pieces still touch legacy routes. The migration is tracked as follow-up work.
 See [docs/architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).
 
 ## Cross-Platform Notes

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -22,6 +22,25 @@ Welcome to `token.place`! This document provides a high-level overview of the pr
 
 This ensures that plaintext prompts and responses never reach the relay or any intermediate service. See [docs/ARCHITECTURE.md](ARCHITECTURE.md) for more details.
 
+
+## API v1-only architecture baseline (v0.1.0)
+
+- API v1 is the active API for `v0.1.0` and the only active runtime integration target.
+- API v1 is non-streaming for relay/client-server inference: return responses only after full
+  generation is complete.
+- Do not add streaming to API v1.
+- API v2 exists but is incomplete; do not route runtime traffic through API v2 yet.
+- Deprecated legacy relay endpoints (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`)
+  must not be used in active production paths, extended for new features, or revived as fallbacks.
+- Active inference paths for `server.py`, `relay.py`, `client.py`, desktop Tauri, and relay HTML
+  chat UI should align on API v1 E2EE routes.
+- Relay must remain ciphertext-only plus safe routing metadata. If a path cannot preserve E2EE,
+  it must fail closed.
+
+Known migration context: `relay.py`, desktop Tauri, and relay HTML chat UI are not fully aligned
+yet and some E2E pieces still touch legacy routes. Prompts 1-4 own that migration work.
+See [docs/architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).
+
 ## Cross-Platform Notes
 
 The project runs on Windows, macOS and Linux. Path handling, configuration locations and launcher scripts adapt automatically. For platform specifics and Docker instructions, see [CROSS_PLATFORM.md](CROSS_PLATFORM.md).

--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -1,0 +1,81 @@
+# API v1-only E2EE relay architecture (v0.1.0)
+
+This note is the canonical architecture baseline for the API v1 relay repair sequence
+(Prompts 0-4).
+
+## Release target and scope
+
+- **API v1 is the active API for token.place v0.1.0.**
+- **API v1 is non-streaming.** Responses are returned only after full model generation is
+  complete.
+- **Do not add streaming to API v1** for relay/client-server inference paths.
+
+## Runtime routing rules (must-follow)
+
+All active production inference paths must use API v1 E2EE routes:
+
+- `server.py` API/runtime inference paths
+- `relay.py` relay paths
+- `client.py` client paths
+- `desktop-tauri` compute-node / bridge paths
+- relay landing-page HTML chat UI served by `relay.py`
+
+If a path cannot preserve API v1 E2EE invariants, it must **fail closed** instead of routing
+plaintext or using deprecated fallbacks.
+
+## API v2 status
+
+- API v2 exists in the repository, but it is currently incomplete.
+- Do **not** route active runtime traffic through API v2 yet.
+- Do **not** migrate server, relay, client, desktop, or relay HTML chat UI runtime paths to API v2
+  until API v1 is launched and v0.1.0 is finalized.
+
+## Deprecated legacy relay endpoints
+
+The following endpoints are deprecated legacy relay routes:
+
+- `/sink`
+- `/faucet`
+- `/source`
+- `/retrieve`
+- `/next_server`
+
+Rules:
+
+- Do not use them in active production inference paths.
+- Do not extend them for new features.
+- Do not reintroduce them as compatibility fallbacks in active runtime traffic.
+- Use API v1 E2EE relay routes instead.
+
+Legacy routes may remain temporarily for historical compatibility and migration staging, but they
+must be clearly labeled deprecated legacy behavior in docs and code comments.
+
+## E2EE invariant (relay-blind requirement)
+
+Relay-visible surfaces must remain ciphertext-only plus safe routing metadata.
+
+Relay-owned state, relay logs, relay diagnostics, and relay HTTP payloads must never include
+plaintext model payload content, including:
+
+- plaintext prompts
+- OpenAI `messages`
+- legacy `prompt` fields
+- assistant response text
+- tool arguments
+- model output text or equivalent content payloads
+
+Any path that would expose plaintext to relay-owned surfaces must fail closed.
+
+## Migration context (why this exists)
+
+There is a known alignment gap between `relay.py`, desktop-tauri flows, and the relay landing-page
+HTML chat UI. Some end-to-end flow segments still hit deprecated legacy routes.
+
+Prompts 1-4 in this sequence own the implementation repair:
+
+1. restore/audit API v1 relay/server route contract,
+2. migrate desktop bridge paths,
+3. migrate relay landing-page chat path and remove plaintext bypass behavior,
+4. add final guardrails proving active production paths no longer use legacy routes.
+
+This Prompt 0 documentation baseline intentionally does **not** implement those code migrations.

--- a/llms.txt
+++ b/llms.txt
@@ -27,3 +27,16 @@ Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python
 - Tests live in `tests/` and cover Python, JS, and Playwright
 - Docs in `docs/` with onboarding and style guides
 - See AGENTS.md for the Markdown version of this file
+
+
+## API architecture baseline (v0.1.0)
+- API v1 is the active API for v0.1.0 and the only active runtime integration target.
+- API v1 is non-streaming for relay/client-server inference; return only full responses.
+- Do not add streaming to API v1.
+- API v2 exists but is incomplete; do not route runtime traffic through API v2 yet.
+- Deprecated legacy relay routes: `/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`.
+  Do not use or extend them for active production paths.
+- Active inference paths for `server.py`, `relay.py`, `client.py`, desktop Tauri flows, and relay
+  HTML chat UI should use API v1 E2EE routes.
+- Relay must remain ciphertext-only (+ routing metadata). If E2EE is not possible, fail closed.
+- See docs/architecture/api_v1_e2ee_relay.md for migration context and Prompt 1-4 alignment work.

--- a/llms.txt
+++ b/llms.txt
@@ -39,4 +39,4 @@ Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python
 - Active inference paths for `server.py`, `relay.py`, `client.py`, desktop Tauri flows, and relay
   HTML chat UI should use API v1 E2EE routes.
 - Relay must remain ciphertext-only (+ routing metadata). If E2EE is not possible, fail closed.
-- See docs/architecture/api_v1_e2ee_relay.md for migration context and Prompt 1-4 alignment work.
+- See docs/architecture/api_v1_e2ee_relay.md for migration context and follow-up alignment work.


### PR DESCRIPTION
### Motivation
- Create an unambiguous, evergreen documentation baseline that makes API v1 the only active runtime target for `v0.1.0`, deprecates legacy relay routes, and prevents coding agents from reintroducing legacy flows. 
- Emphasize the non-streaming, relay-blind E2EE invariant and the requirement that any path that cannot preserve E2EE must fail closed. 
- Surface the known alignment gap between `relay.py`, desktop Tauri, and the relay landing-page UI so follow-up prompts (1–4) can safely implement the migration work.

### Description
- Add a canonical architecture note at `docs/architecture/api_v1_e2ee_relay.md` that documents: API v1-only for `v0.1.0`, API v1 non-streaming, API v2 incomplete/do-not-use-yet, deprecated legacy endpoints (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`), component alignment rules, and the relay-blind E2EE fail-closed invariant. 
- Update high-signal, agent-facing docs to point to the baseline and use unambiguous guardrail language by editing `README.md`, `AGENTS.md`, `docs/AGENTS.md`, `docs/ONBOARDING.md`, `docs/LLM_ASSISTANT_GUIDE.md`, `llms.txt`, and `CLAUDE.md`. 
- Clarify historical references to legacy sink/source behavior as deprecated/historical compatibility only and add links from README/AGENTS to the new architecture note. 
- This change is docs-only and touches no production code, runtime routes, or test logic.

### Testing
- Ran repository searches to verify updated language and deprecated-route coverage with `rg "/sink|/faucet|/source|/retrieve|/next_server" README.md AGENTS.md llms.txt CLAUDE.md docs`, which returned the updated, explicitly deprecated references. 
- Verified presence of API v1/non-streaming/E2EE guardrail text via `rg "API v1|non-streaming|v0.1.0|API v2|deprecated|E2EE|ciphertext" README.md AGENTS.md docs` which confirmed the new wording is present. 
- Produced a working diff overview of the changed files to review scope and ensure only docs changed. 
- `pre-commit run --all-files` was not executed in this environment because `pre-commit` is not installed here, and `./scripts/scan-secrets.py` was not present for a secrets scan in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a42a3adc832f9eb345baec945c4f)