### PR TITLE
Finish API v1 E2EE relay desktop bridge response path

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -79,6 +79,7 @@ def test_compute_node_runtime_ensure_model_ready_download_failure():
 def test_compute_node_runtime_polling_thread_delegates_to_relay():
     relay_client = MagicMock()
     relay_client.poll_relay_continuously = MagicMock()
+    relay_client.poll_api_v1_encrypted_work_continuously = MagicMock()
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
     crypto_manager = MagicMock()
@@ -86,7 +87,7 @@ def test_compute_node_runtime_polling_thread_delegates_to_relay():
     thread = MagicMock()
 
     def fake_thread_factory(*, target, daemon):
-        assert target == relay_client.poll_relay_continuously
+        assert target == relay_client.poll_api_v1_encrypted_work_continuously
         assert daemon is True
         return thread
 

--- a/tests/unit/test_legacy_route_usage_guardrails.py
+++ b/tests/unit/test_legacy_route_usage_guardrails.py
@@ -10,6 +10,7 @@ def test_active_production_paths_do_not_reference_legacy_relay_routes():
         root / "api" / "v1" / "compute_provider.py",
         root / "client.py",
         root / "utils" / "crypto_helpers.py",
+        root / "utils" / "compute_node_runtime.py",
         root / "static" / "chat.js",
         root / "desktop" / "src" / "services" / "desktopBridgeClient.ts",
         root / "desktop" / "src" / "services" / "desktopApiClient.ts",
@@ -26,5 +27,29 @@ def test_active_production_paths_do_not_reference_legacy_relay_routes():
             pattern = re.compile(rf"(?<![A-Za-z0-9_]){re.escape(route)}(?![A-Za-z0-9_])")
             if pattern.search(text):
                 violations.append(f"{path.relative_to(root)} uses deprecated route {route}")
+
+    assert not violations, "\n".join(violations)
+
+
+def test_api_v1_relay_client_paths_do_not_reference_legacy_relay_routes():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "utils" / "networking" / "relay_client.py"
+    text = path.read_text(encoding="utf-8")
+    active_sections = [
+        ("def poll_api_v1_encrypted_work", "def _api_v1_response_relay_url"),
+        ("def _api_v1_response_relay_url", "def process_client_request"),
+        ("if api_v1_request_payload is not None:", "chat_history = _extract_chat_history"),
+        ("def poll_api_v1_encrypted_work_continuously", "def poll_relay_continuously"),
+    ]
+
+    violations: list[str] = []
+    for start_marker, end_marker in active_sections:
+        start = text.index(start_marker)
+        end = text.index(end_marker, start + len(start_marker))
+        section = text[start:end]
+        for route in LEGACY_ROUTES:
+            pattern = re.compile(rf"(?<![A-Za-z0-9_]){re.escape(route)}(?![A-Za-z0-9_])")
+            if pattern.search(section):
+                violations.append(f"{path.relative_to(root)} active API v1 path uses {route}")
 
     assert not violations, "\n".join(violations)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -945,6 +945,18 @@ class TestRelayClient:
             temperature=0.2,
             max_tokens=50,
         )
