### PR TITLE
Desktop: preflight Python runtime deps on macOS and block relay.py autostart

### DIFF
--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""macOS lifecycle guard: desktop app must not autostart or retain relay."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_APP = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug" / "token.place.app"
+
+
+def _port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.3)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _has_process_matching(pattern: str) -> bool:
+    proc = subprocess.run(["ps", "ax"], capture_output=True, text=True, check=False)
+    return proc.returncode == 0 and pattern in proc.stdout
+
+
+def _assert_no_relay_port_listener() -> None:
+    lsof = shutil.which("lsof")
+    if not lsof:
+        assert not _port_in_use(5010), "127.0.0.1:5010 is listening after app shutdown"
+        return
+    probe = subprocess.run(
+        [lsof, "-nP", "-iTCP:5010", "-sTCP:LISTEN"], capture_output=True, text=True, check=False
+    )
+    assert probe.returncode != 0 or "LISTEN" not in probe.stdout, probe.stdout
+
+
+def main() -> int:
+    if platform.system() != "Darwin":
+        print("SKIP: desktop no-relay lifecycle e2e is macOS-only")
+        return 0
+    if not DESKTOP_APP.exists():
+        print(f"SKIP: desktop app binary not found: {DESKTOP_APP}")
+        return 0
+
+    env = os.environ.copy()
+    env["TOKENPLACE_DESKTOP_SKIP_AUTOSTART"] = "1"
+    env["TOKENPLACE_DESKTOP_DISABLE_OPERATOR_AUTOSTART"] = "1"
+
+    with tempfile.TemporaryDirectory(prefix="token-place-no-relay-home-") as home:
+        env["HOME"] = home
+        app = subprocess.Popen(
+            ["open", "-W", str(DESKTOP_APP)],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        time.sleep(2)
+        subprocess.run(["osascript", "-e", 'tell application "token.place" to quit'], check=False)
+        app.wait(timeout=60)
+
+    assert not _has_process_matching("relay.py"), "relay.py process exists after desktop shutdown"
+    _assert_no_relay_port_listener()
+    assert not _has_process_matching("python relay.py"), "detached python relay.py remains after shutdown"
+    assert not _has_process_matching("launchctl.*relay"), "launchctl relay job remains after shutdown"
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -127,7 +127,7 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
         [
             sys.executable,
             "-c",
-            "import psutil,requests,dotenv; print('desktop-runtime-imports-ok')",
+            "import psutil,requests,dotenv,cryptography; print('desktop-runtime-imports-ok')",
         ],
         cwd=tmp_root,
         env=env,

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -141,6 +141,7 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
         "No module named 'psutil'",
         "No module named 'requests'",
         "No module named 'dotenv'",
+        "No module named 'cryptography'",
         "NotOpenSSLWarning",
         "~/Library/Python",
     ]

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -75,6 +75,36 @@ def create_packaged_layout(tmp_root: Path) -> Path:
     return python_dir / "compute_node_bridge.py"
 
 
+def run_desktop_dependency_preflight(tmp_root: Path) -> None:
+    resources_root = tmp_root / "resources"
+    env = os.environ.copy()
+    env["PYTHONNOUSERSITE"] = "1"
+    env["TOKEN_PLACE_PYTHON_IMPORT_ROOT"] = str(resources_root)
+    env["PYTHONPATH"] = str(resources_root / "python")
+
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, pathlib, sys; "
+                "sys.path.insert(0, r'" + str(resources_root / 'python') + "'); "
+                "import desktop_runtime_setup as mod; "
+                "print(json.dumps(mod.ensure_desktop_python_dependencies()))"
+            ),
+        ],
+        cwd=tmp_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, combined
+    payload = json.loads(result.stdout.strip())
+    assert payload.get("ok") == "true", combined
+
+
 def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
     env = os.environ.copy()
     env["PYTHONNOUSERSITE"] = "1"
@@ -193,6 +223,7 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
         bridge_script = create_packaged_layout(Path(tmpdir))
+        run_desktop_dependency_preflight(Path(tmpdir))
         run_model_bridge_inspect_probe(Path(tmpdir))
         run_compute_bridge_import_probe(Path(tmpdir))
 

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -55,9 +55,12 @@ def create_packaged_layout(tmp_root: Path) -> Path:
 
     for filename in (
         "compute_node_bridge.py",
+        "desktop_runtime_setup.py",
+        "desktop_gpu_packaging.py",
         "inference_sidecar.py",
         "model_bridge.py",
         "path_bootstrap.py",
+        "requirements_desktop_runtime.txt",
     ):
         shutil.copy2(
             REPO_ROOT / "desktop-tauri" / "src-tauri" / "python" / filename,
@@ -119,6 +122,21 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
     forbidden_stderr_only = ["/Users/", "~/Library/Python"]
     for marker in forbidden_stderr_only:
         assert marker not in result.stderr, combined
+
+    check_imports = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "import psutil,requests,dotenv; print('desktop-runtime-imports-ok')",
+        ],
+        cwd=tmp_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert check_imports.returncode == 0, f"{check_imports.stdout}\n{check_imports.stderr}"
+    assert "desktop-runtime-imports-ok" in check_imports.stdout
 
 
 
@@ -296,6 +314,15 @@ def main() -> int:
                 bridge.wait(timeout=15)
             if bridge.returncode != 0:
                 raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
+            forbidden_output = (
+                "No module named",
+                "ModuleNotFoundError",
+                "ImportError",
+                "compute-node bridge exited before emitting a startup event",
+                "desktop_runtime_setup module missing",
+            )
+            for marker in forbidden_output:
+                assert marker not in bridge_output, bridge_output
 
         finally:
             if bridge is not None and bridge.poll() is None:

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -75,12 +75,21 @@ def create_packaged_layout(tmp_root: Path) -> Path:
     return python_dir / "compute_node_bridge.py"
 
 
-def run_desktop_dependency_preflight(tmp_root: Path) -> None:
+def _packaged_env(tmp_root: Path) -> dict[str, str]:
     resources_root = tmp_root / "resources"
