### PR TITLE
🛠️ ci: add OCI Helm chart publishing workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,127 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to publish
+        required: false
+        default: main
+
+jobs:
+  validate-and-package:
+    name: Validate and package chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart_meta.outputs.chart_version }}
+      package_file: ${{ steps.package.outputs.package_file }}
+      chart_ref: ${{ steps.chart_meta.outputs.chart_ref }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies when lock file exists
+        if: ${{ hashFiles('charts/tokenplace/Chart.lock') != '' }}
+        run: helm dependency build charts/tokenplace
+
+      - name: Lint chart
+        run: helm lint charts/tokenplace
+
+      - name: Template smoke render (staging-like)
+        run: |
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.token.place \
+            --set image.tag=main-deadbee
+
+      - name: Capture chart metadata
+        id: chart_meta
+        run: |
+          set -euo pipefail
+          chart_name="$(helm show chart charts/tokenplace | awk -F': ' '/^name:/{print $2}')"
+          chart_version="$(helm show chart charts/tokenplace | awk -F': ' '/^version:/{print $2}')"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=oci://ghcr.io/futuroptimist/charts/${chart_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Package chart
+        id: package
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package charts/tokenplace --destination dist
+          package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
+          echo "package_file=${package_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload chart package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokenplace-chart-package
+          path: ${{ steps.package.outputs.package_file }}
+
+      - name: Publish validation summary
+        run: |
+          {
+            echo "## Helm chart validation"
+            echo ""
+            echo "Chart reference: \`${{ steps.chart_meta.outputs.chart_ref }}\`"
+            echo "Chart version: \`${{ steps.chart_meta.outputs.chart_version }}\`"
+            echo "Packaged artifact: \`${{ steps.package.outputs.package_file }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish chart to GHCR OCI
+    runs-on: ubuntu-latest
+    needs: validate-and-package
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download packaged chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tokenplace-chart-package
+          path: dist
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to OCI registry
+        id: push
+        run: |
+          set -euo pipefail
+          package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
+          chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
+          helm push "${package_file}" "oci://ghcr.io/futuroptimist/charts"
+          echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart summary
+        run: |
+          {
+            echo "## Helm chart published"
+            echo ""
+            echo "Chart reference: \`${{ steps.push.outputs.chart_ref }}\`"
+            echo "Chart version: \`${{ needs.validate-and-package.outputs.chart_version }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -59,9 +59,11 @@ jobs:
           set -euo pipefail
           chart_name="$(helm show chart charts/tokenplace | awk -F': ' '/^name:/{print $2}')"
           chart_version="$(helm show chart charts/tokenplace | awk -F': ' '/^version:/{print $2}')"
-          registry_owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          chart_ref="oci://ghcr.io/futuroptimist/charts/${chart_name}"
+          test "${chart_name}" = "tokenplace"
+          test "${chart_ref}" = "oci://ghcr.io/futuroptimist/charts/tokenplace"
           echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
-          echo "chart_ref=oci://ghcr.io/${registry_owner}/charts/${chart_name}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Package chart
         id: package
@@ -69,13 +71,9 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           helm package charts/tokenplace --destination dist
-          mapfile -t package_files < <(find dist -maxdepth 1 -type f -name '*.tgz' | sort)
-          if [ "${#package_files[@]}" -ne 1 ]; then
-            echo "Expected exactly one packaged chart in dist, found ${#package_files[@]}." >&2
-            printf '%s\n' "${package_files[@]}" >&2 || true
-            exit 1
-          fi
-          package_file="${package_files[0]}"
+          package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
+          test -n "${package_file}"
+          test -f "${package_file}"
           echo "package_file=${package_file}" >> "$GITHUB_OUTPUT"
 
       - name: Upload chart package artifact
@@ -125,13 +123,9 @@ jobs:
         id: push
         run: |
           set -euo pipefail
-          mapfile -t package_files < <(find dist -maxdepth 1 -type f -name '*.tgz' | sort)
-          if [ "${#package_files[@]}" -ne 1 ]; then
-            echo "Expected exactly one packaged chart artifact in dist, found ${#package_files[@]}." >&2
-            printf '%s\n' "${package_files[@]}" >&2 || true
-            exit 1
-          fi
-          package_file="${package_files[0]}"
+          package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
+          test -n "${package_file}"
+          test -f "${package_file}"
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
           if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,4 +1,6 @@
 name: Publish Helm chart
+env:
+  HELM_VERSION: v3.17.3
 
 on:
   pull_request:
@@ -33,6 +35,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
 
       - name: Build chart dependencies when lock file exists
         if: ${{ hashFiles('charts/tokenplace/Chart.lock') != '' }}
@@ -55,8 +59,9 @@ jobs:
           set -euo pipefail
           chart_name="$(helm show chart charts/tokenplace | awk -F': ' '/^name:/{print $2}')"
           chart_version="$(helm show chart charts/tokenplace | awk -F': ' '/^version:/{print $2}')"
+          registry_owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
-          echo "chart_ref=oci://ghcr.io/futuroptimist/charts/${chart_name}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=oci://ghcr.io/${registry_owner}/charts/${chart_name}" >> "$GITHUB_OUTPUT"
 
       - name: Package chart
         id: package
@@ -64,7 +69,13 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           helm package charts/tokenplace --destination dist
-          package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
+          mapfile -t package_files < <(find dist -maxdepth 1 -type f -name '*.tgz' | sort)
+          if [ "${#package_files[@]}" -ne 1 ]; then
+            echo "Expected exactly one packaged chart in dist, found ${#package_files[@]}." >&2
+            printf '%s\n' "${package_files[@]}" >&2 || true
+            exit 1
+          fi
+          package_file="${package_files[0]}"
           echo "package_file=${package_file}" >> "$GITHUB_OUTPUT"
 
       - name: Upload chart package artifact
@@ -87,7 +98,7 @@ jobs:
     name: Publish chart to GHCR OCI
     runs-on: ubuntu-latest
     needs: validate-and-package
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.repository == 'futuroptimist/token.place'
     permissions:
       contents: read
       packages: write
@@ -101,6 +112,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
 
       - name: Log in to GHCR
         run: |
@@ -112,9 +125,20 @@ jobs:
         id: push
         run: |
           set -euo pipefail
-          package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
+          mapfile -t package_files < <(find dist -maxdepth 1 -type f -name '*.tgz' | sort)
+          if [ "${#package_files[@]}" -ne 1 ]; then
+            echo "Expected exactly one packaged chart artifact in dist, found ${#package_files[@]}." >&2
+            printf '%s\n' "${package_files[@]}" >&2 || true
+            exit 1
+          fi
+          package_file="${package_files[0]}"
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
-          helm push "${package_file}" "oci://ghcr.io/futuroptimist/charts"
+          chart_registry="${chart_ref%/*}"
+          if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
+            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Bump charts/tokenplace/Chart.yaml version before publishing." >&2
+            exit 1
+          fi
+          helm push "${package_file}" "${chart_registry}"
           echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Publish chart summary


### PR DESCRIPTION
### Motivation
- Add automated validation and OCI publishing for the canonical Helm chart so PRs validate templates and `main` pushes publish an OCI chart to GHCR. 
- Ensure PRs only run lint/template/package steps and only non-PR events (push/workflow_dispatch) perform authenticated `helm push`.
- Keep the canonical chart identity derived from `charts/tokenplace/Chart.yaml` so the published chart name is `tokenplace`.

### Description
- Add `.github/workflows/ci-helm.yml` which defines the `Publish Helm chart` workflow triggered on `pull_request` to `main`, `push` to `main`, and `workflow_dispatch` with an optional `ref`. 
- Implement a `validate-and-package` job that checks out the repo, sets up Helm, conditionally runs `helm dependency build` when `Chart.lock` exists, runs `helm lint`, performs a staging-like `helm template` smoke render, packages the chart into `dist`, captures chart metadata, and uploads the packaged artifact. 
- Implement a `publish` job (gated to non-PR events) that downloads the packaged artifact, logs into GHCR using `GITHUB_TOKEN`, and pushes the packaged chart to `oci://ghcr.io/futuroptimist/charts` with `packages: write` permission. 
- Emit step outputs and workflow summaries with the full chart reference and chart version derived from chart metadata.

### Testing
- Ran `pre-commit run --all-files`, which bootstrapped hooks and reported YAML/template validation failures in existing chart templates (the `check-yaml` hook failed). 
- Attempted local `helm` commands (`helm lint`, `helm template`, `helm package`) but they could not be executed in the environment because the `helm` binary is not installed. 
- The workflow is designed so PRs will validate and package only, and pushes/workflow_dispatch will publish; actual publish behavior will be verified in CI on `main` or by manual `workflow_dispatch` runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b8ad53f0832f97d4655156f81a3c)