### PR TITLE
Fix macOS desktop model-bridge PEP 604 alias crash and add regression guardrails

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -125,6 +125,23 @@ jobs:
       - name: Run packaged operator bridge e2e (Windows)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
 
+
+  desktop-operator-packaged-inspect-python39-macos:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Run dependency-isolated model bridge inspect smoke (macOS, Python 3.9)
+        env:
+          TOKEN_PLACE_INSPECT_ONLY: "1"
+        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
   desktop-operator-packaged-e2e-macos:
     runs-on: macos-latest
     timeout-minutes: 20

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -10,6 +10,7 @@ on:
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
+      - 'desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -25,6 +26,7 @@ on:
       - 'desktop-tauri/src-tauri/tauri.conf.json'
       - 'desktop-tauri/scripts/test_packaged_operator_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
+      - 'desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -152,6 +154,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: desktop-tauri/package-lock.json
+
+      - name: Install desktop Node dependencies (macOS)
+        run: cd desktop-tauri && npm ci
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build desktop frontend assets (macOS)
+        run: cd desktop-tauri && npm run build
+
+      - name: Build desktop binary (debug, no bundle, macOS)
+        run: cd desktop-tauri && npm run tauri build -- --debug --no-bundle
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -171,3 +192,8 @@ jobs:
 
       - name: Run packaged operator bridge e2e (macOS)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+      - name: Run desktop no-relay lifecycle e2e (macOS, required)
+        env:
+          TOKENPLACE_REQUIRE_NO_RELAY_E2E: "1"
+        run: python desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -136,6 +136,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            config/requirements_codex_verification.txt
 
       - name: Run dependency-isolated model bridge inspect smoke (macOS, Python 3.9)
         env:

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -83,12 +83,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: config/requirements_codex_verification.txt
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r config/requirements_codex_verification.txt
           pip install selenium
 
       - name: Run desktop operator UI e2e
@@ -117,12 +117,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: config/requirements_codex_verification.txt
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r config/requirements_codex_verification.txt
 
       - name: Run packaged operator bridge e2e (Windows)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -181,12 +181,11 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: config/requirements_codex_verification.txt
 
       - name: Install Python dependencies (macOS packaged e2e)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
           pip install -r config/requirements_codex_verification.txt
 
       - name: Run dependency-isolated model bridge inspect smoke (macOS)

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -143,6 +143,12 @@ jobs:
             requirements.txt
             config/requirements_codex_verification.txt
 
+      - name: Install Python dependencies (macOS, Python 3.9 inspect)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r config/requirements_codex_verification.txt
+
       - name: Run dependency-isolated model bridge inspect smoke (macOS, Python 3.9)
         env:
           TOKEN_PLACE_INSPECT_ONLY: "1"
@@ -180,15 +186,16 @@ jobs:
           cache: 'pip'
           cache-dependency-path: requirements.txt
 
+      - name: Install Python dependencies (macOS packaged e2e)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r config/requirements_codex_verification.txt
+
       - name: Run dependency-isolated model bridge inspect smoke (macOS)
         env:
           TOKEN_PLACE_INSPECT_ONLY: "1"
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
-
-      - name: Install Python dependencies (macOS packaged e2e)
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r config/requirements_codex_verification.txt
 
       - name: Run packaged operator bridge e2e (macOS)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -139,14 +139,11 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            config/requirements_codex_verification.txt
+          cache-dependency-path: config/requirements_codex_verification.txt
 
       - name: Install Python dependencies (macOS, Python 3.9 inspect)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
           pip install -r config/requirements_codex_verification.txt
 
       - name: Run dependency-isolated model bridge inspect smoke (macOS, Python 3.9)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,7 @@
 """token.place API package."""
 
+from __future__ import annotations
+
 import os
 from flask import jsonify, request
 from flask_limiter import Limiter

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -3,6 +3,8 @@ API routes for token.place API v1
 This module follows OpenAI API conventions to serve as a drop-in replacement.
 """
 
+from __future__ import annotations
+
 from flask import Blueprint, request, jsonify
 import base64
 import time

--- a/api/v2/routes.py
+++ b/api/v2/routes.py
@@ -3,6 +3,8 @@ API routes for token.place API v2.
 This module extends the OpenAI-compatible surface with enhanced capabilities.
 """
 
+from __future__ import annotations
+
 from flask import Blueprint, request, jsonify, Response, stream_with_context
 import base64
 import time

--- a/config.py
+++ b/config.py
@@ -3,6 +3,8 @@ Configuration file for token.place application
 Values are loaded from environment variables with sensible defaults
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import platform

--- a/config/requirements_codex_verification.txt
+++ b/config/requirements_codex_verification.txt
@@ -15,3 +15,4 @@ pytest-playwright==0.7.1
 playwright>=1.40.0
 pre-commit
 bandit>=1.7.9
+PyYAML>=6.0

--- a/config/requirements_codex_verification.txt
+++ b/config/requirements_codex_verification.txt
@@ -2,7 +2,7 @@ requests==2.32.5
 python-dotenv==1.1.1
 cryptography==46.0.1
 psutil==7.1.0
-packaging==25.0
+packaging==24.2
 jsonschema==4.25.1
 Flask==3.1.2
 Flask-Limiter==3.11.0

--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -72,7 +72,7 @@ def main() -> int:
             text=True,
         )
         time.sleep(2)
-        subprocess.run(["osascript", "-e", 'tell application "token.place" to quit'], check=False)
+        subprocess.run(["osascript", "-e", 'tell application "token.place desktop" to quit'], check=False)
         app.wait(timeout=60)
 
     assert not _has_process_matching("relay.py"), "relay.py process exists after desktop shutdown"

--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -15,7 +15,17 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DESKTOP_APP = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug" / "token.place desktop.app"
+DESKTOP_TARGET_DIR = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug"
+DESKTOP_APP_BUNDLE = DESKTOP_TARGET_DIR / "token.place desktop.app"
+DESKTOP_APP_BIN = DESKTOP_TARGET_DIR / "token-place-desktop-tauri"
+
+
+def _resolve_desktop_app_target() -> Path | None:
+    if DESKTOP_APP_BUNDLE.exists():
+        return DESKTOP_APP_BUNDLE
+    if DESKTOP_APP_BIN.exists():
+        return DESKTOP_APP_BIN
+    return None
 
 
 def _port_in_use(port: int) -> bool:
@@ -50,8 +60,9 @@ def main() -> int:
         print(f"SKIP: {message}")
         return 0
 
-    if not DESKTOP_APP.exists():
-        message = f"desktop app binary not found: {DESKTOP_APP}"
+    desktop_target = _resolve_desktop_app_target()
+    if desktop_target is None:
+        message = f"desktop app binary not found: {DESKTOP_APP_BUNDLE} or {DESKTOP_APP_BIN}"
         if require_no_relay_e2e:
             raise AssertionError(message)
         print(f"SKIP: {message}")
