### PR TITLE
📝 docs: update Sugarkube relay-only OCI deployment runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,22 @@ See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay
 
 ## sugarkube deployment
 
-`relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
-operationally separate from GPU-heavy compute nodes.
-In the short-to-medium term architecture, sugarkube scope remains relay-only.
+`relay.py` is the only token.place runtime component deployed in Sugarkube for the near-term phase.
+`server.py` and desktop/host compute nodes remain external.
+
+Current relay operations model in Sugarkube:
+
+- one pod, one Gunicorn worker, one replica
+- in-memory relay state (registrations/queued messages/replies)
+- accepted state loss on pod replacement until shared-state architecture lands
+
+Artifact references:
+
+- Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
+- OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
+
+Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:
@@ -749,7 +762,7 @@ Alternatively, you can visit http://127.0.0.1:5010 in your browser to use the we
 
 For a complete walkthrough of the Raspberry Pi 5 setup—including hardware recommendations, Docker instructions, k3s cluster steps, and troubleshooting (including rpi-clone prompts)—see [docs/RPI_DEPLOYMENT_GUIDE.md](docs/RPI_DEPLOYMENT_GUIDE.md#bill-of-materials).
 
-If you're booting via the [`sugarkube`](https://github.com/futuroptimist/sugarkube) Pi image, copy the Helm bundle from [`k8s/sugarkube/`](k8s/sugarkube/) into `/etc/sugarkube/helm-bundles.d/` so the relay deploys automatically once k3s is ready.
+If you're booting via the [`sugarkube`](https://github.com/futuroptimist/sugarkube) Pi image, deploy token.place via Sugarkube's Helm OCI install/upgrade flow using the published token.place chart and image tags (see the Sugarkube runbooks linked above), rather than local chart bundle copies.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ Current relay operations model in Sugarkube:
 - in-memory relay state (registrations/queued messages/replies)
 - accepted state loss on pod replacement until shared-state architecture lands
 
+Because the relay runs as a Kubernetes `Deployment`, default `RollingUpdate` behavior can
+temporarily create an extra pod during upgrades (`maxSurge`). Operators that require strict
+single-pod semantics during upgrades should enforce a single-pod rollout strategy (for example
+`Recreate` or `maxSurge=0`) in Sugarkube values.
+
 Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -34,10 +34,10 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 
 ```bash
 # Run from sugarkube checkout.
-just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA set=image.repository=ghcr.io/futuroptimist/tokenplace-relay
 
 # Upgrade existing release.
-just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA set=image.repository=ghcr.io/futuroptimist/tokenplace-relay
 ```
 
 ## Validation checklist

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -34,10 +34,10 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 
 ```bash
 # Run from sugarkube checkout.
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
 
 # Upgrade existing release.
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist
@@ -50,7 +50,7 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace -n tokenplace`) so rollback targets are explicit.
+Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
 
 - Roll back to previous image tag and/or Helm revision.
 - Verify readiness and `/healthz` immediately after rollback.

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -1,64 +1,19 @@
 # token.place relay on k3s+sugarkube (dev)
 
-> **Environment status:** **Planned / active development target**.
-> Keep dev secondary to staging/prod and limited to relay-only validation.
+> **Environment status:** secondary/non-target environment for this prompt.
 
 ## Scope
 
-Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
+Keep dev aligned with the same relay-only contract used for staging/prod:
 
-- ingress/tunnel plumbing
-- relay image/chart updates
-- registration and polling behavior with external compute nodes
+- In-cluster: `relay.py` only.
+- External compute remains out-of-cluster: `server.py`, desktop Tauri nodes, Macs, Windows PCs,
+  Raspberry Pi GPU/AI hat nodes, and other compute hosts.
+- No required in-cluster backend/GPU service.
+- Preserve API v1 relay-blind E2EE guardrails.
 
-## Prerequisites
+## Notes
 
-- sugarkube dev cluster access
-- helm/kubectl tooling
-- relay image tag available
-- dev hostname and Cloudflare tunnel route configured
-
-## Topology
-
-- In-cluster: `relay.py` deployment + service + ingress
-- External: `server.py` and/or desktop compute nodes (Windows/macOS/Raspberry Pi)
-  - No required in-cluster backend/GPU service.
-
-## Release model
-
-- Use mutable dev tags for fast iteration when needed.
-- Prefer pinned immutable tags before promotion to staging.
-- Preserve API v1 relay-blind E2EE guardrails (relay handles ciphertext + routing metadata only).
-
-## Deployment workflow (template)
-
-Before running the helper commands, set `image.repository: ghcr.io/futuroptimist/tokenplace-relay` in `docs/examples/tokenplace-relay.values.dev.yaml` in the sugarkube checkout.
-
-```bash
-# Run from sugarkube checkout.
-just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
-
-# Upgrade existing release.
-just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
-```
-
-## Validation checklist
-
-- [ ] `kubectl get pods` shows ready relay pod(s)
-- [ ] ingress host resolves in dev
-- [ ] `GET /livez` returns `{"status":"alive"}`
-- [ ] `GET /healthz` returns ready status (200)
-- [ ] external compute node can register/poll relay
-
-## Rollback
-
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
-
-- Roll back to previous image tag and/or Helm revision.
-- Verify readiness and `/healthz` immediately after rollback.
-
-## Operator notes
-
-- Keep this environment permissive for debugging, but avoid introducing config assumptions that
-  cannot be promoted.
-- Treat dev as relay-only: cluster runs `relay.py`; compute remains external.
+- Avoid stale local-chart/legacy-contract workflows (`./deploy/charts/tokenplace-relay`).
+- Dev runbooks/wrappers are Sugarkube-owned and may evolve independently from this repo.
+- Redis/shared-state/multi-replica relay architecture remains future work and out of scope.

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -32,12 +32,14 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 
 ## Deployment workflow (template)
 
+Before running the helper commands, set `image.repository: ghcr.io/futuroptimist/tokenplace-relay` in `docs/examples/tokenplace-relay.values.dev.yaml` in the sugarkube checkout.
+
 ```bash
 # Run from sugarkube checkout.
