### PR TITLE
Add env-driven warm-load controls to desktop compute-node bridge

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import queue
 import sys
 import threading
@@ -198,6 +199,13 @@ def _sleep_with_cancel(seconds: float) -> bool:
     return stop_requested()
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
 def run(args: argparse.Namespace) -> int:
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
@@ -265,19 +273,34 @@ def run(args: argparse.Namespace) -> int:
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
 
-    print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_api_v1_runtime_ready():
-        emit(
-            {
-                "type": "error",
-                "message": "failed to initialize API v1 model runtime",
-                "active_relay_url": runtime.relay_client.relay_url,
-            }
+    warm_load_enabled = _env_bool("TOKENPLACE_DESKTOP_WARM_LOAD", True)
+    sidecar_mode_enabled = _env_bool("TOKENPLACE_DESKTOP_SIDECAR_MODE", False)
+    dual_runtime_enabled = _env_bool("TOKENPLACE_DESKTOP_DUAL_RUNTIME", False)
+    if sidecar_mode_enabled and not dual_runtime_enabled:
+        warm_load_enabled = False
+        print(
+            "desktop.compute_node_bridge.warm_load.skipped sidecar_mode=enabled dual_runtime=disabled",
+            file=sys.stderr,
         )
-        print("desktop.compute_node_bridge.model_init.failed", file=sys.stderr)
-        return 1
+    elif sidecar_mode_enabled and dual_runtime_enabled:
+        print("desktop.compute_node_bridge.runtime_mode dual_mode=enabled", file=sys.stderr)
 
-    print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
+    if warm_load_enabled:
+        print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
+        if not runtime.ensure_api_v1_runtime_ready():
+            emit(
+                {
+                    "type": "error",
+                    "message": "failed to initialize API v1 model runtime",
+                    "active_relay_url": runtime.relay_client.relay_url,
+                }
+            )
+            print("desktop.compute_node_bridge.model_init.failed", file=sys.stderr)
+            return 1
+
+        print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
+    else:
+        print("desktop.compute_node_bridge.model_init.not_started", file=sys.stderr)
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     print(_runtime_diagnostics_summary(diagnostics), file=sys.stderr)
     last_error: Optional[str] = None


### PR DESCRIPTION
### Motivation
- Prevent accidental duplicate model/runtime initialization by making bridge warm-load behavior explicit and configurable so the persistent compute-node bridge can be the default warm runtime while sidecar-only workflows remain available.

### Description
- Added a small helper `def _env_bool(name, default)` and three environment flags: `TOKENPLACE_DESKTOP_WARM_LOAD` (default on), `TOKENPLACE_DESKTOP_SIDECAR_MODE`, and `TOKENPLACE_DESKTOP_DUAL_RUNTIME` to gate warm-load and runtime-mode behavior in `desktop-tauri/src-tauri/python/compute_node_bridge.py`.
- When sidecar-only mode is enabled (and `DUAL_RUNTIME` is not opt-in) the bridge now explicitly skips warm-loading and emits a structured log `desktop.compute_node_bridge.warm_load.skipped`.
- When warm-load is enabled the bridge performs the existing API v1 runtime warmup and logs `model_init.start` / `model_init.ready`, otherwise it emits `model_init.not_started` so startup state is explicit in logs.
- Preserved existing diagnostics emission (`compute_mode_diagnostics`) and added a dual-mode info log `desktop.compute_node_bridge.runtime_mode dual_mode=enabled` when both bridge and sidecar are intentionally enabled.

### Testing
- Compiled the modified Python module with `python -m py_compile desktop-tauri/src-tauri/python/compute_node_bridge.py` which succeeded.
- Ran the bridge unit test invocation `pytest -q tests/unit/test_desktop_compute_node_bridge.py` but the test bootstrap failed with `ModuleNotFoundError: No module named 'requests'` from `tests/conftest.py`, so unit tests could not complete in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a112681b14c832f83027bb04a3e44fa)