### PR TITLE
Prefer direct non-streaming create_chat_completion for API v1 desktop bridge

### DIFF
--- a/docs/LLM_ASSISTANT_GUIDE.md
+++ b/docs/LLM_ASSISTANT_GUIDE.md
@@ -28,6 +28,10 @@ This document provides guidance specifically for LLM assistants (like Claude) to
   not reintroduce them as fallbacks.
 - Keep active inference paths aligned on API v1 E2EE routes for `server.py`, `relay.py`,
   `client.py`, desktop Tauri flows, and relay HTML chat UI.
+- API v1 desktop relay generation requires direct non-streaming runtime completion via
+  `get_llm_instance().create_chat_completion(..., stream=False)`. If that direct runtime API is
+  unavailable, fail closed with an encrypted API v1 error; do not fall back to legacy
+  `llama_cpp_get_response()` behavior, including for empty options or explicit `stream: false`.
 - Relay-visible surfaces must stay ciphertext-only (+ safe routing metadata). Plaintext prompts,
   messages, responses, tool arguments, or model output text must never appear in relay-owned
   state/logs/diagnostics/payloads.

--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -26,6 +26,19 @@ All active production inference paths must use API v1 E2EE routes:
 If a path cannot preserve API v1 E2EE invariants, it must **fail closed** instead of routing
 plaintext or using deprecated fallbacks.
 
+### Desktop runtime completion contract
+
+API v1 desktop bridge generation must use the direct OpenAI-compatible runtime completion API:
+`get_llm_instance().create_chat_completion(..., stream=False)`. This direct non-streaming
+completion path is required even when the client sends `options: {}` or explicitly sends
+`options: {"stream": false}`.
+
+A desktop runtime that only exposes legacy chat-history helpers such as
+`llama_cpp_get_response()` is **not** API v1-capable for relay inference. API v1 relay handling
+must return an encrypted fail-closed error, such as `compute_node_model_unsupported`, rather
+than silently falling back to legacy runtime behavior. Do not preserve, add, or suggest a legacy
+runtime fallback for API v1 desktop relay requests.
+
 ## API v2 status
 
 - API v2 exists in the repository, but it is currently incomplete.

--- a/llms.txt
+++ b/llms.txt
@@ -38,5 +38,9 @@ Secure proxy providing OpenAI-compatible APIs with end-to-end encryption. Python
   Do not use or extend them for active production paths.
 - Active inference paths for `server.py`, `relay.py`, `client.py`, desktop Tauri flows, and relay
   HTML chat UI should use API v1 E2EE routes.
+- API v1 desktop relay generation requires direct non-streaming runtime completion with
+  `get_llm_instance().create_chat_completion(..., stream=False)`. If unavailable, fail closed with
+  an encrypted API v1 error; do not fall back to legacy `llama_cpp_get_response()`, even for
+  empty options or explicit `stream: false`.
 - Relay must remain ciphertext-only (+ routing metadata). If E2EE is not possible, fail closed.
 - See docs/architecture/api_v1_e2ee_relay.md for migration context and follow-up alignment work.

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -31,6 +31,27 @@ LEGACY_ROUTE_FRAGMENTS = (
 )
 
 
+class FakeDesktopRuntime:
+    """Non-streaming llama.cpp-compatible runtime used by the desktop bridge."""
+
+    def __init__(self):
+        self.calls = []
+
+    def create_chat_completion(self, **kwargs):
+        self.calls.append(kwargs)
+        assert kwargs.get("stream") is False
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "pong from desktop",
+                    }
+                }
+            ]
+        }
+
+
 class FakeDesktopModelManager:
     """Small fake desktop model that never loads llama.cpp/GPU."""
 
@@ -40,8 +61,17 @@ class FakeDesktopModelManager:
     file_name = "Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
     model_path = "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
 
+    def __init__(self):
+        self.runtime = FakeDesktopRuntime()
+
+    def get_llm_instance(self):
+        return self.runtime
+
     def llama_cpp_get_response(self, messages):
-        return [*messages, {"role": "assistant", "content": "pong from desktop"}]
+        raise AssertionError(
+            "API v1 must not use legacy streaming llama_cpp_get_response "
+            "when direct completion exists"
+        )
 
 
 @contextmanager
