### PR TITLE
docs: fix Windows virtualenv activation paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ chat as a primary path or fallback chain. Desktop local prompt smoke-test stream
    ```powershell
    .\.venv\Scripts\Activate.ps1
    ```
+   If PowerShell activation fails because scripts are disabled, run:
+   ```powershell
+   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   ```
+   Windows (Command Prompt):
+   ```bat
+   .\.venv\Scripts\activate.bat
+   ```
    Linux/macOS:
    ```bash
    source .venv/bin/activate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,15 @@ chat as a primary path or fallback chain. Desktop local prompt smoke-test stream
 
 2. Create and activate a Python virtual environment:
    ```bash
-   python -m venv env
-   # Windows
-   env\Scripts\activate
-   # Linux/macOS
-   source env/bin/activate
+   python -m venv .venv
+   ```
+   Windows (PowerShell):
+   ```powershell
+   .\.venv\Scripts\Activate.ps1
+   ```
+   Linux/macOS:
+   ```bash
+   source .venv/bin/activate
    ```
 
 3. Install Python dependencies:

--- a/README.md
+++ b/README.md
@@ -419,11 +419,19 @@ source .venv/bin/activate
 
 #### windows
 
-```sh
-.\env\Scripts\activate
+PowerShell:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
 ```
 
-If this command doesn't work (e.g. `Activate.ps1 cannot be loaded because running scripts is disabled on this system`), you may have to run the following command in an Administrator PowerShell session:
+Command Prompt:
+
+```bat
+.\.venv\Scripts\activate.bat
+```
+
+If PowerShell activation doesn't work (e.g. `Activate.ps1 cannot be loaded because running scripts is disabled on this system`), you may have to run the following command in an Administrator PowerShell session:
 
 ```sh
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser

--- a/README.md
+++ b/README.md
@@ -431,9 +431,9 @@ Command Prompt:
 .\.venv\Scripts\activate.bat
 ```
 
-If PowerShell activation doesn't work (e.g. `Activate.ps1 cannot be loaded because running scripts is disabled on this system`), you may have to run the following command in an Administrator PowerShell session:
+If PowerShell activation doesn't work (e.g. `Activate.ps1 cannot be loaded because running scripts is disabled on this system`), run the following in PowerShell (no administrator rights required for `-Scope CurrentUser`):
 
-```sh
+```powershell
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 


### PR DESCRIPTION
## Summary
- Correct README Windows activation: use `.venv` (not `env`) and document PowerShell (`Activate.ps1`) and Command Prompt (`activate.bat`) entrypoints.
- Align CONTRIBUTING.md with the same `.venv` layout used elsewhere in the repo (README create step, `.gitignore`, `docs/relay-deploy.md`).
## Problem
Setup docs told readers to create a venv at `.venv` but activate from `env\Scripts\activate` on Windows. That mismatch breaks copy-paste setup on Windows and disagreed with the documented Unix path (`source .venv/bin/activate`).
## Test plan
- [ ] On Windows PowerShell: `python -m venv .venv` then `.\.venv\Scripts\Activate.ps1` — prompt shows `(.venv)`.
- [ ] On Windows cmd: `.\.venv\Scripts\activate.bat` — prompt shows `(.venv)`.
- [ ] On Linux/macOS: `source .venv/bin/activate` still works unchanged.
- [ ] CONTRIBUTING steps match README for create + activate.