### PR TITLE
api/v1 E2EE: route/provider/runtime fixes to enforce API v1 relay E2EE and remove legacy path usage

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -133,7 +133,10 @@ class DistributedApiV1ComputeProvider:
     timeout_seconds: float = 30.0
 
     def _relay_url(self, path: str) -> str:
-        return f"{self.base_url.rstrip('/')}{path}"
+        base_url = self.base_url.rstrip("/")
+        if base_url.endswith("/api/v1") and path.startswith("/api/v1/"):
+            path = path[len("/api/v1"):]
+        return f"{base_url}{path}"
 
     def _poll_interval_seconds(self) -> float:
         return min(max(self.timeout_seconds / 20.0, 0.1), 0.5)

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -226,6 +226,9 @@ class DistributedApiV1ComputeProvider:
         faucet_payload = {
             "client_public_key": crypto_manager.public_key_b64,
             "server_public_key": server_public_key,
+            "request_id": relay_request_id,
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
             **encrypted_envelope,
         }
 
@@ -445,17 +448,19 @@ def _read_api_v1_provider_env() -> tuple[str, str, bool]:
 def get_api_v1_compute_provider_for_mode(
     *,
     mode: str,
+    distributed_url: str | None = None,
     distributed_fallback_enabled: bool | None = None,
 ) -> ApiV1ComputeProvider:
     """Resolve provider with an explicit mode override for request-scoped routing."""
 
     normalized_mode = (mode or "local").strip().lower()
-    _, distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
+    _, env_distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
     if distributed_fallback_enabled is None:
         distributed_fallback_enabled = fallback_enabled_from_env
+    selected_distributed_url = distributed_url if distributed_url is not None else env_distributed_url
     return _build_api_v1_compute_provider(
         normalized_mode,
-        distributed_url,
+        selected_distributed_url.strip(),
         bool(distributed_fallback_enabled),
     )
 

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -265,7 +265,10 @@ class DistributedApiV1ComputeProvider:
                 retrieve_timeout = min(poll_interval + 0.5, _remaining_timeout())
                 retrieve_response = requests.post(
                     self._relay_url("/api/v1/relay/responses/retrieve"),
-                    json={"client_public_key": crypto_manager.public_key_b64},
+                    json={
+                        "client_public_key": crypto_manager.public_key_b64,
+                        "request_id": relay_request_id,
+                    },
                     timeout=retrieve_timeout,
                 )
             except requests.RequestException:

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -12,6 +12,8 @@ import uuid
 import logging
 import os
 import math
+import ipaddress
+from urllib.parse import urlparse
 
 from api.v1.encryption import encryption_manager
 from api.security import ensure_operator_access
@@ -88,13 +90,104 @@ def _should_force_desktop_bridge_distributed(request_metadata, is_encrypted_requ
     return request_metadata.get("relay_path") == "api_v1_e2ee"
 
 
-def _request_relay_base_url() -> str:
-    """Return the API v1 relay base URL for same-origin desktop bridge work."""
+def _normalise_relay_origin(value: str) -> str:
+    """Return a normalized HTTP(S) origin, or an empty string for invalid input."""
 
-    configured = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    candidate = (value or "").strip().rstrip("/")
+    if not candidate:
+        return ""
+
+    parsed = urlparse(candidate)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.path not in {"", "/"}
+    ):
+        return ""
+
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return ""
+
+    netloc = hostname
+    if parsed.port is not None:
+        netloc = f"{hostname}:{parsed.port}"
+    return f"{parsed.scheme.lower()}://{netloc}"
+
+
+def _origin_host_is_loopback(origin: str) -> bool:
+    """Return True when an origin targets a loopback host."""
+
+    hostname = (urlparse(origin).hostname or "").lower()
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _request_remote_addr_is_loopback() -> bool:
+    """Return True when the inbound Flask request came from loopback."""
+
+    remote_addr = request.remote_addr or ""
+    try:
+        return ipaddress.ip_address(remote_addr).is_loopback
+    except ValueError:
+        return False
+
+
+def _trusted_configured_relay_origins() -> list[str]:
+    """Return relay origins trusted for request-scoped same-origin routing."""
+
+    config = get_config()
+    candidates = [
+        config.get("relay.server_url", ""),
+        config.get("api.relay_url", ""),
+    ]
+    candidates.extend(config.get("relay.server_pool", []) or [])
+
+    trusted: list[str] = []
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        origin = _normalise_relay_origin(candidate)
+        if origin and origin not in trusted:
+            trusted.append(origin)
+    return trusted
+
+
+def _request_relay_base_url() -> str:
+    """Return a trusted API v1 relay base URL for desktop bridge work."""
+
+    configured = _normalise_relay_origin(
+        os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "")
+    )
     if configured:
         return configured
