### PR TITLE
Embed Gatekeeper guidance inside macOS preview DMG and validate contents

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -294,28 +294,37 @@ jobs:
             dmg_name="token.place-desktop-${version}-apple-silicon.dmg"
             dmg_path="release-artifacts/${dmg_name}"
 
+            dmg_staging_dir="release-artifacts/dmg-staging"
+            rm -rf "${dmg_staging_dir}"
+            mkdir -p "${dmg_staging_dir}"
+
+            cp -R "${app_path}" "${dmg_staging_dir}/"
+            ln -s /Applications "${dmg_staging_dir}/Applications"
+
             rm -f "${dmg_path}"
-            hdiutil create -volname "token.place desktop" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
             if [[ "${dmg_path}" == *"tokenplace Desktop"* ]] || [[ "${dmg_path}" == *"tokenplace Desktop Setup"* ]] || [[ "${dmg_path}" == *"desktop/electron-builder"* ]]; then
               echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
               exit 1
             fi
 
             preview_notice="release-artifacts/README-macos-apple-silicon-preview.txt"
+            dmg_notice="${dmg_staging_dir}/README BEFORE OPENING.txt"
             if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This DMG is signed with a configured Apple signing identity but is not notarized." \
-                "Because notarization/stapling is not part of this workflow yet," \
-                "macOS may still show Gatekeeper warnings such as:" \
+                "This preview DMG is signed with a configured Apple signing identity and is not notarized." \
+                "The first normal double-click may show: \"Apple could not verify ... is free of malware.\"" \
+                "This is expected for unpaid/non-notarized GitHub preview releases." \
                 "\"Apple could not verify ... is free of malware.\"" \
                 "" \
                 "If you trust this source and the release checksums:" \
-                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
-                "2) If macOS blocks it after first launch attempt, go to:" \
-                "   System Settings -> Privacy & Security" \
-                "   and use the Allow/Open option for the app." \
+                "1) Drag or copy token.place desktop.app to Applications." \
+                "2) Try opening once from Applications." \
+                "3) If macOS blocks it, click Done." \
+                "4) Open System Settings -> Privacy & Security." \
+                "5) Click Open Anyway / Allow / Open for token.place desktop." \
+                "6) Or Control-click/right-click the app and choose Open when available." \
                 "" \
                 "Only install and run this preview build when you trust the release source" \
                 "and checksum file." \
@@ -326,18 +335,20 @@ jobs:
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This DMG is ad-hoc signed and is not notarized." \
-                "Because this preview build does not use paid Apple Developer ID notarization," \
-                "macOS may show Gatekeeper warnings such as:" \
+                "This preview DMG is ad-hoc signed and is not notarized." \
+                "The first normal double-click may show: \"Apple could not verify ... is free of malware.\"" \
+                "This is expected for unpaid/non-notarized GitHub preview releases." \
                 "\"Apple could not verify ... is free of malware.\"" \
                 "" \
                 "This is expected for unpaid/ad-hoc preview distribution." \
                 "" \
                 "If you trust this source and the release checksums:" \
-                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
-                "2) If macOS blocks it after first launch attempt, go to:" \
-                "   System Settings -> Privacy & Security" \
-                "   and use the Allow/Open option for the app." \
+                "1) Drag or copy token.place desktop.app to Applications." \
+                "2) Try opening once from Applications." \
+                "3) If macOS blocks it, click Done." \
+                "4) Open System Settings -> Privacy & Security." \
+                "5) Click Open Anyway / Allow / Open for token.place desktop." \
+                "6) Or Control-click/right-click the app and choose Open when available." \
                 "" \
                 "Only install and run this preview build when you trust the release source" \
                 "and checksum file." \
@@ -345,6 +356,8 @@ jobs:
                 "For no-warning public macOS distribution, use paid Apple Developer ID" \
                 "signing plus notarization." > "${preview_notice}"
             fi
