### PR TITLE
🧭 chore: add canonical tokenplace Helm chart for relay

### DIFF
--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tokenplace
+description: Canonical Helm chart for deploying the token.place relay
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/charts/tokenplace/templates/_helpers.tpl
+++ b/charts/tokenplace/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{- define "tokenplace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tokenplace.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "tokenplace.name" . -}}
+{{- if eq .Release.Name $name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tokenplace.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "tokenplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "tokenplace.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tokenplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "tokenplace.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{ printf "%s@%s" $repo .Values.image.digest }}
+{{- else if .Values.image.tag -}}
+{{ printf "%s:%s" $repo .Values.image.tag }}
+{{- else -}}
+{{ printf "%s:%s" $repo .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tokenplace.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tokenplace.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "tokenplace.fullname" . }}
+      {{- else if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: relay
+          image: {{ include "tokenplace.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: RELAY_HOST
+              value: "0.0.0.0"
+            - name: RELAY_PORT
+              value: {{ .Values.containerPort | quote }}
+            - name: RELAY_WORKERS
+              value: "1"
+            - name: TOKENPLACE_FRONTEND_MODE
+              value: "production"
+            - name: TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH
+              value: "0"
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tokenplace/templates/ingress.yaml
+++ b/charts/tokenplace/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tokenplace.fullname" . }}
+                port:
+                  name: http
+  {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.secretName .Values.ingress.host }}
+  tls:
+    - secretName: {{ .Values.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.ingress.host | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/tokenplace/templates/service.yaml
+++ b/charts/tokenplace/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "tokenplace.selectorLabels" . | nindent 4 }}

--- a/charts/tokenplace/templates/serviceaccount.yaml
+++ b/charts/tokenplace/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -1,0 +1,69 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+containerPort: 5010
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+env: {}
+extraEnv: []
+envFrom: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 300m
+    memory: 256Mi
+
+nodeSelector: {}
+affinity: {}
+tolerations: []

--- a/deploy/charts/tokenplace-relay/Chart.yaml
+++ b/deploy/charts/tokenplace-relay/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tokenplace-relay
-description: Helm chart for deploying the token.place relay service
+description: DEPRECATED: use charts/tokenplace (canonical token.place relay chart)
 version: 0.1.0
 appVersion: "0.1.0"
 type: application

--- a/deploy/charts/tokenplace-relay/README.md
+++ b/deploy/charts/tokenplace-relay/README.md
@@ -1,0 +1,8 @@
+# Deprecated chart: tokenplace-relay
+
+This chart is deprecated. Use the canonical app-owned chart at:
+
+- `charts/tokenplace`
+
+Do not add new features here; all active Helm chart development should happen in
+`charts/tokenplace`.

--- a/deploy/charts/tokenplace-relay/values.yaml
+++ b/deploy/charts/tokenplace-relay/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/${OWNER}/tokenplace-relay
+  repository: ghcr.io/futuroptimist/tokenplace-relay
   tag: "0.1.0"     # defaults to chart appVersion when digest is unset
   digest: ""      # immutable digest preferred in prod
   pullPolicy: IfNotPresent


### PR DESCRIPTION
### Motivation
- Provide an app-owned, Sugarkube-friendly canonical Helm chart that deploys the token.place relay only and does not require in-cluster GPU or backend services. 
- Replace the ad-hoc legacy chart location with a clear canonical chart layout and safe relay runtime defaults for relay-only staging/prod installs.

### Description
- Add a new canonical chart at `charts/tokenplace` with `Chart.yaml`, `values.yaml`, and templates for `Deployment`, `Service`, optional `Ingress`, optional `ServiceAccount`, and `_helpers.tpl` for consistent naming and labels. 
- Ship DSPACE-like values: `replicaCount: 1`, `image.repository`/`tag`/`digest`/`pullPolicy`, `containerPort: 5010`, `env` map + `extraEnv` list + `envFrom`, service/ingress controls, resource requests/limits, and node/affinity/toleration hooks. 
- Configure secure, read-only-root-compatible pod defaults including `podSecurityContext`/`securityContext` (`runAsNonRoot: true`, `runAsUser: 1000`, `runAsGroup: 1000`, drop all capabilities, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`) and mount `/tmp` as an `emptyDir`. 
- Set relay-safe runtime env defaults: `RELAY_HOST=0.0.0.0`, `RELAY_PORT={{ .Values.containerPort }}`, `RELAY_WORKERS=1`, `TOKENPLACE_FRONTEND_MODE=production`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0`, and avoid setting any `TOKENPLACE_RELAY_UPSTREAM_URL` or creating GPU/headless ExternalName resources by default. 
- Add optional ingress support with `className`, `host`, `annotations`, and optional TLS (`enabled` + `secretName`) while ensuring labels include `app.kubernetes.io/name` and `app.kubernetes.io/instance` for Sugarkube discovery. 
- Mark the legacy chart at `deploy/charts/tokenplace-relay` as deprecated by updating its `Chart.yaml` description and adding `deploy/charts/tokenplace-relay/README.md` that points to `charts/tokenplace`, and normalize the legacy `image.repository` to `ghcr.io/futuroptimist/tokenplace-relay`.

### Testing
- `helm lint charts/tokenplace` was attempted but could not run in this environment because the `helm` binary is not installed, so linting is blocked. 
- `helm template tokenplace charts/tokenplace --namespace tokenplace --set ingress.enabled=true --set ingress.host=staging.token.place --set image.tag=main-deadbee` was attempted but blocked for the same reason, preventing template-render verification here. 
- Secret-scan and repository checks were attempted (`./scripts/scan-secrets.py` invoked against staged changes) but the expected scan script was not present in the environment, so that check could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a27ca7c0832f8e453286ee4d3cef)