### PR TITLE
Avoid importing server-side `api.v1` in desktop bridge; use runtime model for API v1 E2EE requests

### DIFF
--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -40,13 +40,11 @@ class FakeRelayClientRouting(FakeRelayClient):
 
     def process_client_request(self, payload):
         endpoint = '/source'
-        if payload.get('stream') is True and payload.get('stream_session_id'):
+        if payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee':
+            endpoint = '/api/v1/relay/responses'
+        elif payload.get('stream') is True and payload.get('stream_session_id'):
             endpoint = '/stream/source'
         self.endpoint_calls.append((endpoint, payload))
-        return True
-
-    def process_api_v1_chat_request(self, payload):
-        self.endpoint_calls.append(('/api/v1/relay/responses', payload))
         return True
 
 
@@ -132,7 +130,7 @@ class ApiV1Runtime(FakeRuntime):
 
     def process_relay_request(self, payload):
         self._processed.append(payload)
-        return self.relay_client.process_api_v1_chat_request(payload)
+        return self.relay_client.process_client_request(payload)
 
 
 class MalformedWaitThenApiV1Runtime(ApiV1Runtime):
@@ -696,9 +694,13 @@ def test_run_api_v1_payload_uses_relay_api_v1_response_endpoint(capsys, monkeypa
     assert endpoint == '/api/v1/relay/responses'
     assert payload['request_id'] == 'req-1'
 
-    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert any(event.get('registered') is True for event in status_events)
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.work_received' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
+    assert "ModuleNotFoundError: No module named 'api'" not in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -902,15 +902,14 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
-    @patch('api.v1.models.generate_response')
     def test_process_client_request_api_v1_e2ee_success(
         self,
-        mock_generate_response,
         mock_post,
         relay_client,
         mock_crypto_manager,
+        mock_model_manager,
     ):
-        """API v1 relay envelopes should call generate_response and post encrypted response."""
+        """API v1 relay envelopes use the desktop runtime model and post encrypted response."""
         request_data = TEST_VALID_RESPONSE.copy()
         decrypted_payload = {
             "protocol": "tokenplace_api_v1_relay_e2ee",
@@ -924,7 +923,7 @@ class TestRelayClient:
             },
         }
         mock_crypto_manager.decrypt_message.return_value = decrypted_payload
-        mock_generate_response.return_value = [
+        mock_model_manager.llama_cpp_get_response.return_value = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there"},
         ]
@@ -940,11 +939,8 @@ class TestRelayClient:
         result = relay_client.process_client_request(request_data)
 
         assert result is True
-        mock_generate_response.assert_called_once_with(
-            "llama-3-8b-instruct",
+        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
             [{"role": "user", "content": "Hello"}],
-            temperature=0.2,
-            max_tokens=50,
         )
         mock_crypto_manager.encrypt_message.assert_called_with(
             {
@@ -973,13 +969,12 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
-    @patch('api.v1.models.generate_response')
     def test_process_client_request_api_v1_e2ee_posts_response_to_polling_relay(
         self,
-        mock_generate_response,
         mock_post,
         relay_client,
         mock_crypto_manager,
+        mock_model_manager,
     ):
         """API v1 responses should be submitted to the relay that supplied the work."""
 
@@ -996,7 +991,7 @@ class TestRelayClient:
                 "options": {},
             },
         }
-        mock_generate_response.return_value = [
+        mock_model_manager.llama_cpp_get_response.return_value = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there"},
         ]
@@ -1011,13 +1006,12 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
-    @patch('api.v1.models.generate_response')
     def test_process_client_request_api_v1_e2ee_rejects_mismatched_bound_key(
         self,
-        mock_generate_response,
         mock_post,
         relay_client,
         mock_crypto_manager,
+        mock_model_manager,
     ):
         """API v1 relay envelopes with mismatched encrypted key bindings are rejected."""
         request_data = TEST_VALID_RESPONSE.copy()
@@ -1036,8 +1030,127 @@ class TestRelayClient:
         result = relay_client.process_client_request(request_data)
 
         assert result is False
