### PR TITLE
🔒 Restore API v1 E2EE relay route contract

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -876,6 +876,89 @@ def sink():
     return jsonify(response_data)
 
 
+
+
+# API v1 E2EE relay route aliases
+@app.route('/api/v1/relay/servers/register', methods=['POST'])
+def api_v1_relay_servers_register():
+    """Register compute nodes and optionally claim queued ciphertext work."""
+    return sink()
+
+
+@app.route('/api/v1/relay/servers/poll', methods=['POST'])
+def api_v1_relay_servers_poll():
+    """Poll for queued ciphertext work for a compute node."""
+    return sink()
+
+
+@app.route('/api/v1/relay/requests', methods=['POST'])
+def api_v1_relay_requests():
+    """Queue an encrypted client work envelope for a specific compute node."""
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    relay_request = {
+        'client_public_key': data.get('client_public_key'),
+        'server_public_key': data.get('server_public_key'),
+        'chat_history': data.get('ciphertext'),
+        'cipherkey': data.get('cipherkey'),
+        'iv': data.get('iv'),
+        'request_id': data.get('request_id'),
+        'protocol': data.get('protocol'),
+        'version': data.get('version'),
+    }
+
+    if not all([relay_request['server_public_key'], relay_request['chat_history'], relay_request['cipherkey'], relay_request['iv']]):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    with app.test_request_context('/faucet', method='POST', json=relay_request):
+        return faucet()
+
+
+@app.route('/api/v1/relay/responses', methods=['POST'])
+def api_v1_relay_responses():
+    """Queue an encrypted compute response envelope for client retrieval."""
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    relay_response = {
+        'client_public_key': data.get('client_public_key'),
+        'chat_history': data.get('ciphertext'),
+        'cipherkey': data.get('cipherkey'),
+        'iv': data.get('iv'),
+        'request_id': data.get('request_id'),
+        'protocol': data.get('protocol'),
+        'version': data.get('version'),
+    }
+    if not all([relay_response['client_public_key'], relay_response['chat_history'], relay_response['cipherkey'], relay_response['iv']]):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    with app.test_request_context('/source', method='POST', json=relay_response):
+        return source()
+
+
+@app.route('/api/v1/relay/responses/retrieve', methods=['POST'])
+def api_v1_relay_responses_retrieve():
+    """Retrieve an encrypted response envelope for a client public key."""
+    data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({'error': 'Invalid request data'}), 400
+
+    with app.test_request_context('/retrieve', method='POST', json={'client_public_key': data.get('client_public_key')}):
+        response = retrieve()
+
+    payload, status = response if isinstance(response, tuple) else (response, 200)
+    body = payload.get_json()
+    if status == 200 and 'chat_history' in body:
+        body = {
+            'client_public_key': data.get('client_public_key'),
+            'ciphertext': body.get('chat_history'),
+            'cipherkey': body.get('cipherkey'),
+            'iv': body.get('iv'),
+        }
+    return jsonify(body), status
 @app.route('/unregister', methods=['POST'])
 def unregister():
     """Explicitly unregister a compute node and clear relay queue/session state."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -301,6 +301,72 @@ def test_relay_api_v1_source_fails_closed(client):
     assert data["error"]["code"] == "distributed_api_v1_relay_disabled"
 
 
+
+
+def test_api_v1_relay_e2ee_contract_round_trip(client):
+    register_payload = {"server_public_key": DUMMY_SERVER_PUB_KEY}
+    register_resp = client.post('/api/v1/relay/servers/register', json=register_payload)
+    assert register_resp.status_code == 200
+
+    request_payload = {
+        'request_id': 'req-e2ee-1',
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'ciphertext': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+    }
+    enqueue_resp = client.post('/api/v1/relay/requests', json=request_payload)
+    assert enqueue_resp.status_code == 200
+
+    poll_resp = client.post('/api/v1/relay/servers/poll', json=register_payload)
+    assert poll_resp.status_code == 200
+    polled = poll_resp.get_json()
+    assert polled['chat_history'] == request_payload['ciphertext']
+    assert polled['cipherkey'] == request_payload['cipherkey']
+    assert polled['iv'] == request_payload['iv']
+
+    response_payload = {
+        'request_id': 'req-e2ee-1',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'ciphertext': 'ciphertext-response',
+        'cipherkey': 'cipherkey-response',
+        'iv': 'iv-response',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+    }
+    source_resp = client.post('/api/v1/relay/responses', json=response_payload)
+    assert source_resp.status_code == 200
+
+    retrieve_resp = client.post('/api/v1/relay/responses/retrieve', json={'client_public_key': DUMMY_CLIENT_PUB_KEY})
+    assert retrieve_resp.status_code == 200
+    retrieved = retrieve_resp.get_json()
+    assert retrieved['ciphertext'] == response_payload['ciphertext']
+    assert retrieved['cipherkey'] == response_payload['cipherkey']
+    assert retrieved['iv'] == response_payload['iv']
+
+
+def test_api_v1_relay_routes_do_not_store_plaintext_messages(client):
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    payload = {
+        'request_id': 'req-e2ee-2',
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'ciphertext': 'sentinel-ciphertext-only',
+        'cipherkey': 'sentinel-key',
+        'iv': 'sentinel-iv',
+        'messages': [{'role': 'user', 'content': 'LEAK-ME-PLAINTEXT'}],
+        'prompt': 'LEAK-ME-PLAINTEXT',
+    }
+    resp = client.post('/api/v1/relay/requests', json=payload)
+    assert resp.status_code == 200
+
+    queued = client_inference_requests[DUMMY_SERVER_PUB_KEY][0]
+    assert 'messages' not in queued
+    assert 'prompt' not in queued
+    assert queued['chat_history'] == 'sentinel-ciphertext-only'
 class _RelayClientApiV1CryptoStub:
     def __init__(self, decrypted_payload):
         self.decrypted_payload = decrypted_payload


### PR DESCRIPTION
### Motivation
- Restore a minimal API v1 relay transport contract so downstream callers can migrate off legacy endpoints while preserving relay-blind E2EE invariants.
- Ensure the relay only sees ciphertext + safe routing metadata and that plaintext API v1 dispatch remains fail-closed.
- Provide a clear, tested contract for compute-node register/poll, request enqueue, response submit, and response retrieve under API v1 names.

### Description
- Added API v1 E2EE relay route aliases to `relay.py`: `POST /api/v1/relay/servers/register`, `POST /api/v1/relay/servers/poll`, `POST /api/v1/relay/requests`, `POST /api/v1/relay/responses`, and `POST /api/v1/relay/responses/retrieve` which adapt envelopes onto existing encrypted queue paths (`/faucet`/`/sink`/`/source`/`/retrieve`).
- Implemented ciphertext-envelope mapping where `ciphertext -> chat_history` and preserved fields `cipherkey`, `iv`, `request_id`, `protocol`, and `version` while rejecting requests that omit required ciphertext fields.
- Kept existing plaintext fail-closed handlers under `/relay/api/v1/...` untouched so plaintext distributed API v1 chat remains disabled.
- Added focused tests in `tests/test_relay.py` that exercise register/enqueue/poll/respond/retrieve round-trip for ciphertext envelopes and assert that plaintext `messages`/`prompt` fields are not stored in relay-owned queues.

### Testing
- Ran `python -m pytest -q tests/test_relay.py` which executed the new tests but the run failed in this environment with `ModuleNotFoundError: No module named 'requests'` due to a missing test dependency; the new tests themselves are present and executable in a properly provisioned environment.
- Verified repository searches for legacy endpoints and message-sentinel patterns via `rg` returned expected references and no new code references legacy endpoints in the new API v1 paths.
- `pre-commit run --all-files` could not be executed in this environment (`pre-commit: command not found`), but local CI should run full checks; the patch includes only `relay.py` and `tests/test_relay.py` changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a8ef5628832f8bdcd54c6237172c)