### PR TITLE
Enforce strict single-pod relay rollout in canonical Helm chart

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -59,6 +59,16 @@ jobs:
           grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "1"'
           ! grep -n "rollingUpdate:" /tmp/tokenplace-render.yaml
 
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            --set ingress.enabled=true \
+            --set ingress.host=staging.token.place \
+            --set image.tag=main-deadbee \
+            --set-json strategy={} > /tmp/tokenplace-render-strategy-empty.yaml
+
+          grep -n "type: Recreate" /tmp/tokenplace-render-strategy-empty.yaml
+          ! grep -n "rollingUpdate:" /tmp/tokenplace-render-strategy-empty.yaml
+
       - name: Capture chart metadata
         id: chart_meta
         run: |

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -57,6 +57,7 @@ jobs:
           grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
           grep -n "type: Recreate" /tmp/tokenplace-render.yaml
           grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml
+          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n "value: \"1\""
 
       - name: Capture chart metadata
         id: chart_meta

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -51,7 +51,12 @@ jobs:
             --namespace tokenplace \
             --set ingress.enabled=true \
             --set ingress.host=staging.token.place \
-            --set image.tag=main-deadbee
+            --set image.tag=main-deadbee > /tmp/tokenplace-render.yaml
+
+          grep -n "replicas: 1" /tmp/tokenplace-render.yaml
+          grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
+          grep -n "type: Recreate" /tmp/tokenplace-render.yaml
+          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml
 
       - name: Capture chart metadata
         id: chart_meta

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -69,6 +69,11 @@ jobs:
           grep -n "type: Recreate" /tmp/tokenplace-render-strategy-empty.yaml
           ! grep -n "rollingUpdate:" /tmp/tokenplace-render-strategy-empty.yaml
 
+          # Upgrade-path guard: template retains explicit stale-field clear branch
+          # when switching live defaulted RollingUpdate Deployments to Recreate.
+          grep -n 'else if and (eq $strategyType "Recreate") $existingHasRollingUpdate' charts/tokenplace/templates/deployment.yaml
+          grep -n 'rollingUpdate: null' charts/tokenplace/templates/deployment.yaml
+
       - name: Capture chart metadata
         id: chart_meta
         run: |

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -56,8 +56,8 @@ jobs:
           grep -n "replicas: 1" /tmp/tokenplace-render.yaml
           grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
           grep -n "type: Recreate" /tmp/tokenplace-render.yaml
-          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml
-          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n "value: \"1\""
+          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "1"'
+          ! grep -n "rollingUpdate:" /tmp/tokenplace-render.yaml
 
       - name: Capture chart metadata
         id: chart_meta

--- a/README.md
+++ b/README.md
@@ -256,10 +256,8 @@ Current relay operations model in Sugarkube:
 - in-memory relay state (registrations/queued messages/replies)
 - accepted state loss on pod replacement until shared-state architecture lands
 
-Because the relay runs as a Kubernetes `Deployment`, default `RollingUpdate` behavior can
-temporarily create an extra pod during upgrades (`maxSurge`). Operators that require strict
-single-pod semantics during upgrades should enforce a single-pod rollout strategy (for example
-`Recreate` or `maxSurge=0`) in Sugarkube values.
+The canonical token.place Helm chart now defaults to strict single-pod rollout semantics for this
+stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate`.
 
 Artifact references:
 

--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tokenplace
 description: Canonical Helm chart for deploying token.place relay
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 type: application

--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tokenplace
 description: Canonical Helm chart for deploying token.place relay
-version: 0.1.1
+version: 0.1.0
 appVersion: "0.1.0"
 type: application

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "tokenplace.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if and (eq .Values.strategy.type "RollingUpdate") .Values.strategy.rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "tokenplace.selectorLabels" . | nindent 6 }}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -6,11 +6,14 @@ metadata:
     {{- include "tokenplace.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- $strategyType := default "Recreate" .Values.strategy.type }}
   strategy:
-    type: {{ .Values.strategy.type }}
-    {{- if and (eq .Values.strategy.type "RollingUpdate") .Values.strategy.rollingUpdate }}
+    type: {{ $strategyType }}
+    {{- if and (eq $strategyType "RollingUpdate") .Values.strategy.rollingUpdate }}
     rollingUpdate:
       {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+    {{- else if eq $strategyType "Recreate" }}
+    rollingUpdate: null
     {{- end }}
   selector:
     matchLabels:

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -11,17 +11,19 @@ spec:
       so the manifest never renders `type: <no value>`.
   */}}
   {{- $strategyType := default "Recreate" .Values.strategy.type }}
+  {{- $existing := lookup "apps/v1" "Deployment" .Release.Namespace (include "tokenplace.fullname" .) }}
+  {{- $existingHasRollingUpdate := and $existing $existing.spec $existing.spec.strategy $existing.spec.strategy.rollingUpdate }}
   strategy:
     type: {{ $strategyType }}
     {{- /*
-        Keep the default Recreate render free of `rollingUpdate` keys.
-        Helm's three-way merge compares chart-rendered old/new manifests, so when this
-        chart does not render rollingUpdate for Recreate, the desired state omits it.
-        CI verifies the Recreate default and the sparse-strategy override render shape.
+        Keep default Recreate renders free of rollingUpdate keys, but clear the live
+        field during upgrades from older defaulted RollingUpdate Deployments.
     */}}
     {{- if and (eq $strategyType "RollingUpdate") .Values.strategy.rollingUpdate }}
     rollingUpdate:
       {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+    {{- else if and (eq $strategyType "Recreate") $existingHasRollingUpdate }}
+    rollingUpdate: null
     {{- end }}
   selector:
     matchLabels:

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -6,9 +6,19 @@ metadata:
     {{- include "tokenplace.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- /*
+      Resolve strategy type from a potentially sparse object (e.g. --set-json strategy={})
+      so the manifest never renders `type: <no value>`.
+  */}}
   {{- $strategyType := default "Recreate" .Values.strategy.type }}
   strategy:
     type: {{ $strategyType }}
+    {{- /*
+        Keep the default Recreate render free of `rollingUpdate` keys.
+        Helm's three-way merge compares chart-rendered old/new manifests, so when this
+        chart does not render rollingUpdate for Recreate, the desired state omits it.
+        CI verifies the Recreate default and the sparse-strategy override render shape.
+    */}}
     {{- if and (eq $strategyType "RollingUpdate") .Values.strategy.rollingUpdate }}
     rollingUpdate:
       {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -12,8 +12,6 @@ spec:
     {{- if and (eq $strategyType "RollingUpdate") .Values.strategy.rollingUpdate }}
     rollingUpdate:
       {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
-    {{- else if eq $strategyType "Recreate" }}
-    rollingUpdate: null
     {{- end }}
   selector:
     matchLabels:

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+strategy:
+  type: Recreate
+
 image:
   repository: ghcr.io/futuroptimist/tokenplace-relay
   tag: "main"

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -21,10 +21,8 @@ Relay state is in-memory (registrations, queued messages, replies). Current prod
 State loss on pod death/replacement is an accepted risk for this phase. Durable/shared state and
 multi-replica relay topology are future work.
 
-Kubernetes `Deployment` upgrades may temporarily run more than one pod with default
-`RollingUpdate` behavior (`maxSurge`). If strict single-pod relay operation is required during
-upgrade windows, set an explicit single-pod rollout strategy (for example `Recreate` or
-`maxSurge=0` with compatible availability settings) in Sugarkube values.
+The canonical token.place Helm chart now defaults to strict single-pod rollout behavior for this
+stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate`.
 
 ## Artifacts and release tags
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -22,10 +22,8 @@ Operational policy for staging is intentionally:
 State loss on pod restart/replacement is accepted for now. Shared-state and multi-replica relay
 architecture are future work and out of scope.
 
