### PR TITLE
✨ Warm-load desktop bridge runtime after relay registration

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -195,7 +195,7 @@ def main() -> int:
                     f"{bridge_output[-2000:]}"
                 )
 
-            bridge.wait(timeout=20)
+            bridge.wait(timeout=60)
             if bridge.returncode != 0:
                 raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
 

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -195,7 +195,16 @@ def main() -> int:
                     f"{bridge_output[-2000:]}"
                 )
 
-            bridge.wait(timeout=60)
+            try:
+                bridge.stdin.close()
+            except OSError:
+                pass
+
+            try:
+                bridge.wait(timeout=90)
+            except subprocess.TimeoutExpired:
+                bridge.terminate()
+                bridge.wait(timeout=15)
             if bridge.returncode != 0:
                 raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import queue
 import sys
 import threading
@@ -56,6 +57,7 @@ _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
+WARM_LOAD_DEFAULT = "1"
 
 
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
@@ -148,6 +150,11 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
         f"offloaded_layers={diagnostics.get('offloaded_layers', diagnostics.get('n_gpu_layers'))} "
         f"kv_cache_device={diagnostics.get('kv_cache_device') or 'unknown'}"
     )
+
+
+def _env_enabled(name: str, default: str = "0") -> bool:
+    value = os.getenv(name, default)
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
 def _start_stdin_reader() -> None:
@@ -265,21 +272,47 @@ def run(args: argparse.Namespace) -> int:
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
 
-    print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_api_v1_runtime_ready():
-        emit(
-            {
-                "type": "error",
-                "message": "failed to initialize API v1 model runtime",
-                "active_relay_url": runtime.relay_client.relay_url,
-            }
-        )
-        print("desktop.compute_node_bridge.model_init.failed", file=sys.stderr)
-        return 1
+    warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)
+    warm_load_state = "not_started"
+    warm_load_started_at = 0.0
+    warm_load_duration_ms: Optional[int] = None
+    warm_load_failed: Optional[str] = None
+    warm_load_fatal = False
 
-    print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
+    def ensure_runtime_ready(reason: str) -> bool:
+        nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
+        if warm_load_state == "ready":
+            return True
+        if warm_load_state == "warming":
+            return False
+        warm_load_state = "warming"
+        warm_load_started_at = time.perf_counter()
+        print(
+            "desktop.compute_node_bridge.model_init.start "
+            f"reason={reason} state={warm_load_state}",
+            file=sys.stderr,
+        )
+        ready = runtime.ensure_api_v1_runtime_ready()
+        warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+        if not ready:
+            warm_load_state = "failed"
+            warm_load_failed = "failed to initialize API v1 model runtime"
+            print(
+                "desktop.compute_node_bridge.model_init.failed "
+                f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                file=sys.stderr,
+            )
+            return False
+        warm_load_state = "ready"
+        print(
+            "desktop.compute_node_bridge.model_init.ready "
+            f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+            file=sys.stderr,
+        )
+        print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
+        return True
+
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
-    print(_runtime_diagnostics_summary(diagnostics), file=sys.stderr)
     last_error: Optional[str] = None
     emit(
         {
@@ -301,6 +334,8 @@ def run(args: argparse.Namespace) -> int:
             "use_mock_llm": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
             "model_path": args.model,
             "last_error": None,
+            "warm_load_state": warm_load_state,
+            "warm_load_enabled": warm_load_enabled,
         }
     )
 
@@ -353,6 +388,18 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
             elif api_v1_payload:
+                if warm_load_enabled and warm_load_state == "not_started":
+                    if not ensure_runtime_ready("post_registration"):
+                        emit(
+                            {
+                                "type": "error",
+                                "message": warm_load_failed or "failed to initialize API v1 model runtime",
+                                "active_relay_url": runtime.relay_client.relay_url,
+                                "warm_load_state": warm_load_state,
+                            }
+                        )
+                        warm_load_fatal = True
+                        break
                 print(
                     "desktop.compute_node_bridge.process_request",
                     file=sys.stderr,
@@ -404,8 +451,24 @@ def run(args: argparse.Namespace) -> int:
                     "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
                     "model_path": args.model,
                     "last_error": last_error,
+                    "warm_load_state": warm_load_state,
+                    "warm_load_enabled": warm_load_enabled,
+                    "warm_load_duration_ms": warm_load_duration_ms,
                 }
             )
