### PR TITLE
Fix macOS Tauri: blank GGUF default on first launch and operator startup visibility

### DIFF
--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -497,6 +497,13 @@ def main() -> int:
         driver = start_driver(app_binary)
         wait = WebDriverWait(driver, 45)
         wait_for_ui_ready(driver)
+        initial_model_input = driver.find_element(
+            By.XPATH,
+            "(//label[normalize-space()='Model GGUF path']/following::input[1])[1]",
+        )
+        assert initial_model_input.get_attribute("value") == "", (
+            "first-launch model path must be blank before user selection"
+        )
 
         runtime_resolved_path = read_runtime_resolved_path(driver)
         with tempfile.NamedTemporaryFile(suffix=".gguf", delete=False) as model_file:
@@ -528,6 +535,14 @@ def main() -> int:
                 "//p[contains(.,'Registered:')]//strong[normalize-space()='yes']",
             )
         )
+        time.sleep(2)
+        assert (
+            driver.find_element(
+                By.XPATH,
+                "//p[contains(.,'Running:')]//strong",
+            ).text.strip().lower()
+            == "yes"
+        ), "operator running state did not remain stable after startup"
 
         prompt = driver.find_element(
             By.XPATH,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -438,7 +438,7 @@ pub async fn start_compute_node(
             *stdin_slot = pending_stdin.take();
             let mut status = state.status.lock().await;
             *status = ComputeNodeStatus {
-                running: true,
+                running: false,
                 registered: false,
                 active_relay_url: request.relay_base_url.clone(),
                 requested_mode: format!("{:?}", request.mode).to_lowercase(),

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -23,6 +23,73 @@ describe('desktop app start failure handling', () => {
     cleanup();
   });
 
+  it('keeps model path blank on first launch when config has no saved model path', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      return Promise.resolve(
+        command === 'detect_backend'
+          ? {
+              platform_label: 'macos',
+              preferred_mode: 'auto',
+              available_backend: 'metal',
+              availability_label: 'Metal-capable platform (Apple Silicon)',
+            }
+          : command === 'get_compute_node_status'
+            ? {
+                running: false,
+                registered: false,
+                active_relay_url: '',
+                requested_mode: 'auto',
+                effective_mode: 'cpu',
+                backend_available: 'unknown',
+                backend_selected: 'cpu',
+                backend_used: 'cpu',
+                fallback_reason: null,
+                model_path: '',
+                last_error: null,
+              }
+            : {
+                canonical_family_url: 'https://example.test/models',
+                filename: 'model.gguf',
+                url: 'https://example.test/model.gguf',
+                models_dir: '/tmp',
+                resolved_model_path: '/tmp/runtime-default.gguf',
+                exists: false,
+                size_bytes: null,
+              }
+      );
+    });
+
+    render(<App />);
+    const modelInput = document.querySelectorAll('input')[0] as HTMLInputElement | undefined;
+    expect(modelInput).toBeTruthy();
+    if (!modelInput) {
+      return;
+    }
+    expect(modelInput.value).toBe('');
+    expect(
+      invokeMock.mock.calls.some(
+        (args) => args[0] === 'save_config' && args[1]?.config?.model_path === '/tmp/runtime-default.gguf'
+      )
+    ).toBe(false);
+  });
+
+  it('restores persisted model path when previously saved by the user', async () => {
+    render(<App />);
+    const modelInput = document.querySelectorAll('input')[0] as HTMLInputElement | undefined;
+    expect(modelInput).toBeTruthy();
+    if (!modelInput) {
+      return;
+    }
+    await waitFor(() => expect(modelInput.value).toBe('/tmp/model.gguf'));
+  });
+
   beforeEach(() => {
     invokeMock.mockReset();
     listenMock.mockReset();
@@ -249,10 +316,17 @@ describe('desktop app start failure handling', () => {
     const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
     fireEvent.click(startOperatorButton);
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-
     const computeHandler = eventHandlers.get('compute_node_event');
     expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        last_error: null,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
     computeHandler?.({
       payload: {
         type: 'error',

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -113,13 +113,6 @@ export function App() {
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
         setArtifact(info);
 
-        if (loadedConfig.model_path.trim()) {
-          return;
-        }
-
-        const next = { ...loadedConfig, model_path: info.resolved_model_path };
-        await invoke('save_config', { config: next });
-        setConfig(next);
       } catch (e) {
         setError(formatErrorMessage(e));
       }
@@ -159,6 +152,16 @@ export function App() {
   useEffect(() => {
     const unlisten = listen<Record<string, unknown>>('compute_node_event', (evt) => {
       const payload = evt.payload;
+      if (
+        payload.type === 'error' &&
+        (typeof payload.message === 'string' || typeof payload.last_error === 'string')
+      ) {
+        setError(
+          typeof payload.message === 'string'
+            ? payload.message
+            : (payload.last_error as string)
+        );
+      }
       setComputeStatus((prev) => ({
         running:
           typeof payload.running === 'boolean'
@@ -313,7 +316,7 @@ export function App() {
       setError('');
       setComputeStatus((prev) => ({
         ...prev,
-        running: true,
+        running: false,
         registered: false,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,

--- a/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
+++ b/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
@@ -1,0 +1,47 @@
+# 2026-05-24: Desktop macOS operator startup regression and e2e coverage gap
+
+## Summary
+Two desktop-tauri regressions impacted macOS users: the model path field could be auto-populated
+from runtime-resolved defaults on first launch, and operator startup failures could appear as a
+brief `Running: yes` transition before returning to `Running: no` without a clearly surfaced UI
+error context.
+
+## User impact
+- First launch could show a non-user-selected GGUF path, including environment-specific absolute
+  paths.
+- Clicking **Start operator** could fail quickly, leaving users with unclear diagnostics.
+
+## Symptoms
+- `Model GGUF path` displayed a machine-specific path before any user browse/download action.
+- `Start operator` briefly showed running, then stopped, with no durable/obvious error signal in
+  the top-level UI status.
+
+## Root causes
+1. The renderer bootstrap path auto-saved `inspect_model_artifact().resolved_model_path` into
+   config when `load_config()` returned an empty model path.
+2. The UI and backend startup flow both treated startup as immediately running before bridge
+   startup health events were emitted, creating transient green status before immediate exit.
+
+## Why existing e2e coverage missed this
+- The desktop e2e test immediately filled `Model GGUF path`, so it did not assert first-launch
+  blank-path behavior.
+- The test asserted `Running: yes` and `Registered: yes` but did not verify stable running state
+  after a short post-start interval.
+
+## Fix implemented
+- Removed renderer auto-population/saving of model path when config is empty.
+- Start flow no longer sets running optimistically before bridge startup events.
+- Compute-node event errors now also surface in the visible UI error banner.
+- e2e now asserts initial blank model path and validates running stays `yes` after startup.
+
+## Tests updated
+- `desktop-tauri/src/App.test.tsx`
+  - added first-launch blank model path assertion
+  - added persisted model path restoration assertion
+- `desktop-tauri/scripts/test_desktop_operator_ui_e2e.py`
+  - added first-launch blank model path assertion
+  - added stable post-start running assertion window
+
+## Follow-ups
+- Keep macOS desktop e2e on CI runners with tauri-driver support; if runner availability changes,
+  preserve the stable-running assertions in the strongest available desktop integration job.


### PR DESCRIPTION
### Motivation
- Prevent leaking runtime- or developer-specific absolute GGUF paths into the UI on a fresh first launch by stopping automatic save/population of a runtime-resolved model path.
- Make operator startup failures visible and avoid optimistic UI state that briefly showed `Running: yes` before the bridge exited, which left macOS users without actionable diagnostics.

### Description
- Renderer: removed the bootstrap auto-save that wrote `inspect_model_artifact().resolved_model_path` into persistent config when `load_config()` returned an empty `model_path`, so first-launch `Model GGUF path` stays blank. (`desktop-tauri/src/App.tsx`)
- Renderer: stopped setting `computeStatus.running` optimistically during start and now only reflects bridge-emitted status events; compute-node errors are also surfaced into the visible UI error banner for actionable feedback. (`desktop-tauri/src/App.tsx`)
- Backend: changed compute-node startup status initialization to avoid marking `running: true` before startup events are observed, preventing a transient green state. (`desktop-tauri/src-tauri/src/compute_node.rs`)
- Tests/e2e: added unit test assertions for first-launch blank model path and persisted model-path restore in `App.test.tsx`, and strengthened the desktop WebDriver e2e to assert the initial model input is blank and that `Running: yes` remains stable after startup. (`desktop-tauri/src/App.test.tsx`, `desktop-tauri/scripts/test_desktop_operator_ui_e2e.py`)
- Documentation: added an outage report documenting the regression, root cause, fixes, and follow-ups. (`outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md`)

### Testing
- Ran component/unit tests: `npm run --prefix desktop-tauri test` (Vitest) and all desktop renderer tests passed locally (`7 passed`).
- Attempted Rust unit tests: `cargo test compute_node:: --quiet` ran but failed in this environment due to missing system `glib-2.0` / `pkg-config` build dependencies (CI/container environment limitation), not a code assertion failure.
- Updated e2e script `desktop-tauri/scripts/test_desktop_operator_ui_e2e.py` to assert first-launch blank path and stable running state; the e2e is present and should be run on macOS CI or locally with `tauri-driver` and runtime deps to validate the full integration path.
- Notes: CI/runner constraints prevented running the Rust tests and the full packaged-desktop WebDriver e2e in this environment; these are documented in the outage file and the PR how-to-test notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13676069a4832f85b7fe0c61b69f55)