### PR TITLE
Warm-load desktop bridge runtime on relay registration and expose lifecycle state

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -150,6 +150,11 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
     )
 
 
+def _env_flag(name: str, default: bool) -> bool:
+    raw = str(__import__("os").environ.get(name, "1" if default else "0")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def _start_stdin_reader() -> None:
     global _stdin_reader_started
     with _stdin_reader_lock:
@@ -265,19 +270,18 @@ def run(args: argparse.Namespace) -> int:
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
 
-    print("desktop.compute_node_bridge.model_init.start", file=sys.stderr)
-    if not runtime.ensure_api_v1_runtime_ready():
-        emit(
-            {
-                "type": "error",
-                "message": "failed to initialize API v1 model runtime",
-                "active_relay_url": runtime.relay_client.relay_url,
-            }
-        )
-        print("desktop.compute_node_bridge.model_init.failed", file=sys.stderr)
-        return 1
+    warm_load_enabled = _env_flag("TOKENPLACE_DESKTOP_WARM_LOAD", True)
+    dual_mode_enabled = _env_flag("TOKENPLACE_DESKTOP_DUAL_RUNTIME", False)
+    runtime_path = str(__import__("os").environ.get("TOKENPLACE_DESKTOP_RUNTIME_PATH", "bridge")).strip().lower()
+    warm_state = "not_started"
+    warm_failed = False
+    warm_started_at = 0.0
+    warm_completed_at = 0.0
 
-    print("desktop.compute_node_bridge.model_init.ready", file=sys.stderr)
+    if runtime_path == "sidecar" and not dual_mode_enabled:
+        warm_load_enabled = False
+        print("desktop.compute_node_bridge.warm_load.skipped runtime_path=sidecar dual_mode=0", file=sys.stderr)
+
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     print(_runtime_diagnostics_summary(diagnostics), file=sys.stderr)
     last_error: Optional[str] = None
@@ -300,6 +304,9 @@ def run(args: argparse.Namespace) -> int:
             "llama_repo_stub_imported": repo_llama_cpp_shim_imported,
             "use_mock_llm": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
             "model_path": args.model,
+            "runtime_path": runtime_path,
+            "warm_load_enabled": warm_load_enabled,
+            "warm_state": warm_state,
             "last_error": None,
         }
     )
@@ -352,7 +359,38 @@ def run(args: argparse.Namespace) -> int:
                         "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
                         "operator; update relay.py to repo HEAD"
                     )
+            elif warm_load_enabled and warm_state == "not_started":
+                warm_state = "warming"
+                warm_started_at = time.time()
+                print("desktop.compute_node_bridge.model_warm_load.start", file=sys.stderr)
+                if runtime.ensure_api_v1_runtime_ready():
+                    warm_state = "ready"
+                    warm_completed_at = time.time()
+                    print(
+                        "desktop.compute_node_bridge.model_warm_load.ready "
+                        f"duration_ms={int((warm_completed_at - warm_started_at) * 1000)}",
+                        file=sys.stderr,
+                    )
+                    print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
+                else:
+                    warm_state = "failed"
+                    warm_failed = True
+                    print("desktop.compute_node_bridge.model_warm_load.failed", file=sys.stderr)
             elif api_v1_payload:
+                if warm_state == "warming":
+                    wait_deadline = time.time() + max(wait_seconds, 0)
+                    while warm_state == "warming" and time.time() < wait_deadline:
+                        time.sleep(0.05)
+                if warm_failed:
+                    last_error = "failed to initialize API v1 model runtime"
+                if warm_state in {"failed", "not_started"} and warm_load_enabled:
+                    last_error = "runtime not ready; retry request"
+                if last_error:
+                    diagnostics = compute_mode_diagnostics(runtime.model_manager)
+                    emit({"type": "status", "running": True, "registered": registered, "active_relay_url": active_relay_url, "requested_mode": diagnostics.get("requested_mode"), "effective_mode": diagnostics.get("effective_mode"), "backend_available": diagnostics.get("backend_available"), "backend_selected": diagnostics.get("backend_selected"), "backend_used": diagnostics.get("backend_used"), "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")), "kv_cache_device": diagnostics.get("kv_cache_device"), "fallback_reason": diagnostics.get("fallback_reason"), "interpreter": runtime_setup.get("interpreter", sys.executable), "llama_module_path": runtime_setup.get("llama_module_path", "missing"), "model_path": args.model, "runtime_path": runtime_path, "warm_load_enabled": warm_load_enabled, "warm_state": warm_state, "last_error": last_error})
+                    if _sleep_with_cancel(wait_seconds):
+                        break
+                    continue
                 print(
                     "desktop.compute_node_bridge.process_request",
                     file=sys.stderr,
@@ -403,6 +441,9 @@ def run(args: argparse.Namespace) -> int:
                     "interpreter": runtime_setup.get("interpreter", sys.executable),
                     "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
                     "model_path": args.model,
+                    "runtime_path": runtime_path,
+                    "warm_load_enabled": warm_load_enabled,
+                    "warm_state": warm_state,
                     "last_error": last_error,
                 }
             )

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -776,8 +776,8 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     stderr = output.err
     assert 'desktop.compute_node_bridge.start' in stderr
     assert 'desktop.compute_node_bridge.relay_target.resolved' in stderr
