### PR TITLE
Use explicit 202 pending semantics for API v1 relay response retrieval

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -278,6 +278,19 @@ class DistributedApiV1ComputeProvider:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
 
+            if retrieve_response.status_code == 202:
+                time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
+                continue
+
+            if retrieve_response.status_code == 404:
+                raise _error_from_code(
+                    "compute_node_bridge_error",
+                    message=(
+                        "relay response retrieval reported unknown request id "
+                        f"for {relay_request_id}"
+                    ),
+                )
+
             if retrieve_response.status_code != 200:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue

--- a/client.py
+++ b/client.py
@@ -333,6 +333,16 @@ class ChatClient:
                         logger.debug(
                             "Response data is incomplete, waiting for complete response..."
                         )
+                elif response.status_code == 202:
+                    logger.debug(
+                        "Relay response pending for request_id=%s",
+                        request_id,
+                    )
+                elif response.status_code == 404:
+                    logger.warning(
+                        "Relay response request_id=%s not found for client key.",
+                        request_id,
+                    )
                 else:
                     logger.warning(
                         "Unexpected status code from /api/v1/relay/responses/retrieve endpoint: %s",

--- a/relay.py
+++ b/relay.py
@@ -379,6 +379,7 @@ def _validate_server_registration():
 known_servers = {}
 client_inference_requests = {}
 client_responses = {}
+pending_client_request_ids = {}
 client_responses_lock = threading.Lock()
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
@@ -845,6 +846,34 @@ def _pop_client_response(client_public_key, request_id=None):
         return client_responses.pop(client_public_key)
 
 
+def _mark_pending_client_request(client_public_key, request_id):
+    if not client_public_key or not request_id:
+        return
+    with client_responses_lock:
+        pending = pending_client_request_ids.setdefault(client_public_key, set())
+        pending.add(request_id)
+
+
+def _clear_pending_client_request(client_public_key, request_id):
+    if not client_public_key or not request_id:
+        return
+    with client_responses_lock:
+        pending = pending_client_request_ids.get(client_public_key)
+        if not pending:
+            return
+        pending.discard(request_id)
+        if not pending:
+            pending_client_request_ids.pop(client_public_key, None)
+
+
+def _is_pending_client_request(client_public_key, request_id):
+    if not client_public_key or not request_id:
+        return False
+    with client_responses_lock:
+        pending = pending_client_request_ids.get(client_public_key, set())
+        return request_id in pending
+
+
 @app.route('/api/v1/relay/servers/register', methods=['POST'])
 def api_v1_relay_servers_register():
     """Register or heartbeat a compute node for API v1 encrypted relay workloads."""
@@ -944,6 +973,7 @@ def api_v1_relay_requests():
         return jsonify({'error': {'message': 'Missing client public key', 'code': 400}}), 400
 
     envelope['e2ee_v1'] = True
+    _mark_pending_client_request(envelope.get("client_public_key"), envelope.get("request_id"))
     queued_at = time.time()
     envelope['_queued_at'] = queued_at
     with client_inference_requests_changed:
@@ -993,7 +1023,16 @@ def api_v1_relay_responses_retrieve():
     client_public_key = data['client_public_key']
     response = _pop_client_response(client_public_key, data.get('request_id'))
     if response is None:
+        request_id = data.get('request_id')
+        if _is_pending_client_request(client_public_key, request_id):
+            LOGGER.debug(
+                "relay.api_v1.response_pending",
+                extra={"client_public_key": client_public_key, "request_id": request_id},
+            )
+            return jsonify({'status': 'pending'}), 202
         return jsonify({'error': {'message': 'No response available for the given public key', 'code': 404}}), 404
+
+    _clear_pending_client_request(client_public_key, response.get("request_id"))
 
     return jsonify(response), 200
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -19,6 +19,7 @@ from relay import app
 from relay import (
     known_servers,
     client_inference_requests,
+    pending_client_request_ids,
     client_responses,
     streaming_sessions,
     streaming_sessions_by_client,
@@ -39,6 +40,7 @@ def client():
     # Reset state before each test
     known_servers.clear()
     client_inference_requests.clear()
+    pending_client_request_ids.clear()
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
@@ -54,6 +56,7 @@ def client():
     # Clean up state after test (optional, as fixture resets before)
     known_servers.clear()
     client_inference_requests.clear()
+    pending_client_request_ids.clear()
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
@@ -1215,6 +1218,28 @@ def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(clie
     assert retrieved.status_code == 200
     assert retrieved.get_json()['request_id'] == 'req-1'
     assert DUMMY_CLIENT_PUB_KEY not in client_responses
+
+
+def test_api_v1_response_retrieve_returns_pending_for_known_inflight_request(client):
+    request_payload = {
+        'request_id': 'req-pending',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    }
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    assert client.post('/api/v1/relay/requests', json=request_payload).status_code == 200
+
+    pending = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-pending'},
+    )
+    assert pending.status_code == 202
+    assert pending.get_json() == {'status': 'pending'}
 
 
 def test_api_v1_relay_plaintext_messages_not_stored(client):


### PR DESCRIPTION
### Motivation
- Prevent expected in-flight relay polling from appearing as repeated HTTP 404s and reduce log noise by distinguishing pending work from truly-missing request IDs.
- Preserve existing API v1 behavior for completed responses (`200`) and unknown IDs (`404`) while adding an explicit pending indicator for in-progress work.
- Avoid adding persistent/shared storage or changing E2EE payload shapes; keep single-relay in-memory semantics.

### Description
- Added an in-memory `pending_client_request_ids` map and helper functions `_mark_pending_client_request`, `_clear_pending_client_request`, and `_is_pending_client_request` to track in-flight API v1 request IDs (relay.py). 
- Mark requests pending when `/api/v1/relay/requests` queues an envelope, clear pending IDs when a response is successfully retrieved, and return `202 {

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100c25b3e8832fb31f89f31130f631)