### PR TITLE
Fix desktop packaged API v1 E2EE inference path (remove server `api.v1` import)

### DIFF
--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -696,9 +696,13 @@ def test_run_api_v1_payload_uses_relay_api_v1_response_endpoint(capsys, monkeypa
     assert endpoint == '/api/v1/relay/responses'
     assert payload['request_id'] == 'req-1'
 
-    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert any(event.get('registered') is True for event in status_events)
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.work_received' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
+    assert "ModuleNotFoundError: No module named 'api'" not in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -902,15 +902,14 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
-    @patch('api.v1.models.generate_response')
     def test_process_client_request_api_v1_e2ee_success(
         self,
-        mock_generate_response,
         mock_post,
         relay_client,
         mock_crypto_manager,
+        mock_model_manager,
     ):
-        """API v1 relay envelopes should call generate_response and post encrypted response."""
+        """API v1 relay envelopes should use runtime model and post encrypted response."""
         request_data = TEST_VALID_RESPONSE.copy()
         decrypted_payload = {
             "protocol": "tokenplace_api_v1_relay_e2ee",
@@ -924,7 +923,7 @@ class TestRelayClient:
             },
         }
         mock_crypto_manager.decrypt_message.return_value = decrypted_payload
-        mock_generate_response.return_value = [
+        mock_model_manager.llama_cpp_get_response.return_value = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there"},
         ]
@@ -940,11 +939,8 @@ class TestRelayClient:
         result = relay_client.process_client_request(request_data)
 
         assert result is True
-        mock_generate_response.assert_called_once_with(
-            "llama-3-8b-instruct",
-            [{"role": "user", "content": "Hello"}],
-            temperature=0.2,
-            max_tokens=50,
+        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
+            [{"role": "user", "content": "Hello"}]
         )
         mock_crypto_manager.encrypt_message.assert_called_with(
             {
@@ -972,14 +968,164 @@ class TestRelayClient:
             timeout=relay_client._request_timeout,
         )
 
+
     @patch('utils.networking.relay_client.requests.post')
-    @patch('api.v1.models.generate_response')
-    def test_process_client_request_api_v1_e2ee_posts_response_to_polling_relay(
+    def test_process_client_request_api_v1_e2ee_does_not_import_server_api_models(
         self,
-        mock_generate_response,
         mock_post,
         relay_client,
         mock_crypto_manager,
+        mock_model_manager,
+        monkeypatch,
+    ):
+        """Packaged desktop API v1 work should not require importing api.v1.models."""
+        import builtins
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-no-api-import",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "No server api package"}],
+                "options": {},
+            },
+        }
+        mock_model_manager.llama_cpp_get_response.return_value = [
+            {"role": "user", "content": "No server api package"},
+            {"role": "assistant", "content": "Runtime model response"},
+        ]
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+        original_import = builtins.__import__
+
+        def fail_api_v1_models_import(name, *args, **kwargs):
+            if name == 'api.v1.models':
+                raise ModuleNotFoundError("No module named 'api'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, '__import__', fail_api_v1_models_import)
+
+        assert relay_client.process_client_request(request_data) is True
+        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
+            [{"role": "user", "content": "No server api package"}]
+        )
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == 'http://localhost:5000/api/v1/relay/responses'
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_invalid_runtime_output_posts_encrypted_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Invalid desktop runtime output should become an encrypted API v1 error response."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-output",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_model_manager.llama_cpp_get_response.return_value = [
+            {"role": "assistant", "content": ""},
+        ]
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_internal_error"
+        )
+        assert encrypted_envelope["request_id"] == "req-invalid-output"
+        mock_post.assert_called_once()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_unsupported_model_posts_encrypted_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Unsupported API v1 models should produce encrypted errors instead of timeouts."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-unsupported-model",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "unavailable-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_model_unsupported"
+        )
+        assert encrypted_envelope["client_public_key"] == request_data["client_public_key"]
+        mock_post.assert_called_once()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_unsupported_options_posts_encrypted_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Unsupported API v1 generation options should fail closed with encrypted errors."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-unsupported-options",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {"logprobs": True},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_options_unsupported"
+        )
+        mock_post.assert_called_once()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_e2ee_posts_response_to_polling_relay(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
     ):
         """API v1 responses should be submitted to the relay that supplied the work."""
 
