### PR TITLE
Embed Gatekeeper guidance in macOS Apple Silicon preview DMG and validate contents

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -293,57 +293,63 @@ jobs:
             version="${ref_slug#desktop-v}"
             dmg_name="token.place-desktop-${version}-apple-silicon.dmg"
             dmg_path="release-artifacts/${dmg_name}"
-
-            rm -f "${dmg_path}"
-            hdiutil create -volname "token.place desktop" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
-            if [[ "${dmg_path}" == *"tokenplace Desktop"* ]] || [[ "${dmg_path}" == *"tokenplace Desktop Setup"* ]] || [[ "${dmg_path}" == *"desktop/electron-builder"* ]]; then
-              echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
-              exit 1
-            fi
-
+            dmg_stage_dir="$RUNNER_TEMP/token-place-dmg-stage"
+            preview_notice_name="README BEFORE OPENING.txt"
             preview_notice="release-artifacts/README-macos-apple-silicon-preview.txt"
+
             if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This DMG is signed with a configured Apple signing identity but is not notarized." \
-                "Because notarization/stapling is not part of this workflow yet," \
-                "macOS may still show Gatekeeper warnings such as:" \
-                "\"Apple could not verify ... is free of malware.\"" \
+                "This preview build is ad-hoc signed and not notarized for public Gatekeeper trust." \
+                "Even with CI signing credentials, this workflow does not perform Developer ID notarization." \
+                "The first normal double-click may show:" \
+                "\"Apple could not verify \\\"token.place desktop\\\" is free of malware.\"" \
+                "This is expected for unpaid/non-notarized GitHub preview releases." \
                 "" \
                 "If you trust this source and the release checksums:" \
-                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
-                "2) If macOS blocks it after first launch attempt, go to:" \
-                "   System Settings -> Privacy & Security" \
-                "   and use the Allow/Open option for the app." \
+                "1) Drag/copy token.place desktop.app to Applications." \
+                "2) Try opening it once from Applications." \
+                "3) If macOS blocks it, click Done." \
+                "4) Open System Settings -> Privacy & Security." \
+                "5) Click Open Anyway / Allow / Open for token.place desktop." \
+                "6) Or Control-click (right-click) the app and choose Open when available." \
                 "" \
-                "Only install and run this preview build when you trust the release source" \
-                "and checksum file." \
+                "Only install if you trust this GitHub release and verify checksums." \
                 "" \
-                "For no-warning public macOS distribution, use paid Apple Developer ID" \
-                "signing plus notarization." > "${preview_notice}"
+                "Normal no-warning public macOS distribution requires paid Developer ID signing + notarization." > "${preview_notice}"
             else
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This DMG is ad-hoc signed and is not notarized." \
-                "Because this preview build does not use paid Apple Developer ID notarization," \
-                "macOS may show Gatekeeper warnings such as:" \
-                "\"Apple could not verify ... is free of malware.\"" \
+                "This preview build is ad-hoc signed and not notarized." \
+                "The first normal double-click may show:" \
+                "\"Apple could not verify \\\"token.place desktop\\\" is free of malware.\"" \
                 "" \
-                "This is expected for unpaid/ad-hoc preview distribution." \
+                "This is expected for unpaid/non-notarized GitHub preview releases." \
                 "" \
                 "If you trust this source and the release checksums:" \
-                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
-                "2) If macOS blocks it after first launch attempt, go to:" \
-                "   System Settings -> Privacy & Security" \
-                "   and use the Allow/Open option for the app." \
+                "1) Drag/copy token.place desktop.app to Applications." \
+                "2) Try opening it once from Applications." \
+                "3) If macOS blocks it, click Done." \
+                "4) Open System Settings -> Privacy & Security." \
+                "5) Click Open Anyway / Allow / Open for token.place desktop." \
+                "6) Or Control-click (right-click) the app and choose Open when available." \
                 "" \
-                "Only install and run this preview build when you trust the release source" \
-                "and checksum file." \
+                "Only install if you trust this GitHub release and verify checksums." \
                 "" \
