### PR TITLE
ci: add Helm OCI chart publishing workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,124 @@
+name: Publish Helm chart
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to publish
+        required: false
+        default: main
+
+jobs:
+  helm-validate-and-package:
+    name: Lint, template, and package chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_name: ${{ steps.meta.outputs.chart_name }}
+      chart_version: ${{ steps.meta.outputs.chart_version }}
+      package_file: ${{ steps.meta.outputs.package_file }}
+      chart_ref: ${{ steps.meta.outputs.chart_ref }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Read chart metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          chart_name="$(helm show chart charts/tokenplace | awk -F': ' '$1 == "name" {print $2; exit}')"
+          chart_version="$(helm show chart charts/tokenplace | awk -F': ' '$1 == "version" {print $2; exit}')"
+          package_file="${chart_name}-${chart_version}.tgz"
+          chart_ref="oci://ghcr.io/futuroptimist/charts/${chart_name}"
+
+          echo "chart_name=${chart_name}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "package_file=${package_file}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Build chart dependencies (if present)
+        run: |
+          set -euo pipefail
+          if [ -f charts/tokenplace/Chart.lock ] || [ -d charts/tokenplace/charts ]; then
+            helm dependency build charts/tokenplace
+          else
+            echo "No chart dependencies detected; skipping helm dependency build"
+          fi
+
+      - name: Helm lint
+        run: helm lint charts/tokenplace
+
+      - name: Helm template smoke render
+        run: |
+          set -euo pipefail
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.token.place \
+            --set image.tag=main-deadbee >/dev/null
+
+      - name: Package chart
+        run: helm package charts/tokenplace
+
+      - name: Upload packaged chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: packaged-chart
+          path: ${{ steps.meta.outputs.package_file }}
+
+  publish-chart:
+    name: Publish chart to GHCR OCI
+    runs-on: ubuntu-latest
+    needs: helm-validate-and-package
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download packaged chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: packaged-chart
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Authenticate to GHCR
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to GHCR OCI
+        run: |
+          set -euo pipefail
+          helm push "${{ needs.helm-validate-and-package.outputs.package_file }}" \
+            oci://ghcr.io/futuroptimist/charts
+
+      - name: Publish workflow summary
+        run: |
+          {
+            echo "## Helm chart publish"
+            echo ""
+            echo "Chart: \
+\`${{ needs.helm-validate-and-package.outputs.chart_name }}\`"
+            echo "Version: \
+\`${{ needs.helm-validate-and-package.outputs.chart_version }}\`"
+            echo "Reference: \
+\`${{ needs.helm-validate-and-package.outputs.chart_ref }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide an automated CI flow to validate and publish the canonical `tokenplace` Helm chart as an OCI chart to GHCR. 
- Ensure PRs perform lint/template/package validation without publishing while `push`/manual dispatch publish the chart to `oci://ghcr.io/futuroptimist/charts`.

### Description
- Add `.github/workflows/ci-helm.yml` which triggers on `pull_request` to `main`, `push` to `main`, and `workflow_dispatch` with a `ref` input. 
- Implement `helm-validate-and-package` job that checks out the repo, sets up Helm, conditionally runs `helm dependency build` when `Chart.lock` or vendored `charts/` exist, runs `helm lint`, runs a staging-like `helm template` smoke render, and runs `helm package`. 
- Implement `publish-chart` job that runs only on non-PR events, sets `permissions: packages: write`, authenticates to GHCR using `GITHUB_TOKEN` via `helm registry login`, pushes the packaged chart with `helm push` to `oci://ghcr.io/futuroptimist/charts`, and records chart metadata in the workflow summary. 
- Chart metadata is read from `charts/tokenplace` so the published reference resolves to `oci://ghcr.io/futuroptimist/charts/tokenplace`, and the workflow uploads/downloads the packaged chart artifact between jobs to separate validation and publish phases.

### Testing
- Attempted local `helm lint charts/tokenplace` which failed in this environment because the `helm` binary is not installed (`/bin/bash: helm: command not found`).
- Attempted local `helm template ...` and `helm package charts/tokenplace` which were blocked for the same missing-`helm` reason. 
- Attempted to run the repository secret scan helper `./scripts/scan-secrets.py` which is not present in this environment, so automated local secret-scan validation could not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b8ad53f0832f97d4655156f81a3c)