### PR TITLE
Keep macOS desktop preview releases ad-hoc and add Gatekeeper guidance

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -297,6 +297,21 @@ jobs:
               echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
               exit 1
             fi
+
+            warning_path="release-artifacts/README-macos-apple-silicon-preview.txt"
+            cat > "${warning_path}" <<'EOF'
+            token.place desktop macOS Apple Silicon preview build
+
+            This DMG is ad-hoc signed and not notarized.
+            macOS Gatekeeper may show “Apple could not verify …” warnings when opening after download.
+            This is expected for unpaid preview distribution that does not use paid Apple Developer ID signing + notarization.
+
+            Manual open options:
+            1) Control-click (or right-click) token.place desktop.app, then choose Open.
+            2) If launch is blocked first, open System Settings → Privacy & Security and allow/open the app.
+
+            Only install if you trust this GitHub release and verify published checksums.
+            EOF
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -106,6 +106,14 @@ You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.
 
 
+### Unpaid macOS preview releases
+
+- No paid Apple Developer Program account is required to publish preview Apple Silicon DMGs.
+- Preview DMGs are ad-hoc signed and not notarized, so Gatekeeper warnings after browser/GitHub download are expected.
+- Users must manually open/whitelist the app (right-click/control-click → **Open**, or allow it from **System Settings → Privacy & Security** after a blocked launch).
+- Public no-warning distribution requires paid **Developer ID signing + notarization**.
+
+
 The local prompt panel still uses `src-tauri/python/inference_sidecar.py` as a smoke test for local model setup.
 
 

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-ad-hoc-macos-gatekeeper-warning",
+  "summary": "Apple Silicon preview DMGs can correctly ship Tauri branding while still showing expected Gatekeeper warnings because builds are ad-hoc signed and not notarized.",
+  "impact": "Users may interpret macOS verification warnings as an artifact mismatch unless release assets explicitly document unpaid preview behavior and manual-open instructions.",
+  "fix": "Kept ad-hoc signing fallback, preserved artifact guardrails, and added a macOS preview warning asset plus docs to explain expected Gatekeeper behavior.",
+  "lessons": "Correct artifact provenance and honest trust messaging must both be validated so preview release UX is explicit without requiring paid signing secrets."
+}

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
@@ -1,0 +1,36 @@
+# Desktop release follow-up: ad-hoc macOS Gatekeeper warning messaging (2026-05-24)
+
+## Summary
+The Apple Silicon DMG now has the correct Tauri artifact name, icon, and architecture,
+but users can still see "Apple could not verify ..." after downloading from GitHub Releases.
+That warning is expected for ad-hoc signed, non-notarized preview distribution.
+
+## Symptom
+- Downloaded `token.place-desktop-<version>-apple-silicon.dmg` opens to a correctly
+  branded app, but macOS shows Gatekeeper warning text such as
+  "Apple could not verify ..." on first launch.
+
+## Root cause
+- The build is intentionally on the unpaid ad-hoc signing path and is not notarized.
+- This is not a stale Electron artifact issue when DMG naming/icon/architecture
+  validations pass.
+
+## Decision
+- Keep unpaid preview releases enabled and acceptable for Apple Silicon DMGs.
+- Do not require paid Apple Developer Program credentials for preview release
+  artifact generation.
+- Clearly warn users that Gatekeeper warnings are expected and provide manual
+  open steps.
+
+## Remediation
+- Ensure workflow keeps `TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'` fallback when
+  Developer ID signing credentials are absent.
+- Generate and publish `README-macos-apple-silicon-preview.txt` alongside the DMG
+  to explain ad-hoc/non-notarized behavior and manual open instructions.
+- Preserve deterministic release guardrails: Tauri-only staging, expected icon,
+  Apple Silicon binary validation, checksum output, and stale Electron marker
+  rejection.
+
+## Optional future path
+- Add paid Developer ID signing + notarization for public no-warning distribution
+  if and when project policy chooses that path.

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -50,6 +50,29 @@ def test_workflow_requires_exactly_one_staged_macos_dmg() -> None:
     assert 'Expected exactly one staged macOS .dmg in release-artifacts' in text
 
 
+
+def test_workflow_uses_ad_hoc_signing_fallback_without_paid_secrets() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert "Developer ID certificate and identity are not fully configured" in text
+    assert "export TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'" in text
+    assert "export APPLE_SIGNING_IDENTITY='-'" in text
+
+
+def test_workflow_does_not_require_notarization_secrets_for_artifact_generation() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'APPLE_NOTARYTOOL_KEYCHAIN_PROFILE is set, but notarization/stapling is not performed' in text
+    assert '--expect-notarization' not in text
+
+
+def test_workflow_emits_macos_preview_warning_asset_with_manual_open_guidance() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'README-macos-apple-silicon-preview.txt' in text
+    assert 'ad-hoc signed and not notarized' in text
+    assert 'Apple could not verify' in text
+    assert 'System Settings → Privacy & Security' in text
+    assert 'Developer ID signing + notarization' in text
+    assert 'verify published checksums' in text
+
 def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
     text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
     assert 'CFBundleDisplayName' in text


### PR DESCRIPTION
### Motivation

- Make Apple Silicon preview DMGs honest and usable without requiring paid Apple Developer signing/notarization while preserving Tauri artifact correctness and validation.
- Ensure CI does not fail public macOS release jobs when Developer ID/notarization secrets are absent and does not imply the DMG is notarized or Gatekeeper-ready.
- Provide clear, calm guidance for end users to manually open/whitelist ad-hoc preview builds so Gatekeeper warnings are expected and actionable.

### Description

- Update `.github/workflows/desktop-release.yml` to keep an explicit ad-hoc signing fallback (`TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'` / `APPLE_SIGNING_IDENTITY='-'`) when paid signing credentials are missing and to emit a non-gating warning if `APPLE_NOTARYTOOL_KEYCHAIN_PROFILE` is present but notarization/stapling is not performed.
- Add generation of a release-side text asset `release-artifacts/README-macos-apple-silicon-preview.txt` alongside the DMG that explains the build is ad-hoc/not notarized, that Gatekeeper warnings are expected, how to manually open the app (right-click/Open or System Settings → Privacy & Security), and to verify checksums before installing.
- Add a concise “Unpaid macOS preview releases” section to `desktop-tauri/README.md` that documents the unpaid/ad-hoc preview path and distinguishes it from paid Developer ID + notarization no-warning distribution.
- Add an outage/follow-up entry `outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.{md,json}` documenting the symptom, root cause, decision, remediation, and optional future paid-notarization path.
- Extend `tests/unit/test_desktop_release_artifacts.py` with assertions that the workflow contains the ad-hoc fallback strings, does not require notarization secrets to produce artifacts, and includes the macOS preview warning asset and its expected content while preserving existing Tauri-specific artifact guardrails.

### Testing

- Ran `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` which succeeded. 
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` which passed (all new and existing artifact guardrail tests passed).
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` which passed after installing focused verification requirements; the test asserting CI workflow sentinel behavior passed. 
- Searched repository for relevant terms with `rg -n "ad-hoc|notarized|Gatekeeper|Privacy & Security|Developer ID|TAURI_BUNDLE_MACOS_SIGNING_IDENTITY|apple-silicon"` to verify assets/docs/workflow updates and ran `pre-commit run --all-files`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1250b7aca4832f99046f6cd30f4e18)