+    home_dir = tmp_root / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
+    env["HOME"] = str(home_dir)
     env["PYTHONNOUSERSITE"] = "1"
     env["TOKEN_PLACE_PYTHON_IMPORT_ROOT"] = str(resources_root)
     env["PYTHONPATH"] = str(resources_root / "python")
+    return env
+
+
+def run_desktop_dependency_preflight(tmp_root: Path) -> None:
+    resources_root = tmp_root / "resources"
+    env = _packaged_env(tmp_root)
 
     result = subprocess.run(  # noqa: S603
         [
@@ -106,9 +115,7 @@ def run_desktop_dependency_preflight(tmp_root: Path) -> None:
 
 
 def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
-    env = os.environ.copy()
-    env["PYTHONNOUSERSITE"] = "1"
-    env.pop("PYTHONPATH", None)
+    env = _packaged_env(tmp_root)
 
     model_bridge = tmp_root / "resources" / "python" / "model_bridge.py"
     result = subprocess.run(  # noqa: S603
@@ -158,7 +165,16 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
         [
             sys.executable,
             "-c",
-            "import psutil,requests,dotenv,cryptography; print('desktop-runtime-imports-ok')",
+            (
+                "import pathlib,sys; "
+                "python_dir=pathlib.Path(r'" + str(model_bridge.parent) + "'); "
+                "sys.path.insert(0,str(python_dir)); "
+                "import desktop_runtime_setup as mod; "
+                "payload=mod.ensure_desktop_python_dependencies(); "
+                "assert payload.get('ok')=='true', payload; "
+                "import psutil,requests,dotenv,cryptography; "
+                "print('desktop-runtime-imports-ok')"
+            ),
         ],
         cwd=tmp_root,
         env=env,
@@ -172,9 +188,7 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
 
 
 def run_compute_bridge_import_probe(tmp_root: Path) -> None:
-    env = os.environ.copy()
-    env["PYTHONNOUSERSITE"] = "1"
-    env.pop("PYTHONPATH", None)
+    env = _packaged_env(tmp_root)
 
     compute_bridge = tmp_root / "resources" / "python" / "compute_node_bridge.py"
     result = subprocess.run(  # noqa: S603

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -41,8 +41,15 @@ except ModuleNotFoundError:
             "fallback_reason": "desktop_runtime_setup module missing",
         }
 
-    def ensure_desktop_python_dependencies(*, runtime_root: Optional[Path] = None) -> Dict[str, str]:
-        return {"ok": "true", "action": "desktop_runtime_setup module missing", "missing": ""}
+    def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> Dict[str, str]:
+        return {
+            "ok": "false",
+            "action": "desktop_runtime_setup module missing",
+            "missing": "unknown",
+            "interpreter": sys.executable,
+            "import_root": str(repo_root) if repo_root is not None else "unknown",
+            "detail": "desktop_runtime_setup module missing",
+        }
 
     def maybe_reexec_for_runtime_refresh(
         _runtime_setup: Dict[str, str], *, allow_reexec: bool = True

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -26,6 +26,7 @@ try:
     from desktop_runtime_setup import (
         desktop_gpu_runtime_failure_message,
         ensure_desktop_llama_runtime,
+        ensure_desktop_python_dependencies,
         maybe_reexec_for_runtime_refresh,
     )
 except ModuleNotFoundError:
@@ -40,6 +41,9 @@ except ModuleNotFoundError:
             "fallback_reason": "desktop_runtime_setup module missing",
         }
 
+    def ensure_desktop_python_dependencies(*, runtime_root: Optional[Path] = None) -> Dict[str, str]:
+        return {"ok": "true", "action": "desktop_runtime_setup module missing", "missing": ""}
+
     def maybe_reexec_for_runtime_refresh(
         _runtime_setup: Dict[str, str], *, allow_reexec: bool = True
     ) -> None:
@@ -47,11 +51,13 @@ except ModuleNotFoundError:
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
-try:
-    from utils.llm.model_manager import _is_repo_llama_cpp_shim
-except ModuleNotFoundError:
-    def _is_repo_llama_cpp_shim(_module_path: Any) -> bool:
+
+def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
+    try:
+        from utils.llm.model_manager import _is_repo_llama_cpp_shim as _shim_detector
+    except ModuleNotFoundError:
         return False
+    return _shim_detector(module_path)
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
@@ -235,6 +241,21 @@ def run(args: argparse.Namespace) -> int:
         f"repo_llama_cpp_shim_imported={repo_llama_cpp_shim_imported}",
         file=sys.stderr,
     )
+    dependency_setup = ensure_desktop_python_dependencies()
+    if dependency_setup.get("ok") != "true":
+        missing = dependency_setup.get("missing") or "unknown"
+        detail = dependency_setup.get("detail") or dependency_setup.get("action") or "dependency bootstrap failed"
+        emit({
+            "type": "error",
+            "message": (
+                "desktop runtime dependency preflight failed "
+                f"(interpreter={dependency_setup.get('interpreter', sys.executable)} "
+                f"import_root={dependency_setup.get('import_root', 'unknown')} "
+                f"missing={missing}): {detail}"
+            ),
+        })
+        return 1
+
     gpu_runtime_error = desktop_gpu_runtime_failure_message(args.mode, runtime_setup)
     if gpu_runtime_error:
         emit({"type": "error", "message": gpu_runtime_error})

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -240,14 +240,6 @@ def run(args: argparse.Namespace) -> int:
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
     )
-    repo_llama_cpp_shim_imported = _is_repo_llama_cpp_shim(
-        runtime_setup.get("llama_module_path", "")
-    )
-    print(
-        "desktop.runtime_setup.import_guard "
-        f"repo_llama_cpp_shim_imported={repo_llama_cpp_shim_imported}",
-        file=sys.stderr,
-    )
     dependency_setup = ensure_desktop_python_dependencies()
     if dependency_setup.get("ok") != "true":
         missing = dependency_setup.get("missing") or "unknown"
@@ -262,6 +254,14 @@ def run(args: argparse.Namespace) -> int:
             ),
         })
         return 1