-                "For no-warning public macOS distribution, use paid Apple Developer ID" \
-                "signing plus notarization." > "${preview_notice}"
+                "Normal no-warning public macOS distribution requires paid Developer ID signing + notarization." > "${preview_notice}"
+            fi
+            rm -rf "${dmg_stage_dir}"
+            mkdir -p "${dmg_stage_dir}"
+            cp -R "${app_path}" "${dmg_stage_dir}/"
+            cp "${preview_notice}" "${dmg_stage_dir}/${preview_notice_name}"
+            ln -s /Applications "${dmg_stage_dir}/Applications"
+            rm -f "${dmg_path}"
+            hdiutil create -volname "token.place desktop" -srcfolder "${dmg_stage_dir}" -ov -format UDZO "${dmg_path}"
+            if [[ "${dmg_path}" == *"tokenplace Desktop"* ]] || [[ "${dmg_path}" == *"tokenplace Desktop Setup"* ]] || [[ "${dmg_path}" == *"desktop/electron-builder"* ]]; then
+              echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
+              exit 1
             fi
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -301,8 +301,8 @@ jobs:
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This preview build is signed with the configured Apple identity but not notarized for public Gatekeeper trust." \
-                "Even with CI signing credentials, this workflow does not perform Developer ID notarization." \
+                "This preview build is signed with the configured Apple signing identity, but it is not notarized." \
+                "Unpaid/no-credential preview builds use ad-hoc signing; either way, this workflow does not perform Developer ID notarization." \
                 "The first normal double-click may show:" \
                 "\"Apple could not verify \\\"token.place desktop\\\" is free of malware.\"" \
                 "This is expected for unpaid/non-notarized GitHub preview releases." \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -301,7 +301,7 @@ jobs:
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This preview build is ad-hoc signed and not notarized for public Gatekeeper trust." \
+                "This preview build is signed with the configured Apple identity but not notarized for public Gatekeeper trust." \
                 "Even with CI signing credentials, this workflow does not perform Developer ID notarization." \
                 "The first normal double-click may show:" \
                 "\"Apple could not verify \\\"token.place desktop\\\" is free of malware.\"" \

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -108,10 +108,17 @@ Desktop binaries are published by the GitHub Actions workflow
   Apple Developer Program account.
 - These preview builds use ad-hoc signing and are not notarized, so Gatekeeper
   warnings after browser/GitHub download are expected.
+- The mounted DMG now includes an inline opening guide (`README BEFORE OPENING.txt`)
+  plus a sidecar release asset (`README-macos-apple-silicon-preview.txt`) that
+  explain the same manual-open flow.
 - Users must manually open/whitelist trusted previews:
-  - Control-click (or right-click) the app and choose **Open**, or
-  - after a blocked launch, use **System Settings → Privacy & Security**
-    to allow/open the app.
+  - Drag/copy `token.place desktop.app` to **Applications** and try opening once.
+  - If macOS blocks with the expected “Apple could not verify…” dialog, click
+    **Done**, then use **System Settings → Privacy & Security** to
+    **Open Anyway / Allow / Open**.
+  - Control-click (or right-click) and choose **Open** remains a fallback path.
+- This flow does not remove Gatekeeper warnings for unpaid preview releases; it
+  explains the expected manual allow/open steps.
 - No-warning public distribution generally requires paid
   Developer ID signing plus notarization.
 

--- a/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.json
+++ b/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-preview-dmg-missing-inline-gatekeeper-guidance",
+  "summary": "Correct Apple Silicon preview DMGs still showed expected \"Apple could not verify\" Gatekeeper warnings, but mounted DMGs lacked inline guidance before app launch.",
+  "impact": "Users could misinterpret expected unpaid ad-hoc/non-notarized Gatekeeper behavior as a packaging failure when opening directly from the DMG.",
+  "fix": "Updated DMG staging to include an inline README opening guide and Applications symlink, retained sidecar preview README release asset, and added validator checks that mounted DMGs include required preview guidance text.",
+  "lessons": "When ad-hoc/non-notarized preview builds are intentional, guidance must be embedded in the first-run surface (mounted DMG) in addition to release-page sidecar notes."
+}

