### PR TITLE
Embed Gatekeeper guidance inside macOS preview DMG staging

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -293,57 +293,61 @@ jobs:
             version="${ref_slug#desktop-v}"
             dmg_name="token.place-desktop-${version}-apple-silicon.dmg"
             dmg_path="release-artifacts/${dmg_name}"
+            dmg_stage_dir="$RUNNER_TEMP/token-place-desktop-dmg-stage"
 
             rm -f "${dmg_path}"
-            hdiutil create -volname "token.place desktop" -srcfolder "${app_path}" -ov -format UDZO "${dmg_path}"
-            if [[ "${dmg_path}" == *"tokenplace Desktop"* ]] || [[ "${dmg_path}" == *"tokenplace Desktop Setup"* ]] || [[ "${dmg_path}" == *"desktop/electron-builder"* ]]; then
-              echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
-              exit 1
-            fi
+            rm -rf "${dmg_stage_dir}"
+            mkdir -p "${dmg_stage_dir}"
 
             preview_notice="release-artifacts/README-macos-apple-silicon-preview.txt"
             if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This DMG is signed with a configured Apple signing identity but is not notarized." \
-                "Because notarization/stapling is not part of this workflow yet," \
-                "macOS may still show Gatekeeper warnings such as:" \
-                "\"Apple could not verify ... is free of malware.\"" \
+                "This preview build is ad-hoc signed and not notarized." \
+                "Normal no-warning distribution requires paid Developer ID signing + notarization." \
+                "The first normal double-click may show: Apple could not verify \"token.place desktop\" is free of malware." \
+                "This is expected for unpaid/non-notarized GitHub preview releases." \
                 "" \
-                "If you trust this source and the release checksums:" \
-                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
-                "2) If macOS blocks it after first launch attempt, go to:" \
-                "   System Settings -> Privacy & Security" \
-                "   and use the Allow/Open option for the app." \
+                "Only install if you trust this GitHub release and checksum files." \
+                "Recommended flow:" \
+                "1) Drag/copy token.place desktop.app to Applications." \
+                "2) Try opening once from Applications." \
+                "3) If macOS blocks it, click Done." \
+                "4) Go to System Settings -> Privacy & Security." \
+                "5) Click Open Anyway / Allow / Open for token.place desktop." \
+                "6) Or Control-click/right-click token.place desktop.app and choose Open when available." \
                 "" \
-                "Only install and run this preview build when you trust the release source" \
-                "and checksum file." \
-                "" \
-                "For no-warning public macOS distribution, use paid Apple Developer ID" \
-                "signing plus notarization." > "${preview_notice}"
+                "Normal no-warning distribution requires paid Developer ID signing + notarization." > "${preview_notice}"
             else
               printf '%s\n' \
                 "token.place desktop macOS Apple Silicon preview build" \
                 "" \
-                "This DMG is ad-hoc signed and is not notarized." \
-                "Because this preview build does not use paid Apple Developer ID notarization," \
-                "macOS may show Gatekeeper warnings such as:" \
-                "\"Apple could not verify ... is free of malware.\"" \
+                "This preview build is ad-hoc signed and not notarized." \
+                "Normal no-warning distribution requires paid Developer ID signing + notarization." \
+                "The first normal double-click may show: Apple could not verify \"token.place desktop\" is free of malware." \
                 "" \
-                "This is expected for unpaid/ad-hoc preview distribution." \
+                "This is expected for unpaid/non-notarized GitHub preview releases." \
                 "" \
-                "If you trust this source and the release checksums:" \
-                "1) Open the DMG, then Control-click (or right-click) the app and choose Open." \
-                "2) If macOS blocks it after first launch attempt, go to:" \
-                "   System Settings -> Privacy & Security" \
-                "   and use the Allow/Open option for the app." \
+                "Only install if you trust this GitHub release and checksum files." \
+                "Recommended flow:" \
+                "1) Drag/copy token.place desktop.app to Applications." \
+                "2) Try opening once from Applications." \
+                "3) If macOS blocks it, click Done." \
+                "4) Go to System Settings -> Privacy & Security." \
+                "5) Click Open Anyway / Allow / Open for token.place desktop." \
+                "6) Or Control-click/right-click token.place desktop.app and choose Open when available." \
                 "" \