-    return request.host_url.rstrip("/")
+
+    request_origin = _normalise_relay_origin(request.host_url)
+    trusted_origins = _trusted_configured_relay_origins()
+    if request_origin in trusted_origins:
+        return request_origin
+
+    if (
+        request_origin
+        and _origin_host_is_loopback(request_origin)
+        and _request_remote_addr_is_loopback()
+    ):
+        return request_origin
+
+    if trusted_origins:
+        return trusted_origins[0]
+
+    raise ComputeProviderError(
+        "desktop bridge distributed routing requires a trusted relay origin",
+        code="untrusted_relay_origin",
+        error_type="invalid_request_error",
+        public_message="No trusted relay origin is configured for this request.",
+        status_code=400,
+    )
 
 
 def _get_service_name() -> str:

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -109,9 +109,20 @@ def _normalise_relay_origin(value: str) -> str:
     if not hostname:
         return ""
 
+    try:
+        port = parsed.port
+    except ValueError:
+        return ""
+
     netloc = hostname
-    if parsed.port is not None:
-        netloc = f"{hostname}:{parsed.port}"
+    try:
+        if ipaddress.ip_address(hostname).version == 6:
+            netloc = f"[{hostname}]"
+    except ValueError:
+        pass
+
+    if port is not None:
+        netloc = f"{netloc}:{port}"
     return f"{parsed.scheme.lower()}://{netloc}"
 
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -85,9 +85,16 @@ def _should_force_desktop_bridge_distributed(request_metadata, is_encrypted_requ
         return False
     if request_metadata.get("inference_target") != "desktop_bridge_api_v1_e2ee":
         return False
-    if request_metadata.get("relay_path") != "api_v1_e2ee":
-        return False
-    return bool(os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip())
+    return request_metadata.get("relay_path") == "api_v1_e2ee"
+
+
+def _request_relay_base_url() -> str:
+    """Return the API v1 relay base URL for same-origin desktop bridge work."""
+
+    configured = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    if configured:
+        return configured
+    return request.host_url.rstrip("/")
 
 
 def _get_service_name() -> str:
@@ -347,6 +354,7 @@ def _handle_chat_completion_request(data):
         provider = (
             get_api_v1_compute_provider_for_mode(
                 mode="distributed",
+                distributed_url=_request_relay_base_url(),
                 distributed_fallback_enabled=False,
             )
             if force_desktop_bridge_distributed

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -166,20 +166,17 @@ def _request_relay_base_url() -> str:
     if configured:
         return configured
 
-    request_origin = _normalise_relay_origin(request.host_url)
     trusted_origins = _trusted_configured_relay_origins()
-    if request_origin in trusted_origins:
-        return request_origin
+    if trusted_origins:
+        return trusted_origins[0]
 
+    request_origin = _normalise_relay_origin(request.host_url)
     if (
         request_origin
         and _origin_host_is_loopback(request_origin)
         and _request_remote_addr_is_loopback()
     ):
         return request_origin
-
-    if trusted_origins:
-        return trusted_origins[0]
 
     raise ComputeProviderError(
         "desktop bridge distributed routing requires a trusted relay origin",

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -168,6 +168,19 @@ def _trusted_configured_relay_origins() -> list[str]:
     return trusted
 
 
+def _request_loopback_relay_origin() -> str:
+    """Return the request origin only when it is verified loopback-local."""
+
+    request_origin = _normalise_relay_origin(request.host_url)
+    if (
+        request_origin
+        and _origin_host_is_loopback(request_origin)
+        and _request_remote_addr_is_loopback()
+    ):
+        return request_origin
+    return ""
+
+
 def _request_relay_base_url() -> str:
     """Return a trusted API v1 relay base URL for desktop bridge work."""
 
@@ -177,17 +190,13 @@ def _request_relay_base_url() -> str:
     if configured:
         return configured
 
+    loopback_origin = _request_loopback_relay_origin()
+    if loopback_origin:
+        return loopback_origin
+
     trusted_origins = _trusted_configured_relay_origins()
     if trusted_origins:
         return trusted_origins[0]
-
-    request_origin = _normalise_relay_origin(request.host_url)
-    if (
-        request_origin
-        and _origin_host_is_loopback(request_origin)
-        and _request_remote_addr_is_loopback()
-    ):
-        return request_origin
 
     raise ComputeProviderError(
         "desktop bridge distributed routing requires a trusted relay origin",

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -98,10 +98,11 @@ def _normalise_relay_origin(value: str) -> str:
         return ""
 
     parsed = urlparse(candidate)
+    path = parsed.path.rstrip("/")
     if (
         parsed.scheme not in {"http", "https"}
         or not parsed.netloc
-        or parsed.path not in {"", "/"}
+        or path not in {"", "/api/v1"}
     ):
         return ""
 
@@ -123,7 +124,7 @@ def _normalise_relay_origin(value: str) -> str:
 
     if port is not None:
         netloc = f"{netloc}:{port}"
-    return f"{parsed.scheme.lower()}://{netloc}"
+    return f"{parsed.scheme.lower()}://{netloc}{path}"
 
 
 def _origin_host_is_loopback(origin: str) -> bool:

--- a/desktop-tauri/src-tauri/src/forward.rs
+++ b/desktop-tauri/src-tauri/src/forward.rs
@@ -17,39 +17,10 @@ pub struct RelayEnvelope {
     pub iv: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct NextServerResponse {
-    server_public_key: String,
-}
-
-pub async fn encrypt_and_forward(relay_base_url: &str, final_output: &str) -> anyhow::Result<()> {
-    let relay = relay_base_url.trim_end_matches('/');
-    let server = reqwest::get(format!("{relay}/next_server"))
-        .await?
-        .json::<NextServerResponse>()
-        .await?;
-
-    let (pub_key_b64, _private_key_b64) = crate::keygen::generate_rsa_keypair_b64()?;
-    let payload = serde_json::to_string(&vec![serde_json::json!({
-        "role": "assistant",
-        "content": final_output,
-    })])?;
-
-    let envelope =
-        assemble_relay_envelope(&server.server_public_key, &pub_key_b64, payload.as_bytes())?;
-
-    let response = reqwest::Client::new()
-        .post(format!("{relay}/faucet"))
-        .json(&envelope)
-        .send()
-        .await?;
-    anyhow::ensure!(
-        response.status().is_success(),
-        "relay forward failed: {}",
-        response.status()
-    );
-
-    Ok(())
+pub async fn encrypt_and_forward(_relay_base_url: &str, _final_output: &str) -> anyhow::Result<()> {
+    anyhow::bail!(
+        "debug relay forwarding is disabled; use the API v1 relay E2EE desktop bridge path"
+    )
 }
 
 pub fn assemble_relay_envelope(

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -457,7 +457,7 @@ export function App() {
           <button disabled={!canStart} onClick={startInference}>Start local inference</button>
           <button disabled={status !== 'starting' && status !== 'streaming'} onClick={cancelInference}>Cancel</button>
           <button disabled={!output || isForwarding} onClick={forwardEncrypted}>
-            Debug relay forward (legacy /next_server + /faucet)
+            Debug relay forward (disabled; API v1 E2EE only)
           </button>
         </div>
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1300,10 +1300,10 @@ def test_desktop_bridge_relay_base_url_uses_configured_origin_for_untrusted_host
         assert routes_module._request_relay_base_url() == "https://token.place"
 
 
-def test_desktop_bridge_relay_base_url_prefers_configured_origin_over_loopback_host(
+def test_desktop_bridge_relay_base_url_prefers_loopback_host_over_default_config(
     monkeypatch,
 ):
-    """Configured relay origins take precedence over localhost Host fallback."""
+    """Verified loopback desktop requests stay on their same-origin local relay."""
 
     monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
     import api.v1.routes as routes_module
@@ -1324,7 +1324,23 @@ def test_desktop_bridge_relay_base_url_prefers_configured_origin_over_loopback_h
         base_url="http://127.0.0.1:5010",
         environ_base={"REMOTE_ADDR": "127.0.0.1"},
     ):
-        assert routes_module._request_relay_base_url() == "https://token.place"
+        assert routes_module._request_relay_base_url() == "http://127.0.0.1:5010"
+
+
+def test_desktop_bridge_relay_base_url_prefers_env_over_loopback_host(
+    monkeypatch,
+):
+    """The explicit distributed relay URL remains highest precedence."""
+
+    monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "https://relay.example/")
+    import api.v1.routes as routes_module
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="http://127.0.0.1:5010",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    ):
+        assert routes_module._request_relay_base_url() == "https://relay.example"
 
 
 def test_desktop_bridge_relay_base_url_fails_closed_without_trusted_origin(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1240,6 +1240,68 @@ def test_normalise_relay_origin_preserves_ipv6_loopback_brackets():
     )
 
 
+def test_normalise_relay_origin_preserves_api_v1_base_paths():
+    """Explicit API v1 relay bases remain trusted instead of being ignored."""
+
+    import api.v1.routes as routes_module
+
+    assert (
+        routes_module._normalise_relay_origin("https://relay.example/api/v1/")
+        == "https://relay.example/api/v1"
+    )
+    assert (
+        routes_module._normalise_relay_origin("http://[::1]:5010/api/v1")
+        == "http://[::1]:5010/api/v1"
+    )
+    assert routes_module._normalise_relay_origin("https://relay.example/api/v2") == ""
+
+
+def test_desktop_bridge_relay_base_url_preserves_env_api_v1_base_over_loopback(
+    monkeypatch,
+):
+    """Path-scoped explicit relay URLs must not fall back to same-origin routing."""
+
+    monkeypatch.setenv(
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+        "https://relay.example/api/v1/",
+    )
+    import api.v1.routes as routes_module
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="http://127.0.0.1:5010",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    ):
+        assert routes_module._request_relay_base_url() == "https://relay.example/api/v1"
+
+
+def test_desktop_bridge_relay_base_url_preserves_config_api_v1_base_for_untrusted_host(
+    monkeypatch,
+):
+    """Path-scoped trusted config relay URLs must not be ignored for forged hosts."""
+
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    import api.v1.routes as routes_module
+
+    class FakeConfig:
+        def get(self, key, default=None):
+            values = {
+                "relay.server_url": "https://relay.example/api/v1/",
+                "api.relay_url": "",
+                "relay.server_pool": [],
+            }
+            return values.get(key, default)
+
+    monkeypatch.setattr(routes_module, "get_config", lambda: FakeConfig())
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="https://attacker.example",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    ):
+        assert routes_module._request_relay_base_url() == "https://relay.example/api/v1"
+
+
 def test_desktop_bridge_relay_base_url_allows_ipv6_loopback_same_origin_only_from_loopback(
     monkeypatch,
 ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1229,6 +1229,50 @@ def test_desktop_bridge_metadata_routes_to_same_origin_api_v1_relay_when_env_uns
     assert response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"] == "distributed_relay_e2ee"
 
 
+def test_normalise_relay_origin_preserves_ipv6_loopback_brackets():
+    """IPv6 literal origins must keep brackets when reconstructed with ports."""
+
+    import api.v1.routes as routes_module
+
+    assert (
+        routes_module._normalise_relay_origin("http://[::1]:5010")
+        == "http://[::1]:5010"
+    )
+
+
+def test_desktop_bridge_relay_base_url_allows_ipv6_loopback_same_origin_only_from_loopback(
+    monkeypatch,
+):
+    """Bracketed IPv6 localhost fallback is limited to loopback clients."""
+
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    import api.v1.routes as routes_module
+    from api.v1.compute_provider import ComputeProviderError
+
+    class EmptyConfig:
+        def get(self, _key, default=None):
+            return default
+
+    monkeypatch.setattr(routes_module, "get_config", lambda: EmptyConfig())
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="http://[::1]:5010",
+        environ_base={"REMOTE_ADDR": "::1"},
+    ):
+        assert routes_module._request_relay_base_url() == "http://[::1]:5010"
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="http://[::1]:5010",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    ):
+        with pytest.raises(ComputeProviderError) as exc_info:
+            routes_module._request_relay_base_url()
+
+    assert exc_info.value.code == "untrusted_relay_origin"
+
+
 def test_desktop_bridge_relay_base_url_uses_configured_origin_for_untrusted_host(
     monkeypatch,
 ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1152,3 +1152,72 @@ def test_alias_get_model(client, monkeypatch):
     resp_api = client.get(f'/api/v1/models/{model_id}')
     assert resp_alias.status_code == resp_api.status_code
     assert resp_alias.get_json() == resp_api.get_json()
+
+
+def test_desktop_bridge_metadata_routes_to_same_origin_api_v1_relay_when_env_unset(
+    monkeypatch, client, client_keys
+):
+    """Explicit desktop API v1 E2EE metadata must enqueue via same-origin relay."""
+
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    import api.v1.routes as routes_module
+
+    captured = {}
+
+    class FakeDistributedProvider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            captured["model_id"] = model_id
+            captured["messages"] = messages
+            captured["options"] = options
+            return {"role": "assistant", "content": "desktop bridge response"}
+
+    def fake_get_provider_for_mode(**kwargs):
+        captured["provider_kwargs"] = kwargs
+        return FakeDistributedProvider()
+
+    monkeypatch.setattr(
+        routes_module,
+        "get_api_v1_compute_provider_for_mode",
+        fake_get_provider_for_mode,
+    )
+    monkeypatch.setattr(
+        routes_module,
+        "get_api_v1_resolved_provider_path",
+        lambda _provider: "distributed",
+    )
+    monkeypatch.setattr(
+        routes_module,
+        "get_api_v1_last_backend_path",
+        lambda: "distributed_relay_e2ee",
+    )
+
+    public_key = client.get("/api/v1/public-key").get_json()["public_key"]
+    encrypted_messages = _encrypt_messages_for_server(
+        [{"role": "user", "content": "hello desktop"}],
+        public_key,
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "encrypted": True,
+            "client_public_key": client_keys["public_key_b64"],
+            "messages": encrypted_messages,
+            "metadata": {
+                "inference_target": "desktop_bridge_api_v1_e2ee",
+                "relay_path": "api_v1_e2ee",
+            },
+        },
+        base_url="http://127.0.0.1:5010",
+    )
+
+    assert response.status_code == 200
+    assert captured["provider_kwargs"] == {
+        "mode": "distributed",
+        "distributed_url": "http://127.0.0.1:5010",
+        "distributed_fallback_enabled": False,
+    }
+    assert captured["messages"] == [{"role": "user", "content": "hello desktop"}]
+    assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
+    assert response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"] == "distributed_relay_e2ee"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1221,3 +1221,57 @@ def test_desktop_bridge_metadata_routes_to_same_origin_api_v1_relay_when_env_uns
     assert captured["messages"] == [{"role": "user", "content": "hello desktop"}]
     assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
     assert response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"] == "distributed_relay_e2ee"
+
+
+def test_desktop_bridge_relay_base_url_uses_configured_origin_for_untrusted_host(
+    monkeypatch,
+):
+    """Forged Host headers must not control outbound desktop relay routing."""
+
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    import api.v1.routes as routes_module
+
+    class FakeConfig:
+        def get(self, key, default=None):
+            values = {
+                "relay.server_url": "https://token.place/",
+                "api.relay_url": "",
+                "relay.server_pool": ["https://token.place/"],
+            }
+            return values.get(key, default)
+
+    monkeypatch.setattr(routes_module, "get_config", lambda: FakeConfig())
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="https://attacker.example",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    ):
+        assert routes_module._request_relay_base_url() == "https://token.place"
+
+
+def test_desktop_bridge_relay_base_url_fails_closed_without_trusted_origin(
+    monkeypatch,
+):
+    """Desktop distributed override must fail closed when no trusted relay exists."""
+
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    import api.v1.routes as routes_module
+    from api.v1.compute_provider import ComputeProviderError
+
+    class EmptyConfig:
+        def get(self, _key, default=None):
+            return default
+
+    monkeypatch.setattr(routes_module, "get_config", lambda: EmptyConfig())
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="https://attacker.example",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    ):
+        with pytest.raises(ComputeProviderError) as exc_info:
+            routes_module._request_relay_base_url()
+
+    assert exc_info.value.code == "untrusted_relay_origin"
+    assert exc_info.value.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1157,10 +1157,16 @@ def test_alias_get_model(client, monkeypatch):
 def test_desktop_bridge_metadata_routes_to_same_origin_api_v1_relay_when_env_unset(
     monkeypatch, client, client_keys
 ):
-    """Explicit desktop API v1 E2EE metadata must enqueue via same-origin relay."""
+    """Explicit desktop API v1 E2EE metadata may use loopback same-origin locally."""
 
     monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
     import api.v1.routes as routes_module
+
+    class EmptyConfig:
+        def get(self, _key, default=None):
+            return default
+
+    monkeypatch.setattr(routes_module, "get_config", lambda: EmptyConfig())
 
     captured = {}
 
@@ -1246,6 +1252,33 @@ def test_desktop_bridge_relay_base_url_uses_configured_origin_for_untrusted_host
         "/api/v1/chat/completions",
         base_url="https://attacker.example",
         environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    ):