--- a/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md
+++ b/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md
@@ -1,0 +1,29 @@
+# Outage follow-up: desktop release preview DMG missing inline Gatekeeper guidance (2026-05-24)
+
+- **Date:** 2026-05-24
+- **Slug:** `desktop-release-preview-dmg-missing-inline-gatekeeper-guidance`
+- **Affected area:** Desktop Tauri macOS Apple Silicon release packaging (`.github/workflows/desktop-release.yml`)
+
+## Symptom
+
+The Apple Silicon DMG artifact was correct (Tauri app, expected icon/name), but users who double-clicked the app in the mounted DMG still saw:
+
+"Apple could not verify \"token.place desktop\" is free of malware."
+
+## Root cause
+
+This behavior is expected for ad-hoc/non-notarized preview releases. The release pipeline only surfaced guidance in a sidecar release asset (`README-macos-apple-silicon-preview.txt`), while the mounted DMG itself contained only the app, so users naturally encountered Gatekeeper first without inline instructions.
+
+## Remediation
+
+- Kept unpaid ad-hoc signing fallback (`TAURI_BUNDLE_MACOS_SIGNING_IDENTITY='-'`).
+- Added DMG staging directory so mounted DMG contains:
+  - `token.place desktop.app`
+  - `README BEFORE OPENING.txt` with explicit manual-open guidance
+  - `/Applications` symlink for expected drag-install UX
+- Kept sidecar release asset generation (`README-macos-apple-silicon-preview.txt`).
+- Hardened artifact validation to mount DMG read-only on macOS CI and assert README presence/content with key phrases (`ad-hoc signed`, `not notarized`, `Apple could not verify`, `Privacy & Security`, `Developer ID`, `notarization`).
+
+## Future optional path
+
+To remove Gatekeeper warning dialogs entirely, move to paid Apple Developer ID signing plus notarization/stapling. This remains optional and is not required for unpaid preview distribution.

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -4,11 +4,22 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import plistlib
 import subprocess
+import tempfile
 from pathlib import Path
 
 STALE_BRANDS = ("tokenplace Desktop", "tokenplace Desktop Setup", "desktop/electron-builder")
+DMG_PREVIEW_README_NAMES = ("README BEFORE OPENING.txt", "README-macos-apple-silicon-preview.txt")
+DMG_PREVIEW_REQUIRED_PHRASES = (
+    "ad-hoc signed",
+    "not notarized",
+    "Apple could not verify",
+    "Privacy & Security",
+    "Developer ID",
+    "notarization",
+)
 
 
 def _fail(msg: str) -> None:
@@ -37,6 +48,28 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
+def _validate_dmg_contents(dmg_path: Path) -> None:
+    if os.uname().sysname != "Darwin":
+        print("::warning::Skipping DMG mounted-content checks outside macOS.")
+        return
+    with tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-") as mount_dir:
+        _run(["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", mount_dir, str(dmg_path)])
+        try:
+            root = Path(mount_dir)
+            apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == ".app")
+            if len(apps) != 1:
+                _fail(f"DMG must contain exactly one .app at root; found {len(apps)}")
+            readme_path = next((root / name for name in DMG_PREVIEW_README_NAMES if (root / name).is_file()), None)
+            if readme_path is None:
+                _fail(f"DMG must include one preview README at root: {DMG_PREVIEW_README_NAMES}")
+            readme_text = readme_path.read_text(encoding="utf-8")
+            missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
+            if missing:
+                _fail(f"DMG preview README missing required phrases: {missing}")
+        finally:
+            _run(["hdiutil", "detach", mount_dir])
+
+
 def main() -> None:
     args = _parse_args()
     app_path = Path(args.app_path)
@@ -53,6 +86,7 @@ def main() -> None:
         _fail(f"dmg artifact missing or invalid: {dmg_path}")
     if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
         _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
+    _validate_dmg_contents(dmg_path)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -22,7 +22,7 @@ DMG_PREVIEW_REQUIRED_PHRASES = (
 )
 DMG_PREVIEW_SIGNING_PHRASE_OPTIONS = (
     "ad-hoc signed",
-    "signed with the configured Apple identity",
+    "signed with the configured Apple signing identity",
 )
 
 
@@ -73,7 +73,7 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
             if expect_signing:
                 if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
                     _fail(
-                        "DMG preview README must describe configured Apple identity signing when --expect-signing is set"
+                        "DMG preview README must describe configured Apple signing identity when --expect-signing is set"
                     )
             elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
                 _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -5,13 +5,14 @@ import argparse
 import hashlib
 import json
 import os
+import platform
 import plistlib
 import subprocess
 import tempfile
 from pathlib import Path
 
 STALE_BRANDS = ("tokenplace Desktop", "tokenplace Desktop Setup", "desktop/electron-builder")