+    repo_llama_cpp_shim_imported = _is_repo_llama_cpp_shim(
+        runtime_setup.get("llama_module_path", "")
+    )
+    print(
+        "desktop.runtime_setup.import_guard "
+        f"repo_llama_cpp_shim_imported={repo_llama_cpp_shim_imported}",
+        file=sys.stderr,
+    )
 
     gpu_runtime_error = desktop_gpu_runtime_failure_message(args.mode, runtime_setup)
     if gpu_runtime_error:

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -590,13 +590,23 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
 
 
 
-def ensure_desktop_python_dependencies(*, runtime_root: Optional[Path] = None) -> Dict[str, str]:
+def _resolve_desktop_requirements_path(repo_root: Path) -> Path:
+    candidates = [
+        repo_root / "python" / "requirements_desktop_runtime.txt",
+        repo_root / "resources" / "python" / "requirements_desktop_runtime.txt",
+        Path(__file__).resolve().parent / "requirements_desktop_runtime.txt",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return candidates[0]
+
+
+def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure baseline desktop bridge Python dependencies are importable."""
 
-    root = _resolve_runtime_root(repo_root=runtime_root)
-    requirements_path = root / "python" / "requirements_desktop_runtime.txt"
-    if not requirements_path.is_file():
-        requirements_path = root / "resources" / "python" / "requirements_desktop_runtime.txt"
+    root = _resolve_runtime_root(repo_root=repo_root)
+    requirements_path = _resolve_desktop_requirements_path(root)
 
     required_modules = ("psutil", "requests", "dotenv")
     missing = [name for name in required_modules if importlib.util.find_spec(name) is None]
@@ -614,6 +624,7 @@ def ensure_desktop_python_dependencies(*, runtime_root: Optional[Path] = None) -
         }
 
     env = os.environ.copy()
+    env["PYTHONNOUSERSITE"] = "0"
     cmd = [sys.executable, "-m", "pip", "install", "--disable-pip-version-check", "-r", str(requirements_path)]
     ok, output = _run_pip_install(cmd, env)
     if not ok:

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -624,8 +624,16 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
         }
 
     env = os.environ.copy()
-    env["PYTHONNOUSERSITE"] = "0"
-    cmd = [sys.executable, "-m", "pip", "install", "--disable-pip-version-check", "-r", str(requirements_path)]
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-user",
+        "-r",
+        str(requirements_path),
+    ]
     ok, output = _run_pip_install(cmd, env)
     if not ok:
         return {
@@ -638,6 +646,7 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
             "detail": _summarize_install_error(output),
         }
 
+    importlib.invalidate_caches()
     missing_after = [name for name in required_modules if importlib.util.find_spec(name) is None]
     return {
         "ok": "true" if not missing_after else "false",

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -606,6 +607,22 @@ def _desktop_dependency_target(runtime_root: Path) -> Path:
     return runtime_root / ".token_place_desktop_site"
 
 
+def _resolve_desktop_dependency_target(runtime_root: Path) -> tuple[Optional[Path], Optional[str]]:
+    preferred_targets = [
+        _desktop_dependency_target(runtime_root),
+        Path.home() / ".token_place_desktop_site",
+        Path(tempfile.gettempdir()) / ".token_place_desktop_site",
+    ]
+    errors: list[str] = []
+    for candidate in preferred_targets:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            return candidate, None
+        except OSError as exc:
+            errors.append(f"{candidate}: {exc}")
+    return None, "; ".join(errors) if errors else "no writable install target"
+
+
 def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure baseline desktop bridge Python dependencies are importable."""
 
@@ -628,8 +645,17 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
         }
 
     env = os.environ.copy()
-    target_dir = _desktop_dependency_target(root)
-    target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir, target_error = _resolve_desktop_dependency_target(root)
+    if target_dir is None:
+        return {
+            "ok": "false",
+            "action": "install_target_unavailable",
+            "missing": ",".join(missing),
+            "interpreter": sys.executable,
+            "import_root": str(root),
+            "requirements": str(requirements_path),
+            "detail": target_error or "unable to create desktop dependency install target",
+        }
     target_dir_str = str(target_dir)
     if target_dir_str not in sys.path:
         sys.path.insert(0, target_dir_str)

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -602,6 +602,10 @@ def _resolve_desktop_requirements_path(repo_root: Path) -> Path:
     return candidates[0]
 
 