+        assert routes_module._request_relay_base_url() == "https://token.place"
+
+
+def test_desktop_bridge_relay_base_url_prefers_configured_origin_over_loopback_host(
+    monkeypatch,
+):
+    """Configured relay origins take precedence over localhost Host fallback."""
+
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    import api.v1.routes as routes_module
+
+    class FakeConfig:
+        def get(self, key, default=None):
+            values = {
+                "relay.server_url": "https://token.place/",
+                "api.relay_url": "",
+                "relay.server_pool": [],
+            }
+            return values.get(key, default)
+
+    monkeypatch.setattr(routes_module, "get_config", lambda: FakeConfig())
+
+    with app.test_request_context(
+        "/api/v1/chat/completions",
+        base_url="http://127.0.0.1:5010",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
     ):
         assert routes_module._request_relay_base_url() == "https://token.place"
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1449,3 +1449,71 @@ def test_legacy_next_server_can_be_enabled_with_compatibility_flag(client, monke
     response = client.get("/next_server")
     assert response.status_code == 200
     assert response.get_json()["server_public_key"] == DUMMY_SERVER_PUB_KEY
+
+
+def test_api_v1_provider_envelope_is_queued_polled_responded_and_retrieved_ciphertext_only(client):
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+
+    request_plaintext = 'PLAINTEXT_REQUEST_SENTINEL_DO_NOT_STORE'
+    request_payload = {
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'request_id': 'req-provider-style',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request-provider-style',
+        'cipherkey': 'cipherkey-request-provider-style',
+        'iv': 'iv-request-provider-style',
+        'messages': [{'role': 'user', 'content': request_plaintext}],
+    }
+
+    queued = client.post('/api/v1/relay/requests', json=request_payload)
+    assert queued.status_code == 200
+    relay_state = client_inference_requests[DUMMY_SERVER_PUB_KEY][0]
+    assert relay_state['protocol'] == 'tokenplace_api_v1_relay_e2ee'
+    assert relay_state['version'] == 1
+    assert relay_state['request_id'] == 'req-provider-style'
+    assert relay_state['e2ee_v1'] is True
+    assert 'messages' not in relay_state
+    assert request_plaintext not in json.dumps(relay_state)
+
+    polled = client.post(
+        '/api/v1/relay/servers/poll',
+        json={'server_public_key': DUMMY_SERVER_PUB_KEY},
+    )
+    assert polled.status_code == 200
+    polled_payload = polled.get_json()
+    assert polled_payload['protocol'] == 'tokenplace_api_v1_relay_e2ee'
+    assert polled_payload['version'] == 1
+    assert polled_payload['request_id'] == 'req-provider-style'
+    assert polled_payload['chat_history'] == 'ciphertext-request-provider-style'
+    assert request_plaintext not in json.dumps(polled_payload)
+
+    response_plaintext = 'PLAINTEXT_RESPONSE_SENTINEL_DO_NOT_STORE'
+    response_payload = {
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'request_id': 'req-provider-style',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'ciphertext-response-provider-style',
+        'cipherkey': 'cipherkey-response-provider-style',
+        'iv': 'iv-response-provider-style',
+        'api_v1_response': {'message': {'role': 'assistant', 'content': response_plaintext}},
+    }
+    submitted = client.post('/api/v1/relay/responses', json=response_payload)
+    assert submitted.status_code == 200
+    queued_response = client_responses[DUMMY_CLIENT_PUB_KEY]
+    assert queued_response['protocol'] == 'tokenplace_api_v1_relay_e2ee'
+    assert queued_response['request_id'] == 'req-provider-style'
+    assert 'api_v1_response' not in queued_response
+    assert response_plaintext not in json.dumps(queued_response)
+
+    retrieved = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-provider-style'},
+    )
+    assert retrieved.status_code == 200
+    retrieved_payload = retrieved.get_json()
+    assert retrieved_payload['request_id'] == 'req-provider-style'
+    assert retrieved_payload['chat_history'] == 'ciphertext-response-provider-style'
+    assert response_plaintext not in json.dumps(retrieved_payload)

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -44,6 +44,21 @@ class _FailingEncryptCryptoManager(_FakeCryptoManager):
         raise ValueError("invalid server key")
 
 
