### PR TITLE
Fix desktop-tauri first-launch GGUF path and operator start failure visibility

### DIFF
--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -139,6 +139,24 @@ def assert_model_path_exists(path: str) -> None:
         raise AssertionError(f"model path does not exist: {path}")
 
 
+def wait_for_running_stability(
+    driver: webdriver.Remote, expected: str, stable_seconds: float = 2.0
+) -> None:
+    status_xpath = "//p[contains(.,'Running:')]//strong"
+    wait = WebDriverWait(driver, 45, poll_frequency=0.25)
+    wait.until(
+        lambda d: d.find_element(By.XPATH, status_xpath).text.strip().lower() == expected.lower()
+    )
+    deadline = time.time() + stable_seconds
+    while time.time() < deadline:
+        current = driver.find_element(By.XPATH, status_xpath).text.strip().lower()
+        if current != expected.lower():
+            raise AssertionError(
+                f"Running state became unstable: expected {expected!r}, observed {current!r}"
+            )
+        time.sleep(0.2)
+
+
 def fill_input_by_label(driver: webdriver.Remote, label_text: str, value: str) -> None:
     locator = (
         f"(//label[normalize-space()='{label_text}']/following::input[1] | "
@@ -499,6 +517,13 @@ def main() -> int:
         wait_for_ui_ready(driver)
 
         runtime_resolved_path = read_runtime_resolved_path(driver)
+        initial_model_value = driver.find_element(
+            By.XPATH,
+            "(//label[normalize-space()='Model GGUF path']/following::input[1])[1]",
+        ).get_attribute("value")
+        assert initial_model_value == "", (
+            f"expected first-launch model path to be blank; got {initial_model_value!r}"
+        )
         with tempfile.NamedTemporaryFile(suffix=".gguf", delete=False) as model_file:
             model_path = model_file.name
         if runtime_resolved_path:
@@ -516,12 +541,7 @@ def main() -> int:
         wait_for_start_operator_enabled(driver, relay_log, driver_log)
         driver.find_element(By.XPATH, "//button[.='Start operator']").click()
 
-        wait.until(
-            lambda d: d.find_element(
-                By.XPATH,
-                "//p[contains(.,'Running:')]//strong[normalize-space()='yes']",
-            )
-        )
+        wait_for_running_stability(driver, "yes", stable_seconds=3.0)
         wait.until(
             lambda d: d.find_element(
                 By.XPATH,

--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -149,7 +149,11 @@ def wait_for_running_stability(
     )
     deadline = time.time() + stable_seconds
     while time.time() < deadline:
-        current = driver.find_element(By.XPATH, status_xpath).text.strip().lower()
+        try:
+            current = driver.find_element(By.XPATH, status_xpath).text.strip().lower()
+        except (NoSuchElementException, StaleElementReferenceException, WebDriverException):
+            time.sleep(0.2)
+            continue
         if current != expected.lower():
             raise AssertionError(
                 f"Running state became unstable: expected {expected!r}, observed {current!r}"
@@ -462,6 +466,14 @@ def main() -> int:
     env["PYTHONPATH"] = (
         f"{REPO_ROOT}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(REPO_ROOT)
     )
+    isolated_home = Path(tempfile.mkdtemp(prefix="token-place-desktop-e2e-home-"))
+    env["HOME"] = str(isolated_home)
+    env["XDG_CONFIG_HOME"] = str(isolated_home / ".config")
+    env["XDG_DATA_HOME"] = str(isolated_home / ".local" / "share")
+    env["APPDATA"] = str(isolated_home / "AppData" / "Roaming")
+    Path(env["XDG_CONFIG_HOME"]).mkdir(parents=True, exist_ok=True)
+    Path(env["XDG_DATA_HOME"]).mkdir(parents=True, exist_ok=True)
+    Path(env["APPDATA"]).mkdir(parents=True, exist_ok=True)
 
     relay = subprocess.Popen(  # noqa: S603
         [
@@ -592,6 +604,7 @@ def main() -> int:
                 Path(model_path).unlink()
         terminate_process(tauri_driver)
         terminate_process(relay)
+        shutil.rmtree(isolated_home, ignore_errors=True)
 
     return 0
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -199,6 +199,71 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+  it('keeps model path blank on first launch when config has no persisted model path', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'detect_backend') {
+        return Promise.resolve({
+          platform_label: 'macos',
+          preferred_mode: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
+        });
+      }
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: false,
+          registered: false,
+          active_relay_url: '',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '',
+          last_error: null,
+        });
+      }
+      if (command === 'inspect_model_artifact') {
+        return Promise.resolve({
+          canonical_family_url: 'https://example.test/models',
+          filename: 'model.gguf',
+          url: 'https://example.test/model.gguf',
+          models_dir: '/tmp',
+          resolved_model_path: 'C:\\Users\\dev\\Downloads\\model.gguf',
+          exists: false,
+          size_bytes: null,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(<App />);
+    const modelInput = (await screen.findAllByRole('textbox'))[0];
+    await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe(''));
+    expect(
+      invokeMock.mock.calls.some(
+        (call) =>
+          call[0] === 'save_config' &&
+          typeof call[1]?.config?.model_path === 'string' &&
+          call[1].config.model_path.includes('C:\\Users\\dev')
+      )
+    ).toBe(false);
+  });
+
+  it('restores persisted user-selected model path from saved config', async () => {
+    render(<App />);
+    const modelInput = (await screen.findAllByRole('textbox'))[0];
+    await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe('/tmp/model.gguf'));
+  });
+
   it('surfaces bridge startup exits through compute_node_event errors', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'start_compute_node') {
@@ -249,7 +314,6 @@ describe('desktop app start failure handling', () => {
     const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
     fireEvent.click(startOperatorButton);
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
 
     const computeHandler = eventHandlers.get('compute_node_event');
     expect(computeHandler).toBeTruthy();

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -246,7 +246,7 @@ describe('desktop app start failure handling', () => {
     });
 
     render(<App />);
-    const modelInput = (await screen.findAllByRole('textbox'))[0];
+    const modelInput = (await screen.findByLabelText('Model GGUF path')) as HTMLInputElement;
     await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe(''));
     expect(
       invokeMock.mock.calls.some(
@@ -260,7 +260,7 @@ describe('desktop app start failure handling', () => {
 
   it('restores persisted user-selected model path from saved config', async () => {
     render(<App />);
-    const modelInput = (await screen.findAllByRole('textbox'))[0];
+    const modelInput = (await screen.findByLabelText('Model GGUF path')) as HTMLInputElement;
     await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe('/tmp/model.gguf'));
   });
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -199,6 +199,72 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+  it('blocks duplicate start clicks while compute-node startup is pending', async () => {
+    let resolveStart: (() => void) | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'start_compute_node') {
+        return new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      if (command === 'detect_backend') {
+        return Promise.resolve({
+          platform_label: 'macos',
+          preferred_mode: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
+        });
+      }
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: false,
+          registered: false,
+          active_relay_url: '',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '',
+          last_error: null,
+        });
+      }
+      return Promise.resolve({
+        canonical_family_url: 'https://example.test/models',
+        filename: 'model.gguf',
+        url: 'https://example.test/model.gguf',
+        models_dir: '/tmp',
+        resolved_model_path: '/tmp/model.gguf',
+        exists: true,
+        size_bytes: 1,
+      });
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+
+    fireEvent.click(startOperatorButton);
+    fireEvent.click(startOperatorButton);
+
+    expect(
+      invokeMock.mock.calls.filter(([command]) => command === 'start_compute_node')
+    ).toHaveLength(1);
+    expect(startOperatorButton.disabled).toBe(true);
+    expect(stopOperatorButton.disabled).toBe(false);
+
+    resolveStart?.();
+  });
+
   it('keeps model path blank on first launch when config has no persisted model path', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'detect_backend') {

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -260,7 +260,7 @@ describe('desktop app start failure handling', () => {
       invokeMock.mock.calls.filter(([command]) => command === 'start_compute_node')
     ).toHaveLength(1);
     expect(startOperatorButton.disabled).toBe(true);
-    expect(stopOperatorButton.disabled).toBe(false);
+    expect(stopOperatorButton.disabled).toBe(true);
 
     resolveStart?.();
   });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -113,13 +113,6 @@ export function App() {
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
         setArtifact(info);
 
-        if (loadedConfig.model_path.trim()) {
-          return;
-        }
-
-        const next = { ...loadedConfig, model_path: info.resolved_model_path };
-        await invoke('save_config', { config: next });
-        setConfig(next);
       } catch (e) {
         setError(formatErrorMessage(e));
       }
@@ -201,6 +194,15 @@ export function App() {
                 ? payload.message
                 : prev.last_error,
       }));
+      if (payload.type === 'error') {
+        const computeMessage =
+          typeof payload.last_error === 'string'
+            ? payload.last_error
+            : typeof payload.message === 'string'
+              ? payload.message
+              : 'compute-node operator failed';
+        setError(computeMessage);
+      }
     });
 
     return () => {
@@ -313,7 +315,7 @@ export function App() {
       setError('');
       setComputeStatus((prev) => ({
         ...prev,
-        running: true,
+        running: false,
         registered: false,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -443,7 +443,7 @@ export function App() {
         <div style={{ display: 'flex', gap: 8 }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
           <button
-            disabled={!computeStatus.running && !isStartingComputeNode}
+            disabled={!computeStatus.running}
             onClick={stopComputeNode}
           >
             Stop operator

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -442,7 +442,12 @@ export function App() {
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
         <div style={{ display: 'flex', gap: 8 }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
-          <button disabled={!computeStatus.running} onClick={stopComputeNode}>Stop operator</button>
+          <button
+            disabled={!computeStatus.running && !isStartingComputeNode}
+            onClick={stopComputeNode}
+          >
+            Stop operator
+          </button>
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -95,6 +95,7 @@ export function App() {
   const [isDownloadingModel, setIsDownloadingModel] = useState(false);
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
+  const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');
 
@@ -194,6 +195,9 @@ export function App() {
                 ? payload.message
                 : prev.last_error,
       }));
+      if (payload.type === 'started' || payload.type === 'error') {
+        setIsStartingComputeNode(false);
+      }
       if (payload.type === 'error') {
         const computeMessage =
           typeof payload.last_error === 'string'
@@ -228,8 +232,8 @@ export function App() {
   );
 
   const canStartComputeNode = useMemo(
-    () => Boolean(config.model_path.trim()) && !computeStatus.running,
-    [config.model_path, computeStatus.running]
+    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
+    [config.model_path, computeStatus.running, isStartingComputeNode]
   );
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
@@ -312,6 +316,7 @@ export function App() {
 
   const startComputeNode = async () => {
     try {
+      setIsStartingComputeNode(true);
       setError('');
       setComputeStatus((prev) => ({
         ...prev,
@@ -335,6 +340,7 @@ export function App() {
         },
       });
     } catch (e) {
+      setIsStartingComputeNode(false);
       const message = formatErrorMessage(e);
       setComputeStatus((prev) => ({
         ...prev,
@@ -373,9 +379,10 @@ export function App() {
     <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
       <h1>token.place desktop compute node</h1>
       <p>Platform GPU availability: <strong>{backend?.availability_label ?? 'loading...'}</strong></p>
-      <label>Model GGUF path</label>
+      <label htmlFor="model-path-input">Model GGUF path</label>
       <div style={{ display: 'flex', gap: 8 }}>
         <input
+          id="model-path-input"
           value={config.model_path}
           style={{ width: '100%' }}
           onChange={(e) => updateConfig({ ...config, model_path: e.target.value })}

--- a/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.json
+++ b/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-macos-start-operator-e2e-gap",
+  "summary": "Desktop Tauri operator UI regressed by showing a machine-specific model path on first launch and by allowing macOS start failures to appear as brief running transitions without a visible in-app error.",
+  "impact": "New users saw misleading pre-filled GGUF paths, and macOS users could click Start operator and observe a revert to Running: no without actionable failure context in the UI.",
+  "fix": "Removed first-launch model-path auto-save from runtime artifact inspection, made operator lifecycle rely on backend events instead of optimistic running flips, surfaced compute-node error events in the visible error banner, and hardened desktop e2e checks for blank-first-launch state and running-state stability.",
+  "lessons": "Desktop startup UX must guard against duplicate/in-flight starts, always surface backend startup errors in visible UI state, and isolate persisted app config in e2e runs to avoid false first-launch assumptions."
+}

--- a/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
+++ b/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
@@ -1,0 +1,50 @@
+# 2026-05-24 desktop macOS start-operator regression and e2e gap
+
+## Summary
+The desktop Tauri operator UI regressed in two ways: first-launch model path displayed a machine-
+specific value, and operator start failures on macOS could present as a brief `Running: yes` flip
+without a visible UI error.
+
+## User impact
+- New users could see a misleading pre-filled GGUF path before selecting a model.
+- macOS users could click **Start operator** and see it revert to `Running: no` without clear
+  in-app failure context.
+
+## Symptoms
+- Initial load could populate **Model GGUF path** from runtime artifact resolution rather than
+  preserved user config.
+- **Start operator** could transiently show running status and then exit, with diagnostics only in
+  backend logs/events.
+
+## Root causes
+1. UI initialization auto-saved `inspect_model_artifact().resolved_model_path` into
+   `config.model_path` whenever persisted `model_path` was blank.
+2. UI set `running: true` optimistically before confirmed bridge startup events, and event-driven
+   operator errors were not mirrored into the global visible error banner.
+
+## Why existing e2e missed this (especially on macOS)
+- The desktop UI e2e test explicitly writes a temporary model path before start and did not assert
+  first-launch blank state.
+- The test asserted `Running: yes` once, but did not validate that state remained stable for a
+  post-start window, so quick start/exit transitions could evade detection.
+
+## Fix implemented
+- Removed auto-population/auto-save of model path from runtime artifact inspection when config is
+  blank.
+- Updated start behavior to avoid optimistic `running: true` before backend status events confirm
+  startup.
+- Propagated compute-node error events to a visible UI error message.
+- Strengthened desktop UI e2e to assert blank initial model input and stable `Running: yes` after
+  Start operator.
+
+## Tests added/updated
+- Updated React unit tests to verify:
+  - first-launch blank config remains blank even if runtime resolved path is Windows-style,
+  - persisted model path is restored,
+  - operator start failures are surfaced.
+- Updated desktop UI e2e to verify blank initial path and running-state stability.
+
+## Follow-up
+- Keep macOS desktop UI e2e in CI coverage where runner capacity permits; if execution scope
+  changes, preserve the stability assertion and blank-initial-path check in whichever workflow owns
+  desktop operator verification.

--- a/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
+++ b/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
@@ -45,6 +45,13 @@ without a visible UI error.
 - Updated desktop UI e2e to verify blank initial path and running-state stability.
 
 ## Follow-up
-- Keep macOS desktop UI e2e in CI coverage where runner capacity permits; if execution scope
-  changes, preserve the stability assertion and blank-initial-path check in whichever workflow owns
-  desktop operator verification.
+- Current CI limitation: `.github/workflows/desktop-operator-e2e.yml` runs
+  `test_desktop_operator_ui_e2e.py` only on Linux because it depends on `tauri-driver` +
+  WebKitGTK/Xvfb orchestration that is currently provisioned only in the Ubuntu job.
+- Strongest automated macOS substitute currently in CI is
+  `desktop-operator-packaged-e2e-macos`, which runs
+  `desktop-tauri/scripts/test_packaged_operator_e2e.py` (including inspect-only and full packaged
+  bridge coverage) to validate macOS operator startup/bridge behavior.
+- When macOS Tauri UI WebDriver plumbing is added to CI, add an explicit macOS job for
+  `test_desktop_operator_ui_e2e.py` without weakening the blank-initial-path or running-stability
+  assertions.


### PR DESCRIPTION
### Motivation
- Fix two regressions in the Tauri desktop compute-node UI: a machine-specific GGUF path appearing on first launch and silent operator start failures on macOS. 
- Ensure failures are visible to users and do not rely on optimistic UI state flips. 
- Close the e2e/test gap by strengthening the relay+Tauri desktop e2e to catch transient start/exit behavior.

### Description
- Removed auto-population / auto-save of `inspect_model_artifact().resolved_model_path` into `config.model_path` when the saved config is blank so first-launch GGUF input remains empty. 
- Stopped the optimistic `running: true` flip on `Start operator` and instead wait for backend events; the UI no longer marks the operator running until confirmed by compute-node events. 
- Propagated compute-node `error` events into the visible UI error banner by setting the global `error` state when an error event arrives. 
- Added unit tests in `desktop-tauri/src/App.test.tsx` to assert: blank first-launch model path (even when runtime resolved path looks like a Windows path), persisted user-selected path restoration, and surfaced compute-node start failures. 
- Hardened the desktop UI e2e `desktop-tauri/scripts/test_desktop_operator_ui_e2e.py` to assert the model input is blank on first launch and to assert `Running: yes` is stable for a short window (not just a transient one). 
- Added an outage write-up at `outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md` describing the incident, root causes, fixes, and tests added.

### Testing
- Ran UI unit tests: `cd desktop-tauri && npm test`; this runs `vitest` and all desktop-tauri tests passed (`7 tests, 7 passed`).
- Ran project pre-commit checks: `pre-commit run --all-files`; this surfaced unrelated existing YAML/Helm parsing errors in `charts/tokenplace/templates/*` and did not pass (failures are pre-existing and outside this change set). 
- Attempted higher-level checks: `npm test` (top-level) and a scan-secrets invocation were exercised in the workflow; the repo-local `./scripts/scan-secrets.py` was not present so that check was not executed here. 
- Note: the packaged desktop e2e (`desktop-tauri/scripts/test_desktop_operator_ui_e2e.py`) was updated to assert blank initial model path and running-state stability, but a full packaged e2e run was not executed in this CI-limited environment; the test script is ready for CI environments that can launch the Tauri binary and webdriver.

Commands run and key results:
- `cd desktop-tauri && npm test` → `vitest` run; all tests in `src/App.test.tsx` passed.
- `pre-commit run --all-files` → failed on existing YAML parsing issues in Helm templates (unrelated to these changes).
- `git add && git commit` performed locally to record the change set; PR prepared with the changes described above.

If you want, I can: (1) open a follow-up issue to track fixing the unrelated Helm YAML lint failures so pre-commit passes, or (2) run the full packaged e2e in an environment that can build and execute the Tauri binary and webdriver and report back with the results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13676069a4832f85b7fe0c61b69f55)