+def _desktop_dependency_target(runtime_root: Path) -> Path:
+    return runtime_root / ".token_place_desktop_site"
+
+
 def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure baseline desktop bridge Python dependencies are importable."""
 
@@ -624,13 +628,20 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
         }
 
     env = os.environ.copy()
+    target_dir = _desktop_dependency_target(root)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir_str = str(target_dir)
+    if target_dir_str not in sys.path:
+        sys.path.insert(0, target_dir_str)
+
     cmd = [
         sys.executable,
         "-m",
         "pip",
         "install",
         "--disable-pip-version-check",
-        "--no-user",
+        "--target",
+        target_dir_str,
         "-r",
         str(requirements_path),
     ]

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -629,7 +629,7 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
     root = _resolve_runtime_root(repo_root=repo_root)
     requirements_path = _resolve_desktop_requirements_path(root)
 
-    required_modules = ("psutil", "requests", "dotenv")
+    required_modules = ("psutil", "requests", "dotenv", "cryptography")
     missing = [name for name in required_modules if importlib.util.find_spec(name) is None]
     if not missing:
         return {"ok": "true", "action": "already_satisfied", "missing": ""}

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -7,7 +7,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -611,7 +610,6 @@ def _resolve_desktop_dependency_target(runtime_root: Path) -> tuple[Optional[Pat
     preferred_targets = [
         _desktop_dependency_target(runtime_root),
         Path.home() / ".token_place_desktop_site",
-        Path(tempfile.gettempdir()) / ".token_place_desktop_site",
     ]
     errors: list[str] = []
     for candidate in preferred_targets:

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -587,6 +588,54 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
     }
 
 
+
+
+def ensure_desktop_python_dependencies(*, runtime_root: Optional[Path] = None) -> Dict[str, str]:
+    """Ensure baseline desktop bridge Python dependencies are importable."""
+
+    root = _resolve_runtime_root(repo_root=runtime_root)
+    requirements_path = root / "python" / "requirements_desktop_runtime.txt"
+    if not requirements_path.is_file():
+        requirements_path = root / "resources" / "python" / "requirements_desktop_runtime.txt"
+
+    required_modules = ("psutil", "requests", "dotenv")
+    missing = [name for name in required_modules if importlib.util.find_spec(name) is None]
+    if not missing:
+        return {"ok": "true", "action": "already_satisfied", "missing": ""}
+
+    if not requirements_path.is_file():
+        return {
+            "ok": "false",
+            "action": "requirements_missing",
+            "missing": ",".join(missing),
+            "interpreter": sys.executable,
+            "import_root": str(root),
+            "requirements": str(requirements_path),
+        }
+
+    env = os.environ.copy()
+    cmd = [sys.executable, "-m", "pip", "install", "--disable-pip-version-check", "-r", str(requirements_path)]
+    ok, output = _run_pip_install(cmd, env)
+    if not ok:
+        return {
+            "ok": "false",
+            "action": "install_failed",
+            "missing": ",".join(missing),
+            "interpreter": sys.executable,
+            "import_root": str(root),
+            "requirements": str(requirements_path),
+            "detail": _summarize_install_error(output),
+        }
+
+    missing_after = [name for name in required_modules if importlib.util.find_spec(name) is None]
+    return {
+        "ok": "true" if not missing_after else "false",
+        "action": "installed" if not missing_after else "post_install_missing",
+        "missing": ",".join(missing_after),
+        "interpreter": sys.executable,
+        "import_root": str(root),
+        "requirements": str(requirements_path),
+    }
 def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
     detected_platform = platform.lower()
     if detected_platform.startswith("win"):

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -20,6 +20,29 @@ from path_bootstrap import ensure_runtime_import_paths
 
 ensure_runtime_import_paths(__file__)
 
+try:
+    from desktop_runtime_setup import ensure_desktop_python_dependencies
+except ModuleNotFoundError:
+    def ensure_desktop_python_dependencies() -> Dict[str, str]:
+        return {"ok": "false", "action": "desktop_runtime_setup_missing", "missing": "unknown"}
+
+
+def _run_dependency_preflight() -> Dict[str, Any]:
+    result = ensure_desktop_python_dependencies()
+    if result.get("ok") == "true":
+        return {"ok": True}
+    missing = result.get("missing") or "unknown"
+    action = result.get("action") or "dependency bootstrap failed"
+    detail = result.get("detail") or action
+    return {
+        "ok": False,
+        "error": (
+            "Missing Python dependency for model downloads "
+            f"(missing={missing}; interpreter={result.get('interpreter', sys.executable)}; "
+            f"import_root={result.get('import_root', 'unknown')}; action={action}; detail={detail})."
+        ),
+    }
+
 def _default_models_dir() -> Path:
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / "token.place" / "models"
@@ -105,6 +128,9 @@ def _get_model_manager(*, allow_inspect_fallback: bool = False):
 
 
 def inspect_model() -> int:
+    preflight = _run_dependency_preflight()
+    if not preflight.get("ok", False):
+        return _response(**preflight)
     manager, error_status = _get_model_manager(allow_inspect_fallback=True)
     if error_status is not None:
         return _response(**error_status)
@@ -112,6 +138,9 @@ def inspect_model() -> int:
 
 
 def download_model() -> int:
+    preflight = _run_dependency_preflight()
+    if not preflight.get("ok", False):
+        return _response(**preflight)
     manager, error_status = _get_model_manager()
     if error_status is not None:
         return _response(**error_status)

--- a/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
+++ b/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
@@ -1,3 +1,3 @@
 psutil==7.1.0
-requests==2.32.3
-python-dotenv==1.0.1
+requests==2.32.5
+python-dotenv==1.1.1

--- a/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
+++ b/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
@@ -1,0 +1,3 @@
+psutil==7.1.0
+requests==2.32.3
+python-dotenv==1.0.1

--- a/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
+++ b/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
@@ -1,3 +1,4 @@
 psutil==7.1.0
 requests==2.32.5
 python-dotenv==1.1.1
+cryptography==46.0.1

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -442,9 +442,13 @@ mod tests {
             "python/inference_sidecar.py",
             "python/model_bridge.py",
             "python/path_bootstrap.py",
+            "python/desktop_gpu_packaging.py",
+            "python/desktop_runtime_setup.py",
+            "python/requirements_desktop_runtime.txt",
             "../../utils",
             "../../config.py",
             "../../encrypt.py",
+            "../../requirements.txt",
         ];
 
         // Intentional strict count: this guards against accidental bundle bloat.
@@ -452,6 +456,13 @@ mod tests {
             resources.len(),
             required.len(),
             "bundle.resources should only include required Python bridge/runtime resources"
+        );
+
+
+
+        assert!(
+            resources.iter().all(|entry| !entry.as_str().unwrap_or_default().contains("relay.py")),
+            "bundle.resources must never include relay.py"
         );
 
         for script in required {

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -27,6 +27,7 @@
     "resources": [
       "python/desktop_gpu_packaging.py",
       "python/desktop_runtime_setup.py",
+      "python/requirements_desktop_runtime.txt",
       "python/compute_node_bridge.py",
       "python/inference_sidecar.py",
       "python/model_bridge.py",

--- a/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.json
+++ b/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-25",
+  "slug": "desktop-macos-runtime-deps-and-relay-autostart-guard",
+  "summary": "Packaged-like macOS desktop operator startup could fail early on missing psutil, and desktop needed explicit anti-regression guardrails to prevent relay.py bundling/autostart ownership.",
+  "impact": "Desktop operator startup could fail before status events and produced brittle diagnostics; desktop relay lifecycle boundaries were under-guarded.",
+  "fix": "Added desktop runtime dependency manifest and preflight bootstrap, made resource metrics resilient when psutil is missing, and added desktop no-relay-autostart static guards.",
+  "lessons": "Desktop packaged interpreters require app-owned dependency preflight, and desktop-vs-relay process boundaries need explicit static/lifecycle guard coverage."
+}

--- a/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.md
+++ b/outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.md
@@ -1,0 +1,31 @@
+# Outage: desktop macOS operator startup dependency gap and relay autostart guard regression
+
+- **Date:** 2026-05-25
+- **Slug:** `desktop-macos-runtime-deps-and-relay-autostart-guard`
+- **Affected area:** desktop-tauri operator startup and desktop app process lifecycle
+
+## Summary
+On packaged-like macOS launches, `Start operator` could fail early with `compute-node bridge exited before emitting a startup event: No module named 'psutil'`.
+A separate regression concern also required hard guards to ensure desktop-tauri never bundles or autostarts `relay.py` and never owns localhost:5010 relay lifecycle.
+
+## Root causes
+- The bridge import chain pulled `utils.system.resource_monitor` during startup, and `psutil` was imported at module import time.
+- Desktop bridge startup used `PYTHONNOUSERSITE=1` and could resolve to interpreters missing desktop runtime deps.
+- Existing coverage validated import/layout paths but did not enforce a desktop-specific dependency preflight contract and explicit no-relay-autostart desktop guardrails.
+
+## Why tests missed it
+- Packaged bridge checks did not require an app-owned dependency preflight before bridge runtime imports.
+- No dedicated desktop static guard test existed to assert that Tauri resources and Rust desktop startup sources exclude `relay.py` autostart paths.
+
+## Fix
+- Added desktop runtime dependency manifest and bootstrap preflight in `desktop_runtime_setup.py` for packaged/runtime contexts.
+- Made resource monitor resilient to missing `psutil` (metrics degrade safely).
+- Added desktop static guard tests that prevent `relay.py` inclusion/spawn paths from desktop-tauri resources and startup sources.
+
+## Tests
+- `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_resource_monitor.py tests/unit/test_desktop_no_relay_autostart.py`
+- `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py`
+
+## Follow-up
+- Keep desktop dependency preflight manifest in sync with bridge/runtime imports.
+- Extend full lifecycle macOS app open/close e2e in environments where GUI automation is available.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1052,6 +1052,26 @@ def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_pat
         path_bootstrap_path.read_text(encoding='utf-8'),
         encoding='utf-8',
     )
+    (python_dir / 'desktop_runtime_setup.py').write_text(
+        """
+def desktop_gpu_runtime_failure_message(_mode, _runtime_setup):
+    return None
+
+
+def ensure_desktop_llama_runtime(_mode):
+    return {"selected_backend": "cpu", "detected_device": "cpu", "runtime_action": "skipped"}
+
+
+def ensure_desktop_python_dependencies(*, repo_root=None):
+    return {"ok": "true", "action": "already_satisfied", "missing": ""}
+
+
+def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):
+    return None
+""".strip()
+        + "\n",
+        encoding='utf-8',
+    )
     (utils_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
@@ -1432,3 +1452,26 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monk
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
+
+
+def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        lambda: {
+            'ok': 'false',
+            'action': 'requirements_missing',
+            'missing': 'psutil',
+            'interpreter': 'python',
+            'import_root': '/runtime',
+            'detail': 'requirements missing',
+        },
+    )
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+    assert status == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get("type") == "error")
+    assert "dependency preflight failed" in error_event["message"]

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -30,8 +30,9 @@ def test_inspect_returns_shared_model_manager_metadata(capsys):
     manager = MagicMock()
     manager.get_model_artifact_metadata.return_value = metadata
 
-    with patch.object(model_bridge, '_get_model_manager', return_value=(manager, None)):
-        status = model_bridge.inspect_model()
+    with patch.object(model_bridge, '_run_dependency_preflight', return_value={'ok': True}):
+        with patch.object(model_bridge, '_get_model_manager', return_value=(manager, None)):
+            status = model_bridge.inspect_model()
 
     assert status == 0
     manager.get_model_artifact_metadata.assert_called_once_with()
@@ -39,8 +40,9 @@ def test_inspect_returns_shared_model_manager_metadata(capsys):
 
 
 def test_inspect_returns_bridge_error_when_manager_init_fails(capsys):
-    with patch.object(model_bridge, '_get_model_manager', return_value=(None, {'ok': False, 'error': 'boom'})):
-        status = model_bridge.inspect_model()
+    with patch.object(model_bridge, '_run_dependency_preflight', return_value={'ok': True}):
+        with patch.object(model_bridge, '_get_model_manager', return_value=(None, {'ok': False, 'error': 'boom'})):
+            status = model_bridge.inspect_model()
 
     assert status == 1
     assert json.loads(capsys.readouterr().out.strip()) == {'ok': False, 'error': 'boom'}
@@ -50,8 +52,9 @@ def test_download_returns_actionable_error_when_download_fails(capsys):
     manager = MagicMock()
     manager.download_model_if_needed.return_value = False
 
-    with patch.object(model_bridge, '_get_model_manager', return_value=(manager, None)):
-        status = model_bridge.download_model()
+    with patch.object(model_bridge, '_run_dependency_preflight', return_value={'ok': True}):
+        with patch.object(model_bridge, '_get_model_manager', return_value=(manager, None)):
+            status = model_bridge.download_model()
 
     assert status == 1
     manager.download_model_if_needed.assert_called_once_with()
@@ -78,13 +81,22 @@ def test_download_returns_metadata_when_download_succeeds(capsys):
     manager.download_model_if_needed.return_value = True
     manager.get_model_artifact_metadata.return_value = metadata
 
-    with patch.object(model_bridge, '_get_model_manager', return_value=(manager, None)):
-        status = model_bridge.download_model()
+    with patch.object(model_bridge, '_run_dependency_preflight', return_value={'ok': True}):
+        with patch.object(model_bridge, '_get_model_manager', return_value=(manager, None)):
+            status = model_bridge.download_model()
 
     assert status == 0
     manager.download_model_if_needed.assert_called_once_with()
     manager.get_model_artifact_metadata.assert_called_once_with()
     assert json.loads(capsys.readouterr().out.strip()) == {'ok': True, 'payload': metadata}
+
+
+def test_inspect_fails_when_dependency_preflight_fails(capsys):
+    with patch.object(model_bridge, '_run_dependency_preflight', return_value={'ok': False, 'error': 'deps bad'}):
+        status = model_bridge.inspect_model()
+
+    assert status == 1
+    assert json.loads(capsys.readouterr().out.strip()) == {'ok': False, 'error': 'deps bad'}
 
 
 def test_get_model_manager_reports_missing_dependency(capsys):
@@ -246,6 +258,11 @@ def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_
     (python_dir / 'model_bridge.py').write_text(MODULE_PATH.read_text(encoding='utf-8'), encoding='utf-8')
     path_bootstrap_path = MODULE_PATH.parent / 'path_bootstrap.py'
     (python_dir / 'path_bootstrap.py').write_text(path_bootstrap_path.read_text(encoding='utf-8'), encoding='utf-8')
+    desktop_runtime_setup_path = MODULE_PATH.parent / 'desktop_runtime_setup.py'
+    (python_dir / 'desktop_runtime_setup.py').write_text(desktop_runtime_setup_path.read_text(encoding='utf-8'), encoding='utf-8')
+    desktop_gpu_packaging_path = MODULE_PATH.parent / 'desktop_gpu_packaging.py'
+    (python_dir / 'desktop_gpu_packaging.py').write_text(desktop_gpu_packaging_path.read_text(encoding='utf-8'), encoding='utf-8')
+    (python_dir / 'requirements_desktop_runtime.txt').write_text('psutil==7.1.0\nrequests==2.32.5\npython-dotenv==1.1.1\ncryptography==46.0.1\n', encoding='utf-8')
     (import_root / 'utils' / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / 'model_manager.py').write_text(

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -328,3 +328,37 @@ def test_download_returns_error_when_dotenv_missing(capsys):
     response = json.loads(capsys.readouterr().out.strip())
     assert response['ok'] is False
     assert "No module named 'dotenv'" in response['error']
+
+
+def test_run_dependency_preflight_formats_failure_context():
+    with patch.object(
+        model_bridge,
+        'ensure_desktop_python_dependencies',
+        return_value={'ok': 'false', 'missing': 'cryptography', 'action': 'install_failed', 'detail': 'permission denied'},
+    ):
+        payload = model_bridge._run_dependency_preflight()
+
+    assert payload['ok'] is False
+    assert 'missing=cryptography' in payload['error']
+    assert 'action=install_failed' in payload['error']
+    assert 'detail=permission denied' in payload['error']
+
+
+def test_main_returns_json_error_on_unhandled_exception(capsys):
+    with patch.object(model_bridge.argparse.ArgumentParser, 'parse_args', return_value=SimpleNamespace(action='inspect')):
+        with patch.object(model_bridge, 'inspect_model', side_effect=RuntimeError('unexpected boom')):
+            status = model_bridge.main()
+
+    assert status == 1
+    assert json.loads(capsys.readouterr().out.strip()) == {
+        'ok': False,
+        'error': 'Model bridge failure: unexpected boom',
+    }
+
+
+def test_download_fails_when_dependency_preflight_fails(capsys):
+    with patch.object(model_bridge, '_run_dependency_preflight', return_value={'ok': False, 'error': 'deps bad'}):
+        status = model_bridge.download_model()
+
+    assert status == 1
+    assert json.loads(capsys.readouterr().out.strip()) == {'ok': False, 'error': 'deps bad'}

--- a/tests/unit/test_desktop_no_relay_autostart.py
+++ b/tests/unit/test_desktop_no_relay_autostart.py
@@ -1,0 +1,24 @@
+"""Desktop guardrails: tauri app must not bundle or autostart relay.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tauri_bundle_resources_exclude_relay_py() -> None:
+    config = json.loads((REPO_ROOT / "desktop-tauri" / "src-tauri" / "tauri.conf.json").read_text())
+    resources = config["bundle"]["resources"]
+    assert all("relay.py" not in str(entry) for entry in resources)
+
+
+def test_desktop_rust_sources_do_not_include_relay_spawn_patterns() -> None:
+    forbidden = ("Command::new(\"relay.py\"", "python relay.py", "localhost:5010", "127.0.0.1:5010")
+    src_root = REPO_ROOT / "desktop-tauri" / "src-tauri" / "src"
+    for path in src_root.glob("*.rs"):
+        text = path.read_text(encoding="utf-8")
+        for pattern in forbidden:
+            assert pattern not in text, f"desktop source contains forbidden relay pattern {pattern}: {path}"

