### PR TITLE
📝 Update Sugarkube relay OCI deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,28 @@ See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay
 
 ## sugarkube deployment
 
-`relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
-operationally separate from GPU-heavy compute nodes.
-In the short-to-medium term architecture, sugarkube scope remains relay-only.
+`relay.py` is the first token.place component targeted for sugarkube. In the near-term deployment
+model, sugarkube scope is relay-only.
+
+Current architecture constraints:
+
+- In-cluster component: `relay.py` only.
+- External components: `server.py`, desktop Tauri compute nodes, Macs, Windows PCs, Raspberry Pi
+  GPU/AI hats, and other compute nodes.
+- No in-cluster backend/GPU service is required for this phase.
+- Relay state is in-memory (registrations/messages/replies), so operations currently target one
+  pod, one Gunicorn worker, one replica, with accepted state loss on pod death.
+- Redis/multi-replica relay state architecture is future work and out of scope for this phase.
+
+Canonical deployment artifacts:
+
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred validation tags: immutable `main-<shortsha>`
+- Mutable `main-latest` is convenience-only and not for production sign-off
+
+Sugarkube command wrappers and values live in the sugarkube repo; token.place owns and publishes
+the runtime/image/chart artifacts.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,61 +1,62 @@
 # token.place relay on k3s+sugarkube (prod)
 
 > **Environment status:** **Planned / post-staging promotion target**.
-> Production runbook is prepared now for future onboarding and consistent operations.
+> Production runbook for relay-only deployment.
 
 ## Scope
 
-Run `relay.py` on sugarkube production with strict change control. Compute nodes remain external
-until parity and later API v1 migration phases are complete.
+Production runs `relay.py` only in sugarkube.
 
-## Prerequisites
+- `server.py` plus desktop/hardware compute nodes remain external.
+- No in-cluster backend/GPU service is required in this phase.
+- Relay state is in-memory today (registrations/messages/replies), so production uses one pod,
+  one Gunicorn worker, one replica.
+- State loss on pod death is accepted for now.
 
-- production cluster access with audited credentials
-- approved production image tag and release notes
-- production Cloudflare hostname/tunnel configured
-- production secrets/config material validated
-- rollback owner/on-call identified
+Redis-backed/multi-replica relay state is future work and out of scope.
 
-## Topology
+## Artifacts and tags
 
-- Public ingress terminates through Cloudflare+tunnel to sugarkube Traefik
-- relay pods run in dedicated namespace with health probes and resource limits
-- external compute nodes connect via approved relay URL
-  - workstation focus remains Windows CUDA / macOS Metal; Raspberry Pi remains a later target
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Required for sign-off: immutable `main-<shortsha>` approved in staging
+- Convenience only: mutable `main-latest`
 
-## Release model
+## Deployment workflow (from sugarkube repo)
 
-- staged promotion only (dev -> staging -> prod)
-- immutable tag requirement for production rollout
-- maintenance window or controlled rollout policy per operator team
+Run from a **sugarkube checkout**, not from token.place.
 
-## Deployment workflow (template)
+Production install/upgrade pattern:
 
 ```bash
-# TODO: replace with production-approved sugarkube command wrapper when finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+If release does not exist yet, use `just helm-oci-install` with the same values/version/tag
+inputs.
+
+Sugarkube-specific tokenplace wrappers may be introduced later; they should preserve the same OCI
+chart source and immutable tag policy.
 
 ## Validation checklist
 
-- [ ] production relay endpoints reachable and healthy
-- [ ] registration/polling from external compute nodes succeeds
-- [ ] error rate/latency within expected baseline
-- [ ] rollback command and previous revision confirmed before sign-off
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
-
-- immediate rollback to prior known-good Helm revision/image tag
-- validate health and request flow
-- record deployment outcome and follow-up actions
+- Record revision before rollout: `helm history tokenplace -n tokenplace`
+- Roll back immediately to prior known-good revision/tag if validation fails.
+- Re-run validation commands post-rollback.
 
 ## Operator notes
 