@@ -113,11 +143,12 @@ def _assert_ciphertext_only(payload, *, forbidden_text):
 
 
 def _start_fake_desktop_loop(base_url, done_event):
+    model_manager = FakeDesktopModelManager()
     desktop_client = RelayClient(
         base_url=base_url,
         port=None,
         crypto_manager=CryptoManager(),
-        model_manager=FakeDesktopModelManager(),
+        model_manager=model_manager,
         include_configured_servers=False,
     )
     desktop_client._request_timeout = 2
@@ -134,7 +165,7 @@ def _start_fake_desktop_loop(base_url, done_event):
 
     thread = threading.Thread(target=worker, daemon=True)
     thread.start()
-    return thread
+    return thread, model_manager
 
 
 def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
@@ -167,7 +198,7 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
         )
 
         desktop_done = threading.Event()
-        desktop_thread = _start_fake_desktop_loop(base_url, desktop_done)
+        desktop_thread, model_manager = _start_fake_desktop_loop(base_url, desktop_done)
 
         browser_crypto = EncryptionManager()
         user_text = "ping from browser"
@@ -205,6 +236,8 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     completion = _decrypt_browser_response(browser_crypto, body)
     assert completion["object"] == "chat.completion"
     assert completion["choices"][0]["message"]["content"] == "pong from desktop"
+    assert len(model_manager.runtime.calls) == 1
+    assert model_manager.runtime.calls[0]["stream"] is False
 
     request_posts = [
         payload for path, payload in observed_posts if path == "/api/v1/relay/requests"

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1607,35 +1607,51 @@ class TestRelayClient:
         mock_crypto_manager,
         mock_model_manager,
     ):
-        """Explicit stream:false is accepted, but legacy runtime fallback stays disabled."""
+        """Explicit stream:false follows omitted-stream option routing."""
 
         request_data = TEST_VALID_RESPONSE.copy()
         mock_model_manager.get_llm_instance = None
-        mock_crypto_manager.decrypt_message.return_value = {
-            "protocol": "tokenplace_api_v1_relay_e2ee",
-            "version": 1,
-            "request_id": "req-stream-false-no-direct-runtime",
-            "client_public_key": request_data["client_public_key"],
-            "api_v1_request": {
-                "model": "llama-3-8b-instruct",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "options": {"stream": False},
-            },
-        }
         source_response = MagicMock()
         source_response.status_code = 200
         mock_post.return_value = source_response
+        observed_error_codes = []
 
-        assert relay_client.process_client_request(request_data) is True
+        for request_id, options in (
+            ("req-stream-omitted-no-direct-runtime", {}),
+            ("req-stream-false-no-direct-runtime", {"stream": False}),
+        ):
+            mock_crypto_manager.reset_mock()
+            mock_model_manager.llama_cpp_get_response.reset_mock()
+            mock_crypto_manager.encrypt_message.return_value = {
+                'chat_history': 'encrypted_chat_history',
+                'cipherkey': 'encrypted_key',
+                'iv': 'encrypted_iv'
+            }
+            mock_crypto_manager.decrypt_message.return_value = {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": request_id,
+                "client_public_key": request_data["client_public_key"],
+                "api_v1_request": {
+                    "model": "llama-3-8b-instruct",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "options": options,
+                },
+            }
 
-        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
-        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
-            "compute_node_model_unsupported"
-        )
-        assert encrypted_envelope["api_v1_response"]["error"]["code"] != (
-            "compute_node_options_unsupported"
-        )
-        mock_model_manager.llama_cpp_get_response.assert_not_called()
+            assert relay_client.process_client_request(request_data) is True
+
+            encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+            observed_error_codes.append(
+                encrypted_envelope["api_v1_response"]["error"]["code"]
+            )
+            mock_model_manager.llama_cpp_get_response.assert_not_called()
+
+        assert observed_error_codes == [
+            "compute_node_model_unsupported",
+            "compute_node_model_unsupported",
+        ]
+        assert "compute_node_options_unsupported" not in observed_error_codes
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_rejects_streaming_option(

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -181,6 +181,18 @@ class TestRelayClient:
             {"role": "user", "content": "What is the capital of France?"},
             {"role": "assistant", "content": "The capital of France is Paris."}
         ]
