### PR TITLE
fix: harden Desktop Tauri release publish path for workflow_dispatch

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -116,12 +116,12 @@ jobs:
 
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
+          token: ${{ github.token }}
           tag_name: ${{ needs.resolve-release-context.outputs.tag_name }}
           name: ${{ needs.resolve-release-context.outputs.tag_name }}
-          generate_release_notes: true
+          generate_release_notes: ${{ github.event_name == 'push' }}
+          overwrite_files: true
           fail_on_unmatched_files: true
           files: |
             release-assets/windows/**/*.exe

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -226,6 +226,8 @@ jobs:
 
       - name: Stage bundle artifacts
         shell: bash
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
           mkdir -p release-artifacts
@@ -240,10 +242,17 @@ jobs:
 
             app_path="${app_files[0]}"
             app_name="$(basename "${app_path}" .app)"
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag_name }}" ]; then
-              ref_slug="${{ inputs.tag_name }}"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${INPUT_TAG_NAME:-}" ]; then
+              case "${INPUT_TAG_NAME}" in
+                desktop-v*) ;;
+                *)
+                  echo "workflow_dispatch input 'tag_name' must match desktop-v*" >&2
+                  exit 1
+                  ;;
+              esac
+              ref_slug="${INPUT_TAG_NAME}"
             else
-              ref_slug="${{ github.ref_name }}"
+              ref_slug="${GITHUB_REF_NAME:-manual}"
             fi
             ref_slug="${ref_slug//\//-}"
             dmg_path="release-artifacts/${app_name}_${ref_slug}_${{ matrix.tauri_target }}.dmg"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -240,7 +240,11 @@ jobs:
 
             app_path="${app_files[0]}"
             app_name="$(basename "${app_path}" .app)"
-            ref_slug="${{ github.ref_name || inputs.tag_name || 'manual' }}"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag_name }}" ]; then
+              ref_slug="${{ inputs.tag_name }}"
+            else
+              ref_slug="${{ github.ref_name }}"
+            fi
             ref_slug="${ref_slug//\//-}"
             dmg_path="release-artifacts/${app_name}_${ref_slug}_${{ matrix.tauri_target }}.dmg"
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -339,13 +339,13 @@ jobs:
 
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
+          token: ${{ github.token }}
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
-          generate_release_notes: true
+          generate_release_notes: ${{ github.event_name == 'push' }}
           fail_on_unmatched_files: true
+          overwrite_files: true
           files: |
             release-assets/macos/*
             release-assets/windows/*


### PR DESCRIPTION
### Motivation
- Manual `workflow_dispatch` republish runs execute on `refs/heads/main`, which caused `generate_release_notes: true` and the release action to consult the branch ref and surface "Bad credentials" when publishing an existing `desktop-v*` tag, so the publish step must use the intended tag context and the default `GITHUB_TOKEN` without forcing Node24.

### Description
- In `.github/workflows/desktop-release.yml` explicitly pass `token: ${{ github.token }}` to `softprops/action-gh-release`, change `generate_release_notes` to ` ${{ github.event_name == 'push' }}`, remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, and enable `overwrite_files: true` while preserving strict `desktop-v*` tag validation and the `dry_run` gating.

### Testing
- Ran `pre-commit run --all-files` (passed), verified workflow occurrences with `rg`, and confirmed the change is a small workflow-only diff via `git diff --stat`, noting the repository's `./scripts/scan-secrets.py` was not executable in this environment so that specific scan was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1145067564832fb39d4b00f6464845)