### PR TITLE
♻️ Separate relay registration from heartbeat polling

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -394,6 +394,8 @@ SERVER_STALE_SECONDS_ENV = "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS"
 DEFAULT_SERVER_STALE_SECONDS = 30
 API_V1_POLL_WAIT_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS"
 DEFAULT_API_V1_POLL_WAIT_SECONDS = 10
+SERVER_HEARTBEAT_SECONDS_ENV = "TOKEN_PLACE_API_V1_SERVER_HEARTBEAT_SECONDS"
+DEFAULT_SERVER_HEARTBEAT_SECONDS = 10
 
 
 def _server_ping_age_seconds(last_ping: Any) -> float:
@@ -423,6 +425,15 @@ def _api_v1_poll_wait_seconds() -> float:
     if wait_seconds < 0:
         return 0.0
     return wait_seconds
+
+
+def _server_heartbeat_seconds() -> float:
+    raw = os.environ.get(SERVER_HEARTBEAT_SECONDS_ENV, str(DEFAULT_SERVER_HEARTBEAT_SECONDS))
+    try:
+        heartbeat_seconds = float(raw)
+    except ValueError:
+        return float(DEFAULT_SERVER_HEARTBEAT_SECONDS)
+    return max(heartbeat_seconds, 1.0)
 
 
 def _pop_next_api_v1_request(public_key: str):
@@ -917,14 +928,19 @@ def api_v1_relay_servers_register():
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
 
-    if public_key in known_servers:
+    is_reregister = public_key in known_servers
+    if is_reregister:
         known_servers[public_key]['last_ping'] = datetime.now()
     else:
         known_servers[public_key] = {
             'public_key': public_key,
             'last_ping': datetime.now(),
-            'last_ping_duration': 10,
+            'last_ping_duration': _server_heartbeat_seconds(),
         }
