### PR TITLE
Add explicit pending semantics for API v1 relay response retrieval

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -278,6 +278,10 @@ class DistributedApiV1ComputeProvider:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
+            if retrieve_response.status_code == 202:
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
+                continue
+
             if retrieve_response.status_code != 200:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue

--- a/client.py
+++ b/client.py
@@ -287,7 +287,12 @@ class ChatClient:
                     },
                     timeout=REQUEST_TIMEOUT,
                 )
-                if response.status_code == 200:
+                if response.status_code == 202:
+                    logger.debug(
+                        "API v1 relay response still pending for request_id=%s.",
+                        request_id,
+                    )
+                elif response.status_code == 200:
                     data = response.json()
                     if 'chat_history' in data and 'iv' in data and 'cipherkey' in data:
                         encrypted_chat_history_b64 = data['chat_history']

--- a/relay.py
+++ b/relay.py
@@ -379,6 +379,7 @@ def _validate_server_registration():
 known_servers = {}
 client_inference_requests = {}
 client_responses = {}
+pending_response_request_ids = {}
 client_responses_lock = threading.Lock()
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
@@ -805,6 +806,11 @@ def _extract_ciphertext_envelope(payload, *, require_server_key=False):
 def _queue_client_response(client_public_key, envelope):
     """Queue an encrypted response while preserving per-request retrieval."""
     with client_responses_lock:
+        request_id = envelope.get('request_id')
+        if request_id:
+            pending_ids = pending_response_request_ids.get(client_public_key)
+            if pending_ids is not None:
+                pending_ids.discard(request_id)
         existing = client_responses.get(client_public_key)
         if existing is None:
             client_responses[client_public_key] = envelope
@@ -843,6 +849,22 @@ def _pop_client_response(client_public_key, request_id=None):
         if request_id and queued.get('request_id') != request_id:
             return None
         return client_responses.pop(client_public_key)
+
+
+def _mark_response_pending(client_public_key, request_id):
+    """Track request ids with outstanding responses so pending retrieval returns 202."""
+    if not request_id:
+        return
+    with client_responses_lock:
+        pending_response_request_ids.setdefault(client_public_key, set()).add(request_id)
+
+
+def _is_response_pending(client_public_key, request_id):
+    """Return whether a request id is still pending completion."""
+    if not request_id:
+        return False
+    with client_responses_lock:
+        return request_id in pending_response_request_ids.get(client_public_key, set())
 
 
 @app.route('/api/v1/relay/servers/register', methods=['POST'])
@@ -944,6 +966,7 @@ def api_v1_relay_requests():
         return jsonify({'error': {'message': 'Missing client public key', 'code': 400}}), 400
 
     envelope['e2ee_v1'] = True
+    _mark_response_pending(envelope.get('client_public_key'), envelope.get('request_id'))
     queued_at = time.time()
     envelope['_queued_at'] = queued_at
     with client_inference_requests_changed:
@@ -993,6 +1016,13 @@ def api_v1_relay_responses_retrieve():
     client_public_key = data['client_public_key']
     response = _pop_client_response(client_public_key, data.get('request_id'))
     if response is None:
+        request_id = data.get('request_id')
+        if _is_response_pending(client_public_key, request_id):
+            LOGGER.debug(
+                "relay.api_v1.response_pending",
+                extra={"client_public_key": client_public_key, "request_id": request_id},
+            )
+            return jsonify({'status': 'pending', 'request_id': request_id}), 202
         return jsonify({'error': {'message': 'No response available for the given public key', 'code': 404}}), 404
 
     return jsonify(response), 200

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -20,6 +20,7 @@ from relay import (
     known_servers,
     client_inference_requests,
     client_responses,
+    pending_response_request_ids,
     streaming_sessions,
     streaming_sessions_by_client,
 )
@@ -40,6 +41,7 @@ def client():
     known_servers.clear()
     client_inference_requests.clear()
     client_responses.clear()
+    pending_response_request_ids.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
 
@@ -55,6 +57,7 @@ def client():
     known_servers.clear()
     client_inference_requests.clear()
     client_responses.clear()
+    pending_response_request_ids.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
 
