### PR TITLE
🧰 Fix macOS packaged desktop startup dependency fallback and add macOS packaged e2e smoke

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -124,3 +124,24 @@ jobs:
 
       - name: Run packaged operator bridge e2e (Windows)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+  desktop-operator-packaged-e2e-macos:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run packaged operator bridge e2e (macOS)
+        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -91,6 +91,36 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
         bridge_script = create_packaged_layout(Path(tmpdir))
+        model_bridge_script = bridge_script.parent / "model_bridge.py"
+
+        model_probe_env = env.copy()
+        model_probe_env["PYTHONNOUSERSITE"] = "1"
+        model_probe = subprocess.run(
+            [sys.executable, str(model_bridge_script), "inspect"],
+            cwd=tmpdir,
+            env=model_probe_env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if model_probe.returncode != 0:
+            raise RuntimeError(
+                "packaged model bridge inspect failed unexpectedly: "
+                f"stdout={model_probe.stdout} stderr={model_probe.stderr}"
+            )
+        combined_probe_output = f"{model_probe.stdout}\n{model_probe.stderr}"
+        forbidden_fragments = (
+            "Missing Python dependency for model downloads",
+            "No module named 'psutil'",
+            "No module named \"psutil\"",
+            "NotOpenSSLWarning",
+        )
+        for fragment in forbidden_fragments:
+            if fragment in combined_probe_output:
+                raise RuntimeError(
+                    "packaged model bridge startup emitted dependency/runtime warning: "
+                    f"{fragment}; output={combined_probe_output}"
+                )
 
         relay = subprocess.Popen(  # noqa: S603
             [

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -45,10 +46,43 @@ def _get_model_manager():
     return get_model_manager(), None
 
 
+def _fallback_model_metadata() -> Dict[str, Any]:
+    """Build model metadata without importing heavy optional download dependencies."""
+    from config import get_config  # lazy import to preserve script bootstrap behavior
+
+    cfg = get_config()
+    filename = cfg.get("model.filename", "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")
+    url = cfg.get(
+        "model.url",
+        (
+            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
+            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+        ),
+    )
+    canonical_family_url = cfg.get(
+        "model.canonical_family_url", "https://huggingface.co/meta-llama/Meta-Llama-3-8B"
+    )
+    models_dir = cfg.get("paths.models_dir")
+    resolved_model_path = os.path.join(models_dir, filename)
+    exists = os.path.exists(resolved_model_path)
+    return {
+        "canonical_family_url": canonical_family_url,
+        "filename": filename,
+        "url": url,
+        "models_dir": models_dir,
+        "resolved_model_path": resolved_model_path,
+        "exists": exists,
+        "size_bytes": os.path.getsize(resolved_model_path) if exists else None,
+    }
+
+
 def inspect_model() -> int:
     manager, error_status = _get_model_manager()
     if error_status is not None:
-        return error_status
+        return _response(
+            True,
+            payload=_fallback_model_metadata(),
+        )
     return _response(True, payload=manager.get_model_artifact_metadata())
 
 

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -38,9 +38,27 @@ def test_inspect_returns_shared_model_manager_metadata(capsys):
     assert json.loads(capsys.readouterr().out.strip()) == {'ok': True, 'payload': metadata}
 
 
-def test_inspect_returns_bridge_error_when_manager_init_fails(capsys):
+def test_inspect_returns_fallback_metadata_when_manager_init_fails(capsys):
+    fallback_metadata = {
+        'canonical_family_url': 'https://example.com/family',
+        'filename': 'fallback.gguf',
+        'url': 'https://example.com/fallback.gguf',
+        'models_dir': '/tmp/models',
+        'resolved_model_path': '/tmp/models/fallback.gguf',
+        'exists': False,
+        'size_bytes': None,
+    }
+    with patch.object(model_bridge, '_fallback_model_metadata', return_value=fallback_metadata):
+        with patch.object(model_bridge, '_get_model_manager', return_value=(None, 1)):
+            status = model_bridge.inspect_model()
+
+    assert status == 0
+    assert json.loads(capsys.readouterr().out.strip()) == {'ok': True, 'payload': fallback_metadata}
+
+
+def test_download_returns_bridge_error_when_manager_init_fails(capsys):
     with patch.object(model_bridge, '_get_model_manager', return_value=(None, 1)):
-        status = model_bridge.inspect_model()
+        status = model_bridge.download_model()
 
     assert status == 1
     assert capsys.readouterr().out.strip() == ''


### PR DESCRIPTION
### Motivation
- Packaged Apple Silicon desktop apps could show a scary runtime error on first UI load when optional Python deps (e.g. `psutil`) were missing and the packaged app inadvertently relied on user-global site-packages. 
- The UI only needs deterministic model metadata for startup; heavy model-download/runtime imports should be optional and not block the UI.
- Add CI-level macOS packaged smoke coverage to prevent regressions that surface `No module named 'psutil'`/`urllib3` warnings in packaged startup.

### Description
- Implemented a lightweight fallback in `desktop-tauri/src-tauri/python/model_bridge.py` by adding `_fallback_model_metadata()` and returning that from `inspect_model()` when importing the full `utils.llm.model_manager` fails, preserving explicit error behavior for `download`.
- Updated `desktop-tauri/scripts/test_packaged_operator_e2e.py` to run a packaged `model_bridge.py inspect` probe with `PYTHONNOUSERSITE=1` and fail if output contains dependency/runtime warning fragments (e.g. `Missing Python dependency for model downloads`, `No module named 'psutil'`, `NotOpenSSLWarning`).
- Added a macOS packaged e2e job (`desktop-operator-packaged-e2e-macos`) to `.github/workflows/desktop-operator-e2e.yml` mirroring the existing Windows packaged packaged-bridge e2e job.
- Adjusted unit tests in `tests/unit/test_desktop_model_bridge.py` to expect fallback metadata on inspect failure and to keep `download` failing loudly when manager init is unavailable.

### Testing
- Compiled affected scripts with `python -m py_compile` for `desktop-tauri/src-tauri/python/model_bridge.py`, `desktop-tauri/scripts/test_packaged_operator_e2e.py`, and the adjusted tests, and compilation succeeded.
- Ran unit tests: `pytest tests/unit/test_desktop_model_bridge.py -q` and `pytest tests/unit/test_workflow_ci_sentinel.py -q`, and all tests passed locally.
- Ran `pre-commit run --all-files` and hooks passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127b974d94832f88404b82d8a395a8)