-Kubernetes `Deployment` upgrades may briefly run more than one pod under the default
-`RollingUpdate` strategy (`maxSurge`). To preserve strict single-pod semantics for stateful relay
-operations, operators should configure a single-pod rollout policy (for example `Recreate` or
-`maxSurge=0` with matching availability constraints) in Sugarkube values.
+The canonical token.place Helm chart now defaults to strict single-pod rollout semantics for this
+stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate`.
 
 ## Artifacts and tags
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -22,9 +22,8 @@ replies are held in process memory. Current operating model:
 Multi-replica + shared state (Redis or similar) is explicitly future work and out of scope for
 this phase.
 
-Note on upgrades: because relay is deployed via Kubernetes `Deployment`, default `RollingUpdate`
-can briefly run more than one pod during upgrades. If strict one-pod behavior is required, enforce
-single-pod rollout settings (for example `Recreate` or `maxSurge=0`) in Sugarkube values.
+Note on upgrades: the canonical token.place Helm chart now defaults to strict single-pod rollout
+behavior for relay state safety by rendering `strategy.type: Recreate` with `replicaCount: 1`.
 
 ## Artifact ownership and source of truth
 


### PR DESCRIPTION
### Motivation
- The relay keeps registrations, queued messages, and replies in process memory, so transient dual-pod rollouts can split or lose in-flight state and must be prevented during v0.1.0 staging. 
- Make the canonical Helm chart enforce single-pod replacement semantics by default rather than relying on operator-side overrides.

### Description
- Added a `strategy` values block to `charts/tokenplace/values.yaml` with `type: Recreate` as the default. 
- Updated `charts/tokenplace/templates/deployment.yaml` to render `spec.strategy.type` from values and only emit `rollingUpdate` when `strategy.type` is `RollingUpdate`. 
- Kept `replicaCount: 1` and `RELAY_WORKERS` set to `"1"` (no change to relay worker defaults). 
- Strengthened CI smoke rendering in `.github/workflows/ci-helm.yml` to write the templated manifest to `/tmp/tokenplace-render.yaml` and assert presence of `replicas: 1`, `strategy.type: Recreate`, and `RELAY_WORKERS` via `grep`; and updated onboarding/staging/prod docs and the README to state the canonical chart default is `Recreate` single-pod rollouts.

### Testing
- Attempted `helm lint charts/tokenplace` but Helm is not installed in the current environment so the command could not run (`/bin/bash: helm: command not found`).
- Attempted `helm template ... > /tmp/tokenplace-render.yaml` but it could not run for the same reason (`/bin/bash: helm: command not found`), however the CI job was updated to run an equivalent render and `grep` checks in GitHub Actions.
- Ran `pre-commit run --all-files` which started and ran multiple hooks; `check-yaml` failed on templated chart YAML (this is a templated-files parsing failure seen during hook execution and is pre-existing to this change), while other early hooks passed.
- The Git commit containing these changes was created (`helm: enforce single-pod relay rollout strategy`) and CI will run the added smoke `grep` validations on GitHub Actions when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154bcc0f90832f92bd70a20f32621a)