### PR TITLE
🧱 ci: add GHCR relay image workflow

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'write' || 'read' }}
+      packages: write
     outputs:
       immutable_image_tag: ${{ steps.tags.outputs.branch_tag }}
 
@@ -42,8 +42,8 @@ jobs:
           echo "created=${created}" >> "$GITHUB_OUTPUT"
           echo "repository=${repository}" >> "$GITHUB_OUTPUT"
           echo "branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "default_tag=${repository}:main" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${repository}:main-latest" >> "$GITHUB_OUTPUT"
-          echo "sha_tag=${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,7 +66,7 @@ jobs:
           tags: tokenplace-relay:smoke
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.tags.outputs.short_sha }}
             org.opencontainers.image.created=${{ steps.tags.outputs.created }}
           cache-from: type=gha,scope=relay-image
           cache-to: type=gha,mode=max,scope=relay-image
@@ -90,8 +90,7 @@ jobs:
           for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:5010/livez \
               && curl -fsS http://127.0.0.1:5010/healthz \
-              && curl -fsS http://127.0.0.1:5010/ >/dev/null \
-              && curl -fsS http://127.0.0.1:5010/metrics >/dev/null; then
+              && curl -fsS http://127.0.0.1:5010/ >/dev/null; then
               break
             fi
             sleep 1
@@ -100,9 +99,8 @@ jobs:
           curl -fsS http://127.0.0.1:5010/livez >/dev/null
           curl -fsS http://127.0.0.1:5010/healthz >/dev/null
           curl -fsS http://127.0.0.1:5010/ >/dev/null
-          curl -fsS http://127.0.0.1:5010/metrics >/dev/null
 
-          docker exec tokenplace-relay-smoke sh -c "ps -o args= 1" | grep -F -- '--workers 1'
+          docker exec tokenplace-relay-smoke sh -c "tr '\\0' ' ' < /proc/1/cmdline" | grep -F -- '--workers 1'
 
       - name: Log in to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -123,11 +121,11 @@ jobs:
           provenance: false
           tags: |
             ${{ steps.tags.outputs.branch_tag }}
+            ${{ steps.tags.outputs.default_tag }}
             ${{ steps.tags.outputs.latest_tag }}
-            ${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.tags.outputs.short_sha }}
             org.opencontainers.image.created=${{ steps.tags.outputs.created }}
           cache-from: type=gha,scope=relay-image
           cache-to: type=gha,mode=max,scope=relay-image
@@ -138,8 +136,8 @@ jobs:
             echo "## Relay image tags"
             echo ""
             echo "Immutable tag: \`${{ steps.tags.outputs.branch_tag }}\`"
+            echo "Default mutable tag: \`${{ steps.tags.outputs.default_tag }}\`"
             echo "Mutable tag: \`${{ steps.tags.outputs.latest_tag }}\`"
-            echo "Compatibility tag: \`${{ steps.tags.outputs.sha_tag }}\`"
             echo ""
             echo "Pushed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,145 @@
