### PR TITLE
Enforce desktop-bridge API v1 distributed chat path

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -435,6 +435,13 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
 
 
+def get_api_v1_compute_provider_for_desktop_bridge() -> ApiV1ComputeProvider:
+    """Resolve distributed-only provider for explicit desktop-bridge relay mode."""
+
+    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    return _build_api_v1_compute_provider("distributed", distributed_url, False)
+
+
 def get_api_v1_resolved_provider_path(provider: ApiV1ComputeProvider) -> str:
     """Return a stable diagnostics label for the resolved provider instance."""
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -35,6 +35,7 @@ from api.v1.models import (
 )
 from api.v1.compute_provider import (
     get_api_v1_compute_provider,
+    get_api_v1_compute_provider_for_desktop_bridge,
     get_api_v1_last_backend_path,
     get_api_v1_resolved_provider_path,
     ComputeProviderError,
@@ -324,8 +325,19 @@ def _handle_chat_completion_request(data):
                 if isinstance(message, dict)
             ]
 
+        request_metadata = data.get("metadata")
+        desktop_bridge_mode_requested = (
+            isinstance(request_metadata, dict)
+            and request_metadata.get("tokenplace_execution_target")
+            == "desktop_bridge_api_v1_e2ee"
+        )
+
         log_info(f"Generating response using model {model_id}")
-        provider = get_api_v1_compute_provider()
+        provider = (
+            get_api_v1_compute_provider_for_desktop_bridge()
+            if desktop_bridge_mode_requested
+            else get_api_v1_compute_provider()
+        )
         resolved_provider_name = provider.__class__.__name__
         resolved_provider_path = get_api_v1_resolved_provider_path(provider)
         log_info(
@@ -378,7 +390,6 @@ def _handle_chat_completion_request(data):
             },
         }
 
-        request_metadata = data.get("metadata")
         if isinstance(request_metadata, dict) and request_metadata:
             response_data["metadata"] = request_metadata
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -387,7 +387,10 @@ new Vue({
                     model: "llama-3-8b-instruct",
                     encrypted: true,
                     client_public_key: this.encodeClientPublicKeyForApi(),
-                    messages: encryptedData
+                    messages: encryptedData,
+                    metadata: {
+                        tokenplace_execution_target: 'desktop_bridge_api_v1_e2ee'
+                    }
                 };
 
                 // Send the request to the API
@@ -495,10 +498,25 @@ new Vue({
                 compute_node_bridge_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_unreachable: 'The LLM server is unavailable right now. Please try again.',
                 compute_node_bridge_error: 'Unable to contact the LLM server right now. Please try again.',
-                compute_node_invalid_payload: 'The LLM server returned an invalid response. Please try again.'
+                compute_node_invalid_payload: 'The LLM server returned an invalid response. Please try again.',
+                distributed_mode_required: 'Desktop bridge mode requires a reachable relay compute node.'
             };
 
             return codeToMessage[errorCode] || fallbackMessage;
+        },
+
+        isInvalidAssistantContent(content) {
+            if (typeof content !== 'string') {
+                return true;
+            }
+            const normalized = content.trim();
+            if (!normalized) {
+                return true;
+            }
+            if (normalized.toLowerCase() === 'stub') {
+                return true;
+            }
+            return normalized === 'Sorry, I encountered an issue generating a response. Please try again.';
         },
 
         // Send a message to the server
@@ -530,6 +548,9 @@ new Vue({
                     // For API response, extract last message
                     else if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;
+                        if (!assistantMessage || this.isInvalidAssistantContent(assistantMessage.content)) {
+                            throw new Error('Invalid assistant response content for desktop bridge mode');
+                        }
                         this.appendAssistantMessage(assistantMessage);
                     }
                     // For legacy response format (full chat history)

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -534,6 +534,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"
+        assert assistant_text.strip().lower() != "stub"
         assert "Sorry, I encountered an issue generating a response." not in assistant_text
         assert assistant_text not in transient_bridge_errors
         assert "Unknown streaming error" not in assistant_text
@@ -615,6 +616,9 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         encrypted_request = v1_requests[0].post_data_json
         assert encrypted_request.get("encrypted") is True
         assert encrypted_request.get("stream") in (None, False)
+        metadata = encrypted_request.get("metadata")
+        assert isinstance(metadata, dict)
+        assert metadata.get("tokenplace_execution_target") == "desktop_bridge_api_v1_e2ee"
         client_public_key = encrypted_request.get("client_public_key")
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)


### PR DESCRIPTION
### Motivation
- Landing-page chat could silently resolve to the local provider and surface placeholder responses (`stub` or generic failure text) while desktop-bridge intent was expected, so the flow must fail closed when distributed execution is requested.
- Make desktop-bridge intent explicit in API v1 payloads so provider selection can be deterministic and auditable.

### Description
- Add explicit execution metadata to landing-page API v1 requests by including `metadata.tokenplace_execution_target = 'desktop_bridge_api_v1_e2ee'` in the payload sent from `static/chat.js` and map a new user-facing error code for missing distributed mode. (`static/chat.js`)
- Harden the UI by adding `isInvalidAssistantContent` and rejecting `stub`, empty, or generic-failure assistant content as invalid for desktop-bridge mode so the UI fails instead of treating placeholders as success. (`static/chat.js`)
- Add `get_api_v1_compute_provider_for_desktop_bridge()` which resolves a distributed-only provider (no local fallback) for explicit desktop-bridge requests. (`api/v1/compute_provider.py`)
- Update API v1 chat routing to select the distributed-only provider when the desktop-bridge metadata flag is present, while leaving the default behavior unchanged when metadata is absent. (`api/v1/routes.py`)
- Strengthen the real-inference landing-page E2E test to assert non-`stub` assistant content and to verify the outbound request contains the `tokenplace_execution_target` metadata. (`tests/e2e/test_ui.py`)

### Testing
- Attempted to run focused API tests with `python -m pytest -q tests/test_api.py -k "distributed_no_fallback_returns_503 or chat_completion"`, but the run failed due to the test environment missing the `requests` dependency (`ModuleNotFoundError: No module named 'requests'`).
- Attempted to run lint/pre-commit with `pre-commit run --all-files`, but the host environment does not have `pre-commit` installed (`pre-commit: command not found`).
- Note: the E2E landing-chat test to validate the full desktop-bridge flow is included and should be run locally or in CI with dependencies installed using `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'` (the change includes the focused assertions required by that test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f307d736e4832fa03a485917bae31e)