--- a/tests/unit/test_desktop_no_relay_autostart.py
+++ b/tests/unit/test_desktop_no_relay_autostart.py
@@ -10,15 +10,25 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_tauri_bundle_resources_exclude_relay_py() -> None:
-    config = json.loads((REPO_ROOT / "desktop-tauri" / "src-tauri" / "tauri.conf.json").read_text())
+    config = json.loads(
+        (REPO_ROOT / "desktop-tauri" / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8")
+    )
     resources = config["bundle"]["resources"]
     assert all("relay.py" not in str(entry) for entry in resources)
 
 
 def test_desktop_rust_sources_do_not_include_relay_spawn_patterns() -> None:
-    forbidden = ("Command::new(\"relay.py\"", "python relay.py", "localhost:5010", "127.0.0.1:5010")
+    forbidden = (
+        "Command::new(\"relay.py\"",
+        "Command::new(\"python\").arg(\"relay.py\")",
+        "Command::new(\"python3\").arg(\"relay.py\")",
+        "python relay.py",
+        "localhost:5010",
+        "127.0.0.1:5010",
+        "0.0.0.0:5010",
+    )
     src_root = REPO_ROOT / "desktop-tauri" / "src-tauri" / "src"
-    for path in src_root.glob("*.rs"):
+    for path in src_root.rglob("*.rs"):
         text = path.read_text(encoding="utf-8")
         for pattern in forbidden:
             assert pattern not in text, f"desktop source contains forbidden relay pattern {pattern}: {path}"

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -855,12 +855,12 @@ def test_ensure_desktop_python_dependencies_reports_requirements_missing(monkeyp
 
     assert result['ok'] == 'false'
     assert result['action'] == 'requirements_missing'
-    assert result['missing'] == 'psutil,requests,dotenv'
+    assert result['missing'] == 'psutil,requests,dotenv,cryptography'
 
 
 def test_ensure_desktop_python_dependencies_reports_install_failed(monkeypatch, tmp_path):
     requirements = tmp_path / 'requirements_desktop_runtime.txt'
-    requirements.write_text('psutil\nrequests\npython-dotenv\n', encoding='utf-8')
+    requirements.write_text('psutil\nrequests\npython-dotenv\ncryptography\n', encoding='utf-8')
     monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: tmp_path)
     monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_requirements_path', lambda _root: requirements)
     monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: None)
