### PR TITLE
🛠️ Fix Desktop Tauri release publish for workflow_dispatch republish

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -339,12 +339,11 @@ jobs:
 
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
+          token: ${{ github.token }}
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
-          generate_release_notes: true
+          generate_release_notes: ${{ github.event_name == 'push' }}
           fail_on_unmatched_files: true
           files: |
             release-assets/macos/*


### PR DESCRIPTION
### Motivation
- A manual `workflow_dispatch` republish for `desktop-v*` built artifacts but the `softprops/action-gh-release` publish step failed with a "Bad credentials" error because release-note generation could consult `refs/heads/main` during dispatch runs. 
- Make republish of an existing desktop tag reliable while preserving tag-push generated notes and existing dry-run/PR behavior without introducing new secrets.

### Description
- Explicitly pass the default Actions token to the publish step by adding `token: ${{ github.token }}` to the `softprops/action-gh-release` invocation in `.github/workflows/desktop-release.yml`.
- Prevent manual dispatch from deriving release notes from the workflow branch by changing `generate_release_notes` to `${{ github.event_name == 'push' }}` so notes are generated for tag pushes only.
- Remove the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment override from the publish step to avoid forcing Node 24 on the action runtime.
- Preserve strict `desktop-v*` tag validation and the `dry_run` gating so PR builds skip publishing and `workflow_dispatch` requires `tag_name` unless `dry_run=true`.

### Testing
- Ran `pre-commit run --all-files`, which executed the repository checks (including the project checks) and succeeded.
- Verified workflow changes with targeted `rg`/manual inspection of `.github/workflows/desktop-release.yml` and confirmed the publish conditionals for `push`, `workflow_dispatch` and `dry_run` remain correct.
- Confirmed the change diff is small and limited to the workflow file and noted a local `./scripts/scan-secrets.py` was not present when attempting the repo-specific secret scan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1145067564832fb39d4b00f6464845)