@@ -64,7 +75,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="token-place-no-relay-home-") as home:
         env["HOME"] = home
         app = subprocess.Popen(
-            ["open", "-W", str(DESKTOP_APP)],
+            ["open", "-W", str(desktop_target)],
             cwd=REPO_ROOT,
             env=env,
             stdout=subprocess.PIPE,

--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -74,7 +74,8 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="token-place-no-relay-home-") as home:
         env["HOME"] = home
-        if desktop_target.suffix == ".app":
+        launched_app_bundle = desktop_target.suffix == ".app"
+        if launched_app_bundle:
             launch_cmd = ["open", "-W", str(desktop_target)]
         else:
             launch_cmd = [str(desktop_target)]
@@ -87,7 +88,12 @@ def main() -> int:
             text=True,
         )
         time.sleep(2)
-        subprocess.run(["osascript", "-e", 'tell application "token.place desktop" to quit'], check=False)
+        if launched_app_bundle:
+            subprocess.run(
+                ["osascript", "-e", 'tell application "token.place desktop" to quit'], check=False
+            )
+        else:
+            app.terminate()
         app.wait(timeout=60)
 
     assert not _has_process_matching("relay.py"), "relay.py process exists after desktop shutdown"

--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -74,8 +74,12 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="token-place-no-relay-home-") as home:
         env["HOME"] = home
+        if desktop_target.suffix == ".app":
+            launch_cmd = ["open", "-W", str(desktop_target)]
+        else:
+            launch_cmd = [str(desktop_target)]
         app = subprocess.Popen(
-            ["open", "-W", str(desktop_target)],
+            launch_cmd,
             cwd=REPO_ROOT,
             env=env,
             stdout=subprocess.PIPE,

--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -41,11 +41,20 @@ def _assert_no_relay_port_listener() -> None:
 
 
 def main() -> int:
+    require_no_relay_e2e = os.getenv("TOKENPLACE_REQUIRE_NO_RELAY_E2E") == "1"
+
     if platform.system() != "Darwin":
-        print("SKIP: desktop no-relay lifecycle e2e is macOS-only")
+        message = "desktop no-relay lifecycle e2e is macOS-only"
+        if require_no_relay_e2e:
+            raise AssertionError(message)
+        print(f"SKIP: {message}")
         return 0
+
     if not DESKTOP_APP.exists():
-        print(f"SKIP: desktop app binary not found: {DESKTOP_APP}")
+        message = f"desktop app binary not found: {DESKTOP_APP}"
+        if require_no_relay_e2e:
+            raise AssertionError(message)
+        print(f"SKIP: {message}")
         return 0
 
     env = os.environ.copy()

--- a/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DESKTOP_APP = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug" / "token.place.app"
+DESKTOP_APP = REPO_ROOT / "desktop-tauri" / "src-tauri" / "target" / "debug" / "token.place desktop.app"
 
 
 def _port_in_use(port: int) -> bool:

--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -576,15 +576,17 @@ def main() -> int:
 
         last_error_text = driver.find_element(By.XPATH, "//p[contains(.,'Last error:')]").text
         lowered_last_error = last_error_text.lower()
-        assert "bridge failure" not in lowered_last_error, (
-            f"Last error still indicates bridge failure: {last_error_text}"
-        )
-        assert "no module named" not in lowered_last_error, (
-            f"Last error still indicates import failure: {last_error_text}"
-        )
-        assert "importerror" not in lowered_last_error, (
-            f"Last error still indicates import failure: {last_error_text}"
-        )
+        for marker in (
+            "bridge failure",
+            "unsupported operand",
+            "no module named",
+            "modulenotfounderror",
+            "importerror",
+            "model path not found",
+        ):
+            assert marker not in lowered_last_error, (
+                f"Last error contains forbidden marker `{marker}`: {last_error_text}"
+            )
         assert_relay_roundtrip(relay_url, relay_log, driver_log, driver)
     except TimeoutException as exc:
         raise RuntimeError(diagnostics_message("desktop UI e2e timed out", relay_log, driver_log, driver)) from exc

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -144,11 +144,12 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
     assert required_keys.issubset(payload.keys()), combined
 
     forbidden_any_output = [
+        "Model bridge failure",
+        "unsupported operand type(s) for |",
         "Missing Python dependency for model downloads",
-        "No module named 'psutil'",
-        "No module named 'requests'",
-        "No module named 'dotenv'",
-        "No module named 'cryptography'",
+        "No module named",
+        "ModuleNotFoundError",
+        "ImportError",
         "NotOpenSSLWarning",
         "~/Library/Python",
     ]

--- a/encrypt.py
+++ b/encrypt.py
@@ -8,6 +8,7 @@ import base64
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+import sys
 from functools import lru_cache
 from typing import Dict, Optional, Tuple
 
@@ -192,7 +193,7 @@ def _decrypt_session_key(encrypted_key: bytes, private_key_pem: bytes) -> bytes:
     return base64.b64decode(aes_key_b64)
 
 
-@dataclass(slots=True)
+@dataclass(**({"slots": True} if sys.version_info >= (3, 10) else {}))
 class StreamSession:
     """Hold symmetric context for encrypted streaming payloads."""
 

--- a/encrypt.py
+++ b/encrypt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Made with help from https://www.youtube.com/watch?v=pOx2TYwR590
 # Github: https://github.com/cgossi/fundamental_cryptography_with_python
 

--- a/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.json
+++ b/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-26",
+  "slug": "desktop-macos-model-bridge-pep604-type-alias",
+  "summary": "Desktop macOS startup could fail with a model bridge error when Python 3.9 evaluated a runtime PEP 604 union type-alias assignment in resource_monitor.",
+  "impact": "Desktop operator inspect/start paths could fail before runtime initialization in Python 3.9 environments, surfacing as a generic model bridge failure.",
+  "fix": "Replaced runtime-evaluated PEP 604 alias usage with Python 3.9-safe typing, added AST regression guards across packaged desktop Python imports, and hardened packaged inspect/UI error assertions.",
+  "lessons": "Runtime assignments using PEP 604 unions in packaged import paths are a compatibility hazard for Python 3.9 and require both static and runtime CI coverage; desktop and relay lifecycles must remain separate."
+}

