### PR TITLE
🐛 fix: prewarm API v1 desktop bridge runtime before relay polling

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -266,11 +266,11 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_model_ready():
+    if not runtime.ensure_api_v1_runtime_ready():
         emit(
             {
                 "type": "error",
-                "message": "failed to initialize model runtime",
+                "message": "failed to initialize API v1 model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
             }
         )

--- a/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
+++ b/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
@@ -1,0 +1,43 @@
+# API v1 desktop bridge cold runtime timeout (May 21, 2026)
+
+## Summary
+The API v1 encrypted desktop relay path could time out on the first browser request because the desktop bridge reported readiness before the llama.cpp runtime was actually initialized.
+
+## Impact
+- Browser requests to `/api/v1/chat/completions` could return `504 compute_node_timeout` after ~30 seconds.
+- Relay accepted and queued API v1 E2EE requests but did not receive a response envelope in time.
+- Desktop bridge had already registered and was polling, but first request still paid cold runtime initialization.
+
+## Timeline
+1. Browser `POST /api/v1/chat/completions` started.
+2. Relay accepted queue write via `POST /api/v1/relay/requests`.
+3. Desktop bridge polled and received API v1 E2EE work; request was decrypted in desktop runtime.
+4. Relay repeatedly polled `POST /api/v1/relay/responses/retrieve` and saw `404` (not ready yet).
+5. Relay timed out and returned `504 compute_node_timeout` to browser.
+
+## Root cause
+`desktop-tauri/src-tauri/python/compute_node_bridge.py` used `runtime.ensure_model_ready()` and then emitted startup readiness, but that check only verified model availability/download. Actual llama.cpp instance initialization happened later through `ModelManager.get_llm_instance()` during request processing, inside the distributed timeout window.
+
+## Why tests missed it
+Existing encrypted desktop bridge E2E coverage used fake/instant desktop runtimes. That validated API v1 protocol/encryption invariants, but not readiness semantics against cold runtime initialization latency.
+
+## Fix
+- Added `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` that:
+  - runs `ensure_model_ready()`,
+  - forces runtime init via `model_manager.get_llm_instance()`,
+  - validates callable `create_chat_completion`,
+  - fails closed on any warmup/validation failure.
+- Updated desktop bridge startup to require API v1 runtime warmup before `started` emission and before relay register/poll loop.
+
+## Regression tests added
+- Unit coverage for `ensure_api_v1_runtime_ready()` success/failure paths.
+- Desktop bridge startup tests verifying warmup failure is surfaced as immediate startup error.
+- Desktop bridge startup ordering regression that asserts warmup occurs before polling.
+
+## Manual verification (Windows/local relay)
+1. Start relay with distributed provider configured.
+2. Start desktop Tauri compute node.
+3. Confirm startup logs show model init and runtime warmup before first registration/poll.
+4. Send a chat message from UI.
+5. Confirm relay logs `POST /api/v1/relay/responses` 200 before `/api/v1/chat/completions` returns.
+6. Confirm no browser 504 and no repeated retrieve-only 404 loop.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -78,6 +78,47 @@ def test_compute_node_runtime_ensure_model_ready_download_failure():
     model_manager.download_model_if_needed.assert_called_once_with()
 
 
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_success():
+    llm_instance = MagicMock()
+    llm_instance.create_chat_completion = MagicMock()
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = False
+    model_manager.download_model_if_needed.return_value = True
+    model_manager.get_llm_instance.return_value = llm_instance
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is True
+
+
+@pytest.mark.parametrize(
+    "get_instance,expected",
+    [
+        (None, False),
+        (lambda: None, False),
+        (lambda: object(), False),
+    ],
+)
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_failure_cases(get_instance, expected):
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = False
+    model_manager.download_model_if_needed.return_value = True
+    if get_instance is not None:
+        model_manager.get_llm_instance.side_effect = get_instance
+    else:
+        delattr(model_manager, "get_llm_instance")
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is expected
+
+
 def test_compute_node_runtime_polling_thread_delegates_to_relay():
     relay_client = MagicMock()
     relay_client.poll_relay_continuously = MagicMock()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -69,6 +69,9 @@ class FakeRuntime:
     def ensure_model_ready(self):
         return True
 
+    def ensure_api_v1_runtime_ready(self):
+        return self.ensure_model_ready()
+
     def register_and_poll_once(self):
         if self._responses:
             return self._responses.pop(0)
