### PR TITLE
Harden Desktop Tauri Apple Silicon release staging and guardrails

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -242,6 +242,10 @@ jobs:
 
             app_path="${app_files[0]}"
             app_name="$(basename "${app_path}" .app)"
+            version="${app_name##*-}"
+            if [ -z "${version}" ] || [ "${version}" = "${app_name}" ]; then
+              version="${GITHUB_REF_NAME#desktop-v}"
+            fi
             if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${INPUT_TAG_NAME:-}" ]; then
               case "${INPUT_TAG_NAME}" in
                 desktop-v*) ;;
@@ -255,10 +259,23 @@ jobs:
               ref_slug="${GITHUB_REF_NAME:-manual}"
             fi
             ref_slug="${ref_slug//\//-}"
-            dmg_path="release-artifacts/${app_name}_${ref_slug}_${{ matrix.tauri_target }}.dmg"
+            dmg_name="token.place-desktop-${version}-apple-silicon.dmg"
+            dmg_path="release-artifacts/${dmg_name}"
 
             rm -f "${dmg_path}"
-            hdiutil create -volname "${app_name}" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
+            hdiutil create -volname "token.place desktop" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
+
+            python ../scripts/validate_desktop_tauri_release_artifacts.py \
+              --staging-dir release-artifacts \
+              --app-path "${app_path}" \
+              --source-icon src-tauri/icons/icon.icns
+
+            if [ -n "${APPLE_CERTIFICATE:-}" ] || [ -n "${APPLE_CERTIFICATE_BASE64:-}" ] || [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+              /usr/bin/codesign --verify --deep --strict --verbose=2 "${app_path}"
+              /usr/sbin/spctl -a -vv --type execute "${app_path}"
+            else
+              echo "::warning::No Apple signing secrets/identity configured; macOS release is preview/dev-only and may fail Gatekeeper checks."
+            fi
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"
@@ -280,6 +297,21 @@ jobs:
             echo "Unsupported runner.os: ${{ runner.os }}" >&2
             exit 1
           fi
+
+      - name: Validate staged artifact names
+        shell: bash
+        run: |
+          set -euo pipefail
+          banned=("tokenplace Desktop" "tokenplace Desktop Setup" "desktop/electron-builder")
+          while IFS= read -r path; do
+            base="$(basename "${path}")"
+            for marker in "${banned[@]}"; do
+              if [[ "${base}" == *"${marker}"* ]]; then
+                echo "Found stale marker ${marker} in staged artifact ${base}" >&2
+                exit 1
+              fi
+            done
+          done < <(find release-artifacts -type f)
 
       - name: Generate SHA256 checksums
         shell: bash

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -89,6 +89,19 @@ Desktop binaries are published by the GitHub Actions workflow
    ```
 2. GitHub Actions builds `desktop-tauri/` artifacts on macOS and Windows and
    uploads them to the GitHub Release named `desktop-v0.1.0`.
+3. For Apple Silicon Macs (M1/M2/M3/M4), Releases must show one obvious DMG named
+   `token.place-desktop-<version>-apple-silicon.dmg`.
+
+Release guardrails in `.github/workflows/desktop-release.yml` enforce:
+- Tauri-only staging from `desktop-tauri/src-tauri/target/.../bundle` (no legacy Electron assets).
+- Rejection of stale Electron markers (`tokenplace Desktop`, `tokenplace Desktop Setup`,
+  `desktop/electron-builder`).
+- macOS bundle icon validation against `desktop-tauri/src-tauri/icons/icon.icns`.
+
+Signing/notarization expectations:
+- If Apple signing identity/secrets are configured, CI verifies with `codesign` and `spctl`.
+- If signing identity/secrets are absent, CI emits an explicit preview/dev-only warning;
+  unsigned or ad-hoc-signed builds are not treated as fully Gatekeeper-ready notarized releases.
 
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.

--- a/outages/2026-05-23-desktop-release-stale-electron-dmg-and-gatekeeper.md
+++ b/outages/2026-05-23-desktop-release-stale-electron-dmg-and-gatekeeper.md
@@ -1,0 +1,48 @@
+# Desktop release outage: stale Electron-style DMG naming and Gatekeeper confusion (2026-05-23)
+
+## Summary
+A `desktop-v0.1.0` GitHub Release exposed a confusing macOS DMG asset name (`tokenplace Desktop-0.1.0-arm64.dmg`) and users reported Gatekeeper rejection (`...is damaged and can't be opened`). The release page also created icon/branding confusion versus the Tauri desktop icon set.
+
+## Impact
+- Apple Silicon users could download an artifact that looked like a legacy Electron output.
+- Users saw a high-friction install failure path and unclear trust posture.
+- Release page clarity for the Desktop Tauri distribution was degraded.
+
+## Symptoms
+- macOS prompt: **"...is damaged and can't be opened. You should move it to the Trash."**
+- Wrong/unexpected app icon relative to `desktop-tauri/src-tauri/icons/`.
+- Multiple/ambiguous desktop assets and stale naming cues.
+
+## Root cause
+- Stale legacy Electron-style naming/artifact leakage risk was not blocked at release staging.
+- Release asset naming did not force an obvious Apple Silicon Tauri DMG identity.
+- Signing/notarization state was not clearly surfaced as preview/dev-only when Apple credentials were absent.
+
+## Remediation
+- Enforced Tauri-only staging from `desktop-tauri/src-tauri/target/.../bundle` in Desktop Tauri release workflow.
+- Standardized Apple Silicon DMG naming to `token.place-desktop-<version>-apple-silicon.dmg`.
+- Added stale artifact/branding guardrails that fail the workflow on:
+  - `tokenplace Desktop`
+  - `tokenplace Desktop Setup`
+  - `desktop/electron-builder`
+- Added macOS validation for:
+  - Apple Silicon executable architecture (`arm64`/`aarch64`)
+  - bundled app icon presence and SHA256 match with `desktop-tauri/src-tauri/icons/icon.icns`
+- Added signing validation split:
+  - verify `codesign --verify --deep --strict --verbose=2` and `spctl -a -vv --type execute` when signing secrets/identity exist
+  - explicit preview/dev-only warning when they do not
+
+## Prevention and regression coverage
+- New unit tests assert Desktop Tauri workflow pathing, naming guardrails, and icon config expectations.
+- Workflow now includes deterministic staging validation script execution before publishing artifacts.
+
+## Manual verification steps
+1. Run the Desktop Tauri release workflow for a desktop tag (or workflow_dispatch with `tag_name`).
+2. Confirm release assets include exactly one obvious Apple Silicon DMG: `token.place-desktop-<version>-apple-silicon.dmg`.
+3. Mount/open the DMG and inspect app metadata:
+   - app icon present under `Contents/Resources/icon.icns`
+   - executable reports `arm64`/`aarch64`
+4. Validate signing posture:
+   - with Apple signing configured: `codesign` and `spctl` checks pass
+   - without credentials: workflow emits explicit unsigned preview warning
+5. Confirm no release asset names or metadata include stale Electron markers.

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import plistlib
+import subprocess
+from pathlib import Path
+
+FORBIDDEN_MARKERS = (
+    "tokenplace Desktop",
+    "tokenplace Desktop Setup",
+    "desktop/electron-builder",
+)
+
+
+def _run(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SystemExit(f"Command failed ({' '.join(cmd)}):\n{proc.stdout}\n{proc.stderr}")
+    return proc.stdout.strip()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_no_forbidden_text(*values: str) -> None:
+    joined = "\n".join(values)
+    for marker in FORBIDDEN_MARKERS:
+        if marker in joined:
+            raise SystemExit(f"Forbidden stale Electron marker found: {marker}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--staging-dir", type=Path, required=True)
+    parser.add_argument("--app-path", type=Path, required=True)
+    parser.add_argument("--source-icon", type=Path, required=True)
+    parser.add_argument("--expect-unsigned-preview", action="store_true")
+    args = parser.parse_args()
+
+    staging_files = [p.name for p in args.staging_dir.glob("*") if p.is_file()]
+    if not staging_files:
+        raise SystemExit("No release artifacts staged")
+    _assert_no_forbidden_text(*staging_files)
+
+    app_name = args.app_path.stem
+    _assert_no_forbidden_text(app_name)
+
+    info_plist = args.app_path / "Contents" / "Info.plist"
+    if not info_plist.exists():
+        raise SystemExit(f"Missing Info.plist at {info_plist}")
+    with info_plist.open("rb") as fh:
+        info = plistlib.load(fh)
+
+    bundle_name = str(info.get("CFBundleName", ""))
+    display_name = str(info.get("CFBundleDisplayName", ""))
+    icon_file = str(info.get("CFBundleIconFile", "icon.icns"))
+    _assert_no_forbidden_text(bundle_name, display_name, icon_file)
+
+    icon_path = args.app_path / "Contents" / "Resources" / icon_file
+    if icon_path.suffix != ".icns":
+        icon_path = icon_path.with_suffix(".icns")
+    if not icon_path.exists():
+        raise SystemExit(f"Missing bundled macOS icon file: {icon_path}")
+    if _sha256(icon_path) != _sha256(args.source_icon):
+        raise SystemExit("Bundled icon.icns does not match desktop-tauri/src-tauri/icons/icon.icns")
+
+    binary_name = str(info.get("CFBundleExecutable") or app_name)
+    binary_path = args.app_path / "Contents" / "MacOS" / binary_name
+    if not binary_path.exists():
+        raise SystemExit(f"Missing app executable at {binary_path}")
+
+    arch_output = _run(["file", str(binary_path)])
+    arch_lower = arch_output.lower()
+    if "arm64" not in arch_lower and "aarch64" not in arch_lower:
+        raise SystemExit(f"Executable is not Apple Silicon: {arch_output}")
+    if "x86_64" in arch_lower and "arm64" not in arch_lower:
+        raise SystemExit(f"Executable is x86_64-only: {arch_output}")
+
+    if args.expect_unsigned_preview:
+        print("::warning::Desktop macOS build may be unsigned/preview-only unless Developer ID secrets are configured.")
+
+    print("Desktop Tauri release artifact validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "desktop-release.yml"
+TAURI_CONFIG = ROOT / "desktop-tauri" / "src-tauri" / "tauri.conf.json"
+
+
+def test_desktop_release_workflow_uses_tauri_bundle_paths_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "src-tauri/target/${{ matrix.tauri_target }}/release/bundle" in text
+    assert "src-tauri/target/release/bundle/nsis" in text
+    assert "src-tauri/target/release/bundle/msi" in text
+    assert "banned=(\"tokenplace Desktop\" \"tokenplace Desktop Setup\" \"desktop/electron-builder\")" in text
+
+
+def test_workflow_has_obvious_apple_silicon_dmg_name_and_stale_branding_guard() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "token.place-desktop-${version}-apple-silicon.dmg" in text
+    assert "tokenplace Desktop" in text
+    assert "tokenplace Desktop Setup" in text
+    assert "validate_desktop_tauri_release_artifacts.py" in text
+
+
+def test_tauri_icons_include_expected_set() -> None:
+    text = TAURI_CONFIG.read_text(encoding="utf-8")
+    assert '"icons/icon.icns"' in text
+    assert '"icons/icon.ico"' in text
+    assert '"icons/128x128@2x.png"' in text
+    assert '"icons/128x128.png"' in text


### PR DESCRIPTION
### Motivation
- A recent macOS release exposed a confusing Electron-style DMG (`tokenplace Desktop-...-arm64.dmg`) that failed Gatekeeper and showed the wrong icon, implying stale Electron artifacts leaked into the Tauri release flow. 
- The release pipeline needed an obvious Apple Silicon DMG filename and fast-fail guardrails to prevent stale Electron branding, incorrect icons, and unsigned/incorrect-architecture artifacts from being published. 
- Changes must be deterministic, CI-friendly without Apple secrets, and include regression tests and an outage write-up.

### Description
- Update `.github/workflows/desktop-release.yml` to stage macOS artifacts only from the Tauri bundle path and produce a single explicit Apple Silicon DMG named `token.place-desktop-${version}-apple-silicon.dmg`, set DMG volume name to `token.place desktop`, and run artifact/name validations before checksums and upload. 
- Add `scripts/validate_desktop_tauri_release_artifacts.py`, a deterministic, unit-testable validator that rejects forbidden Electron markers, verifies `Info.plist` metadata, verifies bundled `Contents/Resources/icon.icns` matches `desktop-tauri/src-tauri/icons/icon.icns` by SHA256, and asserts the app executable is Apple Silicon (`arm64`/`aarch64`). 
- Add CI guardrails: conditional `codesign`/`spctl` verification when Apple signing env vars are present, otherwise emit an explicit unsigned/preview warning; add a workflow step that rejects staged files with stale Electron markers. 
- Add unit tests `tests/unit/test_desktop_release_artifacts.py` that statically assert Tauri bundle paths are used, the new DMG naming/guardrail lines exist, and `tauri.conf.json` references the expected icon files; update `desktop-tauri/README.md` with the Apple Silicon DMG naming and signing expectations; add an outage write-up at `outages/2026-05-23-desktop-release-stale-electron-dmg-and-gatekeeper.md` documenting symptoms, root cause, remediation, and verification steps.

### Testing
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and it passed. 
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and it passed. 
- Ran repo static checks (`rg -n "tokenplace Desktop|electron-builder|package:mac|desktop/electron" .github/workflows desktop-tauri scripts tests outages docs README.md`) to verify patterns and guardrails presence and it returned the expected matches. 
- Attempted `pre-commit run --all-files`; this was executed but the repository-wide `run-checks` hook failed due to unrelated repo-level test/run-checks failures outside these changes (noted as a warning and not caused by the introduced files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f657cae4832f943942b0058ddd60)