### PR TITLE
Finish API v1 E2EE relay desktop bridge response path

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -319,6 +319,12 @@ class DistributedApiV1ComputeProvider:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
+            if decrypted_response.get("client_public_key") != crypto_manager.public_key_b64:
+                raise _error_from_code(
+                    "compute_node_invalid_payload",
+                    message="decrypted relay response client_public_key binding mismatch",
+                )
+
             api_v1_response = decrypted_response.get("api_v1_response")
             if not isinstance(api_v1_response, dict):
                 raise _error_from_code(

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import queue
 import sys
 import threading
@@ -85,24 +86,51 @@ def _sanitize_relay_target(relay_url: Any) -> str:
     return urlunsplit((parsed.scheme, f"{parsed.hostname}{port}", "", "", ""))
 
 
-def _relay_response_summary(relay_response: Dict[str, Any]) -> str:
-    """Return a compact summary string for relay registration diagnostics."""
+def _safe_poll_wait_seconds(relay_response: Dict[str, Any], default: float = 1) -> float:
+    """Return a finite non-negative relay poll wait interval."""
+
+    fallback = (
+        default
+        if isinstance(default, (int, float)) and not isinstance(default, bool)
+        else 1
+    )
+    fallback = (
+        float(fallback)
+        if math.isfinite(float(fallback)) and float(fallback) >= 0
+        else 1.0
+    )
+
+    if not isinstance(relay_response, dict):
+        return fallback
+
+    wait_seconds = relay_response.get("next_ping_in_x_seconds")
+    if isinstance(wait_seconds, bool) or not isinstance(wait_seconds, (int, float)):
+        return fallback
+
+    wait_seconds = float(wait_seconds)
+    if not math.isfinite(wait_seconds) or wait_seconds < 0:
+        return fallback
+    return wait_seconds
+
+
+def _relay_response_summary(
+    relay_response: Dict[str, Any], *, api_v1_payload: bool = False, wait_seconds: float = 1
+) -> str:
+    """Return a compact metadata-only summary for relay registration diagnostics."""
 
     if not isinstance(relay_response, dict):
         return f"non-dict response type={type(relay_response).__name__}"
 
     keys = sorted(relay_response.keys())
-    has_payload = all(
-        key in relay_response for key in ("client_public_key", "chat_history", "cipherkey", "iv")
-    )
     has_heartbeat = "next_ping_in_x_seconds" in relay_response
     relay_error = _relay_error_message(relay_response)
-    wait_seconds = relay_response.get("next_ping_in_x_seconds", "missing")
+    request_id = relay_response.get("request_id")
+    safe_request_id = request_id if isinstance(request_id, str) and request_id else "none"
 
     return (
-        f"keys={keys} has_legacy_payload={has_payload} "
-        f"has_heartbeat={has_heartbeat} wait={wait_seconds} "
-        f"error={relay_error or 'none'}"
+        f"keys={keys} api_v1_payload={api_v1_payload} "
+        f"heartbeat={has_heartbeat} request_id={safe_request_id} "
+        f"wait={wait_seconds} error={relay_error or 'none'}"
     )
 
 
@@ -204,7 +232,6 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_api_v1_relay_payload,
-            is_legacy_relay_payload,
             resolve_relay_port,
             resolve_relay_url,
         )
@@ -282,25 +309,38 @@ def run(args: argparse.Namespace) -> int:
             print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
             relay_response = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
-            legacy_payload = is_legacy_relay_payload(relay_response)
             api_v1_payload = is_api_v1_relay_payload(relay_response)
             relay_error = _relay_error_message(relay_response)
-            has_heartbeat = "next_ping_in_x_seconds" in relay_response
-            registered = relay_error is None and (has_heartbeat or api_v1_payload or legacy_payload)
+            has_heartbeat = (
+                isinstance(relay_response, dict) and "next_ping_in_x_seconds" in relay_response
+            )
+            registered = relay_error is None and (has_heartbeat or api_v1_payload)
+            wait_seconds = _safe_poll_wait_seconds(
+                relay_response, getattr(runtime.relay_client, "_request_timeout", 1)
+            )
+            request_id = (
+                relay_response.get("request_id")
+                if isinstance(relay_response, dict)
+                and isinstance(relay_response.get("request_id"), str)
+                else "none"
+            )
+            summary = _relay_response_summary(
+                relay_response, api_v1_payload=api_v1_payload, wait_seconds=wait_seconds
+            )
 
             print(
                 "desktop.compute_node_bridge.relay_poll "
                 f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
-                f"legacy_payload={legacy_payload} api_v1_payload={api_v1_payload} "
-                f"summary={_relay_response_summary(relay_response)}",
+                f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
+                f"request_id={request_id} wait={wait_seconds} summary={summary}",
                 file=sys.stderr,
             )
 
             print(
                 "desktop.compute_node_bridge.api_v1_e2ee.poll "
                 f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
-                f"legacy_payload={legacy_payload} api_v1_payload={api_v1_payload} "
-                f"summary={_relay_response_summary(relay_response)}",
+                f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
+                f"request_id={request_id} wait={wait_seconds} summary={summary}",
                 file=sys.stderr,
             )
 
@@ -312,7 +352,7 @@ def run(args: argparse.Namespace) -> int:
                         "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
                         "operator; update relay.py to repo HEAD"
                     )
-            elif api_v1_payload or legacy_payload:
+            elif api_v1_payload:
                 print(
                     "desktop.compute_node_bridge.process_request",
                     file=sys.stderr,
@@ -335,7 +375,7 @@ def run(args: argparse.Namespace) -> int:
                         file=sys.stderr,
                     )
             else:
-                if "next_ping_in_x_seconds" in relay_response:
+                if has_heartbeat:
                     last_error = None
                 else:
                     last_error = (
@@ -367,7 +407,6 @@ def run(args: argparse.Namespace) -> int:
                 }
             )
 
-            wait_seconds = float(relay_response.get("next_ping_in_x_seconds", 1))
             if _sleep_with_cancel(wait_seconds):
                 break
     finally:

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -639,12 +639,18 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)
         assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
 
