### PR TITLE
🐛 fix: use non-streaming API v1 desktop runtime

### DIFF
--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -31,6 +31,23 @@ LEGACY_ROUTE_FRAGMENTS = (
 )
 
 
+class FakeDesktopRuntime:
+    """Direct non-streaming llama.cpp-compatible runtime fake."""
+
+    def create_chat_completion(self, **kwargs):
+        assert kwargs["stream"] is False
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "pong from desktop",
+                    }
+                }
+            ]
+        }
+
+
 class FakeDesktopModelManager:
     """Small fake desktop model that never loads llama.cpp/GPU."""
 
@@ -40,8 +57,17 @@ class FakeDesktopModelManager:
     file_name = "Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
     model_path = "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
 
-    def llama_cpp_get_response(self, messages):
-        return [*messages, {"role": "assistant", "content": "pong from desktop"}]
+    def __init__(self):
+        self.runtime = FakeDesktopRuntime()
+
+    def get_llm_instance(self):
+        return self.runtime
+
+    def llama_cpp_get_response(self, _messages):
+        raise AssertionError(
+            "API v1 must not use legacy streaming llama_cpp_get_response "
+            "when direct completion exists"
+        )
 
 
 @contextmanager

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1383,26 +1383,37 @@ class RelayClient:
 
         safe_options = {key: value for key, value in options.items() if key != "stream"}
         options_require_direct_completion = bool(safe_options)
-        if "stream" in options:
-            safe_options["stream"] = False
-        if options_require_direct_completion and not has_direct_runtime_completion:
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": "compute_node_options_unsupported",
-                    "message": (
-                        "Requested options require direct runtime completion support"
-                    ),
-                },
-            )
 
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
-            if safe_options and has_direct_runtime_completion:
+            create_chat_completion = None
+            if has_direct_runtime_completion:
                 llm_instance = get_llm_instance()
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
-                if not callable(create_chat_completion):
+
+            if callable(create_chat_completion):
+                log_info(
+                    (
+                        "API v1 runtime generation branch selected: "
+                        "request_id={} model_id={} protocol={} branch={}"
+                    ),
+                    request_id,
+                    model_id,
+                    "tokenplace_api_v1_relay_e2ee",
+                    "direct_non_streaming_completion",
+                )
+                completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+                completion_kwargs["stream"] = False
+                completion = create_chat_completion(
+                    messages=runtime_messages,
+                    **completion_kwargs,
+                )
+                assistant_message = self._assistant_message_from_runtime_completion(
+                    completion
+                )
+            else:
+                if options_require_direct_completion:
                     return self._api_v1_response_envelope(
                         request_id,
                         error={
@@ -1412,16 +1423,6 @@ class RelayClient:
                             ),
                         },
                     )
-
-                completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
-                completion = create_chat_completion(
-                    messages=runtime_messages,
-                    **completion_kwargs,
-                )
-                assistant_message = self._assistant_message_from_runtime_completion(
-                    completion
-                )
-            else:
                 if not has_runtime_chat:
                     return self._api_v1_response_envelope(
                         request_id,
@@ -1430,6 +1431,16 @@ class RelayClient:
                             "message": "Desktop runtime does not expose chat inference",
                         },
                     )
+                log_info(
+                    (
+                        "API v1 runtime generation branch selected: "
+                        "request_id={} model_id={} protocol={} branch={}"
+                    ),
+                    request_id,
+                    model_id,
+                    "tokenplace_api_v1_relay_e2ee",
+                    "legacy_llama_cpp_get_response_fallback",
+                )
                 response_history = llama_cpp_get_response(list(runtime_messages))
                 if isinstance(response_history, list) and response_history:
                     assistant_message = self._valid_api_v1_assistant_message(


### PR DESCRIPTION
### Motivation
- Close the remaining desktop-runtime gap where API v1 E2EE relay work could fall back to the legacy streaming `llama_cpp_get_response()` path and never reach `/api/v1/relay/responses`, causing timeouts for non-streaming API v1 desktop bridges.
- Ensure API v1 desktop bridge always uses a complete non-streaming runtime completion when the runtime exposes `create_chat_completion`, since API v1 is explicitly non-streaming.

### Description
- Prefer a direct runtime completion by calling `get_llm_instance().create_chat_completion(...)` whenever that callable is available, even when `options` are empty, and always enforce `stream=False` for API v1 paths in `_generate_api_v1_response_with_runtime_model()`.
- Preserve existing option validation and fail-closed behavior for unsupported options that require direct completion, and keep the legacy `llama_cpp_get_response()` fallback only when direct runtime completion is genuinely unavailable.
- Add metadata-only diagnostics via `log_info()` to indicate which branch was selected (direct non-streaming completion vs legacy fallback) and include only `request_id`, `model_id`, `protocol`, and a branch label.
- Add an integration regression in `tests/integration/test_api_v1_desktop_bridge_e2ee.py` that supplies a fake runtime exposing `create_chat_completion(...)` and a `llama_cpp_get_response(...)` that raises if used, and assert the desktop runtime path uses `create_chat_completion(stream=False)` and produces the expected decrypted `chat.completion` body and a single `POST /api/v1/relay/responses`.

### Testing
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and the in-process E2E regression passed, proving the desktop bridge uses `create_chat_completion(stream=False)` and the browser decrypts `choices[0].message.content == "pong from desktop"`.
- Ran `pytest tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py tests/unit/test_legacy_route_usage_guardrails.py -q` and all targeted unit tests passed.
- Ran `pre-commit run --all-files` and project checks completed successfully after bootstrapping the test environment (note: `setuptools<81` was required in the test runner environment to provide `pkg_resources`).
- Ran the legacy-route grep check and inspected hits to confirm no new API v2 or legacy relay routes were introduced into the API v1 desktop bridge critical path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0970b80090832f86804893fd700d54)