-just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA set=image.repository=ghcr.io/futuroptimist/tokenplace-relay
+just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
 
 # Upgrade existing release.
-just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA set=image.repository=ghcr.io/futuroptimist/tokenplace-relay
+just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -28,16 +28,28 @@ Keep dev aligned with the same relay-only contract used for staging/prod:
 > - `<DEV_VALUES_FILE>` (dev values file path)
 > - either `<VERSION_FILE>` or an explicit `version=`/`tag=` argument
 
-First install:
+First install with a version file:
 
 ```bash
 just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=<DEV_VALUES_FILE> version_file=<VERSION_FILE> default_tag=main-REPLACE_SHORTSHA
 ```
 
-Upgrade existing release:
+First install with an explicit tag:
+
+```bash
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=<DEV_VALUES_FILE> tag=main-REPLACE_SHORTSHA default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade existing release with a version file:
 
 ```bash
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=<DEV_VALUES_FILE> version_file=<VERSION_FILE> default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade existing release with an explicit tag:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=<DEV_VALUES_FILE> tag=main-REPLACE_SHORTSHA default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -1,7 +1,7 @@
 # token.place relay on k3s+sugarkube (dev)
 
 > **Environment status:** **Planned / active development target**.
-> Focus is relay-only deployment; compute nodes stay external in this phase.
+> Keep dev secondary to staging/prod and limited to relay-only validation.
 
 ## Scope
 
@@ -21,23 +21,23 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 ## Topology
 
 - In-cluster: `relay.py` deployment + service + ingress
-- External: `server.py` and/or desktop compute nodes using legacy relay contract
-  - Typical external operators: Windows 11 CUDA or macOS Apple Silicon Metal; CPU fallback valid.
+- External: `server.py` and/or desktop compute nodes (Windows/macOS/Raspberry Pi)
+  - No required in-cluster backend/GPU service.
 
 ## Release model
 
 - Use mutable dev tags for fast iteration when needed.
 - Prefer pinned immutable tags before promotion to staging.
-- If token.place-specific `just` helpers are unavailable, run Helm commands directly and track
-  the missing automation as follow-up work.
+- Preserve API v1 relay-blind E2EE guardrails (relay handles ciphertext + routing metadata only).
 
 ## Deployment workflow (template)
 
 ```bash
-# TODO: replace with token.place-specific sugarkube wrapper once finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+# Run from sugarkube checkout.
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+
+# Upgrade existing release.
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist
@@ -50,7 +50,7 @@ helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+Record the current revision before rollout (`helm history tokenplace -n tokenplace`) so rollback targets are explicit.
 
 - Roll back to previous image tag and/or Helm revision.
 - Verify readiness and `/healthz` immediately after rollback.
@@ -59,4 +59,4 @@ Record the current revision before rollout (`helm history tokenplace-relay -n to
 
 - Keep this environment permissive for debugging, but avoid introducing config assumptions that
   cannot be promoted.