+
+            if registered and warm_load_enabled and warm_load_state == "not_started":
+                if not ensure_runtime_ready("post_registration"):
+                    emit(
+                        {
+                            "type": "error",
+                            "message": warm_load_failed or "failed to initialize API v1 model runtime",
+                            "active_relay_url": runtime.relay_client.relay_url,
+                            "warm_load_state": warm_load_state,
+                        }
+                    )
+                    warm_load_fatal = True
+                    break
 
             if _sleep_with_cancel(wait_seconds):
                 break
@@ -434,7 +497,7 @@ def run(args: argparse.Namespace) -> int:
             "last_error": None,
         }
     )
-    return 0
+    return 1 if warm_load_fatal else 0
 
 
 def main() -> int:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -433,6 +433,35 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
 
+            if registered and warm_load_enabled and warm_load_state == "not_started" and api_v1_payload:
+                if not bridge_runtime_allowed:
+                    warm_load_state = "not_started"
+                    print(
+                        "desktop.compute_node_bridge.model_init.skipped "
+                        f"reason=api_v1_request runtime_path={runtime_path} "
+                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
+                        file=sys.stderr,
+                    )
+                elif not ensure_runtime_ready("api_v1_request", active_relay_url=active_relay_url):
+                    last_error = warm_load_failed or "failed to initialize API v1 model runtime"
+                    emit_status_event(
+                        registered=True,
+                        active_relay_url=active_relay_url,
+                        current_last_error=last_error,
+                    )
+                    emit(
+                        {
+                            "type": "error",
+                            "message": last_error,
+                            "active_relay_url": runtime.relay_client.relay_url,
+                            "warm_load_state": warm_load_state,
+                            "warm_load_duration_ms": warm_load_duration_ms,
+                            "runtime_path": runtime_path,
+                        }
+                    )
+                    warm_load_fatal = True
+                    break
+
             if not registered:
                 if relay_error is not None:
                     last_error = relay_error
@@ -446,30 +475,6 @@ def run(args: argparse.Namespace) -> int:
                     f"desktop.compute_node_bridge.request_route runtime_path={runtime_path}",
                     file=sys.stderr,
                 )
-                if (
-                    warm_load_enabled
-                    and warm_load_state == "not_started"
-                    and bridge_runtime_allowed
-                ):
-                    if not ensure_runtime_ready("api_v1_request", active_relay_url=active_relay_url):
-                        last_error = warm_load_failed or "failed to initialize API v1 model runtime"
-                        emit_status_event(
-                            registered=True,
-                            active_relay_url=active_relay_url,
-                            current_last_error=last_error,
-                        )
-                        emit(
-                            {
-                                "type": "error",
-                                "message": last_error,
-                                "active_relay_url": runtime.relay_client.relay_url,
-                                "warm_load_state": warm_load_state,
-                                "warm_load_duration_ms": warm_load_duration_ms,
-                                "runtime_path": runtime_path,
-                            }
-                        )
-                        warm_load_fatal = True
-                        break
                 print(
                     "desktop.compute_node_bridge.process_request",
                     file=sys.stderr,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -58,6 +58,7 @@ _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
+RUNTIME_PATH_DEFAULT = "bridge"
 
 
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
@@ -155,6 +156,13 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
 def _env_enabled(name: str, default: str = "0") -> bool:
     value = os.getenv(name, default)
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _runtime_path_from_env() -> str:
+    value = os.getenv("TOKENPLACE_DESKTOP_RUNTIME_PATH", RUNTIME_PATH_DEFAULT)
+    if value.strip().lower() == "sidecar":
+        return "sidecar"
+    return "bridge"
 
 
 def _start_stdin_reader() -> None:
@@ -273,6 +281,9 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)
+    runtime_path = _runtime_path_from_env()
+    dual_runtime_enabled = _env_enabled("TOKENPLACE_DESKTOP_DUAL_RUNTIME", "0")
+    bridge_runtime_allowed = runtime_path == "bridge" or dual_runtime_enabled
     warm_load_state = "not_started"
     warm_load_started_at = 0.0
     warm_load_duration_ms: Optional[int] = None