+def test_distributed_compute_provider_relay_url_preserves_api_v1_base():
+    """Path-scoped API v1 relay bases should not duplicate the API prefix."""
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://relay.example/api/v1")
+
+    assert (
+        provider._relay_url("/api/v1/relay/servers/next")
+        == "https://relay.example/api/v1/relay/servers/next"
+    )
+    assert (
+        provider._relay_url("/api/v1/relay/responses/retrieve")
+        == "https://relay.example/api/v1/relay/responses/retrieve"
+    )
+
+
 def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch):
     fake_crypto = _FakeCryptoManager()
     posted_payloads = []

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -134,16 +134,12 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
         options={"temperature": 0.2},
     )
     assert response["content"] == "Distributed secure response"
-    assert retrieve_calls == [
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-        {"client_public_key": fake_crypto.public_key_b64},
-    ]
+    relay_request_id = fake_crypto._encrypted["cipher-1"]["request_id"]
+    expected_retrieve_payload = {
+        "client_public_key": fake_crypto.public_key_b64,
+        "request_id": relay_request_id,
+    }
+    assert retrieve_calls == [expected_retrieve_payload] * 8
     assert posted_payloads[0][0] == "https://node-a.example/api/v1/relay/requests"
     assert posted_payloads[1][0] == "https://node-a.example/api/v1/relay/responses/retrieve"
     touched_urls = [

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -1,4 +1,5 @@
 import copy
+from urllib.parse import urlparse
 
 from api.v1 import compute_provider
 from api.v1.compute_provider import (
@@ -58,6 +59,10 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
         posted_payloads.append((url, copy.deepcopy(json), timeout))
         if url.endswith("/api/v1/relay/requests"):
             assert "messages" not in json
+            assert json["protocol"] == "tokenplace_api_v1_relay_e2ee"
+            assert json["version"] == 1
+            assert isinstance(json["request_id"], str)
+            assert json["request_id"].startswith("api-v1-")
             assert "chat_history" in json and json["chat_history"]
             return _FakeResponse(200, {"message": "Request received"})
         if url.endswith("/api/v1/relay/responses/retrieve"):
@@ -141,6 +146,16 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
     ]
     assert posted_payloads[0][0] == "https://node-a.example/api/v1/relay/requests"
     assert posted_payloads[1][0] == "https://node-a.example/api/v1/relay/responses/retrieve"
+    touched_urls = [
+        posted_payloads[0][0],
+        posted_payloads[1][0],
+        "https://node-a.example/api/v1/relay/servers/next",
+    ]
+    assert not any(
+        urlparse(url).path == legacy
+        for url in touched_urls
+        for legacy in ("/sink", "/faucet", "/source", "/retrieve", "/next_server")
+    )
 
 
 def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -119,6 +119,9 @@ def test_compute_node_runtime_request_flow_delegates_to_relay_client():
     )
 
     payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "request_id": "req-1",
         "client_public_key": "key",
         "chat_history": "payload",
         "cipherkey": "cipher",