-    assert 'desktop.compute_node_bridge.model_init.start' in stderr
-    assert 'desktop.compute_node_bridge.model_init.ready' in stderr
+    assert 'desktop.compute_node_bridge.model_warm_load.start' in stderr
+    assert 'desktop.compute_node_bridge.model_warm_load.ready' in stderr
     assert 'desktop.compute_node_bridge.runtime_state' in stderr
     assert 'desktop.compute_node_bridge.relay_poll' in stderr
     assert 'desktop.compute_node_bridge.stop' in stderr
@@ -1226,7 +1226,7 @@ def test_relay_error_message_normalizes_non_string_truthy_values():
     assert compute_node_bridge._relay_error_message({"error": 503}) == "503"
 
 
-def test_run_warms_runtime_before_first_register_poll(capsys, monkeypatch):
+def test_run_starts_warm_load_after_successful_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1240,15 +1240,15 @@ def test_run_warms_runtime_before_first_register_poll(capsys, monkeypatch):
             return {"next_ping_in_x_seconds": 0}
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=OrderedRuntime)
-    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 1)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(call_order) > 2)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:2] == ["warm", "poll"]
+    assert call_order[:2] == ["poll", "warm"]
     _ = capsys.readouterr()
 
 
-def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
+def test_run_reports_retry_when_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
@@ -1262,9 +1262,13 @@ def test_run_does_not_poll_when_runtime_warmup_fails(capsys, monkeypatch):
             return {"next_ping_in_x_seconds": 0}
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=FailingWarmupRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: len(calls) > 2)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
-    assert status == 1
-    assert calls == ["warm"]
-    payload = json.loads(capsys.readouterr().out.strip())
-    assert payload["type"] == "error"
+    assert status == 0
+    assert calls[:2] == ["poll", "warm"]
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get("type") == "status"]
+    assert status_events
+    assert "desktop.compute_node_bridge.model_warm_load.failed" in captured.err


### PR DESCRIPTION
### Motivation
- Prevent duplicate model/runtime initialization by making the persistent desktop bridge explicitly warm-load the LLM after successful relay registration.
- Make warm-load behavior observable and configurable so consumer defaults warm-load while allowing dev/troubleshoot opt-out and explicit sidecar-only or dual-mode opt-in.
- Ensure requests use the warm bridge runtime when available and surface clear retry/pending semantics when the bridge is still warming.

### Description
- Move warm-load trigger from startup to post-registration and introduce an explicit warm-load lifecycle (`not_started`, `warming`, `ready`, `failed`).
- Add environment/config toggles: `TOKENPLACE_DESKTOP_WARM_LOAD` (defaults on), `TOKENPLACE_DESKTOP_RUNTIME_PATH` (`bridge`/`sidecar`), and `TOKENPLACE_DESKTOP_DUAL_RUNTIME` (opt-in for dual-mode); skip warm-load when runtime path is `sidecar` unless dual-mode is enabled.
- Emit structured stderr logs for warm-load start/ready/failed and include runtime diagnostics and warm-load duration; include `runtime_path`, `warm_load_enabled`, and `warm_state` in emitted status payloads.
- Prevent request-scoped sidecar cold-start when the bridge is warming/ready by returning a clear retry/status event when runtime is not ready and waiting briefly for warm completion if a request arrives during warming.
- Update unit tests to reflect post-registration warm-load ordering, ready/failed log assertions, and retry semantics when warm-up fails.

### Testing
- Ran `pytest -q tests/unit/test_desktop_compute_node_bridge.py -k 'warm_load or warmup or operator_status_events'`, results: 3 tests selected and all passed.
- Ran `pre-commit run --all-files` hooks (initialization and lint/security hooks executed successfully in this environment; full project checks started during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a112681b14c832f83027bb04a3e44fa)