-- Legacy contract is expected here until post-parity API v1 migration.
+- Treat dev as relay-only: cluster runs `relay.py`; compute remains external.

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -12,8 +12,51 @@ Keep dev aligned with the same relay-only contract used for staging/prod:
 - No required in-cluster backend/GPU service.
 - Preserve API v1 relay-blind E2EE guardrails.
 
+## Artifacts and tags
+
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Prefer immutable `main-<shortsha>` when validating changes; `main-latest` is convenience-only.
+
+## Deployment commands (run from Sugarkube repo)
+
+> These commands run from a **Sugarkube checkout**, not from token.place.
+>
+> `docs/examples/tokenplace.values.dev.yaml` and `docs/apps/tokenplace.version` are
+> **Sugarkube-owned future contract artifacts** expected after follow-up Sugarkube prompts land.
+
+First install:
+
+```bash
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade existing release:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+## Validation checklist
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+Optional note: true relay traffic validation requires a registered external compute node plus an
+E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
+
+## Rollback
+
+- Record baseline revision: `helm history tokenplace -n tokenplace`
+- Roll back release and/or tag per Sugarkube process.
+- Re-run validation checks and capture operator notes.
+
 ## Notes
 
 - Avoid stale local-chart/legacy-contract workflows (`./deploy/charts/tokenplace-relay`).
-- Dev runbooks/wrappers are Sugarkube-owned and may evolve independently from this repo.
 - Redis/shared-state/multi-replica relay architecture remains future work and out of scope.

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -22,19 +22,22 @@ Keep dev aligned with the same relay-only contract used for staging/prod:
 
 > These commands run from a **Sugarkube checkout**, not from token.place.
 >
-> `docs/examples/tokenplace.values.dev.yaml` and `docs/apps/tokenplace.version` are
-> **Sugarkube-owned future contract artifacts** expected after follow-up Sugarkube prompts land.
+> Use Sugarkube-owned dev inputs that exist in your checkout.
+>
+> Required before running commands:
+> - `<DEV_VALUES_FILE>` (dev values file path)
+> - either `<VERSION_FILE>` or an explicit `version=`/`tag=` argument
 
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=<DEV_VALUES_FILE> version_file=<VERSION_FILE> default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade existing release:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=<DEV_VALUES_FILE> version_file=<VERSION_FILE> default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist
@@ -42,10 +45,12 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/
+curl -fsS https://<DEV_HOST>/livez
+curl -fsS https://<DEV_HOST>/healthz
+curl -fsS https://<DEV_HOST>/
 ```