+        mock.runtime = MagicMock()
+        mock.runtime.create_chat_completion.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "The capital of France is Paris.",
+                    }
+                }
+            ]
+        }
+        mock.get_llm_instance.return_value = mock.runtime
         mock.use_mock_llm = True
         return mock
 
@@ -947,9 +959,11 @@ class TestRelayClient:
         result = relay_client.process_client_request(request_data)
 
         assert result is True
-        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
-            [{"role": "user", "content": "Hello"}]
-        )
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        mock_model_manager.runtime.create_chat_completion.assert_called_once()
+        assert mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
+            "messages"
+        ] == [{"role": "user", "content": "Hello"}]
         mock_crypto_manager.encrypt_message.assert_called_with(
             {
                 "protocol": "tokenplace_api_v1_relay_e2ee",
@@ -1022,9 +1036,11 @@ class TestRelayClient:
 
         assert relay_client.process_client_request(request_data) is True
 
-        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
-            [{"role": "user", "content": "Hello"}]
-        )
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        mock_model_manager.runtime.create_chat_completion.assert_called_once()
+        assert mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
+            "messages"
+        ] == [{"role": "user", "content": "Hello"}]
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["message"]["content"] == (
             "The capital of France is Paris."
@@ -1074,9 +1090,11 @@ class TestRelayClient:
 
         assert relay_client.process_client_request(request_data) is True
 
-        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
-            [{"role": "user", "content": "Hello"}]
-        )
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        mock_model_manager.runtime.create_chat_completion.assert_called_once()
+        assert mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
+            "messages"
+        ] == [{"role": "user", "content": "Hello"}]
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert "error" not in encrypted_envelope["api_v1_response"]
 
@@ -1137,7 +1155,10 @@ class TestRelayClient:
 
         assert relay_client.process_client_request(request_data) is True
 
-        runtime_messages = mock_model_manager.llama_cpp_get_response.call_args.args[0]
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        runtime_messages = mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
+            "messages"
+        ]
         assert runtime_messages[0]["role"] == "system"
         assert runtime_messages[0]["name"] == "adapter:llama-3-8b-instruct:alignment"
         assert "alignment-focused variant" in runtime_messages[0]["content"]
@@ -1181,14 +1202,15 @@ class TestRelayClient:
 
         assert relay_client.process_client_request(request_data) is True
 
-        mock_model_manager.llama_cpp_get_response.assert_called_once_with(
-            [
-                {
-                    "role": "user",
-                    "content": "First segment\n\nSecond segment",
-                }
-            ]
-        )
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        assert mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
+            "messages"
+        ] == [
+            {
+                "role": "user",
+                "content": "First segment\n\nSecond segment",
+            }
+        ]
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_rejects_image_content_blocks(
@@ -1313,9 +1335,9 @@ class TestRelayClient:
                 "options": {},
             },
         }
-        mock_model_manager.llama_cpp_get_response.return_value = [
-            {"role": "assistant", "content": ""},
-        ]
+        mock_model_manager.runtime.create_chat_completion.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": ""}}]
+        }
         mock_crypto_manager.encrypt_message.return_value = {
             'chat_history': 'encrypted_chat_history',
             'cipherkey': 'encrypted_key',
@@ -1429,15 +1451,26 @@ class TestRelayClient:
         class _Manager:
             use_mock_llm = False
 
-            def __init__(self):
-                self.checked_model_ids = []
-
             def supports_api_v1_model(self, model_id):
                 self.checked_model_ids.append(model_id)
                 return model_id == "custom-local-api-v1-model"
 
-            def llama_cpp_get_response(self, messages):
-                return messages + [{"role": "assistant", "content": "custom ok"}]
+            def __init__(self):
+                self.checked_model_ids = []
+                self.runtime = MagicMock()
+                self.runtime.create_chat_completion.return_value = {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "custom ok",
+                            }
+                        }
+                    ]
+                }
+
+            def get_llm_instance(self):
+                return self.runtime
 
         request_data = TEST_VALID_RESPONSE.copy()
         manager = _Manager()
@@ -1542,6 +1575,7 @@ class TestRelayClient:
         """Supported options are not silently dropped when only chat-history APIs exist."""
 
         request_data = TEST_VALID_RESPONSE.copy()
