### PR TITLE
Keep macOS Desktop Tauri release on ad-hoc preview path with Gatekeeper guidance

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -297,6 +297,25 @@ jobs:
               echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
               exit 1
             fi
+
+            cat > release-artifacts/README-macos-apple-silicon-preview.txt <<'EOF'
+            token.place desktop macOS Apple Silicon preview build
+
+            This preview DMG is ad-hoc signed and is not notarized.
+            Because it is not notarized, macOS Gatekeeper may show warnings such as
+            “Apple could not verify "token.place desktop" is free of malware...”
+            after download from browser/GitHub.
+
+            This warning is expected for unpaid/ad-hoc preview distribution without
+            a paid Apple Developer Program Developer ID + notarization path.
+
+            If you trust this release and its published checksums, you can open manually:
+            1) Control-click (or right-click) token.place desktop.app and choose Open.
+            2) If macOS still blocks first launch, open System Settings → Privacy & Security,
+               then allow/open the app from the security prompt.
+
+            Only install and run this preview build when you trust the source and checksums.
+            EOF
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -102,6 +102,21 @@ Desktop binaries are published by the GitHub Actions workflow
    - If signing credentials are configured, CI validates with `codesign` and
      `spctl` so signed builds fail fast when trust checks break.
 
+## Unpaid macOS preview releases
+
+- token.place can publish Apple Silicon preview DMGs without a paid $99/year
+  Apple Developer Program account by using ad-hoc signing.
+- These ad-hoc preview builds are **not notarized** and will commonly show
+  Gatekeeper warnings (for example, “Apple could not verify ...”) after
+  browser/GitHub download.
+- Users should manually allow first launch only when they trust the source and
+  checksums:
+  - Control-click/right-click `token.place desktop.app` and choose **Open**.
+  - Or after a blocked launch attempt, use **System Settings → Privacy & Security**
+    to allow/open the app.
+- Normal no-warning public distribution requires paid **Developer ID signing +
+  notarization**.
+
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.
 

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-ad-hoc-macos-gatekeeper-warning",
+  "summary": "Correct Tauri Apple Silicon DMGs still showed expected macOS Gatekeeper verification warnings under ad-hoc/non-notarized preview distribution.",
+  "impact": "Users could interpret expected Gatekeeper warnings as a packaging defect unless preview behavior and manual-open steps were explicitly documented.",
+  "fix": "Preserved ad-hoc fallback, added a release warning text asset, and documented manual-open expectations while retaining deterministic Tauri/icon/architecture/stale-marker validations.",
+  "lessons": "Artifact correctness and trust-readiness are separate concerns; preview releases must clearly label non-notarized behavior and user-open steps."
+}

--- a/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
+++ b/outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md
@@ -1,0 +1,41 @@
+# Outage: desktop release ad-hoc macOS Gatekeeper warning is expected for preview builds
+
+- **Date:** 2026-05-24
+- **Slug:** `desktop-release-ad-hoc-macos-gatekeeper-warning`
+- **Affected area:** Desktop Tauri macOS Apple Silicon release preview artifacts
+
+## Summary
+The GitHub Releases macOS asset was correctly produced as a Tauri Apple Silicon
+DMG with expected naming and icon validation, but users still saw
+"Apple could not verify ..." Gatekeeper warnings after download.
+
+## Symptom
+- Downloading `token.place-desktop-<version>-apple-silicon.dmg` can show
+  `"token.place desktop" Not Opened` and
+  `Apple could not verify ...` warnings on macOS.
+
+## Root cause
+- The release path intentionally supports unpaid preview distribution via
+  ad-hoc signing (or otherwise non-notarized artifacts) when paid Apple
+  Developer ID/notarization credentials are not configured.
+- This is distinct from stale Electron artifact issues; naming/path/icon and
+  architecture checks can all pass while Gatekeeper still warns for
+  non-notarized binaries.
+
+## Decision
+Unpaid preview releases remain acceptable and expected, provided release
+messaging clearly states the trust model and manual-open steps.
+
+## Remediation
+- Keep ad-hoc signing fallback in CI for macOS releases when paid secrets are
+  absent.
+- Add a release-side warning asset (`README-macos-apple-silicon-preview.txt`)
+  alongside the DMG explaining Gatekeeper behavior and manual-open instructions.
+- Keep deterministic release validation for Tauri-only staging, Apple Silicon
+  architecture, icon checks, checksum output, and stale Electron marker blocks.
+- Update desktop-tauri docs to distinguish unpaid preview behavior from paid
+  Developer ID + notarization distribution.
+
+## Future optional path
+A paid Apple Developer Program path can be added later for Developer ID signing
+and notarization to enable standard no-warning distribution.

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -55,3 +55,25 @@ def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
     assert 'CFBundleDisplayName' in text
     assert 'CFBundleExecutable' in text
     assert 'token.place-desktop-<version>-apple-silicon.dmg' in text
