### PR TITLE
Migrate landing chat to API v1 distributed relay path and reject stub responses

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -426,13 +426,20 @@ def _build_api_v1_compute_provider(
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     """Resolve the active provider based on environment configuration."""
 
+    mode, distributed_url, distributed_fallback_enabled = _read_api_v1_provider_env()
+    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
+
+
+def _read_api_v1_provider_env() -> tuple[str, str, bool]:
+    """Read and normalize API v1 provider environment configuration."""
+
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
     distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
+    return mode, distributed_url, distributed_fallback_enabled
 
 
 def get_api_v1_compute_provider_for_mode(
@@ -443,12 +450,9 @@ def get_api_v1_compute_provider_for_mode(
     """Resolve provider with an explicit mode override for request-scoped routing."""
 
     normalized_mode = (mode or "local").strip().lower()
-    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    _, distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
     if distributed_fallback_enabled is None:
-        distributed_fallback_enabled = (
-            os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
-            not in {"0", "false", "no", "off"}
-        )
+        distributed_fallback_enabled = fallback_enabled_from_env
     return _build_api_v1_compute_provider(
         normalized_mode,
         distributed_url,

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -435,6 +435,27 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
 
 
+def get_api_v1_compute_provider_for_mode(
+    *,
+    mode: str,
+    distributed_fallback_enabled: bool | None = None,
+) -> ApiV1ComputeProvider:
+    """Resolve provider with an explicit mode override for request-scoped routing."""
+
+    normalized_mode = (mode or "local").strip().lower()
+    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    if distributed_fallback_enabled is None:
+        distributed_fallback_enabled = (
+            os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
+            not in {"0", "false", "no", "off"}
+        )
+    return _build_api_v1_compute_provider(
+        normalized_mode,
+        distributed_url,
+        bool(distributed_fallback_enabled),
+    )
+
+
 def get_api_v1_resolved_provider_path(provider: ApiV1ComputeProvider) -> str:
     """Return a stable diagnostics label for the resolved provider instance."""
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -78,6 +78,18 @@ DEFAULT_SERVICE_NAME = 'token.place'
 SERVICE_NAME = os.getenv('SERVICE_NAME', DEFAULT_SERVICE_NAME)
 
 
+def _should_force_desktop_bridge_distributed(request_metadata, is_encrypted_request: bool) -> bool:
+    """Allow desktop-bridge distributed override only for explicit API v1 E2EE intent."""
+
+    if not isinstance(request_metadata, dict) or not is_encrypted_request:
+        return False
+    if request_metadata.get("inference_target") != "desktop_bridge_api_v1_e2ee":
+        return False
+    if request_metadata.get("relay_path") != "api_v1_e2ee":
+        return False
+    return bool(os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip())
+
+
 def _get_service_name() -> str:
     """Return the configured service identifier for health responses."""
 
@@ -326,9 +338,9 @@ def _handle_chat_completion_request(data):
             ]
 
         request_metadata = data.get("metadata")
-        force_desktop_bridge_distributed = bool(
-            isinstance(request_metadata, dict)
-            and request_metadata.get("inference_target") == "desktop_bridge_api_v1_e2ee"
+        force_desktop_bridge_distributed = _should_force_desktop_bridge_distributed(
+            request_metadata,
+            is_encrypted_request,
         )
 
         log_info(f"Generating response using model {model_id}")

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -35,6 +35,7 @@ from api.v1.models import (
 )
 from api.v1.compute_provider import (
     get_api_v1_compute_provider,
+    get_api_v1_compute_provider_for_mode,
     get_api_v1_last_backend_path,
     get_api_v1_resolved_provider_path,
     ComputeProviderError,
@@ -324,8 +325,21 @@ def _handle_chat_completion_request(data):
                 if isinstance(message, dict)
             ]
 
+        request_metadata = data.get("metadata")
+        force_desktop_bridge_distributed = bool(
+            isinstance(request_metadata, dict)
+            and request_metadata.get("inference_target") == "desktop_bridge_api_v1_e2ee"
+        )
+
         log_info(f"Generating response using model {model_id}")
-        provider = get_api_v1_compute_provider()
+        provider = (
+            get_api_v1_compute_provider_for_mode(
+                mode="distributed",
+                distributed_fallback_enabled=False,
+            )
+            if force_desktop_bridge_distributed
+            else get_api_v1_compute_provider()
+        )
         resolved_provider_name = provider.__class__.__name__
         resolved_provider_path = get_api_v1_resolved_provider_path(provider)
         log_info(
@@ -378,7 +392,6 @@ def _handle_chat_completion_request(data):
             },
         }
 
-        request_metadata = data.get("metadata")
         if isinstance(request_metadata, dict) and request_metadata:
             response_data["metadata"] = request_metadata
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -387,7 +387,11 @@ new Vue({
                     model: "llama-3-8b-instruct",
                     encrypted: true,
                     client_public_key: this.encodeClientPublicKeyForApi(),
-                    messages: encryptedData
+                    messages: encryptedData,
+                    metadata: {
+                        inference_target: "desktop_bridge_api_v1_e2ee",
+                        relay_path: "api_v1_e2ee"
+                    }
                 };
 
                 // Send the request to the API
@@ -501,6 +505,20 @@ new Vue({
             return codeToMessage[errorCode] || fallbackMessage;
         },
 
+        isInvalidAssistantResponseContent(content) {
+            if (typeof content !== 'string') {
+                return true;
+            }
+            const normalized = content.trim();
+            if (!normalized) {
+                return true;
+            }
+            if (normalized.toLowerCase() === 'stub') {
+                return true;
+            }
+            return normalized === 'Sorry, I encountered an issue generating a response. Please try again.';
+        },
+
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
@@ -530,6 +548,9 @@ new Vue({
                     // For API response, extract last message
                     else if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;
+                        if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
+                            throw new Error('Invalid assistant response content from API v1 relay path');
+                        }
                         this.appendAssistantMessage(assistantMessage);
                     }
                     // For legacy response format (full chat history)

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,3 +1,6 @@
+const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
+const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
+
 new Vue({
     el: '#app',
     data: {
@@ -491,7 +494,7 @@ new Vue({
         getUserFacingApiError(errorPayload) {
             const error = errorPayload && typeof errorPayload === 'object' ? errorPayload.error : null;
             const errorCode = error && typeof error.code === 'string' ? error.code : '';
-            const fallbackMessage = 'Sorry, I encountered an issue generating a response. Please try again.';
+            const fallbackMessage = ASSISTANT_GENERIC_FALLBACK_MESSAGE;
 
             const codeToMessage = {
                 no_registered_compute_nodes: 'No LLM servers are available right now.',
@@ -516,7 +519,7 @@ new Vue({
             if (normalized.toLowerCase() === 'stub') {
                 return true;
             }
-            return normalized === 'Sorry, I encountered an issue generating a response. Please try again.';
+            return normalized === ASSISTANT_GENERIC_FALLBACK_MESSAGE;
         },
 
         // Send a message to the server
@@ -549,7 +552,7 @@ new Vue({
                     else if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;
                         if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
-                            throw new Error('Invalid assistant response content from API v1 relay path');
+                            throw new Error('invalid_assistant_response_content');
                         }
                         this.appendAssistantMessage(assistantMessage);
                     }
@@ -572,14 +575,17 @@ new Vue({
                     // Add a failure message if we couldn't get a response
                     this.chatHistory.push({
                         role: 'assistant',
-                        content: 'Sorry, I encountered an issue generating a response. Please try again.'
+                        content: ASSISTANT_GENERIC_FALLBACK_MESSAGE
                     });
                 }
             } catch (error) {
                 console.error('Error sending message:', error);
+                const isInvalidRelayResponse = error && error.message === 'invalid_assistant_response_content';
                 this.chatHistory.push({
                     role: 'assistant',
-                    content: 'Sorry, an error occurred while sending your message. Please try again.'
+                    content: isInvalidRelayResponse
+                        ? ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE
+                        : 'Sorry, an error occurred while sending your message. Please try again.'
                 });
             } finally {
                 this.isGeneratingResponse = false;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -504,6 +504,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "The LLM server is unavailable right now. Please try again.",
             "The LLM server took too long to respond. Please try again.",
         }
+        disallowed_assistant_outputs = {
+            "stub",
+            "Sorry, I encountered an issue generating a response. Please try again.",
+        }
         for _ in range(2):
             textarea.fill(prompt_text)
             page.locator("button", has_text="Send").click()
@@ -529,12 +533,17 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 },
             )
             assistant_text = assistant_message.inner_text().strip()
-            if assistant_text and assistant_text not in transient_bridge_errors:
+            if (
+                assistant_text
+                and assistant_text not in transient_bridge_errors
+                and assistant_text not in disallowed_assistant_outputs
+            ):
                 break
 
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"
         assert "Sorry, I encountered an issue generating a response." not in assistant_text
+        assert assistant_text.lower() != "stub"
         assert assistant_text not in transient_bridge_errors
         assert "Unknown streaming error" not in assistant_text
 
@@ -615,6 +624,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         encrypted_request = v1_requests[0].post_data_json
         assert encrypted_request.get("encrypted") is True
         assert encrypted_request.get("stream") in (None, False)
+        metadata = encrypted_request.get("metadata")
+        assert isinstance(metadata, dict)
+        assert metadata.get("inference_target") == "desktop_bridge_api_v1_e2ee"
+        assert metadata.get("relay_path") == "api_v1_e2ee"
         client_public_key = encrypted_request.get("client_public_key")
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -543,7 +543,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"
-        assert "Sorry, I encountered an issue generating a response." not in assistant_text
+        assert assistant_text.lower() != "stub"
+        assert assistant_text != "Sorry, I encountered an issue generating a response. Please try again."
+        assert assistant_text != "Sorry, an error occurred while sending your message. Please try again."
+        assert assistant_text != "Sorry, the relay returned an invalid response. Please try again."
         assert assistant_text not in transient_bridge_errors
         assert "Unknown streaming error" not in assistant_text
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -505,8 +505,9 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "The LLM server took too long to respond. Please try again.",
         }
         disallowed_assistant_outputs = {
-            "stub",
             "Sorry, I encountered an issue generating a response. Please try again.",
+            "Sorry, the relay returned an invalid response. Please try again.",
+            "Sorry, an error occurred while sending your message. Please try again.",
         }
         for _ in range(2):
             textarea.fill(prompt_text)
@@ -543,7 +544,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"
         assert "Sorry, I encountered an issue generating a response." not in assistant_text
-        assert assistant_text.lower() != "stub"
         assert assistant_text not in transient_bridge_errors
         assert "Unknown streaming error" not in assistant_text
 

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -6,6 +6,7 @@ from api.v1.compute_provider import (
     DistributedApiV1ComputeProvider,
     FallbackApiV1ComputeProvider,
     LocalApiV1ComputeProvider,
+    get_api_v1_compute_provider_for_mode,
     get_api_v1_resolved_provider_path,
 )
 from relay import app
@@ -628,3 +629,22 @@ def test_distributed_compute_provider_maps_missing_assistant_message(monkeypatch
     except ComputeProviderError as exc:
         assert exc.code == "compute_node_invalid_payload"
         assert "compute node response missing assistant message" in str(exc)
+
+
+def test_get_api_v1_compute_provider_for_mode_distributed_without_url_raises(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    try:
+        get_api_v1_compute_provider_for_mode(mode="distributed", distributed_fallback_enabled=False)
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+
+
+def test_get_api_v1_compute_provider_for_mode_reads_fallback_from_env(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1")
+
+    provider = get_api_v1_compute_provider_for_mode(mode="distributed", distributed_fallback_enabled=None)
+    assert isinstance(provider, LocalApiV1ComputeProvider)


### PR DESCRIPTION
### Motivation
- Prevent landing-page chat from silently resolving to the local provider when desktop-bridge distributed inference is intended, which produced false-success outputs like `stub` or generic fallback text. 
- Ensure the browser UI and backend choose the API v1 E2EE relay path end-to-end for desktop bridge mode so relay remains ciphertext-only and diagnostics show the true execution backend.

### Description
- Add explicit metadata to landing-page encrypted requests in `static/chat.js` (`metadata.inference_target = "desktop_bridge_api_v1_e2ee"`, `metadata.relay_path = "api_v1_e2ee"`) so backend can detect desktop-bridge intent. 
- Add client-side validation `isInvalidAssistantResponseContent` in `static/chat.js` and throw on empty/`stub`/generic-fallback assistant text to avoid treating false-success responses as valid. 
- Introduce `get_api_v1_compute_provider_for_mode` in `api/v1/compute_provider.py` to resolve a request-scoped provider mode without mutating global env behavior. 
- Update `api/v1/routes.py` chat completion handling to force the `distributed` provider with fallback disabled when request metadata indicates desktop-bridge API v1 E2EE intent, while preserving default behavior for other requests. 
- Strengthen the E2E test `tests/e2e/test_ui.py` to assert the outbound encrypted request contains the new metadata and to reject `stub`/generic-fallback assistant outputs, and to continue asserting the resolved provider/diagnostics are `distributed`/`distributed_relay_e2ee`.

### Testing
- Ran unit test invocation for the compute-provider suite with `python -m pytest -q tests/unit/test_api_v1_compute_provider.py`, which failed in this environment due to missing dependency `requests` (`ModuleNotFoundError: No module named 'requests'`).
- Executed repository checks `rg "/sink|/faucet|/source|/retrieve|/next_server" static api relay.py tests/e2e` and `rg "stub|Sorry, I encountered an issue|LocalApiV1ComputeProvider|distributed|api_v1_e2ee|desktop bridge" static api tests/e2e` to validate presence/absence of legacy routes and markers; these greps returned expected matches for diagnostics and confirmed no landing-path rewrites to legacy endpoints. 
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in this environment; please run locally or CI to verify linting and full test matrix.
- Updated E2E assertions in `tests/e2e/test_ui.py` to fail if the client or backend returns `stub`/generic fallback text when desktop-bridge mode is intended; these tests should be run in CI or a local environment with the distributed compute URL and dependencies available to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f307d736e4832fa03a485917bae31e)