### PR TITLE
chore: add canonical tokenplace Helm chart for relay deployment

### DIFF
--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tokenplace
+description: Canonical Helm chart for deploying the token.place relay service
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/charts/tokenplace/templates/_helpers.tpl
+++ b/charts/tokenplace/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{- define "tokenplace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tokenplace.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tokenplace.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "tokenplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "tokenplace.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tokenplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "tokenplace.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{ printf "%s@%s" $repo .Values.image.digest }}
+{{- else if .Values.image.tag -}}
+{{ printf "%s:%s" $repo .Values.image.tag }}
+{{- else -}}
+{{ printf "%s:%s" $repo .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tokenplace.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tokenplace.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "tokenplace.fullname" . }}
+      {{- else if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: relay
+          image: {{ include "tokenplace.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: RELAY_HOST
+              value: "0.0.0.0"
+            - name: RELAY_PORT
+              value: {{ .Values.containerPort | quote }}
+            - name: RELAY_WORKERS
+              value: "1"
+            - name: TOKENPLACE_FRONTEND_MODE
+              value: "production"
+            - name: TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH
+              value: "0"
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tokenplace/templates/ingress.yaml
+++ b/charts/tokenplace/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.ingress.enabled .Values.ingress.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tokenplace.fullname" . }}
+                port:
+                  name: http
+  {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.secretName }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+{{- end }}

--- a/charts/tokenplace/templates/service.yaml
+++ b/charts/tokenplace/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "tokenplace.selectorLabels" . | nindent 4 }}

--- a/charts/tokenplace/templates/serviceaccount.yaml
+++ b/charts/tokenplace/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -1,0 +1,68 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 5010
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+env: {}
+extraEnv: []
+envFrom: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 300m
+    memory: 256Mi
+
+nodeSelector: {}
+affinity: {}
+tolerations: []

--- a/deploy/charts/tokenplace-relay/README.md
+++ b/deploy/charts/tokenplace-relay/README.md
@@ -1,0 +1,5 @@
+# Deprecated chart
+
+This chart is deprecated and no longer the canonical token.place Helm chart.
+
+Use `charts/tokenplace` instead.


### PR DESCRIPTION
### Motivation
- Provide a single canonical Helm chart Sugarkube can install from OCI that deploys the token.place relay only and avoids coupling to GPU/backend services.
- Ensure relay runtime defaults are safe for relay-only staging/prod: single worker, readiness independent from upstream, and container settings suitable for shell-safe entrypoints and read-only filesystems.

### Description
- Add `charts/tokenplace` with `Chart.yaml`, `values.yaml`, and templates for `Deployment`, `Service`, optional `Ingress`, `ServiceAccount`, and `_helpers.tpl` that render resources named by the Helm release (default release `tokenplace`).
- Values follow DSPACE-like conventions: `replicaCount: 1`, `image.{repository,tag,digest,pullPolicy}`, `containerPort: 5010`, `service` settings, `ingress` toggles (`enabled`, `className`, `host`, `annotations`, `tls`), `env` map, `extraEnv` list, `envFrom`, resources, and pod/container security contexts.
- Deployment defaults include `RELAY_HOST=0.0.0.0`, `RELAY_PORT={{ .Values.containerPort }}`, `RELAY_WORKERS=1`, `TOKENPLACE_FRONTEND_MODE=production`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0`, with no default `TOKENPLACE_RELAY_UPSTREAM_URL`; `/tmp` is mounted as an `emptyDir` and probes are configured for `/livez` and `/healthz`.
- Deprecate the legacy `deploy/charts/tokenplace-relay` by adding a `README.md` pointing to the new `charts/tokenplace` to avoid dual active charts.

### Testing
- Attempted `helm lint charts/tokenplace` but it could not be run in this environment because `helm` is not installed, so linting is pending in CI or a local dev environment.
- Attempted `helm template tokenplace charts/tokenplace --namespace tokenplace --set ingress.enabled=true --set ingress.host=staging.token.place --set image.tag=main-deadbee` to validate rendered manifests, but the command was blocked for the same `helm` availability reason, so template verification is pending.
- Attempted repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` but the helper script was not present in this environment, so the automated secret-check step is pending.
- No automated tests ran and passed in this environment; please run `helm lint` and `helm template` locally or in CI to validate the chart (verification commands are provided in the PR notes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a27ca7c0832f8e453286ee4d3cef)