-                "Only install and run this preview build when you trust the release source" \
-                "and checksum file." \
-                "" \
-                "For no-warning public macOS distribution, use paid Apple Developer ID" \
-                "signing plus notarization." > "${preview_notice}"
+                "Normal no-warning distribution requires paid Developer ID signing + notarization." > "${preview_notice}"
+            fi
+            cp "${preview_notice}" "${dmg_stage_dir}/README BEFORE OPENING.txt"
+            cp -R "${app_path}" "${dmg_stage_dir}/$(basename "${app_path}")"
+            ln -s /Applications "${dmg_stage_dir}/Applications"
+
+            hdiutil create -volname "token.place desktop" -srcfolder "${dmg_stage_dir}" -ov -format UDZO "${dmg_path}"
+            if [[ "${dmg_path}" == *"tokenplace Desktop"* ]] || [[ "${dmg_path}" == *"tokenplace Desktop Setup"* ]] || [[ "${dmg_path}" == *"desktop/electron-builder"* ]]; then
+              echo "stale Electron branding detected in staged DMG path: ${dmg_path}" >&2
+              exit 1
             fi
           elif [ "${{ runner.os }}" = "Windows" ]; then
             nsis_dir="src-tauri/target/release/bundle/nsis"

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -108,10 +108,14 @@ Desktop binaries are published by the GitHub Actions workflow
   Apple Developer Program account.
 - These preview builds use ad-hoc signing and are not notarized, so Gatekeeper
   warnings after browser/GitHub download are expected.
+- The mounted preview DMG includes `README BEFORE OPENING.txt` with the
+  expected Gatekeeper dialog and step-by-step opening guidance.
 - Users must manually open/whitelist trusted previews:
-  - Control-click (or right-click) the app and choose **Open**, or
-  - after a blocked launch, use **System Settings → Privacy & Security**
-    to allow/open the app.
+  - Drag/copy `token.place desktop.app` to Applications and try opening once.
+  - If macOS blocks launch, click **Done**, then use
+    **System Settings → Privacy & Security** to allow/open the app, or use
+    Control-click (right-click) + **Open** when available.
+- This unpaid preview flow does **not** eliminate Gatekeeper warnings.
 - No-warning public distribution generally requires paid
   Developer ID signing plus notarization.
 

--- a/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.json
+++ b/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-release-preview-dmg-missing-inline-gatekeeper-guidance",
+  "summary": "Correct Apple Silicon preview DMGs still showed expected Gatekeeper warnings, but inline user guidance was missing from the mounted DMG.",
+  "impact": "Users naturally double-clicked the app in the DMG and saw 'Apple could not verify' without immediate instructions, increasing support confusion.",
+  "fix": "Stage the DMG from app + inline README (+ Applications symlink), keep the sidecar README release asset, and validate DMG-root README presence/content in artifact checks.",
+  "lessons": "When unpaid ad-hoc/non-notarized distribution is intentional, opening guidance must be embedded at first user touchpoint; no-warning UX still requires paid Developer ID notarization."
+}

--- a/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md
+++ b/outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md
@@ -1,0 +1,32 @@
+# Outage follow-up: desktop release preview DMG missing inline Gatekeeper guidance (2026-05-24)
+
+- **Date:** 2026-05-24
+- **Slug:** `desktop-release-preview-dmg-missing-inline-gatekeeper-guidance`
+- **Affected area:** Desktop Tauri macOS Apple Silicon preview DMG UX
+
+## Symptom
+
+Users downloaded the correct Apple Silicon Tauri DMG and still hit:
+"Apple could not verify \"token.place desktop\" is free of malware..."
+after double-clicking the app.
+
+## Root cause
+
+This warning is expected for ad-hoc/non-notarized preview builds. Guidance existed
+only as a sidecar release asset (`README-macos-apple-silicon-preview.txt`) and
+was not visible inside the mounted DMG where users opened the app.
+
+## Remediation
+
+- Keep unpaid ad-hoc signing fallback for preview releases.
+- Build DMGs from a staging folder that contains:
+  - `token.place desktop.app`
+  - inline opening guide (`README BEFORE OPENING.txt`)
+  - `/Applications` symlink for drag-install flow.
+- Keep publishing sidecar `README-macos-apple-silicon-preview.txt` in release assets.
+- Validate DMG-root README presence and required guidance phrases during CI validation.
+
+## Future optional path
+
+To remove the warning entirely, use paid Apple Developer ID signing with
+notarization/stapling in a future release pipeline.

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -9,6 +9,15 @@ import subprocess
 from pathlib import Path
 
 STALE_BRANDS = ("tokenplace Desktop", "tokenplace Desktop Setup", "desktop/electron-builder")