-        mock_generate_response.assert_not_called()
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
         mock_post.assert_not_called()
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_e2ee_does_not_require_api_package(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+        monkeypatch,
+    ):
+        """Packaged desktop API v1 processing must survive when api.v1.models is unavailable."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        sentinel = "PLAINTEXT_SENTINEL_SHOULD_STAY_ENCRYPTED"
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-no-api-package",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": sentinel}],
+                "options": {},
+            },
+        }
+        mock_model_manager.llama_cpp_get_response.return_value = [
+            {"role": "user", "content": sentinel},
+            {"role": "assistant", "content": "Runtime model response"},
+        ]
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        real_import = __import__
+
+        def blocked_api_import(name, *args, **kwargs):
+            if name == "api.v1.models" or name.startswith("api."):
+                raise ModuleNotFoundError("No module named 'api'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", blocked_api_import)
+
+        assert relay_client.process_client_request(request_data) is True
+        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
+            [{"role": "user", "content": sentinel}],
+        )
+        mock_post.assert_called_once()
+        posted_payload = mock_post.call_args.kwargs["json"]
+        assert mock_post.call_args.args[0] == "http://localhost:5000/api/v1/relay/responses"
+        assert posted_payload["request_id"] == "req-no-api-package"
+        assert posted_payload["protocol"] == "tokenplace_api_v1_relay_e2ee"
+        assert posted_payload["version"] == 1
+        assert sentinel not in json.dumps(posted_payload)
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_invalid_runtime_output_posts_encrypted_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-output",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_model_manager.llama_cpp_get_response.return_value = [
+            {"role": "assistant", "content": ""},
+        ]
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_internal_error"
+        )
+        assert mock_post.call_args.kwargs["json"]["request_id"] == "req-invalid-output"
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_unsupported_model_posts_encrypted_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-unsupported-model",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "unrelated-model-id",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_model_unsupported"
+        )
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_rejects_mismatched_bound_client_key(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import importlib
 import ipaddress
 import json
 import jsonschema
@@ -752,6 +753,230 @@ class RelayClient:
 
         return self._last_api_v1_work_relay_url or self.relay_url
 
+    def _api_v1_error_response_envelope(
+        self,
+        request_id: str,
+        code: str,
+        message: str,
+    ) -> Dict[str, Any]:
+        """Build a relay-safe API v1 encrypted error response envelope."""
+
+        return {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": request_id,
+            "api_v1_response": {
+                "error": {
+                    "code": code,
+                    "message": message,
+                }
+            },
+        }
+
+    @staticmethod
+    def _desktop_runtime_model_ids(model_manager: Any) -> set[str]:
+        """Return model identifiers the attached desktop runtime can safely claim."""
+
+        model_ids: set[str] = {
+            "llama-3-8b-instruct",
+            "meta-llama-3-8b-instruct",
+            "meta-llama-3.1-8b-instruct",
+        }
+        for attr in (
+            "api_v1_model_id",
+            "model_id",
+            "model_name",
+            "file_name",
+            "model_path",
+            "canonical_family_url",
+        ):
+            value = getattr(model_manager, attr, None)
+            if not isinstance(value, str) or not value.strip():
+                continue
+            value = value.strip()
+            model_ids.add(value)
+            basename = os.path.basename(value).strip()
+            if basename:
+                model_ids.add(basename)
+                model_ids.add(os.path.splitext(basename)[0])
+            if "meta-llama" in value.lower() and "3" in value.lower():
+                model_ids.add("llama-3-8b-instruct")
+
+        configured_ids = getattr(model_manager, "api_v1_model_ids", None)
+        if isinstance(configured_ids, (list, tuple, set, frozenset)):
+            for value in configured_ids:
+                if isinstance(value, str) and value.strip():
+                    model_ids.add(value.strip())
+
+        return {model_id.lower() for model_id in model_ids if model_id}
+
+    def _try_generate_api_v1_response_with_server_model(
+        self,
+        model_id: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any],
+    ) -> Tuple[Optional[Any], Optional[Tuple[str, str]]]:
+        """Best-effort non-desktop compatibility path when no runtime manager exists.
+
+        Desktop bridge success never depends on this optional import: packaged
+        desktop runtimes attach a model manager with ``llama_cpp_get_response``.
+        """
+
+        try:
+            generate_response = importlib.import_module("api.v1.models").generate_response
+        except Exception:
+            return None, (
+                "compute_node_model_unsupported",
+                "Desktop runtime model manager cannot serve API v1 chat requests",
+            )
+
+        try:
+            return generate_response(model_id, [dict(m) for m in messages], **options), None
+        except Exception as exc:
+            error_type = getattr(exc, "error_type", "")
+            if error_type == "model_not_found":
+                code = "compute_node_model_unsupported"
+            elif error_type in {
+                "model_load_error",
+                "model_inference_error",
+                "model_response_error",
+            }:
+                code = "compute_node_model_error"
+            else:
+                code = "compute_node_internal_error"
+            return None, (code, str(exc) or "API v1 model generation failed")
+
+    def _generate_api_v1_response_with_runtime_model(
+        self,
+        request_id: str,
+        model_id: str,
+        messages: Any,
+        options: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Generate an API v1 response using the attached desktop runtime model manager.
+
+        This path intentionally avoids importing server-only ``api`` modules so a
+        packaged desktop bridge can process relay work with its initialized model
+        runtime. It returns encrypted-response-ready envelopes and never logs
+        plaintext prompt or model output content.
+        """
+
+        if not isinstance(messages, list) or not messages:
+            return self._api_v1_error_response_envelope(
+                request_id,
+                "compute_node_invalid_request",
+                "Messages must be a non-empty list",
+            )
+
+        for message in messages:
+            if not isinstance(message, dict):
+                return self._api_v1_error_response_envelope(
+                    request_id,
+                    "compute_node_invalid_request",
+                    "Each message must be an object",
+                )
+            if not isinstance(message.get("role"), str) or not isinstance(
+                message.get("content"), str
+            ):
+                return self._api_v1_error_response_envelope(
+                    request_id,
+                    "compute_node_invalid_request",
+                    "Each message must include string role and content fields",
+                )
+
+        unsupported_options = {
+            key
+            for key, value in options.items()
+            if key == "stream" and value is True
+        }
+        if unsupported_options:
+            return self._api_v1_error_response_envelope(
+                request_id,
+                "compute_node_options_unsupported",
+                "Requested API v1 options are not supported by this desktop runtime",
+            )
+
+        inference_handler = getattr(self.model_manager, "llama_cpp_get_response", None)
+        if not callable(inference_handler):
+            response_history, optional_error = (
+                self._try_generate_api_v1_response_with_server_model(
+                    model_id,
+                    messages,
+                    options,
+                )
+            )
+            if optional_error is not None:
+                return self._api_v1_error_response_envelope(
+                    request_id,
+                    optional_error[0],
+                    optional_error[1],
+                )
+        else:
+            supported_model_ids = self._desktop_runtime_model_ids(self.model_manager)
+            requested_model = model_id.strip().lower()
+            requested_base_model = requested_model.split(":", 1)[0]
+            if (
+                requested_model not in supported_model_ids
+                and requested_base_model not in supported_model_ids
+            ):
+                return self._api_v1_error_response_envelope(
+                    request_id,
+                    "compute_node_model_unsupported",
+                    "Requested model is not available in this desktop runtime",
+                )
+
+            try:
+                response_history = inference_handler([dict(m) for m in messages])
+            except Exception:
+                log_error(
+                    "Desktop runtime-model execution failed for API v1 relay request",
+                    exc_info=True,
+                )
+                return self._api_v1_error_response_envelope(
+                    request_id,
+                    "compute_node_model_error",
+                    "Desktop runtime failed during inference",
+                )
+
+        if not isinstance(response_history, list) or not response_history:
+            log_error("Desktop runtime returned invalid API v1 response history")
+            return self._api_v1_error_response_envelope(
+                request_id,
+                "compute_node_internal_error",
+                "LLM returned invalid response history",
+            )
+
+        assistant_message = response_history[-1]
+        if not isinstance(assistant_message, dict):
+            log_error("Desktop runtime returned invalid API v1 assistant message")
+            return self._api_v1_error_response_envelope(
+                request_id,
+                "compute_node_internal_error",
+                "LLM returned invalid assistant message",
+            )
+
+        content = assistant_message.get("content")
+        if (
+            assistant_message.get("role") != "assistant"
+            or not isinstance(content, str)
+            or not content.strip()
+        ):
+            log_error("Desktop runtime returned invalid API v1 assistant response content")
+            return self._api_v1_error_response_envelope(
+                request_id,
+                "compute_node_internal_error",
+                "LLM returned invalid assistant response content",
+            )
+
+        return {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": request_id,
+            "api_v1_response": {
+                "message": dict(assistant_message),
+            },
+        }
+
     def process_client_request(self, request_data: Dict[str, Any]) -> bool:
         """
         Process a client request from the relay.
@@ -793,8 +1018,6 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if api_v1_request_payload is not None:
-                from api.v1.models import ModelError, generate_response
-
                 def _post_api_v1_source(response_envelope: Dict[str, Any]) -> bool:
                     try:
                         bound_response_envelope = {
@@ -842,129 +1065,13 @@ class RelayClient:
                         )
                         return False
 
-                api_v1_options = dict(api_v1_request_payload["options"])
-                try:
-                    response_history = generate_response(
-                        api_v1_request_payload["model"],
-                        api_v1_request_payload["messages"],
-                        **api_v1_options,
-                    )
-                    if not isinstance(response_history, list) or not response_history:
-                        log_error("LLM returned invalid API v1 response history")
-                        return _post_api_v1_source(
-                            {
-                                "protocol": "tokenplace_api_v1_relay_e2ee",
-                                "version": 1,
-                                "request_id": api_v1_request_payload["request_id"],
-                                "api_v1_response": {
-                                    "error": {
-                                        "code": "compute_node_internal_error",
-                                        "message": "LLM returned invalid response history",
-                                    }
-                                },
-                            }
-                        )
-                    assistant_message = response_history[-1]
-                    if not isinstance(assistant_message, dict):
-                        log_error("LLM returned invalid API v1 assistant message")
-                        return _post_api_v1_source(
-                            {
-                                "protocol": "tokenplace_api_v1_relay_e2ee",
-                                "version": 1,
-                                "request_id": api_v1_request_payload["request_id"],
-                                "api_v1_response": {
-                                    "error": {
-                                        "code": "compute_node_internal_error",
-                                        "message": "LLM returned invalid assistant message",
-                                    }
-                                },
-                            }
-                        )
-
-                    return _post_api_v1_source(
-                        {
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            "request_id": api_v1_request_payload["request_id"],
-                            "api_v1_response": {
-                                "message": assistant_message,
-                            },
-                        }
-                    )
-                except ModelError as exc:
-                    error_type = getattr(exc, "error_type", "")
-                    if error_type in {"model_not_found", "model_load_error"} and hasattr(
-                        self.model_manager, "llama_cpp_get_response"
-                    ):
-                        log_info(
-                            "API v1 relay request model '%s' unavailable (%s); "
-                            "falling back to active compute-node runtime model",
-                            api_v1_request_payload["model"],
-                            error_type,
-                        )
-                        try:
-                            fallback_response_history = self.model_manager.llama_cpp_get_response(
-                                api_v1_request_payload["messages"]
-                            )
-                        except Exception as fallback_exc:
-                            log_error(
-                                "Fallback runtime-model execution failed for API v1 relay request: {}",
-                                str(fallback_exc),
-                                exc_info=True,
-                            )
-                        else:
-                            if isinstance(fallback_response_history, list) and fallback_response_history:
-                                fallback_assistant_message = fallback_response_history[-1]
-                                if isinstance(fallback_assistant_message, dict):
-                                    return _post_api_v1_source(
-                                        {
-                                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                                            "version": 1,
-                                            "request_id": api_v1_request_payload["request_id"],
-                                            "api_v1_response": {
-                                                "message": fallback_assistant_message,
-                                            },
-                                        }
-                                    )
-                            log_error("Fallback runtime-model execution returned invalid API v1 output")
-
-                    model_error_code = (
-                        "compute_node_model_unsupported"
-                        if error_type == "model_not_found"
-                        else "compute_node_model_error"
-                    )
-                    return _post_api_v1_source(
-                        {
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            "request_id": api_v1_request_payload["request_id"],
-                            "api_v1_response": {
-                                "error": {
-                                    "code": model_error_code,
-                                    "message": str(exc),
-                                }
-                            },
-                        }
-                    )
-                except Exception as exc:
-                    log_error(
-                        "Unexpected error processing API v1 relay request: {}",
-                        str(exc),
-                        exc_info=True,
-                    )
-                    return _post_api_v1_source(
-                        {
-                            "protocol": "tokenplace_api_v1_relay_e2ee",
-                            "version": 1,
-                            "request_id": api_v1_request_payload["request_id"],
-                            "api_v1_response": {
-                                "error": {
-                                    "code": "compute_node_internal_error",
-                                    "message": "Unexpected internal error during inference",
-                                }
-                            },
-                        }
-                    )
+                response_envelope = self._generate_api_v1_response_with_runtime_model(
+                    api_v1_request_payload["request_id"],
+                    api_v1_request_payload["model"],
+                    api_v1_request_payload["messages"],
+                    dict(api_v1_request_payload["options"]),
+                )
+                return _post_api_v1_source(response_envelope)
 
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,


### PR DESCRIPTION
### Motivation

- Diagnose and fix a runtime failure in the packaged desktop/Tauri compute bridge where API v1 E2EE work decoding succeeded but `RelayClient.process_client_request()` crashed with `ModuleNotFoundError: No module named 'api'` when it attempted `from api.v1.models import ModelError, generate_response`.
- Ensure the desktop packaged bridge does not require server-only `api` modules and instead uses its attached `model_manager` to satisfy API v1 E2EE inference requests while preserving E2EE and legacy-route invariants.

### Description

- Traced the failure to `utils/networking/relay_client.py` where the API v1 E2EE branch directly imported `api.v1.models.generate_response`, which is not available in packaged desktop runtimes, causing `ModuleNotFoundError` before any inference/response submission.
- Removed the hard dependency on `api.v1.models` in the desktop/runtime execution path and added a desktop-safe path that uses the attached `self.model_manager` to run inference via `llama_cpp_get_response` when available; implemented `_generate_api_v1_response_with_runtime_model(...)` to perform validation, call the runtime model, and produce API v1 response envelopes (including structured API v1 errors for unsupported models/options or invalid runtime output).
- Added an optional compatibility helper `_try_generate_api_v1_response_with_server_model(...)` that lazily imports `api.v1.models.generate_response` only as a best-effort fallback when no runtime handler is present; this helper returns structured error tuples instead of raising, so packaged desktop success does not depend on the import.
- Added small helpers: `_api_v1_error_response_envelope(...)` and `_desktop_runtime_model_ids(...)` to build safely-encrypted error envelopes and enumerate supported model ids from the runtime manager without leaking plaintext logs.
- Reworked `process_client_request()` to call the new runtime helper and always post an encrypted API v1 response to the relay (`/api/v1/relay/responses`) after either successful inference or structured error; preserved key-binding checks and never logs plaintext message content.
- Updated tests to cover the regression: added tests simulating `api` import missing and asserting the RelayClient still processes API v1 E2EE payloads by using the runtime model manager, encrypting and posting the response; updated desktop bridge tests to assert no `ModuleNotFoundError` appears and that `work_received` / `response_submitted` events are emitted; kept legacy-route guardrail tests unchanged but re-run to confirm no regressions.

### Testing

- Ran targeted unit test files: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_legacy_route_usage_guardrails.py`, and all tests in those suites passed after the changes.
- Ran broader suites used in verification including `tests/test_relay.py`, `tests/test_api.py`, `tests/unit/test_api_v1_compute_provider.py` and eventually the full test run (`python -m pytest -q`); the test run completed with the repository test matrix passing (tests exercised the new runtime path and the added regression scenarios).
- Verified new/modified tests asserting: (1) API v1 E2EE processing succeeds when `api.v1.models` cannot be imported, (2) desktop bridge run emits `desktop.compute_node_bridge.api_v1_e2ee.work_received` and `...response_submitted` and contains no `ModuleNotFoundError`, and (3) unsupported model/options and invalid runtime outputs produce encrypted API v1 error envelopes; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081a6cfaf8832fa4f5810748d1e3b5)