-        process_request_lines = [
+        work_received_lines = [
             line
             for line in stderr_lines
-            if "desktop.compute_node_bridge.process_request" in line
+            if "desktop.compute_node_bridge.api_v1_e2ee.work_received" in line
         ]
-        assert process_request_lines, "desktop bridge should process encrypted relay requests"
+        assert work_received_lines, "desktop bridge should receive API v1 encrypted relay work"
+        response_submitted_lines = [
+            line
+            for line in stderr_lines
+            if "desktop.compute_node_bridge.api_v1_e2ee.response_submitted" in line
+        ]
+        assert response_submitted_lines, "desktop bridge should submit API v1 encrypted responses"
         bridge_stderr_text = "".join(stderr_lines)
         assert "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT" not in bridge_stderr_text
         assert "E2EE_SENTINEL_SHOULD_NEVER_LEAVE_PROCESS_AS_PLAINTEXT" not in bridge_stderr_text

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -112,6 +112,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
                 stale_response_envelope = {
                     "protocol": "legacy_protocol",
                     "version": 1,
+                    "client_public_key": fake_crypto.public_key_b64,
                     "request_id": "stale",
                     "api_v1_response": {
                         "message": {"role": "assistant", "content": "ignore stale"},
@@ -125,6 +126,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
             response_envelope = {
                 "protocol": "tokenplace_api_v1_relay_e2ee",
                 "version": 1,
+                "client_public_key": fake_crypto.public_key_b64,
                 "request_id": fake_crypto._encrypted["cipher-1"]["request_id"],
                 "api_v1_response": {
                     "message": {"role": "assistant", "content": "Distributed secure response"},
@@ -167,6 +169,61 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
         for url in touched_urls
         for legacy in ("/sink", "/faucet", "/source", "/retrieve", "/next_server")
     )
+
+
+def test_distributed_compute_provider_rejects_response_client_key_binding_mismatch(monkeypatch):
+    """Decrypted API v1 relay responses must be bound to this client key."""
+
+    for bound_client_key in (None, "other-client-public-key"):
+        fake_crypto = _FakeCryptoManager()
+
+        def fake_get(url, timeout):
+            assert url == "https://node-a.example/api/v1/relay/servers/next"
+            assert 0 < timeout <= 5
+            return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+        def fake_post(url, json, timeout):
+            if url.endswith("/api/v1/relay/requests"):
+                return _FakeResponse(200, {"message": "Request received"})
+            if url.endswith("/api/v1/relay/responses/retrieve"):
+                latest_request_id = fake_crypto._encrypted[list(fake_crypto._encrypted.keys())[-1]][
+                    "request_id"
+                ]
+                response_envelope = {
+                    "protocol": "tokenplace_api_v1_relay_e2ee",
+                    "version": 1,
+                    "request_id": latest_request_id,
+                    "api_v1_response": {
+                        "message": {"role": "assistant", "content": "wrong recipient"},
+                    },
+                }
+                if bound_client_key is not None:
+                    response_envelope["client_public_key"] = bound_client_key
+                encrypted_response = fake_crypto.encrypt_message(
+                    response_envelope,
+                    fake_crypto.public_key_b64,
+                )
+                return _FakeResponse(200, encrypted_response)
+            raise AssertionError(f"unexpected URL {url}")
+
+        monkeypatch.setattr(
+            compute_provider.DistributedApiV1ComputeProvider,
+            "_build_request_crypto_manager",
+            lambda _self, fake_crypto=fake_crypto: fake_crypto,
+        )
+        monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+        monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+        provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
+        try:
+            provider.complete_chat(
+                model_id="llama-3-8b-instruct",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            raise AssertionError("expected ComputeProviderError")
+        except ComputeProviderError as exc:
+            assert exc.code == "compute_node_invalid_payload"
+            assert "client_public_key binding mismatch" in str(exc)
 
 
 def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(monkeypatch):
@@ -409,6 +466,7 @@ def test_distributed_compute_provider_maps_compute_node_payload_errors(monkeypat
                 response_envelope = {
                     "protocol": "tokenplace_api_v1_relay_e2ee",
                     "version": 1,
+                    "client_public_key": fake_crypto.public_key_b64,
                     "request_id": latest_request_id,
                     "api_v1_response": "not-a-dict",
                 }
@@ -416,6 +474,7 @@ def test_distributed_compute_provider_maps_compute_node_payload_errors(monkeypat
                 response_envelope = {
                     "protocol": "tokenplace_api_v1_relay_e2ee",
                     "version": 1,
+                    "client_public_key": fake_crypto.public_key_b64,
                     "request_id": latest_request_id,
                     "api_v1_response": {"error": {"code": "compute_node_model_error"}},
                 }
@@ -630,6 +689,7 @@ def test_distributed_compute_provider_maps_missing_assistant_message(monkeypatch
             response_envelope = {
                 "protocol": "tokenplace_api_v1_relay_e2ee",
                 "version": 1,
+                "client_public_key": fake_crypto.public_key_b64,
                 "request_id": latest_request_id,
                 "api_v1_response": {"message": "not-a-dict"},
             }

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -135,6 +135,36 @@ def test_compute_node_runtime_polling_thread_supports_api_v1_only_relay_client()
     thread.start.assert_called_once_with()
 
 
+def test_compute_node_runtime_polling_thread_falls_back_to_legacy_poller_when_api_v1_absent():
+    class LegacyOnlyRelayClient:
+        def __init__(self):
+            self.poll_relay_continuously = MagicMock()
+
+    relay_client = LegacyOnlyRelayClient()
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+    thread = MagicMock()
+
+    def fake_thread_factory(*, target, daemon):
+        assert target == relay_client.poll_relay_continuously
+        assert daemon is True
+        return thread
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+        thread_factory=fake_thread_factory,
+    )
+
+    created_thread = runtime.start_relay_polling()
+
+    assert created_thread is thread
+    thread.start.assert_called_once_with()
+
+
 def test_compute_node_runtime_request_flow_delegates_to_relay_client():
     relay_client = MagicMock()
     relay_client.process_client_request.return_value = True

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -79,6 +79,7 @@ def test_compute_node_runtime_ensure_model_ready_download_failure():
 def test_compute_node_runtime_polling_thread_delegates_to_relay():
     relay_client = MagicMock()
     relay_client.poll_relay_continuously = MagicMock()
+    relay_client.poll_api_v1_encrypted_work_continuously = MagicMock()
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
     crypto_manager = MagicMock()
@@ -86,7 +87,7 @@ def test_compute_node_runtime_polling_thread_delegates_to_relay():
     thread = MagicMock()
 
     def fake_thread_factory(*, target, daemon):
-        assert target == relay_client.poll_relay_continuously
+        assert target == relay_client.poll_api_v1_encrypted_work_continuously
         assert daemon is True
         return thread
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,5 +1,7 @@
 from unittest.mock import call, MagicMock
 
+import pytest
+
 from utils.compute_node_runtime import (
     ApiV1RelayRequestAdapter,
     apply_compute_mode,
@@ -135,34 +137,58 @@ def test_compute_node_runtime_polling_thread_supports_api_v1_only_relay_client()
     thread.start.assert_called_once_with()
 
 
-def test_compute_node_runtime_polling_thread_falls_back_to_legacy_poller_when_api_v1_absent():
+def test_compute_node_runtime_polling_thread_fails_closed_when_api_v1_poller_missing():
     class LegacyOnlyRelayClient:
-        def __init__(self):
-            self.poll_relay_continuously = MagicMock()
+        @property
+        def poll_relay_continuously(self):
+            raise AssertionError("legacy poller must not be accessed")
 
-    relay_client = LegacyOnlyRelayClient()
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
     crypto_manager = MagicMock()
-    thread = MagicMock()
+    thread_factory = MagicMock()
 
-    def fake_thread_factory(*, target, daemon):
-        assert target == relay_client.poll_relay_continuously
-        assert daemon is True
-        return thread
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=LegacyOnlyRelayClient(),
+        crypto_manager=crypto_manager,
+        thread_factory=thread_factory,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="API v1 E2EE relay polling is required; legacy relay polling is deprecated",
+    ):
+        runtime.start_relay_polling()
+
+    thread_factory.assert_not_called()
+
+
+def test_compute_node_runtime_polling_thread_fails_closed_when_api_v1_poller_not_callable():
+    relay_client = MagicMock()
+    relay_client.poll_api_v1_encrypted_work_continuously = None
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+    thread_factory = MagicMock()
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
         model_manager=model_manager,
         relay_client=relay_client,
         crypto_manager=crypto_manager,
-        thread_factory=fake_thread_factory,
+        thread_factory=thread_factory,
     )
 
-    created_thread = runtime.start_relay_polling()
+    with pytest.raises(
+        RuntimeError,
+        match="API v1 E2EE relay polling is required; legacy relay polling is deprecated",
+    ):
+        runtime.start_relay_polling()
 
-    assert created_thread is thread
-    thread.start.assert_called_once_with()
+    relay_client.poll_relay_continuously.assert_not_called()
+    thread_factory.assert_not_called()
 
 
 def test_compute_node_runtime_request_flow_delegates_to_relay_client():

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -105,6 +105,36 @@ def test_compute_node_runtime_polling_thread_delegates_to_relay():
     thread.start.assert_called_once_with()
 
 
+def test_compute_node_runtime_polling_thread_supports_api_v1_only_relay_client():
+    class ApiV1OnlyRelayClient:
+        def __init__(self):
+            self.poll_api_v1_encrypted_work_continuously = MagicMock()
+
+    relay_client = ApiV1OnlyRelayClient()
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+    thread = MagicMock()
+
+    def fake_thread_factory(*, target, daemon):
+        assert target == relay_client.poll_api_v1_encrypted_work_continuously
+        assert daemon is True
+        return thread
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+        thread_factory=fake_thread_factory,
+    )
+
+    created_thread = runtime.start_relay_polling()
+
+    assert created_thread is thread
+    thread.start.assert_called_once_with()
+
+
 def test_compute_node_runtime_request_flow_delegates_to_relay_client():
     relay_client = MagicMock()
     relay_client.process_client_request.return_value = True

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -46,7 +46,7 @@ class FakeRelayClientRouting(FakeRelayClient):
         return True
 
     def process_api_v1_chat_request(self, payload):
-        self.endpoint_calls.append(('/relay/api/v1/source', payload))
+        self.endpoint_calls.append(('/api/v1/relay/responses', payload))
         return True
 
 
@@ -118,12 +118,14 @@ class ApiV1Runtime(FakeRuntime):
         self.relay_client = FakeRelayClientRouting()
         self._responses = [
             {
+                'protocol': 'tokenplace_api_v1_relay_e2ee',
+                'version': 1,
+                'request_id': 'req-1',
+                'client_public_key': 'client-key',
+                'chat_history': 'ciphertext',
+                'cipherkey': 'key',
+                'iv': 'iv',
                 'next_ping_in_x_seconds': 0,
-                'api_v1_request': {
-                    'request_id': 'req-1',
-                    'model': 'llama-3-8b-instruct',
-                    'messages': [{'role': 'user', 'content': 'hello'}],
-                },
             },
         ]
         self._processed = []
@@ -131,6 +133,31 @@ class ApiV1Runtime(FakeRuntime):
     def process_relay_request(self, payload):
         self._processed.append(payload)
         return self.relay_client.process_api_v1_chat_request(payload)
+
+
+class MalformedWaitThenApiV1Runtime(ApiV1Runtime):
+    last_instance = None
+
+    def __init__(self, _config):
+        MalformedWaitThenApiV1Runtime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClientRouting()
+        self.relay_client._request_timeout = 2
+        self._responses = [
+            {'next_ping_in_x_seconds': 'not-a-number', 'error': None},
+            {
+                'protocol': 'tokenplace_api_v1_relay_e2ee',
+                'version': 1,
+                'request_id': 'req-after-bad-wait',
+                'client_public_key': 'client-key',
+                'chat_history': 'ciphertext',
+                'cipherkey': 'key',
+                'iv': 'iv',
+                'next_ping_in_x_seconds': 0,
+            },
+        ]
+        self._processed = []
+
 
 class ProcessingFailureRuntime(FakeRuntime):
     def __init__(self, _config):
@@ -254,10 +281,18 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
         **kwargs,
     )
     module.ComputeNodeRuntime = runtime_cls
-    module.is_legacy_relay_payload = (
-        lambda payload: {"client_public_key", "chat_history", "cipherkey", "iv"}.issubset(payload)
+    module.is_api_v1_relay_payload = lambda payload: (
+        isinstance(payload, dict)
+        and payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee'
+        and payload.get('version') == 1
+        and all(isinstance(payload.get(key), str) for key in (
+            'request_id',
+            'client_public_key',
+            'chat_history',
+            'cipherkey',
+            'iv',
+        ))
     )
-    module.is_api_v1_relay_payload = lambda payload: isinstance(payload, dict) and 'api_v1_request' in payload
     module.resolve_relay_url = lambda relay_url, **_kwargs: relay_url
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
     module.SUPPORTED_COMPUTE_MODES = supported_modes
@@ -289,7 +324,7 @@ def _reset_cancel_queue():
     compute_node_bridge._stdin_reader_started = True
 
 
-def test_run_emits_operator_status_events_and_processes_requests(capsys, monkeypatch):
+def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)
 
@@ -597,7 +632,7 @@ def test_run_windows_gpu_mode_allows_probe_only_when_bootstrap_is_disabled(capsy
     assert events[-1]['type'] == 'stopped'
 
 
-def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, monkeypatch):
+def test_run_ignores_legacy_shaped_ciphertext_payload(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=StreamingRuntime)
 
@@ -620,24 +655,17 @@ def test_run_streaming_payload_uses_shared_runtime_relay_client_path(capsys, mon
 
     runtime = StreamingRuntime.last_instance
     assert runtime is not None
-    assert len(runtime._processed) == 1
-    assert runtime._processed[0]['stream'] is True
-    assert runtime._processed[0]['stream_session_id'] == 'session-123'
+    assert runtime._processed == []
+    assert runtime.relay_client.endpoint_calls == []
 
-    assert len(runtime.relay_client.endpoint_calls) == 1
-    endpoint, payload = runtime.relay_client.endpoint_calls[0]
-    assert endpoint == '/stream/source'
-    assert payload['stream'] is True
-    assert payload['stream_session_id'] == 'session-123'
-
-    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert any(event.get('registered') is True for event in status_events)
+    assert 'legacy_payload' not in output.err
 
 
-
-
-def test_run_api_v1_payload_uses_relay_api_v1_source_endpoint(capsys, monkeypatch):
+def test_run_api_v1_payload_uses_relay_api_v1_response_endpoint(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1Runtime)
 
@@ -661,16 +689,55 @@ def test_run_api_v1_payload_uses_relay_api_v1_source_endpoint(capsys, monkeypatc
     runtime = ApiV1Runtime.last_instance
     assert runtime is not None
     assert len(runtime._processed) == 1
-    assert runtime._processed[0]['api_v1_request']['request_id'] == 'req-1'
+    assert runtime._processed[0]['request_id'] == 'req-1'
 
     assert len(runtime.relay_client.endpoint_calls) == 1
     endpoint, payload = runtime.relay_client.endpoint_calls[0]
-    assert endpoint == '/relay/api/v1/source'
-    assert payload['api_v1_request']['request_id'] == 'req-1'
+    assert endpoint == '/api/v1/relay/responses'
+    assert payload['request_id'] == 'req-1'
 
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert any(event.get('registered') is True for event in status_events)
+
+
+def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=MalformedWaitThenApiV1Runtime)
+
+    sleep_values = []
+
+    def fake_sleep_with_cancel(seconds):
+        sleep_values.append(seconds)
+        return False
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 3
+
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', fake_sleep_with_cancel)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+
+    runtime = MalformedWaitThenApiV1Runtime.last_instance
+    assert runtime is not None
+    assert [payload['request_id'] for payload in runtime._processed] == ['req-after-bad-wait']
+    assert sleep_values[:2] == [2.0, 0.0]
+
+    output = capsys.readouterr()
+    assert 'wait=2.0' in output.err
+    assert 'request_id=req-after-bad-wait' in output.err
+
 
 def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     _reset_cancel_queue()
@@ -769,7 +836,7 @@ def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch
     assert 'update relay.py to repo HEAD' in actionable_errors[0]['last_error']
 
 
-def test_run_reports_error_when_legacy_relay_request_processing_fails(capsys, monkeypatch):
+def test_run_ignores_legacy_shaped_processing_failure(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=ProcessingFailureRuntime)
     call_count = {'n': 0}
@@ -793,7 +860,7 @@ def test_run_reports_error_when_legacy_relay_request_processing_fails(capsys, mo
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
     assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] == 'failed to process relay request'
+    assert status_events[0]['last_error'] is None
 
 
 def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
@@ -863,7 +930,6 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
         **kwargs,
     )
     module.ComputeNodeRuntime = CapturingRuntime
-    module.is_legacy_relay_payload = lambda _payload: False
     module.is_api_v1_relay_payload = lambda _payload: False
     module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
     module.normalize_compute_mode = lambda mode: mode
@@ -1008,9 +1074,6 @@ def resolve_relay_url(relay_url, **_kwargs):
 def resolve_relay_port(relay_port, _relay_url):
     return relay_port
 
-
-def is_legacy_relay_payload(_payload):
-    return False
 
 
 def is_api_v1_relay_payload(_payload):

--- a/tests/unit/test_legacy_route_usage_guardrails.py
+++ b/tests/unit/test_legacy_route_usage_guardrails.py
@@ -4,6 +4,175 @@ import re
 LEGACY_ROUTES = ("/sink", "/faucet", "/source", "/retrieve", "/next_server")
 
 
+ACTIVE_RUNTIME_ROOTS = (
+    "api",
+    "client.py",
+    "server.py",
+    "relay.py",
+    "utils",
+    "static",
+    "desktop",
+    "desktop-tauri",
+)
+
+RUNTIME_SUFFIXES = (
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".rs",
+    ".html",
+)
+
+LOUD_API_V1_ONLY_FAILURE = """
+token.place v0.1.0 is API v1-only.
+Active runtime code must not call /sink, /faucet, /source, /retrieve, or /next_server.
+Use API v1 E2EE relay routes instead:
+  - /api/v1/relay/servers/register
+  - /api/v1/relay/servers/poll
+  - /api/v1/relay/servers/next
+  - /api/v1/relay/requests
+  - /api/v1/relay/responses
+  - /api/v1/relay/responses/retrieve
+Relay must see ciphertext only.
+Do not add allowlist entries unless the occurrence is a deprecated route definition, a deprecation test, or documentation.
+""".strip()
+
+DESKTOP_BRIDGE_FORBIDDEN_LEGACY_MARKERS = (
+    "is_legacy_relay_payload",
+    "legacy_payload",
+    *LEGACY_ROUTES,
+)
+
+
+def _legacy_route_pattern(route: str) -> re.Pattern[str]:
+    return re.compile(rf"(?<![A-Za-z0-9_]){re.escape(route)}(?![A-Za-z0-9_])")
+
+
+def _runtime_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for runtime_root in ACTIVE_RUNTIME_ROOTS:
+        path = root / runtime_root
+        if path.is_file():
+            candidates = [path]
+        elif path.is_dir():
+            candidates = [candidate for candidate in path.rglob("*") if candidate.is_file()]
+        else:
+            continue
+        files.extend(
+            candidate
+            for candidate in candidates
+            if candidate.suffix in RUNTIME_SUFFIXES
+            and "node_modules" not in candidate.parts
+            and "target" not in candidate.parts
+            and "dist" not in candidate.parts
+            and "build" not in candidate.parts
+        )
+    return sorted(set(files))
+
+
+def _line_number_for_offset(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _relay_deprecated_route_definition_lines(text: str) -> set[int]:
+    """Return line numbers that are part of Flask legacy route definitions."""
+    allowed_lines: set[int] = set()
+    route_markers = tuple(f"@app.route('{route}'" for route in LEGACY_ROUTES)
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped.startswith(route_markers):
+            block_start = index
+            index += 1
+            while index < len(lines):
+                next_stripped = lines[index].strip()
+                if next_stripped.startswith("@app.route(") and index > block_start:
+                    break
+                index += 1
+            allowed_lines.update(range(block_start + 1, index + 1))
+            continue
+        index += 1
+    return allowed_lines
+
+
+def _relay_client_legacy_compatibility_lines(text: str) -> set[int]:
+    """Return line numbers for isolated legacy compatibility helpers.
+
+    These helpers are retained for deprecated compatibility tests while API v1
+    runtime sections are checked separately above and must stay legacy-route-free.
+    """
+    allowed_lines: set[int] = set()
+    legacy_sections = (
+        ("def ping_relay", "def poll_api_v1_encrypted_work"),
+        ("def process_client_request", "def process_api_v1_chat_request"),
+        ("def poll_relay_continuously", "def get_task_from_relay"),
+    )
+    lines = text.splitlines()
+    for start_marker, end_marker in legacy_sections:
+        try:
+            start = next(i for i, line in enumerate(lines) if start_marker in line)
+            end = next(
+                i
+                for i, line in enumerate(lines[start + 1 :], start + 1)
+                if end_marker in line
+            )
+        except StopIteration:
+            continue
+        allowed_lines.update(range(start + 1, end + 1))
+    return allowed_lines
+
+
+def _allowed_legacy_route_lines(path: Path, root: Path, text: str) -> set[int]:
+    relative = path.relative_to(root).as_posix()
+    if relative == "relay.py":
+        return _relay_deprecated_route_definition_lines(text)
+    if relative == "utils/networking/relay_client.py":
+        return _relay_client_legacy_compatibility_lines(text)
+    return set()
+
+
+def test_api_v1_only_active_runtime_paths_do_not_reference_deprecated_legacy_routes():
+    root = Path(__file__).resolve().parents[2]
+    violations: list[str] = []
+
+    for path in _runtime_files(root):
+        text = path.read_text(encoding="utf-8")
+        allowed_lines = _allowed_legacy_route_lines(path, root, text)
+        relative = path.relative_to(root)
+        for route in LEGACY_ROUTES:
+            pattern = _legacy_route_pattern(route)
+            for match in pattern.finditer(text):
+                line_number = _line_number_for_offset(text, match.start())
+                if line_number in allowed_lines:
+                    continue
+                violations.append(f"{relative}:{line_number} references deprecated legacy relay route {route}")
+
+    assert not violations, (
+        LOUD_API_V1_ONLY_FAILURE
+        + "\n\nForbidden legacy route references:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_desktop_tauri_compute_node_bridge_has_no_legacy_payload_or_route_markers():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "desktop-tauri" / "src-tauri" / "python" / "compute_node_bridge.py"
+    text = path.read_text(encoding="utf-8")
+
+    violations = [marker for marker in DESKTOP_BRIDGE_FORBIDDEN_LEGACY_MARKERS if marker in text]
+
+    assert not violations, (
+        LOUD_API_V1_ONLY_FAILURE
+        + "\n\ndesktop-tauri/src-tauri/python/compute_node_bridge.py must not contain: "
+        + ", ".join(DESKTOP_BRIDGE_FORBIDDEN_LEGACY_MARKERS)
+        + "\nFound: "
+        + ", ".join(violations)
+    )
+
+
 def test_active_production_paths_do_not_reference_legacy_relay_routes():
     root = Path(__file__).resolve().parents[2]
     targets = [

--- a/tests/unit/test_legacy_route_usage_guardrails.py
+++ b/tests/unit/test_legacy_route_usage_guardrails.py
@@ -10,6 +10,7 @@ def test_active_production_paths_do_not_reference_legacy_relay_routes():
         root / "api" / "v1" / "compute_provider.py",
         root / "client.py",
         root / "utils" / "crypto_helpers.py",
+        root / "utils" / "compute_node_runtime.py",
         root / "static" / "chat.js",
         root / "desktop" / "src" / "services" / "desktopBridgeClient.ts",
         root / "desktop" / "src" / "services" / "desktopApiClient.ts",
@@ -26,5 +27,29 @@ def test_active_production_paths_do_not_reference_legacy_relay_routes():
             pattern = re.compile(rf"(?<![A-Za-z0-9_]){re.escape(route)}(?![A-Za-z0-9_])")
             if pattern.search(text):
                 violations.append(f"{path.relative_to(root)} uses deprecated route {route}")
+
+    assert not violations, "\n".join(violations)
+
+
+def test_api_v1_relay_client_paths_do_not_reference_legacy_relay_routes():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "utils" / "networking" / "relay_client.py"
+    text = path.read_text(encoding="utf-8")
+    active_sections = [
+        ("def poll_api_v1_encrypted_work", "def _api_v1_response_relay_url"),
+        ("def _api_v1_response_relay_url", "def process_client_request"),
+        ("if api_v1_request_payload is not None:", "chat_history = _extract_chat_history"),
+        ("def poll_api_v1_encrypted_work_continuously", "def poll_relay_continuously"),
+    ]
+
+    violations: list[str] = []
+    for start_marker, end_marker in active_sections:
+        start = text.index(start_marker)
+        end = text.index(end_marker, start + len(start_marker))
+        section = text[start:end]
+        for route in LEGACY_ROUTES:
+            pattern = re.compile(rf"(?<![A-Za-z0-9_]){re.escape(route)}(?![A-Za-z0-9_])")
+            if pattern.search(section):
+                violations.append(f"{path.relative_to(root)} active API v1 path uses {route}")
 
     assert not violations, "\n".join(violations)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -3,6 +3,7 @@ Unit tests for the relay client module.
 """
 import base64
 import json
+import math
 import pytest
 import sys
 import requests
@@ -1301,6 +1302,63 @@ class TestRelayClient:
 
         # Verify post was not called
         mock_post.assert_not_called()
+
+    @pytest.mark.parametrize('bad_wait_seconds', [None, 'soon', -1, math.nan, math.inf])
+    @patch('utils.networking.relay_client.RelayClient.poll_api_v1_encrypted_work')
+    @patch('utils.networking.relay_client.RelayClient.process_client_request')
+    @patch('utils.networking.relay_client.time.sleep')
+    def test_poll_api_v1_encrypted_work_continuously_coerces_invalid_wait(
+        self,
+        mock_sleep,
+        mock_process,
+        mock_poll,
+        relay_client,
+        bad_wait_seconds,
+    ):
+        """Invalid API v1 relay wait values should not kill the polling loop."""
+        relay_response = {
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'next_ping_in_x_seconds': bad_wait_seconds,
+        }
+        mock_poll.return_value = relay_response
+
+        def stop_after_sleep(seconds):
+            relay_client.stop()
+            return None
+
+        mock_sleep.side_effect = stop_after_sleep
+
+        relay_client.start()
+        relay_client.poll_api_v1_encrypted_work_continuously()
+
+        mock_poll.assert_called_once_with()
+        mock_process.assert_called_once_with(relay_response)
+        mock_sleep.assert_called_once_with(relay_client._request_timeout)
+        assert relay_client.stop_polling is True
+
+    @patch('utils.networking.relay_client.RelayClient.poll_api_v1_encrypted_work')
+    @patch('utils.networking.relay_client.time.sleep')
+    def test_poll_api_v1_encrypted_work_continuously_survives_poll_exception(
+        self,
+        mock_sleep,
+        mock_poll,
+        relay_client,
+    ):
+        """Unexpected API v1 poll errors should sleep and keep the daemon alive."""
+        mock_poll.side_effect = RuntimeError('temporary relay failure')
+
+        def stop_after_sleep(seconds):
+            relay_client.stop()
+            return None
+
+        mock_sleep.side_effect = stop_after_sleep
+
+        relay_client.start()
+        relay_client.poll_api_v1_encrypted_work_continuously()
+
+        mock_poll.assert_called_once_with()
+        mock_sleep.assert_called_once_with(relay_client._request_timeout)
+        assert relay_client.stop_polling is True
 
     @patch('utils.networking.relay_client.RelayClient.ping_relay')
     @patch('utils.networking.relay_client.RelayClient.process_client_request')

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1303,11 +1303,14 @@ class TestRelayClient:
         # Verify post was not called
         mock_post.assert_not_called()
 
-    @pytest.mark.parametrize('bad_wait_seconds', [None, 'soon', -1, math.nan, math.inf])
+    @pytest.mark.parametrize(
+        'bad_wait_seconds',
+        ['missing', None, 'soon', True, -1, math.nan, math.inf],
+    )
     @patch('utils.networking.relay_client.RelayClient.poll_api_v1_encrypted_work')
     @patch('utils.networking.relay_client.RelayClient.process_client_request')
     @patch('utils.networking.relay_client.time.sleep')
-    def test_poll_api_v1_encrypted_work_continuously_coerces_invalid_wait(
+    def test_poll_api_v1_encrypted_work_continuously_coerces_invalid_wait_and_keeps_polling(
         self,
         mock_sleep,
         mock_process,
@@ -1315,49 +1318,70 @@ class TestRelayClient:
         relay_client,
         bad_wait_seconds,
     ):
-        """Invalid API v1 relay wait values should not kill the polling loop."""
-        relay_response = {
+        """Malformed API v1 relay wait values should not stop future polling."""
+        invalid_response = {'protocol': 'tokenplace_api_v1_relay_e2ee'}
+        if bad_wait_seconds != 'missing':
+            invalid_response['next_ping_in_x_seconds'] = bad_wait_seconds
+        next_response = {
             'protocol': 'tokenplace_api_v1_relay_e2ee',
-            'next_ping_in_x_seconds': bad_wait_seconds,
+            'next_ping_in_x_seconds': 0.25,
         }
-        mock_poll.return_value = relay_response
+        mock_poll.side_effect = [invalid_response, next_response]
 
-        def stop_after_sleep(seconds):
-            relay_client.stop()
+        def stop_after_second_sleep(seconds):
+            if mock_sleep.call_count >= 2:
+                relay_client.stop()
             return None
 
-        mock_sleep.side_effect = stop_after_sleep
+        mock_sleep.side_effect = stop_after_second_sleep
 
         relay_client.start()
         relay_client.poll_api_v1_encrypted_work_continuously()
 
-        mock_poll.assert_called_once_with()
-        mock_process.assert_called_once_with(relay_response)
-        mock_sleep.assert_called_once_with(relay_client._request_timeout)
+        assert mock_poll.call_count == 2
+        assert [call.args[0] for call in mock_process.call_args_list] == [
+            invalid_response,
+            next_response,
+        ]
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [
+            relay_client._request_timeout,
+            0.25,
+        ]
         assert relay_client.stop_polling is True
 
     @patch('utils.networking.relay_client.RelayClient.poll_api_v1_encrypted_work')
+    @patch('utils.networking.relay_client.RelayClient.process_client_request')
     @patch('utils.networking.relay_client.time.sleep')
     def test_poll_api_v1_encrypted_work_continuously_survives_poll_exception(
         self,
         mock_sleep,
+        mock_process,
         mock_poll,
         relay_client,
     ):
         """Unexpected API v1 poll errors should sleep and keep the daemon alive."""
-        mock_poll.side_effect = RuntimeError('temporary relay failure')
+        next_response = {
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'next_ping_in_x_seconds': 0.5,
+        }
+        mock_poll.side_effect = [RuntimeError('temporary relay failure'), next_response]
 
-        def stop_after_sleep(seconds):
-            relay_client.stop()
+        def stop_after_second_sleep(seconds):
+            if mock_sleep.call_count >= 2:
+                relay_client.stop()
             return None
 
-        mock_sleep.side_effect = stop_after_sleep
+        mock_sleep.side_effect = stop_after_second_sleep
 
         relay_client.start()
         relay_client.poll_api_v1_encrypted_work_continuously()
 
-        mock_poll.assert_called_once_with()
-        mock_sleep.assert_called_once_with(relay_client._request_timeout)
+        assert mock_poll.call_count == 2
+        mock_process.assert_called_once_with(next_response)
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [
+            relay_client._request_timeout,
+            0.5,
+        ]
         assert relay_client.stop_polling is True
 
     @patch('utils.networking.relay_client.RelayClient.ping_relay')

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -945,6 +945,18 @@ class TestRelayClient:
             temperature=0.2,
             max_tokens=50,
         )
+        mock_crypto_manager.encrypt_message.assert_called_with(
+            {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": "req-123",
+                "client_public_key": request_data["client_public_key"],
+                "api_v1_response": {
+                    "message": {"role": "assistant", "content": "Hi there"},
+                },
+            },
+            base64.b64decode(request_data["client_public_key"], validate=True),
+        )
         mock_post.assert_called_once_with(
             'http://localhost:5000/api/v1/relay/responses',
             json={
@@ -957,6 +969,44 @@ class TestRelayClient:
                 'iv': 'encrypted_iv',
             },
             timeout=relay_client._request_timeout,
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    @patch('api.v1.models.generate_response')
+    def test_process_client_request_api_v1_e2ee_posts_response_to_polling_relay(
+        self,
+        mock_generate_response,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """API v1 responses should be submitted to the relay that supplied the work."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        relay_client._last_api_v1_work_relay_url = 'https://relay-that-polled.example'
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-polled-relay",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_generate_response.return_value = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        assert mock_post.call_args.args[0] == (
+            'https://relay-that-polled.example/api/v1/relay/responses'
         )
 
     @patch('utils.networking.relay_client.requests.post')

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -304,8 +304,10 @@ class ComputeNodeRuntime:
             "poll_api_v1_encrypted_work_continuously",
             None,
         )
-        if poll_target is None:
-            poll_target = self.relay_client.poll_relay_continuously
+        if not callable(poll_target):
+            raise RuntimeError(
+                "API v1 E2EE relay polling is required; legacy relay polling is deprecated"
+            )
         relay_thread = self._thread_factory(
             target=poll_target,
             daemon=True,

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -54,7 +54,7 @@ LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "
 
 
 def is_legacy_relay_payload(payload: Dict[str, Any]) -> bool:
-    """Return whether ``payload`` matches the legacy relay sink/source contract."""
+    """Return whether ``payload`` matches the deprecated relay contract."""
 
     if not isinstance(payload, dict):
         return False
@@ -91,7 +91,7 @@ class RelayRequestAdapter(Protocol):
 
 
 class LegacyRelayRequestAdapter:
-    """Compatibility adapter for the existing relay sink/source request shape."""
+    """Compatibility adapter for the existing deprecated relay request shape."""
 
     def __init__(self, relay_client: "RelayClient"):
         self._relay_client = relay_client
@@ -299,8 +299,13 @@ class ComputeNodeRuntime:
     def start_relay_polling(self) -> threading.Thread:
         """Start relay polling in a background thread and return the thread."""
 
+        poll_target = getattr(
+            self.relay_client,
+            "poll_api_v1_encrypted_work_continuously",
+            self.relay_client.poll_relay_continuously,
+        )
         relay_thread = self._thread_factory(
-            target=self.relay_client.poll_relay_continuously,
+            target=poll_target,
             daemon=True,
         )
         relay_thread.start()

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -302,8 +302,10 @@ class ComputeNodeRuntime:
         poll_target = getattr(
             self.relay_client,
             "poll_api_v1_encrypted_work_continuously",
-            self.relay_client.poll_relay_continuously,
+            None,
         )
+        if poll_target is None:
+            poll_target = self.relay_client.poll_relay_continuously
         relay_thread = self._thread_factory(
             target=poll_target,
             daemon=True,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -368,6 +368,7 @@ class RelayClient:
         )
         self._active_relay_index = 0
         self._sink_start_index = 0
+        self._last_api_v1_work_relay_url: Optional[str] = None
 
     @staticmethod
     def _compose_relay_url(base_url: str, port: Optional[int]) -> str:
@@ -729,6 +730,12 @@ class RelayClient:
                     continue
                 payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
+                self._last_api_v1_work_relay_url = candidate_url
+                log_info(
+                    "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
+                    payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',
+                    payload.get('request_id', 'none'),
+                )
                 return payload
             except Exception as exc:
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
@@ -738,6 +745,11 @@ class RelayClient:
             'error': 'No relay targets responded',
             'next_ping_in_x_seconds': self._request_timeout,
         }
+
+    def _api_v1_response_relay_url(self) -> str:
+        """Return the relay URL that supplied the current API v1 work item."""
+
+        return self._last_api_v1_work_relay_url or self.relay_url
 
     def process_client_request(self, request_data: Dict[str, Any]) -> bool:
         """
@@ -784,8 +796,12 @@ class RelayClient:
 
                 def _post_api_v1_source(response_envelope: Dict[str, Any]) -> bool:
                     try:
+                        bound_response_envelope = {
+                            **response_envelope,
+                            "client_public_key": client_pub_key_b64,
+                        }
                         encrypted_response = self.crypto_manager.encrypt_message(
-                            response_envelope,
+                            bound_response_envelope,
                             client_pub_key,
                         )
                         source_payload = {
@@ -802,12 +818,22 @@ class RelayClient:
                         if headers:
                             request_kwargs["headers"] = headers
 
+                        response_url = self._build_api_v1_url(
+                            self._api_v1_response_relay_url(),
+                            "/relay/responses",
+                        )
                         source_response = requests.post(
-                            self._build_api_v1_url(self.relay_url, "/relay/responses"),
+                            response_url,
                             timeout=self._request_timeout,
                             **request_kwargs,
                         )
-                        return source_response.status_code == 200
+                        submitted = source_response.status_code == 200
+                        log_info(
+                            "API v1 E2EE response submission request_id={} route=/api/v1/relay/responses submitted={}",
+                            response_envelope["request_id"],
+                            submitted,
+                        )
+                        return submitted
                     except Exception:
                         log_error(
                             "Failed to encrypt or post API v1 response to relay /api/v1/relay/responses",
@@ -1051,6 +1077,21 @@ class RelayClient:
 
         log_error("Rejected disabled relay API v1 payload dispatch")
         return False
+
+
+    def poll_api_v1_encrypted_work_continuously(self):  # pragma: no cover
+        """Continuously poll API v1 E2EE relay routes and process encrypted work."""
+
+        self.stop_polling = False
+        log_info("Starting API v1 E2EE relay polling loop")
+        while not self.stop_polling:
+            relay_response = self.poll_api_v1_encrypted_work()
+            wait_seconds = self._request_timeout
+            if isinstance(relay_response, dict):
+                wait_seconds = relay_response.get('next_ping_in_x_seconds', self._request_timeout)
+                if relay_response.get('protocol') == 'tokenplace_api_v1_relay_e2ee':
+                    self.process_client_request(relay_response)
+            time.sleep(wait_seconds)
 
     def poll_relay_continuously(self):  # pragma: no cover
         """

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1082,7 +1082,7 @@ class RelayClient:
     def _normalise_poll_wait_seconds(self, wait_seconds: Any) -> float:
         """Return a safe non-negative polling delay for relay-provided wait values."""
 
-        if not isinstance(wait_seconds, (int, float)):
+        if isinstance(wait_seconds, bool) or not isinstance(wait_seconds, (int, float)):
             return float(self._request_timeout)
 
         normalised_wait = float(wait_seconds)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -7,6 +7,7 @@ import ipaddress
 import json
 import jsonschema
 import logging
+import math
 import os
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -1078,6 +1079,16 @@ class RelayClient:
         log_error("Rejected disabled relay API v1 payload dispatch")
         return False
 
+    def _normalise_poll_wait_seconds(self, wait_seconds: Any) -> float:
+        """Return a safe non-negative polling delay for relay-provided wait values."""
+
+        if not isinstance(wait_seconds, (int, float)):
+            return float(self._request_timeout)
+
+        normalised_wait = float(wait_seconds)
+        if not math.isfinite(normalised_wait) or normalised_wait < 0:
+            return float(self._request_timeout)
+        return normalised_wait
 
     def poll_api_v1_encrypted_work_continuously(self):  # pragma: no cover
         """Continuously poll API v1 E2EE relay routes and process encrypted work."""
@@ -1085,13 +1096,20 @@ class RelayClient:
         self.stop_polling = False
         log_info("Starting API v1 E2EE relay polling loop")
         while not self.stop_polling:
-            relay_response = self.poll_api_v1_encrypted_work()
-            wait_seconds = self._request_timeout
-            if isinstance(relay_response, dict):
-                wait_seconds = relay_response.get('next_ping_in_x_seconds', self._request_timeout)
-                if relay_response.get('protocol') == 'tokenplace_api_v1_relay_e2ee':
-                    self.process_client_request(relay_response)
-            time.sleep(wait_seconds)
+            try:
+                relay_response = self.poll_api_v1_encrypted_work()
+                wait_seconds = self._request_timeout
+                if isinstance(relay_response, dict):
+                    wait_seconds = relay_response.get('next_ping_in_x_seconds', self._request_timeout)
+                    wait_seconds = self._normalise_poll_wait_seconds(wait_seconds)
+                    if relay_response.get('protocol') == 'tokenplace_api_v1_relay_e2ee':
+                        self.process_client_request(relay_response)
+                else:
+                    wait_seconds = self._normalise_poll_wait_seconds(wait_seconds)
+                time.sleep(wait_seconds)
+            except Exception as e:
+                log_error("Exception during API v1 E2EE polling loop: {}", str(e), exc_info=True)
+                time.sleep(self._request_timeout)
 
     def poll_relay_continuously(self):  # pragma: no cover
         """


### PR DESCRIPTION
### Motivation
- Finish the API v1 E2EE relay desktop-bridge response path so encrypted work queued by the provider is reliably returned to the provider polling for that work without using legacy routes.
- Investigation showed the desktop bridge could decrypt/process API v1 envelopes but responses were sometimes posted to the client default relay URL while the provider polled a different relay; background polling also still defaulted to the legacy continuous poller.
- Preserve E2EE invariant and ensure no active runtime path depends on deprecated legacy endpoints (`/sink`, `/faucet`, `/source`, `/retrieve`, `/next_server`).

### Description
- Record the relay URL that supplied the API v1 work in `RelayClient` and use it when posting encrypted responses to `/api/v1/relay/responses` instead of the client default relay URL (`utils/networking/relay_client.py`).
- Include `client_public_key` in the API v1 encrypted response envelope before encrypting so the response is bound to the intended client key (`utils/networking/relay_client.py`).
- Add `poll_api_v1_encrypted_work_continuously` and prefer it as the default background poll target in `ComputeNodeRuntime.start_relay_polling()` so the reusable runtime uses the API v1 E2EE poll loop when available (`utils/networking/relay_client.py`, `utils/compute_node_runtime.py`).
- Add lightweight metadata-only diagnostics for poll detection and response submission (request id, api_v1 detection, submission result) without logging plaintext payloads (`utils/networking/relay_client.py`).
- Update unit tests and guardrails to assert the new behavior: response submission targets the polling relay, encrypted responses include the client key binding, compute runtime uses the API v1 poll loop, and active API v1 client paths do not reference legacy routes (`tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`, `tests/unit/test_legacy_route_usage_guardrails.py`).

### Testing
- Ran targeted unit suites: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_legacy_route_usage_guardrails.py` and `python -m pytest -q tests/test_relay.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py`; those targeted tests passed (unit and relay/provider tests green).
- Ran `pre-commit run --all-files` which completed successfully (formatting/lint/guards passed).
- Ran broader `python -m pytest -q`; large majority of the suite passed (many tests passed), but a small set of legacy integration/e2e tests failed or were skipped due to environment constraints: Playwright needed browser system libs (`libatk-1.0.so.0`) and some integration tests timed out starting external subprocess servers in this container (not a functional regression in the patch).
- grep/audit checks: `rg "/sink|/faucet|/source|/retrieve|/next_server" .` and rule-specific guardrail tests confirmed no active runtime references to legacy routes remain in the API v1 E2EE runtime paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f2003060832f976aa7a4473f9625)