### PR TITLE
Bundle stdlib-backed `requests` for deterministic macOS desktop bridge startup

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -58,6 +58,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
         "inference_sidecar.py",
         "model_bridge.py",
         "path_bootstrap.py",
+        "requests.py",
     ):
         shutil.copy2(
             REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / filename,

--- a/desktop-tauri/src-tauri/python/requests.py
+++ b/desktop-tauri/src-tauri/python/requests.py
@@ -1,0 +1,105 @@
+"""Minimal stdlib-backed subset of the ``requests`` API for desktop bridge runtime.
+
+This module exists so packaged desktop Python bridge scripts do not depend on
+user-global ``requests`` installations. It intentionally implements only the
+surface used by token.place bridge startup/runtime paths.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+
+class RequestException(Exception):
+    """Base request compatibility exception."""
+
+
+class ConnectionError(RequestException):
+    """Raised on transport/connectivity failures."""
+
+
+class Timeout(RequestException):
+    """Raised on transport timeouts."""
+
+
+class HTTPError(RequestException):
+    """Raised when ``raise_for_status`` sees a non-2xx response."""
+
+
+@dataclass
+class Response:
+    status_code: int
+    content: bytes
+    headers: Dict[str, str]
+    reason: str = ""
+
+    @property
+    def text(self) -> str:
+        return self.content.decode("utf-8", errors="replace")
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"{self.status_code} {self.reason}".strip())
+
+    def iter_lines(self, decode_unicode: bool = False) -> Iterator[str | bytes]:
+        for line in self.content.splitlines():
+            if decode_unicode:
+                yield line.decode("utf-8", errors="replace")
+            else:
+                yield line
+
+
+def _perform(
+    method: str,
+    url: str,
+    *,
+    json_payload: Optional[Dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+) -> Response:
+    headers = {"Accept": "application/json"}
+    body: bytes | None = None
+    if json_payload is not None:
+        body = json.dumps(json_payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urlrequest.Request(url, method=method, data=body, headers=headers)
+    try:
+        with urlrequest.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            raw = resp.read()
+            return Response(
+                status_code=int(getattr(resp, "status", 200)),
+                content=raw,
+                headers={k: v for k, v in resp.headers.items()},
+                reason=getattr(resp, "reason", "") or "",
+            )
+    except urlerror.HTTPError as exc:
+        raw = exc.read() if hasattr(exc, "read") else b""
+        return Response(
+            status_code=int(getattr(exc, "code", 500)),
+            content=raw,
+            headers={k: v for k, v in getattr(exc, "headers", {}).items()},
+            reason=getattr(exc, "reason", "") or "",
+        )
+    except urlerror.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        if isinstance(reason, TimeoutError) or isinstance(reason, socket.timeout):
+            raise Timeout(str(exc)) from exc
+        raise ConnectionError(str(exc)) from exc
+    except TimeoutError as exc:
+        raise Timeout(str(exc)) from exc
+
+
+def get(url: str, *, timeout: Optional[float] = None, stream: bool = False) -> Response:
+    del stream  # compatibility arg
+    return _perform("GET", url, timeout=timeout)
+
+
+def post(url: str, *, json: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> Response:
+    return _perform("POST", url, json_payload=json, timeout=timeout)

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -442,6 +442,7 @@ mod tests {
             "python/inference_sidecar.py",
             "python/model_bridge.py",
             "python/path_bootstrap.py",
+            "python/requests.py",
             "../../utils",
             "../../config.py",
             "../../encrypt.py",

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -31,6 +31,7 @@
       "python/inference_sidecar.py",
       "python/model_bridge.py",
       "python/path_bootstrap.py",
+      "python/requests.py",
       "../../utils",
       "../../config.py",
       "../../encrypt.py",

--- a/outages/2026-05-24-desktop-macos-bridge-requests-missing.json
+++ b/outages/2026-05-24-desktop-macos-bridge-requests-missing.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-24",
+  "slug": "desktop-macos-bridge-requests-missing",
+  "summary": "macOS desktop operator startup failed with `No module named 'requests'` before bridge startup events in clean packaged/runtime environments.",
+  "impact": "Operators could not start from the desktop app unless the host Python environment happened to provide `requests`.",
+  "fix": "Bundled a stdlib-backed `requests` compatibility module with desktop Python resources and aligned packaged e2e fixtures/resource guards to enforce deterministic bridge imports.",
+  "lessons": "Desktop bridge startup dependencies must be explicitly packaged and tested in clean environments that do not inherit global/site Python modules."
+}

--- a/outages/2026-05-24-desktop-macos-bridge-requests-missing.md
+++ b/outages/2026-05-24-desktop-macos-bridge-requests-missing.md
@@ -1,0 +1,33 @@
+# 2026-05-24 macOS desktop operator startup failure (`No module named 'requests'`)
+
+## Summary
+macOS desktop operator startup could fail before the bridge emitted its startup event when packaged/runtime Python could not import `requests`.
+
+## User impact
+- Clicking **Start operator** could immediately fail with:
+  - `compute-node bridge exited before emitting a startup event: No module named 'requests'`
+- Operator remained unavailable even though the UI startup error plumbing existed.
+
+## Symptoms
+- `Running` did not stabilize at `yes`.
+- **Last error** showed a bridge startup/import failure.
+- Failures reproduced in clean Python environments without contributor-local site-packages.
+
+## Root cause
+`compute_node_bridge.py` imports shared runtime modules (`utils.compute_node_runtime` -> `utils.networking.relay_client` and `utils.llm.model_manager`) that import `requests` at module import time. Packaged desktop Python resources did not include a deterministic `requests` runtime dependency.
+
+## Why existing tests missed it
+- Prior coverage depended on environments where `requests` was already present (global/site packages or dev venv), masking packaging/runtime dependency gaps.
+- macOS packaged startup coverage existed but did not guarantee dependency independence from ambient Python installs in all paths.
+
+## Fix implemented
+- Added a bundled stdlib-backed `desktop-tauri/src-tauri/python/requests.py` compatibility module implementing the subset of `requests` used by bridge startup/runtime (`get`, `post`, `Response`, and request exceptions).
+- Included the compatibility module in Tauri bundled resources.
+- Updated packaged operator e2e resource layout fixture to include the same module so tests mirror packaged app behavior.
+
+## Tests added/updated
+- Updated Tauri resource-guard unit test to require `python/requests.py` in bundle resources.
+- Updated packaged operator e2e layout fixture to copy `requests.py`, keeping clean-environment startup checks deterministic.
+
+## Follow-up
+- Continue converging bridge/runtime networking code onto explicit deterministic runtime surfaces so ambient Python packages cannot mask missing packaged dependencies.


### PR DESCRIPTION
### Motivation
- The desktop Tauri operator could fail during startup with: `compute-node bridge exited before emitting a startup event: No module named 'requests'` because bridge import-time paths pulled in `requests` that was not guaranteed in isolated packaged Python runtimes.  
- The intent is to make packaged and dev desktop startup deterministic and independent of the host/global Python environment by removing the undeclared runtime dependency from the bridge startup path.

### Description
- Added a minimal stdlib-backed `requests` compatibility shim at `desktop-tauri/src-tauri/python/requests.py` implementing the subset used by the bridge (`get`, `post`, `Response`, and compatible exceptions).  
- Included `python/requests.py` in Tauri bundle resources in `desktop-tauri/src-tauri/tauri.conf.json` so packaged macOS apps include the compatibility module.  
- Updated the Rust bundle-resource guard test in `desktop-tauri/src-tauri/src/main.rs` to require the new `python/requests.py` entry and updated the packaged-layout e2e fixture in `desktop-tauri/scripts/test_packaged_operator_e2e.py` to copy `requests.py` into the synthetic packaged `resources/python` layout.  
- Added outage documentation for the incident as `outages/2026-05-24-desktop-macos-bridge-requests-missing.md` and its JSON sidecar `outages/2026-05-24-desktop-macos-bridge-requests-missing.json`.

### Testing
- Ran the packaged-layout clean-environment regression with `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and the script completed successfully validating the bridge `inspect`/startup probe in a `PYTHONNOUSERSITE` environment (pass).  
- Executed the Tauri bundle resource unit test with `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml tauri_bundle_resources_include_python_bridge_scripts` but the run failed in this Linux CI container due to missing system `glib-2.0` / `pkg-config` native deps required by Tauri GTK tooling (environment failure, not a code regression).  
- Ran `pre-commit run --all-files` which completed its configured hooks for the changed files, but reported pre-existing unrelated `check-yaml` failures in `charts/tokenplace/templates/*.yaml` not introduced by this change (partial pass, unrelated failures).  
- Verification summary: `test_packaged_operator_e2e.py` confirms the bridge startup no longer fails with `No module named 'requests'` in a clean packaged layout, the package now deterministically ships a `requests` shim, and CI-native Tauri tests require system tooling not available in this container (listed limitation).

Files changed (exact):
- `desktop-tauri/src-tauri/python/requests.py` (new)
- `desktop-tauri/src-tauri/tauri.conf.json` (added bundle resource)
- `desktop-tauri/src-tauri/src/main.rs` (updated bundle-resource guard test)
- `desktop-tauri/scripts/test_packaged_operator_e2e.py` (fixture copy updated)
- `outages/2026-05-24-desktop-macos-bridge-requests-missing.md` (new)
- `outages/2026-05-24-desktop-macos-bridge-requests-missing.json` (new)

Remaining limitations and follow-ups:
- Full macOS packaged-app UI e2e using Tauri driver (native WebDriver + macOS packaging) was not executed here due to environment limits; the strongest practical automated substitute (`test_packaged_operator_e2e.py`) was run and passed.  
- The `cargo test` Tauri unit requires system `glib`/`pkg-config` on the runner; add those system deps to the macOS CI job or run that test on proper macOS/Linux images with required native libraries as a CI follow-up.  
- Encourage future work to reduce ambient import-time side effects so third-party networking surfaces are explicit and minimal for packaging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138364cb3c832f8adeec656d911d81)