@@ -181,6 +184,22 @@ def test_api_v1_relay_payload_detection_identifies_valid_api_v1_envelope():
         "cipherkey": "k",
         "iv": "i",
     }) is True
+
+
+def test_api_v1_relay_payload_is_not_reported_as_legacy():
+    payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "request_id": "req-1",
+        "client_public_key": "k",
+        "chat_history": "c",
+        "cipherkey": "k",
+        "iv": "i",
+        "e2ee_v1": True,
+    }
+
+    assert is_api_v1_relay_payload(payload) is True
+    assert is_legacy_relay_payload(payload) is False
 
 
 def test_api_v1_relay_payload_detection_rejects_legacy_messages_shape():
@@ -358,7 +377,7 @@ def test_compute_node_runtime_register_and_poll_once_delegates_to_relay_client()
     relay_client.poll_api_v1_encrypted_work.assert_called_once_with()
 
 
-def test_compute_node_runtime_default_legacy_adapter_path_remains_active():
+def test_compute_node_runtime_default_path_is_api_v1_only():
     relay_client = MagicMock()
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
@@ -371,7 +390,8 @@ def test_compute_node_runtime_default_legacy_adapter_path_remains_active():
         crypto_manager=crypto_manager,
     )
 
-    assert any(isinstance(adapter, LegacyRelayRequestAdapter) for adapter in runtime.request_adapters)
+    assert any(isinstance(adapter, ApiV1RelayRequestAdapter) for adapter in runtime.request_adapters)
+    assert not any(isinstance(adapter, LegacyRelayRequestAdapter) for adapter in runtime.request_adapters)
 
     legacy_payload = {
         "client_public_key": "key",
@@ -386,9 +406,9 @@ def test_compute_node_runtime_default_legacy_adapter_path_remains_active():
         "processed": runtime.process_relay_request(legacy_payload),
     }
 
