### PR TITLE
📝 docs: update Sugarkube relay runbooks for relay-only OCI deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,21 +235,28 @@ See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay
 
 ## Deployment topology
 
-- **Current / legacy local flow (today):** local or self-hosted `relay.py` + `server.py` on the
-  deprecated legacy sink/source contract (historical compatibility only; not for active production paths).
-- **Near-term multi-node legacy flow (deprecated/historical migration context only):** multiple
-  compute nodes (including desktop-tauri after parity) register through `relay.py` using the same
-  legacy contract until API v1 distributed migration is complete.
-- **Future distributed API v1 flow (post-parity):** distributed compute migrates to API v1-aligned
-  contracts after parity and operational readiness gates are complete.
-- **Operator platform targets:** Windows 11 + NVIDIA/CUDA and macOS Apple Silicon + Metal first,
-  CPU fallback always supported, Raspberry Pi as a later low-power compute-node target.
+- **Sugarkube runtime scope (current phase):** `relay.py` only.
+- **External compute plane (current phase):** `server.py`, desktop Tauri compute nodes, Macs,
+  Windows PCs, Raspberry Pi GPU/AI hats, and other compute nodes remain out-of-cluster.
+- **No in-cluster backend/GPU dependency:** sugarkube relay deployment does not require an
+  in-cluster compute service in this phase.
+- **Current relay operational model:** one pod, one Gunicorn worker, one replica.
+- **State model:** relay-owned registrations/messages/replies are in-memory; state loss on pod
+  death is accepted for now.
+- **Future work:** shared state (Redis/in-memory DB) + multi-replica relay architecture.
 
 ## sugarkube deployment
 
-`relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
-operationally separate from GPU-heavy compute nodes.
-In the short-to-medium term architecture, sugarkube scope remains relay-only.
+token.place publishes relay artifacts; sugarkube owns environment values and deployment wrappers.
+
+- Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Canonical Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred staging/prod tags: immutable `main-<shortsha>`
+- `main-latest` is convenience-only and not production sign-off material.
+- Default hostnames: staging `https://staging.token.place`, production `https://token.place`
+  (operators may override via sugarkube values and Cloudflare routes).
+
+Runbooks:
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -5,58 +5,34 @@
 
 ## Scope
 
-Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
+Deploy `relay.py` to sugarkube dev for iterative validation.
 
-- ingress/tunnel plumbing
-- relay image/chart updates
-- registration and polling behavior with external compute nodes
+- In-cluster: relay deployment only.
+- External: `server.py` and desktop compute nodes.
+- No in-cluster backend/GPU service required.
 
-## Prerequisites
+## Deployment workflow (from sugarkube checkout)
 
-- sugarkube dev cluster access
-- helm/kubectl tooling
-- relay image tag available
-- dev hostname and Cloudflare tunnel route configured
-
-## Topology
-
-- In-cluster: `relay.py` deployment + service + ingress
-- External: `server.py` and/or desktop compute nodes using legacy relay contract
-  - Typical external operators: Windows 11 CUDA or macOS Apple Silicon Metal; CPU fallback valid.
-
-## Release model
-
-- Use mutable dev tags for fast iteration when needed.
-- Prefer pinned immutable tags before promotion to staging.
-- If token.place-specific `just` helpers are unavailable, run Helm commands directly and track
-  the missing automation as follow-up work.
-
-## Deployment workflow (template)
+Use OCI chart/image flows from a **sugarkube** checkout:
 
 ```bash
-# TODO: replace with token.place-specific sugarkube wrapper once finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Upgrade existing release:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist
 
-- [ ] `kubectl get pods` shows ready relay pod(s)
-- [ ] ingress host resolves in dev
-- [ ] `GET /livez` returns `{"status":"alive"}`
-- [ ] `GET /healthz` returns ready status (200)
-- [ ] external compute node can register/poll relay
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
 
-## Rollback
-
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
-
-- Roll back to previous image tag and/or Helm revision.
-- Verify readiness and `/healthz` immediately after rollback.
-
-## Operator notes
-
-- Keep this environment permissive for debugging, but avoid introducing config assumptions that
-  cannot be promoted.
-- Legacy contract is expected here until post-parity API v1 migration.
+Dev hostname/routing can be overridden in sugarkube values and Cloudflare tunnel settings.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,61 +1,66 @@
 # token.place relay on k3s+sugarkube (prod)
 
 > **Environment status:** **Planned / post-staging promotion target**.
-> Production runbook is prepared now for future onboarding and consistent operations.
+> Production runbook is prepared now for consistent relay operations.
 
 ## Scope
 
-Run `relay.py` on sugarkube production with strict change control. Compute nodes remain external
-until parity and later API v1 migration phases are complete.
+Production deploys `relay.py` only with default hostname `https://token.place`.
 