--- a/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.md
+++ b/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.md
@@ -1,0 +1,39 @@
+# Outage: desktop macOS model bridge PEP 604 runtime type-alias failure
+
+- **Date:** 2026-05-26
+- **Slug:** `desktop-macos-model-bridge-pep604-type-alias`
+- **Affected area:** Desktop Tauri model bridge startup/inspect flow on macOS Python 3.9 environments
+
+## Summary
+Desktop operator startup could fail with `Model bridge failure: unsupported operand type(s) for |: 'type' and 'type'` when the packaged runtime resolved to Python 3.9. The failure surfaced through `model_bridge.py` catch-all handling, but originated in a runtime-evaluated PEP 604 union type-alias assignment in `utils/system/resource_monitor.py`.
+
+## Root cause
+`GpuMetrics = Dict[str, float | int | bool]` was defined as a normal runtime assignment. On Python 3.9, evaluating `float | int | bool` at import time raises `TypeError` because PEP 604 runtime union operands are only supported in Python 3.10+.
+
+## Why tests missed it
+- Existing desktop packaged bridge tests primarily ran on Python 3.11.
+- No static guard existed to detect runtime-evaluated `|` unions in assignments across the desktop-packaged Python import graph.
+
+## Fix
+- Replaced runtime alias usage with Python 3.9-safe typing in `utils/system/resource_monitor.py` (`Union[...]`).
+- Added static AST guard coverage to fail on runtime `Assign` nodes containing PEP 604 `|` unions in the desktop-packaged Python import graph.
+- Strengthened packaged inspect probe assertions to explicitly reject bridge/import/PEP604 failure signatures.
+- Strengthened desktop UI e2e last-error assertions to reject `unsupported operand` / import failures / model-path-not-found markers.
+
+## Relay lifecycle architecture note
+This incident does **not** change architecture boundaries: the desktop Tauri app must not autolaunch, supervise, or own `relay.py`. Relay lifecycle remains separate and may only be started by explicit external harnesses (for example e2e fixtures).
+
+## Verification and regression coverage
+- Unit checks for `resource_monitor` and desktop bridge behavior.
+- Static AST guard for runtime-evaluated PEP 604 alias assignments.
+- Packaged model-bridge inspect probe rejects:
+  - `Model bridge failure`
+  - `unsupported operand type(s) for |`
+  - `No module named`
+  - `ModuleNotFoundError`
+  - `ImportError`
+- Existing no-relay-autostart guardrails remain in coverage.
+
+## Follow-up
+- Keep inspect-only packaged checks running under Python 3.9 in CI to catch compatibility regressions early.
+- Continue treating desktop runtime compatibility and no-relay lifecycle invariants as release blockers for desktop changes.

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -11,6 +11,7 @@ SCAN_ROOTS = (
     REPO_ROOT / "desktop-tauri" / "src-tauri" / "python",
     REPO_ROOT / "utils",
     REPO_ROOT / "config.py",
+    REPO_ROOT / "encrypt.py",
 )
 
 

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -58,26 +58,35 @@ def _is_typing_like_name(node: ast.AST) -> bool:
     return False
 
 
-def _is_simple_type_atom(node: ast.AST) -> bool:
+def _simple_type_atom_info(node: ast.AST) -> tuple[bool, bool]:
+    """Return (is_type_atom, is_explicit_type_marker)."""
     if isinstance(node, ast.Name):
-        # Builtin/simple runtime types frequently used directly in aliases.
         if node.id in {"str", "bytes", "int", "float", "bool", "object", "None"}:
-            return True
-        # Imported/project type names are usually CapWords, while ALL_CAPS is
-        # typically a runtime constant used in bitwise expressions.
-        return bool(node.id) and node.id[0].isupper() and not node.id.isupper()
+            return True, True
+        if bool(node.id) and node.id[0].isupper():
+            # CapWords and acronym-style type names (UUID, IO, URL, etc.).
+            return True, not node.id.isupper()
+        return False, False
     if isinstance(node, ast.Attribute):
         # e.g. pathlib.Path, decimal.Decimal, module.TreeNode
-        return True
+        return True, True
     if isinstance(node, ast.Constant):
-        return node.value is None or node.value is Ellipsis
-    return False
+        if node.value is None or node.value is Ellipsis:
+            return True, True
+    return False, False
+
+
+def _typing_like_union_chain_info(node: ast.AST) -> tuple[bool, bool]:
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left_ok, left_explicit = _typing_like_union_chain_info(node.left)
+        right_ok, right_explicit = _typing_like_union_chain_info(node.right)
+        return left_ok and right_ok, left_explicit or right_explicit
+    return _simple_type_atom_info(node)
 
 
 def _is_typing_like_union_chain(node: ast.AST) -> bool:
-    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return _is_typing_like_union_chain(node.left) and _is_typing_like_union_chain(node.right)
-    return _is_simple_type_atom(node)
+    ok, has_explicit = _typing_like_union_chain_info(node)
+    return ok and has_explicit
 
 
 def _contains_typing_like_context(value: ast.AST) -> bool:
@@ -234,6 +243,10 @@ def test_runtime_typing_union_alias_detection_regressions() -> None:
     )
     assert isinstance(wrapper_alias_assign, ast.Assign)
     assert _is_runtime_typing_union_alias(wrapper_alias_assign.value)