+        mock_crypto_manager.encrypt_message.assert_called_with(
+            {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": "req-123",
+                "client_public_key": request_data["client_public_key"],
+                "api_v1_response": {
+                    "message": {"role": "assistant", "content": "Hi there"},
+                },
+            },
+            base64.b64decode(request_data["client_public_key"], validate=True),
+        )
         mock_post.assert_called_once_with(
             'http://localhost:5000/api/v1/relay/responses',
             json={
@@ -957,6 +969,44 @@ class TestRelayClient:
                 'iv': 'encrypted_iv',
             },
             timeout=relay_client._request_timeout,
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    @patch('api.v1.models.generate_response')
+    def test_process_client_request_api_v1_e2ee_posts_response_to_polling_relay(
+        self,
+        mock_generate_response,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """API v1 responses should be submitted to the relay that supplied the work."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        relay_client._last_api_v1_work_relay_url = 'https://relay-that-polled.example'
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-polled-relay",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_generate_response.return_value = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        assert mock_post.call_args.args[0] == (
+            'https://relay-that-polled.example/api/v1/relay/responses'
         )
 
     @patch('utils.networking.relay_client.requests.post')

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -54,7 +54,7 @@ LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "
 
 
 def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
-    """Return whether ``payload`` matches the legacy relay sink/source contract."""
+    """Return whether ``payload`` matches the deprecated relay contract."""
 
     if not isinstance(payload, dict):
         return False
@@ -91,7 +91,7 @@ class RelayRequestAdapter(Protocol):
 
 
 class LegacyRelayRequestAdapter:
-    """Compatibility adapter for the existing relay sink/source request shape."""
+    """Compatibility adapter for the existing deprecated relay request shape."""
 
     def __init__(self, relay_client: "RelayClient"):
         self._relay_client = relay_client
@@ -299,8 +299,13 @@ class ComputeNodeRuntime:
     def start_relay_polling(self) -> threading.Thread:
         """Start relay polling in a background thread and return the thread."""
 
+        poll_target = getattr(
+            self.relay_client,
+            "poll_api_v1_encrypted_work_continuously",
+            self.relay_client.poll_relay_continuously,
+        )
         relay_thread = self._thread_factory(
-            target=self.relay_client.poll_relay_continuously,
+            target=poll_target,
             daemon=True,
         )
         relay_thread.start()

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -368,6 +368,7 @@ class RelayClient:
         )
         self._active_relay_index = 0
         self._sink_start_index = 0
+        self._last_api_v1_work_relay_url: Optional[str] = None
 
     @staticmethod
     def _compose_relay_url(base_url: str, port: Optional[int]) -> str:
@@ -729,6 +730,12 @@ class RelayClient:
                     continue
                 payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
+                self._last_api_v1_work_relay_url = candidate_url
+                log_info(
+                    "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
+                    payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',
+                    payload.get('request_id', 'none'),
+                )
                 return payload
             except Exception as exc:
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
@@ -738,6 +745,11 @@ class RelayClient:
             'error': 'No relay targets responded',
             'next_ping_in_x_seconds': self._request_timeout,
         }
+
+    def _api_v1_response_relay_url(self) -> str:
+        """Return the relay URL that supplied the current API v1 work item."""
+
+        return self._last_api_v1_work_relay_url or self.relay_url
 
     def process_client_request(self, request_data: Dict[str, Any]) -> bool:
         """
@@ -784,8 +796,12 @@ class RelayClient:
 
                 def _post_api_v1_source(response_envelope: Dict[str, Any]) -> bool:
                     try:
+                        bound_response_envelope = {
+                            **response_envelope,
+                            "client_public_key": client_pub_key_b64,
+                        }
                         encrypted_response = self.crypto_manager.encrypt_message(
-                            response_envelope,
+                            bound_response_envelope,
                             client_pub_key,
                         )
                         source_payload = {
@@ -802,12 +818,22 @@ class RelayClient:
                         if headers:
                             request_kwargs["headers"] = headers
 
+                        response_url = self._build_api_v1_url(
+                            self._api_v1_response_relay_url(),
+                            "/relay/responses",
+                        )
                         source_response = requests.post(
-                            self._build_api_v1_url(self.relay_url, "/relay/responses"),
+                            response_url,
                             timeout=self._request_timeout,
                             **request_kwargs,
                         )
-                        return source_response.status_code == 200
+                        submitted = source_response.status_code == 200
+                        log_info(
+                            "API v1 E2EE response submission request_id={} route=/api/v1/relay/responses submitted={}",
+                            response_envelope["request_id"],
+                            submitted,
+                        )
+                        return submitted
                     except Exception:
                         log_error(
                             "Failed to encrypt or post API v1 response to relay /api/v1/relay/responses",
@@ -1051,6 +1077,21 @@ class RelayClient:
 
         log_error("Rejected disabled relay API v1 payload dispatch")
         return False
+
+
+    def poll_api_v1_encrypted_work_continuously(self):  # pragma: no cover
+        """Continuously poll API v1 E2EE relay routes and process encrypted work."""
+
+        self.stop_polling = False
+        log_info("Starting API v1 E2EE relay polling loop")
+        while not self.stop_polling:
+            relay_response = self.poll_api_v1_encrypted_work()
+            wait_seconds = self._request_timeout
+            if isinstance(relay_response, dict):
+                wait_seconds = relay_response.get('next_ping_in_x_seconds', self._request_timeout)
+                if relay_response.get('protocol') == 'tokenplace_api_v1_relay_e2ee':
+                    self.process_client_request(relay_response)
+            time.sleep(wait_seconds)
 
     def poll_relay_continuously(self):  # pragma: no cover
         """


### PR DESCRIPTION
### Motivation
- Finish the API v1 E2EE relay desktop-bridge response path so encrypted work queued by the provider is reliably returned to the provider polling for that work without using legacy routes.
- Investigation showed the desktop bridge could decrypt/process API v1 envelopes but responses were sometimes posted to the client default relay URL while the provider polled a different relay; background polling also still defaulted to the legacy continuous poller.
- Preserve E2EE invariant and ensure no active runtime path depends on deprecated legacy endpoints (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`).

### Description
- Record the relay URL that supplied the API v1 work in `RelayClient` and use it when posting encrypted responses to `/api/v1/relay/responses` instead of the client default relay URL (`utils/networking/relay_client.py`).
- Include `client_public_key` in the API v1 encrypted response envelope before encrypting so the response is bound to the intended client key (`utils/networking/relay_client.py`).
- Add `poll_api_v1_encrypted_work_continuously` and prefer it as the default background poll target in `ComputeNodeRuntime.start_relay_polling()` so the reusable runtime uses the API v1 E2EE poll loop when available (`utils/networking/relay_client.py`, `utils/compute_node_runtime.py`).
- Add lightweight metadata-only diagnostics for poll detection and response submission (request id, api_v1 detection, submission result) without logging plaintext payloads (`utils/networking/relay_client.py`).
- Update unit tests and guardrails to assert the new behavior: response submission targets the polling relay, encrypted responses include the client key binding, compute runtime uses the API v1 poll loop, and active API v1 client paths do not reference legacy routes (`tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`, `tests/unit/test_legacy_route_usage_guardrails.py`).

### Testing
- Ran targeted unit suites: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_legacy_route_usage_guardrails.py` and `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py`; those targeted tests passed (unit and relay/provider tests green).
- Ran `pre-commit run --all-files` which completed successfully (formatting/lint/guards passed).
- Ran broader `python -m pytest -q`; large majority of the suite passed (many tests passed), but a small set of legacy integration/e2e tests failed or were skipped due to environment constraints: Playwright needed browser system libs (`libatk-1.0.so.0`) and some integration tests timed out starting external subprocess servers in this container (not a functional regression in the patch).
- grep/audit checks: `rg "/sink|/faucet|/source|/retrieve|/next_server" .` and rule-specific guardrail tests confirmed no active runtime references to legacy routes remain in the API v1 E2EE runtime paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f2003060832f976aa7a4473f9625)