@@ -996,7 +1142,7 @@ class TestRelayClient:
                 "options": {},
             },
         }
-        mock_generate_response.return_value = [
+        mock_model_manager.llama_cpp_get_response.return_value = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there"},
         ]
@@ -1011,13 +1157,12 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
-    @patch('api.v1.models.generate_response')
     def test_process_client_request_api_v1_e2ee_rejects_mismatched_bound_key(
         self,
-        mock_generate_response,
         mock_post,
         relay_client,
         mock_crypto_manager,
+        mock_model_manager,
     ):
         """API v1 relay envelopes with mismatched encrypted key bindings are rejected."""
         request_data = TEST_VALID_RESPONSE.copy()
@@ -1036,7 +1181,7 @@ class TestRelayClient:
         result = relay_client.process_client_request(request_data)
 
         assert result is False
-        mock_generate_response.assert_not_called()
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
         mock_post.assert_not_called()
 
     @patch('utils.networking.relay_client.requests.post')

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -752,6 +752,201 @@ class RelayClient:
 
         return self._last_api_v1_work_relay_url or self.relay_url
 
+    def _post_api_v1_e2ee_response(
+        self,
+        response_envelope: Dict[str, Any],
+        client_pub_key_b64: str,
+        client_pub_key: bytes,
+    ) -> bool:
+        """Encrypt and submit an API v1 E2EE response to the relay that supplied work."""
+
+        try:
+            bound_response_envelope = {
+                **response_envelope,
+                "client_public_key": client_pub_key_b64,
+            }
+            encrypted_response = self.crypto_manager.encrypt_message(
+                bound_response_envelope,
+                client_pub_key,
+            )
+            source_payload = {
+                "client_public_key": client_pub_key_b64,
+                "request_id": response_envelope["request_id"],
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                **encrypted_response,
+            }
+            request_kwargs = {
+                "json": source_payload,
+            }
+            headers = self._auth_headers()
+            if headers:
+                request_kwargs["headers"] = headers
+
+            response_url = self._build_api_v1_url(
+                self._api_v1_response_relay_url(),
+                "/relay/responses",
+            )
+            source_response = requests.post(
+                response_url,
+                timeout=self._request_timeout,
+                **request_kwargs,
+            )
+            submitted = source_response.status_code == 200
+            log_info(
+                "API v1 E2EE response submission request_id={} route=/api/v1/relay/responses submitted={}",
+                response_envelope["request_id"],
+                submitted,
+            )
+            return submitted
+        except Exception:
+            log_error(
+                "Failed to encrypt or post API v1 response to relay /api/v1/relay/responses",
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
+    def _api_v1_response_envelope(
+        request_id: str,
+        *,
+        message: Optional[Dict[str, Any]] = None,
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        api_v1_response: Dict[str, Any]
+        if message is not None:
+            api_v1_response = {"message": message}
+        else:
+            api_v1_response = {
+                "error": {
+                    "code": error_code or "compute_node_internal_error",
+                    "message": error_message or "Compute node failed to process the request",
+                }
+            }
+
+        return {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": request_id,
+            "api_v1_response": api_v1_response,
+        }
+
+    def _desktop_runtime_supports_api_v1_model(self, requested_model: str) -> bool:
+        """Return whether the attached desktop runtime can satisfy the requested model id."""
+
+        requested = requested_model.strip()
+        if not requested:
+            return False
+
+        # The landing-page/API v1 default is backed by the packaged desktop model.
+        supported_names = {"llama-3-8b-instruct"}
+        for attr in ("model_id", "model_name", "file_name"):
+            value = getattr(self.model_manager, attr, None)
+            if isinstance(value, str) and value.strip():
+                supported_names.add(value.strip())
+
+        model_path = getattr(self.model_manager, "model_path", None)
+        if isinstance(model_path, str) and model_path.strip():
+            basename = os.path.basename(model_path.strip())
+            supported_names.add(model_path.strip())
+            supported_names.add(basename)
+            if "." in basename:
+                supported_names.add(basename.rsplit(".", 1)[0])
+
+        return requested in supported_names
+
+    def _generate_api_v1_response_with_runtime_model(
+        self,
+        model_id: str,
+        messages: List[Dict[str, Any]],
+        options: Dict[str, Any],
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, str]]]:
+        """Generate an API v1 assistant message using the attached desktop model manager."""
+
+        if not self._desktop_runtime_supports_api_v1_model(model_id):
+            return None, {
+                "code": "compute_node_model_unsupported",
+                "message": "Requested model is not available on this compute node",
+            }
+
+        if not hasattr(self.model_manager, "llama_cpp_get_response"):
+            return None, {
+                "code": "compute_node_model_unsupported",
+                "message": "Compute node runtime does not expose a supported inference backend",
+            }
+
+        supported_options = {"max_tokens", "temperature", "top_p", "stop"}
+        unsupported_options = sorted(set(options) - supported_options)
+        if unsupported_options:
+            return None, {
+                "code": "compute_node_options_unsupported",
+                "message": "Requested generation options are not supported by this compute node",
+            }
+
+        config = getattr(self.model_manager, "config", None)
+        original_config_values: Dict[str, Any] = {}
+        option_to_config_key = {
+            "max_tokens": "model.max_tokens",
+            "temperature": "model.temperature",
+            "top_p": "model.top_p",
+            "stop": "model.stop_tokens",
+        }
+        can_override_config = isinstance(config, dict)
+        if can_override_config:
+            for option_name, config_key in option_to_config_key.items():
+                if option_name in options:
+                    original_config_values[config_key] = config.get(config_key)
+                    config[config_key] = options[option_name]
+
+        try:
+            response_history = self.model_manager.llama_cpp_get_response(messages)
+        except Exception:
+            log_error(
+                "Runtime-model execution failed for API v1 relay request",
+                exc_info=True,
+            )
+            return None, {
+                "code": "compute_node_model_error",
+                "message": "Compute node model execution failed",
+            }
+        finally:
+            if can_override_config:
+                for config_key, original_value in original_config_values.items():
+                    if original_value is None:
+                        config.pop(config_key, None)
+                    else:
+                        config[config_key] = original_value
+
+        if not isinstance(response_history, list) or not response_history:
+            log_error("Runtime model returned invalid API v1 response history")
+            return None, {
+                "code": "compute_node_internal_error",
+                "message": "LLM returned invalid response history",
+            }
+
+        assistant_message = response_history[-1]
+        if not isinstance(assistant_message, dict):
+            log_error("Runtime model returned invalid API v1 assistant message")
+            return None, {
+                "code": "compute_node_internal_error",
+                "message": "LLM returned invalid assistant message",
+            }
+
+        content = assistant_message.get("content")
+        if (
+            assistant_message.get("role") != "assistant"
+            or not isinstance(content, str)
+            or not content.strip()
+        ):
+            log_error("Runtime model returned invalid API v1 assistant content")
+            return None, {
+                "code": "compute_node_internal_error",
+                "message": "LLM returned invalid assistant response content",
+            }
+
+        return assistant_message, None
+
     def process_client_request(self, request_data: Dict[str, Any]) -> bool:
         """
         Process a client request from the relay.
@@ -793,178 +988,28 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if api_v1_request_payload is not None:
-                from api.v1.models import ModelError, generate_response
+                assistant_message, runtime_error = self._generate_api_v1_response_with_runtime_model(
+                    api_v1_request_payload["model"],
+                    api_v1_request_payload["messages"],
+                    dict(api_v1_request_payload["options"]),
+                )
+                if runtime_error is not None:
+                    response_envelope = self._api_v1_response_envelope(
+                        api_v1_request_payload["request_id"],
+                        error_code=runtime_error["code"],
+                        error_message=runtime_error["message"],
+                    )
+                else:
+                    response_envelope = self._api_v1_response_envelope(
+                        api_v1_request_payload["request_id"],
+                        message=assistant_message,
+                    )
 
-                def _post_api_v1_source(response_envelope: Dict[str, Any]) -> bool:
-                    try:
-                        bound_response_envelope = {
-                            **response_envelope,
-                            "client_public_key": client_pub_key_b64,
-                        }
-                        encrypted_response = self.crypto_manager.encrypt_message(
-                            bound_response_envelope,
-                            client_pub_key,
-                        )
-                        source_payload = {
-                            "client_public_key": client_pub_key_b64,
-                            "request_id": response_envelope["request_id"],
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            **encrypted_response,
-                        }
-                        request_kwargs = {
-                            "json": source_payload,
-                        }
-                        headers = self._auth_headers()
-                        if headers:
-                            request_kwargs["headers"] = headers
-
-                        response_url = self._build_api_v1_url(
-                            self._api_v1_response_relay_url(),
-                            "/relay/responses",
-                        )
-                        source_response = requests.post(
-                            response_url,
-                            timeout=self._request_timeout,
-                            **request_kwargs,
-                        )
-                        submitted = source_response.status_code == 200
-                        log_info(
-                            "API v1 E2EE response submission request_id={} route=/api/v1/relay/responses submitted={}",
-                            response_envelope["request_id"],
-                            submitted,
-                        )
-                        return submitted
-                    except Exception:
-                        log_error(
-                            "Failed to encrypt or post API v1 response to relay /api/v1/relay/responses",
-                            exc_info=True,
-                        )
-                        return False
-
-                api_v1_options = dict(api_v1_request_payload["options"])
-                try:
-                    response_history = generate_response(
-                        api_v1_request_payload["model"],
-                        api_v1_request_payload["messages"],
-                        **api_v1_options,
-                    )
-                    if not isinstance(response_history, list) or not response_history:
-                        log_error("LLM returned invalid API v1 response history")
-                        return _post_api_v1_source(
-                            {
-                                "protocol": "tokenplace_api_v1_relay_e2ee",
-                                "version": 1,
-                                "request_id": api_v1_request_payload["request_id"],
-                                "api_v1_response": {
-                                    "error": {
-                                        "code": "compute_node_internal_error",
-                                        "message": "LLM returned invalid response history",
-                                    }
-                                },
-                            }
-                        )
-                    assistant_message = response_history[-1]
-                    if not isinstance(assistant_message, dict):
-                        log_error("LLM returned invalid API v1 assistant message")
-                        return _post_api_v1_source(
-                            {
-                                "protocol": "tokenplace_api_v1_relay_e2ee",
-                                "version": 1,
-                                "request_id": api_v1_request_payload["request_id"],
-                                "api_v1_response": {
-                                    "error": {
-                                        "code": "compute_node_internal_error",
-                                        "message": "LLM returned invalid assistant message",
-                                    }
-                                },
-                            }
-                        )
-
-                    return _post_api_v1_source(
-                        {
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            "request_id": api_v1_request_payload["request_id"],
-                            "api_v1_response": {
-                                "message": assistant_message,
-                            },
-                        }
-                    )
-                except ModelError as exc:
-                    error_type = getattr(exc, "error_type", "")
-                    if error_type in {"model_not_found", "model_load_error"} and hasattr(
-                        self.model_manager, "llama_cpp_get_response"
-                    ):
-                        log_info(
-                            "API v1 relay request model '%s' unavailable (%s); "
-                            "falling back to active compute-node runtime model",
-                            api_v1_request_payload["model"],
-                            error_type,
-                        )
-                        try:
-                            fallback_response_history = self.model_manager.llama_cpp_get_response(
-                                api_v1_request_payload["messages"]
-                            )
-                        except Exception as fallback_exc:
-                            log_error(
-                                "Fallback runtime-model execution failed for API v1 relay request: {}",
-                                str(fallback_exc),
-                                exc_info=True,
-                            )
-                        else:
-                            if isinstance(fallback_response_history, list) and fallback_response_history:
-                                fallback_assistant_message = fallback_response_history[-1]
-                                if isinstance(fallback_assistant_message, dict):
-                                    return _post_api_v1_source(
-                                        {
-                                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                                            "version": 1,
-                                            "request_id": api_v1_request_payload["request_id"],
-                                            "api_v1_response": {
-                                                "message": fallback_assistant_message,
-                                            },
-                                        }
-                                    )
-                            log_error("Fallback runtime-model execution returned invalid API v1 output")
-
-                    model_error_code = (
-                        "compute_node_model_unsupported"
-                        if error_type == "model_not_found"
-                        else "compute_node_model_error"
-                    )
-                    return _post_api_v1_source(
-                        {
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            "request_id": api_v1_request_payload["request_id"],
-                            "api_v1_response": {
-                                "error": {
-                                    "code": model_error_code,
-                                    "message": str(exc),
-                                }
-                            },
-                        }
-                    )
-                except Exception as exc:
-                    log_error(
-                        "Unexpected error processing API v1 relay request: {}",
-                        str(exc),
-                        exc_info=True,
-                    )
-                    return _post_api_v1_source(
-                        {
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            "request_id": api_v1_request_payload["request_id"],
-                            "api_v1_response": {
-                                "error": {
-                                    "code": "compute_node_internal_error",
-                                    "message": "Unexpected internal error during inference",
-                                }
-                            },
-                        }
-                    )
+                return self._post_api_v1_e2ee_response(
+                    response_envelope,
+                    client_pub_key_b64,
+                    client_pub_key,
+                )
 
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,


### PR DESCRIPTION
### Motivation
- Investigated the packaged-desktop failure and confirmed `RelayClient.process_client_request()` imported `api.v1.models` after decrypting API v1 E2EE work, producing `ModuleNotFoundError: No module named 'api'` in the Tauri/packaged runtime.  
- The desktop bridge already initializes a `ComputeNodeRuntime` with a `model_manager`; the compute bridge must use that runtime instead of server-only `api` modules.  
- Preserve E2EE, non-streaming API v1 semantics and ensure any unsupported model/options or runtime failures are returned as encrypted API v1 error responses rather than causing plaintext errors or timeouts.

### Description
- Replaced the server-side `api.v1.models` dependency in the API v1 E2EE branch of `RelayClient.process_client_request()` with a runtime-backed implementation that uses the attached `model_manager`. (changed: `utils/networking/relay_client.py`).
- Added small RelayClient helpers: `_desktop_runtime_supports_api_v1_model(...)`, `_generate_api_v1_response_with_runtime_model(...)`, `_api_v1_response_envelope(...)`, and `_post_api_v1_e2ee_response(...)` to normalize runtime output and always encrypt and POST `/api/v1/relay/responses` with the original `request_id` and `client_public_key` binding. (new helpers live in `utils/networking/relay_client.py`).
- Updated `process_client_request()` API v1 branch to call the new helper, produce structured API v1 error envelopes for unsupported models/options or runtime failures, and to never import `api.v1.models` when processing desktop-packaged work. (in `utils/networking/relay_client.py`).
- Added and adapted unit tests to validate the packaged-runtime failure mode and behavior: desktop runtime fallback/no `api` import, invalid runtime output -> encrypted error, unsupported model/options -> encrypted error, and ensure responses are posted to the supplying relay URL; and tightened bridge assertions for `work_received` / `response_submitted`. (changed: `tests/unit/test_relay_client.py`, `tests/unit/test_desktop_compute_node_bridge.py`).
- Confirmed active runtime path remains API v1-only and that the desktop bridge continues to call `ComputeNodeRuntime.process_relay_request()` (no legacy route reintroduction). (inspected `utils/compute_node_runtime.py` and `desktop-tauri/src-tauri/python/compute_node_bridge.py`).

### Testing
- Ran focused unit suites: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py`, and the targeted tests passed (new and existing unit cases covering the packaged-runtime `api` import regression succeeded).  
- Ran the legacy-route guardrail tests: `python -m pytest -q tests/unit/test_legacy_route_usage_guardrails.py` and they passed.  
- Attempted broader API/integration test runs (`tests/test_relay.py`, `tests/test_api.py`, `tests/unit/test_api_v1_compute_provider.py` and full `pytest -q`), but collection failed in this environment due to missing standard-library modules in the test host (Python 3.14 environment reported missing `imghdr` and `pkg_resources` during test collection), so full-suite verification is blocked by the test environment rather than this change.  
- `pre-commit` checks were started but the project-wide test phase in that hook hit the same environment collection errors; linters and other hooks ran as far as they could in this environment.

If you want, I can split the change into a small helper-only patch and follow up with additional test cleanup, or I can attempt local repro of the full relay -> desktop -> relay flow if you can supply a packaged-desktop runtime path / local GGUF model or allow enabling the skipped E2E test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081a6cfaf8832fa4f5810748d1e3b5)