@@ -304,6 +315,7 @@ def run(args: argparse.Namespace) -> int:
                 "warm_load_state": warm_load_state,
                 "warm_load_enabled": warm_load_enabled,
                 "warm_load_duration_ms": warm_load_duration_ms,
+                "runtime_path": runtime_path,
             }
         )
 
@@ -371,8 +383,15 @@ def run(args: argparse.Namespace) -> int:
             "last_error": None,
             "warm_load_state": warm_load_state,
             "warm_load_enabled": warm_load_enabled,
+            "runtime_path": runtime_path,
         }
     )
+    if runtime_path == "sidecar" and dual_runtime_enabled:
+        print(
+            "desktop.compute_node_bridge.runtime_path.dual_mode_enabled "
+            "runtime_path=sidecar dual_runtime_enabled=True",
+            file=sys.stderr,
+        )
 
     try:
         while not stop_requested():
@@ -424,6 +443,34 @@ def run(args: argparse.Namespace) -> int:
                     )
             elif api_v1_payload:
                 print(
+                    f"desktop.compute_node_bridge.request_route runtime_path={runtime_path}",
+                    file=sys.stderr,
+                )
+                if (
+                    warm_load_enabled
+                    and warm_load_state == "not_started"
+                    and bridge_runtime_allowed
+                ):
+                    if not ensure_runtime_ready("api_v1_request", active_relay_url=active_relay_url):
+                        last_error = warm_load_failed or "failed to initialize API v1 model runtime"
+                        emit_status_event(
+                            registered=True,
+                            active_relay_url=active_relay_url,
+                            current_last_error=last_error,
+                        )
+                        emit(
+                            {
+                                "type": "error",
+                                "message": last_error,
+                                "active_relay_url": runtime.relay_client.relay_url,
+                                "warm_load_state": warm_load_state,
+                                "warm_load_duration_ms": warm_load_duration_ms,
+                                "runtime_path": runtime_path,
+                            }
+                        )
+                        warm_load_fatal = True
+                        break
+                print(
                     "desktop.compute_node_bridge.process_request",
                     file=sys.stderr,
                 )
@@ -454,24 +501,34 @@ def run(args: argparse.Namespace) -> int:
                     )
 
             if registered and warm_load_enabled and warm_load_state == "not_started":
-                if not ensure_runtime_ready("post_registration", active_relay_url=active_relay_url):
-                    last_error = warm_load_failed or "failed to initialize API v1 model runtime"
-                    emit_status_event(
-                        registered=True,
-                        active_relay_url=active_relay_url,
-                        current_last_error=last_error,
+                if not bridge_runtime_allowed:
+                    warm_load_state = "not_started"
+                    print(
+                        "desktop.compute_node_bridge.model_init.skipped "
+                        f"reason=post_registration runtime_path={runtime_path} "
+                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
+                        file=sys.stderr,
                     )
-                    emit(
-                        {
-                            "type": "error",
-                            "message": last_error,
-                            "active_relay_url": runtime.relay_client.relay_url,
-                            "warm_load_state": warm_load_state,
-                            "warm_load_duration_ms": warm_load_duration_ms,
-                        }
-                    )
-                    warm_load_fatal = True
-                    break
+                else:
+                    if not ensure_runtime_ready("post_registration", active_relay_url=active_relay_url):
+                        last_error = warm_load_failed or "failed to initialize API v1 model runtime"
+                        emit_status_event(
+                            registered=True,
+                            active_relay_url=active_relay_url,
+                            current_last_error=last_error,
+                        )
+                        emit(
+                            {
+                                "type": "error",
+                                "message": last_error,
+                                "active_relay_url": runtime.relay_client.relay_url,
+                                "warm_load_state": warm_load_state,
+                                "warm_load_duration_ms": warm_load_duration_ms,
+                                "runtime_path": runtime_path,
+                            }
+                        )
+                        warm_load_fatal = True
+                        break
             emit_status_event(
                 registered=registered,
                 active_relay_url=active_relay_url,
@@ -506,6 +563,7 @@ def run(args: argparse.Namespace) -> int:
             "warm_load_state": warm_load_state,
             "warm_load_enabled": warm_load_enabled,
             "warm_load_duration_ms": warm_load_duration_ms,
+            "runtime_path": runtime_path,
         }
     )
     return 1 if warm_load_fatal else 0

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -359,6 +359,26 @@ def run(args: argparse.Namespace) -> int:
         print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
         return True
 