-    assert runtime.register_and_poll_once() == {"relayStatus": "ok", "processed": True}
+    assert runtime.register_and_poll_once() == {"relayStatus": "ok", "processed": False}
     relay_client.poll_api_v1_encrypted_work.assert_called_once_with()
-    relay_client.process_client_request.assert_called_once_with(legacy_payload)
+    relay_client.process_client_request.assert_not_called()
 
 
 def test_compute_node_runtime_stop_delegates_to_relay_client():

--- a/tests/unit/test_legacy_route_usage_guardrails.py
+++ b/tests/unit/test_legacy_route_usage_guardrails.py
@@ -13,6 +13,8 @@ def test_active_production_paths_do_not_reference_legacy_relay_routes():
         root / "static" / "chat.js",
         root / "desktop" / "src" / "services" / "desktopBridgeClient.ts",
         root / "desktop" / "src" / "services" / "desktopApiClient.ts",
+        root / "desktop-tauri" / "src" / "App.tsx",
+        root / "desktop-tauri" / "src-tauri" / "src" / "forward.rs",
     ]
 
     violations: list[str] = []

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -58,6 +58,8 @@ def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
 
     if not isinstance(payload, dict):
         return False
+    if payload.get("protocol") == "tokenplace_api_v1_relay_e2ee" or payload.get("e2ee_v1") is True:
+        return False
     return LEGACY_RELAY_REQUIRED_FIELDS.issubset(payload.keys())
 
 
