### PR TITLE
Keep macOS Desktop release on unpaid ad-hoc preview path with Gatekeeper guidance

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -297,6 +297,30 @@ jobs:
               echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
               exit 1
             fi
+
+            preview_notice="release-artifacts/README-macos-apple-silicon-preview.txt"
+            cat > "${preview_notice}" <<'EOF'
+            token.place desktop macOS Apple Silicon preview build
+
+            This DMG is ad-hoc signed and is not notarized.
+            Because this preview build does not use paid Apple Developer ID notarization,
+            macOS may show Gatekeeper warnings such as:
+            "Apple could not verify ... is free of malware."
+
+            This is expected for unpaid/ad-hoc preview distribution.
+
+            If you trust this source and the release checksums:
+            1) Open the DMG, then Control-click (or right-click) the app and choose Open.
+            2) If macOS blocks it after first launch attempt, go to:
+               System Settings -> Privacy & Security
+               and use the Allow/Open option for the app.
+
+            Only install and run this preview build when you trust the release source
+            and checksum file.
+
+            For no-warning public macOS distribution, use paid Apple Developer ID
+            signing plus notarization.
+            EOF
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"
@@ -342,6 +366,10 @@ jobs:
           dmg_path="$(find release-artifacts -maxdepth 1 -type f -name '*.dmg' | sort | head -n 1)"
           if [ -z "${dmg_path}" ]; then
             echo "Expected staged macOS .dmg in release-artifacts." >&2
+            exit 1
+          fi
+          if [ ! -f release-artifacts/README-macos-apple-silicon-preview.txt ]; then
+            echo "Expected release-artifacts/README-macos-apple-silicon-preview.txt for macOS preview guidance." >&2
             exit 1
           fi
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -299,28 +299,49 @@ jobs:
             fi
 
             preview_notice="release-artifacts/README-macos-apple-silicon-preview.txt"
-            cat > "${preview_notice}" <<'EOF'
-            token.place desktop macOS Apple Silicon preview build
-
-            This DMG is ad-hoc signed and is not notarized.
-            Because this preview build does not use paid Apple Developer ID notarization,
-            macOS may show Gatekeeper warnings such as:
-            "Apple could not verify ... is free of malware."
-
-            This is expected for unpaid/ad-hoc preview distribution.
-
-            If you trust this source and the release checksums:
-            1) Open the DMG, then Control-click (or right-click) the app and choose Open.
-            2) If macOS blocks it after first launch attempt, go to:
-               System Settings -> Privacy & Security
-               and use the Allow/Open option for the app.
-
-            Only install and run this preview build when you trust the release source
-            and checksum file.
-
-            For no-warning public macOS distribution, use paid Apple Developer ID
-            signing plus notarization.
-            EOF
+            if [ -n "${CONFIGURED_APPLE_SIGNING_IDENTITY:-}" ]; then
+              printf '%s\n' \
+                "token.place desktop macOS Apple Silicon preview build" \
+                "" \
+                "This DMG is signed with a configured Apple signing identity but is not notarized." \
+                "Because notarization/stapling is not part of this workflow yet," \
+                "macOS may still show Gatekeeper warnings such as:" \
+                "\"Apple could not verify ... is free of malware.\"" \
+                "" \
+                "If you trust this source and the release checksums:" \
+                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
+                "2) If macOS blocks it after first launch attempt, go to:" \
+                "   System Settings -> Privacy & Security" \
+                "   and use the Allow/Open option for the app." \
+                "" \
+                "Only install and run this preview build when you trust the release source" \
+                "and checksum file." \
+                "" \
+                "For no-warning public macOS distribution, use paid Apple Developer ID" \
+                "signing plus notarization." > "${preview_notice}"
+            else
+              printf '%s\n' \
+                "token.place desktop macOS Apple Silicon preview build" \
+                "" \
+                "This DMG is ad-hoc signed and is not notarized." \
+                "Because this preview build does not use paid Apple Developer ID notarization," \
+                "macOS may show Gatekeeper warnings such as:" \
+                "\"Apple could not verify ... is free of malware.\"" \
+                "" \
+                "This is expected for unpaid/ad-hoc preview distribution." \
+                "" \
+                "If you trust this source and the release checksums:" \
+                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
+                "2) If macOS blocks it after first launch attempt, go to:" \
+                "   System Settings -> Privacy & Security" \
+                "   and use the Allow/Open option for the app." \
+                "" \
+                "Only install and run this preview build when you trust the release source" \
+                "and checksum file." \
+                "" \
+                "For no-warning public macOS distribution, use paid Apple Developer ID" \
+                "signing plus notarization." > "${preview_notice}"
+            fi
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -256,6 +256,9 @@ jobs:
         shell: bash
         env:
           INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
           set -euo pipefail
           mkdir -p release-artifacts
