### PR TITLE
Reduce API v1 relay dispatch latency with condition-based long-poll

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -378,11 +378,24 @@ def _validate_server_registration():
 
 known_servers = {}
 client_inference_requests = {}
+client_inference_requests_condition = threading.Condition()
 client_responses = {}
 client_responses_lock = threading.Lock()
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
+
+
+def _relay_server_poll_wait_timeout_seconds() -> float:
+    raw = os.environ.get("TOKENPLACE_API_V1_RELAY_POLL_WAIT_TIMEOUT_SECONDS", "10")
+    try:
+        return max(float(raw), 0.0)
+    except (TypeError, ValueError):
+        LOGGER.warning(
+            "relay.api_v1.poll_wait_timeout.invalid",
+            extra={"configured_value": raw, "fallback_seconds": 10.0},
+        )
+        return 10.0
 
 IGNORED_LOG_ENDPOINTS = {"livez", "healthz", "metrics"}
 SERVER_STALE_SECONDS_ENV = "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS"
@@ -841,7 +854,15 @@ def api_v1_relay_servers_poll():
     if public_key not in known_servers:
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
-    queued_requests = client_inference_requests.get(public_key, [])
+    wait_timeout_seconds = _relay_server_poll_wait_timeout_seconds()
+    poll_started_at = time.time()
+
+    with client_inference_requests_condition:
+        queued_requests = client_inference_requests.get(public_key, [])
+        if not queued_requests and wait_timeout_seconds > 0:
+            client_inference_requests_condition.wait(timeout=wait_timeout_seconds)
+            queued_requests = client_inference_requests.get(public_key, [])
+
     if not queued_requests:
         return jsonify({'message': 'No requests available'}), 200
 
@@ -878,6 +899,19 @@ def api_v1_relay_servers_poll():
     if not queued_requests:
         client_inference_requests.pop(public_key, None)
 
+    queue_wait_ms = int(max((time.time() - poll_started_at) * 1000, 0))
+    LOGGER.info(
+        "relay.api_v1.request_dispatched",
+        extra={
+            "request_id": first_request.get("request_id"),
+            "server_public_key": public_key,
+            "compute_node_selected": public_key,
+            "request_queued_at": first_request.get("queued_at"),
+            "request_dispatched_at": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
+            "queue_wait_ms": queue_wait_ms,
+            "queue_depth_after_dispatch": len(queued_requests),
+        },
+    )
     return jsonify(first_request), 200
 
 
@@ -900,7 +934,10 @@ def api_v1_relay_requests():
         return jsonify({'error': {'message': 'Missing client public key', 'code': 400}}), 400
 
     envelope['e2ee_v1'] = True
-    client_inference_requests.setdefault(server_public_key, []).append(envelope)
+    envelope['queued_at'] = datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+    with client_inference_requests_condition:
+        client_inference_requests.setdefault(server_public_key, []).append(envelope)
+        client_inference_requests_condition.notify_all()
     return jsonify({'message': 'Request received'}), 200
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1384,6 +1384,83 @@ def test_api_v1_register_does_not_dequeue_requests(client):
     assert DUMMY_SERVER_PUB_KEY not in client_inference_requests or len(client_inference_requests[DUMMY_SERVER_PUB_KEY]) == 0
 
 