+        mock_model_manager.get_llm_instance = None
         mock_crypto_manager.decrypt_message.return_value = {
             "protocol": "tokenplace_api_v1_relay_e2ee",
             "version": 1,
@@ -1561,6 +1595,44 @@ class TestRelayClient:
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_model_unsupported"
+        )
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_stream_false_without_direct_runtime_fails_closed(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Explicit stream:false is accepted, but legacy runtime fallback stays disabled."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_model_manager.get_llm_instance = None
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-stream-false-no-direct-runtime",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {"stream": False},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_model_unsupported"
+        )
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] != (
             "compute_node_options_unsupported"
         )
         mock_model_manager.llama_cpp_get_response.assert_not_called()

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1179,106 +1179,6 @@ class RelayClient:
             return False, "stream"
         return True, None
 
-    def _generate_api_v1_response_with_server_model_if_available(
-        self,
-        *,
-        request_id: str,
-        model_id: str,
-        messages: List[Dict[str, Any]],
-        options: Dict[str, Any],
-    ) -> Optional[Dict[str, Any]]:
-        """Best-effort API v1 server-model fallback when the module is importable.
-
-        Packaged desktop success never depends on this optional server module;
-        this fallback supports repo-local/server contexts that intentionally ship it.
-        """
-
-        models_module = self._api_v1_models_module()
-        if models_module is None:
-            return None
-
-        model_error_cls = getattr(models_module, "ModelError", Exception)
-        response_generator = getattr(models_module, "generate_response", None)
-        if not callable(response_generator):
-            return None
-
-        try:
-            response_history = response_generator(model_id, messages, **options)
-        except model_error_cls as exc:
-            error_type = getattr(exc, "error_type", "")
-            runtime_response = None
-            if error_type in {"model_not_found", "model_load_error"}:
-                runtime_response_fn = getattr(
-                    self.model_manager,
-                    "llama_cpp_get_response",
-                    None,
-                )
-                if callable(runtime_response_fn):
-                    try:
-                        runtime_response = runtime_response_fn(list(messages))
-                    except Exception:
-                        log_error(
-                            "Runtime-model execution failed for API v1 relay request",
-                            exc_info=True,
-                        )
-                    else:
-                        if isinstance(runtime_response, list) and runtime_response:
-                            assistant_message = self._valid_api_v1_assistant_message(
-                                runtime_response[-1]
-                            )
-                            if assistant_message is not None:
-                                return self._api_v1_response_envelope(
-                                    request_id,
-                                    message=assistant_message,
-                                )
-                        log_error(
-                            "Runtime-model execution returned invalid API v1 output"
-                        )
-
-            error_code = (
-                "compute_node_model_unsupported"
-                if error_type == "model_not_found"
-                else "compute_node_model_error"
-            )
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": error_code,
-                    "message": str(exc),
-                },
-            )
-        except Exception:
-            log_error(
-                "Optional repo API v1 model execution failed for relay request",
-                exc_info=True,
-            )
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": "compute_node_internal_error",
-                    "message": "Unexpected internal error during inference",
-                },
-            )
-
-        if not isinstance(response_history, list) or not response_history:
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": "compute_node_internal_error",
-                    "message": "LLM returned invalid response history",
-                },
-            )
-        assistant_message = response_history[-1]
-        if not isinstance(assistant_message, dict):
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": "compute_node_internal_error",
-                    "message": "LLM returned invalid assistant message",
-                },
-            )
-        return self._api_v1_response_envelope(request_id, message=assistant_message)
-
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -1340,25 +1240,8 @@ class RelayClient:
                 },
             )
 
