### PR TITLE
Desktop: bootstrap macOS desktop Python deps and add no-relay autostart guards

### DIFF
--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Best-effort lifecycle guard: desktop launch/close must not leave relay.py on 5010."""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MACOS_DEBUG_APP = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug" / "bundle" / "macos" / "token.place desktop.app" / "Contents" / "MacOS" / "token.place desktop"
+
+
+def _run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def _assert_no_localhost_5010_listener() -> None:
+    output = _run(["lsof", "-nP", "-iTCP:5010", "-sTCP:LISTEN"])
+    assert "relay.py" not in output, output
+
+
+def main() -> int:
+    if platform.system() != "Darwin":
+        print("skip: lifecycle e2e targets macOS only")
+        return 0
+    if not MACOS_DEBUG_APP.exists():
+        print(f"skip: debug desktop binary not found at {MACOS_DEBUG_APP}")
+        return 0
+
+    _assert_no_localhost_5010_listener()
+    proc = subprocess.Popen([str(MACOS_DEBUG_APP)], cwd=REPO_ROOT)  # noqa: S603
+    try:
+        time.sleep(5)
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+    time.sleep(1)
+    _assert_no_localhost_5010_listener()
+    relay_ps = _run(["ps", "aux"])
+    assert "relay.py" not in relay_ps, relay_ps
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -58,6 +58,7 @@ def create_packaged_layout(tmp_root: Path) -> Path:
         "inference_sidecar.py",
         "model_bridge.py",
         "path_bootstrap.py",
+        "requirements_desktop_runtime.txt",
     ):
         shutil.copy2(
             REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / filename,

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -36,6 +36,7 @@ GPU_RUNTIME_FATAL_ACTIONS = frozenset(
 PIP_INSTALL_TIMEOUT_SECONDS = 300
 PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
 INSTALL_ERROR_SUMMARY_MAX_LEN = 512
+DEPENDENCY_BOOTSTRAP_TIMEOUT_SECONDS = 300
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
 ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
@@ -441,11 +442,53 @@ def _resolve_requirements_path(target_root: Path) -> Path:
     return candidates[0]
 
 
+def _resolve_desktop_runtime_requirements_path(target_root: Path) -> Path:
+    candidates = [
+        target_root / "python" / "requirements_desktop_runtime.txt",
+        target_root / "resources" / "python" / "requirements_desktop_runtime.txt",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _ensure_desktop_runtime_dependencies(target_root: Path) -> tuple[bool, str, str]:
+    requirements_path = _resolve_desktop_runtime_requirements_path(target_root)
+    if not requirements_path.exists():
+        return True, "manifest_missing", f"desktop runtime requirements manifest not found at {requirements_path}"
+
+    cmd = [sys.executable, "-m", "pip", "install", "-r", str(requirements_path)]
+    ok, output = _run_pip_install(
+        cmd,
+        os.environ.copy(),
+        timeout_seconds=DEPENDENCY_BOOTSTRAP_TIMEOUT_SECONDS,
+    )
+    if ok:
+        return True, "installed", "desktop runtime dependencies available"
+    return False, "install_failed", _summarize_install_error(output)
+
+
 def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
     target_root = _resolve_runtime_root(repo_root=repo_root)
+    dep_ok, dep_action, dep_reason = _ensure_desktop_runtime_dependencies(target_root)
+    if not dep_ok:
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                f"desktop runtime dependency bootstrap failed (action={dep_action}, "
+                f"interpreter={sys.executable}): {dep_reason}"
+            ),
+            "runtime_action": "dependency_bootstrap_failed",
+            "detected_device": "cpu",
+            "interpreter": sys.executable,
+            "prefix": sys.prefix,
+            "interpreter_prefix": sys.prefix,
+            "llama_module_path": "unknown",
+        }
     before = _probe_runtime(target_root)
     if _is_repo_local_llama_module(before.llama_module_path, target_root):
         return {

--- a/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
+++ b/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
@@ -1,0 +1,3 @@
+psutil==7.1.0
+requests==2.32.5
+python-dotenv==1.1.1

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -31,6 +31,7 @@
       "python/inference_sidecar.py",
       "python/model_bridge.py",
       "python/path_bootstrap.py",
+      "python/requirements_desktop_runtime.txt",
       "../../utils",
       "../../config.py",
       "../../encrypt.py",

--- a/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.json
+++ b/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-25",
+  "slug": "desktop-macos-runtime-deps-and-relay-autostart-guard",
+  "summary": "Packaged-like macOS desktop launches could fail before bridge startup when psutil was missing from the resolved interpreter, and desktop coverage lacked explicit no-relay-autostart lifecycle guards.",
+  "impact": "Start operator could fail with an early bridge exit and desktop lifecycle regressions around unintended relay startup on localhost:5010 were not explicitly guarded.",
+  "fix": "Bundled a curated desktop runtime dependency manifest, added deterministic dependency bootstrap in desktop_runtime_setup for the chosen interpreter, made resource_monitor resilient to missing psutil, added static no-relay-autostart tests, and added a macOS lifecycle e2e guard script asserting no relay.py/localhost:5010 leakage after app close.",
+  "lessons": "Packaged desktop runtime dependencies must be app-owned and validated against the exact interpreter path with PYTHONNOUSERSITE semantics, and desktop lifecycle tests should explicitly guard against accidental local relay autostart."
+}

--- a/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.md
+++ b/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.md
@@ -1,0 +1,44 @@
+# Outage: desktop macOS bridge dependency gap and relay autostart regression guard
+
+- **Date:** 2026-05-25
+- **Slug:** `desktop-macos-runtime-deps-and-relay-autostart-guard`
+- **Affected area:** desktop-tauri operator startup and desktop process lifecycle
+
+## Summary
+Packaged-like desktop launches on macOS could fail before the bridge emitted a startup event when
+the resolved Python interpreter did not already have `psutil` installed. In the same window, we
+also lacked explicit desktop lifecycle guard coverage proving the app never starts `relay.py`
+locally (including localhost:5010).
+
+## Symptoms
+- UI showed: `compute-node bridge exited before emitting a startup event: No module named 'psutil'`.
+- Operator never reached `Running: yes` in clean packaged-like launches with `PYTHONNOUSERSITE=1`.
+- No dedicated desktop guard test asserted that desktop resources/startup paths exclude relay autostart.
+
+## Root causes
+1. The desktop bridge import chain could reach `utils.system.resource_monitor` before startup status,
+   and `resource_monitor` imported `psutil` at module import time.
+2. Packaged desktop runtime setup did not own deterministic installation/verification of a curated
+   desktop runtime dependency set for the interpreter chosen by Tauri.
+3. Desktop tests lacked explicit no-relay-autostart static/lifecycle checks tied to localhost:5010.
+
+## Why tests missed it
+- Existing packaged bridge coverage primarily validated import/start behavior, but did not guarantee
+  dependency provisioning happened in the exact packaged-interpreter path before bridge runtime import.
+- No dedicated test existed to assert desktop runtime resources/startup code excludes `relay.py`.
+
+## Fix
+- Added a curated desktop runtime dependency manifest bundled in Tauri resources:
+  `desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt`.
+- Added deterministic desktop dependency bootstrap in `desktop_runtime_setup.py` using the selected
+  interpreter before runtime probing.
+- Made `utils.system.resource_monitor` resilient when `psutil` is unavailable (metrics fall back to
+  safe defaults) so optional metrics imports do not crash early startup.
+- Added static guard tests ensuring desktop resources/runtime code do not bundle or spawn `relay.py`.
+- Added a macOS-focused lifecycle e2e guard script asserting no listener on localhost:5010 and no
+  lingering `relay.py` after desktop app launch/close.
+
+## Regression tests
+- `tests/unit/test_desktop_no_relay_autostart.py`
+- `desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py`
+- `desktop-tauri/scripts/test_packaged_operator_e2e.py` (packaged layout now includes curated runtime requirements manifest)

--- a/tests/unit/test_desktop_no_relay_autostart.py
+++ b/tests/unit/test_desktop_no_relay_autostart.py
@@ -1,0 +1,26 @@
+"""Guards that desktop-tauri runtime does not bundle or autostart relay.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tauri_resources_do_not_bundle_relay_py() -> None:
+    tauri_conf = REPO_ROOT / "desktop-tauri" / "src-tauri" / "tauri.conf.json"
+    text = tauri_conf.read_text(encoding="utf-8")
+    assert "relay.py" not in text
+
+
+def test_desktop_runtime_sources_do_not_spawn_relay_py() -> None:
+    desktop_sources = [
+        REPO_ROOT / "desktop-tauri" / "src" / "App.tsx",
+        REPO_ROOT / "desktop-tauri" / "src-tauri" / "src" / "main.rs",
+        REPO_ROOT / "desktop-tauri" / "src-tauri" / "src" / "compute_node.rs",
+        REPO_ROOT / "desktop-tauri" / "src-tauri" / "src" / "python_runtime.rs",
+    ]
+    for source in desktop_sources:
+        content = source.read_text(encoding="utf-8")
+        assert "relay.py" not in content