-- Keep relay lightweight in-cluster; avoid coupling production relay rollout to simultaneous
-  compute-runtime migrations.
-- Post-API-v1 target state should align all token.place components on API v1 contracts, but that is
-  a later phase and not assumed by this runbook today.
+- Default production hostname is `https://token.place`; operators may override hostname in
+  sugarkube values and Cloudflare routes.
+- Keep API v1 relay-blind E2EE guardrails intact; do not treat legacy relay routes as active
+  production paths.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,63 +1,64 @@
 # token.place relay on k3s+sugarkube (staging)
 
 > **Environment status:** **Current + planned hardening**.
-> Staging is used to validate relay operations before production rollout.
+> Staging validates relay-only operations before production rollout.
 
 ## Scope
 
-Relay-only staging at `staging.token.place` (or equivalent environment hostname), with external
-compute nodes still using legacy sink/source contract.
+Relay-only staging at `https://staging.token.place` by default.
 
-## Prerequisites
+- In-cluster runtime is `relay.py` only.
+- `server.py` and desktop/hardware compute nodes remain external.
+- No in-cluster backend/GPU service is required in this phase.
 
-- staging cluster namespace access
-- relay image tag selected (prefer immutable)
-- Cloudflare tunnel + DNS route for staging hostname
-- environment config/secrets prepared
+The relay is technically stateful in this phase (in-memory registrations/messages/replies), so
+current staging target is one pod, one Gunicorn worker, one replica. Pod-loss state loss is
+accepted for now.
 
-## Topology
+## Artifacts and tags
 
-- Client -> Cloudflare -> tunnel -> Traefik ingress -> relay service/pod
-- compute nodes (`server.py`, later desktop parity nodes) remain external
-  - expected operators are workstation nodes (Windows CUDA, macOS Metal, CPU fallback)
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred tag: immutable `main-<shortsha>`
+- Convenience only: `main-latest` (not for sign-off)
 
-## Release model
+## Deployment workflow (from sugarkube repo)
 
-- Promote tested dev artifacts into staging.
-- Prefer immutable tags (`main-<sha>` / `sha-<sha>`) over mutable latest tags.
-- Maintain changelog notes for each staging deploy.
+Run from a **sugarkube checkout**, not from token.place.
 
-## Deployment workflow (template)
-
-Run from the repository root so the chart path resolves (`./deploy/charts/tokenplace-relay`).
-Use agreed sugarkube wrapper once available; until then:
+First install pattern:
 
 ```bash
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace \
-  --set ingress.hosts[0].host=staging.token.place \
-  --set gpuExternalName.host=<staging-gpu-hostname>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Replace placeholder values with finalized staging values (or a staging values file) before
-> rollout.
+Upgrade pattern for existing release:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific tokenplace wrappers may be added later; they should preserve the same OCI
+chart source and immutable-tag promotion process.
 
 ## Validation checklist
 
-- [ ] relay pod(s) healthy and stable
-- [ ] ingress route serves `https://staging.token.place/healthz`
-- [ ] relay receives expected registration/poll traffic from external nodes
-- [ ] smoke test request flow succeeds end-to-end on legacy contract
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
-
-- revert Helm release revision and/or pinned image tag
-- confirm health endpoint and registration flow after rollback
-- capture incident notes in outages/ if customer-visible
+- Record revision before rollout: `helm history tokenplace -n tokenplace`
+- Roll back to prior known-good release revision and immutable image tag.
+- Re-run validation checks above after rollback.
 
 ## Operator notes
 
-- Staging should mirror production ingress/security posture where practical.
-- Do not assume API v1 distributed compute is enabled yet; this environment is still pre-migration.
+- Default staging hostname is `https://staging.token.place`; operators may override hostname via
+  sugarkube values and Cloudflare route configuration.
+- Redis/multi-replica relay state architecture is future work and out of scope for this phase.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -1,94 +1,103 @@
 # Relay on sugarkube onboarding (token.place)
 
