### PR TITLE
Fix desktop macOS operator startup regression and GGUF default-path leak

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -150,3 +150,59 @@ jobs:
 
       - name: Run packaged operator bridge e2e (macOS)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+  desktop-operator-ui-e2e-macos:
+    runs-on: macos-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: desktop-tauri/package-lock.json
+
+      - name: Install desktop Node dependencies
+        working-directory: desktop-tauri
+        run: npm ci
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver
+
+      - name: Build desktop frontend assets
+        working-directory: desktop-tauri
+        run: npm run build
+
+      - name: Build desktop binary (debug, no bundle)
+        working-directory: desktop-tauri
+        run: npm run tauri build -- --debug --no-bundle
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install selenium
+
+      - name: Run desktop operator UI e2e (macOS)
+        run: python desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+
+      - name: Upload desktop e2e logs on failure (macOS)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-operator-ui-e2e-macos-logs
+          path: .desktop-e2e-logs/
+          include-hidden-files: true
+          if-no-files-found: warn

--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -131,6 +131,13 @@ def diagnostics_message(
         f"page_source_tail={page_source_tail}"
     )
 
+def capture_failure_screenshot(driver: webdriver.Remote | None, logs_dir: Path, name: str) -> None:
+    if driver is None:
+        return
+    screenshot_path = logs_dir / name
+    with contextlib.suppress(Exception):
+        driver.save_screenshot(str(screenshot_path))
+
 
 def assert_model_path_exists(path: str) -> None:
     if not path.strip():
@@ -499,6 +506,13 @@ def main() -> int:
         wait_for_ui_ready(driver)
 
         runtime_resolved_path = read_runtime_resolved_path(driver)
+        initial_model_path = driver.find_element(
+            By.XPATH,
+            "(//label[normalize-space()='Model GGUF path']/following::input[1])[1]",
+        ).get_attribute("value")
+        assert initial_model_path == "", (
+            "expected first-launch Model GGUF path input to be blank when no user config exists"
+        )
         with tempfile.NamedTemporaryFile(suffix=".gguf", delete=False) as model_file:
             model_path = model_file.name
         if runtime_resolved_path:
@@ -528,6 +542,9 @@ def main() -> int:
                 "//p[contains(.,'Registered:')]//strong[normalize-space()='yes']",
             )
         )
+        time.sleep(3)
+        running_text = driver.find_element(By.XPATH, "//p[contains(.,'Running:')]//strong").text
+        assert running_text.strip().lower() == "yes", "operator running state was not stable"
 
         prompt = driver.find_element(
             By.XPATH,
@@ -555,12 +572,15 @@ def main() -> int:
         )
         assert_relay_roundtrip(relay_url, relay_log, driver_log, driver)
     except TimeoutException as exc:
+        capture_failure_screenshot(driver, logs_dir, "desktop-ui-e2e-timeout.png")
         raise RuntimeError(diagnostics_message("desktop UI e2e timed out", relay_log, driver_log, driver)) from exc
     except AssertionError as exc:
+        capture_failure_screenshot(driver, logs_dir, "desktop-ui-e2e-assertion.png")
         raise RuntimeError(
             diagnostics_message(f"desktop UI e2e assertion failed: {exc}", relay_log, driver_log, driver)
         ) from exc
     except WebDriverException as exc:
+        capture_failure_screenshot(driver, logs_dir, "desktop-ui-e2e-webdriver.png")
         raise RuntimeError(
             diagnostics_message(f"desktop UI e2e webdriver failure: {exc}", relay_log, driver_log, driver)
         ) from exc

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -249,7 +249,7 @@ describe('desktop app start failure handling', () => {
     const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
     fireEvent.click(startOperatorButton);
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
 
     const computeHandler = eventHandlers.get('compute_node_event');
     expect(computeHandler).toBeTruthy();
@@ -267,6 +267,58 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last error:/).textContent).toContain(
       'before emitting a startup event'
     );
