### PR TITLE
fix: prewarm API v1 desktop runtime before relay polling

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -266,11 +266,11 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_model_ready():
+    if not runtime.ensure_api_v1_runtime_ready():
         emit(
             {
                 "type": "error",
-                "message": "failed to initialize model runtime",
+                "message": "failed to warm API v1 model runtime",
                 "active_relay_url": runtime.relay_client.relay_url,
             }
         )

--- a/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
+++ b/outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md
@@ -1,0 +1,54 @@
+# API v1 Desktop Bridge Cold Runtime Timeout (2026-05-21)
+
+## Summary
+The API v1 encrypted desktop relay path could return `504 compute_node_timeout` when the first
+chat request hit a desktop compute node that had registered before its llama.cpp runtime was fully
+initialized.
+
+## Impact
+- Browser calls to `POST /api/v1/chat/completions` could time out after ~30 seconds.
+- Relay selected a registered compute node and queued encrypted API v1 work, but no completion
+  response was posted back in time.
+- Desktop bridge logs showed E2EE payload receipt/decryption without a matching
+  `response_submitted` event before relay timeout.
+
+## Timeline (from supplied logs)
+1. Browser submits `POST /api/v1/chat/completions`.
+2. Relay accepts work via `POST /api/v1/relay/requests`.
+3. Desktop bridge receives/decrypts API v1 E2EE work.
+4. Relay repeatedly polls `POST /api/v1/relay/responses/retrieve` and receives `404`.
+5. Relay returns `504` with `compute_node_timeout`.
+
+## Root cause
+Bridge startup treated model download/verification as ready state. Real runtime initialization
+occurred lazily on first request via `model_manager.get_llm_instance()`, so cold llama.cpp init
+plus generation consumed the distributed timeout budget.
+
+## Why existing tests missed it
+Existing desktop E2EE integration tests used fast fake runtimes that validated encryption/protocol
+behavior, but did not enforce startup readiness semantics tied to real runtime warmup ordering.
+
+## Fix
+- Added `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` to:
+  - ensure model availability,
+  - force runtime creation through `get_llm_instance()`,
+  - require callable non-streaming `create_chat_completion`,
+  - update runtime diagnostics (`runtime_ready`, `runtime_ready_error`).
+- Updated desktop bridge startup to call warmup before emitting `started` and before first
+  register/poll cycle.
+- Warmup failure now emits a startup `error`, returns non-zero, and fails closed without
+  registering/polling for relay work.
+
+## Regression tests added
+- Unit coverage for runtime warmup helper success/failure conditions.
+- Unit coverage asserting bridge warmup occurs before first poll.
+- Unit coverage asserting warmup failures prevent polling and emit startup errors.
+
+## Manual verification (Windows/local relay)
+1. Start relay with distributed compute provider configured.
+2. Start desktop Tauri compute node bridge.
+3. Verify bridge logs show runtime warmup completion before first register/poll.
+4. Send chat message from UI.
+5. Verify relay logs `POST /api/v1/relay/responses` `200` before
+   `/api/v1/chat/completions` returns.
+6. Confirm no `504 compute_node_timeout` and no repeated retrieve-only `404` loop.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -78,6 +78,67 @@ def test_compute_node_runtime_ensure_model_ready_download_failure():
     model_manager.download_model_if_needed.assert_called_once_with()
 
 
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_success():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = False
+    model_manager.download_model_if_needed.return_value = True
+    model_manager.last_compute_diagnostics = {"requested_mode": "auto"}
+    llm = MagicMock()
+    llm.create_chat_completion = MagicMock()
+    model_manager.get_llm_instance.return_value = llm
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    assert model_manager.last_compute_diagnostics["runtime_ready"] is True
+
+
+@pytest.mark.parametrize(
+    "manager_setup",
+    [
+        lambda manager: setattr(manager, "get_llm_instance", None),
+        lambda manager: setattr(manager.get_llm_instance, "return_value", None),
+    ],
+)
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_failures(manager_setup):
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = False
+    model_manager.download_model_if_needed.return_value = True
+    model_manager.last_compute_diagnostics = {"requested_mode": "auto"}
+    manager_setup(model_manager)
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_compute_diagnostics["runtime_ready"] is False
+
+
+def test_compute_node_runtime_ensure_api_v1_runtime_ready_rejects_non_callable_completion():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = False
+    model_manager.download_model_if_needed.return_value = True
+    model_manager.last_compute_diagnostics = {"requested_mode": "auto"}
+    model_manager.get_llm_instance.return_value = object()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_compute_diagnostics["runtime_ready_error"] == (
+        "missing_create_chat_completion"
+    )
+
+
 def test_compute_node_runtime_polling_thread_delegates_to_relay():
     relay_client = MagicMock()
     relay_client.poll_relay_continuously = MagicMock()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -69,6 +69,9 @@ class FakeRuntime:
     def ensure_model_ready(self):
         return True
 
