### PR TITLE
📝 docs: align sugarkube relay-only OCI deployment runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,25 @@ See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay
 
 ## sugarkube deployment
 
-`relay.py` is the first token.place component targeted for sugarkube because it is lightweight and
-operationally separate from GPU-heavy compute nodes.
-In the short-to-medium term architecture, sugarkube scope remains relay-only.
+Sugarkube deployment scope is relay-only in this phase.
+
+- In-cluster runtime: `relay.py` only, one pod, one Gunicorn worker, one replica.
+- External compute-plane runtime: `server.py`, desktop Tauri compute nodes, Macs, Windows PCs,
+  Raspberry Pi GPU/AI hat nodes, and other compute nodes.
+- No in-cluster backend/GPU service is required for this phase.
+- Relay state (server registrations, client messages, replies) is in-memory; state loss on pod
+  death is currently accepted.
+- Redis/shared-state multi-replica relay architecture is future work and out of scope.
+
+Canonical token.place artifacts:
+
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred staging/prod tags: immutable `main-<shortsha>`
+- `main-latest` is convenience-only and not for production sign-off.
+
+Sugarkube deployment commands are executed from a sugarkube checkout that provides environment
+values and helper recipes.
 
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -9,7 +9,7 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 
 - ingress/tunnel plumbing
 - relay image/chart updates
-- registration and polling behavior with external compute nodes
+- registration and polling behavior with external compute nodes (API v1/E2EE guardrails intact)
 
 ## Prerequisites
 
@@ -21,23 +21,20 @@ Deploy `relay.py` to the sugarkube dev environment for iterative validation of:
 ## Topology
 
 - In-cluster: `relay.py` deployment + service + ingress
-- External: `server.py` and/or desktop compute nodes using legacy relay contract
+- External: `server.py` and/or desktop compute nodes
   - Typical external operators: Windows 11 CUDA or macOS Apple Silicon Metal; CPU fallback valid.
 
 ## Release model
 
 - Use mutable dev tags for fast iteration when needed.
 - Prefer pinned immutable tags before promotion to staging.
-- If token.place-specific `just` helpers are unavailable, run Helm commands directly and track
-  the missing automation as follow-up work.
+- Use immutable tags when promoting to staging/prod; mutable tags are dev convenience only.
 
 ## Deployment workflow (template)
 
 ```bash
-# TODO: replace with token.place-specific sugarkube wrapper once finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+# Run from a sugarkube checkout (not token.place):
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
 ## Validation checklist

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -1,61 +1,67 @@
 # token.place relay on k3s+sugarkube (prod)
 
-> **Environment status:** **Planned / post-staging promotion target**.
-> Production runbook is prepared now for future onboarding and consistent operations.
+> **Environment status:** production runbook for controlled relay-only rollout.
 
 ## Scope
 
-Run `relay.py` on sugarkube production with strict change control. Compute nodes remain external
-until parity and later API v1 migration phases are complete.
+Production sugarkube deploys `relay.py` only.
 
-## Prerequisites
+- In-cluster: one pod / one Gunicorn worker / one replica
+- External: `server.py`, desktop Tauri compute nodes, Macs, Windows PCs, Raspberry Pi GPU/AI hat
+  nodes, and other compute nodes
+- No required in-cluster backend/GPU service in this phase
 
-- production cluster access with audited credentials
-- approved production image tag and release notes
-- production Cloudflare hostname/tunnel configured
-- production secrets/config material validated
-- rollback owner/on-call identified
+The relay keeps operational state in memory (registrations/messages/replies), so state loss on pod
+restart/death is accepted in the current model.
 
-## Topology
+## Artifacts and tag policy
 
-- Public ingress terminates through Cloudflare+tunnel to sugarkube Traefik
-- relay pods run in dedicated namespace with health probes and resource limits
-- external compute nodes connect via approved relay URL
-  - workstation focus remains Windows CUDA / macOS Metal; Raspberry Pi remains a later target
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Use the same staging-approved immutable tag: `main-<shortsha>`
+- `main-latest` is mutable convenience and is not valid for production sign-off
 
-## Release model
+## Deployment workflow (from sugarkube checkout)
 
-- staged promotion only (dev -> staging -> prod)
-- immutable tag requirement for production rollout
-- maintenance window or controlled rollout policy per operator team
+Run from sugarkube checkout (not token.place).
 
-## Deployment workflow (template)
+Install (first-time):
 
 ```bash