+            cp "${preview_notice}" "${dmg_notice}"
+            hdiutil create -volname "token.place desktop" -srcfolder "${dmg_staging_dir}" -ov -format UDZO "${dmg_path}"
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"
             msi_dir="src-tauri/target/release/bundle/msi"

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -106,14 +106,25 @@ Desktop binaries are published by the GitHub Actions workflow
 
 - token.place can publish Apple Silicon preview DMGs without a paid
   Apple Developer Program account.
-- These preview builds use ad-hoc signing and are not notarized, so Gatekeeper
-  warnings after browser/GitHub download are expected.
-- Users must manually open/whitelist trusted previews:
-  - Control-click (or right-click) the app and choose **Open**, or
-  - after a blocked launch, use **System Settings → Privacy & Security**
-    to allow/open the app.
-- No-warning public distribution generally requires paid
-  Developer ID signing plus notarization.
+- These preview builds use ad-hoc signing and are not notarized, so the first
+  normal double-click may show Gatekeeper warnings such as
+  “Apple could not verify ... is free of malware.”
+- This workflow does not remove that warning path for unpaid previews.
+- The mounted DMG now includes an inline opening guide (`README BEFORE OPENING.txt`)
+  plus `token.place desktop.app` (and an `Applications` shortcut) so users see
+  the expected manual-open steps before launch.
+- The release page still includes `README-macos-apple-silicon-preview.txt`
+  as a sidecar copy of the same guidance.
+- Expected unpaid/trusted-release flow:
+  1. Drag or copy the app to Applications.
+  2. Try opening once.
+  3. If blocked, click **Done**.
+  4. Go to **System Settings → Privacy & Security**.
+  5. Click **Open Anyway / Allow / Open** for token.place desktop.
+  6. Or Control-click/right-click the app and choose **Open**.
+- Only install if you trust the GitHub release source and checksum files.
+- No-warning public distribution requires paid Developer ID signing plus
+  notarization.
 
 You can also run the workflow manually with `workflow_dispatch` and provide
 `tag_name` to rebuild/re-publish an existing desktop tag.

--- a/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.json
+++ b/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-preview-dmg-missing-inline-gatekeeper-guidance",
+  "summary": "Users saw expected Gatekeeper verification warnings on the corrected Apple Silicon preview app because the mounted DMG lacked inline opening guidance.",
+  "impact": "Users double-clicked the app first and encountered blocking dialogs without immediate context, creating avoidable confusion for unpaid ad-hoc preview releases.",
+  "fix": "Package the DMG from a staging directory containing the app, README BEFORE OPENING guidance, and Applications symlink; keep the sidecar preview README asset; and validate DMG README presence/content in CI.",
+  "lessons": "When preview distribution is intentionally ad-hoc/non-notarized, place trusted-manual-open guidance inside the mounted installer itself, not only in release-side metadata."
+}

--- a/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md
+++ b/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md
@@ -1,0 +1,32 @@
+# Outage follow-up: desktop release preview DMG missing inline Gatekeeper guidance (2026-05-24)
+
+- **Date:** 2026-05-24
+- **Slug:** `desktop-release-preview-dmg-missing-inline-gatekeeper-guidance`
+- **Affected area:** Desktop Tauri macOS Apple Silicon release packaging and validation (`.github/workflows/desktop-release.yml`, `scripts/validate_desktop_tauri_release_artifacts.py`)
+
+## Symptom
+
+The corrected Tauri Apple Silicon preview DMG still showed “Apple could not verify ...”
+when users double-clicked `token.place desktop.app`.
+
+## Root cause
+
+Ad-hoc/non-notarized preview builds are expected to trigger Gatekeeper, but the
+manual-open instructions existed only as a sidecar GitHub release asset. The
+mounted DMG itself did not include visible guidance.
+
+## Remediation
+
+- Build the DMG from a staging directory that includes:
+  - `token.place desktop.app`
+  - `README BEFORE OPENING.txt`
+  - `Applications` symlink for drag-install UX.
+- Keep publishing `README-macos-apple-silicon-preview.txt` as a release-side asset.
+- Validate mounted DMG contents in CI: exactly one app, preview README at DMG root,
+  and required guidance phrases (`ad-hoc signed`, `not notarized`, `Apple could not verify`,
+  `Privacy & Security`, `Developer ID`, `notarization`).
+
+## Future optional path
+
+To remove Gatekeeper warnings entirely, migrate to paid Developer ID signing plus
+notarization/stapling.

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -6,9 +6,18 @@ import hashlib
 import json
 import plistlib
 import subprocess
