### PR TITLE
Keep macOS desktop preview releases ad-hoc and add Gatekeeper preview warning

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -293,6 +293,28 @@ jobs:
 
             rm -f "${dmg_path}"
             hdiutil create -volname "token.place desktop" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
+            cat > release-artifacts/README-macos-apple-silicon-preview.txt <<'EOF'
+            token.place Desktop macOS preview (Apple Silicon)
+            ================================================
+
+            This preview build is ad-hoc signed and NOT notarized.
+            macOS Gatekeeper may show:
+            "Apple could not verify ... is free of malware" or similar wording.
+
+            This is expected for unpaid/non-notarized preview distribution without
+            a paid Apple Developer Program notarization path.
+
+            Manual open options:
+            1) In Finder, Control-click (or right-click) token.place desktop.app and choose Open.
+            2) If macOS blocks it first, open System Settings -> Privacy & Security,
+               then allow/open token.place desktop from the recent security prompt.
+
+            Only install this app if you trust this repository/release and verify
+            the published checksum file before opening.
+
+            No-warning public macOS distribution normally requires paid Developer ID
+            signing plus Apple notarization.
+            EOF
             if [[ "${dmg_path}" == *"tokenplace Desktop"* ]] || [[ "${dmg_path}" == *"tokenplace Desktop Setup"* ]] || [[ "${dmg_path}" == *"desktop/electron-builder"* ]]; then
               echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
               exit 1
@@ -326,7 +348,6 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_NOTARYTOOL_KEYCHAIN_PROFILE: ${{ secrets.APPLE_NOTARYTOOL_KEYCHAIN_PROFILE }}
         run: |
           set -euo pipefail
           app_path="$(find src-tauri/target/${{ matrix.tauri_target }}/release/bundle/macos -maxdepth 1 -type d -name '*.app' | head -n 1)"
@@ -348,9 +369,6 @@ jobs:
           signing_flag=""
           if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
             signing_flag="--expect-signing"
-            if [ -n "${APPLE_NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]; then
-              echo "::warning::APPLE_NOTARYTOOL_KEYCHAIN_PROFILE is set, but notarization/stapling is not performed in this workflow yet; skipping strict Gatekeeper notarization enforcement."
-            fi
           fi
 
           python ../scripts/validate_desktop_tauri_release_artifacts.py               --app-path "${app_path}"               --dmg-path "${dmg_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -105,6 +105,17 @@ Desktop binaries are published by the GitHub Actions workflow
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.
 
+### Unpaid macOS preview releases
+
+- token.place can publish Apple Silicon preview DMGs without a paid
+  $99/year Apple Developer account by using ad-hoc signing.
+- Because these preview builds are not notarized, macOS Gatekeeper will likely
+  show an "Apple could not verify..." warning after browser/GitHub download.
+- Users can still open the app manually (Control-click/right-click app -> Open),
+  or use **System Settings -> Privacy & Security** after the first blocked open.
+- No-warning public macOS distribution normally requires paid Developer ID
+  signing + notarization.
+
 
 The local prompt panel still uses `src-tauri/python/inference_sidecar.py` as a smoke test for local model setup.
 

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-ad-hoc-macos-gatekeeper-warning",
+  "summary": "Correctly named and validated Apple Silicon DMGs can still show Gatekeeper warnings when distributed via ad-hoc/non-notarized preview signing.",
+  "impact": "Users may see Apple verification warnings even when artifact provenance and naming are correct, which can be misinterpreted as a packaging regression.",
+  "fix": "Kept ad-hoc signing fallback, added explicit preview warning asset with manual-open guidance, and documented unpaid preview vs paid notarized distribution paths.",
+  "lessons": "Artifact correctness and macOS trust-policy posture are separate concerns; preview releases must communicate expected Gatekeeper behavior clearly."
+}

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
@@ -1,0 +1,33 @@
+# Desktop release follow-up: ad-hoc macOS Gatekeeper warning is expected (2026-05-24)
+
+## Summary
+The Desktop Tauri Apple Silicon DMG now has the correct token.place artifact
+name, icon, and architecture validation, but macOS can still warn:
+"Apple could not verify ... is free of malware".
+
+## Symptom
+- GitHub Releases DMG `token.place-desktop-<version>-apple-silicon.dmg` is
+  correct and passes project artifact guardrails.
+- macOS may still block first-open with an Apple verification/Gatekeeper dialog.
+
+## Root cause
+- The preview path is ad-hoc signed and not notarized.
+- This is a trust-policy limitation of unpaid/non-notarized distribution,
+  not a stale Electron artifact issue.
+
+## Decision
+Unpaid preview releases remain acceptable if they are explicit, validated, and
+accompanied by clear user-facing warnings/manual-open instructions.
+
+## Remediation
+- Keep ad-hoc fallback signing in CI when paid signing credentials are absent.
+- Add a release-side warning asset (`README-macos-apple-silicon-preview.txt`)
+  alongside the DMG.
+- Document manual open flow (right-click Open, or System Settings -> Privacy &
+  Security after first block).
+- Preserve deterministic checks for Tauri-only artifacts, icon correctness,
+  stale Electron marker rejection, and Apple Silicon binary validation.
+
+## Optional future path
+Paid Developer ID signing + notarization can be added later for no-warning
+public macOS distribution, but it is not required for preview releases.

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -45,6 +45,23 @@ def test_workflow_sets_explicit_dmg_volume_name() -> None:
     assert 'hdiutil create -volname "token.place desktop"' in text
 
 