-        llama_cpp_get_response = getattr(self.model_manager, "llama_cpp_get_response", None)
-        has_runtime_chat = callable(llama_cpp_get_response)
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
-        manager_defines_llm_instance = callable(
-            getattr(type(self.model_manager), "get_llm_instance", None)
-        )
-        has_direct_runtime_completion = (
-            callable(get_llm_instance) and manager_defines_llm_instance
-        )
-        if not has_runtime_chat and not has_direct_runtime_completion:
-            server_response = self._generate_api_v1_response_with_server_model_if_available(
-                request_id=request_id,
-                model_id=model_id,
-                messages=messages,
-                options=options,
-            )
-            if server_response is not None:
-                return server_response
-
+        has_direct_runtime_completion = callable(get_llm_instance)
         if not self._runtime_model_can_satisfy(model_id):
             return self._api_v1_response_envelope(
                 request_id,
@@ -1384,13 +1267,14 @@ class RelayClient:
         safe_options = {key: value for key, value in options.items() if key != "stream"}
         if "stream" in options:
             safe_options["stream"] = False
-        if safe_options and not has_direct_runtime_completion:
+        if not has_direct_runtime_completion:
             return self._api_v1_response_envelope(
                 request_id,
                 error={
-                    "code": "compute_node_options_unsupported",
+                    "code": "compute_node_model_unsupported",
                     "message": (
-                        "Requested options require direct runtime completion support"
+                        "Desktop runtime does not expose API v1 non-streaming "
+                        "chat completion"
                     ),
                 },
             )
@@ -1424,41 +1308,6 @@ class RelayClient:
                 assistant_message = self._assistant_message_from_runtime_completion(
                     completion
                 )
-            else:
-                if safe_options:
-                    return self._api_v1_response_envelope(
-                        request_id,
-                        error={
-                            "code": "compute_node_options_unsupported",
-                            "message": (
-                                "Requested options require direct runtime completion support"
-                            ),
-                        },
-                    )
-                if not has_runtime_chat:
-                    return self._api_v1_response_envelope(
-                        request_id,
-                        error={
-                            "code": "compute_node_model_unsupported",
-                            "message": "Desktop runtime does not expose chat inference",
-                        },
-                    )
-                log_info(
-                    (
-                        "API v1 runtime generation branch selected: "
-                        "request_id={} model_id={} protocol={} route={} branch={}"
-                    ),
-                    request_id,
-                    model_id,
-                    "tokenplace_api_v1_relay_e2ee",
-                    "/api/v1/relay/responses",
-                    "legacy_llama_cpp_get_response_fallback",
-                )
-                response_history = llama_cpp_get_response(list(runtime_messages))
-                if isinstance(response_history, list) and response_history:
-                    assistant_message = self._valid_api_v1_assistant_message(
-                        response_history[-1]
-                    )
 
             if assistant_message is None:
                 log_error("Desktop runtime returned invalid API v1 assistant output")

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1265,8 +1265,6 @@ class RelayClient:
             )
 
         safe_options = {key: value for key, value in options.items() if key != "stream"}
-        if "stream" in options:
-            safe_options["stream"] = False
         if not has_direct_runtime_completion:
             # API v1 desktop relay generation must fail closed rather than
             # falling back to legacy chat-history runtimes. This is intentional

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1268,6 +1268,9 @@ class RelayClient:
         if "stream" in options:
             safe_options["stream"] = False
         if not has_direct_runtime_completion:
