### PR TITLE
🛠️ Serve Vue production bundle for relay static/desktop assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ Open `http://localhost:5000` or run `python client.py`. For a minimal client use
 `python client_simplified.py`; it clears the screen when running interactively using ANSI codes
 with flushed output. Metrics are exposed at `/metrics`.
 
+### Vue bundle mode (relay landing page)
+
+The relay landing page (`static/index.html`) now defaults to the production Vue bundle
+(`vue.min.js`) so production/static deployments and packaged desktop webviews do not emit Vue
+development-mode warnings.
+
+Local development keeps Vue dev ergonomics on loopback hosts (`localhost`, `127.0.0.1`, `::1`).
+You can force mode explicitly with query params:
+
+- `?vue=dev` → force development Vue bundle
+- `?vue=prod` → force production Vue bundle
+
 ## CI pass criteria
 
 All pull requests must:

--- a/static/index.html
+++ b/static/index.html
@@ -485,8 +485,22 @@
         </div>
     </div>
 
-    <!-- Vue.js -->
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <!-- Vue.js: default to production bundle; allow localhost development override -->
+    <script>
+        (function loadVueBundle() {
+            const params = new URLSearchParams(window.location.search);
+            const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
+            const forceDev = params.get('vue') === 'dev';
+            const forceProd = params.get('vue') === 'prod';
+            const useDevBundle = (forceDev || (isLocalhost && !forceProd));
+
+            const vueScript = document.createElement('script');
+            vueScript.src = useDevBundle
+                ? 'https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js'
+                : 'https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js';
+            document.head.appendChild(vueScript);
+        }());
+    </script>
     <!-- Use JSEncrypt 3.3.2 from jsDelivr, matching the test runner -->
     <script
         src="https://cdn.jsdelivr.net/npm/jsencrypt@3.3.2/bin/jsencrypt.min.js"

--- a/tests/unit/test_vue_bundle_mode.py
+++ b/tests/unit/test_vue_bundle_mode.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_static_index_defaults_to_production_vue_bundle():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+
+    assert "vue.min.js" in index_html, "production Vue bundle should be referenced in template"
+    assert "params.get('vue') === 'dev'" in index_html, "dev override should be explicit"
+    assert "isLocalhost" in index_html, "localhost-only dev ergonomics should be documented in code"
+
+
+def test_static_index_keeps_local_development_override():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+
+    assert "['localhost', '127.0.0.1', '::1']" in index_html
+    assert "params.get('vue') === 'prod'" in index_html


### PR DESCRIPTION
### Motivation
- The relay landing page was loading the Vue development build which emits dev-mode console warnings when served in production or embedded in packaged desktop webviews, so production/static assets must default to the production bundle.
- Local development ergonomics should be preserved on loopback hosts for fast iteration and Vue devtools support.

### Description
- Updated `static/index.html` to dynamically load the production `vue.min.js` by default and only load the dev bundle on loopback hosts, with explicit query-param overrides `?vue=dev` and `?vue=prod` to force mode.
- Added `tests/unit/test_vue_bundle_mode.py` to assert the default production-bundle reference and presence of the localhost/dev overrides in the template.
- Documented the new Vue bundle selection behavior and the override query parameters in `README.md`.
- No changes were made to relay protocol, server behavior, desktop runtime initialization, or any backend storage assumptions.

### Testing
- Ran unit tests with `python -m pytest -q tests/unit/test_vue_bundle_mode.py tests/unit/test_touch_ui.py`, and all tests passed (`7 passed`).
- Ran pre-commit checks with `pre-commit run --all-files`, and the hook suite completed successfully (all hooks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11160a8128832f87be081b3b6a618a)