+    def fail_on_warm_load_error(*, active_relay_url: str) -> None:
+        nonlocal last_error, warm_load_fatal
+        last_error = warm_load_failed or "failed to initialize API v1 model runtime"
+        emit_status_event(
+            registered=True,
+            active_relay_url=active_relay_url,
+            current_last_error=last_error,
+        )
+        emit(
+            {
+                "type": "error",
+                "message": last_error,
+                "active_relay_url": runtime.relay_client.relay_url,
+                "warm_load_state": warm_load_state,
+                "warm_load_duration_ms": warm_load_duration_ms,
+                "runtime_path": runtime_path,
+            }
+        )
+        warm_load_fatal = True
+
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     last_error: Optional[str] = None
     emit(
@@ -433,7 +453,7 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
 
-            if registered and warm_load_enabled and warm_load_state == "not_started" and api_v1_payload:
+            if registered and api_v1_payload and warm_load_enabled and warm_load_state != "ready":
                 if not bridge_runtime_allowed:
                     warm_load_state = "not_started"
                     print(
@@ -443,23 +463,7 @@ def run(args: argparse.Namespace) -> int:
                         file=sys.stderr,
                     )
                 elif not ensure_runtime_ready("api_v1_request", active_relay_url=active_relay_url):
-                    last_error = warm_load_failed or "failed to initialize API v1 model runtime"
-                    emit_status_event(
-                        registered=True,
-                        active_relay_url=active_relay_url,
-                        current_last_error=last_error,
-                    )
-                    emit(
-                        {
-                            "type": "error",
-                            "message": last_error,
-                            "active_relay_url": runtime.relay_client.relay_url,
-                            "warm_load_state": warm_load_state,
-                            "warm_load_duration_ms": warm_load_duration_ms,
-                            "runtime_path": runtime_path,
-                        }
-                    )
-                    warm_load_fatal = True
+                    fail_on_warm_load_error(active_relay_url=active_relay_url)
                     break
 
             if not registered:
@@ -516,23 +520,7 @@ def run(args: argparse.Namespace) -> int:
                     )
                 else:
                     if not ensure_runtime_ready("post_registration", active_relay_url=active_relay_url):