+
+Use the actual dev ingress host for `<DEV_HOST>` (do not validate against staging).
 
 Optional note: true relay traffic validation requires a registered external compute node plus an
 E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -36,40 +36,40 @@ upgrade windows, set an explicit single-pod rollout strategy (for example `Recre
 ## Deployment commands (run from Sugarkube repo)
 
 > Run from a **Sugarkube checkout**, not from token.place.
+>
+> `docs/examples/tokenplace.values.*.yaml` and `docs/apps/tokenplace.version` are
+> **Sugarkube-owned future contract artifacts** expected after follow-up Sugarkube prompts land.
 
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.prod.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade existing release:
 
 ```bash
-just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.prod.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
-
-Sugarkube-specific tokenplace wrapper commands may exist after follow-up Sugarkube work.
 
 ## Validation checklist
 
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=180s
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
-# relay traffic smoke test (requires at least one healthy external compute node)
-curl -fsS https://token.place/api/v1/models
-# optional: run an end-to-end encrypted /api/v1/chat/completions probe through the
-# standard client flow to validate real relay request handling.
 ```
+
+Optional note: true relay traffic validation requires a registered external compute node plus an
+E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 
 ## Rollback
 
-- Record baseline revision: `helm history tokenplace-relay -n tokenplace`
+- Record baseline revision: `helm history tokenplace -n tokenplace`
 - Roll back to prior approved revision/tag.
 - Re-run validation and document outcome.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,61 +1,73 @@
 # token.place relay on k3s+sugarkube (prod)
 
-> **Environment status:** **Planned / post-staging promotion target**.
-> Production runbook is prepared now for future onboarding and consistent operations.
+> **Environment status:** production runbook for promoted staging artifacts.
 
 ## Scope
 
-Run `relay.py` on sugarkube production with strict change control. Compute nodes remain external
-until parity and later API v1 migration phases are complete.
+Production Sugarkube deployment is **relay.py only** at default hostname `https://token.place`.
+Compute plane remains external (`server.py`, desktop Tauri compute nodes, Macs, Windows PCs,
+Raspberry Pi GPU/AI hat nodes, and other compute hosts).
 
-## Prerequisites
+No in-cluster backend/GPU service is required for this phase.
 
-- production cluster access with audited credentials
-- approved production image tag and release notes
-- production Cloudflare hostname/tunnel configured
-- production secrets/config material validated
-- rollback owner/on-call identified
+## Stateful behavior and replica policy
 
-## Topology
+Relay state is in-memory (registrations, queued messages, replies). Current production policy:
 
-- Public ingress terminates through Cloudflare+tunnel to sugarkube Traefik
-- relay pods run in dedicated namespace with health probes and resource limits
-- external compute nodes connect via approved relay URL
-  - workstation focus remains Windows CUDA / macOS Metal; Raspberry Pi remains a later target
+- one pod
+- one Gunicorn worker
+- one replica
 
-## Release model
+State loss on pod death/replacement is an accepted risk for this phase. Durable/shared state and
+multi-replica relay topology are future work.
 
-- staged promotion only (dev -> staging -> prod)
-- immutable tag requirement for production rollout
-- maintenance window or controlled rollout policy per operator team
+## Artifacts and release tags
 
-## Deployment workflow (template)
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Required sign-off tag style: immutable `main-<shortsha>`
+- `main-latest` is convenience-only and not production sign-off
+
+## Deployment commands (run from Sugarkube repo)
+
+> Run from a **Sugarkube checkout**, not from token.place.
+
+First install:
 
 ```bash
-# TODO: replace with production-approved sugarkube command wrapper when finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+Upgrade existing release:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific tokenplace wrapper commands may exist after follow-up Sugarkube work.
 
 ## Validation checklist
 
-- [ ] production relay endpoints reachable and healthy
-- [ ] registration/polling from external compute nodes succeeds
-- [ ] error rate/latency within expected baseline
-- [ ] rollback command and previous revision confirmed before sign-off
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
+
+If operators override hostname/routing, use the equivalent production host in the same checks.
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+- Record baseline revision: `helm history tokenplace -n tokenplace`
+- Roll back to prior approved revision/tag.
+- Re-run validation and document outcome.
 
-- immediate rollback to prior known-good Helm revision/image tag
-- validate health and request flow
-- record deployment outcome and follow-up actions
+## Notes
 
-## Operator notes
-
-- Keep relay lightweight in-cluster; avoid coupling production relay rollout to simultaneous
-  compute-runtime migrations.
-- Post-API-v1 target state should align all token.place components on API v1 contracts, but that is
-  a later phase and not assumed by this runbook today.
+- Preserve API v1 relay-blind E2EE guardrails (relay sees ciphertext + routing metadata only).
+- Do not rely on local chart path deployment (`./deploy/charts/tokenplace-relay`) for
+  Sugarkube steady-state operations.
+- Do not require `gpuExternalName` or `TOKENPLACE_RELAY_UPSTREAM_URL` for production relay
+  readiness in this relay-only phase.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -21,6 +21,11 @@ Relay state is in-memory (registrations, queued messages, replies). Current prod
 State loss on pod death/replacement is an accepted risk for this phase. Durable/shared state and
 multi-replica relay topology are future work.
 
+Kubernetes `Deployment` upgrades may temporarily run more than one pod with default
+`RollingUpdate` behavior (`maxSurge`). If strict single-pod relay operation is required during
+upgrade windows, set an explicit single-pod rollout strategy (for example `Recreate` or
+`maxSurge=0` with compatible availability settings) in Sugarkube values.
+
 ## Artifacts and release tags
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
@@ -35,13 +40,13 @@ multi-replica relay topology are future work.
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.prod.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade existing release:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.prod.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 Sugarkube-specific tokenplace wrapper commands may exist after follow-up Sugarkube work.
@@ -50,17 +55,21 @@ Sugarkube-specific tokenplace wrapper commands may exist after follow-up Sugarku
 
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=180s
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
+# relay traffic smoke test (requires at least one healthy external compute node)
+curl -fsS https://token.place/api/v1/models
+# optional: run an end-to-end encrypted /api/v1/chat/completions probe through the
+# standard client flow to validate real relay request handling.
 ```
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 
 ## Rollback
 
-- Record baseline revision: `helm history tokenplace -n tokenplace`
+- Record baseline revision: `helm history tokenplace-relay -n tokenplace`
 - Roll back to prior approved revision/tag.
 - Re-run validation and document outcome.
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,63 +1,73 @@
 # token.place relay on k3s+sugarkube (staging)
 
-> **Environment status:** **Current + planned hardening**.
-> Staging is used to validate relay operations before production rollout.
+> **Environment status:** active validation environment before production promotion.
 
 ## Scope
 
-Relay-only staging at `staging.token.place` (or equivalent environment hostname), with external
-compute nodes still using legacy sink/source contract.
+Staging deploys **relay.py only** at default hostname `https://staging.token.place`.
+Compute nodes remain external (`server.py`, desktop Tauri nodes, Macs, Windows PCs, Raspberry Pi
+GPU/AI hat nodes, and other compute hosts).
 
-## Prerequisites
+No in-cluster backend/GPU service is required in this phase.
 
-- staging cluster namespace access
-- relay image tag selected (prefer immutable)
-- Cloudflare tunnel + DNS route for staging hostname
-- environment config/secrets prepared
+## Stateful behavior and replica policy
 
-## Topology
+Relay runtime state (registrations, queued messages, replies) is currently in-memory.
+Operational policy for staging is intentionally:
 
-- Client -> Cloudflare -> tunnel -> Traefik ingress -> relay service/pod
-- compute nodes (`server.py`, later desktop parity nodes) remain external
-  - expected operators are workstation nodes (Windows CUDA, macOS Metal, CPU fallback)
+- one pod
+- one Gunicorn worker
+- one replica
 
-## Release model
+State loss on pod restart/replacement is accepted for now. Shared-state and multi-replica relay
+architecture are future work and out of scope.
 
-- Promote tested dev artifacts into staging.
-- Prefer immutable tags (`main-<sha>` / `sha-<sha>`) over mutable latest tags.
-- Maintain changelog notes for each staging deploy.
+## Artifacts and tags
 
-## Deployment workflow (template)
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred tag for validation/sign-off: immutable `main-<shortsha>`
+- `main-latest` is convenience-only
 
-Run from the repository root so the chart path resolves (`./deploy/charts/tokenplace-relay`).
-Use agreed sugarkube wrapper once available; until then:
+## Deployment commands (run from Sugarkube repo)
+
+> These commands run from a **Sugarkube checkout**, not from token.place.
+
+First install:
 
 ```bash
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace \
-  --set ingress.hosts[0].host=staging.token.place \
-  --set gpuExternalName.host=<staging-gpu-hostname>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Replace placeholder values with finalized staging values (or a staging values file) before
-> rollout.
+Upgrade existing release:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific tokenplace wrappers may exist after follow-up Sugarkube prompts.
 
 ## Validation checklist
 
-- [ ] relay pod(s) healthy and stable
-- [ ] ingress route serves `https://staging.token.place/healthz`
-- [ ] relay receives expected registration/poll traffic from external nodes
-- [ ] smoke test request flow succeeds end-to-end on legacy contract
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+If operators use a non-default staging hostname, apply the same checks with that host.
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+- Record baseline revision: `helm history tokenplace -n tokenplace`
+- Roll back release and/or tag per Sugarkube process.
+- Re-run validation checks and capture operator notes.
 
-- revert Helm release revision and/or pinned image tag
-- confirm health endpoint and registration flow after rollback
-- capture incident notes in outages/ if customer-visible
+## Notes
 
-## Operator notes
-
-- Staging should mirror production ingress/security posture where practical.
-- Do not assume API v1 distributed compute is enabled yet; this environment is still pre-migration.
+- Keep API v1 relay-blind E2EE guardrails intact.
+- Do not depend on local chart path deployment (`./deploy/charts/tokenplace-relay`) for
+  Sugarkube steady-state operations.
+- Do not require `gpuExternalName` or `TOKENPLACE_RELAY_UPSTREAM_URL` for staging relay readiness.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -25,8 +25,7 @@ architecture are future work and out of scope.
 Kubernetes `Deployment` upgrades may briefly run more than one pod under the default
 `RollingUpdate` strategy (`maxSurge`). To preserve strict single-pod semantics for stateful relay
 operations, operators should configure a single-pod rollout policy (for example `Recreate` or
-`maxSurge=0` with matching availability constraints) in Sugarkube values before production-like
-validation.
+`maxSurge=0` with matching availability constraints) in Sugarkube values.
 
 ## Artifacts and tags
 
