### PR TITLE
Enforce production rate-limit storage backend (TOKENPLACE_RATE_LIMIT_STORAGE_URI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 | SERVICE_NAME    | token.place  | Service identifier returned by health endpoints (whitespace-only overrides
 |                 |              | fall back to `token.place`)                                             |
 | API_DAILY_QUOTA | 1000/day     | Per-IP daily request quota                                        |
+| TOKENPLACE_RATE_LIMIT_STORAGE_URI | (empty) | Flask-Limiter backend URI. Required in `production`; optional in local development. |
 | USE_MOCK_LLM    | 0            | Use mock LLM instead of downloading a model (`1` to enable)        |
 | TOKEN_PLACE_ENV | development  | Deployment environment (`development`, `testing`, `production`)    |
 | CONTENT_MODERATION_MODE | disabled     | Set to `block` to enable request filtering before inference           |
@@ -89,6 +90,10 @@ retry through a Cloudflare-hosted relay whenever the primary endpoint is unreach
 
 Set `TOKEN_PLACE_RELAY_CLOUDFLARE_URLS` (or `TOKEN_PLACE_RELAY_CLOUDFLARE_URL` for a single
 endpoint) so `server.py` can fail over to a Cloudflare tunnel when the local relays are down.
+
+Set `TOKENPLACE_RATE_LIMIT_STORAGE_URI` in production so Flask-Limiter uses persistent shared storage
+(for example `redis://redis:6379/0`). When `TOKEN_PLACE_ENV=production` and this value is missing,
+startup fails fast to prevent accidental in-memory rate-limit state.
 
 #### Configuration precedence
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,6 +10,34 @@ from prometheus_flask_exporter import PrometheusMetrics
 from api.v1 import routes as v1_routes
 from api.v2 import routes as v2_routes
 
+RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
+
+
+def _token_place_env() -> str:
+    """Return the normalized deployment environment name."""
+
+    return (os.environ.get("TOKEN_PLACE_ENV", "development") or "development").strip().lower()
+
+
+def _is_production_env() -> bool:
+    return _token_place_env() == "production"
+
+
+def _resolve_rate_limit_storage_uri() -> str | None:
+    """Return the limiter storage URI while enforcing production guardrails."""
+
+    storage_uri = (os.environ.get(RATE_LIMIT_STORAGE_URI_ENV, "") or "").strip()
+    if storage_uri:
+        return storage_uri
+
+    if _is_production_env():
+        raise RuntimeError(
+            f"{RATE_LIMIT_STORAGE_URI_ENV} must be configured when TOKEN_PLACE_ENV=production. "
+            "Refusing to start relay/API with in-memory rate-limit storage."
+        )
+
+    return None
+
 
 def _build_rate_limit_response(exc: RateLimitExceeded):
     """Return an OpenAI-style JSON error response for rate limit breaches."""
@@ -40,14 +68,19 @@ def _build_rate_limit_response(exc: RateLimitExceeded):
 def init_app(app):
     """Initialize the API with the Flask app."""
 
-    limiter = Limiter(
-        get_remote_address,
-        app=app,
-        default_limits=[
+    limiter_kwargs = {
+        "key_func": get_remote_address,
+        "app": app,
+        "default_limits": [
             os.environ.get("API_RATE_LIMIT", "60/hour"),
             os.environ.get("API_DAILY_QUOTA", "1000/day"),
         ],
-    )
+    }
+    storage_uri = _resolve_rate_limit_storage_uri()
+    if storage_uri:
+        limiter_kwargs["storage_uri"] = storage_uri
+
+    limiter = Limiter(**limiter_kwargs)
 
     @app.errorhandler(RateLimitExceeded)
     def _handle_rate_limit(exc: RateLimitExceeded):

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -93,3 +93,43 @@ def test_streaming_chat_completion_requests_are_rate_limited(monkeypatch):
     body = limited_response.get_json()
     assert body is not None
     assert body["error"]["code"] == "rate_limit_exceeded"
+
+@patch.dict(os.environ, {}, clear=True)
+def test_development_allows_default_in_memory_rate_limit_storage():
+    """Development mode should keep local in-memory storage defaults."""
+
+    app = Flask(__name__)
+    init_app(app)
+
+
+@patch.dict(os.environ, {"TOKEN_PLACE_ENV": "production"}, clear=True)
+def test_production_requires_explicit_rate_limit_storage_uri():
+    """Production mode should fail fast when no storage URI is configured."""
+
+    app = Flask(__name__)
+
+    try:
+        init_app(app)
+    except RuntimeError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive assertion path
+        raise AssertionError("Expected RuntimeError for missing production limiter storage")
+
+    assert "TOKENPLACE_RATE_LIMIT_STORAGE_URI" in message
+
+
+@patch.dict(
+    os.environ,
+    {
+        "TOKEN_PLACE_ENV": "production",
+        "TOKENPLACE_RATE_LIMIT_STORAGE_URI": "memory://",
+    },
+    clear=True,
+)
+def test_production_uses_configured_rate_limit_storage_uri():
+    """Production mode should pass configured storage URI to Flask-Limiter."""
+
+    app = Flask(__name__)
+    limiter = init_app(app)
+
+    assert str(limiter._storage_uri) == "memory://"


### PR DESCRIPTION
### Motivation
- Prevent Flask-Limiter from silently falling back to in-memory storage in production by making the storage backend explicit and fail-fast when missing.
- Keep local development friction-free by allowing in-memory defaults when not in `production`.

### Description
- Add `TOKENPLACE_RATE_LIMIT_STORAGE_URI` and helpers (`_token_place_env`, `_is_production_env`, `_resolve_rate_limit_storage_uri`) to `api/__init__.py` and use it to set `Limiter(..., storage_uri=...)`, failing startup when `TOKEN_PLACE_ENV=production` and the URI is absent.
- Rework limiter construction to pass kwargs (`limiter_kwargs`) to `Limiter` without changing existing default limits or endpoint behavior.
- Add unit tests in `tests/unit/test_rate_limit.py` that assert development allows in-memory storage, production without a storage URI raises `RuntimeError`, and production with a configured URI configures the limiter storage.
- Update `README.md` to document `TOKENPLACE_RATE_LIMIT_STORAGE_URI` with a Redis-style example and the production fail-fast guidance.

### Testing
- Ran `pytest -q tests/unit/test_rate_limit.py` and all tests passed (6 passed). 
- Ran a broader `pytest -q tests/unit -x` which surfaced an unrelated environment-dependent error (`ModuleNotFoundError: No module named 'pkg_resources'`) and is not caused by these changes.
- Ran `pre-commit run --all-files` where the `run-checks` hook failed in this execution environment due to heavy bootstrap/missing deps; the targeted unit tests above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe65b781c832f932594812d396c8f)