+DMG_README_NAMES = ("README BEFORE OPENING.txt", "README-macos-apple-silicon-preview.txt")
+REQUIRED_README_PHRASES = (
+    "ad-hoc signed",
+    "not notarized",
+    "Apple could not verify",
+    "Privacy & Security",
+    "Developer ID",
+    "notarization",
+)
 
 
 def _fail(msg: str) -> None:
@@ -37,6 +46,42 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
+def _validate_dmg_contents(dmg_path: Path) -> None:
+    attach_output = _run(
+        [
+            "hdiutil",
+            "attach",
+            "-readonly",
+            "-nobrowse",
+            "-noautoopen",
+            str(dmg_path),
+        ]
+    )
+    mountpoint = ""
+    for line in attach_output.splitlines():
+        if "/Volumes/" in line:
+            mountpoint = line.rsplit("\t", 1)[-1].strip()
+    if not mountpoint:
+        _fail(f"Unable to determine mounted DMG path for: {dmg_path}")
+
+    mount_path = Path(mountpoint)
+    try:
+        app_entries = [p for p in mount_path.iterdir() if p.suffix == ".app"]
+        if len(app_entries) != 1:
+            _fail(f"Expected exactly one .app at DMG root; found {len(app_entries)} in {mount_path}")
+
+        readme_path = next((mount_path / name for name in DMG_README_NAMES if (mount_path / name).exists()), None)
+        if readme_path is None:
+            expected = ", ".join(DMG_README_NAMES)
+            _fail(f"Expected preview README at DMG root ({expected}) in {mount_path}")
+        readme_text = readme_path.read_text(encoding="utf-8")
+        for phrase in REQUIRED_README_PHRASES:
+            if phrase not in readme_text:
+                _fail(f"DMG preview README missing required phrase {phrase!r}: {readme_path}")
+    finally:
+        _run(["hdiutil", "detach", mountpoint])
+
+
 def main() -> None:
     args = _parse_args()
     app_path = Path(args.app_path)
@@ -53,6 +98,7 @@ def main() -> None:
         _fail(f"dmg artifact missing or invalid: {dmg_path}")
     if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
         _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
+    _validate_dmg_contents(dmg_path)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -67,12 +67,26 @@ def test_workflow_does_not_gate_release_on_notary_profile() -> None:
 def test_workflow_emits_preview_warning_asset_for_macos_downloads() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'README-macos-apple-silicon-preview.txt' in text
-    assert 'This DMG is ad-hoc signed and is not notarized.' in text
-    assert 'This DMG is signed with a configured Apple signing identity but is not notarized.' in text
-    assert 'Apple could not verify ... is free of malware.' in text
+    assert 'README BEFORE OPENING.txt' in text
+    assert 'This preview build is ad-hoc signed and not notarized.' in text
+    assert 'Apple could not verify \\"token.place desktop\\" is free of malware.' in text
+    assert 'Done.' in text
     assert 'System Settings -> Privacy & Security' in text
