### PR TITLE
Publish semver GHCR relay image on release tag pushes

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       ref:
@@ -24,6 +26,9 @@ jobs:
       short_sha: ${{ steps.tags.outputs.short_sha }}
       created: ${{ steps.tags.outputs.created }}
       repository: ${{ steps.tags.outputs.repository }}
+      publish_tags: ${{ steps.tags.outputs.publish_tags }}
+      summary_tags: ${{ steps.tags.outputs.summary_tags }}
+      semver_tag: ${{ steps.tags.outputs.semver_tag }}
       branch_tag: ${{ steps.tags.outputs.branch_tag }}
       latest_tag: ${{ steps.tags.outputs.latest_tag }}
       sha_tag: ${{ steps.tags.outputs.sha_tag }}
@@ -41,6 +46,7 @@ jobs:
           short_sha="$(git rev-parse --short=7 HEAD)"
           created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           repository="ghcr.io/futuroptimist/tokenplace-relay"
+          semver_tag=""
 
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
           echo "created=${created}" >> "$GITHUB_OUTPUT"
@@ -48,6 +54,41 @@ jobs:
           echo "branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${repository}:main-latest" >> "$GITHUB_OUTPUT"
           echo "sha_tag=${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/tags/"* ]]; then
+            semver_tag="${GITHUB_REF#refs/tags/}"
+            if [[ ! "${semver_tag}" =~ ^v[0-9][0-9A-Za-z._-]*$ ]]; then
+              echo "Invalid release tag '${semver_tag}' for Docker publish." >&2
+              exit 1
+            fi
+            if [[ "${semver_tag}" == *"/"* || "${semver_tag}" == *":"* || "${semver_tag}" == *"@"* || "${semver_tag}" == "." || "${semver_tag}" == ".." ]]; then
+              echo "Unsafe release tag '${semver_tag}' for Docker publish." >&2
+              exit 1
+            fi
+            echo "semver_tag=${semver_tag}" >> "$GITHUB_OUTPUT"
+            echo "publish_tags<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${repository}:${semver_tag}" >> "$GITHUB_OUTPUT"
+            echo "${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "summary_tags<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${repository}:${semver_tag}" >> "$GITHUB_OUTPUT"
+            echo "${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "publish_tags<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
+            echo "${repository}:main-latest" >> "$GITHUB_OUTPUT"
+            echo "${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "summary_tags<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${repository}:main-${short_sha} (immutable)" >> "$GITHUB_OUTPUT"
+            echo "${repository}:main-latest (mutable convenience)" >> "$GITHUB_OUTPUT"
+            echo "${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_tags=" >> "$GITHUB_OUTPUT"
+            echo "summary_tags=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -106,7 +147,7 @@ jobs:
     name: Publish relay image
     runs-on: ubuntu-latest
     needs: build-and-smoke
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main') || github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       packages: write
@@ -138,10 +179,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           provenance: false
-          tags: |
-            ${{ needs.build-and-smoke.outputs.branch_tag }}
-            ${{ needs.build-and-smoke.outputs.latest_tag }}
-            ${{ needs.build-and-smoke.outputs.sha_tag }}
+          tags: ${{ needs.build-and-smoke.outputs.publish_tags }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.short_sha }}
@@ -154,9 +192,16 @@ jobs:
           {
             echo "## Relay image tags"
             echo ""
-            echo "Immutable tag: \`${{ needs.build-and-smoke.outputs.branch_tag }}\`"
-            echo "Mutable tag: \`${{ needs.build-and-smoke.outputs.latest_tag }}\`"
-            echo "SHA tag: \`${{ needs.build-and-smoke.outputs.sha_tag }}\`"
+            if [[ -n "${{ needs.build-and-smoke.outputs.semver_tag }}" ]]; then
+              echo "Publish reason: Git tag \`${{ needs.build-and-smoke.outputs.semver_tag }}\`"
+            else
+              echo "Publish reason: main branch push"
+            fi
+            echo "Published tags:"
+            while IFS= read -r tag; do
+              [[ -z "${tag}" ]] && continue
+              echo "- \`${tag}\`"
+            done <<< "${{ needs.build-and-smoke.outputs.summary_tags }}"
             echo ""
             echo "Pushed: true"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Artifact references:
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
+- Release Git tag pushes (example: `v0.1.0`) also publish canonical semver relay image tags
+  (example: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -32,6 +32,9 @@ upgrade windows, set an explicit single-pod rollout strategy (for example `Recre
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Required sign-off tag style: immutable `main-<shortsha>`
 - `main-latest` is convenience-only and not production sign-off
+- After a release Git tag push (example: `v0.1.0`), use
+  `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` as the canonical release image tag
+  (validated `main-<shortsha>` remains acceptable if explicitly pinned)
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -33,6 +33,8 @@ operations, operators should configure a single-pod rollout policy (for example 
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - `main-latest` is convenience-only
+- Release Git tags (example: `v0.1.0`) publish matching semver image tags
+  (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`) for final release promotion
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -35,6 +35,9 @@ operator workflow.
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - `main-latest` is convenience-only and not production sign-off material
+- Final release Git tags (example: `v0.1.0`) also publish matching semver image tags
+  (example: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`), which become the canonical
+  production release image tags
 
 > The `tokenplace.*` values/version files in command examples below are **Sugarkube-owned future
 > contract artifacts** expected after follow-up Sugarkube prompts land.


### PR DESCRIPTION
### Motivation
- The CI image workflow published `main-*` and `sha-*` tags on pushes to `main` but did not publish a canonical semver image when a release Git tag (for example `v0.1.0`) was pushed. 
- The change ensures that a validated release commit tagged `v0.1.0` produces `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` while preserving existing `main-<shortsha>`, `main-latest`, and `sha-<shortsha>` behavior.

### Description
- Add `push.tags: ["v*"]` trigger to `.github/workflows/ci-image.yml` and keep `pull_request` builds as smoke-only, not publishing. 
- Compute and export `publish_tags`, `summary_tags`, and `semver_tag` in the `Compute image metadata and tags` step, with validation that fails the job for malformed or unsafe tag strings. 
- Make the `publish` job conditional on `refs/heads/main` or `refs/tags/v*`, use `${{ needs.build-and-smoke.outputs.publish_tags }}` as the push list, and update the workflow summary to show publish reason and exact tags pushed. 
- Update docs/README references to document that staging uses `main-<shortsha>` for validation and that after pushing a release tag (example `v0.1.0`) GHCR will publish `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` (canonical release image) while keeping chart publishing unchanged. 
- Publish behavior summary (truth table): `pull_request` -> no publish; `push refs/heads/main` -> `main-<shortsha}`, `main-latest`, `sha-<shortsha>`; `push refs/tags/v0.1.0` -> `v0.1.0`, `sha-<shortsha>`.

### Testing
- Ran a local shell validation script (`/tmp/check_tags.sh`) that exercised the tag computation for `GITHUB_EVENT_NAME=push, GITHUB_REF=refs/heads/main, short_sha=deadbee`, `GITHUB_EVENT_NAME=push, GITHUB_REF=refs/tags/v0.1.0, short_sha=deadbee`, and `GITHUB_EVENT_NAME=pull_request, GITHUB_REF=refs/pull/123/merge, short_sha=deadbee`, and it produced the expected tag lists (success). 
- Searched with `rg` for relevant references (`v0.1.0|main-<shortsha>|main-latest|tokenplace-relay`) to confirm docs and workflow updates were applied (success). 
- Attempted `actionlint .github/workflows/ci-image.yml` but `actionlint` is not available in the environment so it was not run here (`actionlint: command not found`). 
- Ran `pre-commit run --all-files` and it failed due to existing unrelated YAML parse errors in `charts/tokenplace/templates/*.yaml` (pre-existing failure not introduced by this change), so full pre-commit hooks did not complete successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154bfdc1e8832fb566d174f55f764d)