### PR TITLE
Reduce redundant API v1 compute-node registration chatter

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -469,9 +469,17 @@ def _pop_next_api_v1_request(public_key: str):
 
 
 def _evict_stale_servers() -> list[str]:
-    stale_after = _server_stale_seconds()
+    default_stale_after = _server_stale_seconds()
+    now_monotonic = time.monotonic()
     evicted: list[str] = []
     for server_public_key, payload in list(known_servers.items()):
+        polling_until = payload.get("polling_until_monotonic")
+        if isinstance(polling_until, (int, float)) and polling_until > now_monotonic:
+            continue
+        stale_after = payload.get("last_ping_duration", default_stale_after)
+        if not isinstance(stale_after, (int, float)):
+            stale_after = default_stale_after
+        stale_after = max(float(stale_after), 1.0)
         if _server_ping_age_seconds(payload.get("last_ping")) <= stale_after:
             continue
         if _unregister_server(server_public_key):
@@ -967,6 +975,7 @@ def api_v1_relay_servers_poll():
     LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
+    known_servers[public_key]['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
     with client_inference_requests_changed:
         first_request = _pop_next_api_v1_request(public_key)
         if first_request is None and poll_wait_seconds > 0:
@@ -978,7 +987,10 @@ def api_v1_relay_servers_poll():
                 client_inference_requests_changed.wait(timeout=remaining)
                 first_request = _pop_next_api_v1_request(public_key)
 
+    known_servers.get(public_key, {}).pop('polling_until_monotonic', None)
+
     if first_request is None:
+        known_servers[public_key]['last_ping'] = datetime.now()
         return jsonify({'message': 'No requests available'}), 200
 
     queue_wait_ms = None

--- a/relay.py
+++ b/relay.py
@@ -394,6 +394,8 @@ SERVER_STALE_SECONDS_ENV = "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS"
 DEFAULT_SERVER_STALE_SECONDS = 30
 API_V1_POLL_WAIT_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS"
 DEFAULT_API_V1_POLL_WAIT_SECONDS = 10
+API_V1_LEASE_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS"
+DEFAULT_API_V1_LEASE_SECONDS = 30
 
 
 def _server_ping_age_seconds(last_ping: Any) -> float:
@@ -423,6 +425,15 @@ def _api_v1_poll_wait_seconds() -> float:
     if wait_seconds < 0:
         return 0.0
     return wait_seconds
+
+
+def _api_v1_lease_seconds() -> int:
+    raw = os.environ.get(API_V1_LEASE_SECONDS_ENV, str(DEFAULT_API_V1_LEASE_SECONDS))
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_API_V1_LEASE_SECONDS
+    return max(value, 1)
 
 
 def _pop_next_api_v1_request(public_key: str):
@@ -923,8 +934,10 @@ def api_v1_relay_servers_register():
         known_servers[public_key] = {
             'public_key': public_key,
             'last_ping': datetime.now(),
-            'last_ping_duration': 10,
+            'last_ping_duration': _api_v1_lease_seconds(),
         }
+    known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
+    LOGGER.info("server.registered", extra={"server_public_key": public_key})
 
     return jsonify({
         'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],
@@ -949,6 +962,9 @@ def api_v1_relay_servers_poll():
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
     if public_key not in known_servers:
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+    known_servers[public_key]['last_ping'] = datetime.now()
+    known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
+    LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     with client_inference_requests_changed:

--- a/relay.py
+++ b/relay.py
@@ -992,10 +992,10 @@ def api_v1_relay_servers_poll():
     server_payload = known_servers.get(public_key)
     if server_payload is not None:
         server_payload.pop('polling_until_monotonic', None)
+    else:
+        return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
     if first_request is None:
-        if server_payload is None:
-            return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
         server_payload['last_ping'] = datetime.now()
         return jsonify({'message': 'No requests available'}), 200
 

--- a/relay.py
+++ b/relay.py
@@ -938,14 +938,16 @@ def api_v1_relay_servers_register():
 
     if public_key in known_servers:
         known_servers[public_key]['last_ping'] = datetime.now()
+        log_event = "server.reregister"
     else:
         known_servers[public_key] = {
             'public_key': public_key,
             'last_ping': datetime.now(),
             'last_ping_duration': _api_v1_lease_seconds(),
         }
+        log_event = "server.registered"
     known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
-    LOGGER.info("server.registered", extra={"server_public_key": public_key})
+    LOGGER.info(log_event, extra={"server_public_key": public_key})
 
     return jsonify({
         'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],

--- a/relay.py
+++ b/relay.py
@@ -993,6 +993,11 @@ def api_v1_relay_servers_poll():
     if server_payload is not None:
         server_payload.pop('polling_until_monotonic', None)
     else:
+        if first_request is not None:
+            with client_inference_requests_changed:
+                queued_requests = client_inference_requests.setdefault(public_key, [])
+                queued_requests.insert(0, first_request)
+                client_inference_requests_changed.notify_all()
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
     if first_request is None:

--- a/relay.py
+++ b/relay.py
@@ -989,10 +989,14 @@ def api_v1_relay_servers_poll():
                 client_inference_requests_changed.wait(timeout=remaining)
                 first_request = _pop_next_api_v1_request(public_key)
 
-    known_servers.get(public_key, {}).pop('polling_until_monotonic', None)
+    server_payload = known_servers.get(public_key)
+    if server_payload is not None:
+        server_payload.pop('polling_until_monotonic', None)
 
     if first_request is None:
-        known_servers[public_key]['last_ping'] = datetime.now()
+        if server_payload is None:
+            return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+        server_payload['last_ping'] = datetime.now()
         return jsonify({'message': 'No requests available'}), 200
 
     queue_wait_ms = None

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1702,7 +1702,7 @@ def test_api_v1_poll_refreshes_server_lease(client, monkeypatch):
 
 def test_api_v1_stale_server_expires_without_poll_heartbeat(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
-    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
     time.sleep(1.2)
     expired = client.post('/api/v1/relay/servers/poll', json=server_payload)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1619,6 +1619,38 @@ def test_api_v1_provider_envelope_is_queued_polled_responded_and_retrieved_ciphe
     assert response_plaintext not in json.dumps(retrieved_payload)
 
 
+def test_api_v1_poll_requeues_popped_work_if_server_unregistered_before_dispatch(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-requeue-on-unregister-race',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+    assert queued.status_code == 200
+
+    original_pop = relay_module._pop_next_api_v1_request
+
+    def _pop_then_unregister(public_key):
+        popped = original_pop(public_key)
+        if popped is not None:
+            known_servers.pop(public_key, None)
+        return popped
+
+    monkeypatch.setattr(relay_module, '_pop_next_api_v1_request', _pop_then_unregister)
+
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 404
+
+    queued_after = client_inference_requests.get(DUMMY_SERVER_PUB_KEY, [])
+    assert len(queued_after) == 1
+    assert queued_after[0]['request_id'] == 'req-requeue-on-unregister-race'
+
+
 def test_api_v1_poll_long_wait_dispatches_when_request_arrives(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1703,8 +1703,9 @@ def test_api_v1_poll_refreshes_server_lease(client, monkeypatch):
 def test_api_v1_stale_server_expires_without_poll_heartbeat(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
-    time.sleep(1.2)
+    known_servers[DUMMY_SERVER_PUB_KEY]['last_ping'] = datetime.now() - timedelta(seconds=2)
     expired = client.post('/api/v1/relay/servers/poll', json=server_payload)
     assert expired.status_code == 404
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1689,6 +1689,26 @@ def test_api_v1_poll_delivers_fifo_for_multiple_requests(client):
     assert second.get_json()['request_id'] == 'req-fifo-2'
 
 
+def test_api_v1_poll_refreshes_server_lease(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    time.sleep(0.6)
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    time.sleep(0.6)
+    assert client.post('/api/v1/relay/servers/poll', json=server_payload).status_code == 200
+
+
+def test_api_v1_stale_server_expires_without_poll_heartbeat(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    time.sleep(1.2)
+    expired = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert expired.status_code == 404
+
+
 def test_api_v1_poll_long_wait_ignores_unrelated_server_wakeups(client, monkeypatch):
     server_one = base64.b64encode(b"server_public_key_1").decode("utf-8")
     server_two = base64.b64encode(b"server_public_key_2").decode("utf-8")

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -878,6 +878,46 @@ class TestRelayClient:
         ]
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_does_not_register_every_poll(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok, poll_ok]
+
+        relay_client.poll_api_v1_encrypted_work()
+        relay_client.poll_api_v1_encrypted_work()
+
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_after_unknown_node(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        poll_404 = MagicMock(status_code=404)
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_404, register_ok, poll_ok]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert first == {'error': 'HTTP 404', 'next_ping_in_x_seconds': 9}
+        assert second['message'] == 'No requests available'
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_non_dict_payload_returns_bounded_error(self, mock_post, relay_client):
         register_ok = MagicMock(status_code=200)
         register_ok.json.return_value = {'next_ping_in_x_seconds': 7}

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -918,6 +918,43 @@ class TestRelayClient:
         ]
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_cached_poll_wait_reused(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 60}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok, poll_ok]
+
+        relay_client.poll_api_v1_encrypted_work()
+        relay_client.poll_api_v1_encrypted_work()
+
+        second_poll_call = mock_post.call_args_list[2]
+        assert second_poll_call.args[0] == 'http://localhost:5000/api/v1/relay/servers/poll'
+        assert second_poll_call.kwargs['timeout'] == relay_client._api_v1_poll_timeout_seconds(60)
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_when_public_key_changes(self, mock_post, relay_client):
+        register_first = MagicMock(status_code=200)
+        register_first.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        register_second = MagicMock(status_code=200)
+        register_second.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_first, poll_ok, register_second, poll_ok]
+
+        relay_client.poll_api_v1_encrypted_work()
+        relay_client.crypto_manager.public_key_b64 = 'new-server-public-key'
+        relay_client.poll_api_v1_encrypted_work()
+
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_non_dict_payload_returns_bounded_error(self, mock_post, relay_client):
         register_ok = MagicMock(status_code=200)
         register_ok.json.return_value = {'next_ping_in_x_seconds': 7}

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -525,6 +525,9 @@ class RelayClient:
         last_error: Optional[str] = None
         had_success = False
 
+        relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
+        self._api_v1_relay_wait_hints = relay_wait_hints
+
         for offset in range(len(self._relay_urls)):
             index = (self._active_relay_index + offset) % len(self._relay_urls)
             candidate_url = self._relay_urls[index]
@@ -592,6 +595,9 @@ class RelayClient:
         """
         last_error: Optional[Dict[str, Any]] = None
         encountered_error = False
+
+        relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
+        self._api_v1_relay_wait_hints = relay_wait_hints
 
         for offset in range(len(self._relay_urls)):
             index = (self._sink_start_index + offset) % len(self._relay_urls)
@@ -719,27 +725,40 @@ class RelayClient:
         """Poll API v1 relay routes for encrypted work with lease-aware registration."""
 
         last_error: Optional[Dict[str, Any]] = None
+        relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
+        self._api_v1_relay_wait_hints = relay_wait_hints
+
         for offset in range(len(self._relay_urls)):
             index = (self._active_relay_index + offset) % len(self._relay_urls)
             candidate_url = self._relay_urls[index]
 
             try:
-                register_wait = self._request_timeout
-                poll_wait = register_wait
+                cached_hints = relay_wait_hints.get(candidate_url, {})
+                register_wait = cached_hints.get('next_ping_in_x_seconds', self._request_timeout)
+                poll_wait = cached_hints.get('poll_wait_seconds', register_wait)
                 if candidate_url not in self._api_v1_registered_relays:
                     register_response = self.register_api_v1_compute_node(candidate_url)
-                    if isinstance(register_response, dict):
-                        register_wait = register_response.get(
-                            'next_ping_in_x_seconds',
-                            self._request_timeout,
-                        )
-                        poll_wait = register_response.get('poll_wait_seconds', register_wait)
-                        if register_response.get('error'):
-                            last_error = {
-                                'error': register_response.get('error'),
-                                'next_ping_in_x_seconds': register_wait,
-                            }
-                            continue
+                    if not isinstance(register_response, dict):
+                        last_error = {
+                            'error': 'Invalid register response format: expected object payload',
+                            'next_ping_in_x_seconds': self._request_timeout,
+                        }
+                        continue
+                    register_wait = register_response.get(
+                        'next_ping_in_x_seconds',
+                        self._request_timeout,
+                    )
+                    poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                    if register_response.get('error'):
+                        last_error = {
+                            'error': register_response.get('error'),
+                            'next_ping_in_x_seconds': register_wait,
+                        }
+                        continue
+                    relay_wait_hints[candidate_url] = {
+                        'next_ping_in_x_seconds': register_wait,
+                        'poll_wait_seconds': poll_wait,
+                    }
                     self._api_v1_registered_relays.add(candidate_url)
                     log_info("server.registered relay={}", candidate_url)
 
@@ -759,6 +778,7 @@ class RelayClient:
                 if response.status_code != 200:
                     if response.status_code == 404:
                         self._api_v1_registered_relays.discard(candidate_url)
+                        relay_wait_hints.pop(candidate_url, None)
                         log_info("server.reregister reason=unknown_node relay={}", candidate_url)
                     last_error = {
                         'error': f'HTTP {response.status_code}',

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -736,7 +736,17 @@ class RelayClient:
                 cached_hints = relay_wait_hints.get(candidate_url, {})
                 register_wait = cached_hints.get('next_ping_in_x_seconds', self._request_timeout)
                 poll_wait = cached_hints.get('poll_wait_seconds', register_wait)
-                if candidate_url not in self._api_v1_registered_relays:
+                current_public_key = self.crypto_manager.public_key_b64
+                registered_public_key = cached_hints.get('server_public_key')
+                requires_register = candidate_url not in self._api_v1_registered_relays
+                if (
+                    not requires_register
+                    and isinstance(registered_public_key, str)
+                    and registered_public_key != current_public_key
+                ):
+                    requires_register = True
+
+                if requires_register:
                     register_response = self.register_api_v1_compute_node(candidate_url)
                     if not isinstance(register_response, dict):
                         last_error = {
@@ -758,6 +768,7 @@ class RelayClient:
                     relay_wait_hints[candidate_url] = {
                         'next_ping_in_x_seconds': register_wait,
                         'poll_wait_seconds': poll_wait,
+                        'server_public_key': current_public_key,
                     }
                     self._api_v1_registered_relays.add(candidate_url)
                     log_info("server.registered relay={}", candidate_url)
@@ -812,6 +823,7 @@ class RelayClient:
             except Exception as exc:
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
                 self._api_v1_registered_relays.discard(candidate_url)
+                relay_wait_hints.pop(candidate_url, None)
                 last_error = {'error': str(exc), 'next_ping_in_x_seconds': self._request_timeout}
 
         return last_error or {

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -388,6 +388,7 @@ class RelayClient:
         self._active_relay_index = 0
         self._sink_start_index = 0
         self._last_api_v1_work_relay_url: Optional[str] = None
+        self._api_v1_registered_relays: Set[str] = set()
 
     @staticmethod
     def _compose_relay_url(base_url: str, port: Optional[int]) -> str:
@@ -715,7 +716,7 @@ class RelayClient:
         return max(base_timeout, wait_seconds + 1.0)
 
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
-        """Register then poll API v1 relay routes for encrypted work."""
+        """Poll API v1 relay routes for encrypted work with lease-aware registration."""
 
         last_error: Optional[Dict[str, Any]] = None
         for offset in range(len(self._relay_urls)):
@@ -723,18 +724,24 @@ class RelayClient:
             candidate_url = self._relay_urls[index]
 
             try:
-                register_response = self.register_api_v1_compute_node(candidate_url)
                 register_wait = self._request_timeout
                 poll_wait = register_wait
-                if isinstance(register_response, dict):
-                    register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
-                    poll_wait = register_response.get('poll_wait_seconds', register_wait)
-                    if register_response.get('error'):
-                        last_error = {
-                            'error': register_response.get('error'),
-                            'next_ping_in_x_seconds': register_wait,
-                        }
-                        continue
+                if candidate_url not in self._api_v1_registered_relays:
+                    register_response = self.register_api_v1_compute_node(candidate_url)
+                    if isinstance(register_response, dict):
+                        register_wait = register_response.get(
+                            'next_ping_in_x_seconds',
+                            self._request_timeout,
+                        )
+                        poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                        if register_response.get('error'):
+                            last_error = {
+                                'error': register_response.get('error'),
+                                'next_ping_in_x_seconds': register_wait,
+                            }
+                            continue
+                    self._api_v1_registered_relays.add(candidate_url)
+                    log_info("server.registered relay={}", candidate_url)
 
                 request_kwargs: Dict[str, Any] = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
@@ -750,6 +757,9 @@ class RelayClient:
                     **request_kwargs,
                 )
                 if response.status_code != 200:
+                    if response.status_code == 404:
+                        self._api_v1_registered_relays.discard(candidate_url)
+                        log_info("server.reregister reason=unknown_node relay={}", candidate_url)
                     last_error = {
                         'error': f'HTTP {response.status_code}',
                         'next_ping_in_x_seconds': register_wait,
@@ -772,6 +782,7 @@ class RelayClient:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
+                log_info("server.heartbeat relay={}", candidate_url)
                 log_info(
                     "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
                     payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',
@@ -780,6 +791,7 @@ class RelayClient:
                 return payload
             except Exception as exc:
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
+                self._api_v1_registered_relays.discard(candidate_url)
                 last_error = {'error': str(exc), 'next_ping_in_x_seconds': self._request_timeout}
 
         return last_error or {


### PR DESCRIPTION
### Motivation
- The compute-node bridge was calling `/api/v1/relay/servers/register` before every `/api/v1/relay/servers/poll`, creating noisy registration traffic and conflating registration with heartbeat semantics.
- Make registration explicit (one-time on startup) and treat polling as the lease/heartbeat refresh while preserving recovery paths when relay state is lost.

### Description
- Change `RelayClient.poll_api_v1_encrypted_work` to track registered relay URLs and only call `register_api_v1_compute_node` for a candidate URL once; subsequent polls act as heartbeat and refresh the lease client-side (`utils/networking/relay_client.py`).
- On poll errors or a `404` from `/servers/poll` the client will discard the registered flag and re-register on the next attempt, preserving re-registration recovery semantics.
- Add relay-side lease configuration and explicit heartbeat handling with a new env var `TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS` (default `30s`), refresh `last_ping` and `last_ping_duration` on both register and poll, and emit structured relay logs `server.registered` and `server.heartbeat` (`relay.py`).
- Add structured client-side log events `server.registered`, `server.heartbeat`, and `server.reregister` and regression tests that assert steady-state polling avoids repeated registration and that re-registration and expiry behaviors work as intended (`tests/unit/test_relay_client.py`, `tests/test_relay.py`).

### Testing
- Ran targeted pytest cases: `TestRelayClient::test_poll_api_v1_encrypted_work_does_not_register_every_poll`, `TestRelayClient::test_poll_api_v1_encrypted_work_reregisters_after_unknown_node`, `test_api_v1_poll_refreshes_server_lease`, and `test_api_v1_stale_server_expires_without_poll_heartbeat`, all of which passed (4 passed).
- Ran `pre-commit run --all-files` and all hooks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ee072fb8832f9245861ee9094cba)