-    assert 'paid Apple Developer ID' in text
-    assert 'signing plus notarization' in text
+    assert 'Open Anyway / Allow / Open' in text
+    assert 'Developer ID signing + notarization' in text
+    assert 'This is expected for unpaid/non-notarized GitHub preview releases.' in text
+    assert 'System Settings -> Privacy & Security' in text
+    assert 'Only install if you trust this GitHub release and checksum files.' in text
+
+
+def test_workflow_stages_macos_dmg_with_app_readme_and_applications_symlink() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'dmg_stage_dir="$RUNNER_TEMP/token-place-desktop-dmg-stage"' in text
+    assert 'cp "${preview_notice}" "${dmg_stage_dir}/README BEFORE OPENING.txt"' in text
+    assert 'cp -R "${app_path}" "${dmg_stage_dir}/$(basename "${app_path}")"' in text
+    assert 'ln -s /Applications "${dmg_stage_dir}/Applications"' in text
+    assert 'hdiutil create -volname "token.place desktop" -srcfolder "${dmg_stage_dir}"' in text
+    assert 'hdiutil create -volname "token.place desktop" -srcfolder "${app_path}"' not in text
 
 
 def test_validator_checks_display_name_and_executable_and_dmg_pattern() -> None:
@@ -86,6 +100,19 @@ def test_workflow_writes_preview_notice_via_printf() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert "printf '%s\\n' \\" in text
     assert '> "${preview_notice}"' in text
+
+
+def test_validator_checks_dmg_root_preview_readme_contents() -> None:
+    text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
+    assert 'README BEFORE OPENING.txt' in text
+    assert 'README-macos-apple-silicon-preview.txt' in text
+    assert 'Expected exactly one .app at DMG root' in text
+    assert 'ad-hoc signed' in text
+    assert 'not notarized' in text
+    assert 'Apple could not verify' in text
+    assert 'Privacy & Security' in text
+    assert 'Developer ID' in text
+    assert 'notarization' in text
 
 
 def test_preview_notice_uses_full_signing_decision_in_stage_step() -> None:


### PR DESCRIPTION
### Motivation
- Preview Apple Silicon DMGs were ad-hoc signed and not notarized, causing the expected Gatekeeper dialog when users double-clicked the app without any inline guidance in the mounted DMG. 
- The workflow already produced a sidecar `README-macos-apple-silicon-preview.txt`, but users did not see it while opening the DMG, causing avoidable support confusion.

### Description
- Change the macOS release staging step to build the DMG from a staging directory (`$RUNNER_TEMP/token-place-desktop-dmg-stage`) that contains `token.place desktop.app`, an inline `README BEFORE OPENING.txt` (copied from the sidecar preview README), and an `/Applications` symlink, then run `hdiutil create -srcfolder` on that staging folder instead of the raw app. (modified: `.github/workflows/desktop-release.yml`)
- Update the preview README content (both signing branches) to clearly explain ad-hoc/notarized status, the expected "Apple could not verify \"token.place desktop\" is free of malware" dialog, step-by-step manual open flow (drag to Applications, open once, click Done, System Settings → Privacy & Security → Open Anyway / Allow / Open, or Control-click → Open), trust/checksum caveat, and note that no-warning distribution requires paid Developer ID signing + notarization. (modified: `.github/workflows/desktop-release.yml`)
- Harden the DMG validator to attach the DMG read-only in CI, assert exactly one `.app` at the DMG root, ensure a preview README file exists at the DMG root, and check the README contains required phrases such as `ad-hoc signed`, `not notarized`, `Apple could not verify`, `Privacy & Security`, `Developer ID`, and `notarization`. Existing icon/arch/name/executable guardrails are preserved. (modified: `scripts/validate_desktop_tauri_release_artifacts.py`)
- Extend unit tests to assert the new staging behavior, presence and contents of the inline README in the workflow, and validator expectations while keeping the Tauri/icon/Apple Silicon checks intact. (modified: `tests/unit/test_desktop_release_artifacts.py`)
- Update `desktop-tauri/README.md` to document that the mounted preview DMG includes the opening guide and that Gatekeeper warnings are expected for unpaid preview builds. (modified: `desktop-tauri/README.md`)
- Add an outage follow-up entry documenting symptom, root cause, remediation, and optional future paid-notarization path. (added: `outages/2026-05-24-desktop-release-preview-dmg-missing-inline-gatekeeper-guidance.md` and `.json`)

### Testing
- Compiled the validator: `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py` (passed). 
- Unit tests: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` (all tests passed). 
- CI sentinel tests: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` (passed). 
- Searched repository for key phrases and workflow changes with `rg` to verify coverage and references (matches found as expected). 
- Ran `pre-commit run --all-files` to validate formatting/lint hooks (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12695373f0832fb05094a83afd4b0f)