### PR TITLE
🛠️ Fix Desktop Tauri manual release publish token/ref handling

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -339,12 +339,11 @@ jobs:
 
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
-          generate_release_notes: true
+          token: ${{ github.token }}
+          generate_release_notes: ${{ github.event_name == 'push' }}
           fail_on_unmatched_files: true
           files: |
             release-assets/macos/*


### PR DESCRIPTION
### Motivation
- Manual `workflow_dispatch` republish runs were failing in the `softprops/action-gh-release` step with a “Bad credentials” error that referenced `refs/heads/main`, indicating the action was resolving branch context instead of the supplied `tag_name` and not receiving an explicit token.

### Description
- Pass the workflow default token explicitly to the release action by adding `token: ${{ github.token }}` to the `softprops/action-gh-release` step in `.github/workflows/desktop-release.yml`.
- Disable branch-derived automatic release-note generation for manual dispatches by changing `generate_release_notes` to `{{ github.event_name == 'push' }}` so only tag-pushes get generated notes.
- Remove the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env override from the publish step to avoid forcing Node runtime changes on the pinned action.

### Testing
- Ran `rg -n "Desktop Tauri Release|action-gh-release|generate_release_notes|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|github.token|tag_name|dry_run" .github/workflows docs outages` to validate locations of relevant workflow config and confirm changes.
- Ran `pre-commit run --all-files` which completed successfully and reported the project checks as `Passed`.
- Verified `git diff --stat` shows a small workflow-only change to `.github/workflows/desktop-release.yml` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1145067564832fb39d4b00f6464845)