### PR TITLE
Fix macOS desktop bridge startup failure by bundling minimal `requests` shim

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -58,6 +58,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
         "inference_sidecar.py",
         "model_bridge.py",
         "path_bootstrap.py",
+        "requests.py",
     ):
         shutil.copy2(
             REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / filename,
@@ -75,7 +76,10 @@ def create_packaged_layout(tmp_root: Path) -> Path:
 def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
     env = os.environ.copy()
     env["PYTHONNOUSERSITE"] = "1"
-    env.pop("PYTHONPATH", None)
+    env["PYTHONPATH"] = os.pathsep.join([
+        str(tmp_root / "resources" / "python"),
+        str(tmp_root / "resources"),
+    ])
 
     model_bridge = tmp_root / "resources" / "python" / "model_bridge.py"
     result = subprocess.run(  # noqa: S603

--- a/desktop-tauri/src-tauri/python/requests.py
+++ b/desktop-tauri/src-tauri/python/requests.py
@@ -1,0 +1,79 @@
+"""Minimal requests-compatible shim for desktop bridge runtime.
+
+This module intentionally implements only the subset used by the desktop
+compute-node bridge startup/polling path so packaged apps do not depend on a
+system-installed third-party ``requests`` package.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+class RequestException(Exception):
+    """Base request error."""
+
+
+class ConnectionError(RequestException):
+    """Raised when network connection fails."""
+
+
+class Timeout(RequestException):
+    """Raised when a request times out."""
+
+
+class HTTPError(RequestException):
+    """Raised for HTTP status failures."""
+
+
+@dataclass
+class Response:
+    status_code: int
+    _body: bytes
+
+    @property
+    def text(self) -> str:
+        return self._body.decode("utf-8", errors="replace")
+
+    def json(self) -> Any:
+        return _json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"HTTP {self.status_code}: {self.text}")
+
+
+def _request(method: str, url: str, *, json: Any = None, timeout: float | None = None) -> Response:
+    headers = {"Accept": "application/json"}
+    data = None
+    if json is not None:
+        data = _json.dumps(json).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return Response(status_code=resp.status, _body=resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read() if hasattr(exc, "read") else b""
+        return Response(status_code=int(exc.code), _body=body)
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, socket.timeout):
+            raise Timeout(str(exc)) from exc
+        raise ConnectionError(str(exc)) from exc
+    except TimeoutError as exc:
+        raise Timeout(str(exc)) from exc
+
+
+def get(url: str, *, timeout: float | None = None, **_kwargs: Any) -> Response:
+    return _request("GET", url, timeout=timeout)
+
+
+def post(url: str, *, json: Any = None, timeout: float | None = None, **_kwargs: Any) -> Response:
+    return _request("POST", url, json=json, timeout=timeout)

--- a/outages/2026-05-24-macos-desktop-bridge-requests-dependency.md
+++ b/outages/2026-05-24-macos-desktop-bridge-requests-dependency.md
@@ -1,0 +1,27 @@
+# 2026-05-24 — macOS desktop operator startup failed on missing `requests`
+
+## Summary
+macOS desktop operator startup could fail before registration when the packaged compute-node bridge attempted to import Python's third-party `requests` package in an environment where it was not bundled.
+
+## User impact
+Desktop users saw startup fail and operator never reached a stable running/registered state.
+
+## Symptoms
+- UI “Last error” showed: `compute-node bridge exited before emitting a startup event: No module named 'requests'`.
+- `Running` did not remain healthy because bridge startup terminated early.
+
+## Root cause
+Bridge startup imports `utils/networking/relay_client.py`, which imports `requests` at module import time. Packaged desktop startup did not guarantee a bundled `requests` dependency for that runtime path.
+
+## Why tests missed it
+Prior coverage did not enforce a bridge-only import environment that excludes system/global Python packages while still executing the packaged startup path.
+
+## Fix implemented
+- Added a desktop-bridge-local `requests` compatibility shim implemented with Python stdlib (`urllib`) under `desktop-tauri/src-tauri/python/requests.py`.
+- Updated packaged operator e2e layout to include this shim and force bridge/import probes to run with packaged-resource-first `PYTHONPATH`.
+
+## Tests added/repaired
+- Updated `desktop-tauri/scripts/test_packaged_operator_e2e.py` so packaged-mode probes and startup execution prioritize packaged resources and detect missing undeclared modules in the bridge path.
+
+## Follow-up
+- Keep bridge startup dependency checks in packaged-mode e2e to prevent regressions where startup depends on non-packaged third-party modules.


### PR DESCRIPTION
### Motivation
- Packaged macOS Tauri desktop operator could exit early with `No module named 'requests'` because the compute-node bridge import path relied on a third-party `requests` package that may not be present in packaged/clean runtimes.
- The fix must make packaged desktop startup deterministic without relying on users' global Python, Homebrew, or contributor virtualenvs.

### Description
- Add a minimal, urllib-backed `requests` compatibility shim at `desktop-tauri/src-tauri/python/requests.py` implementing `get`, `post`, `Response`, and the common `requests` exception types used by the bridge and relay client.
- Update the packaged-layout e2e probe `desktop-tauri/scripts/test_packaged_operator_e2e.py` to copy the shim into the packaged resources and force packaged-resource-first import resolution by setting `PYTHONPATH` to the packaged `resources/python` and `PYTHONNOUSERSITE=1` so local/global site-packages cannot mask undeclared dependencies.
- Add outage documentation `outages/2026-05-24-macos-desktop-bridge-requests-dependency.md` describing the incident, root cause, fix, and follow-ups.
- Files changed: `desktop-tauri/src-tauri/python/requests.py`, `desktop-tauri/scripts/test_packaged_operator_e2e.py`, and `outages/2026-05-24-macos-desktop-bridge-requests-dependency.md`.

### Testing
- Ran the packaged-operator probe with `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, which completed successfully in this environment and validated the bridge startup/inspect path when packaged resources are used (✅).
- Ran `pre-commit run --all-files`, which executed and passed most hooks but failed on unrelated YAML parsing in `charts/tokenplace/templates/*.yaml` (existing repository issue) and therefore did not block this change (⚠️).
- Verification summary: the bridge startup path no longer fails with `No module named 'requests'` when executed from the packaged-layout probe because the shim is present and `PYTHONPATH` prioritizes packaged resources, and the e2e probe asserts the bridge emits `started` and `registered` events.

Notes and limitations: this change implements the smallest targeted fix by shipping a tiny compatibility shim rather than adding a global dependency; full macOS packaged-app GUI e2e in CI is still environment-dependent and out of scope for this patch, so follow-up should enable macOS-packaged smoke tests in CI if practical.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138364cb3c832f8adeec656d911d81)