+import tempfile
 from pathlib import Path
 
 STALE_BRANDS = ("tokenplace Desktop", "tokenplace Desktop Setup", "desktop/electron-builder")
+README_REQUIRED_PHRASES = (
+    "ad-hoc signed",
+    "not notarized",
+    "Apple could not verify",
+    "Privacy & Security",
+    "Developer ID",
+    "notarization",
+)
 
 
 def _fail(msg: str) -> None:
@@ -24,6 +33,41 @@ def _run(cmd: list[str]) -> str:
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _validate_dmg_contents(dmg_path: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="token-place-dmg-") as tmp:
+        mount_point = Path(tmp) / "mount"
+        mount_point.mkdir(parents=True, exist_ok=True)
+        _run(
+            [
+                "hdiutil",
+                "attach",
+                str(dmg_path),
+                "-readonly",
+                "-nobrowse",
+                "-noautoopen",
+                "-mountpoint",
+                str(mount_point),
+            ]
+        )
+        try:
+            apps = sorted(p for p in mount_point.glob("*.app") if p.is_dir())
+            if len(apps) != 1:
+                _fail(f"DMG must contain exactly one .app bundle at root; found {len(apps)}")
+            readme_candidates = [
+                mount_point / "README BEFORE OPENING.txt",
+                mount_point / "README-macos-apple-silicon-preview.txt",
+            ]
+            readme_path = next((p for p in readme_candidates if p.exists() and p.is_file()), None)
+            if readme_path is None:
+                _fail("DMG root must include README BEFORE OPENING.txt or README-macos-apple-silicon-preview.txt")
+            readme_text = readme_path.read_text(encoding="utf-8")
+            for phrase in README_REQUIRED_PHRASES:
+                if phrase not in readme_text:
+                    _fail(f"DMG preview README is missing required phrase: {phrase}")
+        finally:
+            _run(["hdiutil", "detach", str(mount_point)])
 
 
 def _parse_args() -> argparse.Namespace:
@@ -102,6 +146,8 @@ def main() -> None:
         _fail(f"binary is not Apple Silicon: {arch_out}")
     if "x86_64" in arch_lower and "arm64" not in arch_lower:
         _fail(f"binary is x86_64-only: {arch_out}")
+
+    _validate_dmg_contents(dmg_path)
 
     if args.expect_signing:
         _run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app_path)])

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -43,6 +43,8 @@ def test_tauri_icon_set_references_expected_files() -> None:
 def test_workflow_sets_explicit_dmg_volume_name() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'hdiutil create -volname "token.place desktop"' in text
+    assert '-srcfolder "${dmg_staging_dir}"' in text
+    assert '-srcfolder "${app_path}"' not in text
 
 
 def test_workflow_requires_exactly_one_staged_macos_dmg() -> None:
@@ -67,8 +69,8 @@ def test_workflow_does_not_gate_release_on_notary_profile() -> None:
 def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'README-macos-apple-silicon-preview.txt' in text
-    assert 'This DMG is ad-hoc signed and is not notarized.' in text
-    assert 'This DMG is signed with a configured Apple signing identity but is not notarized.' in text
+    assert 'This preview DMG is ad-hoc signed and is not notarized.' in text
+    assert 'This preview DMG is signed with a configured Apple signing identity and is not notarized.' in text
     assert 'Apple could not verify ... is free of malware.' in text
     assert 'System Settings -> Privacy & Security' in text
     assert 'paid Apple Developer ID' in text
@@ -94,3 +96,48 @@ def test_preview_notice_uses_full_signing_decision_in_stage_step() -> None:
     assert 'APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}' in text
     assert 'APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}' in text
     assert 'if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then' in text
