### PR TITLE
Make macOS packaged desktop resilient to missing optional Python deps (psutil)

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -9,6 +9,7 @@ on:
       - 'desktop-tauri/src-tauri/python/**'
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'desktop-tauri/scripts/test_packaged_model_bridge_smoke.py'
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
       - 'utils/**'
       - 'config.py'
@@ -24,6 +25,7 @@ on:
       - 'desktop-tauri/src-tauri/python/**'
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
+      - 'desktop-tauri/scripts/test_packaged_model_bridge_smoke.py'
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
       - 'utils/**'
       - 'config.py'
@@ -124,3 +126,17 @@ jobs:
 
       - name: Run packaged operator bridge e2e (Windows)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+  desktop-operator-packaged-smoke-macos:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run packaged model bridge startup smoke (macOS)
+        run: python desktop-tauri/scripts/test_packaged_model_bridge_smoke.py

--- a/desktop-tauri/scripts/test_packaged_model_bridge_smoke.py
+++ b/desktop-tauri/scripts/test_packaged_model_bridge_smoke.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Packaged model-bridge smoke test for dependency-isolated startup behavior."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix='token-place-model-bridge-smoke-') as tmpdir:
+        resources_root = Path(tmpdir) / 'resources'
+        python_dir = resources_root / 'python'
+        python_dir.mkdir(parents=True, exist_ok=True)
+
+        shutil.copy2(REPO_ROOT / 'desktop-tauri' / 'src-tauri' / 'python' / 'model_bridge.py', python_dir / 'model_bridge.py')
+        shutil.copy2(REPO_ROOT / 'desktop-tauri' / 'src-tauri' / 'python' / 'path_bootstrap.py', python_dir / 'path_bootstrap.py')
+        shutil.copy2(REPO_ROOT / 'config.py', resources_root / 'config.py')
+
+        env = os.environ.copy()
+        env['PYTHONNOUSERSITE'] = '1'
+        env['PYTHONPATH'] = ''
+
+        result = subprocess.run(
+            [sys.executable, str(python_dir / 'model_bridge.py'), 'inspect'],
+            cwd=tmpdir,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f'inspect failed: rc={result.returncode}; stdout={result.stdout}; stderr={result.stderr}')
+
+        payload = json.loads(result.stdout.strip())
+        if payload.get('ok') is not True:
+            raise RuntimeError(f'inspect returned error payload: {payload}')
+        if 'Missing Python dependency for model downloads' in result.stdout:
+            raise RuntimeError(f'unexpected startup dependency error: {result.stdout}')
+        if "No module named 'psutil'" in result.stdout:
+            raise RuntimeError(f'unexpected psutil import error surfaced: {result.stdout}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -34,28 +35,53 @@ def _get_model_manager():
     try:
         from utils.llm.model_manager import get_model_manager
     except ModuleNotFoundError as exc:
-        return None, _response(
-            False,
-            error=(
-                "Missing Python dependency for model downloads "
-                f"({exc}). Run `pip install -r requirements.txt`."
-            ),
-        )
+        return None, exc
 
     return get_model_manager(), None
 
 
+def _fallback_model_metadata() -> Dict[str, Any]:
+    filename = 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+    url = (
+        'https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/'
+        'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+    )
+    canonical_family_url = 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
+    models_dir = Path(os.environ.get('TOKEN_PLACE_MODELS_DIR', str(Path.home() / '.token-place' / 'models')))
+    resolved_model_path = models_dir / filename
+    return {
+        'canonical_family_url': canonical_family_url,
+        'filename': filename,
+        'url': url,
+        'models_dir': str(models_dir),
+        'resolved_model_path': str(resolved_model_path),
+        'exists': resolved_model_path.exists(),
+        'size_bytes': resolved_model_path.stat().st_size if resolved_model_path.exists() else None,
+        'dependency_status': 'missing_optional_download_dependencies',
+    }
+
+
 def inspect_model() -> int:
-    manager, error_status = _get_model_manager()
-    if error_status is not None:
-        return error_status
+    manager, manager_error = _get_model_manager()
+    if manager_error is not None:
+        if isinstance(manager_error, ModuleNotFoundError):
+            return _response(True, payload=_fallback_model_metadata())
+        return _response(False, error=f"Model bridge failure: {manager_error}")
     return _response(True, payload=manager.get_model_artifact_metadata())
 
 
 def download_model() -> int:
-    manager, error_status = _get_model_manager()
-    if error_status is not None:
-        return error_status
+    manager, manager_error = _get_model_manager()
+    if manager_error is not None:
+        if isinstance(manager_error, ModuleNotFoundError):
+            return _response(
+                False,
+                error=(
+                    "Missing Python dependency for model downloads "
+                    f"({manager_error}). Local model download is unavailable in this runtime."
+                ),
+            )
+        return _response(False, error=f"Model bridge failure: {manager_error}")
 
     if not manager.download_model_if_needed():
         return _response(

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -43,7 +43,8 @@ def test_inspect_returns_bridge_error_when_manager_init_fails(capsys):
         status = model_bridge.inspect_model()
 
     assert status == 1
-    assert capsys.readouterr().out.strip() == ''
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response == {'ok': False, 'error': 'Model bridge failure: 1'}
 
 
 def test_download_returns_actionable_error_when_download_fails(capsys):
@@ -89,13 +90,22 @@ def test_download_returns_metadata_when_download_succeeds(capsys):
 
 def test_get_model_manager_reports_missing_dependency(capsys):
     with patch.dict('sys.modules', {'utils.llm.model_manager': None}):
-        manager, error_status = model_bridge._get_model_manager()
+        manager, manager_error = model_bridge._get_model_manager()
 
     assert manager is None
-    assert error_status == 1
+    assert isinstance(manager_error, ModuleNotFoundError)
+    assert capsys.readouterr().out.strip() == ''
+
+
+def test_inspect_returns_fallback_metadata_when_optional_download_dependency_is_missing(capsys):
+    missing = ModuleNotFoundError("No module named 'psutil'")
+    with patch.object(model_bridge, '_get_model_manager', return_value=(None, missing)):
+        with patch.object(model_bridge, '_fallback_model_metadata', return_value={'filename': 'fallback.gguf'}):
+            status = model_bridge.inspect_model()
+
+    assert status == 0
     response = json.loads(capsys.readouterr().out.strip())
-    assert response['ok'] is False
-    assert 'Missing Python dependency for model downloads' in response['error']
+    assert response == {'ok': True, 'payload': {'filename': 'fallback.gguf'}}
 
 
 def test_main_dispatches_inspect_action():


### PR DESCRIPTION
### Motivation
- Prevent the packaged Apple Silicon Tauri app from surfacing a scary startup error when optional Python runtime deps (e.g., `psutil`) are not present in the packaged runtime or the user global site-packages. 
- Ensure the UI smoke/startup path is deterministic and does not depend on the runner/user global `site-packages` so packaged-app acceptance tests can validate the release artifact.
- Add macOS packaged-app coverage that mirrors existing Windows packaged bridge e2e patterns to catch regressions before release.

### Description
- Change `desktop-tauri/src-tauri/python/model_bridge.py` so `_get_model_manager()` returns the original `ModuleNotFoundError` instead of immediately printing a failing bridge response, and add `_fallback_model_metadata()` that supplies deterministic metadata when optional download dependencies are missing. 
- Make `inspect` return fallback metadata (`ok: true`) when a `ModuleNotFoundError` is encountered so the UI startup path remains green, while `download` still returns an explicit actionable error explaining missing optional dependencies. 
- Add a unit test covering the new fallback behavior in `tests/unit/test_desktop_model_bridge.py` and update existing expectations accordingly. 
- Add a dependency-isolated packaged smoke script `desktop-tauri/scripts/test_packaged_model_bridge_smoke.py` which runs `model_bridge.py inspect` with `PYTHONNOUSERSITE=1` and an empty `PYTHONPATH` to assert no `psutil`/startup dependency errors surface, and wire a `macos-latest` smoke job into `.github/workflows/desktop-operator-e2e.yml` following the existing Windows packaged pattern.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_desktop_model_bridge.py -q` and the broader set `python -m pytest tests/unit/test_desktop_release_artifacts.py tests/unit/test_workflow_ci_sentinel.py -q`; all asserted tests passed. 
- Executed the packaged smoke script locally: `python desktop-tauri/scripts/test_packaged_model_bridge_smoke.py` with `PYTHONNOUSERSITE=1`/empty `PYTHONPATH` and it succeeded, validating no `No module named 'psutil'` or startup dependency error is emitted. 
- Ran `pre-commit run --all-files` and hooks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127b974d94832f88404b82d8a395a8)