### PR TITLE
Fix macOS model-bridge PEP 604 import failure; add static guard & outage doc

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -131,6 +131,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js (macOS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: desktop-tauri/package-lock.json
+
+      - name: Install desktop Node dependencies (macOS)
+        working-directory: desktop-tauri
+        run: npm ci
+
+      - name: Set up Rust (macOS)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build desktop frontend assets (macOS)
+        working-directory: desktop-tauri
+        run: npm run build
+
+      - name: Build desktop binary (debug, no bundle) (macOS)
+        working-directory: desktop-tauri
+        run: npm run tauri build -- --debug --no-bundle
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -150,3 +172,6 @@ jobs:
 
       - name: Run packaged operator bridge e2e (macOS)
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+      - name: Run desktop no-relay autostart lifecycle e2e (macOS)
+        run: python desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -144,6 +144,11 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
     assert required_keys.issubset(payload.keys()), combined
 
     forbidden_any_output = [
+        "Model bridge failure",
+        "unsupported operand type(s) for |",
+        "No module named",
+        "ModuleNotFoundError",
+        "ImportError",
         "Missing Python dependency for model downloads",
         "No module named 'psutil'",
         "No module named 'requests'",

--- a/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.json
+++ b/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-26",
+  "slug": "desktop-macos-model-bridge-pep604-type-alias",
+  "summary": "Desktop macOS model bridge startup failed on Python 3.9 because a runtime-evaluated PEP 604 type-alias assignment raised TypeError during import.",
+  "impact": "Operator startup and model bridge inspect could fail before inference, surfacing as a generic model bridge failure.",
+  "fix": "Replaced runtime-evaluated PEP 604 alias assignments in desktop-packaged Python imports with Python 3.9-safe typing forms, added AST/static regression guards, expanded packaged inspect failure markers, and extended macOS desktop lifecycle CI coverage.",
+  "lessons": "Type-syntax compatibility must be enforced against runtime assignment contexts in packaged Python import paths; desktop app lifecycle remains independent from relay.py ownership."
+}

--- a/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.md
+++ b/outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.md
@@ -1,0 +1,36 @@
+# Outage: desktop macOS model bridge failed on runtime-evaluated PEP 604 type alias
+
+- **Date:** 2026-05-26
+- **Slug:** `desktop-macos-model-bridge-pep604-type-alias`
+- **Affected area:** desktop-tauri operator startup / model bridge inspect on macOS Python 3.9 environments
+
+## Summary
+Desktop operator startup could fail with `Model bridge failure: unsupported operand type(s) for |: 'type' and 'type'` before inference began.
+
+## Root cause
+- `utils/system/resource_monitor.py` declared `GpuMetrics = Dict[str, float | int | bool]` as a runtime assignment.
+- On Python 3.9, `type | type` is invalid outside postponed annotations, so import-time evaluation raised `TypeError`.
+- `model_bridge.py` imports `utils.llm.model_manager`, which imports `utils.system.resource_monitor`; the exception was surfaced through the model bridge catch-all error path.
+
+## Why tests missed it
+- Existing packaged bridge checks focused on dependency presence and happy-path inspect behavior, but did not explicitly reject PEP 604 runtime-type errors.
+- CI did not include a dedicated static guard for runtime-evaluated `|` type alias assignments in the desktop-packaged Python import graph.
+
+## Fix
+- Replaced runtime-evaluated PEP 604 alias usage in desktop-packaged import paths with Python 3.9-safe typing forms (`typing.Union` / `typing.Optional`).
+- Strengthened packaged model bridge inspect probes to fail on:
+  - `Model bridge failure`
+  - `unsupported operand type(s) for |`
+  - `No module named`
+  - `ModuleNotFoundError`
+  - `ImportError`
+- Added AST-based regression guard to block runtime-evaluated PEP 604 alias assignments in desktop-packaged Python scope.
+
+## Tests / prevention
+- Unit guard for AST detection of runtime alias assignments.
+- Unit import smoke for `utils.system.resource_monitor` in desktop path.
+- Packaged inspect e2e now hard-fails on the macOS/Python 3.9 signature error text.
+- macOS desktop workflow now runs no-relay-autostart lifecycle e2e after building the debug desktop app.
+
+## Architecture invariant reaffirmed
+Desktop-tauri remains an analogue of `server.py`. The app must not bundle, autolaunch, supervise, or own `relay.py`; relay lifecycle remains separate and may only be launched by explicit test harnesses when needed.

--- a/tests/unit/test_desktop_python_pep604_guard.py
+++ b/tests/unit/test_desktop_python_pep604_guard.py
@@ -1,0 +1,49 @@
+"""Regression guards for runtime-evaluated PEP 604 aliases in desktop-packaged imports."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _python_files_in_scope() -> list[Path]:
+    roots = [
+        REPO_ROOT / 'desktop-tauri' / 'src-tauri' / 'python',
+        REPO_ROOT / 'utils',
+        REPO_ROOT / 'config.py',
+    ]
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            files.append(root)
+            continue
+        files.extend(sorted(root.rglob('*.py')))
+    return files
+
+
+def _is_runtime_alias_with_pep604(node: ast.Assign) -> bool:
+    return isinstance(node.value, ast.BinOp) and isinstance(node.value.op, ast.BitOr)
+
+
+def test_desktop_packaged_import_graph_has_no_runtime_pep604_alias_assignments() -> None:
+    violations: list[str] = []
+    for path in _python_files_in_scope():
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and _is_runtime_alias_with_pep604(node):
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+
+    assert violations == [], (
+        'Runtime-evaluated PEP 604 alias assignment(s) found; use typing.Union or postpone into annotations: '
+        + ', '.join(violations)
+    )
+
+
+def test_resource_monitor_imports_cleanly_for_desktop_bridge_path() -> None:
+    import utils.system.resource_monitor as resource_monitor
+
+    metrics = resource_monitor._gpu_metrics_default()
+    assert 'gpu_available' in metrics

--- a/utils/system/resource_monitor.py
+++ b/utils/system/resource_monitor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import importlib
 import sys
-from typing import Dict
+from typing import Dict, Optional, Union
 
 
 def _gpu_headroom_multiplier(headroom_percent: float) -> float:
@@ -23,7 +23,7 @@ except (ImportError, OSError):  # pragma: no cover - exercised via import fallba
     psutil = None
 
 
-GpuMetrics = Dict[str, float | int | bool]
+GpuMetrics = Dict[str, Union[float, int, bool]]
 
 
 def _gpu_metrics_default(*, available: bool = False, count: int = 0) -> GpuMetrics:
@@ -158,7 +158,7 @@ def can_allocate_gpu_memory(required_bytes: float, *, headroom_percent: float = 
             pass
 
 
-def _cpu_interval_for_platform(platform: str) -> float | None:
+def _cpu_interval_for_platform(platform: str) -> Optional[float]:
     """Return the psutil sampling interval tuned for the active platform."""
 
     normalized = platform.lower()
@@ -167,7 +167,7 @@ def _cpu_interval_for_platform(platform: str) -> float | None:
     return None
 
 
-def collect_resource_usage() -> Dict[str, float | int | bool]:
+def collect_resource_usage() -> Dict[str, Union[float, int, bool]]:
     """Return current CPU, memory, and GPU utilisation metrics."""
 
     interval = _cpu_interval_for_platform(sys.platform)


### PR DESCRIPTION
### Motivation
- Fix an import-time crash in the desktop model bridge that appeared as `Model bridge failure: unsupported operand type(s) for |: 'type' and 'type'` on macOS/Python 3.9 caused by runtime-evaluated PEP 604 type-alias assignments in the desktop import graph.
- Prevent regressions by statically detecting the same class of runtime `|` alias in the desktop-packaged Python scope and by strengthening packaged inspect probes so the error is caught earlier and reported clearly. 
- Preserve the invariant that the desktop app never bundles, autolaunches, or owns `relay.py` and strengthen lifecycle coverage so this remains enforced in CI.

### Description
- Replace runtime-evaluated PEP 604 aliases in desktop-packaged imports with Python 3.9-safe forms in `utils/system/resource_monitor.py` by using `typing.Union` and `typing.Optional` instead of `|` unions. 
- Add `tests/unit/test_desktop_python_pep604_guard.py`, an AST-based regression test that scans `desktop-tauri/src-tauri/python`, `utils`, and `config.py` for runtime `Assign` nodes using `|` and includes an import-smoke for `resource_monitor`. 
- Harden `desktop-tauri/scripts/test_packaged_operator_e2e.py` to explicitly forbid and fail on the signatures: `Model bridge failure`, `unsupported operand type(s) for |`, `No module named`, `ModuleNotFoundError`, and `ImportError` during the inspect probe. 
- Extend the macOS packaged desktop workflow in `.github/workflows/desktop-operator-e2e.yml` to build the debug app and run the macOS no-relay-autostart lifecycle e2e so the guard is exercised in CI. 
- Add an outage entry (`outages/2026-05-26-desktop-macos-model-bridge-pep604-type-alias.{md,json}`) that documents the incident, root cause, test-gap, fix, and follow-ups.

### Testing
- Ran the focused unit suite: `python -m pytest tests/unit/test_resource_monitor.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_no_relay_autostart.py tests/unit/test_desktop_python_pep604_guard.py` — all tests passed in this environment (`69 passed`).
- Ran the packaged bridge subprocess regression: `python -m pytest tests/unit/test_desktop_model_bridge.py -k inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath` — passed.
- Ran the packaged inspect smoke in-process: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` and the full packaged e2e probe `python desktop-tauri/scripts/test_packaged_operator_e2e.py` — both completed successfully here (inspect probe now rejects the target failure strings).
- Frontend unit tests: `cd desktop-tauri && npm test -- --run` — passed. Native Rust tests: `cd desktop-tauri/src-tauri && cargo test` — not completed here due to missing system `glib-2.0` pkg-config dependency (environment limitation), so CI should run that job on platform runners as configured.

Residual risk / follow-up: CI should exercise the macOS packaged job (the workflow was extended), and a macOS Python 3.9 runner is recommended to exercise the inspect-only guard path in CI; the Rust `cargo test` environment dependency is an external system package and is unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15454a737c832fa806b9055c8cf603)