### PR TITLE
✅ Serve production Vue bundle by default for relay landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,21 @@ To exit, press Ctrl+C/Cmd+C.
 
 Alternatively, you can visit http://localhost:5000 in your browser to use the web interface.
 
+#### Vue bundle mode for relay landing page
+
+The relay landing page (`static/index.html`) now loads the Vue 2 production
+bundle by default, which avoids shipping dev-mode warnings in production/static
+assets and desktop-packaged web views.
+
+- Default behavior (recommended for production and packaged desktop builds):
+  `https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js`
+- Local debugging override (development only):
+  append `?vue=dev` to the landing-page URL, for example
+  `http://localhost:5000/?vue=dev`.
+
+This preserves local development ergonomics while ensuring the default served
+asset path is production-safe.
+
 ### Raspberry Pi 5 deployment
 
 For a complete walkthrough of the Raspberry Pi 5 setup—including hardware recommendations, Docker instructions, k3s cluster steps, and troubleshooting (including rpi-clone prompts)—see [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials).

--- a/static/index.html
+++ b/static/index.html
@@ -485,8 +485,18 @@
         </div>
     </div>
 
-    <!-- Vue.js -->
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <!-- Vue.js (production by default; opt into dev mode with ?vue=dev for local debugging) -->
+    <script>
+        (function loadVueBundle() {
+            const params = new URLSearchParams(window.location.search);
+            const useDevVue = params.get('vue') === 'dev';
+            const vueScript = document.createElement('script');
+            vueScript.src = useDevVue
+                ? 'https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js'
+                : 'https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js';
+            document.head.appendChild(vueScript);
+        })();
+    </script>
     <!-- Use JSEncrypt 3.3.2 from jsDelivr, matching the test runner -->
     <script
         src="https://cdn.jsdelivr.net/npm/jsencrypt@3.3.2/bin/jsencrypt.min.js"

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -10,6 +10,14 @@ def test_send_button_has_touch_optimized_binding():
     )
 
 
+def test_landing_page_defaults_to_production_vue_bundle():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    assert "dist/vue.min.js" in index_html, "landing page must load Vue production bundle by default"
+    assert "params.get('vue') === 'dev'" in index_html, (
+        "landing page must support explicit Vue dev mode toggle for local debugging"
+    )
+
+
 def test_chat_js_defines_touch_detection_hook():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "isTouchInput" in chat_js, "chat.js must expose touch detection state"


### PR DESCRIPTION
### Motivation
- The relay landing page was loading Vue's development build which emits dev-mode console warnings that should not appear in production/static assets or desktop-packaged web views.
- Production deployments and packaged desktop views must default to the minified production Vue bundle while keeping an easy local development escape hatch.

### Description
- Change `static/index.html` to load `vue.min.js` by default and fall back to the full dev bundle only when the URL includes `?vue=dev` (client-side script selector).
- Add a unit/static regression test `tests/unit/test_touch_ui.py::test_landing_page_defaults_to_production_vue_bundle` to assert the production bundle is referenced and the dev toggle is present.
- Document the change in `README.md` with instructions for the default production behavior and the local debugging override `http://localhost:5000/?vue=dev`.
- No backend, relay protocol, or new dependencies were added or modified.

### Testing
- Ran `python -m pytest tests/unit/test_touch_ui.py -q` and the test suite passed (6 tests, all green).
- Ran `pre-commit run --all-files` and hooks completed successfully.
- Performed repository checks (`rg`) to confirm no unintended changes to rate-limit/storage references; those checks completed without introducing new Redis/shared-storage references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11160a8128832f87be081b3b6a618a)