-                        last_error = warm_load_failed or "failed to initialize API v1 model runtime"
-                        emit_status_event(
-                            registered=True,
-                            active_relay_url=active_relay_url,
-                            current_last_error=last_error,
-                        )
-                        emit(
-                            {
-                                "type": "error",
-                                "message": last_error,
-                                "active_relay_url": runtime.relay_client.relay_url,
-                                "warm_load_state": warm_load_state,
-                                "warm_load_duration_ms": warm_load_duration_ms,
-                                "runtime_path": runtime_path,
-                            }
-                        )
-                        warm_load_fatal = True
+                        fail_on_warm_load_error(active_relay_url=active_relay_url)
                         break
             emit_status_event(
                 registered=registered,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -279,14 +279,49 @@ def run(args: argparse.Namespace) -> int:
     warm_load_failed: Optional[str] = None
     warm_load_fatal = False
 
-    def ensure_runtime_ready(reason: str) -> bool:
+    def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
+        diagnostics = compute_mode_diagnostics(runtime.model_manager)
+        emit(
+            {
+                "type": "status",
+                "running": True,
+                "registered": registered,
+                "active_relay_url": active_relay_url,
+                "requested_mode": diagnostics.get("requested_mode"),
+                "effective_mode": diagnostics.get("effective_mode"),
+                "backend_available": diagnostics.get("backend_available"),
+                "backend_selected": diagnostics.get("backend_selected"),
+                "backend_used": diagnostics.get("backend_used"),
+                "offloaded_layers": diagnostics.get(
+                    "offloaded_layers", diagnostics.get("n_gpu_layers")
+                ),
+                "kv_cache_device": diagnostics.get("kv_cache_device"),
+                "fallback_reason": diagnostics.get("fallback_reason"),
+                "interpreter": runtime_setup.get("interpreter", sys.executable),
+                "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
+                "model_path": args.model,
+                "last_error": current_last_error,
+                "warm_load_state": warm_load_state,
+                "warm_load_enabled": warm_load_enabled,
+                "warm_load_duration_ms": warm_load_duration_ms,
+            }
+        )
+
+    def ensure_runtime_ready(reason: str, *, active_relay_url: str) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
         if warm_load_state == "ready":
             return True
         if warm_load_state == "warming":
             return False
         warm_load_state = "warming"
+        warm_load_failed = None
+        warm_load_duration_ms = None
         warm_load_started_at = time.perf_counter()
+        emit_status_event(
+            registered=True,
+            active_relay_url=active_relay_url,
+            current_last_error=last_error,
+        )
         print(
             "desktop.compute_node_bridge.model_init.start "
             f"reason={reason} state={warm_load_state}",
@@ -388,18 +423,6 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
             elif api_v1_payload:
-                if warm_load_enabled and warm_load_state == "not_started":
-                    if not ensure_runtime_ready("post_registration"):
-                        emit(
-                            {
-                                "type": "error",
-                                "message": warm_load_failed or "failed to initialize API v1 model runtime",
-                                "active_relay_url": runtime.relay_client.relay_url,
-                                "warm_load_state": warm_load_state,
-                            }
-                        )
-                        warm_load_fatal = True
-                        break
                 print(
                     "desktop.compute_node_bridge.process_request",
                     file=sys.stderr,
@@ -430,45 +453,30 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
 
-            diagnostics = compute_mode_diagnostics(runtime.model_manager)
-            emit(
-                {
-                    "type": "status",
-                    "running": True,
-                    "registered": registered,
-                    "active_relay_url": active_relay_url,
-                    "requested_mode": diagnostics.get("requested_mode"),
-                    "effective_mode": diagnostics.get("effective_mode"),
-                    "backend_available": diagnostics.get("backend_available"),
-                    "backend_selected": diagnostics.get("backend_selected"),
-                    "backend_used": diagnostics.get("backend_used"),
-                    "offloaded_layers": diagnostics.get(
-                        "offloaded_layers", diagnostics.get("n_gpu_layers")
-                    ),
-                    "kv_cache_device": diagnostics.get("kv_cache_device"),
-                    "fallback_reason": diagnostics.get("fallback_reason"),
-                    "interpreter": runtime_setup.get("interpreter", sys.executable),
-                    "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-                    "model_path": args.model,
-                    "last_error": last_error,
-                    "warm_load_state": warm_load_state,
-                    "warm_load_enabled": warm_load_enabled,
-                    "warm_load_duration_ms": warm_load_duration_ms,
-                }
-            )
-
             if registered and warm_load_enabled and warm_load_state == "not_started":
-                if not ensure_runtime_ready("post_registration"):
+                if not ensure_runtime_ready("post_registration", active_relay_url=active_relay_url):
+                    last_error = warm_load_failed or "failed to initialize API v1 model runtime"
+                    emit_status_event(
+                        registered=True,
+                        active_relay_url=active_relay_url,
+                        current_last_error=last_error,
+                    )
                     emit(
                         {
                             "type": "error",
-                            "message": warm_load_failed or "failed to initialize API v1 model runtime",
+                            "message": last_error,
                             "active_relay_url": runtime.relay_client.relay_url,
                             "warm_load_state": warm_load_state,
+                            "warm_load_duration_ms": warm_load_duration_ms,
                         }
                     )
                     warm_load_fatal = True
                     break
+            emit_status_event(
+                registered=registered,
+                active_relay_url=active_relay_url,
+                current_last_error=last_error,
+            )
 
             if _sleep_with_cancel(wait_seconds):
                 break
@@ -494,7 +502,10 @@ def run(args: argparse.Namespace) -> int:
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "model_path": args.model,
-            "last_error": None,
+            "last_error": last_error,
+            "warm_load_state": warm_load_state,
+            "warm_load_enabled": warm_load_enabled,
+            "warm_load_duration_ms": warm_load_duration_ms,
         }
     )
     return 1 if warm_load_fatal else 0

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1296,3 +1296,103 @@ def test_run_does_not_warm_when_disabled(capsys, monkeypatch):
     assert status == 0
     assert call_order == ["poll", "poll"]
     _ = capsys.readouterr()
+
+
+def test_run_sidecar_runtime_path_skips_bridge_warm_load_without_dual_opt_in(capsys, monkeypatch):
+    _reset_cancel_queue()
+    call_order = []
+
+    class OrderedRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            call_order.append("warm")
+            return True
+
+        def register_and_poll_once(self):
+            call_order.append("poll")
+            return {"next_ping_in_x_seconds": 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 1)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_RUNTIME_PATH", "sidecar")
+    monkeypatch.delenv("TOKENPLACE_DESKTOP_DUAL_RUNTIME", raising=False)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert call_order == ["poll", "poll"]
+    output = capsys.readouterr()
+    assert "model_init.skipped" in output.err
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    started = next(event for event in events if event.get("type") == "started")
+    assert started["runtime_path"] == "sidecar"
+
+
+def test_run_sidecar_runtime_path_with_dual_mode_warms_and_logs_opt_in(capsys, monkeypatch):
+    _reset_cancel_queue()
+    call_order = []
+
+    class OrderedRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            call_order.append("warm")
+            return True
+
+        def register_and_poll_once(self):
+            call_order.append("poll")
+            return {"next_ping_in_x_seconds": 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 2)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_RUNTIME_PATH", "sidecar")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_DUAL_RUNTIME", "1")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert call_order[:3] == ["poll", "warm", "poll"]
+    output = capsys.readouterr()
+    assert "dual_mode_enabled" in output.err
+
+
+def test_run_api_v1_payload_not_dropped_when_warm_not_started(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class ApiPayloadFirstRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            return True
+
+        def register_and_poll_once(self):
+            if not hasattr(self, "_sent"):
+                self._sent = True
+                return {
+                    "protocol": "tokenplace_api_v1_relay_e2ee",
+                    "version": 1,
+                    "request_id": "req-bridge-1",
+                    "client_public_key": "abc",
+                    "chat_history": "ciphertext",
+                    "cipherkey": "key",
+                    "iv": "iv",
+                    "next_ping_in_x_seconds": 0,
+                }
+            return {"next_ping_in_x_seconds": 0}
+
+        def process_relay_request(self, payload):
+            calls.append("process")
+            return bool(payload.get("request_id"))
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiPayloadFirstRuntime)
+    stop_counter = {"n": 0}
+
+    def fake_stop_requested():
+        stop_counter["n"] += 1
+        return stop_counter["n"] > 3
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert calls == ["warm", "process"]
+    output = capsys.readouterr()
+    assert "runtime_path=bridge" in output.err

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -378,7 +378,7 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     status = compute_node_bridge.run(args)
 
     assert status == 1