+
+
+def test_workflow_stages_dmg_with_app_readme_and_applications_link() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'dmg_staging_dir="release-artifacts/dmg-staging"' in text
+    assert 'cp -R "${app_path}" "${dmg_staging_dir}/"' in text
+    assert 'ln -s /Applications "${dmg_staging_dir}/Applications"' in text
+    assert 'dmg_notice="${dmg_staging_dir}/README BEFORE OPENING.txt"' in text
+    assert 'cp "${preview_notice}" "${dmg_notice}"' in text
+
+
+def test_preview_notice_includes_gatekeeper_manual_open_guidance() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'Apple could not verify ... is free of malware.' in text
+    assert 'click Done.' in text
+    assert 'System Settings -> Privacy & Security' in text
+    assert 'Open Anyway / Allow / Open' in text
+    assert 'ad-hoc signed' in text
+    assert 'not notarized' in text
+    assert 'paid Apple Developer ID' in text
+    assert 'notarization' in text
+
+
+def test_validator_checks_dmg_readme_content_requirements() -> None:
+    text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
+    assert 'README BEFORE OPENING.txt' in text
+    assert 'README-macos-apple-silicon-preview.txt' in text
+    assert 'DMG must contain exactly one .app bundle at root' in text
+    for phrase in (
+        'ad-hoc signed',
+        'not notarized',
+        'Apple could not verify',
+        'Privacy & Security',
+        'Developer ID',
+        'notarization',
+    ):
+        assert phrase in text
+
+
+def test_validator_uses_hdiutil_attach_for_dmg_validation() -> None:
+    text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
+    assert 'hdiutil' in text
+    assert 'attach' in text
+    assert '-readonly' in text
+    assert 'hdiutil", "detach"' in text


### PR DESCRIPTION
### Motivation
- Users of unpaid/ad-hoc Apple Silicon preview DMGs were double-clicking the app and seeing the expected Gatekeeper dialog without any inline guidance because guidance lived only as a sidecar release asset.
- The goal is to make preview DMGs self-explanatory and easy to open manually while preserving ad-hoc signing fallback and existing artifact validation.

### Description
- Update `.github/workflows/desktop-release.yml` to build the DMG from a staging directory (`release-artifacts/dmg-staging`) that contains `token.place desktop.app`, an `Applications` symlink, and an inline `README BEFORE OPENING.txt` copied from the generated preview sidecar `README-macos-apple-silicon-preview.txt`, while preserving the DMG name and volume name and keeping the ad-hoc signing fallback (`TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'`).
- Expand and standardize the preview guidance text to explicitly document expected Gatekeeper behavior and manual-open steps (drag to Applications, try open, click Done if blocked, System Settings → Privacy & Security → Open Anyway / Allow / Open, or Control-click → Open), and keep the release-side `README-macos-apple-silicon-preview.txt` asset.
- Harden `scripts/validate_desktop_tauri_release_artifacts.py` to attach the DMG read-only (`hdiutil attach`) in CI and verify the mounted DMG root contains exactly one `.app`, that a preview README exists at DMG root, and that the README contains required phrases (`ad-hoc signed`, `not notarized`, `Apple could not verify`, `Privacy & Security`, `Developer ID`, `notarization`), while preserving existing icon, CFBundle, Apple Silicon, and stale Electron guardrails.
- Extend `tests/unit/test_desktop_release_artifacts.py` to assert DMG staging (staging dir, `cp -R` of `.app`, `ln -s /Applications`), README presence and guidance content, and validator DMG checks; update `desktop-tauri/README.md` to explain the new inline guidance and that Gatekeeper prompts are expected for unpaid previews; add outages follow-up files documenting the change.

### Testing
- Ran `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` and it succeeded.
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and all tests passed (16 passed).
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and tests passed (2 passed).
- Verified repository text matches via ripgrep: `rg -n "README BEFORE OPENING|README-macos-apple-silicon-preview|Apple could not verify|Privacy & Security|Open Anyway|ad-hoc signed|not notarized|Developer ID|notarization|hdiutil create|Applications"` and found the updated workflow, docs, validator, tests, and outage entries.
- Ran `pre-commit run --all-files` and hooks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12695373f0832fb05094a83afd4b0f)