+def test_api_v1_poll_long_poll_dispatches_queued_work_immediately(client, monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_RELAY_POLL_WAIT_TIMEOUT_SECONDS", "1.5")
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    poll_result = {}
+
+    def _poll_in_background():
+        with relay_module.app.test_client() as bg_client:
+            started = time.time()
+            response = bg_client.post('/api/v1/relay/servers/poll', json=server_payload)
+            poll_result['elapsed_seconds'] = time.time() - started
+            poll_result['status_code'] = response.status_code
+            poll_result['payload'] = response.get_json()
+
+    poll_thread = threading.Thread(target=_poll_in_background)
+    poll_thread.start()
+    time.sleep(0.2)
+
+    request_payload = {
+        'request_id': 'req-long-poll-dispatch',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    }
+    assert client.post('/api/v1/relay/requests', json=request_payload).status_code == 200
+
+    poll_thread.join(timeout=3)
+    assert not poll_thread.is_alive()
+    assert poll_result['status_code'] == 200
+    assert poll_result['payload']['request_id'] == 'req-long-poll-dispatch'
+    assert poll_result['elapsed_seconds'] < 1.0
+
+
+def test_api_v1_poll_long_poll_timeout_returns_empty_message(client, monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_API_V1_RELAY_POLL_WAIT_TIMEOUT_SECONDS", "0.2")
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    started = time.time()
+    response = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    elapsed = time.time() - started
+
+    assert response.status_code == 200
+    assert response.get_json() == {'message': 'No requests available'}
+    assert elapsed >= 0.15
+
+
+def test_api_v1_poll_preserves_fifo_order_across_multiple_requests(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    for request_id in ('req-order-1', 'req-order-2'):
+        payload = {
+            'request_id': request_id,
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'version': 1,
+            'client_public_key': DUMMY_CLIENT_PUB_KEY,
+            'server_public_key': DUMMY_SERVER_PUB_KEY,
+            'chat_history': f'ciphertext-{request_id}',
+            'cipherkey': f'cipherkey-{request_id}',
+            'iv': f'iv-{request_id}',
+        }
+        assert client.post('/api/v1/relay/requests', json=payload).status_code == 200
+
+    first = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    second = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.get_json()['request_id'] == 'req-order-1'
+    assert second.get_json()['request_id'] == 'req-order-2'
+
+
 def test_api_v1_poll_requires_registration_token_when_configured(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     known_servers[DUMMY_SERVER_PUB_KEY] = {


### PR DESCRIPTION
### Motivation
- Compute nodes polling `/api/v1/relay/servers/poll` at a fixed cadence caused avoidable dispatch latency; queued work should be delivered immediately to an already-open poll.
- Keep API v1 E2EE semantics unchanged while reducing relay-to-compute-node time-to-dispatch.

### Description
- Add a shared `threading.Condition` (`client_inference_requests_condition`) to coordinate enqueue/poll so `/api/v1/relay/servers/poll` can wait for work instead of busy polling.  The server will wait up to a configurable timeout before returning an empty heartbeat. (`relay.py`)
- Make poll wait timeout configurable via `TOKENPLACE_API_V1_RELAY_POLL_WAIT_TIMEOUT_SECONDS` with a safe numeric fallback. (`relay.py`)
- Stamp queued envelopes with `queued_at` when enqueued and notify waiting polls on enqueue. (`relay.py`)
- Emit structured dispatch logs including `request_queued_at`, `request_dispatched_at`, `queue_wait_ms`, `compute_node_selected`, and `queue_depth_after_dispatch` for observability without leaking plaintext. (`relay.py`)
- Add tests that assert an already-open poll receives work immediately when a request is queued, that a poll with no work returns the heartbeat after timeout, and that FIFO ordering is preserved across multiple requests. (`tests/test_relay.py`)

### Testing
- Ran targeted relay tests: `pytest -q tests/test_relay.py -k "long_poll or route_contract_e2ee_flow or preserves_fifo_order"` and all selected tests passed (4 passed, 0 failed).
- Ran full relay test file: `pytest -q tests/test_relay.py`, which exercises a broader set of relay/relay-client behavior; this run exposed 5 failing relay-client tests unrelated to the new poll/wait logic in this change (failures observed in API v1 relay-client model/error-path assertions).
- Executed repository checks via `pre-commit run --all-files`; the hook invoked the project test runner and reported a Python unit test failure (consistent with the full-relay test failures above), so the pre-commit run failed.

If desired I can follow up to (1) investigate and fix the failing relay-client tests if they are impacted by this patch, or (2) further harden long-poll behavior (metrics, timeouts) per review feedback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff2915130832f936454f72cba2fe3)