### PR TITLE
🐛 Enforce Vue production mode for relay-served static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,13 @@ python server.py
 ```
 
 Relay-served static assets default to **production frontend mode**. In this
-mode `static/index.html` is rendered with Vue's minified production CDN build,
-so deployed relay/static assets and desktop-packaged relay UI avoid Vue
-development-mode warnings.
+mode, requests to `/` (and `/static/index.html`) are rendered with Vue's
+minified production CDN build (`vue.min.js`) to avoid Vue development-mode
+warnings in relay-served HTML flows.
+
+Desktop packaging remains a separate path: `desktop-tauri/frontendDist`
+contains the packaged React/Vite UI assets, so this Vue CDN switch applies only
+to relay-served static HTML and does not change desktop runtime behavior.
 
 For local debugging, opt into development Vue with:
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ python relay.py
 python server.py
 ```
 
+Relay-served static assets default to **production frontend mode**. In this
+mode `static/index.html` is rendered with Vue's minified production CDN build,
+so deployed relay/static assets and desktop-packaged relay UI avoid Vue
+development-mode warnings.
+
+For local debugging, opt into development Vue with:
+
+```bash
+TOKENPLACE_FRONTEND_MODE=development python relay.py
+```
+
+Any value other than `development`/`dev` keeps production Vue.
+
 Or start both services with Docker Compose:
 
 ```bash

--- a/relay.py
+++ b/relay.py
@@ -98,6 +98,29 @@ LOGGER = setup_logging()
 
 DRAINING = threading.Event()
 _ORIGINAL_SIGNAL_HANDLERS: dict[int, Any] = {}
+INDEX_HTML_PATH = os.path.join("static", "index.html")
+VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
+VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
+VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
+
+
+def _frontend_mode() -> str:
+    """Resolve frontend asset mode for relay-served static HTML."""
+
+    mode = os.environ.get("TOKENPLACE_FRONTEND_MODE", "production").strip().lower()
+    if mode in {"dev", "development"}:
+        return "development"
+    return "production"
+
+
+def _vue_script_src_for_mode(mode: str) -> str:
+    return VUE_DEV_SCRIPT_SRC if mode == "development" else VUE_PROD_SCRIPT_SRC
+
+
+def _render_index_html() -> str:
+    with open(INDEX_HTML_PATH, encoding="utf-8") as index_file:
+        html = index_file.read()
+    return html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
 
 
 def _handle_shutdown_signal(signum: int, frame: Any) -> None:
@@ -695,7 +718,7 @@ def _pop_stream_chunks_for_client(client_public_key):
 
 @app.route('/')
 def index():
-    return send_from_directory('static', 'index.html')
+    return Response(_render_index_html(), mimetype='text/html')
 
 # Generic route for serving static files
 @app.route('/static/<path:path>')

--- a/relay.py
+++ b/relay.py
@@ -303,7 +303,7 @@ def _load_public_base_url() -> str | None:
 def create_app() -> Flask:
     """Instantiate and configure the Flask application."""
 
-    flask_app = Flask(__name__)
+    flask_app = Flask(__name__, static_folder=None)
     configure_app_logging(flask_app)
     flask_app.config.update(UPSTREAM_CONFIG)
     try:

--- a/relay.py
+++ b/relay.py
@@ -98,7 +98,8 @@ LOGGER = setup_logging()
 
 DRAINING = threading.Event()
 _ORIGINAL_SIGNAL_HANDLERS: dict[int, Any] = {}
-INDEX_HTML_PATH = os.path.join("static", "index.html")
+STATIC_DIR_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
+INDEX_HTML_PATH = os.path.join(STATIC_DIR_PATH, "index.html")
 VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
 VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
 VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
@@ -718,12 +719,18 @@ def _pop_stream_chunks_for_client(client_public_key):
 
 @app.route('/')
 def index():
-    return Response(_render_index_html(), mimetype='text/html')
+    response = Response(_render_index_html(), mimetype='text/html')
+    response.last_modified = os.path.getmtime(INDEX_HTML_PATH)
+    response.add_etag()
+    response.make_conditional(request)
+    return response
 
 # Generic route for serving static files
 @app.route('/static/<path:path>')
 def serve_static(path):
-    return send_from_directory('static', path)
+    if path == 'index.html':
+        return index()
+    return send_from_directory(STATIC_DIR_PATH, path)
 
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -486,7 +486,7 @@
     </div>
 
     <!-- Vue.js -->
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="__TOKENPLACE_VUE_SCRIPT_SRC__"></script>
     <!-- Use JSEncrypt 3.3.2 from jsDelivr, matching the test runner -->
     <script
         src="https://cdn.jsdelivr.net/npm/jsencrypt@3.3.2/bin/jsencrypt.min.js"

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -8,14 +8,17 @@ import relay
 INDEX_HTML_PATH = Path(relay.INDEX_HTML_PATH)
 
 
-def test_relay_uses_production_vue_by_default(monkeypatch):
+def test_root_route_uses_production_vue_by_default(monkeypatch):
     monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
 
-    html = relay._render_index_html()
+    with relay.app.test_client() as client:
+        response = client.get("/")
 
-    assert relay.VUE_PROD_SCRIPT_SRC in html
-    assert relay.VUE_DEV_SCRIPT_SRC not in html
-    assert relay.VUE_SCRIPT_PLACEHOLDER not in html
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert relay.VUE_PROD_SCRIPT_SRC in body
+    assert relay.VUE_DEV_SCRIPT_SRC not in body
+    assert relay.VUE_SCRIPT_PLACEHOLDER not in body
 
 
 def test_relay_uses_development_vue_when_explicitly_requested(monkeypatch):
@@ -65,3 +68,29 @@ def test_index_route_supports_conditional_get(monkeypatch):
         second_response = client.get("/", headers={"If-None-Match": etag})
 
     assert second_response.status_code == 304
+
+
+def test_root_route_uses_development_vue_when_requested(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_FRONTEND_MODE", "dev")
+
+    with relay.app.test_client() as client:
+        response = client.get("/")
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert relay.VUE_DEV_SCRIPT_SRC in body
+    assert relay.VUE_PROD_SCRIPT_SRC not in body
+
+
+def test_production_served_html_excludes_dev_vue_paths(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
+
+    with relay.app.test_client() as client:
+        root_response = client.get("/")
+        static_response = client.get("/static/index.html")
+
+    for response in (root_response, static_response):
+        body = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert "dist/vue.js" not in body
+        assert relay.VUE_SCRIPT_PLACEHOLDER not in body

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -8,6 +8,12 @@ import relay
 INDEX_HTML_PATH = Path(relay.INDEX_HTML_PATH)
 
 
+def test_flask_builtin_static_route_is_disabled():
+    endpoints = {rule.endpoint for rule in relay.app.url_map.iter_rules()}
+
+    assert "static" not in endpoints
+
+
 def test_root_route_uses_production_vue_by_default(monkeypatch):
     monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
 

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib
+
+
+def _load_relay_module(monkeypatch, mode: str | None):
+    if mode is None:
+        monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
+    else:
+        monkeypatch.setenv("TOKENPLACE_FRONTEND_MODE", mode)
+
+    import relay
+
+    return importlib.reload(relay)
+
+
+def test_relay_uses_production_vue_by_default(monkeypatch):
+    relay = _load_relay_module(monkeypatch, None)
+
+    html = relay._render_index_html()
+
+    assert relay.VUE_PROD_SCRIPT_SRC in html
+    assert relay.VUE_DEV_SCRIPT_SRC not in html
+    assert relay.VUE_SCRIPT_PLACEHOLDER not in html
+
+
+def test_relay_uses_development_vue_when_explicitly_requested(monkeypatch):
+    relay = _load_relay_module(monkeypatch, "development")
+
+    html = relay._render_index_html()
+
+    assert relay.VUE_DEV_SCRIPT_SRC in html
+    assert relay.VUE_PROD_SCRIPT_SRC not in html
+
+
+def test_static_index_uses_runtime_vue_placeholder() -> None:
+    with open("static/index.html", encoding="utf-8") as index_file:
+        html = index_file.read()
+
+    assert "__TOKENPLACE_VUE_SCRIPT_SRC__" in html
+    assert "dist/vue.js" not in html

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
-import importlib
+from pathlib import Path
+
+import relay
 
 
-def _load_relay_module(monkeypatch, mode: str | None):
-    if mode is None:
-        monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
-    else:
-        monkeypatch.setenv("TOKENPLACE_FRONTEND_MODE", mode)
-
-    import relay
-
-    return importlib.reload(relay)
+INDEX_HTML_PATH = Path(relay.INDEX_HTML_PATH)
 
 
 def test_relay_uses_production_vue_by_default(monkeypatch):
-    relay = _load_relay_module(monkeypatch, None)
+    monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
 
     html = relay._render_index_html()
 
@@ -25,7 +19,7 @@ def test_relay_uses_production_vue_by_default(monkeypatch):
 
 
 def test_relay_uses_development_vue_when_explicitly_requested(monkeypatch):
-    relay = _load_relay_module(monkeypatch, "development")
+    monkeypatch.setenv("TOKENPLACE_FRONTEND_MODE", "development")
 
     html = relay._render_index_html()
 
@@ -34,8 +28,40 @@ def test_relay_uses_development_vue_when_explicitly_requested(monkeypatch):
 
 
 def test_static_index_uses_runtime_vue_placeholder() -> None:
-    with open("static/index.html", encoding="utf-8") as index_file:
-        html = index_file.read()
+    html = INDEX_HTML_PATH.read_text(encoding="utf-8")
 
-    assert "__TOKENPLACE_VUE_SCRIPT_SRC__" in html
+    assert relay.VUE_SCRIPT_PLACEHOLDER in html
     assert "dist/vue.js" not in html
+
+
+def test_render_index_html_reads_from_module_anchored_path(monkeypatch):
+    monkeypatch.chdir("/")
+
+    html = relay._render_index_html()
+
+    assert "<html" in html
+
+
+def test_static_index_route_uses_runtime_rendering(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_FRONTEND_MODE", "development")
+
+    with relay.app.test_request_context("/static/index.html"):
+        response = relay.serve_static("index.html")
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert relay.VUE_DEV_SCRIPT_SRC in body
+    assert relay.VUE_SCRIPT_PLACEHOLDER not in body
+
+
+def test_index_route_supports_conditional_get(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
+
+    with relay.app.test_client() as client:
+        first_response = client.get("/")
+        etag = first_response.headers.get("ETag")
+        assert etag
+
+        second_response = client.get("/", headers={"If-None-Match": etag})
+
+    assert second_response.status_code == 304


### PR DESCRIPTION
### Motivation
- Production relay/static assets and desktop-packaged UI were serving the Vue development build and emitting development-mode console warnings.
- The frontend should default to production assets while still allowing local development ergonomics.
- Prevent regressions by adding a deterministic, testable switch for frontend asset selection.

### Description
- Replaced the hardcoded dev Vue CDN reference in `static/index.html` with a runtime placeholder `__TOKENPLACE_VUE_SCRIPT_SRC__` so the served HTML can be adjusted at render time.
- Switched the relay root handler to render `static/index.html` and replace the placeholder with a CDN source chosen by `TOKENPLACE_FRONTEND_MODE`, defaulting to production and using `vue.min.js`.
- Added helpers in `relay.py`: `_frontend_mode()`, `_vue_script_src_for_mode()`, and `_render_index_html()` to centralize the mode decision and injection logic without changing API or relay protocol behavior.
- Added `tests/unit/test_relay_frontend_vue_mode.py` and README notes documenting the `TOKENPLACE_FRONTEND_MODE` override and the production-vs-development behavior.

### Testing
- Ran `pytest -q tests/unit/test_relay_frontend_vue_mode.py` and all tests passed (`3 passed`).
- Ran repository checks including `pre-commit run --all-files` and a project grep for rate-limit/redis markers; pre-commit checks passed and the greps returned expected results.
- A repository-local scan command `./scripts/scan-secrets.py` was not present when attempted, so a scripted cached-diff secret scan was not executed, but `detect-secrets` availability check was performed with no findings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11160a8128832f87be081b3b6a618a)