@@ -884,10 +884,10 @@ def test_ensure_desktop_python_dependencies_reports_install_failed(monkeypatch, 
 
 def test_ensure_desktop_python_dependencies_reports_post_install_missing(monkeypatch, tmp_path):
     requirements = tmp_path / 'requirements_desktop_runtime.txt'
-    requirements.write_text('psutil\nrequests\npython-dotenv\n', encoding='utf-8')
+    requirements.write_text('psutil\nrequests\npython-dotenv\ncryptography\n', encoding='utf-8')
     monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: tmp_path)
     monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_requirements_path', lambda _root: requirements)
-    sequence = iter([None, None, None, object(), object(), None])
+    sequence = iter([None, None, None, None, object(), object(), object(), None])
     monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: next(sequence))
     monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
 
@@ -895,14 +895,14 @@ def test_ensure_desktop_python_dependencies_reports_post_install_missing(monkeyp
 
     assert result['ok'] == 'false'
     assert result['action'] == 'post_install_missing'
-    assert result['missing'] == 'dotenv'
+    assert result['missing'] == 'cryptography'
 
 
 def test_ensure_desktop_python_dependencies_falls_back_to_home_target_when_runtime_root_unwritable(
     monkeypatch, tmp_path
 ):
     requirements = tmp_path / 'requirements_desktop_runtime.txt'
-    requirements.write_text('psutil\nrequests\npython-dotenv\n', encoding='utf-8')
+    requirements.write_text('psutil\nrequests\npython-dotenv\ncryptography\n', encoding='utf-8')
     runtime_root = tmp_path / 'runtime'
     runtime_root.mkdir(parents=True)
     home_dir = tmp_path / 'home'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -838,3 +838,52 @@ def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
 
     module_path = str(shim.resolve()).upper()
     assert desktop_runtime_setup._is_repo_local_llama_module(module_path, repo_root) is True
+
+
+def test_ensure_desktop_python_dependencies_reports_requirements_missing(monkeypatch, tmp_path):
+    runtime_root = tmp_path / 'runtime'
+    (runtime_root / 'utils').mkdir(parents=True)
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: runtime_root)
+    monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: None)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_requirements_path',
+        lambda _root: runtime_root / 'python' / 'requirements_desktop_runtime.txt',
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_python_dependencies(repo_root=runtime_root)
+
+    assert result['ok'] == 'false'
+    assert result['action'] == 'requirements_missing'
+    assert result['missing'] == 'psutil,requests,dotenv'
+
+
+def test_ensure_desktop_python_dependencies_reports_install_failed(monkeypatch, tmp_path):
+    requirements = tmp_path / 'requirements_desktop_runtime.txt'
+    requirements.write_text('psutil\nrequests\npython-dotenv\n', encoding='utf-8')
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: tmp_path)
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_requirements_path', lambda _root: requirements)
+    monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (False, 'install failed: boom'))
+
+    result = desktop_runtime_setup.ensure_desktop_python_dependencies(repo_root=tmp_path)
+
+    assert result['ok'] == 'false'
+    assert result['action'] == 'install_failed'
+    assert result['detail'] == 'install failed: boom'
+
+
+def test_ensure_desktop_python_dependencies_reports_post_install_missing(monkeypatch, tmp_path):
+    requirements = tmp_path / 'requirements_desktop_runtime.txt'
+    requirements.write_text('psutil\nrequests\npython-dotenv\n', encoding='utf-8')
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: tmp_path)
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_requirements_path', lambda _root: requirements)
+    sequence = iter([None, None, None, object(), object(), None])
+    monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: next(sequence))
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
+
+    result = desktop_runtime_setup.ensure_desktop_python_dependencies(repo_root=tmp_path)
+
+    assert result['ok'] == 'false'
+    assert result['action'] == 'post_install_missing'
+    assert result['missing'] == 'dotenv'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -896,3 +896,41 @@ def test_ensure_desktop_python_dependencies_reports_post_install_missing(monkeyp
     assert result['ok'] == 'false'
     assert result['action'] == 'post_install_missing'
     assert result['missing'] == 'dotenv'
+
+
+def test_ensure_desktop_python_dependencies_falls_back_to_home_target_when_runtime_root_unwritable(
+    monkeypatch, tmp_path
+):
+    requirements = tmp_path / 'requirements_desktop_runtime.txt'
+    requirements.write_text('psutil\nrequests\npython-dotenv\n', encoding='utf-8')
+    runtime_root = tmp_path / 'runtime'
+    runtime_root.mkdir(parents=True)
+    home_dir = tmp_path / 'home'
+    home_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: runtime_root)
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_requirements_path', lambda _root: requirements)
+    monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: None)
+    monkeypatch.setattr(desktop_runtime_setup.Path, 'home', staticmethod(lambda: home_dir))
+    captured = {}
+
+    def _capture_run(cmd, *_args, **_kwargs):
+        captured['cmd'] = cmd
+        return False, 'install failed: boom'
+
+    original_mkdir = desktop_runtime_setup.Path.mkdir
+
+    def _fake_mkdir(path_obj, parents=False, exist_ok=False):
+        if str(path_obj).endswith('.token_place_desktop_site') and runtime_root in path_obj.parents:
+            raise PermissionError('read-only bundle')
+        return original_mkdir(path_obj, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(desktop_runtime_setup.Path, 'mkdir', _fake_mkdir)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _capture_run)
+
+    result = desktop_runtime_setup.ensure_desktop_python_dependencies(repo_root=runtime_root)
+
+    assert result['action'] == 'install_failed'
+    assert '--target' in captured['cmd']
+    target_idx = captured['cmd'].index('--target') + 1
+    assert captured['cmd'][target_idx] == str(home_dir / '.token_place_desktop_site')

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -864,13 +864,22 @@ def test_ensure_desktop_python_dependencies_reports_install_failed(monkeypatch, 
     monkeypatch.setattr(desktop_runtime_setup, '_resolve_runtime_root', lambda **_: tmp_path)
     monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_requirements_path', lambda _root: requirements)
     monkeypatch.setattr(desktop_runtime_setup.importlib.util, 'find_spec', lambda _name: None)
-    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (False, 'install failed: boom'))
+    captured = {}
+
+    def _capture_run(cmd, *_args, **_kwargs):
+        captured['cmd'] = cmd
+        return False, 'install failed: boom'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _capture_run)
 
     result = desktop_runtime_setup.ensure_desktop_python_dependencies(repo_root=tmp_path)
 
     assert result['ok'] == 'false'
     assert result['action'] == 'install_failed'
     assert result['detail'] == 'install failed: boom'
