### PR TITLE
🐛 fix: prewarm API v1 runtime before desktop bridge registers/polls

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -266,11 +266,11 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_model_ready():
+    if not runtime.ensure_api_v1_runtime_ready():
         emit(
             {
                 "type": "error",
-                "message": "failed to initialize model runtime",
+                "message": "failed to initialize API v1 model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
             }
         )

--- a/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
+++ b/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
@@ -1,0 +1,54 @@
+# API v1 desktop bridge cold-runtime timeout (2026-05-21)
+
+## Summary
+The API v1 encrypted desktop relay path could return browser-side 504 timeouts on the
+first request because the desktop compute-node bridge advertised readiness before the
+llama.cpp runtime was actually initialized.
+
+## Impact
+- Browser `POST /api/v1/chat/completions` could fail with `compute_node_timeout` (504).
+- Relay repeatedly polled `/api/v1/relay/responses/retrieve` and observed 404 until timeout.
+- Desktop bridge had accepted and decrypted work but had not submitted
+  `/api/v1/relay/responses` before relay timeout.
+
+## Timeline
+1. Browser sends `POST /api/v1/chat/completions`.
+2. Relay accepts queue via `/api/v1/relay/requests`.
+3. Desktop bridge receives and decrypts API v1 E2EE work.
+4. Relay repeatedly checks `/api/v1/relay/responses/retrieve` and receives 404.
+5. Relay returns final 504 `compute_node_timeout` to browser request.
+
+## Root cause
+`compute_node_bridge.py` called `ComputeNodeRuntime.ensure_model_ready()`, which validates
+model availability/download only. Actual runtime initialization occurred later when request
+processing triggered `model_manager.get_llm_instance()`. That cold init cost happened inside
+the active relay timeout budget.
+
+## Why existing tests missed it
+Existing encrypted desktop bridge E2E coverage uses fake/instant desktop runtime behavior.
+That validates envelope flow and encryption semantics, but not startup readiness semantics for
+cold llama.cpp initialization.
+
+## Fix
+- Added `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` to:
+  - run existing model-readiness checks,
+  - force runtime warmup via `model_manager.get_llm_instance()`,
+  - fail closed if warmup returns `None`,
+  - fail closed unless runtime exposes callable non-streaming
+    `create_chat_completion`.
+- Updated desktop bridge startup to require API v1 runtime warmup before emitting `started`
+  and before entering register/poll loop.
+- On warmup failure, bridge now emits structured `type: "error"` and exits nonzero.
+
+## Regression tests added
+- Unit tests for runtime prewarm helper success/failure cases.
+- Unit tests for bridge startup ordering and fail-closed behavior when warmup fails.
+
+## Manual verification (Windows/local relay)
+1. Start relay with distributed provider enabled.
+2. Start desktop Tauri compute node.
+3. Confirm bridge logs model init start/ready before first registration/poll event.
+4. Send a chat message from the UI.
+5. Confirm relay logs `/api/v1/relay/responses` 200 before `/api/v1/chat/completions`
+   returns.
+6. Confirm no 504 and no repeated retrieve-only 404 loop.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import call, MagicMock
 
 import pytest
@@ -76,6 +77,64 @@ def test_compute_node_runtime_ensure_model_ready_download_failure():
 
     assert runtime.ensure_model_ready() is False
     model_manager.download_model_if_needed.assert_called_once_with()
+
+
+def test_ensure_api_v1_runtime_ready_success():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    llm_instance = MagicMock()
+    llm_instance.create_chat_completion = lambda *_args, **_kwargs: {}
+    model_manager.get_llm_instance.return_value = llm_instance
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    model_manager.get_llm_instance.assert_called_once_with()
+
+
+def test_ensure_api_v1_runtime_ready_fails_when_get_llm_missing():
+    model_manager = MagicMock(spec=["use_mock_llm"])
+    model_manager.use_mock_llm = True
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is False
+
+
+def test_ensure_api_v1_runtime_ready_fails_when_get_llm_returns_none():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.get_llm_instance.return_value = None
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is False
+
+
+def test_ensure_api_v1_runtime_ready_fails_when_completion_not_callable():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    llm_instance = SimpleNamespace(create_chat_completion="not-callable")
+    model_manager.get_llm_instance.return_value = llm_instance
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is False
 
 
 def test_compute_node_runtime_polling_thread_delegates_to_relay():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -51,7 +51,10 @@ class FakeRelayClientRouting(FakeRelayClient):
 
 
 class FakeRuntime:
+    last_instance = None
+
     def __init__(self, _config):
+        FakeRuntime.last_instance = self
         self.model_manager = FakeModelManager()
         self.relay_client = FakeRelayClient()
         self._responses = [
@@ -65,11 +68,16 @@ class FakeRuntime:
             },
         ]
         self._processed = []