+
+
+def test_workflow_has_adhoc_signing_fallback_without_paid_secrets() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert "export TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'" in text
+    assert 'using ad-hoc signing for preview/dev-only macOS artifacts' in text
+
+
+def test_workflow_does_not_require_notarization_or_paid_secrets_for_artifact_generation() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'APPLE_NOTARYTOOL_KEYCHAIN_PROFILE is set, but notarization/stapling is not performed' in text
+    assert 'skip' in text.lower()
+    assert '--expect-notarization' not in text
+
+
+def test_workflow_emits_macos_preview_warning_asset() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'README-macos-apple-silicon-preview.txt' in text
+    assert 'ad-hoc signed and is not notarized' in text
+    assert 'Apple could not verify' in text
+    assert 'System Settings → Privacy & Security' in text
+    assert 'Developer ID + notarization path' in text


### PR DESCRIPTION
### Motivation

- Users downloading the Apple Silicon DMG saw Gatekeeper warnings; the intent is to preserve an unpaid/ad-hoc preview release path while making the release honest, documented, and easy to open manually.
- Ensure the macOS release remains Tauri-only, deterministically validated, correctly named (`token.place-desktop-<version>-apple-silicon.dmg`), uses the expected icon and Apple Silicon binary, and rejects stale Electron markers.
- Avoid requiring paid Apple Developer Program secrets or notarization for producing preview artifacts, while preventing accidental gating of public releases on notarization credentials.

### Description

- Updated `.github/workflows/desktop-release.yml` to keep an ad-hoc signing fallback when paid Apple signing secrets are absent by exporting `TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'` and to treat notary-related inputs as warnings (not blockers); preserved existing Tauri-only staging, DMG naming, `hdiutil` volume name `"token.place desktop"`, icon/architecture checks, and stale-Electron guards.
- Added a generated release-side warning text asset `release-artifacts/README-macos-apple-silicon-preview.txt` to be uploaded alongside the DMG that explains the build is ad-hoc/not notarized, that Gatekeeper warnings are expected, and gives explicit manual-open steps (`Control-click`/`Open` or System Settings → Privacy & Security), plus trust/checksum guidance.
- Updated `desktop-tauri/README.md` with a concise `Unpaid macOS preview releases` section clarifying that ad-hoc preview DMGs do not require a paid $99/year Apple account, will commonly show Gatekeeper warnings, and that paid Developer ID signing + notarization is the no-warning path.
- Added an outage/follow-up entry `outages/2026-05-24-desktop-release-ad-hoc-macos-gatekeeper-warning.md` and corresponding `.json` documenting symptom, root cause, decision, remediation, and future optional paid path.
- Extended `tests/unit/test_desktop_release_artifacts.py` to assert the ad-hoc fallback presence, non-gating notarization handling, presence and content of the preview warning asset, and retention of existing guardrails.

### Testing

- Ran `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` and it succeeded.
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and all tests passed (`10 passed`).
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and it passed (`2 passed`).
- Searched repo with `rg -n "ad-hoc|notarized|Gatekeeper|Privacy & Security|Developer ID|TAURI_BUNDLE_MACOS_SIGNING_IDENTITY|apple-silicon"` to verify changes, and ran `pre-commit run --all-files` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1250b7aca4832f99046f6cd30f4e18)