@@ -38,40 +37,40 @@ validation.
 ## Deployment commands (run from Sugarkube repo)
 
 > These commands run from a **Sugarkube checkout**, not from token.place.
+>
+> `docs/examples/tokenplace.values.*.yaml` and `docs/apps/tokenplace.version` are
+> **Sugarkube-owned future contract artifacts** expected after follow-up Sugarkube prompts land.
 
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade existing release:
 
 ```bash
-just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
-
-Sugarkube-specific tokenplace wrappers may exist after follow-up Sugarkube prompts.
 
 ## Validation checklist
 
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=180s
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 curl -fsS https://staging.token.place/
-# relay traffic smoke test (requires a registered external compute node)
-curl -fsS https://staging.token.place/api/v1/models
-# optional: run an end-to-end encrypted /api/v1/chat/completions probe via the client flow
-# to verify register -> poll -> inference -> response works, not just health endpoints.
 ```
+
+Optional note: true relay traffic validation requires a registered external compute node plus an
+E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 
 ## Rollback
 
-- Record baseline revision: `helm history tokenplace-relay -n tokenplace`
+- Record baseline revision: `helm history tokenplace -n tokenplace`
 - Roll back release and/or tag per Sugarkube process.
 - Re-run validation checks and capture operator notes.
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -22,6 +22,12 @@ Operational policy for staging is intentionally:
 State loss on pod restart/replacement is accepted for now. Shared-state and multi-replica relay
 architecture are future work and out of scope.
 
