### PR TITLE
Reduce redundant API v1 compute-node registration chatter

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -917,7 +917,8 @@ def api_v1_relay_servers_register():
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
 
-    if public_key in known_servers:
+    is_reregister = public_key in known_servers
+    if is_reregister:
         known_servers[public_key]['last_ping'] = datetime.now()
     else:
         known_servers[public_key] = {
@@ -925,6 +926,14 @@ def api_v1_relay_servers_register():
             'last_ping': datetime.now(),
             'last_ping_duration': 10,
         }
+    LOGGER.info(
+        "server.registered",
+        extra={
+            "server_public_key": public_key,
+            "reregister": is_reregister,
+            "ttl_seconds": _server_stale_seconds(),
+        },
+    )
 
     return jsonify({
         'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],
@@ -949,6 +958,14 @@ def api_v1_relay_servers_poll():
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
     if public_key not in known_servers:
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+    known_servers[public_key]['last_ping'] = datetime.now()
+    LOGGER.info(
+        "server.heartbeat",
+        extra={
+            "server_public_key": public_key,
+            "ttl_seconds": _server_stale_seconds(),
+        },
+    )
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     with client_inference_requests_changed:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1484,6 +1484,19 @@ def test_api_v1_register_does_not_dequeue_requests(client):
     assert DUMMY_SERVER_PUB_KEY not in client_inference_requests or len(client_inference_requests[DUMMY_SERVER_PUB_KEY]) == 0
 
 
+def test_api_v1_poll_refreshes_server_lease(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    register = client.post('/api/v1/relay/servers/register', json=server_payload)
+    assert register.status_code == 200
+    before = known_servers[DUMMY_SERVER_PUB_KEY]['last_ping']
+    time.sleep(0.01)
+
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    after = known_servers[DUMMY_SERVER_PUB_KEY]['last_ping']
+    assert after > before
+
+
 def test_api_v1_poll_requires_registration_token_when_configured(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     known_servers[DUMMY_SERVER_PUB_KEY] = {

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -903,6 +903,48 @@ class TestRelayClient:
 
         assert result == {'error': 'HTTP 429', 'next_ping_in_x_seconds': 11}
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_does_not_reregister_every_poll(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 10, 'poll_wait_seconds': 10}
+        poll_ok_first = MagicMock(status_code=200)
+        poll_ok_first.json.return_value = {'message': 'No requests available'}
+        poll_ok_second = MagicMock(status_code=200)
+        poll_ok_second.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok_first, poll_ok_second]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert first['next_ping_in_x_seconds'] == 0
+        assert second['next_ping_in_x_seconds'] == 0
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_after_unknown_server(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 8, 'poll_wait_seconds': 10}
+        unknown_server = MagicMock(status_code=404)
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, unknown_server, register_ok, poll_ok]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['next_ping_in_x_seconds'] == 0
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
     def test_process_client_request_missing_fields(self, relay_client):
         """Test processing a client request with missing fields."""
         # Setup request data with missing fields

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -388,6 +388,8 @@ class RelayClient:
         self._active_relay_index = 0
         self._sink_start_index = 0
         self._last_api_v1_work_relay_url: Optional[str] = None
+        self._api_v1_registered_relays: Set[str] = set()
+        self._api_v1_registration_identity = getattr(self.crypto_manager, "public_key_b64", None)
 
     @staticmethod
     def _compose_relay_url(base_url: str, port: Optional[int]) -> str:
@@ -715,7 +717,7 @@ class RelayClient:
         return max(base_timeout, wait_seconds + 1.0)
 
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
-        """Register then poll API v1 relay routes for encrypted work."""
+        """Poll API v1 relay routes for encrypted work, registering only when needed."""
 
         last_error: Optional[Dict[str, Any]] = None
         for offset in range(len(self._relay_urls)):
@@ -723,18 +725,26 @@ class RelayClient:
             candidate_url = self._relay_urls[index]
 
             try:
-                register_response = self.register_api_v1_compute_node(candidate_url)
                 register_wait = self._request_timeout
                 poll_wait = register_wait
-                if isinstance(register_response, dict):
-                    register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
-                    poll_wait = register_response.get('poll_wait_seconds', register_wait)
-                    if register_response.get('error'):
-                        last_error = {
-                            'error': register_response.get('error'),
-                            'next_ping_in_x_seconds': register_wait,
-                        }
-                        continue
+                current_identity = getattr(self.crypto_manager, "public_key_b64", None)
+                should_register = (
+                    candidate_url not in self._api_v1_registered_relays
+                    or self._api_v1_registration_identity != current_identity
+                )
+                if should_register:
+                    register_response = self.register_api_v1_compute_node(candidate_url)
+                    if isinstance(register_response, dict):
+                        register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
+                        poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                        if register_response.get('error'):
+                            last_error = {
+                                'error': register_response.get('error'),
+                                'next_ping_in_x_seconds': register_wait,
+                            }
+                            continue
+                    self._api_v1_registered_relays.add(candidate_url)
+                    self._api_v1_registration_identity = current_identity
 
                 request_kwargs: Dict[str, Any] = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
@@ -749,6 +759,34 @@ class RelayClient:
                     timeout=request_kwargs.pop('timeout'),
                     **request_kwargs,
                 )
+                if response.status_code == 404:
+                    log_info(
+                        "server.reregister relay={} reason=unknown_server",
+                        candidate_url,
+                    )
+                    self._api_v1_registered_relays.discard(candidate_url)
+                    register_response = self.register_api_v1_compute_node(candidate_url)
+                    if isinstance(register_response, dict):
+                        register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
+                        poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                        if register_response.get('error'):
+                            last_error = {
+                                'error': register_response.get('error'),
+                                'next_ping_in_x_seconds': register_wait,
+                            }
+                            continue
+                    self._api_v1_registered_relays.add(candidate_url)
+                    retry_kwargs: Dict[str, Any] = {
+                        'json': {'server_public_key': self.crypto_manager.public_key_b64},
+                        'timeout': self._api_v1_poll_timeout_seconds(poll_wait),
+                    }
+                    if headers:
+                        retry_kwargs['headers'] = headers
+                    response = requests.post(
+                        self._build_api_v1_url(candidate_url, "/relay/servers/poll"),
+                        timeout=retry_kwargs.pop('timeout'),
+                        **retry_kwargs,
+                    )
                 if response.status_code != 200:
                     last_error = {
                         'error': f'HTTP {response.status_code}',


### PR DESCRIPTION
### Motivation
- Compute nodes were calling `/api/v1/relay/servers/register` before every poll, producing noisy traffic and conflating registration with heartbeat semantics.
- Make initial registration explicit and treat polling as the lease/heartbeat refresh to simplify lifecycle and logging.
- Preserve robustness by allowing re-registration when the relay reports an unknown node or loses in-memory state.

### Description
- Treat `/api/v1/relay/servers/register` as a (re)registration event and emit structured `server.registered` logs with a `reregister` flag and TTL metadata in `relay.py`.
- Make `/api/v1/relay/servers/poll` refresh the server lease (`last_ping`) and emit structured `server.heartbeat` logs in `relay.py` so poll acts as an explicit heartbeat.
- Change `RelayClient.poll_api_v1_encrypted_work()` to cache registered relay targets per client identity, register only when needed, and on a `404` poll response automatically re-register and retry, emitting `server.reregister` logs in `utils/networking/relay_client.py`.
- Add tests exercising the new behavior and lease semantics in `tests/unit/test_relay_client.py` and `tests/test_relay.py`, and keep all state in the existing in-process relay model with no new external dependencies.

### Testing
- Ran targeted relay-client unit tests: `pytest -q tests/unit/test_relay_client.py -k "does_not_reregister_every_poll or reregisters_after_unknown_server"` and they passed.
- Ran relay server lease test: `pytest -q tests/test_relay.py -k "poll_refreshes_server_lease"` and it passed.
- Ran broader targeted init/relay-client tests: `pytest -q tests/unit/test_relay_client.py -k "init_can_disable_configured_server_fallbacks or init_excludes_config_and_env_fallback_relays_when_configured_servers_disabled or does_not_reregister_every_poll or reregisters_after_unknown_server"` and they passed.
- Executed `pre-commit run --all-files` in this environment where the repository-level run-checks hook includes an extensive test harness; that hook failed here due to one broader Python Unit Tests stage in the environment, while the targeted tests added by this change remain green as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ee072fb8832f9245861ee9094cba)