@@ -1215,6 +1218,28 @@ def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(clie
     assert retrieved.status_code == 200
     assert retrieved.get_json()['request_id'] == 'req-1'
     assert DUMMY_CLIENT_PUB_KEY not in client_responses
+
+
+def test_api_v1_response_retrieve_returns_pending_for_inflight_request_id(client):
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    request_payload = {
+        'request_id': 'req-pending',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    }
+    assert client.post('/api/v1/relay/requests', json=request_payload).status_code == 200
+
+    pending = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-pending'},
+    )
+    assert pending.status_code == 202
+    assert pending.get_json()['status'] == 'pending'
 
 
 def test_api_v1_relay_plaintext_messages_not_stored(client):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -84,7 +84,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
             retrieve_calls.append(copy.deepcopy(json))
             retrieve_attempt["count"] += 1
             if retrieve_attempt["count"] == 1:
-                return _FakeResponse(503, {"error": "busy"})
+                return _FakeResponse(202, {"status": "pending"})
             if retrieve_attempt["count"] == 2:
                 return _FakeResponse(200, ValueError("not json"))
             if retrieve_attempt["count"] == 3:

--- a/tests/unit/test_chat_client.py
+++ b/tests/unit/test_chat_client.py
@@ -104,3 +104,29 @@ def test_retrieve_response_decodes_api_v1_response_for_request_id():
         json={'client_public_key': client.public_key_b64, 'request_id': 'req-1'},
         timeout=REQUEST_TIMEOUT,
     )
+
+
+def test_retrieve_response_retries_when_status_is_pending():
+    client = ChatClient('http://test', relay_port=5000)
+    encrypted_response = {
+        'chat_history': base64.b64encode(b'ciphertext').decode('utf-8'),
+        'cipherkey': base64.b64encode(b'cipherkey').decode('utf-8'),
+        'iv': base64.b64encode(b'iv').decode('utf-8'),
+    }
+    decrypted_envelope = {
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'request_id': 'req-1',
+        'api_v1_response': {'message': {'role': 'assistant', 'content': 'ok'}},
+    }
+    with patch('client.requests.post') as m_post, patch('client.decrypt') as m_dec, patch('client.time.sleep'):
+        pending_resp = MagicMock(status_code=202)
+        pending_resp.json.return_value = {'status': 'pending'}
+        done_resp = MagicMock(status_code=200)
+        done_resp.json.return_value = encrypted_response
+        m_post.side_effect = [pending_resp, done_resp]
+        m_dec.return_value = json.dumps(decrypted_envelope).encode('utf-8')
+        response = client.retrieve_response(timeout=0.2, request_id='req-1')
+
+    assert response[-1] == {'role': 'assistant', 'content': 'ok'}
+    assert m_post.call_count == 2


### PR DESCRIPTION
### Motivation
- While a compute node is processing, clients polling `/api/v1/relay/responses/retrieve` were receiving repeated `404` responses which looked like missing resources and created noisy logs, so pending/inflight work should be signaled explicitly.

### Description
- Add an in-memory `pending_response_request_ids` map with helper functions `_mark_response_pending` and `_is_response_pending` to track inflight API v1 `request_id`s without introducing shared storage or multi-replica state.
- Mark a `request_id` pending when a request is queued in `api_v1_relay_requests` and clear that pending id when a response is queued in `_queue_client_response`, and make `api_v1_relay/responses/retrieve` return `202` and `{ "status": "pending", "request_id": ... }` for known inflight ids while preserving `200` for completed responses and `404` for truly unknown ids.
- Update polling clients to treat `202` as expected pending state: `DistributedApiV1ComputeProvider` now continues its backoff loop on `202`, and `ChatClient.retrieve_response` logs pending at debug level and keeps retrying instead of warning about unexpected status codes.
- Add/adjust tests to cover the new semantics: `tests/test_relay.py` (pending retrieval), `tests/unit/test_api_v1_compute_provider.py` (mocked initial `202` pending), and `tests/unit/test_chat_client.py` (client retries when `202` returned).

### Testing
- Ran `pre-commit run --all-files` which executed the project checks and test runner; the run surfaced existing Python unit test failures unrelated to the pending-status change (see failing `tests/test_relay.py` relay-client model handling), so the hook returned non-zero.
- Ran targeted pytest: `pytest tests/test_relay.py tests/unit/test_api_v1_compute_provider.py tests/unit/test_chat_client.py -q` where the newly added pending-related tests passed but there were 5 failing tests in `tests/test_relay.py` tied to relay-client model/response handling that predate the pending-status change.
- Ran focused unit tests for the new behavior (e.g. client pending retry and compute-provider flow); these pending-specific tests passed locally (client retry on `202` and relay retrieval returning `202` for inflight `request_id`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100c25b3e8832fb31f89f31130f631)