### PR TITLE
Migrate desktop compute-node transport to API v1 relay E2EE routes

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -100,7 +100,7 @@ def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
     wait_seconds = relay_response.get("next_ping_in_x_seconds", "missing")
 
     return (
-        f"keys={keys} has_legacy_payload={has_payload} "
+        f"keys={keys} has_api_v1_payload={has_payload} "
         f"has_heartbeat={has_heartbeat} wait={wait_seconds} "
         f"error={relay_error or 'none'}"
     )
@@ -285,10 +285,10 @@ def run(args: argparse.Namespace) -> int:
             api_v1_payload = is_api_v1_relay_payload(relay_response)
             heartbeat_ack = "next_ping_in_x_seconds" in relay_response
             relay_error = _relay_error_message(relay_response)
-            registered = relay_error is None and (legacy_payload or api_v1_payload or heartbeat_ack)
+            registered = relay_error is None and (api_v1_payload or heartbeat_ack)
 
             print(
-                "desktop.compute_node_bridge.relay_poll "
+                "desktop.compute_node_bridge.api_v1_e2ee.poll "
                 f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
                 f"legacy_payload={legacy_payload} api_v1_payload={api_v1_payload} "
                 f"heartbeat_ack={heartbeat_ack} "
@@ -304,9 +304,9 @@ def run(args: argparse.Namespace) -> int:
                         "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
                         "operator; update relay.py to repo HEAD"
                     )
-            elif legacy_payload or api_v1_payload:
+            elif api_v1_payload:
                 print(
-                    "desktop.compute_node_bridge.process_request.start "
+                    "desktop.compute_node_bridge.api_v1_e2ee.work_received "
                     f"stream={relay_response.get('stream') is True} api_v1_payload={api_v1_payload}",
                     file=sys.stderr,
                 )

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -348,7 +348,7 @@ class TestRelayClient:
 
         # Verify mock calls
         mock_post.assert_called_once_with(
-            'http://localhost:5000/sink',
+            'http://localhost:5000/api/v1/relay/servers/poll',
             json={'server_public_key': 'mock_public_key_b64'},
             timeout=relay_client._request_timeout
         )
@@ -452,8 +452,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/sink',
-            'http://backup-relay:6000/sink',
+            'http://primary-relay:5000/api/v1/relay/servers/poll',
+            'http://backup-relay:6000/api/v1/relay/servers/poll',
         ]
         assert client.relay_url == 'http://backup-relay:6000'
 
@@ -501,8 +501,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/sink',
-            'https://relay.cloudflare.workers.dev/api/v1/sink',
+            'http://primary-relay:5000/api/v1/relay/servers/poll',
+            'https://relay.cloudflare.workers.dev/api/v1/relay/servers/poll',
         ]
 
     @patch('utils.networking.relay_client.requests.post')
@@ -558,9 +558,9 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/sink',
-            'http://backup-relay:6000/sink',
-            'http://backup-relay:6000/sink',
+            'http://primary-relay:5000/api/v1/relay/servers/poll',
+            'http://backup-relay:6000/api/v1/relay/servers/poll',
+            'http://backup-relay:6000/api/v1/relay/servers/poll',
         ]
         assert client.relay_url == 'http://backup-relay:6000'
 
@@ -609,8 +609,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/sink',
-            'http://backup-relay:6000/sink',
+            'http://primary-relay:5000/api/v1/relay/servers/poll',
+            'http://backup-relay:6000/api/v1/relay/servers/poll',
         ]
         assert client.relay_url == 'http://backup-relay:6000'
 
@@ -816,7 +816,7 @@ class TestRelayClient:
             mock_crypto_manager.decrypt_message.return_value
         )
 
-        # Check the encryption and post to /source
+        # Check the encryption and post to /api/v1/relay/responses
         mock_crypto_manager.encrypt_message.assert_called_once_with(
             mock_model_manager.llama_cpp_get_response.return_value,
             base64.b64decode('Y2xpZW50X2tleV9iNjQ=')
@@ -829,7 +829,7 @@ class TestRelayClient:
             'iv': 'encrypted_iv'
         }
         mock_post.assert_called_once_with(
-            'http://localhost:5000/source',
+            'http://localhost:5000/api/v1/relay/responses',
             json=expected_payload,
             timeout=relay_client._request_timeout
         )
