### PR TITLE
Reduce API v1 relay dispatch latency with server-side long-poll

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -378,6 +378,7 @@ def _validate_server_registration():
 
 known_servers = {}
 client_inference_requests = {}
+client_inference_requests_cv = threading.Condition()
 client_responses = {}
 client_responses_lock = threading.Lock()
 streaming_sessions = {}
@@ -387,6 +388,8 @@ stream_lock = threading.Lock()
 IGNORED_LOG_ENDPOINTS = {"livez", "healthz", "metrics"}
 SERVER_STALE_SECONDS_ENV = "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS"
 DEFAULT_SERVER_STALE_SECONDS = 30
+SERVER_POLL_LONG_WAIT_ENV = "TOKENPLACE_API_V1_RELAY_POLL_WAIT_SECONDS"
+DEFAULT_SERVER_POLL_LONG_WAIT_SECONDS = 10.0
 
 
 def _server_ping_age_seconds(last_ping: Any) -> float:
@@ -416,6 +419,51 @@ def _evict_stale_servers() -> list[str]:
         if _unregister_server(server_public_key):
             evicted.append(server_public_key)
     return evicted
+
+
+def _server_poll_long_wait_seconds() -> float:
+    raw = os.environ.get(
+        SERVER_POLL_LONG_WAIT_ENV,
+        str(DEFAULT_SERVER_POLL_LONG_WAIT_SECONDS),
+    )
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_SERVER_POLL_LONG_WAIT_SECONDS
+    if value < 0:
+        return 0.0
+    return value
+
+
+def _pop_next_server_request(public_key: str) -> dict[str, Any] | None:
+    queued_requests = client_inference_requests.get(public_key, [])
+    if not queued_requests:
+        return None
+
+    first_request = None
+
+    def _is_legacy_ciphertext_payload(payload):
+        return all(key in payload for key in ('client_public_key', 'chat_history', 'cipherkey', 'iv'))
+
+    for idx, candidate in enumerate(queued_requests):
+        if bool(candidate.get('e2ee_v1')):
+            first_request = queued_requests.pop(idx)
+            break
+
+    if first_request is None:
+        while queued_requests:
+            candidate = queued_requests[0]
+            if _is_legacy_ciphertext_payload(candidate):
+                first_request = queued_requests.pop(0)
+                break
+            queued_requests.pop(0)
+
+    if first_request is not None and bool(first_request.get('e2ee_v1')):
+        queued_requests[:] = [item for item in queued_requests if bool(item.get('e2ee_v1'))]
+
+    if not queued_requests:
+        client_inference_requests.pop(public_key, None)
+    return first_request
 
 
 def _live_server_diagnostics() -> list[dict[str, Any]]:
@@ -841,43 +889,34 @@ def api_v1_relay_servers_poll():
     if public_key not in known_servers:
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
-    queued_requests = client_inference_requests.get(public_key, [])
-    if not queued_requests:
-        return jsonify({'message': 'No requests available'}), 200
-
     first_request = None
-
-    def _is_legacy_ciphertext_payload(payload):
-        return all(key in payload for key in ('client_public_key', 'chat_history', 'cipherkey', 'iv'))
-
-    # Prefer explicit API v1 envelopes when both API v1 and legacy ciphertext payloads are queued.
-    for idx, candidate in enumerate(queued_requests):
-        if bool(candidate.get('e2ee_v1')):
-            first_request = queued_requests.pop(idx)
-            break
+    wait_timeout = _server_poll_long_wait_seconds()
+    poll_started = time.time()
+    with client_inference_requests_cv:
+        first_request = _pop_next_server_request(public_key)
+        if first_request is None and wait_timeout > 0:
+            client_inference_requests_cv.wait(timeout=wait_timeout)
+            first_request = _pop_next_server_request(public_key)
 
     if first_request is None:
-        while queued_requests:
-            candidate = queued_requests[0]
-            if _is_legacy_ciphertext_payload(candidate):
-                first_request = queued_requests.pop(0)
-                break
-            queued_requests.pop(0)
-
-
-    if first_request is not None and bool(first_request.get('e2ee_v1')):
-        # When an API v1 envelope is available, keep API v1-only semantics by dropping
-        # legacy ciphertext payloads left in the same queue.
-        queued_requests[:] = [item for item in queued_requests if bool(item.get('e2ee_v1'))]
-
-    if first_request is None:
-        if not queued_requests:
-            client_inference_requests.pop(public_key, None)
         return jsonify({'message': 'No requests available'}), 200
 
-    if not queued_requests:
-        client_inference_requests.pop(public_key, None)
-
+    queued_at = first_request.get("relay_request_queued_at")
+    dispatched_at = time.time()
+    queue_wait_ms = None
+    if isinstance(queued_at, (int, float)):
+        queue_wait_ms = round(max(dispatched_at - queued_at, 0.0) * 1000.0, 3)
+    LOGGER.info(
+        "relay.api_v1.request_dispatched",
+        extra={
+            "server_public_key": public_key,
+            "request_id": first_request.get("request_id"),
+            "request_queued_at_unix": queued_at,
+            "request_dispatched_at_unix": round(dispatched_at, 6),
+            "queue_wait_ms": queue_wait_ms,
+            "poll_wait_ms": round(max(dispatched_at - poll_started, 0.0) * 1000.0, 3),
+        },
+    )
     return jsonify(first_request), 200
 
 
@@ -900,7 +939,19 @@ def api_v1_relay_requests():
         return jsonify({'error': {'message': 'Missing client public key', 'code': 400}}), 400
 
     envelope['e2ee_v1'] = True
