### PR TITLE
Fix desktop model bridge Python 3.9 PEP 604 alias failure

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -125,6 +125,23 @@ jobs:
       - name: Run packaged operator bridge e2e (Windows)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
 
+
+  desktop-operator-inspect-py39-macos:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Run model bridge inspect-only packaged probe (macOS Python 3.9)
+        env:
+          TOKEN_PLACE_INSPECT_ONLY: "1"
+        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
   desktop-operator-packaged-e2e-macos:
     runs-on: macos-latest
     timeout-minutes: 20

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -145,6 +145,11 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
 
     forbidden_any_output = [
         "Missing Python dependency for model downloads",
+        "Model bridge failure",
+        "unsupported operand type(s) for |",
+        "No module named",
+        "ModuleNotFoundError",
+        "ImportError",
         "No module named 'psutil'",
         "No module named 'requests'",
         "No module named 'dotenv'",

--- a/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.json
+++ b/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-26",
+  "slug": "desktop-macos-model-bridge-pep604-type-alias",
+  "summary": "Desktop macOS model bridge could fail during import on Python 3.9 due to runtime-evaluated PEP 604 union type alias assignment.",
+  "impact": "Model bridge inspect/download startup could return Model bridge failure with unsupported operand type(s) for | before operator runtime start.",
+  "fix": "Converted runtime alias unions in resource_monitor to Python 3.9-safe typing forms, added static alias guard, tightened packaged inspect failure assertions, and added macOS Python 3.9 inspect-only workflow coverage.",
+  "lessons": "Desktop packaged import paths must avoid runtime-evaluated PEP 604 alias expressions when Python 3.9 may be selected, and relay lifecycle ownership must remain separate from desktop app startup."
+}

--- a/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.md
+++ b/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.md
@@ -1,0 +1,31 @@
+# Desktop macOS model bridge PEP 604 runtime type alias failure (2026-05-26)
+
+## Summary
+Desktop Tauri model bridge startup could fail on macOS environments resolving to Python 3.9 with:
+`Model bridge failure: unsupported operand type(s) for |: 'type' and 'type'`.
+
+## Root cause
+`utils/system/resource_monitor.py` used a runtime assignment type alias:
+`GpuMetrics = Dict[str, float | int | bool]`.
+This expression is evaluated at import time and is not Python 3.9-compatible, so importing desktop
+model bridge dependencies could raise before inspect/download actions completed.
+
+## Why tests missed it
+Existing packaged bridge checks mainly exercised Python 3.11 and did not include a dedicated Python 3.9
+inspect-only probe or a static guard for runtime-evaluated union aliases in desktop-packaged import paths.
+
+## Fix
+- Replaced runtime-evaluated union aliases in `resource_monitor.py` with Python 3.9-safe typing (`Union`, `Optional`).
+- Added static AST regression guard for runtime-evaluated PEP 604 alias assignments in desktop-packaged Python graph.
+- Strengthened packaged inspect probe assertions to reject bridge/import failures and PEP 604 type errors.
+- Added macOS Python 3.9 inspect-only workflow coverage.
+- Preserved desktop no-relay-autostart invariant: relay lifecycle remains test-harness-owned and separate from app ownership.
+
+## Regression tests
+- Unit/static guard for runtime-evaluated PEP 604 alias assignments.
+- Packaged model bridge inspect probe rejects model bridge failure/import failure markers.
+- Existing desktop no-relay-autostart unit guard remains active.
+
+## Follow-up
+- Keep desktop packaged import graph Python 3.9-safe while macOS launcher/runtime discovery can select 3.9.
+- Maintain explicit relay separation: desktop app must not bundle/autolaunch/supervise `relay.py`.

