### PR TITLE
Harden landing chat guardrails: reject stub/generic assistant responses and map relay-disabled error

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -484,6 +484,23 @@ new Vue({
             return message.content;
         },
 
+        isInvalidAssistantResponseContent(content) {
+            if (typeof content !== 'string') {
+                return true;
+            }
+
+            const normalized = content.trim().toLowerCase();
+            if (!normalized) {
+                return true;
+            }
+
+            if (normalized === 'stub') {
+                return true;
+            }
+
+            return normalized === 'sorry, i encountered an issue generating a response. please try again.';
+        },
+
         getUserFacingApiError(errorPayload) {
             const error = errorPayload && typeof errorPayload === 'object' ? errorPayload.error : null;
             const errorCode = error && typeof error.code === 'string' ? error.code : '';
@@ -495,7 +512,8 @@ new Vue({
                 compute_node_bridge_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_unreachable: 'The LLM server is unavailable right now. Please try again.',
                 compute_node_bridge_error: 'Unable to contact the LLM server right now. Please try again.',
-                compute_node_invalid_payload: 'The LLM server returned an invalid response. Please try again.'
+                compute_node_invalid_payload: 'The LLM server returned an invalid response. Please try again.',
+                distributed_api_v1_relay_disabled: 'Desktop bridge mode is currently unavailable. Please try again shortly.'
             };
 
             return codeToMessage[errorCode] || fallbackMessage;
@@ -530,13 +548,17 @@ new Vue({
                     // For API response, extract last message
                     else if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;
+                        const assistantContent = assistantMessage && assistantMessage.content;
+                        if (this.isInvalidAssistantResponseContent(assistantContent)) {
+                            throw new Error('Invalid assistant response content from API v1 relay path');
+                        }
                         this.appendAssistantMessage(assistantMessage);
                     }
                     // For legacy response format (full chat history)
                     else if (Array.isArray(response)) {
                         const history = response.slice();
                         const candidate = history.length > 0 ? history[history.length - 1] : null;
-                        if (candidate && candidate.role === 'assistant' && typeof candidate.content === 'string') {
+                        if (candidate && candidate.role === 'assistant' && typeof candidate.content === 'string' && !this.isInvalidAssistantResponseContent(candidate.content)) {
                             history.pop();
                             this.chatHistory = history;
                             this.appendAssistantMessage(candidate);


### PR DESCRIPTION
### Motivation
- Prevent landing-page chat from treating placeholder or generic-failure payloads as successful assistant responses when using the API v1 E2EE relay path.
- Surface a clear user-facing message when the desktop-bridge/API v1 relay is disabled so failures are not confused for valid model output.

### Description
- Added `isInvalidAssistantResponseContent` to validate assistant message content and treat empty, `stub`, or the generic fallback string as invalid in `static/chat.js`.
- Added a `distributed_api_v1_relay_disabled` -> friendly message mapping in `getUserFacingApiError` so relay-disabled errors are shown clearly to users.
- Enforced validation before accepting API v1 `choices[0].message` and on the legacy-array fallback so invalid assistant content throws into the error path instead of rendering as success.
- Changes are limited to `static/chat.js` and preserve the existing API v1 non-streaming landing chat flow.

### Testing
- Ran `python -m pytest -q tests/test_api.py tests/test_relay.py tests/unit/test_api_v1_compute_provider.py` and the test suite passed (unit/integration tests completed successfully; total run shown as 114 passed in local run).
- Ran `pre-commit run --all-files` and hooks completed successfully.
- Attempted `python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'`, but the Playwright Chromium launch could not complete in this environment due to a missing system library (`libatk-1.0.so.0`), so the E2E run was not executed here.
- Ran repository greps and sanity checks for legacy relay routes and sentinel strings as part of verification and saw no regressions related to plaintext/E2EE handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f307d736e4832fa03a485917bae31e)