### PR TITLE
Fix API v1 E2EE relay routing and desktop bridge API-v1 handling

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -91,6 +91,28 @@ def _error_from_code(code: str, *, message: str) -> ComputeProviderError:
     )
 
 
+_INVALID_ASSISTANT_CONTENT = {
+    "",
+    "stub",
+    "sorry, the relay returned an invalid response. please try again.",
+    "unable to generate a response right now.",
+}
+
+
+def _is_meaningful_assistant_message(message: Any) -> bool:
+    """Return True only for non-empty, non-placeholder assistant content."""
+
+    if not isinstance(message, dict):
+        return False
+    if message.get("role", "assistant") != "assistant":
+        return False
+    content = message.get("content")
+    if not isinstance(content, str):
+        return False
+    normalized = content.strip()
+    return normalized.lower() not in _INVALID_ASSISTANT_CONTENT
+
+
 class ApiV1ComputeProvider(Protocol):
     """Contract for API v1-compatible compute providers."""
 
@@ -224,6 +246,9 @@ class DistributedApiV1ComputeProvider:
                 message=f"failed to encrypt relay request envelope: {exc}",
             ) from exc
         faucet_payload = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": relay_request_id,
             "client_public_key": crypto_manager.public_key_b64,
             "server_public_key": server_public_key,
             **encrypted_envelope,
@@ -262,7 +287,10 @@ class DistributedApiV1ComputeProvider:
                 retrieve_timeout = min(poll_interval + 0.5, _remaining_timeout())
                 retrieve_response = requests.post(
                     self._relay_url("/api/v1/relay/responses/retrieve"),
-                    json={"client_public_key": crypto_manager.public_key_b64},
+                    json={
+                        "client_public_key": crypto_manager.public_key_b64,
+                        "request_id": relay_request_id,
+                    },
                     timeout=retrieve_timeout,
                 )
             except requests.RequestException:
@@ -324,10 +352,10 @@ class DistributedApiV1ComputeProvider:
                 )
 
             assistant_message = api_v1_response.get("message")
-            if not isinstance(assistant_message, dict):
+            if not _is_meaningful_assistant_message(assistant_message):
                 raise _error_from_code(
                     "compute_node_invalid_payload",
-                    message="compute node response missing assistant message",
+                    message="compute node response missing meaningful assistant content",
                 )
 
             _last_backend_path.set("distributed_relay_e2ee")

--- a/relay.py
+++ b/relay.py
@@ -742,14 +742,19 @@ def _extract_ciphertext_envelope(payload, *, require_server_key=False):
         'cipherkey': payload['cipherkey'],
         'iv': payload['iv'],
     }
+    request_id = payload.get('request_id')
+    protocol = payload.get('protocol')
+    version = payload.get('version')
+    if protocol != 'tokenplace_api_v1_relay_e2ee' or version != 1:
+        return None, ('Invalid API v1 relay envelope protocol', 400)
+    if not isinstance(request_id, str) or not request_id.strip():
+        return None, ('Invalid API v1 relay request id', 400)
+
     if require_server_key:
         envelope['server_public_key'] = payload['server_public_key']
-    if 'request_id' in payload:
-        envelope['request_id'] = payload['request_id']
-    if 'protocol' in payload:
-        envelope['protocol'] = payload['protocol']
-    if 'version' in payload:
-        envelope['version'] = payload['version']
+    envelope['request_id'] = request_id
+    envelope['protocol'] = protocol
+    envelope['version'] = version
     return envelope, None
 
 
@@ -847,28 +852,14 @@ def api_v1_relay_servers_poll():
 
     first_request = None
 
-    def _is_legacy_ciphertext_payload(payload):
-        return all(key in payload for key in ('client_public_key', 'chat_history', 'cipherkey', 'iv'))
-
-    # Prefer explicit API v1 envelopes when both API v1 and legacy ciphertext payloads are queued.
+    # API v1 poll is API v1-only: claim explicit API v1 E2EE envelopes and never
+    # dispatch legacy ciphertext work through the desktop bridge polling path.
     for idx, candidate in enumerate(queued_requests):
         if bool(candidate.get('e2ee_v1')):
             first_request = queued_requests.pop(idx)
             break
 