@@ -275,7 +277,6 @@ class ComputeNodeRuntime:
         if request_adapters is None:
             self.request_adapters = [
                 ApiV1RelayRequestAdapter(self.relay_client),
-                LegacyRelayRequestAdapter(self.relay_client),
             ]
         else:
             self.request_adapters = list(request_adapters)


### PR DESCRIPTION
This pull request implements robust, secure, and configurable support for desktop bridge E2EE relay routing in the API v1 layer, with a focus on trusted relay origin selection, protocol versioning, and improved test coverage. It also disables legacy relay forwarding in the desktop client and ensures all relay requests use the new protocol.

Key changes include:

**API v1 relay protocol and routing improvements:**

* All relay requests and responses now include explicit protocol versioning (`protocol: "tokenplace_api_v1_relay_e2ee"`, `version: 1`, and `request_id`), ensuring only ciphertext is transmitted and plaintext is never stored or forwarded. (`api/v1/compute_provider.py`, `tests/unit/test_api_v1_compute_provider.py`, `tests/test_relay.py`, `tests/unit/test_compute_node_runtime.py`) [[1]](diffhunk://#diff-a7a09f1e6b5885e6344d48daf8ac055cba53a39c4bd32d9805f3b2db6b02ff67R229-R231) [[2]](diffhunk://#diff-a7a09f1e6b5885e6344d48daf8ac055cba53a39c4bd32d9805f3b2db6b02ff67L265-R271) [[3]](diffhunk://#diff-60c32b3b906ed900f802dd6ea58aeb7b9dce6b77925693441de3f043db7d0eecR62-R65) [[4]](diffhunk://#diff-60c32b3b906ed900f802dd6ea58aeb7b9dce6b77925693441de3f043db7d0eecL132-R154) [[5]](diffhunk://#diff-63dce5a9d9430b6ebb5324403818edccbe1c59f8ccf376a83d597c7d41278417R122-R124) [[6]](diffhunk://#diff-a0d9c5597c09639d66b5bd40d242cb7b6b7788b88fa40d17157c9d608275a2e8R1452-R1519)
* The relay retrieval endpoint now requires the `request_id` parameter, enforcing stricter request/response pairing. (`api/v1/compute_provider.py`, `tests/unit/test_api_v1_compute_provider.py`) [[1]](diffhunk://#diff-a7a09f1e6b5885e6344d48daf8ac055cba53a39c4bd32d9805f3b2db6b02ff67L265-R271) [[2]](diffhunk://#diff-60c32b3b906ed900f802dd6ea58aeb7b9dce6b77925693441de3f043db7d0eecL132-R154)

**Trusted relay origin selection and security:**

* Introduced a robust relay base URL selection mechanism in `api/v1/routes.py`, prioritizing (1) environment variable, (2) verified loopback same-origin, and (3) trusted configured origins, with strict validation for loopback and IPv6. This prevents host header spoofing and ensures only trusted relay origins are used for desktop bridge E2EE. (`api/v1/routes.py`, `tests/test_api.py`) [[1]](diffhunk://#diff-b88e004782d0850bbc66044e6029861cda469cb0cbfa2701d253fd00612a43f9L88-R207) [[2]](diffhunk://#diff-b88e004782d0850bbc66044e6029861cda469cb0cbfa2701d253fd00612a43f9R467) [[3]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R1155-R1370)
* Added normalization and validation helpers for relay origins, including IPv6 bracket handling and loopback detection. (`api/v1/routes.py`, `tests/test_api.py`) [[1]](diffhunk://#diff-b88e004782d0850bbc66044e6029861cda469cb0cbfa2701d253fd00612a43f9L88-R207) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R1155-R1370)

**Desktop client changes:**

* Disabled legacy `/next_server` + `/faucet` relay forwarding in the Tauri desktop client, enforcing use of the new API v1 E2EE path. (`desktop-tauri/src-tauri/src/forward.rs`, `desktop-tauri/src/App.tsx`) [[1]](diffhunk://#diff-7ca3e41d75cf810b4edbb65b7b4f990c75f13abd39b710af1f7410e112d1dc0cL20-R23) [[2]](diffhunk://#diff-49a8e82c6a314392be9020316b41207ac4e7c30302c6876fd8578e7a7193eb94L460-R460)

**Testing and validation:**

* Added comprehensive tests for relay origin selection, loopback and IPv6 handling, trusted origin precedence, and the E2EE relay protocol (including ensuring plaintext is never stored or leaked). (`tests/test_api.py`, `tests/test_relay.py`, `tests/unit/test_api_v1_compute_provider.py`) [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R1155-R1370) [[2]](diffhunk://#diff-a0d9c5597c09639d66b5bd40d242cb7b6b7788b88fa40d17157c9d608275a2e8R1452-R1519) [[3]](diffhunk://#diff-60c32b3b906ed900f802dd6ea58aeb7b9dce6b77925693441de3f043db7d0eecR62-R65) [[4]](diffhunk://#diff-60c32b3b906ed900f802dd6ea58aeb7b9dce6b77925693441de3f043db7d0eecL132-R154)

**Minor improvements:**

* Updated provider selection logic to accept an explicit `distributed_url` parameter, allowing for request-scoped relay routing. (`api/v1/compute_provider.py`)

These changes significantly improve the security, reliability, and testability of the desktop bridge relay path and its integration with API v1.