--- a/utils/system/resource_monitor.py
+++ b/utils/system/resource_monitor.py
@@ -17,7 +17,10 @@ def _gpu_headroom_multiplier(headroom_percent: float) -> float:
         percent = 0.0
     return 1.0 + (percent / 100.0 if percent > 1.0 else percent)
 
-import psutil
+try:
+    import psutil
+except ModuleNotFoundError:  # pragma: no cover - packaged probes can run without psutil installed
+    psutil = None
 
 
 GpuMetrics = Dict[str, float | int | bool]
@@ -166,6 +169,13 @@ def _cpu_interval_for_platform(platform: str) -> float | None:
 
 def collect_resource_usage() -> Dict[str, float | int | bool]:
     """Return current CPU, memory, and GPU utilisation metrics."""
+
+    if psutil is None:
+        return {
+            'cpu_percent': 0.0,
+            'memory_percent': 0.0,
+            **_collect_gpu_metrics(),
+        }
 
     interval = _cpu_interval_for_platform(sys.platform)
 


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop launches could fail early with "No module named 'psutil'" because `resource_monitor` imported `psutil` at module-import time while the Tauri-launched interpreter used `PYTHONNOUSERSITE=1` and might not have site packages installed.
- The desktop app must not start or bundle `relay.py` itself, and tests lacked explicit static/lifecycle guards asserting no accidental relay autostart or a listener on localhost:5010.