-    payload = json.loads(capsys.readouterr().out.strip())
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-2])
     assert payload['type'] == 'error'
     assert 'failed to initialize API v1 model runtime' in payload['message']
 
@@ -995,7 +995,7 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     status = compute_node_bridge.main()
 
     assert status == 1
-    payload = json.loads(capsys.readouterr().out.strip())
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
     assert payload['type'] == 'error'
     assert payload['message'].startswith(
         'compute-node bridge exited before emitting a startup event:'
@@ -1226,7 +1226,7 @@ def test_relay_error_message_normalizes_non_string_truthy_values():
     assert compute_node_bridge._relay_error_message({"error": 503}) == "503"
 
 
-def test_run_warms_runtime_before_first_register_poll(capsys, monkeypatch):
+def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1240,15 +1240,16 @@ def test_run_warms_runtime_before_first_register_poll(capsys, monkeypatch):
             return {"next_ping_in_x_seconds": 0}
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
-    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 1)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 2)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:2] == ["warm", "poll"]
+    assert call_order[:3] == ["poll", "warm", "poll"]
     _ = capsys.readouterr()
 
 
-def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
+def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
@@ -1263,8 +1264,32 @@ def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingWarmupRuntime)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     status = compute_node_bridge.run(args)
     assert status == 1
-    assert calls == ["warm"]
-    payload = json.loads(capsys.readouterr().out.strip())
+    assert calls == ["poll", "warm"]
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-2])
     assert payload["type"] == "error"
