### PR TITLE
Harden Desktop Tauri release artifact staging and macOS guardrails

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -254,11 +254,12 @@ jobs:
             else
               ref_slug="${GITHUB_REF_NAME:-manual}"
             fi
-            ref_slug="${ref_slug//\//-}"
-            dmg_path="release-artifacts/${app_name}_${ref_slug}_${{ matrix.tauri_target }}.dmg"
+            version="${ref_slug#desktop-v}"
+            version="${version//\//-}"
+            dmg_path="release-artifacts/token.place-desktop-${version}-apple-silicon.dmg"
 
             rm -f "${dmg_path}"
-            hdiutil create -volname "${app_name}" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
+            hdiutil create -volname "token.place desktop" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"
@@ -278,6 +279,31 @@ jobs:
             cp "${msi_files[@]}" release-artifacts/
           else
             echo "Unsupported runner.os: ${{ runner.os }}" >&2
+            exit 1
+          fi
+
+      - name: Validate macOS staged artifact branding, architecture, icon, and signing
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        run: |
+          set -euo pipefail
+          require_signing=false
+          if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] || [ -n "${APPLE_CERTIFICATE:-}" ]; then
+            require_signing=true
+          fi
+          python ../scripts/validate_desktop_tauri_release_artifacts.py \
+            --staging-dir release-artifacts \
+            ${require_signing:+--require-signing}
+
+      - name: Validate no stale Electron branding in staged artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          if rg -n "tokenplace Desktop|tokenplace Desktop Setup|desktop/electron-builder" release-artifacts; then
+            echo "::error::Stale Electron branding detected in staged release artifacts."
             exit 1
           fi
 

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -89,6 +89,18 @@ Desktop binaries are published by the GitHub Actions workflow
    ```
 2. GitHub Actions builds `desktop-tauri/` artifacts on macOS and Windows and
    uploads them to the GitHub Release named `desktop-v0.1.0`.
+3. The macOS Apple Silicon artifact is staged and published with one obvious
+   name:
+   `token.place-desktop-<version>-apple-silicon.dmg` (for example
+   `token.place-desktop-0.1.0-apple-silicon.dmg`).
+4. Desktop Tauri release staging is Tauri-only (`desktop-tauri/src-tauri/target/.../bundle`).
+   Legacy Electron artifacts (for example `tokenplace Desktop` naming or
+   `desktop/electron-builder` paths) are explicitly blocked by release guardrails.
+5. The release workflow validates the bundled macOS icon (`icon.icns`) against
+   `desktop-tauri/src-tauri/icons/icon.icns` and rejects stale branding metadata.
+6. If Apple signing identity/secrets are absent in CI, builds are treated as
+   preview/dev-only and may trigger Gatekeeper warnings. Fully
+   Developer ID signed and notarized distribution requires Apple credentials.
 
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.

--- a/outages/2026-05-23-desktop-release-stale-electron-dmg-and-gatekeeper.md
+++ b/outages/2026-05-23-desktop-release-stale-electron-dmg-and-gatekeeper.md
@@ -1,0 +1,49 @@
+# Desktop release outage: stale Electron-branded DMG confusion and macOS Gatekeeper failures (2026-05-23)
+
+## Summary
+Desktop release assets for `desktop-v0.1.0` were confusing and unreliable for macOS Apple Silicon users.
+A DMG named like a legacy Electron output (`tokenplace Desktop-0.1.0-arm64.dmg`) was available in releases,
+and users reported Gatekeeper “damaged and can’t be opened” failures plus a wrong app icon.
+
+## Impact
+- Apple Silicon users were not presented with one clear, trustworthy macOS desktop asset.
+- Users saw stale `tokenplace Desktop` branding that did not match current `token.place desktop` branding.
+- Unsigned/non-notarized artifacts could be interpreted as production-ready despite Gatekeeper risk.
+
+## Symptoms
+- macOS warning: “tokenplace Desktop is damaged and can’t be opened. You should move it to the Trash.”
+- Wrong desktop app icon compared to the intended Tauri icon set.
+- Release page asset naming ambiguity between legacy Electron style and Desktop Tauri output.
+
+## Root cause
+- Release staging and naming guardrails were insufficient to prevent stale/legacy Electron-style naming from
+  being published or confused with Tauri assets.
+- Signing/notarization readiness messaging for macOS artifacts was not explicit enough when Apple credentials
+  were unavailable in CI.
+
+## Remediation
+- Enforced Tauri-only release staging from `desktop-tauri/src-tauri/target/.../bundle`.
+- Enforced explicit Apple Silicon DMG naming:
+  `token.place-desktop-<version>-apple-silicon.dmg`.
+- Added stale branding checks that fail fast for:
+  - `tokenplace Desktop`
+  - `tokenplace Desktop Setup`
+  - `desktop/electron-builder`
+- Added macOS artifact validation for architecture (`arm64`/`aarch64`), bundled icon presence and icon hash match
+  against `desktop-tauri/src-tauri/icons/icon.icns`, and stale metadata rejection.
+- Added code-signing validation path (`codesign` + `spctl`) when signing identity/cert secrets are present.
+- Added explicit unsigned preview warning path when signing materials are absent.
+
+## Prevention and regression tests
+- Added unit tests that statically validate desktop release workflow guardrails and icon config wiring.
+- Added deterministic release artifact validation script used by workflow validation.
+
+## Manual verification steps
+1. Trigger `.github/workflows/desktop-release.yml` for a `desktop-v*` tag.
+2. Confirm exactly one obvious Apple Silicon DMG appears:
+   `token.place-desktop-<version>-apple-silicon.dmg`.
+3. Confirm no staged/published artifacts include `tokenplace Desktop` or `desktop/electron-builder`.
+4. Mount DMG and verify app icon and metadata match `token.place desktop` branding.
+5. Verify app binary architecture includes `arm64`.
+6. If signing credentials are configured, verify `codesign --verify --deep --strict` and `spctl -a -vv` pass.
+   If not configured, confirm release notes/documentation mark build as preview/dev-only.

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+STALE_BRANDING_PATTERNS = (
+    "tokenplace Desktop",
+    "tokenplace Desktop Setup",
+    "desktop/electron-builder",
+)
+EXPECTED_ICON_REL = Path("desktop-tauri/src-tauri/icons/icon.icns")
+
+
+def _fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def _run(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    if proc.returncode != 0:
+        _fail(f"Command failed ({' '.join(cmd)}): {proc.stderr.strip() or proc.stdout.strip()}")
+    return proc.stdout.strip()
+
+
+def _contains_stale_branding(text: str) -> str | None:
+    for pattern in STALE_BRANDING_PATTERNS:
+        if pattern in text:
+            return pattern
+    return None
+
+
+def validate(staging_dir: Path, source_icon: Path, tauri_conf: Path, require_signing: bool) -> None:
+    files = sorted(p for p in staging_dir.iterdir() if p.is_file())
+    if not files:
+        _fail(f"No files found in staging directory: {staging_dir}")
+
+    for path in files:
+        match = _contains_stale_branding(path.name)
+        if match:
+            _fail(f"Staged artifact {path.name} contains stale branding pattern: {match}")
+
+    dmg_files = [p for p in files if p.suffix == ".dmg"]
+    if len(dmg_files) != 1:
+        _fail(f"Expected exactly one staged DMG, found {len(dmg_files)}")
+    dmg = dmg_files[0]
+    if "apple-silicon" not in dmg.name:
+        _fail(f"DMG must include apple-silicon marker: {dmg.name}")
+
+    with tempfile.TemporaryDirectory() as td:
+        mount_dir = Path(td) / "mount"
+        mount_dir.mkdir(parents=True, exist_ok=True)
+        _run(["hdiutil", "attach", "-readonly", "-nobrowse", "-mountpoint", str(mount_dir), str(dmg)])
+        try:
+            app_candidates = sorted(mount_dir.glob("*.app"))
+            if not app_candidates:
+                _fail(f"No .app found in mounted DMG: {dmg}")
+            app = app_candidates[0]
+            if _contains_stale_branding(app.name):
+                _fail(f"App bundle contains stale branding: {app.name}")
+
+            info_plist = app / "Contents/Info.plist"
+            if not info_plist.exists():
+                _fail(f"Missing Info.plist in app: {app}")
+            with info_plist.open("rb") as fh:
+                plist = plistlib.load(fh)
+            for key in ("CFBundleDisplayName", "CFBundleName"):
+                value = plist.get(key, "")
+                match = _contains_stale_branding(str(value))
+                if match:
+                    _fail(f"{key} contains stale branding: {match}")
+
+            icon_name = plist.get("CFBundleIconFile", "icon.icns")
+            if not str(icon_name).endswith(".icns"):
+                icon_name = f"{icon_name}.icns"
+            bundled_icon = app / "Contents/Resources" / icon_name
+            if not bundled_icon.exists():
+                _fail(f"Bundled icon missing: {bundled_icon}")
+
+            if hashlib.sha256(source_icon.read_bytes()).hexdigest() != hashlib.sha256(
+                bundled_icon.read_bytes()
+            ).hexdigest():
+                _fail("Bundled app icon does not match desktop-tauri/src-tauri/icons/icon.icns")
+
+            binary = app / "Contents/MacOS" / app.stem
+            if not binary.exists():
+                _fail(f"Expected app binary missing: {binary}")
+
+            archs = _run(["lipo", "-archs", str(binary)])
+            if "arm64" not in archs and "aarch64" not in archs:
+                _fail(f"App binary is not Apple Silicon (arm64/aarch64): {archs}")
+            if "x86_64" in archs and "arm64" not in archs:
+                _fail(f"App binary is x86_64-only, expected Apple Silicon: {archs}")
+
+            if require_signing:
+                _run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app)])
+                _run(["spctl", "-a", "-vv", "--type", "execute", str(app)])
+            else:
+                print("WARNING: Signing identity/secrets unavailable. Build is preview/dev-only.")
+        finally:
+            subprocess.run(["hdiutil", "detach", str(mount_dir)], check=False, capture_output=True, text=True)
+
+    conf_text = tauri_conf.read_text(encoding="utf-8")
+    if "icons/icon.icns" not in conf_text or "icons/128x128@2x.png" not in conf_text:
+        _fail("tauri.conf.json icon list is missing expected token.place icon entries")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--staging-dir", type=Path, required=True)
+    parser.add_argument("--source-icon", type=Path, default=EXPECTED_ICON_REL)
+    parser.add_argument("--tauri-conf", type=Path, default=Path("desktop-tauri/src-tauri/tauri.conf.json"))
+    parser.add_argument("--require-signing", action="store_true")
+    args = parser.parse_args()
+    validate(args.staging_dir, args.source_icon, args.tauri_conf, args.require_signing)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW_PATH = Path('.github/workflows/desktop-release.yml')
+TAURI_CONF_PATH = Path('desktop-tauri/src-tauri/tauri.conf.json')
+
+
+def test_desktop_release_workflow_uses_tauri_bundle_path_only() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding='utf-8')
+    assert 'src-tauri/target/${{ matrix.tauri_target }}/release/bundle' in workflow
+    assert 'nsis_dir="src-tauri/target/release/bundle/nsis"' in workflow
+    assert 'msi_dir="src-tauri/target/release/bundle/msi"' in workflow
+
+
+def test_desktop_release_workflow_uses_clear_apple_silicon_dmg_name() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding='utf-8')
+    assert 'token.place-desktop-${version}-apple-silicon.dmg' in workflow
+    assert 'tokenplace Desktop-0.1.0-arm64.dmg' not in workflow
+
+
+def test_desktop_release_workflow_rejects_stale_electron_branding() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding='utf-8')
+    assert 'tokenplace Desktop|tokenplace Desktop Setup|desktop/electron-builder' in workflow
+
+
+def test_tauri_config_uses_expected_icon_set() -> None:
+    config = TAURI_CONF_PATH.read_text(encoding='utf-8')
+    assert 'icons/icon.icns' in config
+    assert 'icons/icon.ico' in config
+    assert 'icons/128x128@2x.png' in config
+    assert 'icons/128x128.png' in config


### PR DESCRIPTION
### Motivation
- Users downloaded a confusing legacy Electron-styled DMG (`tokenplace Desktop-...-arm64.dmg`) that failed Gatekeeper and showed the wrong icon, indicating stale Electron artifacts leaked into releases.
- The release pipeline needs to publish one obvious Apple Silicon DMG produced by the Tauri build, validate icon/branding and architecture, and surface a clear unsigned vs signed distinction in CI.

### Description
- Updated `.github/workflows/desktop-release.yml` to stage and publish macOS artifacts only from the Tauri bundle path and to name the macOS Apple Silicon DMG as `token.place-desktop-<version>-apple-silicon.dmg`, set the DMG volume name to `token.place desktop`, and keep checksum generation/upload behavior aligned with the renamed file.
- Added a deterministic validator script `scripts/validate_desktop_tauri_release_artifacts.py` that is invoked from the workflow to fail fast on stale Electron branding, assert exactly one Apple Silicon-marked DMG, mount the DMG and validate `.app` metadata, confirm the bundled icon matches `desktop-tauri/src-tauri/icons/icon.icns` (SHA256), check app binary architecture (`lipo -archs`), and optionally verify `codesign`/`spctl` when signing materials are present.
- Added unit tests `tests/unit/test_desktop_release_artifacts.py` that statically assert the workflow stages Tauri bundle outputs, includes the Apple Silicon marker in the DMG name, rejects stale Electron branding patterns, and that `tauri.conf.json` references the expected icon entries.
- Updated `desktop-tauri/README.md` with the intended macOS Apple Silicon asset name, Tauri-only staging guidance, and preview-vs-signed build notes; added an outage post `outages/2026-05-23-desktop-release-stale-electron-dmg-and-gatekeeper.md` documenting the incident, root cause, remediation, and verification steps.

### Testing
- Installed focused verification deps: `python -m pip install -r config/requirements_codex_verification.txt` (succeeded).
- Ran static workflow sentinel tests: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` (passed).
- Ran new desktop release artifact tests: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` (passed).
- Ran `pre-commit run --all-files` (passed) and performed grep checks for stale patterns (used to verify the new guardrails are present).
- No signing secrets or notarization credentials were added; the workflow will run an explicit signing verification path when secrets are present and will emit a clear preview/dev-only warning when they are not.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f657cae4832f943942b0058ddd60)