### PR TITLE
🛡️ relay: enforce production Flask-Limiter storage via TOKENPLACE_RATE_LIMIT_STORAGE_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 |-----------------|--------------|--------------------------------------------------------------------|
 | API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for API requests                                |
 | API_STREAM_RATE_LIMIT | 30/minute   | Per-IP rate limit applied only to streaming chat completions          |
+| TOKENPLACE_RATE_LIMIT_STORAGE_URI | (empty in development) | Flask-Limiter storage backend URI. Required in production (for example `redis://:password@redis:6379/0`); development defaults to in-memory storage. |
 | SERVICE_NAME    | token.place  | Service identifier returned by health endpoints (whitespace-only overrides
 |                 |              | fall back to `token.place`)                                             |
 | API_DAILY_QUOTA | 1000/day     | Per-IP daily request quota                                        |

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,6 +10,23 @@ from prometheus_flask_exporter import PrometheusMetrics
 from api.v1 import routes as v1_routes
 from api.v2 import routes as v2_routes
 
+RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
+_PRODUCTION_ENV_VALUES = {"production", "prod"}
+
+
+def _is_production_env() -> bool:
+    token_place_env = os.environ.get("TOKEN_PLACE_ENV", "").strip().lower()
+    generic_env = os.environ.get("ENVIRONMENT", "").strip().lower()
+    return token_place_env in _PRODUCTION_ENV_VALUES or generic_env in _PRODUCTION_ENV_VALUES
+
+
+def _resolve_rate_limit_storage_uri() -> str | None:
+    value = os.environ.get(RATE_LIMIT_STORAGE_URI_ENV, "")
+    trimmed = value.strip()
+    if trimmed:
+        return trimmed
+    return None
+
 
 def _build_rate_limit_response(exc: RateLimitExceeded):
     """Return an OpenAI-style JSON error response for rate limit breaches."""
@@ -40,6 +57,14 @@ def _build_rate_limit_response(exc: RateLimitExceeded):
 def init_app(app):
     """Initialize the API with the Flask app."""
 
+    storage_uri = _resolve_rate_limit_storage_uri()
+    is_production = _is_production_env()
+    if is_production and not storage_uri:
+        raise RuntimeError(
+            f"{RATE_LIMIT_STORAGE_URI_ENV} must be set in production to avoid in-memory "
+            "rate-limit storage."
+        )
+
     limiter = Limiter(
         get_remote_address,
         app=app,
@@ -47,6 +72,7 @@ def init_app(app):
             os.environ.get("API_RATE_LIMIT", "60/hour"),
             os.environ.get("API_DAILY_QUOTA", "1000/day"),
         ],
+        storage_uri=storage_uri,
     )
 
     @app.errorhandler(RateLimitExceeded)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -5,6 +5,7 @@ import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from flask import Flask
 
 from api import init_app
@@ -93,3 +94,34 @@ def test_streaming_chat_completion_requests_are_rate_limited(monkeypatch):
     body = limited_response.get_json()
     assert body is not None
     assert body["error"]["code"] == "rate_limit_exceeded"
+
+
+@patch.dict(os.environ, {"TOKEN_PLACE_ENV": "development"}, clear=True)
+def test_rate_limiter_allows_in_memory_storage_in_development():
+    """Development mode should boot without explicit limiter storage backend."""
+    app = Flask(__name__)
+    limiter = init_app(app)
+    assert limiter is not None
+
+
+@patch.dict(os.environ, {"TOKEN_PLACE_ENV": "production"}, clear=True)
+def test_rate_limiter_requires_storage_uri_in_production():
+    """Production mode should fail fast when limiter storage is not configured."""
+    app = Flask(__name__)
+    with pytest.raises(RuntimeError, match="TOKENPLACE_RATE_LIMIT_STORAGE_URI"):
+        init_app(app)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "TOKEN_PLACE_ENV": "production",
+        "TOKENPLACE_RATE_LIMIT_STORAGE_URI": "memory://",
+    },
+    clear=True,
+)
+def test_rate_limiter_uses_explicit_storage_uri_in_production():
+    """Production mode should accept an explicit limiter storage backend URI."""
+    app = Flask(__name__)
+    limiter = init_app(app)
+    assert limiter._storage_uri == "memory://"


### PR DESCRIPTION
### Motivation
- Prevent the relay from silently falling back to Flask-Limiter in-memory storage in production by requiring an explicit storage backend URI when running in production.
- Preserve local development ergonomics by allowing the existing in-memory fallback when not in production.

### Description
- Add `TOKENPLACE_RATE_LIMIT_STORAGE_URI` environment variable resolution and a production detector that checks `TOKEN_PLACE_ENV` and `ENVIRONMENT` for `production`/`prod` in `api/__init__.py`.
- Fail fast during API initialization when running in production and no `TOKENPLACE_RATE_LIMIT_STORAGE_URI` is provided, to avoid unsafe in-memory rate-limit tracking.
- Pass the resolved `storage_uri` to `Limiter(...)` so production backends (for example `redis://...`) are used when configured.
- Add unit tests in `tests/unit/test_rate_limit.py` covering development boot behavior, production missing-config failure, and production with explicit storage URI, and update `README.md` environment-variable docs to document the new variable.

### Testing
- Ran `pytest tests/unit/test_rate_limit.py -q`, which passed (6 tests, all passed).
- Ran `pre-commit run --all-files`, which failed due to an unrelated environment/test-collection issue (`ModuleNotFoundError: No module named 'pkg_resources'`) surfaced during repo-wide checks.
- Ran `pytest tests/unit -q` which surfaced the same unrelated collection error in other tests; the new rate-limit unit tests themselves passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe65b781c832f932594812d396c8f)