+
+    acronym_alias_assign = _first_assignment_from_source("MaybeUUID = UUID | str\n")
+    assert isinstance(acronym_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(acronym_alias_assign.value)
 
     bitwise_assign = _first_assignment_from_source("FLAGS = READ | WRITE\n")
     assert isinstance(bitwise_assign, ast.Assign)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -25,80 +25,8 @@ def _iter_python_files() -> list[Path]:
     return files
 
 
-def _is_runtime_union_alias(value: ast.AST) -> bool:
-    if isinstance(value, ast.BinOp) and isinstance(value.op, ast.BitOr):
-        return True
-    if isinstance(value, ast.Subscript):
-        return _is_runtime_union_alias(value.slice)
-    if isinstance(value, ast.Tuple):
-        return any(_is_runtime_union_alias(elt) for elt in value.elts)
-    if isinstance(value, ast.Dict):
-        return any(_is_runtime_union_alias(k) for k in value.keys if k is not None) or any(
-            _is_runtime_union_alias(v) for v in value.values
-        )
-    if isinstance(value, ast.List):
-        return any(_is_runtime_union_alias(elt) for elt in value.elts)
-    return False
-
-
-def _is_typing_like_name(node: ast.AST) -> bool:
-    typing_like_names = {
-        "Dict", "List", "Set", "FrozenSet", "Tuple",
-        "Mapping", "MutableMapping", "Sequence", "Iterable",
-        "Collection", "MutableSequence", "MutableSet",
-        "DefaultDict", "Deque", "Callable",
-        "Optional", "Union", "Literal", "Annotated",
-        "Type", "Final", "Generator",
-    }
-    builtins_generics = {"dict", "list", "set", "frozenset", "tuple"}
-    if isinstance(node, ast.Name):
-        return node.id in typing_like_names or node.id in builtins_generics
-    if isinstance(node, ast.Attribute):
-        return node.attr in typing_like_names or node.attr in builtins_generics
-    return False
-
-
-def _simple_type_atom_info(node: ast.AST) -> tuple[bool, bool]:
-    """Return (is_type_atom, is_explicit_type_marker)."""
-    if isinstance(node, ast.Name):
-        if node.id in {"str", "bytes", "int", "float", "bool", "object", "None"}:
-            return True, True
-        if bool(node.id) and node.id[0].isupper():
-            # CapWords and acronym-style type names (UUID, IO, URL, etc.).
-            return True, True
-        return False, False
-    if isinstance(node, ast.Attribute):
-        # e.g. pathlib.Path, decimal.Decimal, module.TreeNode
-        return True, True
-    if isinstance(node, ast.Constant):
-        if node.value is None or node.value is Ellipsis:
-            return True, True
-    return False, False
-
-
-def _typing_like_union_chain_info(node: ast.AST) -> tuple[bool, bool]:
-    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        left_ok, left_explicit = _typing_like_union_chain_info(node.left)
-        right_ok, right_explicit = _typing_like_union_chain_info(node.right)
-        return left_ok and right_ok, left_explicit or right_explicit
-    return _simple_type_atom_info(node)
-
-
-def _is_typing_like_union_chain(node: ast.AST) -> bool:
-    ok, has_explicit = _typing_like_union_chain_info(node)
-    return ok and has_explicit
-
-
-def _contains_typing_like_context(value: ast.AST) -> bool:
-    if isinstance(value, ast.BinOp) and isinstance(value.op, ast.BitOr):
-        return _is_typing_like_union_chain(value)
-    if isinstance(value, ast.Subscript) and _is_typing_like_name(value.value):
-        return True
-    return any(isinstance(node, ast.Subscript) and _is_typing_like_name(node.value) for node in ast.walk(value))
-
-
-def _is_runtime_typing_union_alias(value: ast.AST) -> bool:
-    return _is_runtime_union_alias(value) and _contains_typing_like_context(value)
+def _contains_runtime_bitor(value: ast.AST) -> bool:
+    return any(isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr) for node in ast.walk(value))
 
 
 def _contains_type_alias_annotation(annotation: ast.AST | None) -> bool:
@@ -112,16 +40,23 @@ def _contains_type_alias_annotation(annotation: ast.AST | None) -> bool:
     return False
 
 
-def _is_alias_like_target(target: ast.AST) -> bool:
-    if not isinstance(target, ast.Name) or not target.id:
-        return False
-    if not target.id[0].isupper():
-        return False
-    if target.id.isupper():
-        # Permit likely type aliases (T, IO, URL, UUID) while excluding
-        # constant-like names (FLAGS, READ, WRITE) to avoid bitwise false positives.
-        return len(target.id) <= 4
-    return True
+def _known_safe_runtime_bitor_assignment(target: ast.AST, value: ast.AST) -> bool:
+    """Narrow escape hatch for legitimate runtime bitwise assignments.
+
+    Import-time `|` in assignment RHS is forbidden by default for Python 3.9 safety
+    in desktop-packaged Python. Add explicit cases here only when known-safe and
+    clearly non-typing.
+    """
+    return (
+        isinstance(target, ast.Name)
+        and target.id == "FLAGS"
+        and isinstance(value, ast.BinOp)
+        and isinstance(value.op, ast.BitOr)
+        and isinstance(value.left, ast.Name)
+        and value.left.id == "READ"
+        and isinstance(value.right, ast.Name)
+        and value.right.id == "WRITE"
+    )
 
 
 def _iter_import_time_child_bodies(node: ast.AST) -> list[list[ast.stmt]]:
@@ -161,21 +96,21 @@ def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignme
             if isinstance(node, ast.Assign):
                 value = node.value
                 targets = node.targets
-                alias_like = all(_is_alias_like_target(target) for target in targets)
             elif isinstance(node, ast.AnnAssign):
                 value = node.value
                 targets = [node.target]
-                alias_like = _contains_type_alias_annotation(node.annotation) or _is_alias_like_target(node.target)
             else:
                 continue
 
-            if value is None or not alias_like:
+            if value is None or not _contains_runtime_bitor(value):
                 continue
 
-            if _is_runtime_typing_union_alias(value):
-                target_names = [ast.unparse(target) for target in targets]
-                rel = path.relative_to(REPO_ROOT)
-                violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(target_names)}")
+            if all(_known_safe_runtime_bitor_assignment(target, value) for target in targets):
+                continue
+
+            target_names = [ast.unparse(target) for target in targets]
+            rel = path.relative_to(REPO_ROOT)
+            violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(target_names)}")
 
     assert not violations, "\n".join(violations)
 
@@ -218,60 +153,57 @@ def test_runtime_typing_union_alias_detection_regressions() -> None:
         "from typing import Dict, TypeAlias\nGpuMetrics: TypeAlias = Dict[str, float | int | bool]\n"
     )
     assert _contains_type_alias_annotation(ann_assign.annotation)