+        self.call_order = []
 
-    def ensure_model_ready(self):
+    def ensure_api_v1_runtime_ready(self):
+        if hasattr(self, 'call_order'):
+            self.call_order.append('warmup')
         return True
 
     def register_and_poll_once(self):
+        if hasattr(self, 'call_order'):
+            self.call_order.append('poll')
         if self._responses:
             return self._responses.pop(0)
         return {'next_ping_in_x_seconds': 0}
@@ -361,7 +369,7 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     _reset_cancel_queue()
 
     class FailingRuntime(FakeRuntime):
-        def ensure_model_ready(self):
+        def ensure_api_v1_runtime_ready(self):
             return False
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRuntime)
@@ -377,7 +385,58 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     assert status == 1
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
-    assert 'failed to initialize model runtime' in payload['message']
+    assert 'failed to initialize API v1 model runtime' in payload['message']
+
+
+def test_run_warms_runtime_before_first_relay_poll(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime)
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert FakeRuntime.last_instance is not None
+    assert FakeRuntime.last_instance.call_order[:2] == ['warmup', 'poll']
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+
+
+def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class FailingWarmupRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            calls.append('warmup')
+            return False
+
+        def register_and_poll_once(self):
+            calls.append('poll')
+            return super().register_and_poll_once()
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FailingWarmupRuntime)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 1
+    assert calls == ['warmup']
 
 
 def test_run_allows_runtime_reexec_when_cuda_runtime_is_repaired(capsys, monkeypatch):
@@ -916,7 +975,7 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
             self.model_manager = FakeModelManager()
             self.relay_client = SimpleNamespace(relay_url=config.relay_url)
 
-        def ensure_model_ready(self):
+        def ensure_api_v1_runtime_ready(self):
             return True
 
         def register_and_poll_once(self):
@@ -1105,7 +1164,7 @@ class ComputeNodeRuntime:
         self.relay_client = _RelayClient(config.relay_url)
         self.model_manager = _ModelManager()
 
-    def ensure_model_ready(self):
+    def ensure_api_v1_runtime_ready(self):
         return True
 
     def register_and_poll_once(self):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -296,6 +296,31 @@ class ComputeNodeRuntime:
         _log_error("Failed to download or verify model")
         return False
 
+    def ensure_api_v1_runtime_ready(self) -> bool:
+        """Warm and validate runtime support for API v1 non-streaming completion."""
+
+        if not self.ensure_model_ready():
+            return False
+
+        get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
+        if not callable(get_llm_instance):
+            _log_error("Model manager missing callable get_llm_instance during runtime warmup")
+            return False
+
+        llm_instance = get_llm_instance()
+        if llm_instance is None:
+            _log_error("Runtime warmup failed: get_llm_instance returned None")
+            return False
+
+        create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
+        if not callable(create_chat_completion):
+            _log_error(
+                "Runtime warmup failed: create_chat_completion missing or non-callable"
+            )
+            return False
+
+        return True
+
     def start_relay_polling(self) -> threading.Thread:
         """Start relay polling in a background thread and return the thread."""
 


### PR DESCRIPTION
### Motivation
- First API v1 encrypted desktop relay requests could hit relay/browser 504s because the bridge advertised readiness before the llama runtime was actually initialized. 
- The cold llama.cpp initialization was happening later on first request via `model_manager.get_llm_instance()`, which consumed the distributed-provider timeout budget and caused timeouts instead of an immediate bridge failure.

### Description
- Add `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` to run model-readiness checks, call `model_manager.get_llm_instance()` to force real runtime initialization, fail when no instance is returned, and require a callable `create_chat_completion` entrypoint. 
- Require API v1 runtime warmup in the desktop bridge startup (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) before emitting `started` and before entering the register/poll loop, and emit a structured `type: "error"` + nonzero exit on warmup failure. 
- Add unit tests covering the new prewarm helper success and failure cases and bridge behavior verifying warmup-before-poll ordering and fail-closed behavior. 
- Add an outages write-up documenting the root cause, timeline, fix, and manual verification steps (`outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md`).

### Testing
- Ran `pytest tests/unit/test_compute_node_runtime.py` and all new and existing unit cases passed. 
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py`, `pytest tests/unit/test_relay_client.py`, and `pytest tests/unit/test_api_v1_compute_provider.py` and the suites passed. 
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and the integration regression(s) passed. 
- `pre-commit run --all-files` was executed but the repository-level `run-checks` hook reported a failure in the broader test runner in this environment; the targeted pytest runs above passed for the modified areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd009e76c832fbd18df0f693abf5b)