+Kubernetes `Deployment` upgrades may briefly run more than one pod under the default
+`RollingUpdate` strategy (`maxSurge`). To preserve strict single-pod semantics for stateful relay
+operations, operators should configure a single-pod rollout policy (for example `Recreate` or
+`maxSurge=0` with matching availability constraints) in Sugarkube values before production-like
+validation.
+
 ## Artifacts and tags
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
@@ -36,13 +42,13 @@ architecture are future work and out of scope.
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 Upgrade existing release:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 Sugarkube-specific tokenplace wrappers may exist after follow-up Sugarkube prompts.
@@ -51,17 +57,21 @@ Sugarkube-specific tokenplace wrappers may exist after follow-up Sugarkube promp
 
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=180s
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 curl -fsS https://staging.token.place/
+# relay traffic smoke test (requires a registered external compute node)
+curl -fsS https://staging.token.place/api/v1/models
+# optional: run an end-to-end encrypted /api/v1/chat/completions probe via the client flow
+# to verify register -> poll -> inference -> response works, not just health endpoints.
 ```
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 
 ## Rollback
 
-- Record baseline revision: `helm history tokenplace -n tokenplace`
+- Record baseline revision: `helm history tokenplace-relay -n tokenplace`
 - Roll back release and/or tag per Sugarkube process.
 - Re-run validation checks and capture operator notes.
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -1,97 +1,82 @@
-# Relay on sugarkube onboarding (token.place)
+# Relay on Sugarkube onboarding (token.place)
 
-This guide explains how and why to run `relay.py` on sugarkube before full desktop/server
-migration is complete.
+This guide defines the **current near-term Sugarkube model** for token.place.
 
-## Why relay.py belongs on sugarkube
+## Scope and architecture (current)
 
-`relay.py` is lightweight compared with compute nodes and is operationally a good fit for k3s:
+Sugarkube scope is **relay-only**:
 
-- stateless request relay behavior
-- modest CPU/memory footprint
-- clear readiness endpoint (`/healthz`) and liveness endpoint (`/livez`)
-- easier centralized ingress/tunnel management
+- In cluster: `relay.py` only.
+- Out of cluster: `server.py`, desktop Tauri compute nodes, Macs, Windows PCs, Raspberry Pi
+  GPU/AI hat nodes, and other compute nodes.
+- No in-cluster backend/GPU service is required for this phase.
 
-This allows token.place to improve relay availability and operator workflows while GPU-heavy
-compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
-Workstation targets for those external compute nodes are Windows 11 + CUDA/NVIDIA and macOS Apple
-Silicon + Metal, with CPU fallback available and Raspberry Pi planned later.
+The relay is **operationally stateful today** because registrations, queued client messages, and
+replies are held in process memory. Current operating model:
 
-Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
+- one pod
+- one Gunicorn worker
+- one replica
+- accepted state loss if the pod restarts or is replaced
 
-## Current status
+Multi-replica + shared state (Redis or similar) is explicitly future work and out of scope for
+this phase.
 
-- **Current:** relay can run locally or in Kubernetes; staging-oriented docs exist.
-- **Planned near-term:** standardized dev/staging/prod sugarkube runbooks for relay.
-- **Not yet:** full post-API-v1 distributed deployment model.
+## Artifact ownership and source of truth
 
-## Minimal requirements
+token.place publishes deployable artifacts; Sugarkube owns environment values, wrappers, and
+operator workflow.
 
-- k3s/sugarkube cluster access (`kubectl`, `helm`)
-- container image access for relay
-- DNS + Cloudflare tunnel route for chosen hostname
-- upstream compute node endpoint(s) reachable from relay route consumers
+- Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
+- OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
+- `main-latest` is convenience-only and not production sign-off material
 
-## Networking expectations
+## Default hostnames
 
-Expected edge path:
+- Staging default: `https://staging.token.place`
+- Production default: `https://token.place`
 
