### PR TITLE
Harden packaged macOS desktop startup when optional Python deps are missing

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -124,3 +124,24 @@ jobs:
 
       - name: Run packaged operator bridge e2e (Windows)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+  desktop-operator-packaged-e2e-macos:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run packaged operator bridge e2e (macOS)
+        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -91,6 +91,29 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
         bridge_script = create_packaged_layout(Path(tmpdir))
+        model_bridge_script = bridge_script.parent / "model_bridge.py"
+
+        inspect_env = env.copy()
+        inspect_env["TOKEN_PLACE_DESKTOP_TEST_MISSING_MODEL_DEPS"] = "1"
+        inspect_env["PYTHONNOUSERSITE"] = "1"
+        inspect_result = subprocess.run(
+            [sys.executable, str(model_bridge_script), "inspect"],
+            cwd=tmpdir,
+            env=inspect_env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if inspect_result.returncode != 0:
+            raise RuntimeError(
+                "packaged model inspect should gracefully succeed when optional deps are missing; "
+                f"stdout={inspect_result.stdout}; stderr={inspect_result.stderr}"
+            )
+        if "Missing Python dependency for model downloads" in inspect_result.stdout:
+            raise RuntimeError(
+                "packaged model inspect surfaced startup dependency error unexpectedly; "
+                f"stdout={inspect_result.stdout}"
+            )
 
         relay = subprocess.Popen(  # noqa: S603
             [

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -31,6 +32,11 @@ def _response(ok: bool, *, payload: Dict[str, Any] | None = None, error: str = "
 
 
 def _get_model_manager():
+    if os.getenv("TOKEN_PLACE_DESKTOP_TEST_MISSING_MODEL_DEPS") == "1":
+        return None, _response(
+            False,
+            error="Missing Python dependency for model downloads (No module named 'psutil').",
+        )
     try:
         from utils.llm.model_manager import get_model_manager
     except ModuleNotFoundError as exc:
@@ -45,9 +51,41 @@ def _get_model_manager():
     return get_model_manager(), None
 
 
+def _inspect_without_model_manager(missing_dependency: str) -> int:
+    from config import get_config
+
+    cfg = get_config()
+    filename = cfg.get("model.filename")
+    url = cfg.get("model.url")
+    canonical_family_url = cfg.get("model.canonical_family_url")
+    models_dir = Path(str(cfg.get("paths.models_dir")))
+    resolved_model_path = models_dir / filename
+
+    payload: Dict[str, Any] = {
+        "canonical_family_url": canonical_family_url,
+        "filename": filename,
+        "url": url,
+        "models_dir": str(models_dir),
+        "resolved_model_path": str(resolved_model_path),
+        "exists": resolved_model_path.exists(),
+        "size_bytes": resolved_model_path.stat().st_size if resolved_model_path.exists() else None,
+        "downloads_available": False,
+        "downloads_unavailable_reason": (
+            "Optional model download dependencies are unavailable in this runtime "
+            f"({missing_dependency}). Download controls remain disabled until runtime "
+            "dependencies are provisioned."
+        ),
+    }
+    return _response(True, payload=payload)
+
+
 def inspect_model() -> int:
     manager, error_status = _get_model_manager()
     if error_status is not None:
+        try:
+            from utils.llm.model_manager import get_model_manager
+        except ModuleNotFoundError as exc:
+            return _inspect_without_model_manager(str(exc))
         return error_status
     return _response(True, payload=manager.get_model_artifact_metadata())
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -34,6 +34,8 @@ struct ModelArtifactInfo {
     resolved_model_path: String,
     exists: bool,
     size_bytes: Option<u64>,
+    downloads_available: Option<bool>,
+    downloads_unavailable_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -41,6 +41,8 @@ interface ModelArtifactInfo {
   resolved_model_path: string;
   exists: boolean;
   size_bytes: number | null;
+  downloads_available?: boolean;
+  downloads_unavailable_reason?: string;
 }
 
 interface SidecarEvent {
@@ -379,10 +381,19 @@ export function App() {
           onChange={(e) => updateConfig({ ...config, model_path: e.target.value })}
         />
         <button type="button" onClick={chooseModelPath}>Browse</button>
-        <button type="button" onClick={downloadModel} disabled={isDownloadingModel}>
+        <button
+          type="button"
+          onClick={downloadModel}
+          disabled={isDownloadingModel || artifact?.downloads_available === false}
+        >
           {isDownloadingModel ? 'Downloading…' : 'Download'}
         </button>
       </div>
+      {artifact?.downloads_available === false && artifact.downloads_unavailable_reason && (
+        <p style={{ marginTop: 8, color: '#555' }}>
+          Model download unavailable: {artifact.downloads_unavailable_reason}
+        </p>
+      )}
       {artifact && (
         <section style={{ marginTop: 8, fontSize: 14 }}>
           <div>

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -38,6 +38,36 @@ def test_inspect_returns_shared_model_manager_metadata(capsys):
     assert json.loads(capsys.readouterr().out.strip()) == {'ok': True, 'payload': metadata}
 
 
+def test_inspect_returns_graceful_metadata_when_optional_deps_missing(capsys):
+    with patch.object(model_bridge, '_get_model_manager', return_value=(None, 1)):
+        with patch.dict('sys.modules', {'utils.llm.model_manager': None}):
+            with patch.object(model_bridge, '_inspect_without_model_manager', return_value=0) as fallback:
+                status = model_bridge.inspect_model()
+
+    assert status == 0
+    fallback.assert_called_once()
+    assert capsys.readouterr().out.strip() == ''
+
+
+def test_inspect_without_model_manager_returns_non_error_payload(capsys, tmp_path):
+    models_dir = tmp_path / 'models'
+    models_dir.mkdir(parents=True)
+    with patch('config.get_config') as get_config:
+        get_config.return_value.get.side_effect = lambda key: {
+            'model.filename': 'mini.gguf',
+            'model.url': 'https://example.com/mini.gguf',
+            'model.canonical_family_url': 'https://example.com/family',
+            'paths.models_dir': str(models_dir),
+        }[key]
+        status = model_bridge._inspect_without_model_manager("No module named 'psutil'")
+
+    assert status == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload['ok'] is True
+    assert payload['payload']['downloads_available'] is False
+    assert "No module named 'psutil'" in payload['payload']['downloads_unavailable_reason']
+
+
 def test_inspect_returns_bridge_error_when_manager_init_fails(capsys):
     with patch.object(model_bridge, '_get_model_manager', return_value=(None, 1)):
         status = model_bridge.inspect_model()


### PR DESCRIPTION
### Motivation
- Packaged Apple Silicon desktop launches could surface a red startup error when optional Python deps (for example `psutil`) were missing from the user global site-packages during the model-inspect path. This caused alarming UI errors on first launch.
- The goal is to make the packaged macOS UI smoke path deterministic and not depend on the user-global Python environment while preserving explicit failures for actual download actions and keeping the ad-hoc macOS preview flow.

### Description
- Make the Python `inspect` bridge fail-open for missing optional model-download dependencies by returning deterministic artifact metadata plus `downloads_available=false` and `downloads_unavailable_reason` instead of emitting a failing error string (`desktop-tauri/src-tauri/python/model_bridge.py`).
- Add a deterministic test hook environment variable `TOKEN_PLACE_DESKTOP_TEST_MISSING_MODEL_DEPS=1` and `PYTHONNOUSERSITE` usage in the packaged smoke script to simulate missing optional deps without relying on host site-packages (used in `desktop-tauri/scripts/test_packaged_operator_e2e.py`).
- Extend the native-side Rust bridge contract to accept the new optional metadata fields (`downloads_available`, `downloads_unavailable_reason`) so the UI can render the fallback payload (`desktop-tauri/src-tauri/src/main.rs`).
- Update the desktop UI typing and runtime behavior to disable the Download button and show a neutral explanatory message when downloads are unavailable rather than surfacing a startup error (`desktop-tauri/src/App.tsx`).
- Add a macOS-packaged e2e/packaged-bridge CI job mirroring the existing Windows packaged job so Apple Silicon packaged artifacts are smoke-tested in CI (`.github/workflows/desktop-operator-e2e.yml`).
- Add unit tests and adjust existing tests to cover the graceful inspect fallback and payload contract (`tests/unit/test_desktop_model_bridge.py`).

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_desktop_model_bridge.py -q` and `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` (all passed).
- Compiled packaged Python scripts: `python -m py_compile desktop-tauri/src-tauri/python/*.py` (succeeded).
- Ran repository checks: `pre-commit run --all-files` (passed in this environment).
- Added packaged smoke assertion: the updated `desktop-tauri/scripts/test_packaged_operator_e2e.py` runs `model_bridge.py inspect` with `TOKEN_PLACE_DESKTOP_TEST_MISSING_MODEL_DEPS=1` and `PYTHONNOUSERSITE=1` and asserts the inspect call succeeds and does not surface the previous "Missing Python dependency for model downloads" error.

Notes: The change avoids depending on user-global Python site-packages for the packaged startup inspect path by returning a deterministic, non-error payload when optional download deps are absent; the actual download action still fails with a clear actionable error if triggered. CI was extended to run the same packaged smoke test on `macos-latest` to catch regressions for Apple Silicon artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127b974d94832f88404b82d8a395a8)