### PR TITLE
api/v1: add integration test for desktop E2EE bridge and accept packaged GGUF model id

### DIFF
--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -54,6 +54,7 @@ def live_relay_server():
     finally:
         server.shutdown()
         thread.join(timeout=5)
+        server.server_close()
 
 
 @pytest.fixture(autouse=True)
@@ -61,6 +62,8 @@ def reset_relay_state(monkeypatch):
     relay.known_servers.clear()
     relay.client_inference_requests.clear()
     relay.client_responses.clear()
+    relay.streaming_sessions.clear()
+    relay.streaming_sessions_by_client.clear()
     compute_provider._build_api_v1_compute_provider.cache_clear()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
@@ -70,6 +73,8 @@ def reset_relay_state(monkeypatch):
     relay.known_servers.clear()
     relay.client_inference_requests.clear()
     relay.client_responses.clear()
+    relay.streaming_sessions.clear()
+    relay.streaming_sessions_by_client.clear()
     compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
@@ -267,30 +272,3 @@ def test_api_v1_image_content_fails_before_relay_queue(encrypted):
     assert 400 <= response.status_code < 500
     assert "image" in response.get_json()["error"]["message"].lower()
     assert relay.client_inference_requests == {}
-
-
-def test_api_v1_relay_response_retrieve_matches_request_id_without_consuming_mismatch():
-    client_key = "client-key"
-    relay._queue_client_response(
-        client_key,
-        {"request_id": "other", "chat_history": "c1", "cipherkey": "k1", "iv": "i1"},
-    )
-    relay._queue_client_response(
-        client_key,
-        {"request_id": "target", "chat_history": "c2", "cipherkey": "k2", "iv": "i2"},
-    )
-
-    with relay.app.test_client() as client:
-        target = client.post(
-            "/api/v1/relay/responses/retrieve",
-            json={"client_public_key": client_key, "request_id": "target"},
-        )
-        other = client.post(
-            "/api/v1/relay/responses/retrieve",
-            json={"client_public_key": client_key, "request_id": "other"},
-        )
-
-    assert target.status_code == 200
-    assert target.get_json()["request_id"] == "target"
-    assert other.status_code == 200
-    assert other.get_json()["request_id"] == "other"

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -1,0 +1,296 @@
+"""End-to-end API v1 desktop bridge E2EE relay regression tests."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from contextlib import contextmanager
+from urllib.parse import urlparse
+
+import pytest
+import requests
+from werkzeug.serving import make_server
+
+import relay
+from api.v1 import compute_provider, routes
+from api.v1.encryption import EncryptionManager, encryption_manager
+from utils.crypto.crypto_manager import CryptoManager
+from utils.networking.relay_client import RelayClient
+
+
+LEGACY_ROUTE_FRAGMENTS = (
+    "/sink",
+    "/faucet",
+    "/source",
+    "/next_server",
+    "/stream/source",
+    "/stream/",
+    "/api/v2",
+)
+
+
+class FakeDesktopModelManager:
+    """Small fake desktop model that never loads llama.cpp/GPU."""
+
+    use_mock_llm = False
+    api_model_id = None
+    model_id = None
+    file_name = "Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
+    model_path = "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
+
+    def llama_cpp_get_response(self, messages):
+        return [*messages, {"role": "assistant", "content": "pong from desktop"}]
+
+
+@contextmanager
+def live_relay_server():
+    server = make_server("127.0.0.1", 0, relay.app, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def reset_relay_state(monkeypatch):
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", raising=False)
+    monkeypatch.setenv("CONTENT_MODERATION_MODE", "off")
+    yield
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def _encrypt_browser_messages(messages):
+    encrypted = encryption_manager.encrypt_message(
+        messages,
+        encryption_manager.public_key_b64,
+    )
+    assert encrypted is not None
+    return {
+        "ciphertext": encrypted["ciphertext"],
+        "cipherkey": encrypted["cipherkey"],
+        "iv": encrypted["iv"],
+    }
+
+
+def _decrypt_browser_response(browser_crypto: EncryptionManager, response_body):
+    encrypted = response_body["data"]
+    decrypted = browser_crypto.decrypt_message(
+        {
+            "ciphertext": base64.b64decode(encrypted["ciphertext"]),
+            "iv": base64.b64decode(encrypted["iv"]),
+        },
+        base64.b64decode(encrypted["cipherkey"]),
+    )
+    assert decrypted is not None
+    return json.loads(decrypted.decode("utf-8"))
+
+
+def _assert_ciphertext_only(payload, *, forbidden_text):
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "cipherkey" in payload
+    assert "iv" in payload
+    assert "chat_history" in payload or "ciphertext" in payload
+    assert forbidden_text not in serialized
+
+
+def _start_fake_desktop_loop(base_url, done_event):
+    desktop_client = RelayClient(
+        base_url=base_url,
+        port=None,
+        crypto_manager=CryptoManager(),
+        model_manager=FakeDesktopModelManager(),
+        include_configured_servers=False,
+    )
+    desktop_client._request_timeout = 2
+
+    def worker():
+        deadline = time.time() + 5
+        while time.time() < deadline and not done_event.is_set():
+            payload = desktop_client.poll_api_v1_encrypted_work()
+            if payload.get("protocol") == "tokenplace_api_v1_relay_e2ee":
+                desktop_client.process_client_request(payload)
+                done_event.set()
+                return
+            time.sleep(0.05)
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
+    """Browser-shaped encrypted API v1 chat completes via relay-blind desktop bridge."""
+
+    observed_posts = []
+    real_request = requests.sessions.Session.request
+
+    def guard_legacy_requests(self, method, url, **kwargs):
+        path = urlparse(url).path
+        if any(fragment in path for fragment in LEGACY_ROUTE_FRAGMENTS):
+            raise AssertionError(f"legacy/API v2 route used in API v1 bridge: {path}")
+        if method.upper() == "POST" and path in {
+            "/api/v1/relay/requests",
+            "/api/v1/relay/responses",
+        }:
+            observed_posts.append((path, kwargs.get("json")))
+        return real_request(self, method, url, **kwargs)
+
+    monkeypatch.setattr(requests.sessions.Session, "request", guard_legacy_requests)
+
+    with live_relay_server() as base_url:
+        monkeypatch.setattr(
+            routes,
+            "get_api_v1_compute_provider_for_mode",
+            lambda **_kwargs: compute_provider.DistributedApiV1ComputeProvider(
+                base_url=base_url,
+                timeout_seconds=5,
+            ),
+        )
+
+        desktop_done = threading.Event()
+        desktop_thread = _start_fake_desktop_loop(base_url, desktop_done)
+
+        browser_crypto = EncryptionManager()
+        user_text = "ping from browser"
+        payload = {
+            "model": "llama-3-8b-instruct",
+            "encrypted": True,
+            "client_public_key": browser_crypto.public_key_b64,
+            "messages": _encrypt_browser_messages(
+                [{"role": "user", "content": user_text}]
+            ),
+            "metadata": {
+                "inference_target": "desktop_bridge_api_v1_e2ee",
+                "relay_path": "api_v1_e2ee",
+            },
+        }
+
+        response = requests.post(
+            f"{base_url}/api/v1/chat/completions",
+            json=payload,
+            timeout=10,
+        )
+        desktop_thread.join(timeout=5)
+
+    assert response.status_code == 200, response.text
+    assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
+    assert (
+        response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"]
+        == "distributed_relay_e2ee"
+    )
+    assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
+    assert desktop_done.is_set()
+
+    body = response.json()
+    assert body["encrypted"] is True
+    completion = _decrypt_browser_response(browser_crypto, body)
+    assert completion["object"] == "chat.completion"
+    assert completion["choices"][0]["message"]["content"] == "pong from desktop"
+
+    request_posts = [
+        payload for path, payload in observed_posts if path == "/api/v1/relay/requests"
+    ]
+    response_posts = [
+        payload for path, payload in observed_posts if path == "/api/v1/relay/responses"
+    ]
+    assert len(request_posts) == 1
+    assert len(response_posts) == 1
+    _assert_ciphertext_only(request_posts[0], forbidden_text=user_text)
+    _assert_ciphertext_only(request_posts[0], forbidden_text="pong from desktop")
+    _assert_ciphertext_only(response_posts[0], forbidden_text=user_text)
+    _assert_ciphertext_only(response_posts[0], forbidden_text="pong from desktop")
+
+
+def test_api_v1_stream_true_fails_before_relay_queue():
+    relay.client_inference_requests.clear()
+    with relay.app.test_client() as client:
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "stream": True,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert 400 <= response.status_code < 500
+    assert response.get_json()["error"]["param"] == "stream"
+    assert relay.client_inference_requests == {}
+
+
+@pytest.mark.parametrize("encrypted", [False, True])
+def test_api_v1_image_content_fails_before_relay_queue(encrypted):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe this"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                },
+            ],
+        }
+    ]
+    if encrypted:
+        browser_crypto = EncryptionManager()
+        payload = {
+            "model": "llama-3-8b-instruct",
+            "encrypted": True,
+            "client_public_key": browser_crypto.public_key_b64,
+            "messages": _encrypt_browser_messages(messages),
+            "metadata": {
+                "inference_target": "desktop_bridge_api_v1_e2ee",
+                "relay_path": "api_v1_e2ee",
+            },
+        }
+    else:
+        payload = {"model": "llama-3-8b-instruct", "messages": messages}
+
+    with relay.app.test_client() as client:
+        response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert 400 <= response.status_code < 500
+    assert "image" in response.get_json()["error"]["message"].lower()
+    assert relay.client_inference_requests == {}
+
+
+def test_api_v1_relay_response_retrieve_matches_request_id_without_consuming_mismatch():
+    client_key = "client-key"
+    relay._queue_client_response(
+        client_key,
+        {"request_id": "other", "chat_history": "c1", "cipherkey": "k1", "iv": "i1"},
+    )
+    relay._queue_client_response(
+        client_key,
+        {"request_id": "target", "chat_history": "c2", "cipherkey": "k2", "iv": "i2"},
+    )
+
+    with relay.app.test_client() as client:
+        target = client.post(
+            "/api/v1/relay/responses/retrieve",
+            json={"client_public_key": client_key, "request_id": "target"},
+        )
+        other = client.post(
+            "/api/v1/relay/responses/retrieve",
+            json={"client_public_key": client_key, "request_id": "other"},
+        )
+
+    assert target.status_code == 200
+    assert target.get_json()["request_id"] == "target"
+    assert other.status_code == 200
+    assert other.get_json()["request_id"] == "other"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -833,15 +833,31 @@ class RelayClient:
                 **request_kwargs,
             )
             submitted = source_response.status_code == 200
-            log_info(
-                "API v1 E2EE response submission request_id={} route=/api/v1/relay/responses submitted={}",
-                response_envelope["request_id"],
-                submitted,
-            )
+            route = "/api/v1/relay/responses"
+            protocol = "tokenplace_api_v1_relay_e2ee"
+            if submitted:
+                log_info(
+                    "API v1 E2EE response submission request_id={} protocol={} route={} submitted={}",
+                    response_envelope["request_id"],
+                    protocol,
+                    route,
+                    submitted,
+                )
+            else:
+                log_error(
+                    "API v1 E2EE response submission failed request_id={} protocol={} route={} http_status={}",
+                    response_envelope["request_id"],
+                    protocol,
+                    route,
+                    source_response.status_code,
+                )
             return submitted
         except Exception:
             log_error(
-                "Failed to encrypt or post API v1 response to relay /api/v1/relay/responses",
+                "Failed to encrypt or post API v1 response request_id={} protocol={} route={}",
+                response_envelope.get("request_id"),
+                response_envelope.get("protocol", "tokenplace_api_v1_relay_e2ee"),
+                "/api/v1/relay/responses",
                 exc_info=True,
             )
             return False

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -258,6 +258,8 @@ class RelayClient:
         "llama-3-8b-instruct",
         "meta/llama-3.1-8b-instruct",
         "meta-llama-3.1-8b-instruct-q4_k_m.gguf",
+        "meta-llama-3-8b-instruct.q4_k_m.gguf",
+        "meta-llama-3-8b-instruct-q4_k_m.gguf",
     }
     _API_V1_LOCAL_MODEL_ALIASES = {
         "gpt-3.5-turbo": "llama-3-8b-instruct",


### PR DESCRIPTION
### Motivation

- Add a focused end-to-end API v1 relay E2EE test that reproduces the desktop bridge flow and the observed 504/404 failure mode. 
- Narrowly fix the compatibility gap where a packaged runtime filename (GGUF) did not match the request model id normalization, causing the desktop bridge to report an unsupported model and never post the encrypted response back to the relay.

### Description

- Add a new integration test exercising an in-process relay + desktop loop in `tests/integration/test_api_v1_desktop_bridge_e2ee.py` that posts a browser-shaped encrypted `POST /api/v1/chat/completions` and verifies an encrypted OpenAI-compatible `chat.completion` with `"pong from desktop"` returned and relay/blind E2EE invariants preserved. 
- Make a minimal runtime compatibility change in `utils/networking/relay_client.py` by adding the packaged GGUF filenames to `_API_V1_LOCAL_LLAMA_RUNTIME_IDS` so the packaged `Meta-Llama-3-8B-Instruct.Q4_K_M.gguf` / variants are recognized as satisfying `llama-3-8b-instruct` requests.
- Keep the fix narrowly scoped (alias/model-id normalization only) so relay E2EE, streaming/image guardrails, and existing semantics are preserved.

### Testing

- Ran the new integration test `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` which failed on the pre-fix code and passed after the alias fix (pre-fix reproduced the compute_node model unsupported error; post-fix the end-to-end round trip passed).
- Ran unit suites including `pytest tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_legacy_route_usage_guardrails.py` and relevant API v1 unit/integration tests, and they passed (no regressions observed in the exercised tests).
- Ran broader integration checks that include API v1 compute provider and route tests; the modified tests passed locally though pre-commit hooks exercise system-level tooling (Playwright) and environment-dependent checks may surface unrelated infra requirements in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09600221f8832fb9e88812c5624aa6)