+    assert '--target' in captured['cmd']
+    target_idx = captured['cmd'].index('--target') + 1
+    assert captured['cmd'][target_idx] == str(tmp_path / '.token_place_desktop_site')
 
 
 def test_ensure_desktop_python_dependencies_reports_post_install_missing(monkeypatch, tmp_path):

--- a/tests/unit/test_resource_monitor.py
+++ b/tests/unit/test_resource_monitor.py
@@ -265,6 +265,16 @@ def test_collect_resource_usage_windows_handles_non_numeric_retry(monkeypatch):
     assert usage['memory_percent'] == pytest.approx(58.0)
 
 
+def test_collect_resource_usage_handles_missing_psutil_module(monkeypatch):
+    from utils.system import resource_monitor as rm
+
+    monkeypatch.setattr(rm, 'psutil', None, raising=False)
+    usage = rm.collect_resource_usage()
+
+    assert usage['cpu_percent'] == 0.0
+    assert usage['memory_percent'] == 0.0
+
+
 def test_collect_resource_usage_windows_handles_retry_errors(monkeypatch):
     """Errors during the immediate retry should be swallowed."""
     from utils.system import resource_monitor as rm

--- a/utils/system/resource_monitor.py
+++ b/utils/system/resource_monitor.py
@@ -17,7 +17,10 @@ def _gpu_headroom_multiplier(headroom_percent: float) -> float:
         percent = 0.0
     return 1.0 + (percent / 100.0 if percent > 1.0 else percent)
 