### Description
- Added a curated desktop runtime requirements manifest `desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt` (psutil, requests, python-dotenv) and included it in Tauri resources in `tauri.conf.json` so packaged layouts carry a manifest the app can use.
- Implemented deterministic dependency bootstrap in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` that attempts to install the curated manifest into the selected interpreter before performing llama runtime probing, and surfaces actionable diagnostics (action + interpreter + reason) when bootstrap fails.
- Made `utils/system/resource_monitor.py` resilient to missing `psutil` by importing it defensively and returning safe defaults when absent to avoid import-time crashes during bridge startup.
- Updated packaged-layout e2e fixture to stage the new curated requirements file; added static unit guards `tests/unit/test_desktop_no_relay_autostart.py` and a macOS-focused lifecycle guard script `desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py` that asserts no `relay.py` is bundled, spawned, or left listening on `127.0.0.1:5010` after app shutdown.
- Added outage documentation (markdown + JSON) describing the symptom, root cause, test gap, fix, and regression tests.

### Testing
- Ran focused unit suites: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_no_relay_autostart.py tests/unit/test_resource_monitor.py -q` and observed all collected tests pass (73 passed).
- Exercised packaged probe helpers via `python -m pytest tests/unit/test_desktop_packaged_layout.py` and updated the packaged fixture to include the curated manifest so the probe checks for missing deps are effective under `PYTHONNOUSERSITE=1`.
- Ran `pre-commit run --all-files` which completed most hooks successfully but failed on `check-yaml` due to existing Helm template YAML parse issues in `charts/tokenplace/templates/*`; this is an unrelated existing repo lint failure and all other hooks (codespell, vulture, bandit, run project checks) passed.  

Residual risks / follow-ups: packaged installers should still ensure pip is available in the chosen interpreter (bootstrap uses the interpreter's `-m pip`), and the macOS lifecycle e2e is best-effort (skips when the debug app binary is not present); follow-up work could vendor a minimal bootstrapping helper binary or improve installer packaging so runtime dependencies are preinstalled in release DMG/PKG builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1493d11654832fa8306483833eca0a)