### PR TITLE
🧰 chore: add GHCR OCI Helm chart publishing workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,136 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to publish
+        required: false
+        default: main
+
+jobs:
+  helm-validate-and-package:
+    name: Lint, template, and package Helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart_meta.outputs.chart_version }}
+      chart_name: ${{ steps.chart_meta.outputs.chart_name }}
+      chart_archive: ${{ steps.package.outputs.chart_archive }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies when lockfile exists
+        run: |
+          set -euo pipefail
+          if [ -f charts/tokenplace/Chart.lock ]; then
+            helm dependency build charts/tokenplace
+          else
+            echo "No Chart.lock found; skipping dependency build."
+          fi
+
+      - name: Read chart metadata
+        id: chart_meta
+        run: |
+          set -euo pipefail
+          chart_name="$(helm show chart charts/tokenplace | awk -F': ' '/^name:/{print $2}')"
+          chart_version="$(helm show chart charts/tokenplace | awk -F': ' '/^version:/{print $2}')"
+          echo "chart_name=${chart_name}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Lint chart
+        run: helm lint charts/tokenplace
+
+      - name: Template smoke render (staging-like)
+        run: |
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.token.place \
+            --set image.tag=main-deadbee
+
+      - name: Package chart
+        id: package
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts
+          helm package charts/tokenplace --destination .artifacts
+          chart_archive=".artifacts/${{ steps.chart_meta.outputs.chart_name }}-${{ steps.chart_meta.outputs.chart_version }}.tgz"
+          test -f "${chart_archive}"
+          echo "chart_archive=${chart_archive}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish chart to GHCR OCI
+    runs-on: ubuntu-latest
+    needs: helm-validate-and-package
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies when lockfile exists
+        run: |
+          set -euo pipefail
+          if [ -f charts/tokenplace/Chart.lock ]; then
+            helm dependency build charts/tokenplace
+          else
+            echo "No Chart.lock found; skipping dependency build."
+          fi
+
+      - name: Package chart
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts
+          helm package charts/tokenplace --destination .artifacts
+
+      - name: Authenticate to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to OCI registry
+        id: push
+        run: |
+          set -euo pipefail
+          chart_archive=".artifacts/${{ needs.helm-validate-and-package.outputs.chart_name }}-${{ needs.helm-validate-and-package.outputs.chart_version }}.tgz"
+          chart_ref="oci://ghcr.io/futuroptimist/charts/${{ needs.helm-validate-and-package.outputs.chart_name }}"
+
+          helm push "${chart_archive}" oci://ghcr.io/futuroptimist/charts
+
+          echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${{ needs.helm-validate-and-package.outputs.chart_version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish workflow summary
+        run: |
+          {
+            echo "## Helm chart publish"
+            echo ""
+            echo "Chart reference: \`${{ steps.push.outputs.chart_ref }}\`"
+            echo "Chart version: \`${{ steps.push.outputs.chart_version }}\`"
+            echo ""
+            echo "Pushed: true"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation

- Provide automated linting, templating, packaging, and OCI publishing for the canonical `tokenplace` Helm chart so PRs validate rendering and `main` publishes an OCI chart to GHCR.
- Match DSPACE-like chart publishing workflows by pushing the packaged chart to `oci://ghcr.io/futuroptimist/charts` and exporting a stable chart reference/version.

### Description

- Add a new workflow at `.github/workflows/ci-helm.yml` named `Publish Helm chart` that triggers on `pull_request` to `main`, `push` to `main`, and `workflow_dispatch` with an optional `ref`.
- Implement a `helm-validate-and-package` job that checks out the requested ref, sets up Helm (`azure/setup-helm@v4`), conditionally runs `helm dependency build charts/tokenplace` when `Chart.lock` exists, runs `helm lint`, performs a `helm template` smoke render with `--namespace tokenplace`, `--set ingress.enabled=true`, `--set ingress.host=staging.token.place`, and `--set image.tag=main-deadbee`, and packages the chart to `.artifacts` while exporting chart metadata outputs.
- Implement a gated `publish` job (runs only when the event is not a PR) that authenticates to GHCR using `GITHUB_TOKEN` and `helm registry login`, then pushes the packaged chart to `oci://ghcr.io/futuroptimist/charts` and publishes a workflow summary containing the chart reference and version.
- Workflow permissions use `contents: read` for validation and `packages: write` for the publish job only, and the chart name is derived from `charts/tokenplace/Chart.yaml` (expected `tokenplace`).

### Testing

- Attempted to run local verification commands `helm lint charts/tokenplace`, `helm template ... --set image.tag=main-deadbee`, and `helm package charts/tokenplace`, but `helm` is not installed in this execution environment so those checks could not run locally.
- Ran `pre-commit run --all-files` as the repo recommends, which surfaced existing YAML parsing failures in the chart template files under `charts/tokenplace/templates/*` (these are pre-existing issues outside the workflow addition and will cause `pre-commit` to fail until fixed).
- The new workflow itself is authored to cause CI to fail on `helm lint` or `helm template` failures in GitHub Actions, and publishing is gated to non-PR events so PRs only validate without publishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b8ad53f0832f97d4655156f81a3c)