### PR TITLE
Add GHCR relay image build/publish workflow

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,156 @@
+name: Build and publish GHCR relay image
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to build
+        required: false
+        default: main
+
+jobs:
+  build-and-smoke:
+    name: Build and smoke-test relay image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      immutable_tag: ${{ steps.tags.outputs.immutable_tag }}
+      image_ref: ${{ steps.tags.outputs.image_ref }}
+      short_sha: ${{ steps.tags.outputs.short_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Derive tags
+        id: tags
+        run: |
+          set -euo pipefail
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          IMAGE="ghcr.io/futuroptimist/tokenplace-relay"
+          BRANCH_NAME="${GITHUB_REF_NAME:-main}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.ref }}" ]; then
+            BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+          fi
+
+          if [ "${BRANCH_NAME}" = "main" ]; then
+            IMMUTABLE_TAG="main-${SHORT_SHA}"
+          else
+            SANITIZED_BRANCH="$(echo "${BRANCH_NAME}" | tr '/_' '--' | tr -cd '[:alnum:]-')"
+            IMMUTABLE_TAG="${SANITIZED_BRANCH}-${SHORT_SHA}"
+          fi
+
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "immutable_tag=${IMMUTABLE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${IMAGE}:${IMMUTABLE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build local image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: tokenplace-relay:smoke
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+
+          docker run -d --rm --name tokenplace-relay-smoke \
+            -p 127.0.0.1:5010:5010 \
+            -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
+            tokenplace-relay:smoke
+
+          cleanup() {
+            docker logs tokenplace-relay-smoke || true
+            docker stop tokenplace-relay-smoke >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5010/livez >/dev/null \
+              && curl -fsS http://127.0.0.1:5010/healthz >/dev/null \
+              && curl -fsS http://127.0.0.1:5010/ >/dev/null \
+              && curl -fsS http://127.0.0.1:5010/metrics >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          docker logs tokenplace-relay-smoke
+          docker logs tokenplace-relay-smoke | grep -E -- '--workers 1|Booting worker with pid' >/dev/null
+
+      - name: Add image summary
+        run: |
+          {
+            echo "## Relay image build summary"
+            echo ""
+            echo "- Immutable tag: \`${{ steps.tags.outputs.immutable_tag }}\`"
+            echo "- Image reference: \`${{ steps.tags.outputs.image_ref }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish multi-arch image to GHCR
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-and-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/futuroptimist/tokenplace-relay:${{ needs.build-and-smoke.outputs.immutable_tag }}
+            ghcr.io/futuroptimist/tokenplace-relay:main-latest
+            ghcr.io/futuroptimist/tokenplace-relay:sha-${{ needs.build-and-smoke.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+
+      - name: Publish image summary
+        run: |
+          {
+            echo "## Published relay image"
+            echo ""
+            echo "- Immutable tag: \`${{ needs.build-and-smoke.outputs.immutable_tag }}\`"
+            echo "- Mutable tag: \`main-latest\`"
+            echo "- Compatibility tag: \`sha-${{ needs.build-and-smoke.outputs.short_sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide a canonical GHCR pipeline for the token.place relay image that produces immutable branch-SHA tags and a mutable convenience tag for Sugarkube rollouts.
- Ensure PRs and manual runs validate the Dockerfile and runtime via a fast smoke test without requiring upstream GPU/backend services.
- Publish multi-arch images for `linux/amd64,linux/arm64` on `main` pushes so Sugarkube can deploy to arm64 devices like Raspberry Pi.

### Description
- Add `.github/workflows/ci-image.yml` implementing a `build-and-smoke` job (PRs and `workflow_dispatch`) and a `publish` job (pushes to `main`).
- Derive deterministic tags and outputs (`short_sha`, `immutable_tag`, `image_ref`) and emit the immutable tag into the workflow summary.
- Use Docker Buildx with GitHub Actions cache, set OCI labels (`org.opencontainers.image.source`, `org.opencontainers.image.revision`, `org.opencontainers.image.created`), build `linux/amd64` for smoke runs, and build/push `linux/amd64,linux/arm64` for publish.
- Implement a smoke test that runs the built image with `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0` and probes `/livez`, `/healthz`, `/`, and `/metrics`, and verifies the one-worker default via startup logs.

### Testing
- Ran `pre-commit run --all-files`, which could not run in this environment because `pre-commit` is not installed, so local pre-commit hooks were not exercised.
- Ran a repository secret-scan attempt via `git diff --cached | ./scripts/scan-secrets.py`, which failed because `./scripts/scan-secrets.py` is not present in this environment.
- The workflow includes an automated smoke-test step that will run in CI for PRs and will be run for publish on `main` pushes; those CI smoke tests will validate the runtime endpoints and tagging when executed in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b243a9a4832fa63f1fedabc16bd4)