@@ -299,7 +302,7 @@ jobs:
             fi
 
             preview_notice="release-artifacts/README-macos-apple-silicon-preview.txt"
-            if [ -n "${CONFIGURED_APPLE_SIGNING_IDENTITY:-}" ]; then
+            if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -99,8 +99,8 @@ Desktop binaries are published by the GitHub Actions workflow
      an explicit preview warning and uses ad-hoc signing for dev/preview builds.
      Those builds are not equivalent to fully Developer ID signed + notarized
      Gatekeeper-ready releases.
-   - If signing credentials are configured, CI validates with `codesign` and
-     `spctl` so signed builds fail fast when trust checks break.
+  - If signing credentials are configured, CI validates with `codesign`.
+    Strict Gatekeeper notarization checks are skipped unless notarization is added.
 
 ### Unpaid macOS preview releases
 

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -102,6 +102,19 @@ Desktop binaries are published by the GitHub Actions workflow
    - If signing credentials are configured, CI validates with `codesign` and
      `spctl` so signed builds fail fast when trust checks break.
 
+### Unpaid macOS preview releases
+
+- token.place can publish Apple Silicon preview DMGs without a paid
+  Apple Developer Program account.
+- These preview builds use ad-hoc signing and are not notarized, so Gatekeeper
+  warnings after browser/GitHub download are expected.
+- Users must manually open/whitelist trusted previews:
+  - Control-click (or right-click) the app and choose **Open**, or
+  - after a blocked launch, use **System Settings → Privacy & Security**
+    to allow/open the app.
+- No-warning public distribution generally requires paid
+  Developer ID signing plus notarization.
+
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.
 

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-ad-hoc-macos-gatekeeper-warning",
+  "summary": "Correctly named/iconed Apple Silicon Tauri DMGs still showed Gatekeeper verification warnings because preview builds are ad-hoc signed and not notarized.",
+  "impact": "Users may interpret expected Gatekeeper prompts as packaging breakage unless preview/non-notarized behavior is explicitly documented in release assets.",
+  "fix": "Kept unpaid ad-hoc signing fallback, added a macOS preview warning text asset alongside the DMG, and documented trusted manual-open steps while preserving artifact validation guardrails.",
+  "lessons": "Preview release pipelines should clearly separate artifact correctness checks from paid Developer ID notarization requirements and communicate expected Gatekeeper behavior up front."
+}

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
@@ -1,0 +1,41 @@
+# Outage follow-up: desktop release ad-hoc macOS Gatekeeper warning (2026-05-24)
+
+- **Date:** 2026-05-24
+- **Slug:** `desktop-release-ad-hoc-macos-gatekeeper-warning`
+- **Affected area:** Desktop Tauri macOS Apple Silicon release artifacts (`.github/workflows/desktop-release.yml`)
+
+## Symptom
+
+Even when the release DMG name/icon/architecture were corrected for Tauri Apple
+Silicon (`token.place-desktop-<version>-apple-silicon.dmg`), macOS still showed
+an "Apple could not verify ..." Gatekeeper warning after download.
+
+## Root cause
+
+The warning came from expected ad-hoc/non-notarized preview distribution, not
+from stale Electron artifacts or incorrect Tauri packaging.
+
+## Decision
+
+Unpaid preview releases remain acceptable:
+
+- keep ad-hoc signing fallback enabled,
+- do not require paid Apple Developer ID certificates or notarization secrets,
+- clearly label preview behavior so users expect Gatekeeper prompts.
+
+## Remediation
+
+- Kept ad-hoc signing fallback (`TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'`) when
+  Developer ID credentials are absent.
+- Added a staged macOS release text asset:
+  `README-macos-apple-silicon-preview.txt`.
+- Documented manual open paths through Control-click/Open and
+  System Settings → Privacy & Security.
+- Kept deterministic artifact validation guardrails for naming, icon, and Apple
+  Silicon architecture.
+
+## Future optional path
+
+A no-warning public path can be added later with paid Developer ID signing plus
+Apple notarization/stapling. That remains optional and is not required for the
+current preview release channel.

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -86,3 +86,11 @@ def test_workflow_writes_preview_notice_via_printf() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert "printf '%s\\n' \\" in text
     assert '> "${preview_notice}"' in text
