### PR TITLE
Prewarm API v1 desktop runtime before relay polling

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -266,11 +266,11 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_model_ready():
+    if not runtime.ensure_api_v1_runtime_ready():
         emit(
             {
                 "type": "error",
-                "message": "failed to initialize model runtime",
+                "message": "failed to initialize API v1 model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
             }
         )

--- a/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.json
+++ b/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-21",
+  "slug": "api-v1-desktop-bridge-cold-runtime-timeout",
+  "summary": "Desktop API v1 relay requests timed out on first use because the bridge reported started after model asset checks but before llama.cpp runtime initialization.",
+  "impact": "First encrypted API v1 desktop relay chat completions could return 504 compute_node_timeout while the compute node was still cold-starting runtime state.",
+  "fix": "Bridge startup now requires ComputeNodeRuntime.ensure_api_v1_runtime_ready(), which warms get_llm_instance(), validates create_chat_completion availability, and fails startup before polling when warmup fails.",
+  "lessons": "Readiness gates must verify full API v1 runtime serving capability, not just model file presence, and startup tests must assert warm-before-poll ordering plus fail-closed behavior."
+}

--- a/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
+++ b/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
@@ -1,0 +1,54 @@
+# API v1 desktop bridge cold-runtime timeout (2026-05-21)
+
+## Summary
+The API v1 encrypted desktop relay flow could return `504 compute_node_timeout` on first
+request because the desktop bridge advertised readiness before llama.cpp runtime warmup
+completed.
+
+## Impact
+- Browser POST to `/api/v1/chat/completions` timed out after the distributed provider window.
+- Relay selected a compute node and queued encrypted work, but the desktop node did not submit
+  `/api/v1/relay/responses` before timeout.
+- Users observed startup-time failures on first request instead of immediate bridge startup errors.
+
+## Timeline
+1. Browser sends POST `/api/v1/chat/completions`.
+2. Relay accepts queue request via `/api/v1/relay/requests`.
+3. Desktop compute-node bridge receives/decrypts API v1 E2EE work.
+4. Relay repeatedly polls `/api/v1/relay/responses/retrieve` and receives `404`.
+5. Relay returns `504` with `compute_node_timeout`.
+
+## Root cause
+`desktop-tauri/src-tauri/python/compute_node_bridge.py` previously gated startup on
+`ComputeNodeRuntime.ensure_model_ready()`, which only ensures/downloads model files. Actual
+runtime init happened later on first request via `ModelManager.get_llm_instance()` during
+request processing, causing first-request cold initialization to consume timeout budget.
+
+## Why existing tests missed it
+Existing encrypted desktop bridge integration coverage uses fake/instant runtimes to verify
+protocol and encryption behavior. That validated API v1 E2EE flow but did not validate startup
+readiness semantics or cold runtime initialization ordering.
+
+## Fix
+- Added `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` to:
+  - ensure model assets are ready,
+  - warm runtime via `get_llm_instance()`,
+  - require callable non-streaming `create_chat_completion`,
+  - annotate diagnostics state with `api_v1_runtime_ready`.
+- Updated desktop bridge startup to require API v1 runtime warmup before emitting `started`
+  or beginning relay register/poll loops.
+- Warmup failure now fails closed with startup `type: "error"` and non-zero exit.
+
+## Regression tests added
+- Desktop bridge unit tests prove warmup occurs before first poll.
+- Desktop bridge unit tests prove warmup failure prevents polling and returns startup error.
+- Runtime unit tests cover warmup success and failure paths (`None`, missing
+  `get_llm_instance`, missing/non-callable `create_chat_completion`).
+
+## Manual verification steps (Windows/local relay)
+1. Start relay with distributed provider configured.
+2. Start desktop Tauri compute node bridge.
+3. Confirm bridge logs indicate runtime warmup before first registration/poll.
+4. Send UI chat request.
+5. Confirm relay logs `/api/v1/relay/responses` `200` before `/api/v1/chat/completions` returns.
+6. Confirm no `504` and no repeated retrieve-only `404` loop.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -78,6 +78,50 @@ def test_compute_node_runtime_ensure_model_ready_download_failure():
     model_manager.download_model_if_needed.assert_called_once_with()
 
 
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_success():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.last_compute_diagnostics = {"requested_mode": "cpu"}
+    llm_runtime = MagicMock()
+    llm_runtime.create_chat_completion = lambda **_kwargs: {}
+    model_manager.get_llm_instance.return_value = llm_runtime
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    assert model_manager.last_compute_diagnostics["api_v1_runtime_ready"] is True
+
+
+@pytest.mark.parametrize(
+    "llm_instance,getter,expected",
+    [
+        (None, True, False),
+        (object(), True, False),
+        (MagicMock(create_chat_completion=None), True, False),
+        (MagicMock(create_chat_completion=lambda **_kwargs: {}), False, False),
+    ],
+)
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_failure_cases(
+    llm_instance, getter, expected
+):
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    if getter:
+        model_manager.get_llm_instance.return_value = llm_instance
+    else:
+        delattr(model_manager, "get_llm_instance")
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is expected
+
+
 def test_compute_node_runtime_polling_thread_delegates_to_relay():
     relay_client = MagicMock()
     relay_client.poll_relay_continuously = MagicMock()

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -122,6 +122,40 @@ def test_compute_node_runtime_ensure_api_v1_runtime_ready_failure_cases(
     assert runtime.ensure_api_v1_runtime_ready() is expected
 
 
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_handles_get_llm_exception():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.get_llm_instance.side_effect = RuntimeError("boom")
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+
+
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_without_diagnostics_dict():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.last_compute_diagnostics = "not-a-dict"
+    llm_runtime = MagicMock()
+    llm_runtime.create_chat_completion = lambda **_kwargs: {}
+    model_manager.get_llm_instance.return_value = llm_runtime
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    assert model_manager.last_compute_diagnostics == "not-a-dict"
+
+
 def test_compute_node_runtime_polling_thread_delegates_to_relay():
     relay_client = MagicMock()
     relay_client.poll_relay_continuously = MagicMock()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -69,6 +69,9 @@ class FakeRuntime:
     def ensure_model_ready(self):
         return True
 
+    def ensure_api_v1_runtime_ready(self):
+        return self.ensure_model_ready()
+
     def register_and_poll_once(self):
         if self._responses:
             return self._responses.pop(0)
@@ -377,7 +380,7 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     assert status == 1
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
-    assert 'failed to initialize model runtime' in payload['message']
+    assert 'failed to initialize API v1 model runtime' in payload['message']
 
 
 def test_run_allows_runtime_reexec_when_cuda_runtime_is_repaired(capsys, monkeypatch):
@@ -919,6 +922,9 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
         def ensure_model_ready(self):
             return True
 
+        def ensure_api_v1_runtime_ready(self):
+            return self.ensure_model_ready()
+
         def register_and_poll_once(self):
             return {'next_ping_in_x_seconds': 0}
 
@@ -1108,6 +1114,9 @@ class ComputeNodeRuntime:
     def ensure_model_ready(self):
         return True
 
+    def ensure_api_v1_runtime_ready(self):
+        return self.ensure_model_ready()
+
     def register_and_poll_once(self):
         return {"next_ping_in_x_seconds": 1}
 
@@ -1215,3 +1224,48 @@ def test_relay_response_summary_handles_non_dict_payloads():
 
 def test_relay_error_message_normalizes_non_string_truthy_values():
     assert compute_node_bridge._relay_error_message({"error": 503}) == "503"
+
+
+def test_run_warms_runtime_before_first_register_poll(capsys, monkeypatch):
+    _reset_cancel_queue()
+    call_order = []
+
+    class OrderedRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            call_order.append("warm")
+            return True
+
+        def register_and_poll_once(self):
+            call_order.append("poll")
+            return {"next_ping_in_x_seconds": 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 1)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert call_order[:2] == ["warm", "poll"]
+    _ = capsys.readouterr()
+
+
+def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class FailingWarmupRuntime(FakeRuntime):
+        def __init__(self, config):
+            super().__init__(config)
+            self.poll_count = 0
+
+        def ensure_api_v1_runtime_ready(self):
+            return False
+
+        def register_and_poll_once(self):
+            self.poll_count += 1
+            return {"next_ping_in_x_seconds": 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FailingWarmupRuntime)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 1
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["type"] == "error"

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1250,27 +1250,21 @@ def test_run_warms_runtime_before_first_register_poll(capsys, monkeypatch):
 
 def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
+    calls = []
 
     class FailingWarmupRuntime(FakeRuntime):
-        last_instance = None
-
-        def __init__(self, config):
-            super().__init__(config)
-            self.poll_count = 0
-            FailingWarmupRuntime.last_instance = self
-
         def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
             return False
 
         def register_and_poll_once(self):
-            self.poll_count += 1
+            calls.append("poll")
             return {"next_ping_in_x_seconds": 0}
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingWarmupRuntime)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 1
-    assert FailingWarmupRuntime.last_instance is not None
-    assert FailingWarmupRuntime.last_instance.poll_count == 0
+    assert calls == ["warm"]
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["type"] == "error"

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1252,9 +1252,12 @@ def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
 
     class FailingWarmupRuntime(FakeRuntime):