-`Client -> Cloudflare -> Tunnel -> Traefik Ingress -> relay Service -> relay Pod`
+Operators can override hostnames in Sugarkube values and Cloudflare route configuration.
 
-Notes:
+## Sugarkube deployment command patterns
 
-- relay remains HTTP inside cluster unless platform policy requires in-cluster TLS.
-- public hostnames should be environment-specific (dev/staging/prod).
-- allow overriding relay URL in desktop/server configs during phased rollout.
+> Run the following from a **Sugarkube checkout**, not from token.place.
 
-## Secrets and config expectations
-
-At minimum, plan for:
-
-- relay registration/auth token material (if enabled)
-- environment-scoped relay public URL and host settings
-- any upstream allowlists or routing config
-
-If exact secret names or chart keys are unsettled, treat them as explicit follow-up tasks rather
-than inventing values.
-
-## Health checks and validation
-
-`relay.py` probe semantics:
-
-- `GET /livez` returns `200 {"status":"alive"}` while process is alive.
-- `GET /healthz` returns `200` when ready, `503` when draining or degraded.
-- When relay is shutting down (SIGTERM/SIGINT), `/healthz` returns `status=draining` and `Retry-After: 0` to speed pod replacement.
-
-Minimum operator checks after deploy:
-
-1. Pod readiness and restart counts are stable.
-2. Ingress host resolves and serves `/healthz`.
-3. Relay can accept registration/polling traffic from external compute nodes.
-
-Example checks:
+First install pattern:
 
 ```bash
-kubectl -n tokenplace get pods
-kubectl -n tokenplace get ingress
-curl -fsS https://<env-host>/livez
-curl -fsS https://<env-host>/healthz
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Current limitations
+Existing release upgrade pattern:
 
-- Compute nodes are still external during parity phases.
-- Legacy sink/source contract remains active until post-parity API v1 migration.
-- Final sugarkube automation wrappers may still be in progress per environment.
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## How this fits the broader roadmap
+Production pattern uses `docs/examples/tokenplace.values.prod.yaml` with the same approved
+immutable tag.
 
-- Relay-on-sugarkube is a **pre-API-v1** operational improvement.
-- Desktop parity and shared compute runtime come first for compute-plane migration.
-- API v1 distributed compute is a later phase once parity and relay ops are stable.
+Tokenplace-specific Sugarkube wrappers may also exist after Sugarkube follow-up prompts; those
+wrappers should call into the same Helm OCI install/upgrade flow.
 
-## Environment runbooks
+## Validation (staging example)
 
-- [k3s-sugarkube-dev.md](k3s-sugarkube-dev.md)
-- [k3s-sugarkube-staging.md](k3s-sugarkube-staging.md)
-- [k3s-sugarkube-prod.md](k3s-sugarkube-prod.md)
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+For production validation, replace the host with `https://token.place`.
+
+## Guardrails
+
+- Keep API v1 relay-blind E2EE invariants intact (ciphertext only + safe routing metadata).
+- Do not treat legacy relay endpoints as active production path.
+- Do not require `TOKENPLACE_RELAY_UPSTREAM_URL` for relay-only Sugarkube readiness.
+- Do not use local chart path deployment (`./deploy/charts/tokenplace-relay`) for Sugarkube
+  steady-state operations.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -36,6 +36,9 @@ operator workflow.
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - `main-latest` is convenience-only and not production sign-off material
 
+> The `tokenplace.*` values/version files in command examples below are **Sugarkube-owned future
+> contract artifacts** expected after follow-up Sugarkube prompts land.
+
 ## Default hostnames
 
 - Staging default: `https://staging.token.place`
@@ -50,35 +53,32 @@ Operators can override hostnames in Sugarkube values and Cloudflare route config
 First install pattern:
 
 ```bash
-just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 Existing release upgrade pattern:
 
 ```bash
-just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-Production pattern uses `docs/examples/tokenplace-relay.values.prod.yaml` with the same approved
+Production pattern uses `docs/examples/tokenplace.values.prod.yaml` with the same approved
 immutable tag.
-
-Tokenplace-specific Sugarkube wrappers may also exist after Sugarkube follow-up prompts; those
-wrappers should call into the same Helm OCI install/upgrade flow.
 
 ## Validation (staging example)
 
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=180s
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 curl -fsS https://staging.token.place/
-# relay traffic smoke test (compute node required)
-curl -fsS https://staging.token.place/api/v1/models
-# optional: execute an encrypted /api/v1/chat/completions smoke request via client flow.
 ```
 
 For production validation, replace the host with `https://token.place`.