+    def ensure_api_v1_runtime_ready(self):
+        return self.ensure_model_ready()
+
     def register_and_poll_once(self):
         if self._responses:
             return self._responses.pop(0)
@@ -364,6 +367,9 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
         def ensure_model_ready(self):
             return False
 
+        def ensure_api_v1_runtime_ready(self):
+            return self.ensure_model_ready()
+
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRuntime)
 
     args = SimpleNamespace(
@@ -377,7 +383,7 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     assert status == 1
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload['type'] == 'error'
-    assert 'failed to initialize model runtime' in payload['message']
+    assert 'failed to warm API v1 model runtime' in payload['message']
 
 
 def test_run_allows_runtime_reexec_when_cuda_runtime_is_repaired(capsys, monkeypatch):
@@ -919,6 +925,9 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
         def ensure_model_ready(self):
             return True
 
+        def ensure_api_v1_runtime_ready(self):
+            return self.ensure_model_ready()
+
         def register_and_poll_once(self):
             return {'next_ping_in_x_seconds': 0}
 
@@ -1108,6 +1117,9 @@ class ComputeNodeRuntime:
     def ensure_model_ready(self):
         return True
 
+    def ensure_api_v1_runtime_ready(self):
+        return self.ensure_model_ready()
+
     def register_and_poll_once(self):
         return {"next_ping_in_x_seconds": 1}
 
@@ -1215,3 +1227,59 @@ def test_relay_response_summary_handles_non_dict_payloads():
 
 def test_relay_error_message_normalizes_non_string_truthy_values():
     assert compute_node_bridge._relay_error_message({"error": 503}) == "503"
+
+
+def test_bridge_warms_runtime_before_first_poll(monkeypatch):
+    events = []
+    calls = []
+
+    class OrderedRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            return True
+
+        def register_and_poll_once(self):
+            calls.append("poll")
+            return {"next_ping_in_x_seconds": 0, "error": None}
+
+    _install_fake_runtime_module(monkeypatch, OrderedRuntime)
+    monkeypatch.setattr(compute_node_bridge, "emit", lambda payload: events.append(payload))
+    monkeypatch.setattr(compute_node_bridge, "stop_requested", lambda: len(events) >= 2)
+    monkeypatch.setattr(compute_node_bridge.time, "sleep", lambda _seconds: None)
+
+    result = compute_node_bridge.run(
+        compute_node_bridge.argparse.Namespace(
+            model="/tmp/model.gguf", mode="auto", relay_url="https://token.place", relay_port=None
+        )
+    )
+    assert result == 0
+    assert calls[0] == "warm"
+    assert "poll" in calls[1:]
+
+
+def test_bridge_does_not_poll_when_runtime_warmup_fails(monkeypatch):
+    events = []
+
+    class FailedWarmRuntime(FakeRuntime):
+        def __init__(self, config):
+            super().__init__(config)
+            self.polled = 0
+
+        def ensure_api_v1_runtime_ready(self):
+            return False
+
+        def register_and_poll_once(self):
+            self.polled += 1
+            return super().register_and_poll_once()
+
+    _install_fake_runtime_module(monkeypatch, FailedWarmRuntime)
+    monkeypatch.setattr(compute_node_bridge, "emit", lambda payload: events.append(payload))
+
+    result = compute_node_bridge.run(
+        compute_node_bridge.argparse.Namespace(
+            model="/tmp/model.gguf", mode="auto", relay_url="https://token.place", relay_port=None
+        )
+    )
+    assert result == 1
+    assert events[0]["type"] == "error"
+    assert events[0]["message"] == "failed to warm API v1 model runtime"

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -296,6 +296,48 @@ class ComputeNodeRuntime:
         _log_error("Failed to download or verify model")
         return False
 
+    def ensure_api_v1_runtime_ready(self) -> bool:
+        """Warm the API v1 runtime and verify non-streaming completion support."""
+
+        if not self.ensure_model_ready():
+            return False
+
+        get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
+        if not callable(get_llm_instance):
+            _log_error("Model manager missing callable get_llm_instance for API v1 runtime warmup")
+            diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+            if isinstance(diagnostics, dict):
+                diagnostics["runtime_ready"] = False
+                diagnostics["runtime_ready_error"] = "missing_get_llm_instance"
+            return False
+
+        llm_runtime = get_llm_instance()
+        if llm_runtime is None:
+            _log_error("API v1 runtime warmup failed: get_llm_instance returned None")
+            diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+            if isinstance(diagnostics, dict):
+                diagnostics["runtime_ready"] = False
+                diagnostics["runtime_ready_error"] = "runtime_unavailable"
+            return False
+
+        create_chat_completion = getattr(llm_runtime, "create_chat_completion", None)
+        if not callable(create_chat_completion):
+            _log_error(
+                "API v1 runtime warmup failed: runtime missing callable create_chat_completion"
+            )
+            diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+            if isinstance(diagnostics, dict):
+                diagnostics["runtime_ready"] = False
+                diagnostics["runtime_ready_error"] = "missing_create_chat_completion"
+            return False
+
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        if isinstance(diagnostics, dict):
+            diagnostics["runtime_ready"] = True
+            diagnostics["runtime_ready_error"] = None
+        _log_info("API v1 runtime warmed and ready for non-streaming completions")
+        return True
+
     def start_relay_polling(self) -> threading.Thread:
         """Start relay polling in a background thread and return the thread."""
 


### PR DESCRIPTION
### Motivation
- The desktop compute-node bridge declared readiness before the llama runtime was fully initialized, causing the first API v1 E2EE request to pay cold runtime initialization and time out (relay 504 / `compute_node_timeout`).
- The intent is to ensure the desktop bridge only registers/polls once it can actually serve non-streaming API v1 completions, and to fail closed with a clear error if warmup fails.

### Description
- Add `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` to force model warmup by calling `get_llm_instance()`, verify a callable `create_chat_completion`, and update `last_compute_diagnostics` with `runtime_ready`/`runtime_ready_error`. (file: `utils/compute_node_runtime.py`)
- Require the desktop bridge to call the new warmup helper before emitting the `started` event and before entering the register/poll loop, and emit an error + exit nonzero on warmup failure. (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Add unit tests covering successful and failing warmup paths and diagnostics updates. (file: `tests/unit/test_compute_node_runtime.py`)
- Add unit tests asserting the bridge warms the runtime before the first poll and that warmup failure prevents registration/polling and emits a startup error. (file: `tests/unit/test_desktop_compute_node_bridge.py`)
- Add outage documentation describing the incident, root cause, and remediation. (file: `outages/2026-05-21-api-v1-desktop-bridge-cold-runtime-timeout.md`)

### Testing
- Ran targeted unit and integration suites: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_api_v1_compute_provider.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`; these tests passed in this environment.
- `pre-commit run --all-files` was executed but the repository-wide `run-checks` hook failed in this environment during full-suite collection due to a missing test dependency (`pkg_resources`) in `tests/unit/test_dependency_audit.py`, which is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd009e76c832fbd18df0f693abf5b)