+        last_instance = None
+
         def __init__(self, config):
             super().__init__(config)
             self.poll_count = 0
+            FailingWarmupRuntime.last_instance = self
 
         def ensure_api_v1_runtime_ready(self):
             return False
@@ -1267,5 +1270,7 @@ def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 1
+    assert FailingWarmupRuntime.last_instance is not None
+    assert FailingWarmupRuntime.last_instance.poll_count == 0
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["type"] == "error"

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -296,6 +296,41 @@ class ComputeNodeRuntime:
         _log_error("Failed to download or verify model")
         return False
 
+    def ensure_api_v1_runtime_ready(self) -> bool:
+        """Warm and validate API v1 non-streaming runtime before polling."""
+
+        if not self.ensure_model_ready():
+            return False
+
+        get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
+        if not callable(get_llm_instance):
+            _log_error("Model manager missing get_llm_instance required for API v1 warmup")
+            return False
+
+        try:
+            llm_runtime = get_llm_instance()
+        except Exception:
+            _log_error("Failed to initialize API v1 runtime for compute node", exc_info=True)
+            return False
+
+        if llm_runtime is None:
+            _log_error("API v1 runtime warmup failed: get_llm_instance returned None")
+            return False
+
+        create_chat_completion = getattr(llm_runtime, "create_chat_completion", None)
+        if not callable(create_chat_completion):
+            _log_error(
+                "API v1 runtime warmup failed: runtime missing callable create_chat_completion"
+            )
+            return False
+
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        if isinstance(diagnostics, dict):
+            diagnostics["api_v1_runtime_ready"] = True
+            self.model_manager.last_compute_diagnostics = diagnostics
+
+        return True
+
     def start_relay_polling(self) -> threading.Thread:
         """Start relay polling in a background thread and return the thread."""
 


