### PR TITLE
🛠️ fix: prefer non-streaming direct API v1 desktop completion

### DIFF
--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -31,8 +31,29 @@ LEGACY_ROUTE_FRAGMENTS = (
 )
 
 
+class FakeDesktopRuntime:
+    """Small fake direct llama.cpp runtime that never loads llama.cpp/GPU."""
+
+    def __init__(self):
+        self.calls = []
+
+    def create_chat_completion(self, **kwargs):
+        self.calls.append(kwargs)
+        assert kwargs.get("stream") is False
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "pong from desktop",
+                    }
+                }
+            ]
+        }
+
+
 class FakeDesktopModelManager:
-    """Small fake desktop model that never loads llama.cpp/GPU."""
+    """Small fake desktop model that exposes direct and legacy runtimes."""
 
     use_mock_llm = False
     api_model_id = None
@@ -40,8 +61,17 @@ class FakeDesktopModelManager:
     file_name = "Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
     model_path = "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
 
-    def llama_cpp_get_response(self, messages):
-        return [*messages, {"role": "assistant", "content": "pong from desktop"}]
+    def __init__(self):
+        self.runtime = FakeDesktopRuntime()
+
+    def get_llm_instance(self):
+        return self.runtime
+
+    def llama_cpp_get_response(self, _messages):
+        raise AssertionError(
+            "API v1 must not use legacy streaming llama_cpp_get_response "
+            "when direct completion exists"
+        )
 
 
 @contextmanager

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1399,10 +1399,34 @@ class RelayClient:
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
-            if safe_options and has_direct_runtime_completion:
+            create_chat_completion = None
+            if has_direct_runtime_completion:
                 llm_instance = get_llm_instance()
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
-                if not callable(create_chat_completion):
+
+            if callable(create_chat_completion):
+                log_info(
+                    (
+                        "API v1 runtime generation branch selected: "
+                        "request_id={} model_id={} protocol={} route={} branch={}"
+                    ),
+                    request_id,
+                    model_id,
+                    "tokenplace_api_v1_relay_e2ee",
+                    "/api/v1/relay/responses",
+                    "direct_non_streaming_completion",
+                )
+                completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+                completion_kwargs["stream"] = False
+                completion = create_chat_completion(
+                    messages=runtime_messages,
+                    **completion_kwargs,
+                )
+                assistant_message = self._assistant_message_from_runtime_completion(
+                    completion
+                )
+            else:
+                if safe_options and has_direct_runtime_completion:
                     return self._api_v1_response_envelope(
                         request_id,
                         error={
@@ -1412,16 +1436,6 @@ class RelayClient:
                             ),
                         },
                     )
-
-                completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
-                completion = create_chat_completion(
-                    messages=runtime_messages,
-                    **completion_kwargs,
-                )
-                assistant_message = self._assistant_message_from_runtime_completion(
-                    completion
-                )
-            else:
                 if not has_runtime_chat:
                     return self._api_v1_response_envelope(
                         request_id,
@@ -1430,6 +1444,17 @@ class RelayClient:
                             "message": "Desktop runtime does not expose chat inference",
                         },
                     )
+                log_info(
+                    (
+                        "API v1 runtime generation branch selected: "
+                        "request_id={} model_id={} protocol={} route={} branch={}"
+                    ),
+                    request_id,
+                    model_id,
+                    "tokenplace_api_v1_relay_e2ee",
+                    "/api/v1/relay/responses",
+                    "legacy_llama_cpp_get_response_fallback",
+                )
                 response_history = llama_cpp_get_response(list(runtime_messages))
                 if isinstance(response_history, list) and response_history:
                     assistant_message = self._valid_api_v1_assistant_message(


### PR DESCRIPTION
### Motivation
- The API v1 desktop bridge sometimes fell back to the legacy streaming `llama_cpp_get_response()` path and stalled, causing the desktop bridge to decrypt the client request but never POST `/api/v1/relay/responses` back to the relay.
- Root cause: `_generate_api_v1_response_with_runtime_model()` only used direct `create_chat_completion()` when `options` were non-empty, so normal UI requests (empty `options`) used the legacy streaming path.

### Description
- Prefer the direct runtime completion path when a `get_llm_instance().create_chat_completion` callable exists and invoke it with `stream=False` so API v1 remains non-streaming, even if `options` is empty (file: `utils/networking/relay_client.py`).
- Preserve previous option validation and only fall back to `llama_cpp_get_response()` when a direct non-streaming completion is genuinely unavailable, with an explicit error when options require direct completion but the runtime lacks it (file: `utils/networking/relay_client.py`).
- Add metadata-only `log_info()` diagnostics that record which branch was taken (`direct_non_streaming_completion` vs `legacy_llama_cpp_get_response_fallback`) and include only request_id, model_id, protocol/route, and branch label (file: `utils/networking/relay_client.py`).
- Add a regression-strengthening integration test that exercises the full E2E API v1 desktop bridge path using a fake model manager exposing both `create_chat_completion()` and `llama_cpp_get_response()` where the latter raises if invoked and the former asserts `stream is False` and returns the expected assistant message (file: `tests/integration/test_api_v1_desktop_bridge_e2ee.py`).

### Testing
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and the encrypted desktop-bridge round-trip tests passed (4 passed).
- Ran `pytest tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_legacy_route_usage_guardrails.py -q` and the selected unit suites passed (all relevant tests passed).
- Verified broader test collections used by the project (API/integration suites) continued to pass in local runs; added `log_info` branch diagnostics appear in test logs.
- Ran `pre-commit run --all-files` where the project checks mostly passed but the pre-commit run failed in the test-run hook due to a missing `pkg_resources` import in the hook environment (environment/tooling issue unrelated to the change); unit/integration tests relevant to this PR passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0970b80090832f86804893fd700d54)