+            # API v1 desktop relay generation must fail closed rather than
+            # falling back to legacy chat-history runtimes. This is intentional
+            # for empty options and explicit stream:false requests as well.
             return self._api_v1_response_envelope(
                 request_id,
                 error={

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1382,10 +1382,9 @@ class RelayClient:
             )
 
         safe_options = {key: value for key, value in options.items() if key != "stream"}
-        options_require_direct_completion = bool(safe_options)
         if "stream" in options:
             safe_options["stream"] = False
-        if options_require_direct_completion and not has_direct_runtime_completion:
+        if safe_options and not has_direct_runtime_completion:
             return self._api_v1_response_envelope(
                 request_id,
                 error={
@@ -1399,20 +1398,24 @@ class RelayClient:
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
-            if safe_options and has_direct_runtime_completion:
+            llm_instance = None
+            create_chat_completion = None
+            if has_direct_runtime_completion:
                 llm_instance = get_llm_instance()
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
-                if not callable(create_chat_completion):
-                    return self._api_v1_response_envelope(
-                        request_id,
-                        error={
-                            "code": "compute_node_options_unsupported",
-                            "message": (
-                                "Requested options require direct runtime completion support"
-                            ),
-                        },
-                    )
 
+            if callable(create_chat_completion):
+                log_info(
+                    (
+                        "API v1 runtime generation branch selected: "
+                        "request_id={} model_id={} protocol={} route={} branch={}"
+                    ),
+                    request_id,
+                    model_id,
+                    "tokenplace_api_v1_relay_e2ee",
+                    "/api/v1/relay/responses",
+                    "direct_non_streaming_completion",
+                )
                 completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
                 completion = create_chat_completion(
                     messages=runtime_messages,
@@ -1422,6 +1425,16 @@ class RelayClient:
                     completion
                 )
             else:
+                if safe_options:
+                    return self._api_v1_response_envelope(
+                        request_id,
+                        error={
+                            "code": "compute_node_options_unsupported",
+                            "message": (
+                                "Requested options require direct runtime completion support"
+                            ),
+                        },
+                    )
                 if not has_runtime_chat:
                     return self._api_v1_response_envelope(
                         request_id,
@@ -1430,6 +1443,17 @@ class RelayClient:
                             "message": "Desktop runtime does not expose chat inference",
                         },
                     )
+                log_info(
+                    (
+                        "API v1 runtime generation branch selected: "
+                        "request_id={} model_id={} protocol={} route={} branch={}"
+                    ),
+                    request_id,
+                    model_id,
+                    "tokenplace_api_v1_relay_e2ee",
+                    "/api/v1/relay/responses",
+                    "legacy_llama_cpp_get_response_fallback",
+                )
                 response_history = llama_cpp_get_response(list(runtime_messages))
                 if isinstance(response_history, list) and response_history:
                     assistant_message = self._valid_api_v1_assistant_message(


### PR DESCRIPTION
### Motivation

API v1 desktop-bridge inference must fail closed unless the compute node exposes the supported direct non-streaming runtime API:

`model_manager.get_llm_instance().create_chat_completion(..., stream=False)`

The previous behavior still allowed API v1 relay requests to fall through to legacy or repo-local fallback paths when direct runtime completion was unavailable. In particular, empty `options` or explicit `stream: false` requests could still reach legacy chat-history/server fallback behavior instead of enforcing the API v1 desktop runtime contract.

That violates the no-legacy-routes invariant and can also hang the desktop bridge before `/api/v1/relay/responses` is posted.

### Description

- Update `_generate_api_v1_response_with_runtime_model()` in `utils/networking/relay_client.py` so API v1 desktop relay generation requires direct runtime completion via `get_llm_instance().create_chat_completion(...)`.
- Always invoke direct runtime completion with `stream=False`, including when the client sends empty `options` or explicitly sends `options: {"stream": false}`.
- Remove the optional repo-local/server `api.v1.models.generate_response(...)` fallback from the API v1 desktop relay path.
- Remove the legacy `llama_cpp_get_response()` fallback from the API v1 desktop relay path.
- Return an encrypted API v1 fail-closed error such as `compute_node_model_unsupported` when the desktop runtime cannot satisfy the direct non-streaming completion contract.
- Preserve API v1 option validation while ensuring unsupported options fail before inference.
- Add metadata-only `log_info` diagnostics for the selected direct runtime branch without logging plaintext prompts, responses, tool arguments, or model output.
- Document the desktop runtime completion contract in:
  - `docs/LLM_ASSISTANT_GUIDE.md`
  - `docs/architecture/api_v1_e2ee_relay.md`
  - `llms.txt`

### Non-goals

- Do not preserve or restore `llama_cpp_get_response()` fallback behavior for API v1 relay inference.
- Do not preserve or restore the optional repo-local/server `api.v1.models.generate_response(...)` fallback inside the API v1 desktop relay path.
- Do not silently downgrade API v1 relay inference to any legacy runtime path.
- Do not weaken the ciphertext-only relay invariant.

### Testing

- Added/updated integration coverage in `tests/integration/test_api_v1_desktop_bridge_e2ee.py` proving the encrypted desktop bridge round trip uses `create_chat_completion(..., stream=False)` and does not call `llama_cpp_get_response()`.
- Added/updated unit coverage in `tests/unit/test_relay_client.py` proving:
  - direct runtime completion is used for API v1 relay inference,
  - legacy chat-history fallback is not called,
  - missing direct runtime support fails closed with encrypted API v1 errors,
  - explicit `stream: false` does not re-enable legacy fallback behavior.

### Verification

```bash
pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q
pytest tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_legacy_route_usage_guardrails.py -q
pytest tests/unit -q
pre-commit run --all-files
```