### PR DESCRIPTION
### Motivation
- First API v1 desktop relay requests were timing out because the bridge reported readiness before the llama runtime was actually initialized, causing the first request to pay cold init latency inside the relay timeout window. 
- The startup gating previously called only `ensure_model_ready()` which verifies/downloads assets but does not force `get_llm_instance()` (the expensive llama.cpp init). 
- The change ensures the bridge advertises `started` only after the runtime can actually serve non-streaming API v1 completions. 

### Description
- Add `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` which calls `ensure_model_ready()`, forces `model_manager.get_llm_instance()`, verifies the returned runtime has a callable `create_chat_completion`, and annotates `model_manager.last_compute_diagnostics` with `api_v1_runtime_ready`. 
- Gate desktop bridge startup on `runtime.ensure_api_v1_runtime_ready()` (replace previous `ensure_model_ready()` check) and emit a clear `type: "error"` startup event and nonzero exit when warmup fails. 
- Update unit tests to cover the new warmup helper and bridge behavior: positive warmup, missing `get_llm_instance`, `None` runtime, non-callable `create_chat_completion`, ordering that proves warmup runs before the first `register_and_poll_once()`, and that failed warmup prevents polling. 
- Add an outage report `outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md` documenting the issue, root cause, fix, regression tests, and manual verification steps. 

### Testing
- Ran `python -m pytest tests/unit/test_compute_node_runtime.py -q` and all tests passed (`33 passed`). 
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and all tests passed (`30 passed`). 
- Ran `python -m pytest tests/unit/test_relay_client.py -q` and `tests/unit/test_api_v1_compute_provider.py -q` and both suites passed (`81 passed` and `21 passed` respectively). 
- Ran `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and the integration tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd009e76c832fbd18df0f693abf5b)