+  });
+
+  it('keeps first-launch model path empty when no saved path exists', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'detect_backend') {
+        return Promise.resolve({
+          platform_label: 'macos',
+          preferred_mode: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
+        });
+      }
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: false,
+          registered: false,
+          active_relay_url: '',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '',
+          last_error: null,
+        });
+      }
+      if (command === 'inspect_model_artifact') {
+        return Promise.resolve({
+          canonical_family_url: 'https://example.test/models',
+          filename: 'model.gguf',
+          url: 'https://example.test/model.gguf',
+          models_dir: '/tmp',
+          resolved_model_path: 'C:\\\\Users\\\\dev\\\\model.gguf',
+          exists: false,
+          size_bytes: null,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(<App />);
+    const modelInput = (await screen.findAllByRole('textbox'))[0] as HTMLInputElement;
+    await waitFor(() => expect(modelInput.value).toBe(''));
+    expect(invokeMock).not.toHaveBeenCalledWith('save_config', expect.anything());
   });
 
   it('keeps running state healthy when started and status events are healthy', async () => {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -112,14 +112,6 @@ export function App() {
 
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
         setArtifact(info);
-
-        if (loadedConfig.model_path.trim()) {
-          return;
-        }
-
-        const next = { ...loadedConfig, model_path: info.resolved_model_path };
-        await invoke('save_config', { config: next });
-        setConfig(next);
       } catch (e) {
         setError(formatErrorMessage(e));
       }
@@ -313,7 +305,7 @@ export function App() {
       setError('');
       setComputeStatus((prev) => ({
         ...prev,
-        running: true,
+        running: false,
         registered: false,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,

--- a/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
+++ b/outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md
@@ -1,0 +1,38 @@
+# 2026-05-24: Desktop macOS Start Operator regression + e2e gap
+
+## Summary
+Two desktop regressions affected the Tauri compute-node operator flow:
+1. First launch prefilled **Model GGUF path** from runtime artifact resolution instead of leaving it blank.
+2. **Start operator** could flip `Running` to `yes` briefly and then back to `no` on startup failure without a visible, actionable UI error.
+
+## User impact
+- First-launch UX showed a non-user-selected model path, including potentially platform-specific paths.
+- On macOS startup failures, users saw an apparent transient start with no immediate actionable feedback.
+
+## Symptoms
+- Model path input populated on initial load before user browse/select action.
+- Clicking **Start operator** could show `Running: yes` transiently, then return to `Running: no`.
+- Failure reason was not reliably visible at the moment startup failed.
+
+## Root causes
+- Frontend initialization path set and persisted `config.model_path` from `inspect_model_artifact().resolved_model_path` when saved config was blank.
+- Frontend start handler optimistically set compute-node `running: true` before backend startup confirmation/event.
+
+## Why existing coverage missed it
+- UI tests covered event-driven error transitions but did not enforce first-launch blank path behavior.
+- UI e2e validated a successful start path but did not assert startup-state stability after the initial running transition.
+- UI e2e was exercised on Linux CI; macOS packaged coverage existed, but macOS UI wiring parity was not validated by the same UI e2e flow.
+
+## Fix implemented
+- Removed auto-population/persistence of model path during app initialization.
+- Updated start-operator UI handling to avoid optimistic `running: true`; running now remains `no` until backend events confirm live state.
+- Strengthened UI e2e to assert blank initial model input and stable running state after start.
+- Enabled macOS CI execution of desktop operator UI e2e.
+
+## Tests added/updated
+- Updated desktop React tests for first-launch blank model path and no implicit save.
+- Updated UI e2e to assert first-launch blank model path, stable running state, and capture screenshots on failure.
+- Added macOS UI e2e job in CI workflow.
+
+## Follow-up
+- Monitor macOS UI e2e runtime and flake rate; split test phases if runtime becomes a bottleneck.


### PR DESCRIPTION
### Motivation
- Prevent first-launch UI from showing or persisting a developer/machine-specific GGUF path and avoid optimistic UI state that hid operator startup failures on macOS.
- Close the e2e/test gap that allowed this macOS behavior to go undetected by adding explicit assertions and macOS UI coverage.

### Description
- Stop auto-populating and saving `model_path` from the model artifact resolver during initialization so a fresh install shows an empty `Model GGUF path` (`desktop-tauri/src/App.tsx`).
- Remove the optimistic `running: true` update in the Start operator handler so the UI waits for backend/bridge events to mark the operator running and surfaces failures into `last_error` (`desktop-tauri/src/App.tsx`).
- Add/adjust unit tests to cover first-launch blank model-path behavior and compute-node start failure visibility and to expect a stable `running:no` when the bridge fails early (`desktop-tauri/src/App.test.tsx`).
- Harden the desktop UI e2e script to assert the initial `Model GGUF path` is blank, assert running-state stability after start, and capture screenshots on failure (`desktop-tauri/scripts/test_desktop_operator_ui_e2e.py`).
- Add a macOS job to the e2e workflow so the relay + Tauri UI path is exercised on macOS (`.github/workflows/desktop-operator-e2e.yml`).
- Add outage documentation summarizing the incident, root causes, fixes, tests added, and follow-ups (`outages/2026-05-24-desktop-macos-start-operator-e2e-gap.md`).

### Testing
- Ran desktop frontend install and tests: `npm ci` (in `desktop-tauri`) completed successfully and `npm test -- --run` (in `desktop-tauri`) ran the React unit tests and all tests passed (6/6).
- Ran `pre-commit run --all-files` which exercised repo checks and surfaced pre-existing unrelated YAML parse failures in chart templates; those YAML failures are unrelated to this change and were not introduced here.
- Updated e2e coverage and CI pipeline: a dedicated macOS UI e2e job was added to `.github/workflows/desktop-operator-e2e.yml` to validate the relay + Tauri start-operator flow on macOS (the job will run in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13676069a4832f85b7fe0c61b69f55)