-# TODO: replace with production-approved sugarkube command wrapper when finalized.
-# Run from the repository root so ./deploy/charts/tokenplace-relay resolves.
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Validation checklist
+Upgrade (existing release):
 
-- [ ] production relay endpoints reachable and healthy
-- [ ] registration/polling from external compute nodes succeeds
-- [ ] error rate/latency within expected baseline
-- [ ] rollback command and previous revision confirmed before sign-off
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Sugarkube-specific token.place wrappers may be added in follow-up prompts.
+
+## Hostname
+
+Default production hostname is `https://token.place`.
+Operators may override hostnames in sugarkube values and Cloudflare routes.
+
+## Validation
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+- Inspect release history: `helm history tokenplace -n tokenplace`
+- Roll back to previous known-good revision/tag
+- Re-run validation commands
+- Capture deployment outcome and follow-ups
 
-- immediate rollback to prior known-good Helm revision/image tag
-- validate health and request flow
-- record deployment outcome and follow-up actions
+## Guardrails
 
-## Operator notes
-
-- Keep relay lightweight in-cluster; avoid coupling production relay rollout to simultaneous
-  compute-runtime migrations.
-- Post-API-v1 target state should align all token.place components on API v1 contracts, but that is
-  a later phase and not assumed by this runbook today.
+- Preserve API v1 relay-blind E2EE invariants.
+- Do not assume legacy relay routes are the active production runtime path.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -1,63 +1,67 @@
 # token.place relay on k3s+sugarkube (staging)
 
-> **Environment status:** **Current + planned hardening**.
-> Staging is used to validate relay operations before production rollout.
+> **Environment status:** current validation environment before production promotion.
 
 ## Scope
 
-Relay-only staging at `staging.token.place` (or equivalent environment hostname), with external
-compute nodes still using legacy sink/source contract.
+Staging runs **relay only** at `https://staging.token.place` by default.
 
-## Prerequisites
+- In-cluster: `relay.py` only (one pod, one worker, one replica)
+- External: `server.py` and all compute nodes (desktop Tauri, Macs, Windows PCs, Raspberry Pi GPU
+  / AI hats, and other nodes)
+- No required in-cluster backend or GPU service in this phase
 
-- staging cluster namespace access
-- relay image tag selected (prefer immutable)
-- Cloudflare tunnel + DNS route for staging hostname
-- environment config/secrets prepared
+The relay is currently stateful in-memory (registrations/messages/replies). State loss on pod death
+is accepted for now.
 
-## Topology
+## Artifacts and tags
 
-- Client -> Cloudflare -> tunnel -> Traefik ingress -> relay service/pod
-- compute nodes (`server.py`, later desktop parity nodes) remain external
-  - expected operators are workstation nodes (Windows CUDA, macOS Metal, CPU fallback)
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Preferred tag for sign-off: immutable `main-<shortsha>`
+- `main-latest` is convenience only and should not be used for production sign-off.
 
-## Release model
+## Deployment workflow (from sugarkube checkout)
 
-- Promote tested dev artifacts into staging.
-- Prefer immutable tags (`main-<sha>` / `sha-<sha>`) over mutable latest tags.
-- Maintain changelog notes for each staging deploy.
+Run these commands from a sugarkube repo checkout (not token.place):
 
-## Deployment workflow (template)
-
-Run from the repository root so the chart path resolves (`./deploy/charts/tokenplace-relay`).
-Use agreed sugarkube wrapper once available; until then:
+First install:
 
 ```bash
-helm upgrade --install tokenplace-relay ./deploy/charts/tokenplace-relay \
-  --namespace tokenplace --create-namespace \
-  --set ingress.hosts[0].host=staging.token.place \
-  --set gpuExternalName.host=<staging-gpu-hostname>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-> Replace placeholder values with finalized staging values (or a staging values file) before
-> rollout.
+Upgrade existing release:
 
-## Validation checklist
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-- [ ] relay pod(s) healthy and stable
-- [ ] ingress route serves `https://staging.token.place/healthz`
-- [ ] relay receives expected registration/poll traffic from external nodes
-- [ ] smoke test request flow succeeds end-to-end on legacy contract
+Sugarkube-specific token.place wrappers may be added as follow-up ergonomics.
+
+## Hostname
+
+Default staging hostname is `https://staging.token.place`.
+Operators may override this in sugarkube values and Cloudflare routes.
+
+## Validation
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
 
 ## Rollback
 