-import psutil
+try:
+    import psutil
+except ModuleNotFoundError:  # pragma: no cover - exercised via import fallback test
+    psutil = None
 
 
 GpuMetrics = Dict[str, float | int | bool]
@@ -170,6 +173,8 @@ def collect_resource_usage() -> Dict[str, float | int | bool]:
     interval = _cpu_interval_for_platform(sys.platform)
 
     try:
+        if psutil is None:
+            raise RuntimeError("psutil unavailable")
         cpu_percent_raw = psutil.cpu_percent(interval=interval)
         if interval == 0.0:
             try:
@@ -185,6 +190,8 @@ def collect_resource_usage() -> Dict[str, float | int | bool]:
         cpu_percent_raw = None
 
     try:
+        if psutil is None:
+            raise RuntimeError("psutil unavailable")
         memory_stats = psutil.virtual_memory()
     except Exception:
         memory_stats = None

--- a/utils/system/resource_monitor.py
+++ b/utils/system/resource_monitor.py
@@ -19,7 +19,7 @@ def _gpu_headroom_multiplier(headroom_percent: float) -> float:
 
 try:
     import psutil
-except ModuleNotFoundError:  # pragma: no cover - exercised via import fallback test
+except (ImportError, OSError):  # pragma: no cover - exercised via import fallback test
     psutil = None
 
 


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop launches could fail early with "No module named 'psutil'" because the bridge used an interpreter with `PYTHONNOUSERSITE=1` that lacked required desktop-only Python packages, causing the compute-node bridge to exit before emitting startup events. 
- The desktop app must deterministically own or validate the Python runtime dependencies it uses so UI flows reach `Running: yes` instead of cryptic early-exit errors. 
- There is a hard requirement that the desktop Tauri app never bundles, autostarts, or retains ownership of `relay.py` or bind localhost:5010 outside explicit test harnesses, so static/lifecycle guards were needed. 

### Description
- Added a curated desktop runtime manifest `desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt` declaring `psutil`, `requests`, and `python-dotenv`. 
- Implemented `ensure_desktop_python_dependencies` in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` which probes the interpreter used by the bridge and installs/validates the desktop runtime requirements (with actionable diagnostics about `interpreter`, `import_root`, and `requirements` path). 
- Called the new dependency preflight from `desktop-tauri/src-tauri/python/compute_node_bridge.py` before importing runtime modules that transitively require desktop deps, and made llama-shim detection lazy to avoid early import fragility. 
- Hardened `utils/system/resource_monitor.py` to import `psutil` optionally and degrade metrics safely when it is missing instead of failing at module import time. 
- Updated Tauri bundle resources (`desktop-tauri/src-tauri/tauri.conf.json`) and the Rust bundle resource test (`desktop-tauri/src-tauri/src/main.rs`) to include the new manifest and to assert `relay.py` is not bundled. 
- Added `tests/unit/test_desktop_no_relay_autostart.py` to statically ensure desktop bundle resources and Rust sources do not include relay spawn patterns or bind the default relay port. 
- Added outage documentation `outages/2026-05-25-desktop-macos-runtime-deps-and-relay-autostart-guard.{md,json}` describing symptoms, root cause, test gap, fix, and follow-ups. 

### Testing
- Ran unit test suite covering the modified areas with: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_runtime_setup.py tests/unit/test_resource_monitor.py tests/unit/test_desktop_no_relay_autostart.py`, which completed successfully as `108 passed` in the final run. 
- Exercised packaged-bridge packaged-layout inspection with: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py`, which completed successfully in the verification run. 
- Residual risks / follow-ups: full macOS GUI lifecycle e2e (open/close app without operator start) should be exercised on macOS CI or a macOS developer machine to assert no detached relay processes in system-wide process tables, and maintainers should keep the desktop manifest in sync with any future bridge import additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1493d11654832fa8306483833eca0a)