-    client_inference_requests.setdefault(server_public_key, []).append(envelope)
+    envelope["relay_request_queued_at"] = time.time()
+    with client_inference_requests_cv:
+        client_inference_requests.setdefault(server_public_key, []).append(envelope)
+        client_inference_requests_cv.notify_all()
+    LOGGER.info(
+        "relay.api_v1.request_queued",
+        extra={
+            "server_public_key": server_public_key,
+            "request_id": envelope.get("request_id"),
+            "request_queued_at_unix": round(envelope["relay_request_queued_at"], 6),
+            "queue_depth": len(client_inference_requests.get(server_public_key, [])),
+        },
+    )
     return jsonify({'message': 'Request received'}), 200
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1313,6 +1313,58 @@ def test_api_v1_poll_skips_legacy_queue_items_and_claims_e2ee_only(client):
     assert DUMMY_SERVER_PUB_KEY not in client_inference_requests
 
 
+def test_api_v1_poll_long_wait_dispatches_immediately_when_work_arrives(client, monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0.25")
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    register = client.post('/api/v1/relay/servers/register', json=server_payload)
+    assert register.status_code == 200
+
+    result: dict[str, object] = {}
+
+    def _poll() -> None:
+        with app.test_client() as thread_client:
+            poll_response = thread_client.post('/api/v1/relay/servers/poll', json=server_payload)
+            result["status"] = poll_response.status_code
+            result["payload"] = poll_response.get_json()
+
+    poll_thread = threading.Thread(target=_poll, daemon=True)
+    poll_thread.start()
+    time.sleep(0.05)
+
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-long-poll-immediate',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+    assert queued.status_code == 200
+    poll_thread.join(timeout=1.0)
+    assert not poll_thread.is_alive()
+    assert result["status"] == 200
+    payload = result["payload"]
+    assert isinstance(payload, dict)
+    assert payload["request_id"] == "req-long-poll-immediate"
+    assert "relay_request_queued_at" in payload
+
+
+def test_api_v1_poll_long_wait_timeout_returns_no_requests(client, monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0.05")
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    register = client.post('/api/v1/relay/servers/register', json=server_payload)
+    assert register.status_code == 200
+
+    started = time.time()
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    elapsed = time.time() - started
+    assert poll.status_code == 200
+    assert poll.get_json() == {'message': 'No requests available'}
+    assert elapsed >= 0.04
+
+
 def test_api_v1_relay_response_plaintext_not_stored(client):
     client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -693,6 +693,16 @@ class RelayClient:
         return response.json()
 
     @staticmethod
+    def _api_v1_poll_timeout_seconds(register_wait: Any, request_timeout: float) -> float:
+        if isinstance(register_wait, bool) or not isinstance(register_wait, (int, float)):
+            wait = float(request_timeout)
+        else:
+            wait = float(register_wait)
+        if not math.isfinite(wait) or wait < 0:
+            wait = float(request_timeout)
+        return max(float(request_timeout), wait + 1.0)
+
+    @staticmethod
     def _build_api_v1_url(relay_url: str, route: str) -> str:
         """Build API v1 URLs without duplicating a pre-existing /api/v1 suffix."""
         base = relay_url.rstrip("/")
@@ -723,7 +733,7 @@ class RelayClient:
 
                 request_kwargs: Dict[str, Any] = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
-                    'timeout': self._request_timeout,
+                    'timeout': self._api_v1_poll_timeout_seconds(register_wait, self._request_timeout),
                 }
                 headers = self._auth_headers()
                 if headers:


### PR DESCRIPTION
### Motivation
- Reduce avoidable relay->compute-node dispatch latency caused by fixed poll cadence so queued API v1 work is delivered to waiting compute nodes promptly. 
- Preserve API v1 E2EE envelope format, existing heartbeat semantics, and backwards compatibility with legacy polling clients. 
- Provide observability so queue wait durations can be measured without exposing plaintext payloads.

### Description
- Add a server-side condition variable and long-poll timeout controlled by `TOKENPLACE_API_V1_RELAY_POLL_WAIT_SECONDS` (default `10.0s`) and implement `_pop_next_server_request` to preserve existing API v1 vs legacy selection semantics. 
- Make `/api/v1/relay/servers/poll` perform a wait (long-poll) that returns immediately if work arrives, and fall back to the existing empty/heartbeat response on timeout. 
- When enqueuing via `/api/v1/relay/requests` record `relay_request_queued_at`, notify waiting polls, and emit structured logs for `request_queued_at_unix`, `request_dispatched_at_unix`, `queue_wait_ms`, `poll_wait_ms`, `server_public_key`, and `request_id`. 
- Update the compute-node relay client poll timeout logic to adapt request timeouts to the relay-advertised wait value (use `wait + 1s` bounded by existing timeout) so long-poll requests do not fail prematurely. 
- Add tests for immediate dispatch to an already-waiting poll and for timeout/no-work behavior, and adjust the long-poll test to use a separate `app.test_client()` inside the polling thread to avoid Flask context issues.

### Testing
- Ran focused relay route tests: `pytest -q tests/test_relay.py -k 'api_v1_poll_long_wait or api_v1_relay_route_contract_e2ee_flow or api_v1_poll_skips_legacy_queue_items_and_claims_e2ee_only'` and all selected tests passed. 
- Ran relay-client unit tests: `pytest -q tests/unit/test_relay_client.py` and the suite passed (all relevant tests passed). 
- Ran `pre-commit run --all-files` as a sanity check but the repository-level hook `run-checks` invoked the full project test runner and failed in this environment due to unrelated environment/setup steps (Playwright/Chromium and a broader Python Unit Tests run), not due to the changes in this PR. 
- Manual verification guidance: start `relay.py` and a compute node, submit an API v1 request to `/api/v1/relay/requests`, and observe the compute-node poll return immediately (and logs containing `queue_wait_ms`) rather than waiting for the old poll cadence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff2915130832f936454f72cba2fe3)