-    if first_request is None:
-        while queued_requests:
-            candidate = queued_requests[0]
-            if _is_legacy_ciphertext_payload(candidate):
-                first_request = queued_requests.pop(0)
-                break
-            queued_requests.pop(0)
-
-
-    if first_request is not None and bool(first_request.get('e2ee_v1')):
-        # When an API v1 envelope is available, keep API v1-only semantics by dropping
-        # legacy ciphertext payloads left in the same queue.
-        queued_requests[:] = [item for item in queued_requests if bool(item.get('e2ee_v1'))]
+    queued_requests[:] = [item for item in queued_requests if bool(item.get('e2ee_v1'))]
 
     if first_request is None:
         if not queued_requests:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1223,6 +1223,8 @@ def test_api_v1_relay_plaintext_messages_not_stored(client):
     plaintext = 'PLAINTEXT_SENTINEL_DO_NOT_STORE'
     payload = {
         'request_id': 'req-no-messages',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
         'client_public_key': DUMMY_CLIENT_PUB_KEY,
         'server_public_key': DUMMY_SERVER_PUB_KEY,
         'chat_history': 'ciphertext-only',
@@ -1245,6 +1247,8 @@ def test_api_v1_relay_requests_requires_client_public_key(client):
 
     response = client.post('/api/v1/relay/requests', json={
         'request_id': 'req-missing-client-key',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
         'server_public_key': DUMMY_SERVER_PUB_KEY,
         'ciphertext': 'ciphertext-request',
         'cipherkey': 'cipherkey-request',
@@ -1267,6 +1271,8 @@ def test_api_v1_register_and_poll_do_not_delegate_to_legacy_sink(client, monkeyp
 
     queued = client.post('/api/v1/relay/requests', json={
         'request_id': 'req-no-sink-delegation',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
         'client_public_key': DUMMY_CLIENT_PUB_KEY,
         'server_public_key': DUMMY_SERVER_PUB_KEY,
         'ciphertext': 'ciphertext-request',
@@ -1319,6 +1325,8 @@ def test_api_v1_relay_response_plaintext_not_stored(client):
     plaintext = 'PLAINTEXT_RESPONSE_SENTINEL_DO_NOT_STORE'
     response_payload = {
         'request_id': 'req-response-no-plaintext',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
         'client_public_key': DUMMY_CLIENT_PUB_KEY,
         'chat_history': 'ciphertext-response-only',
         'cipherkey': 'cipherkey-response-only',
@@ -1362,6 +1370,8 @@ def test_api_v1_register_does_not_dequeue_requests(client):
 
     request_payload = {
         'request_id': 'req-register-heartbeat',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
         'client_public_key': DUMMY_CLIENT_PUB_KEY,
         'server_public_key': DUMMY_SERVER_PUB_KEY,
         'chat_history': 'ciphertext-request',

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -58,6 +58,9 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
         posted_payloads.append((url, copy.deepcopy(json), timeout))
         if url.endswith("/api/v1/relay/requests"):
             assert "messages" not in json
+            assert json["protocol"] == "tokenplace_api_v1_relay_e2ee"
+            assert json["version"] == 1
+            assert isinstance(json["request_id"], str) and json["request_id"]
             assert "chat_history" in json and json["chat_history"]
             return _FakeResponse(200, {"message": "Request received"})
         if url.endswith("/api/v1/relay/responses/retrieve"):
@@ -129,15 +132,16 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
         options={"temperature": 0.2},
     )
     assert response["content"] == "Distributed secure response"
+    request_id = fake_crypto._encrypted["cipher-1"]["request_id"]
     assert retrieve_calls == [
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
+        {"client_public_key": fake_crypto.public_key_b64, "request_id": request_id},
     ]
     assert posted_payloads[0][0] == "https://node-a.example/api/v1/relay/requests"
     assert posted_payloads[1][0] == "https://node-a.example/api/v1/relay/responses/retrieve"
@@ -628,7 +632,7 @@ def test_distributed_compute_provider_maps_missing_assistant_message(monkeypatch
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
         assert exc.code == "compute_node_invalid_payload"
-        assert "compute node response missing assistant message" in str(exc)
+        assert "compute node response missing meaningful assistant content" in str(exc)
 
 
 def test_get_api_v1_compute_provider_for_mode_distributed_without_url_raises(monkeypatch):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -104,7 +104,7 @@ def test_compute_node_runtime_polling_thread_delegates_to_relay():
     thread.start.assert_called_once_with()
 
 
-def test_compute_node_runtime_request_flow_delegates_to_relay_client():
+def test_compute_node_runtime_api_v1_request_flow_delegates_to_relay_client():
     relay_client = MagicMock()
     relay_client.process_client_request.return_value = True
     model_manager = MagicMock()
@@ -119,6 +119,9 @@ def test_compute_node_runtime_request_flow_delegates_to_relay_client():
     )
 
     payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "request_id": "req-1",
         "client_public_key": "key",
         "chat_history": "payload",
         "cipherkey": "cipher",
@@ -358,7 +361,7 @@ def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client()
     relay_client.poll_api_v1_encrypted_work.assert_called_once_with()
 
 
-def test_compute_node_runtime_default_legacy_adapter_path_remains_active():
+def test_compute_node_runtime_default_legacy_adapter_path_is_not_active():
     relay_client = MagicMock()
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
@@ -371,7 +374,7 @@ def test_compute_node_runtime_default_legacy_adapter_path_remains_active():
         crypto_manager=crypto_manager,
     )
 
-    assert any(isinstance(adapter, LegacyRelayRequestAdapter) for adapter in runtime.request_adapters)
+    assert not any(isinstance(adapter, LegacyRelayRequestAdapter) for adapter in runtime.request_adapters)
 
     legacy_payload = {
         "client_public_key": "key",
@@ -386,9 +389,9 @@ def test_compute_node_runtime_default_legacy_adapter_path_remains_active():
         "processed": runtime.process_relay_request(legacy_payload),
     }
 
-    assert runtime.register_and_poll_once() == {"relayStatus": "ok", "processed": True}
+    assert runtime.register_and_poll_once() == {"relayStatus": "ok", "processed": False}
     relay_client.poll_api_v1_encrypted_work.assert_called_once_with()
-    relay_client.process_client_request.assert_called_once_with(legacy_payload)
+    relay_client.process_client_request.assert_not_called()
 
 
 def test_compute_node_runtime_stop_delegates_to_relay_client():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -273,10 +273,7 @@ class ComputeNodeRuntime:
             include_configured_servers=runtime_config.use_configured_relay_fallbacks,
         )
         if request_adapters is None:
-            self.request_adapters = [
-                ApiV1RelayRequestAdapter(self.relay_client),
-                LegacyRelayRequestAdapter(self.relay_client),
-            ]
+            self.request_adapters = [ApiV1RelayRequestAdapter(self.relay_client)]
         else:
             self.request_adapters = list(request_adapters)
 


### PR DESCRIPTION
### Motivation
- Investigation validated that API v1 distributed requests were being queued without required top-level API v1 envelope metadata, causing the desktop bridge to see heartbeat/legacy-shaped payloads instead of claimable API v1 work.
- The relay polling path could surface legacy sink/source ciphertext to active bridge paths and the compute runtime still registered a legacy adapter by default, risking misrouting and stale/empty assistant responses.
- The browser-side `static/chat.js` rejection (`invalid_assistant_response_content`) was symptomatic of the compute-provider returning non-meaningful assistant output or of the bridge not receiving correctly routed API v1 envelopes.

### Description
- Require and validate top-level API v1 E2EE envelope fields (`protocol=='tokenplace_api_v1_relay_e2ee'`, `version==1`, and non-empty `request_id`) on relay request/response intake in `relay.py` by tightening `_extract_ciphertext_envelope`.
- Make `/api/v1/relay/servers/poll` API-v1-only: claim only explicit API v1 E2EE envelopes and drop legacy ciphertext from the compute-node polling path so the desktop bridge sees only API v1 work.
- Update `DistributedApiV1ComputeProvider` in `api/v1/compute_provider.py` to include top-level API v1 metadata when posting encrypted requests (`protocol`, `version`, `request_id`) and to include `request_id` when polling `responses/retrieve` so response retrieval is matched to the request.
- Harden distributed-provider validation to reject decrypted responses that do not contain a meaningful assistant message (reject empty, `stub`, or generic fallback content) before returning success.
- Remove the default legacy relay request adapter from the shared `ComputeNodeRuntime` so API v1 bridge paths do not process legacy sink/source payloads by default (`utils/compute_node_runtime.py`).
- Update unit/regression tests to assert the new contract and request-id retrieval behavior and to reflect the inactive legacy-adapter default.

### Testing
- Ran targeted unit and integration suites; `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py` all passed in the test runs executed locally.
- Ran compute-node and relay client unit suites; `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py` passed.
- Ran the legacy-route-usage guardrail check; `python -m pytest -q tests/unit/test_legacy_route_usage_guardrails.py` passed and `rg "/sink|/faucet|/source|/retrieve|/next_server" .` verified no active production paths reference deprecated routes.
- `pre-commit run --all-files` completed successfully in this environment.
- E2E landing-page test requiring a real on-disk model (`tests/e2e/test_ui.py -k landing_chat_real_inference_with_desktop_bridge_api_v1`) is blocked locally because `TOKENPLACE_REAL_E2E_MODEL_PATH` was not configured; this is an environment requirement rather than a code regression.

Commands used for verification (examples): `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py`, `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py`, `pre-commit run --all-files`, `rg "/sink|/faucet|/source|/retrieve|/next_server" .`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06bd6c5c28832fb62c81bae969092a)