@@ -880,7 +880,7 @@ class TestRelayClient:
             max_tokens=50,
         )
         mock_post.assert_called_once_with(
-            'http://localhost:5000/source',
+            'http://localhost:5000/api/v1/relay/responses',
             json={
                 'client_public_key': request_data["client_public_key"],
                 'chat_history': 'encrypted_chat_history',
@@ -1118,11 +1118,11 @@ class TestRelayClient:
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_source_error(self, mock_post, relay_client, mock_crypto_manager, mock_model_manager, mock_http_response):
-        """Test processing a client request with error from /source endpoint."""
+        """Test processing a client request with error from /api/v1/relay/responses endpoint."""
         # Setup
         request_data = TEST_VALID_RESPONSE.copy()
 
-        # Mock error response from /source
+        # Mock error response from /api/v1/relay/responses
         mock_http_response.status_code = 500
         mock_http_response.text = "Internal server error"
         mock_post.return_value = mock_http_response
@@ -1135,11 +1135,11 @@ class TestRelayClient:
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_empty_response(self, mock_post, relay_client, mock_crypto_manager, mock_model_manager, mock_http_response):
-        """Test processing a client request with empty response from /source."""
+        """Test processing a client request with empty response from /api/v1/relay/responses."""
         # Setup
         request_data = TEST_VALID_RESPONSE.copy()
 
-        # Mock empty response from /source
+        # Mock empty response from /api/v1/relay/responses
         mock_http_response.status_code = 200
         mock_http_response.text = ""
         mock_post.return_value = mock_http_response

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -62,9 +62,16 @@ def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
 
 
 def is_api_v1_relay_payload(payload: Dict[str, Any]) -> bool:
-    """Return whether ``payload`` is a relay API v1 request (disabled)."""
+    """Return whether ``payload`` is a relay API v1 request envelope."""
 
-    return False
+    if not isinstance(payload, dict):
+        return False
+    return (
+        payload.get("protocol") == "tokenplace_api_v1_relay_e2ee"
+        and payload.get("version") == 1
+        and LEGACY_RELAY_REQUIRED_FIELDS.issubset(payload.keys())
+        and "request_id" in payload
+    )
 
 
 class RelayRequestAdapter(Protocol):
@@ -91,17 +98,16 @@ class LegacyRelayRequestAdapter:
 
 
 class ApiV1RelayRequestAdapter:
-    """No-op adapter retained for backwards-compatible imports only."""
+    """Adapter for API v1 E2EE request envelopes."""
 
     def __init__(self, relay_client: "RelayClient"):
         self._relay_client = relay_client
 
     def can_process(self, request_data: Dict[str, Any]) -> bool:
-        return False
+        return is_api_v1_relay_payload(request_data)
 
     def process(self, request_data: Dict[str, Any]) -> bool:
-        _log_warning("Ignoring disabled relay API v1 payload handling in compute node runtime")
-        return False
+        return self._relay_client.process_client_request(request_data)
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -264,6 +270,7 @@ class ComputeNodeRuntime:
         )
         if request_adapters is None:
             self.request_adapters = [
+                ApiV1RelayRequestAdapter(self.relay_client),
                 LegacyRelayRequestAdapter(self.relay_client),
             ]
         else:
@@ -309,7 +316,7 @@ class ComputeNodeRuntime:
         return False
 
     def register_and_poll_once(self) -> Dict[str, Any]:
-        """Ping relay /sink and return response data."""
+        """Register/poll relay API v1 routes and return response data."""
 
         return self.relay_client.ping_relay()
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -578,7 +578,7 @@ class RelayClient:
 
             try:
                 log_info(
-                    "Pinging relay {}/sink with key {}...",
+                    "desktop.compute_node_bridge.api_v1_e2ee.poll relay={} with key {}...",
                     candidate_url,
                     self.crypto_manager.public_key_b64[:10],
                 )
@@ -592,15 +592,34 @@ class RelayClient:
                     request_kwargs['headers'] = headers
 
                 timeout = request_kwargs.pop('timeout', self._request_timeout)
+                register_response = requests.post(
+                    f'{candidate_url}/api/v1/relay/servers/register',
+                    timeout=timeout,
+                    **request_kwargs,
+                )
+                if register_response.status_code != 200:
+                    log_error(
+                        "Error from relay /api/v1/relay/servers/register: status {} ({} bytes)",
+                        register_response.status_code,
+                        len(register_response.text),
+                    )
+                    last_error = {
+                        'error': f"HTTP {register_response.status_code}",
+                        'next_ping_in_x_seconds': self._request_timeout,
+                    }
+                    encountered_error = True
+                    continue
+
+                log_info("desktop.compute_node_bridge.api_v1_e2ee.register relay={}", candidate_url)
                 response = requests.post(
-                    f'{candidate_url}/sink',
+                    f'{candidate_url}/api/v1/relay/servers/poll',
                     timeout=timeout,
                     **request_kwargs,
                 )
 
                 if response.status_code != 200:
                     log_error(
-                        "Error from relay /sink: status {} ({} bytes)",
+                        "Error from relay /api/v1/relay/servers/poll: status {} ({} bytes)",
                         response.status_code,
                         len(response.text),
                     )
@@ -717,14 +736,14 @@ class RelayClient:
                             request_kwargs["headers"] = headers
 
                         source_response = requests.post(
-                            f"{self.relay_url}/source",
+                            f"{self.relay_url}/api/v1/relay/responses",
                             timeout=self._request_timeout,
                             **request_kwargs,
                         )
                         return source_response.status_code == 200
                     except Exception:
                         log_error(
-                            "Failed to encrypt or post API v1 response to relay /source",
+                            "Failed to encrypt or post API v1 response to relay /api/v1/relay/responses",
                             exc_info=True,
                         )
                         return False
@@ -913,7 +932,7 @@ class RelayClient:
                 log_error("Invalid response payload format: {}", str(e))
                 return False
 
-            log_info("Posting response to {}/source. Payload keys: {}", self.relay_url, list(source_payload.keys()))
+            log_info("desktop.compute_node_bridge.api_v1_e2ee.response_submitted relay={} payload_keys={}", self.relay_url, list(source_payload.keys()))
 
             request_kwargs = {
                 'json': source_payload,
@@ -925,24 +944,24 @@ class RelayClient:
 
             timeout = request_kwargs.pop('timeout', self._request_timeout)
             source_response = requests.post(
-                f'{self.relay_url}/source',
+                f'{self.relay_url}/api/v1/relay/responses',
                 timeout=timeout,
                 **request_kwargs
             )
 
             log_info(
-                "Response sent to /source. Status: {}, body length: {}",
+                "Response sent to /api/v1/relay/responses. Status: {}, body length: {}",
                 source_response.status_code,
                 len(source_response.text)
             )
 
             if source_response.status_code != 200:
-                log_error("Error status from /source: {}", source_response.status_code)
+                log_error("Error status from /api/v1/relay/responses: {}", source_response.status_code)
                 return False
 
             response_content = source_response.text.strip()
             if not response_content:
-                log_error("Empty response from /source")
+                log_error("Empty response from /api/v1/relay/responses")
                 return False
 
             return True


### PR DESCRIPTION
### Motivation
- The desktop compute-node / Tauri bridge was still using legacy relay endpoints (`/sink` and `/source`) for registration/polling and response submission, which prevents the active operator path from using the API v1 E2EE relay contract.
- Move the active desktop transport to the API v1 E2EE routes so the relay only ever sees ciphertext and routing metadata while preserving legacy handlers for compatibility.

### Description
- Update `RelayClient.ping_relay()` to perform an API v1 registration (`/api/v1/relay/servers/register`) then poll via `/api/v1/relay/servers/poll`, and add `desktop.compute_node_bridge.api_v1_e2ee.register`/`.poll` diagnostic markers.
- Switch encrypted response submission from the legacy `/source` to `/api/v1/relay/responses`, add `desktop.compute_node_bridge.api_v1_e2ee.response_submitted` logging, and ensure only encrypted envelopes (client key + ciphertext fields) are sent.
- Enable `is_api_v1_relay_payload()` detection and add `ApiV1RelayRequestAdapter` into `ComputeNodeRuntime` adapters so API v1 E2EE envelopes are handled before legacy payloads while retaining legacy adapter for isolated compatibility paths.
- Update the desktop bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) to treat API v1 E2EE payloads as the active work path and to emit API-v1-specific poll/work markers, and update unit tests in `tests/unit/test_relay_client.py` to expect API v1 URLs.

### Testing
- Ran `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py`, which could not complete in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'requests'`).
- Verified route/log marker changes with `rg` searches for `ping_relay`, `api_v1_e2ee.register`, `api_v1_e2ee.poll`, and `api_v1_e2ee.response_submitted`, confirming code now references API v1 routes and diagnostics.
- Recommendation: run `pre-commit run --all-files` and the full test matrix (`python -m pytest -q`) in a dependency-complete environment to validate all tests pass before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bf4702dc832f88a7c5dcad22459f)