-Record the current revision before rollout (`helm history tokenplace-relay -n tokenplace`) so rollback targets are explicit.
+- Inspect release history first: `helm history tokenplace -n tokenplace`
+- Roll back to previous known-good revision/tag
+- Re-run validation commands above
+- Record incident notes if user-visible impact occurred
 
-- revert Helm release revision and/or pinned image tag
-- confirm health endpoint and registration flow after rollback
-- capture incident notes in outages/ if customer-visible
+## Guardrails
 
-## Operator notes
-
-- Staging should mirror production ingress/security posture where practical.
-- Do not assume API v1 distributed compute is enabled yet; this environment is still pre-migration.
+- Keep API v1 relay-blind E2EE invariants intact.
+- Do not treat legacy relay routes as active production-path requirements.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -1,96 +1,87 @@
 # Relay on sugarkube onboarding (token.place)
 
-This guide explains how and why to run `relay.py` on sugarkube before full desktop/server
-migration is complete.
+This guide explains the relay-only deployment model for sugarkube using token.place-owned OCI
+artifacts.
 
-## Why relay.py belongs on sugarkube
+## Scope and architecture (relay-only)
 
-`relay.py` is lightweight compared with compute nodes and is operationally a good fit for k3s:
+Sugarkube scope for this phase is `relay.py` only.
 
-- stateless request relay behavior
-- modest CPU/memory footprint
-- clear readiness endpoint (`/healthz`) and liveness endpoint (`/livez`)
-- easier centralized ingress/tunnel management
+- In-cluster: one `relay.py` pod, one Gunicorn worker, one replica.
+- External: `server.py`, desktop Tauri compute nodes, Macs, Windows PCs, Raspberry Pi GPU/AI hat
+  nodes, and other compute nodes.
+- No in-cluster backend/GPU service is required for this phase.
 
-This allows token.place to improve relay availability and operator workflows while GPU-heavy
-compute nodes (`server.py` and later desktop compute nodes) remain external during parity phases.
-Workstation targets for those external compute nodes are Windows 11 + CUDA/NVIDIA and macOS Apple
-Silicon + Metal, with CPU fallback available and Raspberry Pi planned later.
+The relay is technically stateful today because server registrations, client messages, and replies
+are stored in process memory. With the current one-pod/one-worker model, state loss on pod death is
+accepted for now. Redis (or equivalent shared state), multi-worker, and multi-replica relay
+architecture are future work and out of scope for this onboarding guide.
 
-Roadmap alignment: [desktop compute-node migration roadmap](roadmap/desktop_compute_node_migration.md).
+API v1 relay-blind E2EE guardrails remain mandatory:
 
-## Current status
+- relay-owned state/logs/diagnostics must remain ciphertext-only (plus safe routing metadata)
+- no plaintext relay payload logging or storage
+- fail closed if E2EE envelope expectations are not met
 
-- **Current:** relay can run locally or in Kubernetes; staging-oriented docs exist.
-- **Planned near-term:** standardized dev/staging/prod sugarkube runbooks for relay.
-- **Not yet:** full post-API-v1 distributed deployment model.
+## Canonical deployment artifacts (token.place-owned)
 
-## Minimal requirements
+- Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Relay chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 
-- k3s/sugarkube cluster access (`kubectl`, `helm`)
-- container image access for relay
-- DNS + Cloudflare tunnel route for chosen hostname
-- upstream compute node endpoint(s) reachable from relay route consumers
+Tag policy:
 
-## Networking expectations
+- Preferred for staging/prod validation: immutable `main-<shortsha>`
+- Convenience only: mutable `main-latest` (not production sign-off)
 
-Expected edge path:
+## Sugarkube-owned values and command wrappers
 
-`Client -> Cloudflare -> Tunnel -> Traefik Ingress -> relay Service -> relay Pod`
+The chart/image are published by token.place. Environment values files, approved version pins, and
+`just` wrappers are owned by sugarkube.
 
-Notes:
+Run deployment commands from a **sugarkube checkout**, not from token.place.
 
