### PR TITLE
ci(image): publish GHCR semver tags on release tag pushes

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       ref:
@@ -24,9 +26,12 @@ jobs:
       short_sha: ${{ steps.tags.outputs.short_sha }}
       created: ${{ steps.tags.outputs.created }}
       repository: ${{ steps.tags.outputs.repository }}
+      image_tags: ${{ steps.tags.outputs.image_tags }}
       branch_tag: ${{ steps.tags.outputs.branch_tag }}
       latest_tag: ${{ steps.tags.outputs.latest_tag }}
+      semver_tag: ${{ steps.tags.outputs.semver_tag }}
       sha_tag: ${{ steps.tags.outputs.sha_tag }}
+      publish_reason: ${{ steps.tags.outputs.publish_reason }}
 
     steps:
       - name: Checkout repository
@@ -45,9 +50,48 @@ jobs:
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
           echo "created=${created}" >> "$GITHUB_OUTPUT"
           echo "repository=${repository}" >> "$GITHUB_OUTPUT"
-          echo "branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
-          echo "latest_tag=${repository}:main-latest" >> "$GITHUB_OUTPUT"
-          echo "sha_tag=${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+          branch_tag="${repository}:main-${short_sha}"
+          latest_tag="${repository}:main-latest"
+          sha_tag="${repository}:sha-${short_sha}"
+          semver_tag=""
+          publish_reason=""
+          image_tags=""
+
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            publish_reason="main"
+            image_tags="$(printf '%s\n%s\n%s' "${branch_tag}" "${latest_tag}" "${sha_tag}")"
+          elif [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9].* ]]; then
+            release_tag="${GITHUB_REF#refs/tags/}"
+            if [[ ! "${release_tag}" =~ ^v[0-9]+(\.[0-9]+){2}([-.][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Malformed release tag: ${release_tag}" >&2
+              exit 1
+            fi
+            semver_tag="${repository}:${release_tag}"
+            publish_reason="tag"
+            image_tags="$(printf '%s\n%s' "${semver_tag}" "${sha_tag}")"
+          else
+            publish_reason="none"
+            image_tags="${sha_tag}"
+          fi
+
+          if [[ -z "${sha_tag}" ]]; then
+            echo "Unsafe empty sha tag output" >&2
+            exit 1
+          fi
+
+          if [[ -z "${publish_reason}" ]]; then
+            echo "Publish reason must be set" >&2
+            exit 1
+          fi
+
+          echo "image_tags<<EOF" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${image_tags}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "branch_tag=${branch_tag}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "semver_tag=${semver_tag}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${sha_tag}" >> "$GITHUB_OUTPUT"
+          echo "publish_reason=${publish_reason}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -106,7 +150,7 @@ jobs:
     name: Publish relay image
     runs-on: ubuntu-latest
     needs: build-and-smoke
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read
       packages: write
@@ -138,10 +182,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           provenance: false
-          tags: |
-            ${{ needs.build-and-smoke.outputs.branch_tag }}
-            ${{ needs.build-and-smoke.outputs.latest_tag }}
-            ${{ needs.build-and-smoke.outputs.sha_tag }}
+          tags: ${{ needs.build-and-smoke.outputs.image_tags }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.short_sha }}
@@ -154,8 +195,12 @@ jobs:
           {
             echo "## Relay image tags"
             echo ""
-            echo "Immutable tag: \`${{ needs.build-and-smoke.outputs.branch_tag }}\`"
-            echo "Mutable tag: \`${{ needs.build-and-smoke.outputs.latest_tag }}\`"
+            if [[ "${{ needs.build-and-smoke.outputs.publish_reason }}" == "main" ]]; then
+              echo "Immutable tag: \`${{ needs.build-and-smoke.outputs.branch_tag }}\`"
+              echo "Mutable tag: \`${{ needs.build-and-smoke.outputs.latest_tag }}\`"
+            elif [[ "${{ needs.build-and-smoke.outputs.publish_reason }}" == "tag" ]]; then
+              echo "Semver tag: \`${{ needs.build-and-smoke.outputs.semver_tag }}\`"
+            fi
             echo "SHA tag: \`${{ needs.build-and-smoke.outputs.sha_tag }}\`"
             echo ""
             echo "Pushed: true"

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
+- Staging candidate tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
+- Canonical release tag after `git tag v0.1.0` push: `v0.1.0`
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -32,6 +32,8 @@ upgrade windows, set an explicit single-pod rollout strategy (for example `Recre
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Required sign-off tag style: immutable `main-<shortsha>`
 - `main-latest` is convenience-only and not production sign-off
+- Final release tag push (for example `v0.1.0`) also publishes `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Production may deploy either the validated `main-<shortsha>` or `v0.1.0`; after tag push, `v0.1.0` is the canonical release image tag
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -31,8 +31,9 @@ operations, operators should configure a single-pod rollout policy (for example 
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Preferred tag for validation/sign-off: immutable `main-<shortsha>`
+- Preferred tag for staging validation/sign-off: immutable `main-<shortsha>`
 - `main-latest` is convenience-only
+- Final release tag push (for example `v0.1.0`) also publishes `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -33,8 +33,10 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
+- Preferred deploy tag for staging candidate validation: immutable `main-<shortsha>`
 - `main-latest` is convenience-only and not production sign-off material
+- Final release tag push (for example `v0.1.0`) also publishes `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Production may deploy either the validated `main-<shortsha>` or `v0.1.0`; after tag push, `v0.1.0` is the canonical release image tag
 
 > The `tokenplace.*` values/version files in command examples below are **Sugarkube-owned future
 > contract artifacts** expected after follow-up Sugarkube prompts land.


### PR DESCRIPTION
### Motivation
- The existing GHCR image workflow published `main-*` and `sha-*` tags from `main` pushes but did not publish semver image tags when a Git release tag (for example `v0.1.0`) was pushed.
- We need tag-parity so that pushing `git tag v0.1.0` results in `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` for a canonical release image.

### Description
- Added `on.push.tags: ['v*']` to `.github/workflows/ci-image.yml` and extended the tag-computation step to detect `refs/tags/v*` and `refs/heads/main` paths while leaving `pull_request` and `workflow_dispatch` non-publish behavior intact.
- Preserved `main` push behavior producing `ghcr.io/futuroptimist/tokenplace-relay:main-<shortsha>`, `main-latest`, and `sha-<shortsha>`. For `refs/tags/vX.Y.Z` pushes the workflow now publishes `ghcr.io/futuroptimist/tokenplace-relay:vX.Y.Z` plus `sha-<shortsha>` (and avoids main-looking tags unless the ref is `main`).
- Added guards: a semver-format validation for release tags and checks to fail on unsafe/empty Docker tag outputs to prevent accidental publishes with malformed tags.
- Updated `Publish` step to accept a multiline `image_tags` output and updated the workflow summary to clearly show branch vs semver publish context, and updated docs (`README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`) to describe the release-image flow (staging uses `main-<shortsha>`, `git tag v0.1.0` publishes `v0.1.0`, production may use either but `v0.1.0` is canonical after tag push). 

### Testing
- Simulated tag logic locally with a small Python script for the three cases and confirmed expected outputs: `push refs/heads/main` publishes `main-<shortsha>, main-latest, sha-<shortsha>`; `push refs/tags/v0.1.0` publishes `v0.1.0, sha-<shortsha>`; `pull_request` does not publish. (`python` simulation: passed).
- Ran `rg` checks to verify docs/workflow references to the new behavior (`rg -n "v0.1.0|main-<shortsha>|main-latest|tokenplace-relay"`): found updated docs and workflow references (passed).
- Attempted `actionlint .github/workflows/ci-image.yml` but `actionlint` is not installed in the environment (`actionlint: command not found`).
- Ran `pre-commit run --all-files`; hooks mostly passed but `check-yaml` failed due to pre-existing unrelated YAML parsing issues in `charts/tokenplace/templates/*` (these are unrelated to the workflow changes and blocked a full local pre-commit pass).

Residual notes and follow-ups: the workflow change confines publishing to `push` events only (safe for `workflow_dispatch`), adds semantic validation to reject malformed release tags, and preserves all existing `main`-branch publish behavior; upstream CI should run the full `actionlint` and repository `pre-commit` checks in CI where `actionlint` and chart YAML validation can be resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154bfdc1e8832fb566d174f55f764d)