### PR TITLE
🛠️ fix: harden desktop release publish for manual dispatch

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -339,12 +339,11 @@ jobs:
 
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
-          generate_release_notes: true
+          token: ${{ github.token }}
+          generate_release_notes: ${{ github.event_name == 'push' }}
           fail_on_unmatched_files: true
           files: |
             release-assets/macos/*


### PR DESCRIPTION
### Motivation
- Fix manual `workflow_dispatch` publish failures where the release action attempted branch-based release-note lookups on `refs/heads/main` and failed with "Bad credentials", by ensuring the release action uses the correct token and avoids generating notes outside tag-push events.

### Description
- Update `.github/workflows/desktop-release.yml` to explicitly pass `token: ${{ github.token }}` to `softprops/action-gh-release`, change `generate_release_notes` to ` ${{ github.event_name == 'push' }}` so notes are only auto-generated for tag-pushes, and remove the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env override while preserving existing manual `tag_name` validation for `desktop-v*`.

### Testing
- Ran a focused repository grep (`rg`) to confirm workflow keys and action usage and ran `pre-commit run --all-files`, which passed; an attempted `./scripts/scan-secrets.py` check was not run because the script is not present in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1145067564832fb39d4b00f6464845)