### PR TITLE
Enforce production relay rate-limit storage guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 |-----------------|--------------|--------------------------------------------------------------------|
 | API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for API requests                                |
 | API_STREAM_RATE_LIMIT | 30/minute   | Per-IP rate limit applied only to streaming chat completions          |
+| TOKENPLACE_RATE_LIMIT_STORAGE_URI | memory:// (dev only) | Flask-Limiter backend URI. Required in production (for example `redis://redis:6379/0`). |
 | SERVICE_NAME    | token.place  | Service identifier returned by health endpoints (whitespace-only overrides
 |                 |              | fall back to `token.place`)                                             |
 | API_DAILY_QUOTA | 1000/day     | Per-IP daily request quota                                        |
@@ -89,6 +90,8 @@ retry through a Cloudflare-hosted relay whenever the primary endpoint is unreach
 
 Set `TOKEN_PLACE_RELAY_CLOUDFLARE_URLS` (or `TOKEN_PLACE_RELAY_CLOUDFLARE_URL` for a single
 endpoint) so `server.py` can fail over to a Cloudflare tunnel when the local relays are down.
+
+Set `TOKENPLACE_RATE_LIMIT_STORAGE_URI` in production to a durable backend (typically Redis) so relay rate limits persist across workers and restarts. Development defaults to in-memory storage for easy local startup.
 
 #### Configuration precedence
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -11,7 +11,44 @@ from api.v1 import routes as v1_routes
 from api.v2 import routes as v2_routes
 
 
+_RATE_LIMIT_STORAGE_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
+
+
+def _resolve_runtime_env() -> str:
+    return (
+        os.environ.get("TOKEN_PLACE_ENV")
+        or os.environ.get("ENVIRONMENT")
+        or "development"
+    ).strip().lower()
+
+
+def _is_production_env(env_name: str) -> bool:
+    return env_name in {"production", "prod"}
+
+
+def _resolve_rate_limit_storage_uri(app=None) -> str:
+    configured = os.environ.get(_RATE_LIMIT_STORAGE_ENV, "").strip()
+    runtime_env = _resolve_runtime_env()
+
+    if configured:
+        return configured
+
+    if _is_production_env(runtime_env):
+        raise RuntimeError(
+            "Rate-limit storage is required in production. "
+            f"Set {_RATE_LIMIT_STORAGE_ENV} to a durable backend URI (for example Redis)."
+        )
+
+    if app is not None:
+        app.logger.warning(
+            "rate_limit.storage.memory_fallback",
+            extra={"environment": runtime_env, "storage_backend": "memory"},
+        )
+    return "memory://"
+
+
 def _build_rate_limit_response(exc: RateLimitExceeded):
+
     """Return an OpenAI-style JSON error response for rate limit breaches."""
 
     rate_limit_description = str(exc.limit.limit)
@@ -43,6 +80,7 @@ def init_app(app):
     limiter = Limiter(
         get_remote_address,
         app=app,
+        storage_uri=_resolve_rate_limit_storage_uri(app),
         default_limits=[
             os.environ.get("API_RATE_LIMIT", "60/hour"),
             os.environ.get("API_DAILY_QUOTA", "1000/day"),

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -93,3 +93,58 @@ def test_streaming_chat_completion_requests_are_rate_limited(monkeypatch):
     body = limited_response.get_json()
     assert body is not None
     assert body["error"]["code"] == "rate_limit_exceeded"
+
+
+@patch.dict(os.environ, {"TOKEN_PLACE_ENV": "development"}, clear=True)
+def test_development_defaults_to_in_memory_rate_limit_storage():
+    """Development mode should default to in-memory limiter storage."""
+
+    app = Flask(__name__)
+    limiter = init_app(app)
+
+    assert limiter._storage_uri == "memory://"
+
+
+@patch.dict(os.environ, {"TOKEN_PLACE_ENV": "production"}, clear=True)
+def test_production_requires_explicit_rate_limit_storage_uri():
+    """Production mode should fail fast when storage configuration is missing."""
+
+    app = Flask(__name__)
+
+    try:
+        init_app(app)
+    except RuntimeError as exc:
+        assert "TOKENPLACE_RATE_LIMIT_STORAGE_URI" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError when production storage URI is missing")
+
+
+@patch.dict(
+    os.environ,
+    {
+        "TOKEN_PLACE_ENV": "production",
+        "TOKENPLACE_RATE_LIMIT_STORAGE_URI": "redis://localhost:6379/5",
+    },
+    clear=True,
+)
+def test_production_uses_configured_rate_limit_storage_uri(monkeypatch):
+    """Production mode should pass configured storage URI to Flask-Limiter."""
+
+    captured = {}
+
+    class DummyLimiter:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def shared_limit(self, *_args, **_kwargs):
+            def _decorator(view_func):
+                return view_func
+
+            return _decorator
+
+    monkeypatch.setattr("api.Limiter", DummyLimiter)
+
+    app = Flask(__name__)
+    init_app(app)
+
+    assert captured["storage_uri"] == "redis://localhost:6379/5"


### PR DESCRIPTION
### Motivation
- Prevent Flask-Limiter from silently using in-memory storage in production, which loses persisted rate-limit state across workers and restarts. 
- Keep local developer ergonomics by allowing an in-memory fallback when running in non-production environments. 
- Provide a loud, deterministic guardrail for production so operators explicitly configure a durable backend. 

### Description
- Add an environment-driven rate-limit storage configuration key `TOKENPLACE_RATE_LIMIT_STORAGE_URI` and runtime helpers (`_resolve_runtime_env`, `_is_production_env`, `_resolve_rate_limit_storage_uri`) in `api/__init__.py`. 
- Initialize `Limiter(..., storage_uri=...)` with the resolved URI so Flask-Limiter never defaults silently to memory in production. 
- Fail fast with a `RuntimeError` when running in production (`TOKEN_PLACE_ENV`/`ENVIRONMENT` set to `production` or `prod`) and no storage URI is provided, while emitting a structured `rate_limit.storage.memory_fallback` warning in development. 
- Update `README.md` to document `TOKENPLACE_RATE_LIMIT_STORAGE_URI` (example: Redis URI) and add unit tests in `tests/unit/test_rate_limit.py` covering development fallback, production guardrail, and configured production URI behavior (the production URI test uses a `DummyLimiter` monkeypatch to avoid installing Redis in CI). 

### Testing
- Ran `pytest -q tests/unit/test_rate_limit.py`, which passed (6 tests). 
- Ran `pre-commit run --all-files`, which failed during the full-suite checks due to an unrelated environment/dependency issue (`ModuleNotFoundError: No module named 'pkg_resources'`) encountered by other unit tests during collection. 
- Running the full unit suite with `pytest -q tests/unit -x` reproduced the unrelated collection error (`pkg_resources` missing), confirming the single failing hook is environment/dependency-related and not caused by the rate-limit changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe65b781c832f932594812d396c8f)