-    assert _is_runtime_typing_union_alias(ann_assign.value)
+    assert _contains_runtime_bitor(ann_assign.value)
 
     class_assign = _first_assignment_from_source(
         "from typing import Dict\nclass Metrics:\n    GpuMetrics = Dict[str, float | int | bool]\n"
     )
     assert isinstance(class_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(class_assign.value)
+    assert _contains_runtime_bitor(class_assign.value)
 
     conditional_assign = _first_assignment_from_source(
         "from typing import Dict\nif True:\n    GpuMetrics = Dict[str, float | int | bool]\n"
     )
     assert isinstance(conditional_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(conditional_assign.value)
+    assert _contains_runtime_bitor(conditional_assign.value)
 
     direct_alias_assign = _first_assignment_from_source("GpuMetricValue = float | int | bool\n")
     assert isinstance(direct_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(direct_alias_assign.value)
+    assert _contains_runtime_bitor(direct_alias_assign.value)
 
     callable_alias_assign = _first_assignment_from_source(
         "from typing import Callable\nBytesOrText = Callable[[str | bytes], None]\n"
     )
     assert isinstance(callable_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(callable_alias_assign.value)
+    assert _contains_runtime_bitor(callable_alias_assign.value)
 
     capitalized_alias_assign = _first_assignment_from_source("PathLike = str | Path\n")
     assert isinstance(capitalized_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(capitalized_alias_assign.value)
+    assert _contains_runtime_bitor(capitalized_alias_assign.value)
 
     wrapper_alias_assign = _first_assignment_from_source(
         "from typing import Type\nTypePath = Type[str | Path]\n"
     )
     assert isinstance(wrapper_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(wrapper_alias_assign.value)
+    assert _contains_runtime_bitor(wrapper_alias_assign.value)
 
     acronym_alias_assign = _first_assignment_from_source("MaybeUUID = UUID | str\n")
     assert isinstance(acronym_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(acronym_alias_assign.value)
+    assert _contains_runtime_bitor(acronym_alias_assign.value)
 
     all_acronym_alias_assign = _first_assignment_from_source("MaybeURL = URL | UUID\n")
     assert isinstance(all_acronym_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(all_acronym_alias_assign.value)
+    assert _contains_runtime_bitor(all_acronym_alias_assign.value)
 
     bitwise_assign = _first_assignment_from_source("FLAGS = READ | WRITE\n")
     assert isinstance(bitwise_assign, ast.Assign)
-    assert _is_runtime_union_alias(bitwise_assign.value)
-    assert _is_runtime_typing_union_alias(bitwise_assign.value)
-    assert not all(_is_alias_like_target(target) for target in bitwise_assign.targets)
+    assert _contains_runtime_bitor(bitwise_assign.value)
+    assert _known_safe_runtime_bitor_assignment(bitwise_assign.targets[0], bitwise_assign.value)
 
     uppercase_direct_alias_assign = _first_assignment_from_source("T = str | bytes\n")
     assert isinstance(uppercase_direct_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(uppercase_direct_alias_assign.value)
-    assert all(_is_alias_like_target(target) for target in uppercase_direct_alias_assign.targets)
+    assert _contains_runtime_bitor(uppercase_direct_alias_assign.value)
 
     uppercase_acronym_alias_assign = _first_assignment_from_source("URL = UUID | URL\n")
     assert isinstance(uppercase_acronym_alias_assign, ast.Assign)
-    assert _is_runtime_typing_union_alias(uppercase_acronym_alias_assign.value)
-    assert all(_is_alias_like_target(target) for target in uppercase_acronym_alias_assign.targets)
+    assert _contains_runtime_bitor(uppercase_acronym_alias_assign.value)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -41,6 +41,40 @@ def _is_runtime_union_alias(value: ast.AST) -> bool:
     return False
 
 
+def _is_typing_like_name(node: ast.AST) -> bool:
+    typing_like_names = {
+        "Dict",
+        "List",
+        "Set",
+        "FrozenSet",
+        "Tuple",
+        "Mapping",
+        "MutableMapping",
+        "Sequence",
+        "Iterable",
+        "Optional",
+        "Union",
+        "Literal",
+        "Annotated",
+    }
+    builtins_generics = {"dict", "list", "set", "frozenset", "tuple"}
+    if isinstance(node, ast.Name):
+        return node.id in typing_like_names or node.id in builtins_generics
+    if isinstance(node, ast.Attribute):
+        return node.attr in typing_like_names or node.attr in builtins_generics
+    return False
+
+
+def _contains_typing_like_context(value: ast.AST) -> bool:
+    if isinstance(value, ast.Subscript) and _is_typing_like_name(value.value):
+        return True
+    return any(isinstance(node, ast.Subscript) and _is_typing_like_name(node.value) for node in ast.walk(value))
+
+
+def _is_runtime_typing_union_alias(value: ast.AST) -> bool:
+    return _is_runtime_union_alias(value) and _contains_typing_like_context(value)
+
+
 def _contains_type_alias_annotation(annotation: ast.AST | None) -> bool:
     if annotation is None:
         return False
@@ -104,7 +138,7 @@ def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignme
             if value is None or not alias_like:
                 continue
 
-            if _is_runtime_union_alias(value):
+            if _is_runtime_typing_union_alias(value):
                 target_names = [ast.unparse(target) for target in targets]
                 rel = path.relative_to(REPO_ROOT)
                 violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(target_names)}")
@@ -134,3 +168,36 @@ def test_desktop_packaged_import_graph_has_no_unconditional_dataclass_slots_true
                         )
 
     assert not violations, "\n".join(violations)
+
+
+def _first_assignment_from_source(source: str) -> ast.Assign | ast.AnnAssign:
+    tree = ast.parse(source)
+    for node in _iter_import_time_assignment_nodes(tree):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            return node
+    raise AssertionError("expected assignment in source")
+
+
+def test_runtime_typing_union_alias_detection_regressions() -> None:
+    ann_assign = _first_assignment_from_source(
+        "from typing import Dict, TypeAlias\nGpuMetrics: TypeAlias = Dict[str, float | int | bool]\n"
+    )
+    assert _contains_type_alias_annotation(ann_assign.annotation)
+    assert _is_runtime_typing_union_alias(ann_assign.value)
+
+    class_assign = _first_assignment_from_source(
+        "from typing import Dict\nclass Metrics:\n    GpuMetrics = Dict[str, float | int | bool]\n"
+    )
+    assert isinstance(class_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(class_assign.value)
+
+    conditional_assign = _first_assignment_from_source(
+        "from typing import Dict\nif True:\n    GpuMetrics = Dict[str, float | int | bool]\n"
+    )
+    assert isinstance(conditional_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(conditional_assign.value)
+
+    bitwise_assign = _first_assignment_from_source("FLAGS = READ | WRITE\n")
+    assert isinstance(bitwise_assign, ast.Assign)
+    assert _is_runtime_union_alias(bitwise_assign.value)
+    assert not _is_runtime_typing_union_alias(bitwise_assign.value)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -55,16 +55,32 @@ def _is_alias_like_target(target: ast.AST) -> bool:
     return isinstance(target, ast.Name) and bool(target.id) and target.id[0].isupper()
 
 
+def _iter_import_time_child_bodies(node: ast.AST) -> list[list[ast.stmt]]:
+    if isinstance(node, ast.ClassDef):
+        return [node.body]
+    if isinstance(node, ast.If):
+        return [node.body, node.orelse]
+    if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+        return [node.body, node.orelse]
+    if isinstance(node, ast.With):
+        return [node.body]
+    if isinstance(node, ast.Try):
+        bodies: list[list[ast.stmt]] = [node.body, node.orelse, node.finalbody]
+        bodies.extend(handler.body for handler in node.handlers)
+        return bodies
+    if isinstance(node, ast.Match):
+        return [case.body for case in node.cases]
+    return []
+
+
 def _iter_import_time_assignment_nodes(tree: ast.AST):
-    stack = [tree]
+    stack: list[list[ast.stmt]] = [getattr(tree, "body", [])]
     while stack:
-        scope = stack.pop()
-        body = getattr(scope, "body", [])
+        body = stack.pop()
         for node in body:
             if isinstance(node, (ast.Assign, ast.AnnAssign)):
                 yield node
-            if isinstance(node, ast.ClassDef):
-                stack.append(node)
+            stack.extend(_iter_import_time_child_bodies(node))
 
 
 def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignments() -> None:

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -55,12 +55,24 @@ def _is_alias_like_target(target: ast.AST) -> bool:
     return isinstance(target, ast.Name) and bool(target.id) and target.id[0].isupper()
 
 
+def _iter_import_time_assignment_nodes(tree: ast.AST):
+    stack = [tree]
+    while stack:
+        scope = stack.pop()
+        body = getattr(scope, "body", [])
+        for node in body:
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                yield node
+            if isinstance(node, ast.ClassDef):
+                stack.append(node)
+
+
 def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignments() -> None:
     violations: list[str] = []
 
     for path in _iter_python_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in tree.body:
+        for node in _iter_import_time_assignment_nodes(tree):
             if isinstance(node, ast.Assign):
                 value = node.value
                 targets = node.targets

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -113,12 +113,15 @@ def _contains_type_alias_annotation(annotation: ast.AST | None) -> bool:
 
 
 def _is_alias_like_target(target: ast.AST) -> bool:
-    return (
-        isinstance(target, ast.Name)
-        and bool(target.id)
-        and target.id[0].isupper()
-        and not target.id.isupper()
-    )
+    if not isinstance(target, ast.Name) or not target.id:
+        return False
+    if not target.id[0].isupper():
+        return False
+    if target.id.isupper():
+        # Permit likely type aliases (T, IO, URL, UUID) while excluding
+        # constant-like names (FLAGS, READ, WRITE) to avoid bitwise false positives.
+        return len(target.id) <= 4
+    return True
 
 
 def _iter_import_time_child_bodies(node: ast.AST) -> list[list[ast.stmt]]:
@@ -262,3 +265,13 @@ def test_runtime_typing_union_alias_detection_regressions() -> None:
     assert _is_runtime_union_alias(bitwise_assign.value)
     assert _is_runtime_typing_union_alias(bitwise_assign.value)
     assert not all(_is_alias_like_target(target) for target in bitwise_assign.targets)
+
+    uppercase_direct_alias_assign = _first_assignment_from_source("T = str | bytes\n")
+    assert isinstance(uppercase_direct_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(uppercase_direct_alias_assign.value)
+    assert all(_is_alias_like_target(target) for target in uppercase_direct_alias_assign.targets)
+
+    uppercase_acronym_alias_assign = _first_assignment_from_source("URL = UUID | URL\n")
+    assert isinstance(uppercase_acronym_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(uppercase_acronym_alias_assign.value)
+    assert all(_is_alias_like_target(target) for target in uppercase_acronym_alias_assign.targets)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -88,9 +88,6 @@ def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignme
     violations: list[str] = []
 
     for path in _iter_python_files():
-        rel = path.relative_to(REPO_ROOT)
-        if rel.parts[:2] == ("utils", "testing"):
-            continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in _iter_import_time_assignment_nodes(tree):
             if isinstance(node, ast.Assign):
@@ -119,9 +116,6 @@ def test_desktop_packaged_import_graph_has_no_unconditional_dataclass_slots_true
     violations: list[str] = []
 
     for path in _iter_python_files():
-        rel = path.relative_to(REPO_ROOT)
-        if rel.parts[:2] == ("utils", "testing"):
-            continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
             if not isinstance(node, ast.ClassDef):

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -40,17 +40,44 @@ def _is_runtime_union_alias(value: ast.AST) -> bool:
     return False
 
 
+def _contains_type_alias_annotation(annotation: ast.AST | None) -> bool:
+    if annotation is None:
+        return False
+    for node in ast.walk(annotation):
+        if isinstance(node, ast.Name) and node.id == "TypeAlias":
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == "TypeAlias":
+            return True
+    return False
+
+
+def _is_alias_like_target(target: ast.AST) -> bool:
+    return isinstance(target, ast.Name) and bool(target.id) and target.id[0].isupper()
+
+
 def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignments() -> None:
     violations: list[str] = []
 
     for path in _iter_python_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Assign):
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                value = node.value
+                targets = node.targets
+                alias_like = all(_is_alias_like_target(target) for target in targets)
+            elif isinstance(node, ast.AnnAssign):
+                value = node.value
+                targets = [node.target]
+                alias_like = _contains_type_alias_annotation(node.annotation) or _is_alias_like_target(node.target)
+            else:
                 continue
-            if _is_runtime_union_alias(node.value):
-                targets = [ast.unparse(target) for target in node.targets]
+
+            if value is None or not alias_like:
+                continue
+
+            if _is_runtime_union_alias(value):
+                target_names = [ast.unparse(target) for target in targets]
                 rel = path.relative_to(REPO_ROOT)
-                violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(targets)}")
+                violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(target_names)}")
 
     assert not violations, "\n".join(violations)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -1,0 +1,56 @@
+"""Guard against runtime-evaluated PEP 604 type-alias assignments in desktop Python import paths."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_ROOTS = (
+    REPO_ROOT / "desktop-tauri" / "src-tauri" / "python",
+    REPO_ROOT / "utils",
+    REPO_ROOT / "config.py",
+)
+
+
+def _iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        if root.is_file():
+            files.append(root)
+            continue
+        files.extend(sorted(root.rglob("*.py")))
+    return files
+
+
+def _is_runtime_union_alias(value: ast.AST) -> bool:
+    if isinstance(value, ast.BinOp) and isinstance(value.op, ast.BitOr):
+        return True
+    if isinstance(value, ast.Subscript):
+        return _is_runtime_union_alias(value.slice)
+    if isinstance(value, ast.Tuple):
+        return any(_is_runtime_union_alias(elt) for elt in value.elts)
+    if isinstance(value, ast.Dict):
+        return any(_is_runtime_union_alias(k) for k in value.keys if k is not None) or any(
+            _is_runtime_union_alias(v) for v in value.values
+        )
+    if isinstance(value, ast.List):
+        return any(_is_runtime_union_alias(elt) for elt in value.elts)
+    return False
+
+
+def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignments() -> None:
+    violations: list[str] = []
+
+    for path in _iter_python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if _is_runtime_union_alias(node.value):
+                targets = [ast.unparse(target) for target in node.targets]
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(targets)}")
+
+    assert not violations, "\n".join(violations)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -43,19 +43,11 @@ def _is_runtime_union_alias(value: ast.AST) -> bool:
 
 def _is_typing_like_name(node: ast.AST) -> bool:
     typing_like_names = {
-        "Dict",
-        "List",
-        "Set",
-        "FrozenSet",
-        "Tuple",
-        "Mapping",
-        "MutableMapping",
-        "Sequence",
-        "Iterable",
-        "Optional",
-        "Union",
-        "Literal",
-        "Annotated",
+        "Dict", "List", "Set", "FrozenSet", "Tuple",
+        "Mapping", "MutableMapping", "Sequence", "Iterable",
+        "Collection", "MutableSequence", "MutableSet",
+        "DefaultDict", "Deque", "Callable",
+        "Optional", "Union", "Literal", "Annotated",
     }
     builtins_generics = {"dict", "list", "set", "frozenset", "tuple"}
     if isinstance(node, ast.Name):
@@ -65,7 +57,25 @@ def _is_typing_like_name(node: ast.AST) -> bool:
     return False
 
 
+def _is_simple_type_atom(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id[0].islower()
+    if isinstance(node, ast.Attribute):
+        return True
+    if isinstance(node, ast.Constant):
+        return node.value is None or node.value is Ellipsis
+    return False
+
+
+def _is_typing_like_union_chain(node: ast.AST) -> bool:
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _is_typing_like_union_chain(node.left) and _is_typing_like_union_chain(node.right)
+    return _is_simple_type_atom(node)
+
+
 def _contains_typing_like_context(value: ast.AST) -> bool:
+    if isinstance(value, ast.BinOp) and isinstance(value.op, ast.BitOr):
+        return _is_typing_like_union_chain(value)
     if isinstance(value, ast.Subscript) and _is_typing_like_name(value.value):
         return True
     return any(isinstance(node, ast.Subscript) and _is_typing_like_name(node.value) for node in ast.walk(value))
@@ -163,6 +173,7 @@ def test_desktop_packaged_import_graph_has_no_unconditional_dataclass_slots_true
                     continue
                 for keyword in decorator.keywords:
                     if keyword.arg == "slots" and isinstance(keyword.value, ast.Constant) and keyword.value.value is True:
+                        rel = path.relative_to(REPO_ROOT)
                         violations.append(
                             f"{rel}:{node.lineno} uses dataclass(slots=True) without Python-version gating"
                         )
@@ -196,6 +207,16 @@ def test_runtime_typing_union_alias_detection_regressions() -> None:
     )
     assert isinstance(conditional_assign, ast.Assign)
     assert _is_runtime_typing_union_alias(conditional_assign.value)
+
+    direct_alias_assign = _first_assignment_from_source("GpuMetricValue = float | int | bool\n")
+    assert isinstance(direct_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(direct_alias_assign.value)
+
+    callable_alias_assign = _first_assignment_from_source(
+        "from typing import Callable\nBytesOrText = Callable[[str | bytes], None]\n"
+    )
+    assert isinstance(callable_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(callable_alias_assign.value)
 
     bitwise_assign = _first_assignment_from_source("FLAGS = READ | WRITE\n")
     assert isinstance(bitwise_assign, ast.Assign)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -88,6 +88,9 @@ def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignme
     violations: list[str] = []
 
     for path in _iter_python_files():
+        rel = path.relative_to(REPO_ROOT)
+        if rel.parts[:2] == ("utils", "testing"):
+            continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in _iter_import_time_assignment_nodes(tree):
             if isinstance(node, ast.Assign):
@@ -108,5 +111,32 @@ def test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignme
                 target_names = [ast.unparse(target) for target in targets]
                 rel = path.relative_to(REPO_ROOT)
                 violations.append(f"{rel}:{node.lineno} assigns runtime union alias: {', '.join(target_names)}")
+
+    assert not violations, "\n".join(violations)
+
+
+def test_desktop_packaged_import_graph_has_no_unconditional_dataclass_slots_true() -> None:
+    violations: list[str] = []
+
+    for path in _iter_python_files():
+        rel = path.relative_to(REPO_ROOT)
+        if rel.parts[:2] == ("utils", "testing"):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call):
+                    continue
+                func = decorator.func
+                is_dataclass = isinstance(func, ast.Name) and func.id == "dataclass"
+                if not is_dataclass:
+                    continue
+                for keyword in decorator.keywords:
+                    if keyword.arg == "slots" and isinstance(keyword.value, ast.Constant) and keyword.value.value is True:
+                        violations.append(
+                            f"{rel}:{node.lineno} uses dataclass(slots=True) without Python-version gating"
+                        )
 
     assert not violations, "\n".join(violations)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -48,6 +48,7 @@ def _is_typing_like_name(node: ast.AST) -> bool:
         "Collection", "MutableSequence", "MutableSet",
         "DefaultDict", "Deque", "Callable",
         "Optional", "Union", "Literal", "Annotated",
+        "Type", "Final", "Generator",
     }
     builtins_generics = {"dict", "list", "set", "frozenset", "tuple"}
     if isinstance(node, ast.Name):
@@ -59,8 +60,14 @@ def _is_typing_like_name(node: ast.AST) -> bool:
 
 def _is_simple_type_atom(node: ast.AST) -> bool:
     if isinstance(node, ast.Name):
-        return node.id[0].islower()
+        # Builtin/simple runtime types frequently used directly in aliases.
+        if node.id in {"str", "bytes", "int", "float", "bool", "object", "None"}:
+            return True
+        # Imported/project type names are usually CapWords, while ALL_CAPS is
+        # typically a runtime constant used in bitwise expressions.
+        return bool(node.id) and node.id[0].isupper() and not node.id.isupper()
     if isinstance(node, ast.Attribute):
+        # e.g. pathlib.Path, decimal.Decimal, module.TreeNode
         return True
     if isinstance(node, ast.Constant):
         return node.value is None or node.value is Ellipsis
@@ -217,6 +224,16 @@ def test_runtime_typing_union_alias_detection_regressions() -> None:
     )
     assert isinstance(callable_alias_assign, ast.Assign)
     assert _is_runtime_typing_union_alias(callable_alias_assign.value)
+
+    capitalized_alias_assign = _first_assignment_from_source("PathLike = str | Path\n")
+    assert isinstance(capitalized_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(capitalized_alias_assign.value)
+
+    wrapper_alias_assign = _first_assignment_from_source(
+        "from typing import Type\nTypePath = Type[str | Path]\n"
+    )
+    assert isinstance(wrapper_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(wrapper_alias_assign.value)
 
     bitwise_assign = _first_assignment_from_source("FLAGS = READ | WRITE\n")
     assert isinstance(bitwise_assign, ast.Assign)

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -65,7 +65,7 @@ def _simple_type_atom_info(node: ast.AST) -> tuple[bool, bool]:
             return True, True
         if bool(node.id) and node.id[0].isupper():
             # CapWords and acronym-style type names (UUID, IO, URL, etc.).
-            return True, not node.id.isupper()
+            return True, True
         return False, False
     if isinstance(node, ast.Attribute):
         # e.g. pathlib.Path, decimal.Decimal, module.TreeNode
@@ -113,7 +113,12 @@ def _contains_type_alias_annotation(annotation: ast.AST | None) -> bool:
 
 
 def _is_alias_like_target(target: ast.AST) -> bool:
-    return isinstance(target, ast.Name) and bool(target.id) and target.id[0].isupper()
+    return (
+        isinstance(target, ast.Name)
+        and bool(target.id)
+        and target.id[0].isupper()
+        and not target.id.isupper()
+    )
 
 
 def _iter_import_time_child_bodies(node: ast.AST) -> list[list[ast.stmt]]:
@@ -248,7 +253,12 @@ def test_runtime_typing_union_alias_detection_regressions() -> None:
     assert isinstance(acronym_alias_assign, ast.Assign)
     assert _is_runtime_typing_union_alias(acronym_alias_assign.value)
 
+    all_acronym_alias_assign = _first_assignment_from_source("MaybeURL = URL | UUID\n")
+    assert isinstance(all_acronym_alias_assign, ast.Assign)
+    assert _is_runtime_typing_union_alias(all_acronym_alias_assign.value)
+
     bitwise_assign = _first_assignment_from_source("FLAGS = READ | WRITE\n")
     assert isinstance(bitwise_assign, ast.Assign)
     assert _is_runtime_union_alias(bitwise_assign.value)
-    assert not _is_runtime_typing_union_alias(bitwise_assign.value)
+    assert _is_runtime_typing_union_alias(bitwise_assign.value)
+    assert not all(_is_alias_like_target(target) for target in bitwise_assign.targets)

--- a/tests/unit/test_resource_monitor.py
+++ b/tests/unit/test_resource_monitor.py
@@ -1,4 +1,5 @@
 """Unit tests for the resource monitoring utilities."""
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -518,3 +519,11 @@ def test_can_allocate_gpu_memory_ignores_shutdown_errors(monkeypatch):
 
     assert rm.can_allocate_gpu_memory(4_000_000_000) is False
     assert shutdown_calls == 1
+
+
+def test_resource_monitor_source_avoids_runtime_pep604_alias_assignment() -> None:
+    """Regression: Python 3.9 cannot evaluate ``Dict[..., float | int | bool]`` at runtime."""
+    source = Path(__file__).resolve().parents[2].joinpath("utils", "system", "resource_monitor.py").read_text(
+        encoding="utf-8"
+    )
+    assert "GpuMetrics = Dict[str, float | int | bool]" not in source

--- a/utils/system/resource_monitor.py
+++ b/utils/system/resource_monitor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import importlib
 import sys
-from typing import Dict
+from typing import Dict, Union
 
 
 def _gpu_headroom_multiplier(headroom_percent: float) -> float:
@@ -23,7 +23,7 @@ except (ImportError, OSError):  # pragma: no cover - exercised via import fallba
     psutil = None
 
 
-GpuMetrics = Dict[str, float | int | bool]
+GpuMetrics = Dict[str, Union[float, int, bool]]
 
 
 def _gpu_metrics_default(*, available: bool = False, count: int = 0) -> GpuMetrics:
@@ -167,7 +167,7 @@ def _cpu_interval_for_platform(platform: str) -> float | None:
     return None
 
 
-def collect_resource_usage() -> Dict[str, float | int | bool]:
+def collect_resource_usage() -> Dict[str, Union[float, int, bool]]:
     """Return current CPU, memory, and GPU utilisation metrics."""
 
     interval = _cpu_interval_for_platform(sys.platform)

--- a/utils/testing/platform_matrix.py
+++ b/utils/testing/platform_matrix.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import sys
 from typing import Iterable, MutableMapping, Sequence
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, **({"slots": True} if sys.version_info >= (3, 10) else {}))
 class PlatformMatrixEntry:
     """A single target entry for the CI test matrix."""
 

--- a/utils/testing/stress.py
+++ b/utils/testing/stress.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import time
 from dataclasses import dataclass
 from typing import Optional
@@ -9,7 +10,7 @@ from typing import Optional
 import encrypt
 
 
-@dataclass(slots=True)
+@dataclass(**({"slots": True} if sys.version_info >= (3, 10) else {}))
 class StreamEncryptionStressResult:
     """Summary of a streaming encryption stress run."""
 


### PR DESCRIPTION
### Motivation
- Desktop Tauri startup/inspect could fail on macOS when the packaged Python resolved to 3.9 with a runtime `TypeError: unsupported operand type(s) for |` originating from runtime-evaluated PEP 604 unions in import-time assignments (e.g. `GpuMetrics = Dict[str, float | int | bool]`).
- The goal is to remove the compatibility hazard from desktop-packaged import paths, add static/regression checks to prevent reintroduction, and ensure the failure is fixed end-to-end rather than hidden by the UI.

### Description
- Replace runtime-evaluated PEP 604 union usage with Python 3.9-safe typing in `utils/system/resource_monitor.py` (`float | int | bool` -> `Union[float, int, bool]`) and update the return type hints accordingly.
- Add a static AST guard test `tests/unit/test_desktop_python_pep604_runtime_alias_guard.py` that scans the desktop-packaged import graph (`desktop-tauri/src-tauri/python`, `utils`, `config.py`) and fails if any module-level `Assign` contains a runtime `|` union expression.
- Harden packaged inspection and UI e2e checks: update `desktop-tauri/scripts/test_packaged_operator_e2e.py` to reject `Model bridge failure` / `unsupported operand type(s) for |` / import errors, and tighten desktop UI e2e last-error assertions in `desktop-tauri/scripts/test_desktop_operator_ui_e2e.py` to reject unsupported-operand/import/model-path-not-found markers.
- Add CI/infra coverage to run an inspect-only packaged probe on macOS+Python 3.9 in `.github/workflows/desktop-operator-e2e.yml` and add incident documentation `outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.{md,json}`.

Changed files (high level): `utils/system/resource_monitor.py`, `tests/unit/test_resource_monitor.py`, `tests/unit/test_desktop_python_pep604_runtime_alias_guard.py`, `desktop-tauri/scripts/test_packaged_operator_e2e.py`, `desktop-tauri/scripts/test_desktop_operator_ui_e2e.py`, `.github/workflows/desktop-operator-e2e.yml`, `outages/...`.

### Testing
- Ran unit suite for affected modules: `python -m pytest tests/unit/test_resource_monitor.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_no_relay_autostart.py tests/unit/test_desktop_python_pep604_runtime_alias_guard.py` — all tests passed (69 passed total).
- Ran targeted desktop bridge unit tests: `python -m pytest tests/unit/test_desktop_model_bridge.py -k inspect --maxfail=1` — passed (10 selected tests passed).
- Ran packaged inspect probe in-process: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` — succeeded (inspect-only probe did not report forbidden markers).
- Ran full packaged packaged operator e2e probe: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` — succeeded in this environment.
- Frontend unit tests: `cd desktop-tauri && npm test -- --run` — succeeded (vitest tests passed).
- Rust tests: `cd desktop-tauri/src-tauri && cargo test` — did not complete in this Linux CI container due to missing system `glib-2.0`/pkg-config libraries (environment issue), not code regressions; this is noted in verification output.

All automated checks that exercise the Python import graph and the new AST guard passed in this environment; cargo test failed for environment-native system deps only. The fixes are minimal, targeted, and preserve the desktop <-> relay lifecycle invariants (desktop app does not bundle/autostart `relay.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15454a737c832fa806b9055c8cf603)