### PR TITLE
Enforce strict single-pod Recreate rollout in token.place Helm chart

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -47,11 +47,13 @@ jobs:
 
       - name: Template smoke render (staging-like)
         run: |
-          helm template tokenplace charts/tokenplace \
-            --namespace tokenplace \
-            --set ingress.enabled=true \
-            --set ingress.host=staging.token.place \
-            --set image.tag=main-deadbee
+          set -euo pipefail
+          helm template tokenplace charts/tokenplace             --namespace tokenplace             --set ingress.enabled=true             --set ingress.host=staging.token.place             --set image.tag=main-deadbee > /tmp/tokenplace-render.yaml
+
+          grep -n "replicas: 1" /tmp/tokenplace-render.yaml
+          grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
+          grep -n "type: Recreate" /tmp/tokenplace-render.yaml
+          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml
 
       - name: Capture chart metadata
         id: chart_meta

--- a/README.md
+++ b/README.md
@@ -256,10 +256,9 @@ Current relay operations model in Sugarkube:
 - in-memory relay state (registrations/queued messages/replies)
 - accepted state loss on pod replacement until shared-state architecture lands
 
-Because the relay runs as a Kubernetes `Deployment`, default `RollingUpdate` behavior can
-temporarily create an extra pod during upgrades (`maxSurge`). Operators that require strict
-single-pod semantics during upgrades should enforce a single-pod rollout strategy (for example
-`Recreate` or `maxSurge=0`) in Sugarkube values.
+The canonical token.place Helm chart now defaults to strict single-pod rollouts for this
+stateful phase: `replicaCount: 1` with `strategy.type: Recreate` and `RELAY_WORKERS=1`. Keep
+those defaults unless/until shared relay state exists.
 
 Artifact references:
 

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "tokenplace.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
   selector:
     matchLabels:
       {{- include "tokenplace.selectorLabels" . | nindent 6 }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+strategy:
+  type: Recreate
+
 image:
   repository: ghcr.io/futuroptimist/tokenplace-relay
   tag: "main"

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -21,10 +21,9 @@ Relay state is in-memory (registrations, queued messages, replies). Current prod
 State loss on pod death/replacement is an accepted risk for this phase. Durable/shared state and
 multi-replica relay topology are future work.
 
-Kubernetes `Deployment` upgrades may temporarily run more than one pod with default
-`RollingUpdate` behavior (`maxSurge`). If strict single-pod relay operation is required during
-upgrade windows, set an explicit single-pod rollout strategy (for example `Recreate` or
-`maxSurge=0` with compatible availability settings) in Sugarkube values.
+The canonical token.place chart defaults to strict single-pod rollout behavior in this in-memory
+relay-state phase (`replicaCount: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`). Keep these
+defaults in production unless/until shared relay state is introduced.
 
 ## Artifacts and release tags
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -22,10 +22,9 @@ Operational policy for staging is intentionally:
 State loss on pod restart/replacement is accepted for now. Shared-state and multi-replica relay
 architecture are future work and out of scope.
 
-Kubernetes `Deployment` upgrades may briefly run more than one pod under the default
-`RollingUpdate` strategy (`maxSurge`). To preserve strict single-pod semantics for stateful relay
-operations, operators should configure a single-pod rollout policy (for example `Recreate` or
-`maxSurge=0` with matching availability constraints) in Sugarkube values.
+The canonical token.place chart defaults to strict single-pod rollout behavior for this in-memory
+state phase (`replicaCount: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`). Keep these defaults
+in staging unless/until shared relay state is introduced.
 
 ## Artifacts and tags
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -22,9 +22,9 @@ replies are held in process memory. Current operating model:
 Multi-replica + shared state (Redis or similar) is explicitly future work and out of scope for
 this phase.
 
-Note on upgrades: because relay is deployed via Kubernetes `Deployment`, default `RollingUpdate`
-can briefly run more than one pod during upgrades. If strict one-pod behavior is required, enforce
-single-pod rollout settings (for example `Recreate` or `maxSurge=0`) in Sugarkube values.
+Upgrade behavior is now locked to strict single-pod semantics by default in the canonical
+token.place chart: `replicaCount: 1`, `strategy.type: Recreate`, and `RELAY_WORKERS=1`. Keep
+that posture for this in-memory relay-state phase.
 
 ## Artifact ownership and source of truth
 


### PR DESCRIPTION
### Motivation
- The relay keeps registrations, queued messages, and replies in-process, so transient multi-pod rollouts are unsafe while shared state is not implemented. 
- The chart previously relied on the Kubernetes default `RollingUpdate`, which can briefly create an extra pod during upgrades; the chart should explicitly enforce single-pod behavior.

### Description
- Added a `strategy.type` value (default `Recreate`) to `charts/tokenplace/values.yaml` so the chart expresses single-pod rollout intent by default. 
- Updated `charts/tokenplace/templates/deployment.yaml` to render `spec.strategy.type: {{ .Values.strategy.type }}` so the Deployment manifest includes `Recreate` (and will not render `rollingUpdate` fields for `Recreate`). 
- Strengthened the CI Helm smoke render in `.github/workflows/ci-helm.yml` to `helm template > /tmp/tokenplace-render.yaml` and `grep` for `replicas: 1`, `strategy:`, `type: Recreate`, and the `RELAY_WORKERS` env var to validate the staging-like render. 
- Updated Sugarkube/relay docs (`README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`) to state the canonical chart defaults to strict single-pod `Recreate` rollouts and `RELAY_WORKERS=1` rather than leaving rollout policy as an operator TODO.

### Testing
- Ran the CI-style helm checks locally but `helm` is not present in this environment, so template/lint commands could not run; command error: `/bin/bash: line 1: helm: command not found` (helm steps in CI will run on runners with Helm installed). 
- Added smoke-render assertions in CI so `helm template` on GitHub Actions will produce `/tmp/tokenplace-render.yaml` and run: `grep -n "replicas: 1" /tmp/tokenplace-render.yaml`, `grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml`, `grep -n "type: Recreate" /tmp/tokenplace-render.yaml`, and `grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml` (these will validate the acceptance criteria in CI). 
- Ran `pre-commit run --all-files` in this environment; hooks executed but `check-yaml` failed with existing template YAML parsing errors (not introduced by this change), for example: `check-yaml ... Failed ... while parsing a flow node expected the node content, but found '-' in "charts/tokenplace/templates/deployment.yaml"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154bcc0f90832f92bd70a20f32621a)