### PR TITLE
Restore API v1 E2EE relay routes and add contract tests

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -963,6 +963,36 @@ def retrieve():
         return jsonify({'error': 'No response available for the given public key'}), 200
 
 
+
+
+@app.route('/api/v1/relay/servers/register', methods=['POST'])
+def api_v1_relay_servers_register():
+    """Register or heartbeat a compute node using the API v1 relay contract."""
+    return sink()
+
+
+@app.route('/api/v1/relay/servers/poll', methods=['POST'])
+def api_v1_relay_servers_poll():
+    """Poll encrypted inference work using the API v1 relay contract."""
+    return sink()
+
+
+@app.route('/api/v1/relay/requests', methods=['POST'])
+def api_v1_relay_requests():
+    """Submit ciphertext-only inference work using the API v1 relay contract."""
+    return faucet()
+
+
+@app.route('/api/v1/relay/responses', methods=['POST'])
+def api_v1_relay_responses():
+    """Submit ciphertext-only compute responses using the API v1 relay contract."""
+    return source()
+
+
+@app.route('/api/v1/relay/responses/retrieve', methods=['POST'])
+def api_v1_relay_responses_retrieve():
+    """Retrieve ciphertext-only compute responses using the API v1 relay contract."""
+    return retrieve()
 @app.route('/stream/retrieve', methods=['POST'])
 def stream_retrieve():
     """Return queued streaming chunks for the requesting client."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1020,3 +1020,78 @@ def test_streaming_state_lifecycle(client):
     assert DUMMY_CLIENT_PUB_KEY not in streaming_sessions_by_client
     # Response should be removed from queue
     assert DUMMY_CLIENT_PUB_KEY not in client_responses
+
+
+def test_api_v1_relay_route_contract_round_trip_ciphertext_only(client):
+    """API v1 relay routes should queue/poll/respond/retrieve ciphertext envelopes."""
+    register_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    register_response = client.post('/api/v1/relay/servers/register', json=register_payload)
+    assert register_response.status_code == 200
+
+    sentinel = 'SENTINEL_CIPHERTEXT_PAYLOAD_DO_NOT_PARSE'
+    request_payload = {
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': sentinel,
+        'cipherkey': 'cipherkey-sentinel',
+        'iv': 'iv-sentinel',
+    }
+    queued_response = client.post('/api/v1/relay/requests', json=request_payload)
+    assert queued_response.status_code == 200
+
+    poll_response = client.post('/api/v1/relay/servers/poll', json=register_payload)
+    assert poll_response.status_code == 200
+    poll_data = poll_response.get_json()
+    assert poll_data['client_public_key'] == DUMMY_CLIENT_PUB_KEY
+    assert poll_data['chat_history'] == sentinel
+    assert poll_data['cipherkey'] == 'cipherkey-sentinel'
+    assert poll_data['iv'] == 'iv-sentinel'
+    assert 'messages' not in poll_data
+
+    response_payload = {
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'RESPONSE_CIPHERTEXT_SENTINEL',
+        'cipherkey': 'response-cipherkey',
+        'iv': 'response-iv',
+    }
+    source_response = client.post('/api/v1/relay/responses', json=response_payload)
+    assert source_response.status_code == 200
+
+    retrieve_response = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY},
+    )
+    assert retrieve_response.status_code == 200
+    retrieve_data = retrieve_response.get_json()
+    assert retrieve_data == {
+        'chat_history': 'RESPONSE_CIPHERTEXT_SENTINEL',
+        'cipherkey': 'response-cipherkey',
+        'iv': 'response-iv',
+    }
+
+
+def test_api_v1_relay_chat_completions_plaintext_path_fail_closed(client):
+    """Relay API v1 plaintext chat path must remain disabled."""
+    response = client.post(
+        '/relay/api/v1/chat/completions',
+        json={
+            'model': 'gpt-4o-mini',
+            'messages': [{'role': 'user', 'content': 'plaintext must not queue'}],
+        },
+    )
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert client_inference_requests == {}
+
+
+def test_api_v1_relay_source_plaintext_path_fail_closed(client):
+    """Relay API v1 plaintext source path must remain disabled."""
+    response = client.post(
+        '/relay/api/v1/source',
+        json={'id': 'raw-source-payload', 'content': 'plaintext must not queue'},
+    )
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload['error']['code'] == 'distributed_api_v1_relay_disabled'
+    assert client_responses == {}


### PR DESCRIPTION
### Motivation
- Reintroduce a minimal API v1 relay route contract so callers can migrate to a relay-blind E2EE envelope flow without touching legacy plaintext paths.
- Ensure the relay remains ciphertext-only for distributed inference and that plaintext relay-dispatch paths stay fail-closed.

### Description
- Add API v1 relay endpoints in `relay.py`: `POST /api/v1/relay/servers/register`, `POST /api/v1/relay/servers/poll`, `POST /api/v1/relay/requests`, `POST /api/v1/relay/responses`, and `POST /api/v1/relay/responses/retrieve`, each delegating to the existing ciphertext-only handlers (`sink`, `faucet`, `source`, `retrieve`).
- Add focused tests in `tests/test_relay.py` that verify a ciphertext-only round-trip over the new API v1 routes and assert the plaintext relay API paths (`/relay/api/v1/chat/completions` and `/relay/api/v1/source`) remain disabled (fail-closed).
- Preserve relay-blind behavior by only storing ciphertext envelopes and safe routing metadata and by avoiding any parsing/decryption of model payloads inside the relay.
- No changes to desktop/Tauri bridge or UI callers were made in this PR to keep the migration scope-limited.

### Testing
- Ran `python -m pytest -q tests/test_relay.py` and the suite passed.
- Ran `python -m pytest -q tests/test_api.py tests/unit/test_api_v1_compute_provider.py` and those tests passed.
- Ran the full test suite via `python -m pytest -q` which showed the vast majority of tests passing but produced 4 integration errors caused by a server-registration timeout in the environment (unrelated to the route additions); 1228 tests passed and 30 were skipped in that run.
- Ran `pre-commit run --all-files` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a8ef5628832f8bdcd54c6237172c)