--- a/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
+++ b/tests/unit/test_desktop_python_pep604_runtime_alias_guard.py
@@ -1,0 +1,45 @@
+"""Guard against runtime-evaluated PEP 604 aliases in desktop-packaged Python imports."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_IMPORT_GRAPH_ROOTS = [
+    REPO_ROOT / 'desktop-tauri' / 'src-tauri' / 'python',
+    REPO_ROOT / 'utils',
+    REPO_ROOT / 'config.py',
+]
+
+
+def _iter_python_files():
+    for root in DESKTOP_IMPORT_GRAPH_ROOTS:
+        if root.is_file():
+            yield root
+            continue
+        for path in root.rglob('*.py'):
+            yield path
+
+
+def _has_runtime_union_alias(node: ast.Assign) -> bool:
+    # Runtime assignment like: Alias = Dict[str, int | str]
+    value = node.value
+    if not isinstance(value, ast.Subscript):
+        return False
+    return any(isinstance(subnode, ast.BinOp) and isinstance(subnode.op, ast.BitOr) for subnode in ast.walk(value))
+
+
+def test_no_runtime_pep604_type_aliases_in_desktop_packaged_import_graph():
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and _has_runtime_union_alias(node):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+
+    assert offenders == [], (
+        'Runtime-evaluated PEP 604 union aliases are not Python 3.9 compatible in desktop import paths: '
+        + ', '.join(offenders)
+    )

--- a/utils/system/resource_monitor.py
+++ b/utils/system/resource_monitor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import importlib
 import sys
-from typing import Dict
+from typing import Dict, Optional, Union
 
 
 def _gpu_headroom_multiplier(headroom_percent: float) -> float:
@@ -23,7 +23,7 @@ except (ImportError, OSError):  # pragma: no cover - exercised via import fallba
     psutil = None
 
 
-GpuMetrics = Dict[str, float | int | bool]
+GpuMetrics = Dict[str, Union[float, int, bool]]
 
 
 def _gpu_metrics_default(*, available: bool = False, count: int = 0) -> GpuMetrics:
@@ -158,7 +158,7 @@ def can_allocate_gpu_memory(required_bytes: float, *, headroom_percent: float = 
             pass
 
 
-def _cpu_interval_for_platform(platform: str) -> float | None:
+def _cpu_interval_for_platform(platform: str) -> Optional[float]:
     """Return the psutil sampling interval tuned for the active platform."""
 
     normalized = platform.lower()
@@ -167,7 +167,7 @@ def _cpu_interval_for_platform(platform: str) -> float | None:
     return None
 
 
-def collect_resource_usage() -> Dict[str, float | int | bool]:
+def collect_resource_usage() -> Dict[str, Union[float, int, bool]]:
     """Return current CPU, memory, and GPU utilisation metrics."""
 
     interval = _cpu_interval_for_platform(sys.platform)


### PR DESCRIPTION
### Motivation
- macOS desktop Tauri startup could fail with `Model bridge failure: unsupported operand type(s) for |` when the system Python resolved to 3.9 because a runtime-evaluated PEP 604 union alias was executed during imports.
- The change prevents import-time TypeError classes in the desktop-packaged Python import graph and adds regression coverage so the issue cannot silently recur.

### Description
- Replaced runtime-evaluated PEP 604 unions in `utils/system/resource_monitor.py` with Python 3.9-safe typing (`Union` / `Optional`) for the `GpuMetrics` alias and related return types.
- Added a static AST regression test `tests/unit/test_desktop_python_pep604_runtime_alias_guard.py` that scans desktop-packaged import roots and fails on runtime `|` alias assignments.
- Tightened the packaged inspect probe in `desktop-tauri/scripts/test_packaged_operator_e2e.py` to explicitly reject `Model bridge failure`, `unsupported operand type(s) for |`, and common import failure markers (`No module named`, `ModuleNotFoundError`, `ImportError`).
- Added outage documentation `outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.{md,json}` describing root cause, fix, tests, and follow-ups.
- Added a GitHub Actions macOS Python 3.9 inspect-only job to `.github/workflows/desktop-operator-e2e.yml` to exercise the inspect probe with Python 3.9 in CI.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_resource_monitor.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_no_relay_autostart.py tests/unit/test_desktop_python_pep604_runtime_alias_guard.py` and observed: all unit tests passed (`55 passed`).
- Ran packaged inspect-only probe: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` and it succeeded (exit 0, no forbidden markers).
- Ran full packaged probe: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and it succeeded (exit 0, no forbidden markers).
- JS tests: `cd desktop-tauri && npm test -- --run` failed in this environment due to missing `vitest` executable (environment/tooling limitation), not code change.
- Rust tests: `cd desktop-tauri/src-tauri && cargo test` failed in this environment due to missing system `glib-2.0` / pkg-config setup, not code change.

Residual risks / notes: the fix is narrowly scoped to remove runtime-evaluated `|` aliases from desktop import paths and add detection; CI now includes a macOS Python 3.9 inspect job to prevent regressions. Relay lifecycle guardrails were not changed: the desktop app still must not bundle or autolaunch `relay.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15454a737c832fa806b9055c8cf603)