### PR TITLE
🛠️ fix: separate API v1 register from poll heartbeat

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -919,12 +919,14 @@ def api_v1_relay_servers_register():
 
     if public_key in known_servers:
         known_servers[public_key]['last_ping'] = datetime.now()
+        LOGGER.info("server.reregister", extra={"server_public_key": public_key})
     else:
         known_servers[public_key] = {
             'public_key': public_key,
             'last_ping': datetime.now(),
             'last_ping_duration': 10,
         }
+        LOGGER.info("server.registered", extra={"server_public_key": public_key})
 
     return jsonify({
         'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],
@@ -949,6 +951,8 @@ def api_v1_relay_servers_poll():
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
     if public_key not in known_servers:
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+    known_servers[public_key]['last_ping'] = datetime.now()
+    LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     with client_inference_requests_changed:

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1484,6 +1484,21 @@ def test_api_v1_register_does_not_dequeue_requests(client):
     assert DUMMY_SERVER_PUB_KEY not in client_inference_requests or len(client_inference_requests[DUMMY_SERVER_PUB_KEY]) == 0
 
 
+def test_api_v1_poll_refreshes_server_lease_timestamp(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    register = client.post('/api/v1/relay/servers/register', json=server_payload)
+    assert register.status_code == 200
+    first_ping = known_servers[DUMMY_SERVER_PUB_KEY]['last_ping']
+    assert isinstance(first_ping, datetime)
+
+    time.sleep(0.01)
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    second_ping = known_servers[DUMMY_SERVER_PUB_KEY]['last_ping']
+    assert isinstance(second_ping, datetime)
+    assert second_ping >= first_ping
+
+
 def test_api_v1_poll_requires_registration_token_when_configured(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     known_servers[DUMMY_SERVER_PUB_KEY] = {

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -903,6 +903,48 @@ class TestRelayClient:
 
         assert result == {'error': 'HTTP 429', 'next_ping_in_x_seconds': 11}
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_registers_once_then_heartbeats(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok, poll_ok]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert first['next_ping_in_x_seconds'] == 0
+        assert second['next_ping_in_x_seconds'] == 0
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_after_unknown_node(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 10}
+        poll_unknown = MagicMock(status_code=404)
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_unknown, register_ok, poll_ok]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert first['error'] == 'HTTP 404'
+        assert second['next_ping_in_x_seconds'] == 0
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
     def test_process_client_request_missing_fields(self, relay_client):
         """Test processing a client request with missing fields."""
         # Setup request data with missing fields

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -297,6 +297,12 @@ class RelayClient:
         self.model_manager = model_manager
         self.stop_polling = True  # Flag to control polling loop - starts as True so loop won't run until explicitly started
         self._registration_token: Optional[str] = None
+        self._api_v1_registered_relays: Set[str] = set()
+        self._api_v1_registration_refresh_seconds = max(
+            float(os.getenv("TOKEN_PLACE_API_V1_REGISTER_REFRESH_SECONDS", "300")),
+            1.0,
+        )
+        self._api_v1_last_register_at: Dict[str, float] = {}
         configured_servers: List[Any] = []
         self._cluster_only = False
 
@@ -715,7 +721,7 @@ class RelayClient:
         return max(base_timeout, wait_seconds + 1.0)
 
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
-        """Register then poll API v1 relay routes for encrypted work."""
+        """Poll API v1 relay routes, registering once and re-registering as needed."""
 
         last_error: Optional[Dict[str, Any]] = None
         for offset in range(len(self._relay_urls)):
@@ -723,18 +729,28 @@ class RelayClient:
             candidate_url = self._relay_urls[index]
 
             try:
-                register_response = self.register_api_v1_compute_node(candidate_url)
                 register_wait = self._request_timeout
                 poll_wait = register_wait
-                if isinstance(register_response, dict):
-                    register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
-                    poll_wait = register_response.get('poll_wait_seconds', register_wait)
-                    if register_response.get('error'):
-                        last_error = {
-                            'error': register_response.get('error'),
-                            'next_ping_in_x_seconds': register_wait,
-                        }
-                        continue
+                should_register = candidate_url not in self._api_v1_registered_relays
+                if not should_register:
+                    last_registered_at = self._api_v1_last_register_at.get(candidate_url, 0.0)
+                    should_register = (
+                        time.time() - float(last_registered_at)
+                    ) >= self._api_v1_registration_refresh_seconds
+                if should_register:
+                    register_response = self.register_api_v1_compute_node(candidate_url)
+                    if isinstance(register_response, dict):
+                        register_wait = register_response.get('next_ping_in_x_seconds', self._request_timeout)
+                        poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                        if register_response.get('error'):
+                            last_error = {
+                                'error': register_response.get('error'),
+                                'next_ping_in_x_seconds': register_wait,
+                            }
+                            continue
+                    self._api_v1_registered_relays.add(candidate_url)
+                    self._api_v1_last_register_at[candidate_url] = time.time()
+                    log_info("server.registered relay={}", candidate_url)
 
                 request_kwargs: Dict[str, Any] = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
@@ -750,6 +766,10 @@ class RelayClient:
                     **request_kwargs,
                 )
                 if response.status_code != 200:
+                    if response.status_code == 404:
+                        self._api_v1_registered_relays.discard(candidate_url)
+                        self._api_v1_last_register_at.pop(candidate_url, None)
+                        log_info("server.reregister reason=unknown_node relay={}", candidate_url)
                     last_error = {
                         'error': f'HTTP {response.status_code}',
                         'next_ping_in_x_seconds': register_wait,
@@ -772,6 +792,7 @@ class RelayClient:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
+                log_info("server.heartbeat relay={}", candidate_url)
                 log_info(
                     "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
                     payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',


### PR DESCRIPTION
### Motivation
- Reduce noisy repeated `/api/v1/relay/servers/register` calls that blurred registration vs heartbeat semantics. 
- Make heartbeat/lease semantics explicit so active compute nodes stay registered while enabling robust re-registration after relay state loss.

### Description
- Update `RelayClient` to register per-relay once and track per-relay registration state and timestamp, and add a configurable refresh interval via `TOKEN_PLACE_API_V1_REGISTER_REFRESH_SECONDS` (default `300`).
- Rework `poll_api_v1_encrypted_work` so it only calls `/servers/register` when needed (first contact, periodic refresh, or after errors), and uses `/servers/poll` as the heartbeat/lease refresh path. (See `utils/networking/relay_client.py`.)
- On poll 404 responses the client now forgets the relay registration and triggers re-registration on the next poll attempt, preserving recovery behavior.
- Make relay server lifecycle logging explicit (`server.registered`, `server.reregister`, `server.heartbeat`) and update the relay poll handler to refresh `known_servers[...]['last_ping']` on `/servers/poll`. (See `relay.py`.)
- Add unit tests validating: single-register behavior, re-register on unknown-node (404) responses, and poll refreshing server lease timestamp. (See tests in `tests/unit/test_relay_client.py` and `tests/test_relay.py`.)

### Testing
- Ran the focused pytest scenarios: `pytest -q tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_registers_once_then_heartbeats tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_reregisters_after_unknown_node tests/test_relay.py::test_api_v1_poll_refreshes_server_lease_timestamp`, all passed. 
- Ran repository checks with `pre-commit run --all-files`, which passed. 
- Attempted `git diff --cached | ./scripts/scan-secrets.py` as an automated scan but the referenced script was not present in the workspace (check environment), so that step did not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ee072fb8832f9245861ee9094cba)