-## Prerequisites
+- In scope for sugarkube: `relay.py`.
+- External compute plane: `server.py`, desktop Tauri compute nodes, Macs, Windows PCs,
+  Raspberry Pi GPU/AI hats, and other compute nodes.
+- No in-cluster backend/GPU service is required in this phase.
 
-- production cluster access with audited credentials
-- approved production image tag and release notes
-- production Cloudflare hostname/tunnel configured
-- production secrets/config material validated
-- rollback owner/on-call identified
+## Operational model
 
-## Topology
+Current relay runtime characteristics:
 
-- Public ingress terminates through Cloudflare+tunnel to sugarkube Traefik
-- relay pods run in dedicated namespace with health probes and resource limits
-- external compute nodes connect via approved relay URL
-  - workstation focus remains Windows CUDA / macOS Metal; Raspberry Pi remains a later target
+- one pod
+- one Gunicorn worker
+- one replica
+- in-memory state for registrations/messages/replies
+- accepted state loss on pod death until shared state architecture exists
 
-## Release model
+Redis/shared state and multi-replica relay are future work.
 
-- staged promotion only (dev -> staging -> prod)
-- immutable tag requirement for production rollout
-- maintenance window or controlled rollout policy per operator team
+## Artifact references
 
-## Deployment workflow (template)
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Production sign-off tag: immutable `main-<shortsha>`
+- `main-latest` is convenience-only and not approved for production sign-off.
+
+## Deployment workflow (from sugarkube checkout)
+
+Run from a **sugarkube** checkout (not token.place):
 
 ```bash
-# TODO: replace with production-approved sugarkube command wrapper when finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+For existing releases, use upgrade:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific token.place wrappers are expected as follow-up convenience commands.
 
 ## Validation checklist
 
-- [ ] production relay endpoints reachable and healthy
-- [ ] registration/polling from external compute nodes succeeds
-- [ ] error rate/latency within expected baseline
-- [ ] rollback command and previous revision confirmed before sign-off
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
+
+Operators may override hostname/routing in sugarkube values and Cloudflare tunnel/route config.
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
-
-- immediate rollback to prior known-good Helm revision/image tag
-- validate health and request flow
-- record deployment outcome and follow-up actions
-
-## Operator notes
-
-- Keep relay lightweight in-cluster; avoid coupling production relay rollout to simultaneous
-  compute-runtime migrations.
-- Post-API-v1 target state should align all token.place components on API v1 contracts, but that is
-  a later phase and not assumed by this runbook today.
+- Record revision before rollout: `helm history tokenplace -n tokenplace`
+- Roll back to previous known-good revision/tag.
+- Re-run validation checks after rollback.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,63 +1,67 @@
 # token.place relay on k3s+sugarkube (staging)
 
 > **Environment status:** **Current + planned hardening**.
-> Staging is used to validate relay operations before production rollout.
+> Staging validates relay operations before production rollout.
 
 ## Scope
 
-Relay-only staging at `staging.token.place` (or equivalent environment hostname), with external
-compute nodes still using legacy sink/source contract.
+Relay-only staging with default hostname `https://staging.token.place`.
 
-## Prerequisites
+- In scope for sugarkube: `relay.py` only.
+- Out of scope/in external compute plane: `server.py`, desktop Tauri compute nodes, Macs,
+  Windows PCs, Raspberry Pi GPU/AI hats, and other compute nodes.
+- No in-cluster backend/GPU service is required for this phase.
 
-- staging cluster namespace access
-- relay image tag selected (prefer immutable)
-- Cloudflare tunnel + DNS route for staging hostname
-- environment config/secrets prepared
+## Operational model
 
-## Topology
+The relay is currently stateful because registrations/messages/replies live in process memory.
 
-- Client -> Cloudflare -> tunnel -> Traefik ingress -> relay service/pod
-- compute nodes (`server.py`, later desktop parity nodes) remain external
-  - expected operators are workstation nodes (Windows CUDA, macOS Metal, CPU fallback)
+- one pod
+- one Gunicorn worker
+- one replica
+- state loss on pod death is accepted for now
 
-## Release model
+Redis/shared memory stores and multi-replica relay architecture are future work.
 
-- Promote tested dev artifacts into staging.
-- Prefer immutable tags (`main-<sha>` / `sha-<sha>`) over mutable latest tags.
-- Maintain changelog notes for each staging deploy.
+## Artifact references
 
-## Deployment workflow (template)
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred staging tag: immutable `main-<shortsha>`
+- `main-latest` is convenience-only and is not staging sign-off material.
 