+def test_workflow_has_ad_hoc_signing_fallback_without_paid_secrets() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert "TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'" in text
+    assert 'using ad-hoc signing for preview/dev-only macOS artifacts' in text
+    assert 'APPLE_NOTARYTOOL_KEYCHAIN_PROFILE' not in text
+
+
+def test_workflow_stages_preview_warning_readme_asset() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'README-macos-apple-silicon-preview.txt' in text
+    assert 'ad-hoc signed and NOT notarized' in text
+    assert 'Apple could not verify' in text
+    assert 'System Settings -> Privacy & Security' in text
+    assert 'Developer ID' in text
+    assert 'notarization' in text
+
+
 def test_workflow_requires_exactly_one_staged_macos_dmg() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'Expected exactly one staged macOS .dmg in release-artifacts' in text


### PR DESCRIPTION
### Motivation

- Users downloading the Apple Silicon DMG were seeing a Gatekeeper "Apple could not verify..." warning which is expected for ad-hoc/non-notarized builds, so releases must be honest and user-actionable rather than silently implying notarization. 
- The release pipeline must not require paid Apple Developer Program secrets or notarization to produce a correct Tauri Apple Silicon preview DMG. 
- Changes are scoped to the Desktop Tauri release workflow, docs, tests, and outage notes to keep diffs small and targeted.

### Description

- The GitHub Actions workflow `.github/workflows/desktop-release.yml` now preserves an ad-hoc signing fallback when paid secrets are absent by exporting `TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'` and no longer gates macOS artifact production on notarization-related secrets. 
- The workflow stages a plain-text warning asset `release-artifacts/README-macos-apple-silicon-preview.txt` alongside the DMG explaining the ad-hoc/non-notarized status, expected Gatekeeper wording, and explicit manual-open instructions (`Control/right-click → Open` and `System Settings → Privacy & Security`). 
- Documentation was updated in `desktop-tauri/README.md` with an "Unpaid macOS preview releases" section that distinguishes ad-hoc preview builds from paid Developer ID + notarized no-warning distribution. 
- An outage/follow-up entry was added under `outages/` (`.md` + `.json`) documenting symptom, root cause, decision, remediation, and the optional paid future path. 
- Unit tests in `tests/unit/test_desktop_release_artifacts.py` were extended to assert the ad-hoc signing fallback, absence of gating on notarytool secret, presence of the preview README asset and required wording, while preserving existing Tauri-only, icon, Apple Silicon, checksum, and stale Electron guardrails.

### Testing

- Ran `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` which completed successfully. 
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and all tests passed (`9 passed`). 
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and all tests passed (`2 passed`). 
- Ran `rg` checks to verify the new strings and `pre-commit run --all-files` which completed successfully; a repository secret-scan script referenced in local SOP did not exist in this environment and was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1250b7aca4832f99046f6cd30f4e18)