-This guide explains how and why to run `relay.py` on sugarkube before full desktop/server
-migration is complete.
+This guide explains how and why to run `relay.py` on sugarkube for the current deployment phase.
 
-## Why relay.py belongs on sugarkube
+## Scope and architecture (current phase)
 
-`relay.py` is lightweight compared with compute nodes and is operationally a good fit for k3s:
+Sugarkube scope is **relay-only** in this phase.
 
-- stateless request relay behavior
-- modest CPU/memory footprint
-- clear readiness endpoint (`/healthz`) and liveness endpoint (`/livez`)
-- easier centralized ingress/tunnel management
+- In-cluster runtime: `relay.py` only.
+- External compute/runtime components: `server.py`, desktop Tauri compute nodes, Macs,
+  Windows PCs, Raspberry Pi GPU/AI hats, and other compute nodes.
+- No in-cluster backend/GPU service is required for this phase.
 
-This allows token.place to improve relay availability and operator workflows while GPU-heavy
-compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
-Workstation targets for those external compute nodes are Windows 11 + CUDA/NVIDIA and macOS Apple
-Silicon + Metal, with CPU fallback available and Raspberry Pi planned later.
+The relay is operationally lightweight, but it is technically stateful today because
+registrations, queued client messages, and replies are held in process memory.
 
-Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
+Current operational model:
 
-## Current status
+- one pod
+- one Gunicorn worker
+- one replica
 
-- **Current:** relay can run locally or in Kubernetes; staging-oriented docs exist.
-- **Planned near-term:** standardized dev/staging/prod sugarkube runbooks for relay.
-- **Not yet:** full post-API-v1 distributed deployment model.
+State loss on pod death is accepted for now. Redis/in-memory database backed state,
+replicated relay designs, and multi-replica high availability are future work and out of scope
+for this phase.
 
-## Minimal requirements
+## Canonical deployment artifacts
 
-- k3s/sugarkube cluster access (`kubectl`, `helm`)
-- container image access for relay
-- DNS + Cloudflare tunnel route for chosen hostname
-- upstream compute node endpoint(s) reachable from relay route consumers
+token.place publishes and owns the relay deployment artifacts:
 
-## Networking expectations
+- Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Helm chart (OCI): `oci://ghcr.io/futuroptimist/charts/tokenplace`
 
-Expected edge path:
+Tag guidance:
 
-`Client -> Cloudflare -> Tunnel -> Traefik Ingress -> relay Service -> relay Pod`
+- Preferred for staging/prod validation: immutable `main-<shortsha>`.
+- Convenience only: mutable `main-latest` (not for production sign-off).
 
-Notes:
+## Platform ownership split
 
-- relay remains HTTP inside cluster unless platform policy requires in-cluster TLS.
-- public hostnames should be environment-specific (dev/staging/prod).
-- allow overriding relay URL in desktop/server configs during phased rollout.
+- token.place owns relay runtime code and publishes the relay image/chart.
+- sugarkube owns environment values files, version pin files, release orchestration recipes,
+  and operator runbooks.
 
-## Secrets and config expectations
+## Hostnames
 
-At minimum, plan for:
+Default hostnames used by runbooks:
 
-- relay registration/auth token material (if enabled)
-- environment-scoped relay public URL and host settings
-- any upstream allowlists or routing config
+- Staging: `https://staging.token.place`
+- Production: `https://token.place`
 
-If exact secret names or chart keys are unsettled, treat them as explicit follow-up tasks rather
-than inventing values.
+Operators may override hostnames in sugarkube values and Cloudflare routes.
 
-## Health checks and validation
+## Sugarkube deployment commands
 
-`relay.py` probe semantics:
+Run these commands from a **sugarkube checkout** (not from token.place):
 