-Run from the repository root so the chart path resolves (`./deploy/charts/tokenplace-relay`).
-Use agreed sugarkube wrapper once available; until then:
+## Deployment workflow (from sugarkube checkout)
+
+Run from a **sugarkube** checkout (not token.place):
+
+First install:
 
 ```bash
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace \
-  --set ingress.hosts[0].host=staging.token.place \
-  --set gpuExternalName.host=<staging-gpu-hostname>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Replace placeholder values with finalized staging values (or a staging values file) before
-> rollout.
+Upgrade existing release:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific token.place wrapper recipes are expected as follow-up convenience commands.
 
 ## Validation checklist
 
-- [ ] relay pod(s) healthy and stable
-- [ ] ingress route serves `https://staging.token.place/healthz`
-- [ ] relay receives expected registration/poll traffic from external nodes
-- [ ] smoke test request flow succeeds end-to-end on legacy contract
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+Operators may override hostname/routing in sugarkube values and Cloudflare tunnel/route config.
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
-
-- revert Helm release revision and/or pinned image tag
-- confirm health endpoint and registration flow after rollback
-- capture incident notes in outages/ if customer-visible
-
-## Operator notes
-
-- Staging should mirror production ingress/security posture where practical.
-- Do not assume API v1 distributed compute is enabled yet; this environment is still pre-migration.
+- Record revision before rollout: `helm history tokenplace -n tokenplace`
+- Roll back to previous known-good revision/tag.
+- Re-run validation checks after rollback.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -1,97 +1,87 @@
 # Relay on sugarkube onboarding (token.place)
 
-This guide explains how and why to run `relay.py` on sugarkube before full desktop/server
-migration is complete.
+This guide explains the near-term token.place deployment split for sugarkube.
 
-## Why relay.py belongs on sugarkube
+## Scope and architecture (current phase)
 
-`relay.py` is lightweight compared with compute nodes and is operationally a good fit for k3s:
+Sugarkube scope is **relay-only** and deploys `relay.py` only.
 
-- stateless request relay behavior
-- modest CPU/memory footprint
-- clear readiness endpoint (`/healthz`) and liveness endpoint (`/livez`)
-- easier centralized ingress/tunnel management
+- In-cluster on sugarkube: `relay.py`.
+- Out-of-cluster (external compute plane): `server.py`, desktop Tauri compute nodes,
+  Macs, Windows PCs, Raspberry Pi GPU/AI hats, and other compute nodes.
+- No in-cluster backend/GPU service is required in this phase.
 
-This allows token.place to improve relay availability and operator workflows while GPU-heavy
-compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
-Workstation targets for those external compute nodes are Windows 11 + CUDA/NVIDIA and macOS Apple
-Silicon + Metal, with CPU fallback available and Raspberry Pi planned later.
+The relay is technically stateful today because server registrations, client messages, and
+server replies are kept in process memory. Operationally this means:
 
-Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
+- one pod
+- one Gunicorn worker
+- one replica
+- accepted state loss when the pod exits/restarts
 
-## Current status
+Redis/shared in-memory database and multi-replica relay architecture are future work and out of
+scope for this phase.
 
-- **Current:** relay can run locally or in Kubernetes; staging-oriented docs exist.
-- **Planned near-term:** standardized dev/staging/prod sugarkube runbooks for relay.
-- **Not yet:** full post-API-v1 distributed deployment model.
+## Artifact ownership and references
 
-## Minimal requirements
+token.place publishes the runtime artifacts consumed by sugarkube operators:
 
-- k3s/sugarkube cluster access (`kubectl`, `helm`)
-- container image access for relay
-- DNS + Cloudflare tunnel route for chosen hostname
-- upstream compute node endpoint(s) reachable from relay route consumers
+- Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Canonical chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 
-## Networking expectations
+Tag guidance:
 
-Expected edge path:
+- Preferred for staging/prod sign-off: immutable `main-<shortsha>`.
+- `main-latest` is convenience-only and not production sign-off material.
 
-`Client -> Cloudflare -> Tunnel -> Traefik Ingress -> relay Service -> relay Pod`
+## Hostnames
 
-Notes:
+Default hostnames for this phase:
 
-- relay remains HTTP inside cluster unless platform policy requires in-cluster TLS.
-- public hostnames should be environment-specific (dev/staging/prod).
-- allow overriding relay URL in desktop/server configs during phased rollout.
+- staging: `https://staging.token.place`
+- production: `https://token.place`
 
-## Secrets and config expectations
+Operators may override hostnames in sugarkube values and Cloudflare routes/tunnels.
 
-At minimum, plan for:
+## Sugarkube command patterns (run from sugarkube checkout)
 