+    LOGGER.info(
+        "server.reregister" if is_reregister else "server.registered",
+        extra={"server_public_key": public_key},
+    )
 
     return jsonify({
         'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],
@@ -949,6 +965,8 @@ def api_v1_relay_servers_poll():
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
     if public_key not in known_servers:
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+    known_servers[public_key]['last_ping'] = datetime.now()
+    LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     with client_inference_requests_changed:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -18,6 +18,7 @@ from relay import app
 # Be cautious with direct manipulation in tests, prefer using API endpoints
 from relay import (
     known_servers,
+    _server_ping_age_seconds,
     client_inference_requests,
     client_pending_request_ids,
     client_responses,
@@ -1664,6 +1665,25 @@ def test_api_v1_poll_long_wait_timeout_returns_no_work(client, monkeypatch):
     assert poll.status_code == 200
     assert poll.get_json()['message'] == 'No requests available'
     assert elapsed >= 0.008
+
+
+def test_api_v1_poll_refreshes_server_lease(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    known_servers[DUMMY_SERVER_PUB_KEY]['last_ping'] = datetime.now() - timedelta(seconds=5)
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS', '0')
+
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    assert _server_ping_age_seconds(known_servers[DUMMY_SERVER_PUB_KEY]['last_ping']) < 2
+
+
+def test_api_v1_poll_unknown_server_requires_reregister(client):
+    poll = client.post(
+        '/api/v1/relay/servers/poll',
+        json={'server_public_key': DUMMY_SERVER_PUB_KEY},
+    )
+    assert poll.status_code == 404
 
 
 def test_api_v1_poll_delivers_fifo_for_multiple_requests(client):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -841,6 +841,48 @@ class TestRelayClient:
         assert result['next_ping_in_x_seconds'] == 0
         assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 13.0)
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_registers_once_then_heartbeats_with_poll_only(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 30}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok, poll_ok]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert first['next_ping_in_x_seconds'] == 0
+        assert second['next_ping_in_x_seconds'] == 0
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_after_unknown_node_404(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 30}
+        poll_unknown = MagicMock(status_code=404)
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_unknown, register_ok, poll_ok]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert first['error'] == 'HTTP 404'
+        assert second['next_ping_in_x_seconds'] == 0
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_error_path_uses_register_backoff(self, mock_post, relay_client):

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -693,6 +693,15 @@ class RelayClient:
         return response.json()
 
     @staticmethod
+    def _register_metadata_changed(
+        current: Optional[Dict[str, Any]],
+        incoming: Dict[str, Any],
+    ) -> bool:
+        if not current:
+            return True
+        return current.get("server_public_key") != incoming.get("server_public_key")
+
+    @staticmethod
     def _build_api_v1_url(relay_url: str, route: str) -> str:
         """Build API v1 URLs without duplicating a pre-existing /api/v1 suffix."""
         base = relay_url.rstrip("/")
@@ -715,29 +724,46 @@ class RelayClient:
         return max(base_timeout, wait_seconds + 1.0)
 
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
-        """Register then poll API v1 relay routes for encrypted work."""
+        """Poll API v1 relay routes and only register when needed."""
 
         last_error: Optional[Dict[str, Any]] = None
+        metadata = {'server_public_key': self.crypto_manager.public_key_b64}
+        register_state: Dict[str, Any] = getattr(self, "_api_v1_register_state", {})
         for offset in range(len(self._relay_urls)):
             index = (self._active_relay_index + offset) % len(self._relay_urls)
             candidate_url = self._relay_urls[index]
 
             try:
-                register_response = self.register_api_v1_compute_node(candidate_url)
-                register_wait = self._request_timeout
+                register_wait = float(self._request_timeout)
                 poll_wait = register_wait
-                if isinstance(register_response, dict):
-                    register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
-                    poll_wait = register_response.get('poll_wait_seconds', register_wait)
-                    if register_response.get('error'):
-                        last_error = {
-                            'error': register_response.get('error'),
-                            'next_ping_in_x_seconds': register_wait,
+                register_key = candidate_url
+                prior_state = register_state.get(register_key)
+                should_register = (
+                    prior_state is None
+                    or bool(prior_state.get("needs_reregister"))
+                    or self._register_metadata_changed(prior_state.get("metadata"), metadata)
+                )
+                if should_register:
+                    register_response = self.register_api_v1_compute_node(candidate_url)
+                    if isinstance(register_response, dict):
+                        register_wait = register_response.get(
+                            'next_ping_in_x_seconds',
+                            self._request_timeout,
+                        )
+                        poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                        if register_response.get('error'):
+                            last_error = {
+                                'error': register_response.get('error'),
+                                'next_ping_in_x_seconds': register_wait,
+                            }
+                            continue
+                        register_state[register_key] = {
+                            "metadata": dict(metadata),
+                            "needs_reregister": False,
                         }
-                        continue
 
                 request_kwargs: Dict[str, Any] = {
-                    'json': {'server_public_key': self.crypto_manager.public_key_b64},
+                    'json': metadata,
                     'timeout': self._api_v1_poll_timeout_seconds(poll_wait),
                 }
                 headers = self._auth_headers()
@@ -749,6 +775,16 @@ class RelayClient:
                     timeout=request_kwargs.pop('timeout'),
                     **request_kwargs,
                 )
+                if response.status_code == 404:
+                    register_state[register_key] = {
+                        "metadata": dict(metadata),
+                        "needs_reregister": True,
+                    }
+                    last_error = {
+                        'error': 'HTTP 404',
+                        'next_ping_in_x_seconds': register_wait,
+                    }
+                    continue
                 if response.status_code != 200:
                     last_error = {
                         'error': f'HTTP {response.status_code}',
@@ -772,6 +808,7 @@ class RelayClient:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
+                self._api_v1_register_state = register_state
                 log_info(
                     "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
                     payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',


### PR DESCRIPTION
### Motivation
- Reduce noisy repeated `/api/v1/relay/servers/register` calls by making registration a startup/explicit lifecycle event and treating poll as the steady-state heartbeat/lease refresh. 
- Preserve the existing in-process relay state model and allow robust recovery when the relay restarts or forgets a node. 
- Provide explicit observability for server lifecycle events to make debugging registration/lease issues easier.

### Description
- Add configurable server heartbeat interval via `TOKEN_PLACE_API_V1_SERVER_HEARTBEAT_SECONDS` and helper `_server_heartbeat_seconds()` used to set `last_ping_duration` in `relay.py` so registration responses carry a heartbeat TTL. 
- Make `/api/v1/relay/servers/register` distinguish initial registration vs re-registration and emit structured logs `server.registered` and `server.reregister`, while `/api/v1/relay/servers/poll` now updates `last_ping` and emits `server.heartbeat`. 
- Change `RelayClient.poll_api_v1_encrypted_work()` to maintain per-relay `register_state`, only call `register` when needed (no prior state, metadata change, or flagged re-register), and mark a relay for re-registration when a `404` is returned from `/servers/poll`. 
- Add/adjust tests to assert that a compute node does not register on every poll, that poll refreshes the lease, that unknown-node (404) responses cause re-registration, and that the client re-registers then resumes polling; updated tests live in `tests/unit/test_relay_client.py` and `tests/test_relay.py`.

### Testing
- Ran targeted relay registration tests: `pytest -q tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_registers_once_then_heartbeats_with_poll_only tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_reregisters_after_unknown_node_404 tests/test_relay.py::test_api_v1_poll_refreshes_server_lease tests/test_relay.py::test_api_v1_poll_unknown_server_requires_reregister`, and all targeted tests passed. 
- Ran a broader subset `pytest -q tests/unit/test_relay_client.py tests/test_relay.py`, which exercised the new behavior and passed the new registration/heartbeat assertions while surfacing six failing API v1 model-path tests that are outside the registration/heartbeat scope. 
- Ran `pre-commit run --all-files` and all configured pre-commit checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ee072fb8832f9245861ee9094cba)