### PR TITLE
Fix macOS desktop bridge startup failure by removing startup-time requests dependency

### DIFF
--- a/outages/2026-05-24-macos-compute-node-requests-dependency.md
+++ b/outages/2026-05-24-macos-compute-node-requests-dependency.md
@@ -1,0 +1,27 @@
+# 2026-05-24 macOS desktop compute-node startup dependency gap
+
+## Summary
+macOS desktop operator startup could fail before emitting a bridge startup event with `No module named 'requests'`.
+
+## User impact
+Users could click **Start operator** and see the operator stay stopped with a bridge startup error in the UI.
+
+## Symptoms
+- UI last-error area reported: `compute-node bridge exited before emitting a startup event: No module named 'requests'`.
+- `Running` did not reach a stable started+registered state.
+
+## Root cause
+`utils/llm/model_manager.py` imported `requests` at module import time even though bridge startup only needed runtime/model metadata initialization and not the third-party client. In packaged/clean Python environments where `requests` was absent, import failed before startup events.
+
+## Why existing tests missed it
+Existing desktop tests ran in environments where `requests` was already installed, so they did not assert bridge startup-path imports under a blocked/clean dependency surface.
+
+## Fix implemented
+- Removed `requests` dependency from `utils/llm/model_manager.py` by switching model download I/O to `urllib.request`/`urllib.error` (standard library).
+- Added a unit test that blocks `requests` imports and verifies `utils.llm.model_manager` still imports successfully.
+
+## Tests added/repaired
+- `tests/unit/test_model_manager_imports.py::test_model_manager_imports_without_requests_dependency`
+
+## Follow-up
+- Extend desktop operator start e2e to run in a stricter clean-environment Python job on macOS CI to catch undeclared bridge import dependencies earlier.

--- a/tests/unit/test_model_manager_imports.py
+++ b/tests/unit/test_model_manager_imports.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_model_manager_imports_without_requests_dependency(monkeypatch):
+    class _BlockRequestsFinder:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == 'requests' or fullname.startswith('requests.'):
+                raise ModuleNotFoundError("No module named 'requests'", name='requests')
+            return None
+
+    sys.modules.pop('utils.llm.model_manager', None)
+    finder = _BlockRequestsFinder()
+    sys.meta_path.insert(0, finder)
+    try:
+        module = importlib.import_module('utils.llm.model_manager')
+    finally:
+        sys.meta_path.remove(finder)
+
+    assert hasattr(module, 'ModelManager')

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -4,11 +4,12 @@ Model manager module for handling LLM model downloading, initialization and infe
 import os
 import time
 import logging
-import requests
 import json
 import sys
 import importlib
 from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
 from threading import Lock
 from unittest.mock import MagicMock
 from typing import Dict, List, Any, Optional, Union, Tuple, Iterable
@@ -120,6 +121,33 @@ def llama_cpp_verbose_logging_enabled() -> bool:
         os.getenv('TOKEN_PLACE_VERBOSE_LLM_LOGS') == '1'
         or os.getenv('TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS') == '1'
     )
+
+
+class _UrllibResponseAdapter:
+    def __init__(self, response):
+        self._response = response
+        self.status_code = getattr(response, 'status', 200)
+        self.headers = response.headers
+
+    def iter_content(self, chunk_size: int):
+        while True:
+            data = self._response.read(chunk_size)
+            if data == b'':
+                return
+            yield data
+
+
+class _RequestsCompat:
+    RequestException = URLError
+
+    @staticmethod
+    def get(url: str, *, stream: bool = True, timeout: int | float | None = None):
+        del stream
+        response = urlopen(url, timeout=timeout)  # noqa: S310
+        return _UrllibResponseAdapter(response)
+
+
+requests = _RequestsCompat()
 
 
 class ModelManager:
@@ -324,7 +352,11 @@ class ModelManager:
             bool: True if download was successful, False otherwise
         """
         chunk_size_bytes = chunk_size_mb * 1024 * 1024  # Convert MB to bytes
-        response = requests.get(url, stream=True, timeout=self.download_timeout)
+        try:
+            response = requests.get(url, stream=True, timeout=self.download_timeout)
+        except requests.RequestException as exc:
+            self.log_error(f"Error: Unable to download file: {exc}")
+            return False
 
         if response.status_code != 200:
             self.log_error(f"Error: Unable to download file, status code {response.status_code}")


### PR DESCRIPTION
### Motivation
- The desktop compute-node bridge could exit early on macOS with `No module named 'requests'` because `utils/llm/model_manager.py` imported `requests` at module import time.  
- Packaged/clean Python environments must not rely on user-global or contributor-local Python packages during bridge startup.  

### Description
- Replaced the startup-time third-party `requests` dependency in `utils/llm/model_manager.py` with a small stdlib-backed compatibility adapter using `urllib.request`/`urllib.error`, preserving the `requests.get(...)`-shaped call site for minimal risk.  
- Added a regression unit test `tests/unit/test_model_manager_imports.py` that blocks `requests` via a `sys.meta_path` finder and verifies `utils.llm.model_manager` still imports.  
- Added outage documentation `outages/2026-05-24-macos-compute-node-requests-dependency.md` summarizing the incident, root cause, tests that missed it, the fix, and follow-up.  
- Files changed: `utils/llm/model_manager.py`, `tests/unit/test_model_manager_imports.py`, and `outages/2026-05-24-macos-compute-node-requests-dependency.md`.  

### Testing
- Ran `pytest -q tests/unit/test_model_manager.py tests/unit/test_model_manager_imports.py`, which passed locally with `45 passed` and the new import-blocking test passing.  
- Ran the packaged-layout bridge sanity script `python desktop-tauri/scripts/test_packaged_operator_e2e.py` as the strongest available packaged-bridge substitute and it completed successfully in this environment.  
- Ran `pytest -q tests/unit/test_model_manager_imports.py` individually to confirm the import-blocking regression test passes.  
- Executed `pre-commit run --all-files` which surfaced unrelated repo-wide checks (`check-yaml` and broader `run-checks`) failing outside the scope of this targeted fix, so those failures are pre-existing and not caused by this change.  

Remaining limitations and follow-ups:  
- Full macOS packaged-app GUI e2e (packaged Tauri app on macOS CI) was not executed in this Linux CI environment and should be enabled on macOS CI to catch future packaging-time import gaps; a follow-up to extend macOS CI e2e coverage is recommended.  
- Pre-commit repo-wide failures (YAML template parse and `run-checks`) are pre-existing and outside this fix scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138364cb3c832f8adeec656d911d81)