-- relay remains HTTP inside cluster unless platform policy requires in-cluster TLS.
-- public hostnames should be environment-specific (dev/staging/prod).
-- allow overriding relay URL in desktop/server configs during phased rollout.
-
-## Secrets and config expectations
-
-At minimum, plan for:
-
-- relay registration/auth token material (if enabled)
-- environment-scoped relay public URL and host settings
-- any upstream allowlists or routing config
-
-If exact secret names or chart keys are unsettled, treat them as explicit follow-up tasks rather
-than inventing values.
-
-## Health checks and validation
-
-`relay.py` probe semantics:
-
-- `GET /livez` returns `200 {"status":"alive"}` while process is alive.
-- `GET /healthz` returns `200` when ready, `503` when draining or degraded.
-- When relay is shutting down (SIGTERM/SIGINT), `/healthz` returns `status=draining` and `Retry-After: 0` to speed pod replacement.
-
-Minimum operator checks after deploy:
-
-1. Pod readiness and restart counts are stable.
-2. Ingress host resolves and serves `/healthz`.
-3. Relay can accept registration/polling traffic from external compute nodes.
-
-Example checks:
+Staging first install pattern:
 
 ```bash
-kubectl -n tokenplace get pods
-kubectl -n tokenplace get ingress
-curl -fsS https://<env-host>/livez
-curl -fsS https://<env-host>/healthz
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Current limitations
+Staging upgrade pattern:
 
-- Compute nodes are still external during parity phases.
-- Legacy sink/source contract remains active until post-parity API v1 migration.
-- Final sugarkube automation wrappers may still be in progress per environment.
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## How this fits the broader roadmap
+Production uses the same approved immutable tag and swaps the env values file:
 
-- Relay-on-sugarkube is a **pre-API-v1** operational improvement.
-- Desktop parity and shared compute runtime come first for compute-plane migration.
-- API v1 distributed compute is a later phase once parity and relay ops are stable.
+- `docs/examples/tokenplace.values.prod.yaml`
 
-## Environment runbooks
+Sugarkube-specific token.place wrappers are expected to exist after subsequent sugarkube prompts.
+
+## Hostnames and routing
+
+Default hostnames:
+
+- Staging: `https://staging.token.place`
+- Production: `https://token.place`
+
+Operators may override hostnames in sugarkube values and Cloudflare route configuration.
+
+## Validation
+
+After install/upgrade:
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+For production validation, replace the host with `https://token.place`.
+
+## Runbooks
 
 - [k3s-sugarkube-dev.md](k3s-sugarkube-dev.md)
 - [k3s-sugarkube-staging.md](k3s-sugarkube-staging.md)


### PR DESCRIPTION
### Motivation

- Clarify that short-to-medium-term Sugarkube scope is the relay only and operators should not expect an in-cluster backend/GPU service.
- Make operator runbooks concrete and Sugarkube-friendly by pointing to token.place-owned OCI artifacts and Sugarkube-owned values/wrappers. 
- Remove stale local-chart and GPU/backend wiring guidance that contradicted the relay-only topology and single-worker operational model.

### Description

- Updated the README sugarkube section to document relay-only topology, one pod/one Gunicorn worker/one replica, in-memory statefulness, accepted state loss, and canonical artifact references `ghcr.io/futuroptimist/tokenplace-relay` and `oci://ghcr.io/futuroptimist/charts/tokenplace`.
- Rewrote `docs/relay_sugarkube_onboarding.md` to describe relay-only architecture, preserve API v1 relay-blind E2EE guardrails, and publish tag guidance (`main-<shortsha>` preferred, `main-latest` is convenience-only).
- Replaced local-chart Helm examples in `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`, and `docs/k3s-sugarkube-dev.md` with Sugarkube-oriented OCI install/upgrade patterns using `just helm-oci-install` and `just helm-oci-upgrade` and added concrete validation/rollback commands.
- Added explicit default hostnames for environments (`https://staging.token.place` and `https://token.place`), and removed references requiring `gpuExternalName` or `TOKENPLACE_RELAY_UPSTREAM_URL` for Sugarkube relay-only readiness.

### Testing

- Ran repository scans: `grep -R "deploy/charts/tokenplace-relay" README.md docs || true` and `grep -R "ghcr.io/democratizedspace/tokenplace-relay" README.md docs || true` and `grep -R "gpuExternalName" README.md docs || true` to ensure stale references in the targeted docs were removed; checks passed for the edited files while unrelated docs still contain historical references. 
- Ran unit test suite subset: `python -m pytest -q tests/test_relay.py`; the test run completed but reported 6 failing tests that are pre-existing runtime expectations unrelated to docs-only changes, so no runtime code or Helm templates were modified in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1360fb4f68832f9df5c130b0b8f3de)