-- relay registration/auth token material (if enabled)
-- environment-scoped relay public URL and host settings
-- any upstream allowlists or routing config
+Run the following from a **sugarkube repository checkout**, not from token.place.
 
-If exact secret names or chart keys are unsettled, treat them as explicit follow-up tasks rather
-than inventing values.
-
-## Health checks and validation
-
-`relay.py` probe semantics:
-
-- `GET /livez` returns `200 {"status":"alive"}` while process is alive.
-- `GET /healthz` returns `200` when ready, `503` when draining or degraded.
-- When relay is shutting down (SIGTERM/SIGINT), `/healthz` returns `status=draining` and `Retry-After: 0` to speed pod replacement.
-
-Minimum operator checks after deploy:
-
-1. Pod readiness and restart counts are stable.
-2. Ingress host resolves and serves `/healthz`.
-3. Relay can accept registration/polling traffic from external compute nodes.
-
-Example checks:
+First install pattern:
 
 ```bash
-kubectl -n tokenplace get pods
-kubectl -n tokenplace get ingress
-curl -fsS https://<env-host>/livez
-curl -fsS https://<env-host>/healthz
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Current limitations
+Existing release upgrade pattern:
 
-- Compute nodes are still external during parity phases.
-- Legacy sink/source contract remains active until post-parity API v1 migration.
-- Final sugarkube automation wrappers may still be in progress per environment.
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## How this fits the broader roadmap
+Production pattern uses `docs/examples/tokenplace.values.prod.yaml` with the same approved
+immutable `main-<shortsha>` tag.
 
-- Relay-on-sugarkube is a **pre-API-v1** operational improvement.
-- Desktop parity and shared compute runtime come first for compute-plane migration.
-- API v1 distributed compute is a later phase once parity and relay ops are stable.
+Sugarkube-specific token.place wrappers are expected to exist as follow-up work; these generic OCI
+helpers remain valid in the meantime.
 
-## Environment runbooks
+## Validation
 
-- [k3s-sugarkube-dev.md](k3s-sugarkube-dev.md)
-- [k3s-sugarkube-staging.md](k3s-sugarkube-staging.md)
-- [k3s-sugarkube-prod.md](k3s-sugarkube-prod.md)
+Staging checks:
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+Production uses the same checks with `https://token.place`.
+
+## Guardrails
+
+- Keep relay-blind E2EE invariant: relay state/logs carry ciphertext plus safe routing metadata
+  only.
+- Keep API v1 as the active runtime path for `v0.1.0` and keep it non-streaming.
+- Do not treat legacy relay routes as active production path guidance.


### PR DESCRIPTION
### Motivation

- Align Sugarkube-facing documentation with the near-term deployment model where Sugarkube runs `relay.py` only and compute nodes remain external. 
- Surface canonical token.place-owned artifacts (GHCR image and OCI Helm chart) while moving Sugarkube-specific values and wrappers into Sugarkube workflows. 
- Remove misleading local-chart and in-cluster GPU/backend guidance so operator runbooks are actionable for OCI/Helm-OCI flows while preserving API v1 relay-blind E2EE guardrails. 

### Description

- Updated `README.md` Sugarkube section to declare relay-only scope, in-memory state model, one-pod/one-worker/one-replica operational guidance, and artifact references (`ghcr.io/futuroptimist/tokenplace-relay` and `oci://ghcr.io/futuroptimist/charts/tokenplace`).
- Rewrote `docs/relay_sugarkube_onboarding.md` to document architecture, hostnames, tag guidance (`main-<shortsha>` preferred, `main-latest` convenience-only), and explicit Sugarkube command patterns run from a Sugarkube checkout. 
- Replaced local-chart Helm examples in `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`, and `docs/k3s-sugarkube-dev.md` with OCI/`just` examples and added concrete validation and rollback checks using `kubectl` and `curl` against `https://staging.token.place` / `https://token.place` (with override notes). 
- Removed Sugarkube steady-state suggestions that required `gpuExternalName` or an in-cluster backend and made clear that Redis/multi-replica state is future work. 

### Testing

- Ran grep verification; references to the local chart path (`deploy/charts/tokenplace-relay`) and `gpuExternalName` were removed from the updated runbooks but still appear in other non-target docs (e.g., `docs/relay-deploy.md` and prompt/reference docs). 
- Executed `python -m pytest -q tests/test_relay.py`; the suite ran (66 tests total) with 60 passed and 6 failing, and the failures are from existing runtime/test mismatches unrelated to these docs changes. 
- Ran `pre-commit run --all-files`; the run highlighted a pre-existing `check-yaml` failure in Helm chart templates (outside the docs-only scope) and other hooks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1360fb4f68832f9df5c130b0b8f3de)