### PR TITLE
Helm: enforce strict single-pod Recreate rollouts for relay

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -51,7 +51,14 @@ jobs:
             --namespace tokenplace \
             --set ingress.enabled=true \
             --set ingress.host=staging.token.place \
-            --set image.tag=main-deadbee
+            --set image.tag=main-deadbee > /tmp/tokenplace-render.yaml
+
+      - name: Validate single-pod relay defaults in rendered manifest
+        run: |
+          grep -n "replicas: 1" /tmp/tokenplace-render.yaml
+          grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
+          grep -n "type: Recreate" /tmp/tokenplace-render.yaml
+          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml
 
       - name: Capture chart metadata
         id: chart_meta

--- a/README.md
+++ b/README.md
@@ -256,10 +256,9 @@ Current relay operations model in Sugarkube:
 - in-memory relay state (registrations/queued messages/replies)
 - accepted state loss on pod replacement until shared-state architecture lands
 
-Because the relay runs as a Kubernetes `Deployment`, default `RollingUpdate` behavior can
-temporarily create an extra pod during upgrades (`maxSurge`). Operators that require strict
-single-pod semantics during upgrades should enforce a single-pod rollout strategy (for example
-`Recreate` or `maxSurge=0`) in Sugarkube values.
+The canonical token.place Helm chart now defaults to strict single-pod rollout behavior for this
+stateful phase (`replicaCount: 1` + `strategy.type: Recreate` + `RELAY_WORKERS=1`). This avoids
+transient second relay pods during upgrades until shared-state architecture lands.
 
 Artifact references:
 

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
     {{- include "tokenplace.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    {{- end }}
   selector:
     matchLabels:
       {{- include "tokenplace.selectorLabels" . | nindent 6 }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -1,4 +1,6 @@
 replicaCount: 1
+strategy:
+  type: Recreate
 
 image:
   repository: ghcr.io/futuroptimist/tokenplace-relay

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -21,10 +21,9 @@ Relay state is in-memory (registrations, queued messages, replies). Current prod
 State loss on pod death/replacement is an accepted risk for this phase. Durable/shared state and
 multi-replica relay topology are future work.
 
-Kubernetes `Deployment` upgrades may temporarily run more than one pod with default
-`RollingUpdate` behavior (`maxSurge`). If strict single-pod relay operation is required during
-upgrade windows, set an explicit single-pod rollout strategy (for example `Recreate` or
-`maxSurge=0` with compatible availability settings) in Sugarkube values.
+The canonical token.place chart defaults to strict single-pod rollout behavior for this stateful
+phase (`replicaCount: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`), so upgrade windows do
+not temporarily run a second relay pod.
 
 ## Artifacts and release tags
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -22,10 +22,9 @@ Operational policy for staging is intentionally:
 State loss on pod restart/replacement is accepted for now. Shared-state and multi-replica relay
 architecture are future work and out of scope.
 
-Kubernetes `Deployment` upgrades may briefly run more than one pod under the default
-`RollingUpdate` strategy (`maxSurge`). To preserve strict single-pod semantics for stateful relay
-operations, operators should configure a single-pod rollout policy (for example `Recreate` or
-`maxSurge=0` with matching availability constraints) in Sugarkube values.
+The canonical token.place chart defaults to strict single-pod rollout behavior for this stateful
+phase (`replicaCount: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`), so upgrades do not
+temporarily create a second relay pod.
 
 ## Artifacts and tags
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -22,9 +22,9 @@ replies are held in process memory. Current operating model:
 Multi-replica + shared state (Redis or similar) is explicitly future work and out of scope for
 this phase.
 
-Note on upgrades: because relay is deployed via Kubernetes `Deployment`, default `RollingUpdate`
-can briefly run more than one pod during upgrades. If strict one-pod behavior is required, enforce
-single-pod rollout settings (for example `Recreate` or `maxSurge=0`) in Sugarkube values.
+Note on upgrades: the canonical token.place chart now defaults to strict single-pod rollout
+behavior for this stateful phase (`replicaCount: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`)
+so upgrades do not briefly run a second relay pod.
 
 ## Artifact ownership and source of truth
 


### PR DESCRIPTION
### Motivation
- The relay keeps registrations/queued messages/replies in-process, so transient extra pods during Kubernetes `RollingUpdate` break the current stateful operational model and must be prevented by chart defaults.

### Description
- Added a `strategy.type` value in `charts/tokenplace/values.yaml` defaulting to `Recreate` so the canonical chart enforces single-pod rollouts by default. (`charts/tokenplace/values.yaml`)
- Updated the Deployment template to render `spec.strategy.type` and only emit `rollingUpdate` fields when `strategy.type` is `RollingUpdate`, ensuring `Recreate` renders without rolling-update params. (`charts/tokenplace/templates/deployment.yaml`)
- Extended the Helm CI job to write the staging-like `helm template` output to `/tmp/tokenplace-render.yaml` and validate the smoke render contains `replicas: 1`, a `strategy` block with `type: Recreate`, and the `RELAY_WORKERS` environment entry. (`.github/workflows/ci-helm.yml`)
- Updated user/operator-facing documentation to state the canonical chart now defaults to strict single-pod rollout behavior instead of advising operators to set `Recreate`/`maxSurge=0`. (`README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`)

### Testing
- Ran the local Helm/templating smoke commands used for verification but `helm` is not installed in this environment so `helm lint` and `helm template` could not be executed locally (`helm: command not found`).
- Added CI smoke validations in the workflow that will run inside CI where `helm` is available and will assert `replicas: 1`, presence of `strategy` + `type: Recreate`, and `RELAY_WORKERS=1` in the rendered manifest. (`.github/workflows/ci-helm.yml`) 
- Ran `pre-commit run --all-files` locally; standard hooks passed (trailing whitespace, EOF fix, `codespell`, `vulture`, `bandit`) but `check-yaml` failed while parsing chart templates (existing Helm-template YAML fragments such as `charts/tokenplace/templates/ingress.yaml`, `serviceaccount.yaml`, `service.yaml`, and `deployment.yaml`) in this static check environment. This is a pre-existing template parsing concern surfaced by `check-yaml` and not introduced by the `strategy` value change.

Files touched: `charts/tokenplace/values.yaml`, `charts/tokenplace/templates/deployment.yaml`, `.github/workflows/ci-helm.yml`, `README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154bcc0f90832f92bd70a20f32621a)