-DMG_PREVIEW_README_NAMES = ("README BEFORE OPENING.txt", "README-macos-apple-silicon-preview.txt")
+DMG_PREVIEW_README_NAMES = ("README BEFORE OPENING.txt",)
 DMG_PREVIEW_REQUIRED_PHRASES = (
     "ad-hoc signed",
     "not notarized",
@@ -49,7 +50,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _validate_dmg_contents(dmg_path: Path) -> None:
-    if os.uname().sysname != "Darwin":
+    if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
     with tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-") as mount_dir:

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -14,12 +14,15 @@ from pathlib import Path
 STALE_BRANDS = ("tokenplace Desktop", "tokenplace Desktop Setup", "desktop/electron-builder")
 DMG_PREVIEW_README_NAMES = ("README BEFORE OPENING.txt",)
 DMG_PREVIEW_REQUIRED_PHRASES = (
-    "ad-hoc signed",
     "not notarized",
     "Apple could not verify",
     "Privacy & Security",
     "Developer ID",
     "notarization",
+)
+DMG_PREVIEW_SIGNING_PHRASE_OPTIONS = (
+    "ad-hoc signed",
+    "signed with the configured Apple identity",
 )
 
 
@@ -49,7 +52,7 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def _validate_dmg_contents(dmg_path: Path) -> None:
+def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
@@ -67,6 +70,13 @@ def _validate_dmg_contents(dmg_path: Path) -> None:
             missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
             if missing:
                 _fail(f"DMG preview README missing required phrases: {missing}")
+            if expect_signing:
+                if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
+                    _fail(
+                        "DMG preview README must describe configured Apple identity signing when --expect-signing is set"
+                    )
+            elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
+                _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
         finally:
             _run(["hdiutil", "detach", mount_dir])
 
@@ -87,7 +97,7 @@ def main() -> None:
         _fail(f"dmg artifact missing or invalid: {dmg_path}")
     if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
         _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
-    _validate_dmg_contents(dmg_path)
+    _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -79,7 +79,8 @@ def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
     assert 'preview_notice_name="README BEFORE OPENING.txt"' in text
     assert 'README-macos-apple-silicon-preview.txt' in text
     assert 'This preview build is ad-hoc signed and not notarized.' in text
-    assert 'This preview build is signed with the configured Apple identity but not notarized for public Gatekeeper trust.' in text
+    assert 'This preview build is signed with the configured Apple signing identity, but it is not notarized.' in text
+    assert 'This preview build is ad-hoc signed and not notarized for public Gatekeeper trust.' not in text
     assert 'Apple could not verify' in text
     assert 'token.place desktop' in text
     assert 'click Done' in text

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -79,7 +79,7 @@ def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
     assert 'preview_notice_name="README BEFORE OPENING.txt"' in text
     assert 'README-macos-apple-silicon-preview.txt' in text
     assert 'This preview build is ad-hoc signed and not notarized.' in text
-    assert 'This preview build is ad-hoc signed and not notarized for public Gatekeeper trust.' in text
+    assert 'This preview build is signed with the configured Apple identity but not notarized for public Gatekeeper trust.' in text
     assert 'Apple could not verify' in text
     assert 'token.place desktop' in text
     assert 'click Done' in text
@@ -97,6 +97,7 @@ def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
     assert 'token.place-desktop-<version>-apple-silicon.dmg' in text
     assert 'DMG_PREVIEW_README_NAMES' in text
     assert 'DMG_PREVIEW_REQUIRED_PHRASES' in text
+    assert 'platform.system()' in text
     assert 'hdiutil' in text
 
 

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -45,6 +45,16 @@ def test_workflow_sets_explicit_dmg_volume_name() -> None:
     assert 'hdiutil create -volname "token.place desktop"' in text
 
 
+def test_workflow_stages_dmg_directory_with_app_readme_and_applications_symlink() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'dmg_stage_dir="$RUNNER_TEMP/token-place-dmg-stage"' in text
+    assert 'cp -R "${app_path}" "${dmg_stage_dir}/"' in text
+    assert 'cp "${preview_notice}" "${dmg_stage_dir}/${preview_notice_name}"' in text
+    assert 'ln -s /Applications "${dmg_stage_dir}/Applications"' in text
+    assert '-srcfolder "${dmg_stage_dir}"' in text
+    assert '-srcfolder "${app_path}"' not in text
+
+
 def test_workflow_requires_exactly_one_staged_macos_dmg() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'Expected exactly one staged macOS .dmg in release-artifacts' in text
@@ -66,13 +76,18 @@ def test_workflow_does_not_gate_release_on_notary_profile() -> None:
 
 def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'preview_notice_name="README BEFORE OPENING.txt"' in text
     assert 'README-macos-apple-silicon-preview.txt' in text
-    assert 'This DMG is ad-hoc signed and is not notarized.' in text
-    assert 'This DMG is signed with a configured Apple signing identity but is not notarized.' in text
-    assert 'Apple could not verify ... is free of malware.' in text
+    assert 'This preview build is ad-hoc signed and not notarized.' in text
+    assert 'This preview build is ad-hoc signed and not notarized for public Gatekeeper trust.' in text
+    assert 'Apple could not verify' in text
+    assert 'token.place desktop' in text
+    assert 'click Done' in text
     assert 'System Settings -> Privacy & Security' in text
-    assert 'paid Apple Developer ID' in text
-    assert 'signing plus notarization' in text
+    assert 'Open Anyway / Allow / Open for token.place desktop' in text
+    assert 'Control-click (right-click) the app and choose Open when available.' in text
+    assert 'System Settings -> Privacy & Security' in text
+    assert 'paid Developer ID signing + notarization' in text
 
 
 def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
@@ -80,6 +95,9 @@ def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
     assert 'CFBundleDisplayName' in text
     assert 'CFBundleExecutable' in text
     assert 'token.place-desktop-<version>-apple-silicon.dmg' in text
+    assert 'DMG_PREVIEW_README_NAMES' in text
+    assert 'DMG_PREVIEW_REQUIRED_PHRASES' in text
+    assert 'hdiutil' in text
 
 
 def test_workflow_writes_preview_notice_via_printf() -> None:


### PR DESCRIPTION
### Motivation
- Preview Apple Silicon DMGs were ad-hoc signed and not notarized, causing expected Gatekeeper "Apple could not verify…" dialogs that confused users because guidance lived only as a sidecar release asset and not inside the mounted DMG. 
- Make unpaid preview releases self-explanatory and preserve all existing artifact guardrails without requiring paid Developer ID notarization.

### Description
- Update workflow `.github/workflows/desktop-release.yml` to stage DMG contents in a temp directory and build the DMG from that directory instead of `-srcfolder "$app_path"`, adding `token.place desktop.app`, an inline `README BEFORE OPENING.txt` (generated from the existing preview text) and an `/Applications` symlink while preserving the DMG name, volume name, and ad-hoc signing fallback. 
- Keep the sidecar release asset `release-artifacts/README-macos-apple-silicon-preview.txt` and align its guidance to explicitly describe the expected Gatekeeper dialog and manual-open steps (drag to Applications, try open, click Done, System Settings → Privacy & Security → Open Anyway / Allow / Open, or Control-click → Open). 
- Harden `scripts/validate_desktop_tauri_release_artifacts.py` to (macOS-only) mount the DMG read-only during validation and assert: exactly one `.app` at DMG root, presence of preview README at DMG root, and that the README contains required phrases (`ad-hoc signed`, `not notarized`, `Apple could not verify`, `Privacy & Security`, `Developer ID`, `notarization`), while keeping existing bundle/icon/arch/CFBundleExecutable checks. Off-macOS runs print a warning and skip mounted-content checks. 
- Extend `tests/unit/test_desktop_release_artifacts.py` to assert the new staging directory usage, copy of the app and README, Applications symlink, that DMG is no longer created directly from `"${app_path}"`, and that preview guidance text is present in workflow-generated preview text; keep existing guardrail tests. 
- Update `desktop-tauri/README.md` to document that the mounted DMG contains an opening guide and that Gatekeeper warnings for unpaid previews remain expected. 
- Add outage follow-up files documenting symptom, root cause, remediation, and optional future notarization path (`outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.{md,json}`).

### Testing
- `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` succeeded. 
- `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` passed (all updated unit tests green). 
- `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` passed. 
- Repo-wide `rg` checks for the new README name, help text phrases, `hdiutil create`, and `Applications` symlink found the updated workflow, docs, scripts, tests, and outage entries. 
- `pre-commit run --all-files` completed successfully. 
- Note: `git diff --cached | ./scripts/scan-secrets.py` failed because `./scripts/scan-secrets.py` is not present in the repo; also the new DMG-mounted-content validator is macOS-only and emits a warning and skips mounting when run on non-macOS CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12695373f0832fb05094a83afd4b0f)