+
+
+def test_preview_notice_uses_full_signing_decision_in_stage_step() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}' in text
+    assert 'APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}' in text
+    assert 'APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}' in text
+    assert 'if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then' in text

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -50,6 +50,30 @@ def test_workflow_requires_exactly_one_staged_macos_dmg() -> None:
     assert 'Expected exactly one staged macOS .dmg in release-artifacts' in text
 
 
+def test_workflow_uses_ad_hoc_signing_fallback_without_paid_secrets() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert "export TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'" in text
+    assert "export APPLE_SIGNING_IDENTITY='-'" in text
+    assert 'using ad-hoc signing for preview/dev-only macOS artifacts' in text
+
+
+def test_workflow_does_not_gate_release_on_notary_profile() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'APPLE_NOTARYTOOL_KEYCHAIN_PROFILE is set, but notarization/stapling is not performed' in text
+    assert 'skipping strict Gatekeeper notarization enforcement' in text
+    assert 'signing_flag="--expect-signing"' in text
+
+
+def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'README-macos-apple-silicon-preview.txt' in text
+    assert 'This DMG is ad-hoc signed and is not notarized.' in text
+    assert 'Apple could not verify ... is free of malware.' in text
+    assert 'System Settings -> Privacy & Security' in text
+    assert 'paid Apple Developer ID' in text
+    assert 'signing plus notarization' in text
+
+
 def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
     text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
     assert 'CFBundleDisplayName' in text

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -68,6 +68,7 @@ def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'README-macos-apple-silicon-preview.txt' in text
     assert 'This DMG is ad-hoc signed and is not notarized.' in text
+    assert 'This DMG is signed with a configured Apple signing identity but is not notarized.' in text
     assert 'Apple could not verify ... is free of malware.' in text
     assert 'System Settings -> Privacy & Security' in text
     assert 'paid Apple Developer ID' in text
@@ -79,3 +80,9 @@ def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
     assert 'CFBundleDisplayName' in text
     assert 'CFBundleExecutable' in text
     assert 'token.place-desktop-<version>-apple-silicon.dmg' in text
+
+
+def test_workflow_writes_preview_notice_via_printf() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert "printf '%s\\n' \\" in text
+    assert '> "${preview_notice}"' in text


### PR DESCRIPTION
### Motivation

- Preserve an unpaid/ad-hoc macOS preview release path that does not require Apple Developer Program secrets while making the preview status explicit and safe to use.
- Ensure GitHub Release DMG artifacts remain the correct Tauri Apple Silicon bundles (`token.place-desktop-<version>-apple-silicon.dmg`) with existing icon/architecture/guardrail validations intact.
- Avoid gating public releases on notarization secrets or implying a preview DMG is notarized or Gatekeeper-ready. 

### Description

- Updated `.github/workflows/desktop-release.yml` to keep an ad-hoc signing fallback when paid signing credentials are absent by exporting `TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'` and `APPLE_SIGNING_IDENTITY='-'`, and to avoid failing macOS release jobs solely because notarization secrets are missing. 
- Added a generated preview guidance text asset `release-artifacts/README-macos-apple-silicon-preview.txt` (created in the workflow) and a validation step that the asset is present in staged macOS artifacts. 
- Kept existing Tauri-only staging, explicit DMG naming, DMG volume name, Apple Silicon binary checks, icon/hash validation, and stale Electron-brand rejection logic unchanged. 
- Added a concise “Unpaid macOS preview releases” section to `desktop-tauri/README.md`, added an outage follow-up entry `outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.{md,json}`, and extended `tests/unit/test_desktop_release_artifacts.py` with tests that assert the ad-hoc fallback, non-gating notarization profile behavior, and presence/content of the preview warning asset. 

### Testing

- Ran `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` which succeeded. 
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` which passed (10 tests). 
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` which passed (2 tests). 
- Ran repository checks/grep and `pre-commit run --all-files` which completed successfully; note that an ad-hoc local `./scripts/scan-secrets.py` invocation used in a local commit step was not present in this clone and was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1250b7aca4832f99046f6cd30f4e18)