@@ -361,7 +364,7 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     _reset_cancel_queue()
 
     class FailingRuntime(FakeRuntime):
-        def ensure_model_ready(self):
+        def ensure_api_v1_runtime_ready(self):
             return False
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRuntime)
@@ -377,7 +380,32 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     assert status == 1
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
-    assert 'failed to initialize model runtime' in payload['message']
+    assert 'failed to initialize API v1 model runtime' in payload['message']
+
+
+def test_run_warms_runtime_before_register_and_poll(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class OrderedRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            calls.append('warm')
+            return True
+
+        def register_and_poll_once(self):
+            calls.append('poll')
+            return super().register_and_poll_once()
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+    status = compute_node_bridge.run(
+        SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    )
+    assert status == 0
+    assert calls[:1] == ['warm']
+    assert 'poll' not in calls
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
 
 
 def test_run_allows_runtime_reexec_when_cuda_runtime_is_repaired(capsys, monkeypatch):
@@ -919,6 +947,9 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
         def ensure_model_ready(self):
             return True
 
+        def ensure_api_v1_runtime_ready(self):
+            return self.ensure_model_ready()
+
         def register_and_poll_once(self):
             return {'next_ping_in_x_seconds': 0}
 
@@ -1107,6 +1138,9 @@ class ComputeNodeRuntime:
 
     def ensure_model_ready(self):
         return True
+
+    def ensure_api_v1_runtime_ready(self):
+        return self.ensure_model_ready()
 
     def register_and_poll_once(self):
         return {"next_ping_in_x_seconds": 1}

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -296,6 +296,32 @@ class ComputeNodeRuntime:
         _log_error("Failed to download or verify model")
         return False
 
+    def ensure_api_v1_runtime_ready(self) -> bool:
+        """Warm and validate API v1 runtime readiness before relay polling."""
+
+        if not self.ensure_model_ready():
+            return False
+
+        get_instance = getattr(self.model_manager, "get_llm_instance", None)
+        if not callable(get_instance):
+            _log_error("Model manager missing get_llm_instance; API v1 runtime warmup failed")
+            return False
+
+        llm_instance = get_instance()
+        if llm_instance is None:
+            _log_error("API v1 runtime warmup failed: get_llm_instance returned None")
+            return False
+
+        create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
+        if not callable(create_chat_completion):
+            _log_error(
+                "API v1 runtime warmup failed: create_chat_completion is unavailable"
+            )
+            return False
+
+        _log_info("API v1 runtime warmup ready")
+        return True
+
     def start_relay_polling(self) -> threading.Thread:
         """Start relay polling in a background thread and return the thread."""
 


### PR DESCRIPTION
### Motivation
- The desktop bridge previously reported readiness after model-file checks only, causing the first API v1 relay request to pay cold llama.cpp init inside the distributed timeout and resulting in relay 404/retry loops and browser 504s. 
- Make bridge readiness mean the runtime can actually serve non-streaming API v1 completions and fail closed early if runtime warmup fails.

### Description
- Add `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` which calls `ensure_model_ready()`, forces `model_manager.get_llm_instance()`, verifies the returned instance is non-`None` and exposes a callable `create_chat_completion`, and logs/returns failure when checks fail. (`utils/compute_node_runtime.py`)
- Require the API v1 warmup during bridge startup by replacing the previous `ensure_model_ready()` call with `ensure_api_v1_runtime_ready()` before emitting `started` and before entering the register/poll loop; emit a clear `type: "error"` startup event on warmup failure. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Add and update unit tests to cover warmup success/failure and startup ordering so warmup runs before any registration/poll; update fake runtimes in tests to support the new API. (`tests/unit/test_compute_node_runtime.py`, `tests/unit/test_desktop_compute_node_bridge.py`)
- Add outage documentation describing the root cause, impact, fix, and manual verification steps. (`outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md`)

### Testing
- Ran `python -m pytest tests/unit/test_compute_node_runtime.py -q` and all tests passed (32 passed). 
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and all tests passed (29 passed). 
- Ran `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_api_v1_compute_provider.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`; these suites passed (81, 21, and 4 tests respectively). 
- Ran `pre-commit run --all-files`; the project-level hook failed in this environment due to an unrelated test-collection dependency error (`ModuleNotFoundError: No module named 'pkg_resources'`) when running the full checks, not due to the code changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd009e76c832fbd18df0f693abf5b)