+name: Build and publish GHCR relay image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to build
+        required: false
+        default: main
+
+jobs:
+  relay-image:
+    name: Build, smoke-test, and publish relay image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'write' || 'read' }}
+    outputs:
+      immutable_image_tag: ${{ steps.tags.outputs.branch_tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Compute image metadata and tags
+        id: tags
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          repository="ghcr.io/futuroptimist/tokenplace-relay"
+
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "created=${created}" >> "$GITHUB_OUTPUT"
+          echo "repository=${repository}" >> "$GITHUB_OUTPUT"
+          echo "branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${repository}:main-latest" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU (arm64 for push)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Build relay image locally for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          provenance: false
+          tags: tokenplace-relay:smoke
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.tags.outputs.created }}
+          cache-from: type=gha,scope=relay-image
+          cache-to: type=gha,mode=max,scope=relay-image
+
+      - name: Smoke test relay container
+        run: |
+          set -euo pipefail
+
+          docker run -d --rm --name tokenplace-relay-smoke \
+            -p 127.0.0.1:5010:5010 \
+            -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
+            tokenplace-relay:smoke
+
+          cleanup() {
+            echo "--- container logs ---"
+            docker logs tokenplace-relay-smoke || true
+            docker stop tokenplace-relay-smoke >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5010/livez \
+              && curl -fsS http://127.0.0.1:5010/healthz \
+              && curl -fsS http://127.0.0.1:5010/ >/dev/null \
+              && curl -fsS http://127.0.0.1:5010/metrics >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          curl -fsS http://127.0.0.1:5010/livez >/dev/null
+          curl -fsS http://127.0.0.1:5010/healthz >/dev/null
+          curl -fsS http://127.0.0.1:5010/ >/dev/null
+          curl -fsS http://127.0.0.1:5010/metrics >/dev/null
+
+          docker exec tokenplace-relay-smoke sh -c "ps -o args= 1" | grep -F -- '--workers 1'
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch relay image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.tags.outputs.branch_tag }}
+            ${{ steps.tags.outputs.latest_tag }}
+            ${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.tags.outputs.created }}
+          cache-from: type=gha,scope=relay-image
+          cache-to: type=gha,mode=max,scope=relay-image
+
+      - name: Publish workflow summary
+        run: |
+          {
+            echo "## Relay image tags"
+            echo ""
+            echo "Immutable tag: \`${{ steps.tags.outputs.branch_tag }}\`"
+            echo "Mutable tag: \`${{ steps.tags.outputs.latest_tag }}\`"
+            echo "Compatibility tag: \`${{ steps.tags.outputs.sha_tag }}\`"
+            echo ""
+            echo "Pushed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -15,14 +15,18 @@ on:
         default: main
 
 jobs:
-  relay-image:
-    name: Build, smoke-test, and publish relay image
+  build-and-smoke:
+    name: Build and smoke-test relay image
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     outputs:
-      immutable_image_tag: ${{ steps.tags.outputs.branch_tag }}
+      short_sha: ${{ steps.tags.outputs.short_sha }}
+      created: ${{ steps.tags.outputs.created }}
+      repository: ${{ steps.tags.outputs.repository }}
+      branch_tag: ${{ steps.tags.outputs.branch_tag }}
+      latest_tag: ${{ steps.tags.outputs.latest_tag }}
+      sha_tag: ${{ steps.tags.outputs.sha_tag }}
 
     steps:
       - name: Checkout repository
@@ -42,17 +46,11 @@ jobs:
           echo "created=${created}" >> "$GITHUB_OUTPUT"
           echo "repository=${repository}" >> "$GITHUB_OUTPUT"
           echo "branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
-          echo "default_tag=${repository}:main" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${repository}:main-latest" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Set up QEMU (arm64 for push)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
 
       - name: Build relay image locally for smoke test
         uses: docker/build-push-action@v6
@@ -90,7 +88,8 @@ jobs:
           for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:5010/livez \
               && curl -fsS http://127.0.0.1:5010/healthz \
-              && curl -fsS http://127.0.0.1:5010/ >/dev/null; then
+              && curl -fsS http://127.0.0.1:5010/ >/dev/null \
+              && curl -fsS http://127.0.0.1:5010/metrics >/dev/null; then
               break
             fi
             sleep 1
@@ -99,11 +98,32 @@ jobs:
           curl -fsS http://127.0.0.1:5010/livez >/dev/null
           curl -fsS http://127.0.0.1:5010/healthz >/dev/null
           curl -fsS http://127.0.0.1:5010/ >/dev/null
+          curl -fsS http://127.0.0.1:5010/metrics >/dev/null
 
           docker exec tokenplace-relay-smoke sh -c "tr '\\0' ' ' < /proc/1/cmdline" | grep -F -- '--workers 1'
 
+  publish:
+    name: Publish relay image
+    runs-on: ubuntu-latest
+    needs: build-and-smoke
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU (arm64 for push)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
       - name: Log in to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -111,7 +131,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-arch relay image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -120,13 +139,13 @@ jobs:
           push: true
           provenance: false
           tags: |
-            ${{ steps.tags.outputs.branch_tag }}
-            ${{ steps.tags.outputs.default_tag }}
-            ${{ steps.tags.outputs.latest_tag }}
+            ${{ needs.build-and-smoke.outputs.branch_tag }}
+            ${{ needs.build-and-smoke.outputs.latest_tag }}
+            ${{ needs.build-and-smoke.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.tags.outputs.short_sha }}
-            org.opencontainers.image.created=${{ steps.tags.outputs.created }}
+            org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.short_sha }}
+            org.opencontainers.image.created=${{ needs.build-and-smoke.outputs.created }}
           cache-from: type=gha,scope=relay-image
           cache-to: type=gha,mode=max,scope=relay-image
 
@@ -135,9 +154,9 @@ jobs:
           {
             echo "## Relay image tags"
             echo ""
-            echo "Immutable tag: \`${{ steps.tags.outputs.branch_tag }}\`"
-            echo "Default mutable tag: \`${{ steps.tags.outputs.default_tag }}\`"
-            echo "Mutable tag: \`${{ steps.tags.outputs.latest_tag }}\`"
+            echo "Immutable tag: \`${{ needs.build-and-smoke.outputs.branch_tag }}\`"
+            echo "Mutable tag: \`${{ needs.build-and-smoke.outputs.latest_tag }}\`"
+            echo "SHA tag: \`${{ needs.build-and-smoke.outputs.sha_tag }}\`"
             echo ""
-            echo "Pushed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
+            echo "Pushed: true"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Add a reproducible GHCR pipeline to build, smoke-test, and publish the `ghcr.io/futuroptimist/tokenplace-relay` image with immutable branch-SHA tagging and relay-only smoke checks so Sugarkube can deploy relay-only topologies without requiring GPU/backend services.

### Description
- Add `.github/workflows/ci-image.yml` which triggers on `pull_request` to `main` (build+smoke), `push` to `main` (build+smoke+push), and `workflow_dispatch`; it computes tags (`main-<shortsha>`, `main-latest`, `sha-<shortsha>`), builds with Docker Buildx, runs a local `linux/amd64` smoke build and container tests against `/livez`, `/healthz`, `/`, and `/metrics`, verifies the default one-worker entrypoint (`--workers 1`), and conditionally builds/pushes multi-arch (`linux/amd64,linux/arm64`) images to GHCR with OCI labels and an immutable-image output.

### Testing
- Ran `pre-commit run --all-files`, which reported failures due to pre-existing YAML parse errors in `charts/tokenplace/templates/*` (unrelated to this workflow); `git commit` succeeded and the new workflow file was created, and a repository secret-scan invocation failed here because the referenced script is not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b243a9a4832fa63f1fedabc16bd4)