### PR TITLE
Add canonical tokenplace Helm chart and deprecate legacy chart

### DIFF
--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tokenplace
+description: Canonical Helm chart for deploying the token.place relay
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/charts/tokenplace/templates/_helpers.tpl
+++ b/charts/tokenplace/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "tokenplace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tokenplace.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "tokenplace.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tokenplace.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "tokenplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "tokenplace.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tokenplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "tokenplace.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "tokenplace.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tokenplace.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repo .Values.image.digest -}}
+{{- else -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tokenplace.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tokenplace.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tokenplace.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: tokenplace
+          image: {{ include "tokenplace.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: RELAY_HOST
+              value: "0.0.0.0"
+            - name: RELAY_PORT
+              value: {{ .Values.containerPort | quote }}
+            - name: RELAY_WORKERS
+              value: "1"
+            - name: TOKENPLACE_FRONTEND_MODE
+              value: "production"
+            - name: TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH
+              value: "0"
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tokenplace/templates/ingress.yaml
+++ b/charts/tokenplace/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tokenplace.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.secretName }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+{{- end }}

--- a/charts/tokenplace/templates/service.yaml
+++ b/charts/tokenplace/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tokenplace.selectorLabels" . | nindent 4 }}

--- a/charts/tokenplace/templates/serviceaccount.yaml
+++ b/charts/tokenplace/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tokenplace.serviceAccountName" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -1,0 +1,69 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+containerPort: 5010
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 300m
+    memory: 256Mi
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+env: {}
+extraEnv: []
+envFrom: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/charts/tokenplace-relay/Chart.yaml
+++ b/deploy/charts/tokenplace-relay/Chart.yaml
@@ -4,3 +4,4 @@ description: Helm chart for deploying the token.place relay service
 version: 0.1.0
 appVersion: "0.1.0"
 type: application
+deprecated: true

--- a/deploy/charts/tokenplace-relay/README.md
+++ b/deploy/charts/tokenplace-relay/README.md
@@ -1,0 +1,5 @@
+# Deprecated chart
+
+This legacy chart is deprecated.
+
+Use the canonical chart at `charts/tokenplace` instead.


### PR DESCRIPTION
### Motivation
- Provide a canonical, app-owned Helm chart that Sugarkube will install from OCI for the token.place relay with safe relay-only defaults.
- Make the runtime safe for relay-only deployments by avoiding implicit GPU/backend dependencies and using a single worker by default.
- Consolidate chart maintenance to a single canonical location and avoid maintaining two divergent charts.

### Description
- Add `charts/tokenplace` with `Chart.yaml`, `values.yaml`, and templates for `_helpers.tpl`, `deployment.yaml`, `service.yaml`, `ingress.yaml`, and `serviceaccount.yaml` that render a Deployment, Service, optional Ingress, and optional ServiceAccount.
- Implement DSPACE-style values including `replicaCount: 1`, `image.repository`/`tag`/`digest`/`pullPolicy`, `containerPort: 5010`, `env` (map), `extraEnv` (list), `envFrom`, resource requests/limits, probes for `/livez` and `/healthz`, and ingress TLS knobs.
- Enforce read-only-rootfs-compatible pod/container security contexts (`runAsNonRoot`, `runAsUser`/`runAsGroup`, drop all capabilities, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`) and mount `/tmp` as an `emptyDir` volume.
- Set relay defaults in the Deployment env: `RELAY_HOST=0.0.0.0`, `RELAY_PORT={{ .Values.containerPort }}`, `RELAY_WORKERS=1`, `TOKENPLACE_FRONTEND_MODE=production`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0`, and do not set any upstream GPU/backend services by default.
- Mark the legacy `deploy/charts/tokenplace-relay` chart as deprecated by adding `deprecated: true` to its `Chart.yaml` and add a `README.md` pointing to the new canonical chart.

### Testing
- Ran `pre-commit run --all-files` and the configured hooks completed successfully. 
- Attempted the acceptance `helm` checks (`helm lint` and `helm template`) but the `helm` CLI is not available in this execution environment so those steps were not executed here. 
- Attempted the repository secret-scan wrapper but `./scripts/scan-secrets.py` was not present so the scan step could not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a27ca7c0832f8e453286ee4d3cef)