+
+
+def test_run_does_not_warm_when_disabled(capsys, monkeypatch):
+    _reset_cancel_queue()
+    call_order = []
+
+    class OrderedRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            call_order.append("warm")
+            return True
+
+        def register_and_poll_once(self):
+            call_order.append("poll")
+            return {"next_ping_in_x_seconds": 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 1)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 0
+    assert call_order == ["poll", "poll"]
+    _ = capsys.readouterr()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -378,7 +378,8 @@ def test_run_reports_model_initialization_failures(capsys, monkeypatch):
     status = compute_node_bridge.run(args)
 
     assert status == 1
-    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-2])
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    payload = next(event for event in events if event.get("type") == "error")
     assert payload['type'] == 'error'
     assert 'failed to initialize API v1 model runtime' in payload['message']
 
@@ -995,7 +996,8 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     status = compute_node_bridge.main()
 
     assert status == 1
-    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    payload = next(event for event in events if event.get("type") == "error")
     assert payload['type'] == 'error'
     assert payload['message'].startswith(
         'compute-node bridge exited before emitting a startup event:'
@@ -1268,7 +1270,8 @@ def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypat
     status = compute_node_bridge.run(args)
     assert status == 1
     assert calls == ["poll", "warm"]
-    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-2])
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    payload = next(event for event in events if event.get("type") == "error")
     assert payload["type"] == "error"
 
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1396,3 +1396,39 @@ def test_run_api_v1_payload_not_dropped_when_warm_not_started(capsys, monkeypatc
     assert calls == ["warm", "process"]
     output = capsys.readouterr()
     assert "runtime_path=bridge" in output.err
+
+
+def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class ApiPayloadWarmFailRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            return False
+
+        def register_and_poll_once(self):
+            return {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": "req-bridge-fail-1",
+                "client_public_key": "abc",
+                "chat_history": "ciphertext",
+                "cipherkey": "key",
+                "iv": "iv",
+                "next_ping_in_x_seconds": 0,
+            }
+
+        def process_relay_request(self, _payload):
+            calls.append("process")
+            return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiPayloadWarmFailRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 1
+    assert calls == ["warm"]
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get("type") == "error")
+    assert error_event["warm_load_state"] == "failed"


### PR DESCRIPTION
### Motivation
- Prevent cold-runtime timeouts and accidental duplicate model initialization by making the Tauri desktop compute-node bridge warm the API v1 runtime after successful relay registration instead of relying on implicit pre-poll warmup. 
- Make the warm-load lifecycle explicit and observable so the UI/ops can distinguish `not_started`/`warming`/`ready`/`failed` states and reason about which runtime path served a request. 
- Keep behavior configurable for developer troubleshooting and preserve the existing cold-runtime regression protection and fail-closed semantics on warmup failure. 

### Description
- Add a configurable default-on warm-load toggle via `TOKENPLACE_DESKTOP_WARM_LOAD` and helper `_env_enabled()` to read the setting. 
- Implement a `warm_load_state` lifecycle and `ensure_runtime_ready(reason)` wrapper that performs `runtime.ensure_api_v1_runtime_ready()`, logs `model_init.start`/`model_init.ready`/`model_init.failed` with duration and diagnostics, and updates emitted `started`/`status` payloads with `warm_load_state`, `warm_load_enabled`, and `warm_load_duration_ms`. 
- Make warm-load occur after successful relay registration (post-registration) when enabled, and treat warm-load failure as a fail-closed condition that emits a structured error event and returns a non-zero exit code. 
- Update unit tests in `tests/unit/test_desktop_compute_node_bridge.py` to assert that warm-load happens after registration, can be disabled, and that failed warm-loads are surfaced and stop the bridge. 

### Testing
- Ran the bridge unit tests with `pytest -q tests/unit/test_desktop_compute_node_bridge.py` and the updated/targeted tests covering warm-load behavior passed. 
- Ran focused pytest selections used during development (e.g. post-registration and disabled-warm-load tests) and they passed during verification. 
- Ran `pre-commit run --all-files` which executed the project checks; the targeted bridge tests passed but the full `run-checks` hook reported a failure during the repo-wide run (an unrelated test/run-checks step caused the pre-commit job to fail), so the change is covered by unit tests but a separate unrelated CI issue remains.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a112681b14c832f83027bb04a3e44fa)