-- `GET /livez` returns `200 {"status":"alive"}` while process is alive.
-- `GET /healthz` returns `200` when ready, `503` when draining or degraded.
-- When relay is shutting down (SIGTERM/SIGINT), `/healthz` returns `status=draining` and `Retry-After: 0` to speed pod replacement.
-
-Minimum operator checks after deploy:
-
-1. Pod readiness and restart counts are stable.
-2. Ingress host resolves and serves `/healthz`.
-3. Relay can accept registration/polling traffic from external compute nodes.
-
-Example checks:
+First install pattern:
 
 ```bash
-kubectl -n tokenplace get pods
-kubectl -n tokenplace get ingress
-curl -fsS https://<env-host>/livez
-curl -fsS https://<env-host>/healthz
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Current limitations
+Existing release upgrade pattern:
 
-- Compute nodes are still external during parity phases.
-- Legacy sink/source contract remains active until post-parity API v1 migration.
-- Final sugarkube automation wrappers may still be in progress per environment.
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## How this fits the broader roadmap
+Production promotion pattern (use prod values and same approved immutable tag):
 
-- Relay-on-sugarkube is a **pre-API-v1** operational improvement.
-- Desktop parity and shared compute runtime come first for compute-plane migration.
-- API v1 distributed compute is a later phase once parity and relay ops are stable.
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific `tokenplace` wrapper recipes may also exist after the sugarkube follow-up
+prompts. Those wrappers should call the same OCI chart with the same immutable tag discipline.
+
+## Validation commands
+
+Staging baseline checks:
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+For production, replace `https://staging.token.place` with `https://token.place`.
+
+## Guardrails
+
+- Keep API v1 relay architecture guardrails and relay-blind E2EE invariants intact.
+- Do not assume legacy relay routes are active production paths.
+- Do not require `TOKENPLACE_RELAY_UPSTREAM_URL` for relay-only sugarkube readiness.
+- Do not require `gpuExternalName` placeholders for this phase.
+- Do not use local chart paths such as `./deploy/charts/tokenplace-relay` for sugarkube
+  steady-state deployment.
 
 ## Environment runbooks
 


### PR DESCRIPTION
### Motivation

- Align operator-facing docs with the near-term Sugarkube rollout that runs the relay only (no in-cluster backend/GPU) and uses GHCR images + OCI Helm charts. 
- Remove stale deployment assumptions (local chart steady-state, required gpu/ upstream readiness envs) so runbooks are copy/paste-ready for Sugarkube operators. 
- Preserve API v1 relay-blind E2EE guardrails while making deployment/validation steps concrete for staging and production.

### Description

- Update `README.md` sugarkube section to document the relay-only topology, in-memory statefulness, one-pod/one-worker/one-replica operational model, and canonical artifact references (`ghcr.io/futuroptimist/tokenplace-relay` and `oci://ghcr.io/futuroptimist/charts/tokenplace`).
- Rewrite `docs/relay_sugarkube_onboarding.md` to state architecture boundaries, artifact ownership, immutable tag guidance, host defaults, Sugarkube-side `just helm-oci-*` command examples, validation commands, and guardrails that forbid requiring `TOKENPLACE_RELAY_UPSTREAM_URL`, `gpuExternalName`, or local chart paths for steady-state.
- Update `docs/k3s-sugarkube-staging.md` to use the OCI chart and `just helm-oci-*` install/upgrade patterns, include validation/rollback commands, and state the default staging hostname `https://staging.token.place`.
- Update `docs/k3s-sugarkube-prod.md` to mirror staging updates, require immutable `main-<shortsha>` promotion for sign-off, include production `just` command pattern, validation/rollback commands, and default hostname `https://token.place`.

### Testing

- Ran targeted greps to verify stale references and artifact names; remaining matches are either intentional guardrail notes or exist in non-target prompt/docs outside the edited runbooks. 
- Executed `python -m pytest -q tests/test_relay.py`, which ran the relay test suite but reported 6 failing tests that are unrelated to these docs-only changes. 
- Ran `pre-commit run --all-files`, which failed `check-yaml` on chart template YAML files located in `charts/tokenplace/templates/*.yaml` that are outside the scope of this docs change. 
- No runtime, Helm template, or CI workflow files were modified as part of this PR; docs changes only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1360fb4f68832f9df5c130b0b8f3de)