+
+Optional note: true relay traffic validation requires a registered external compute node and an
+E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`).
 
 ## Guardrails
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -22,6 +22,10 @@ replies are held in process memory. Current operating model:
 Multi-replica + shared state (Redis or similar) is explicitly future work and out of scope for
 this phase.
 
+Note on upgrades: because relay is deployed via Kubernetes `Deployment`, default `RollingUpdate`
+can briefly run more than one pod during upgrades. If strict one-pod behavior is required, enforce
+single-pod rollout settings (for example `Recreate` or `maxSurge=0`) in Sugarkube values.
+
 ## Artifact ownership and source of truth
 
 token.place publishes deployable artifacts; Sugarkube owns environment values, wrappers, and
@@ -46,16 +50,16 @@ Operators can override hostnames in Sugarkube values and Cloudflare route config
 First install pattern:
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
 Existing release upgrade pattern:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace-relay namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace-relay.values.dev.yaml,docs/examples/tokenplace-relay.values.staging.yaml default_tag=main-REPLACE_SHORTSHA
 ```
 
-Production pattern uses `docs/examples/tokenplace.values.prod.yaml` with the same approved
+Production pattern uses `docs/examples/tokenplace-relay.values.prod.yaml` with the same approved
 immutable tag.
 
 Tokenplace-specific Sugarkube wrappers may also exist after Sugarkube follow-up prompts; those
@@ -65,10 +69,13 @@ wrappers should call into the same Helm OCI install/upgrade flow.
 
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=180s
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 curl -fsS https://staging.token.place/
+# relay traffic smoke test (compute node required)
+curl -fsS https://staging.token.place/api/v1/models
+# optional: execute an encrypted /api/v1/chat/completions smoke request via client flow.
 ```
 
 For production validation, replace the host with `https://token.place`.


### PR DESCRIPTION
### Motivation
- Align Sugarkube onboarding and runbooks with the near-term relay-only deployment model where only `relay.py` runs in-cluster and compute nodes remain external. 
- Remove stale guidance that incorrectly implied an in-cluster backend/GPU service, local chart-path steady-state installs, or required `gpuExternalName` / `TOKENPLACE_RELAY_UPSTREAM_URL` for readiness. 
- Document the canonical OCI artifacts and operator-facing Helm OCI workflows so Sugarkube can consume immutable GHCR tags and the published OCI chart.

### Description
- Rewrote the Sugarkube onboarding guide and runbooks to specify relay-only scope, single-pod/one-worker/one-replica policy, and accepted in-memory state loss, and made explicit that multi-replica/shared-state is future work (`docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`).
- Updated `README.md` Sugarkube section to reference the published artifacts and the relay-only operating model and replaced local chart-bundle wording with OCI install guidance. 
- Added concrete Sugarkube-side Helm OCI command examples (first install and upgrade) and pointed to the canonical image `ghcr.io/futuroptimist/tokenplace-relay` and chart `oci://ghcr.io/futuroptimist/charts/tokenplace` with preferred immutable tag format `main-<shortsha>`.
- Removed or negated stale operator requirements in docs: local `./deploy/charts/tokenplace-relay` steady-state installs, `gpuExternalName` placeholders as required values, and required `TOKENPLACE_RELAY_UPSTREAM_URL` for relay readiness; preserved API v1 relay-blind E2EE guardrails throughout.

### Testing
- Ran repository checks that search for stale mentions: `grep -R "deploy/charts/tokenplace-relay" README.md docs || true`, `grep -R "ghcr.io/democratizedspace/tokenplace-relay" README.md docs || true`, and `grep -R "gpuExternalName" README.md docs || true`, which returned only expected residual references updated or intentionally left in `docs/relay-deploy.md` (no new stale guidance in the updated runbooks).
- Executed `python -m pytest -q tests/test_relay.py`; the test suite ran but 6 tests failed due to pre-existing runtime behavior expectations unrelated to documentation changes (failures are in API v1 relay-client response handling and a configured poll-wait expectation), so docs-only scope did not introduce those regressions.
- Ran `pre-commit run --all-files`; hooks failed on existing Helm template YAML issues in chart templates (outside the docs scope) causing YAML parsing hook failures.
- Note: attempted secrets scanning via `./scripts/scan-secrets.py` but the repository does not contain that helper, so the scripted scan was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1360fb4f68832f9df5c130b0b8f3de)