### PR TITLE
Publish GHCR relay image for semver Git tags (v*) in ci-image workflow

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   workflow_dispatch:
     inputs:
       ref:
@@ -24,9 +26,12 @@ jobs:
       short_sha: ${{ steps.tags.outputs.short_sha }}
       created: ${{ steps.tags.outputs.created }}
       repository: ${{ steps.tags.outputs.repository }}
-      branch_tag: ${{ steps.tags.outputs.branch_tag }}
+      main_branch_tag: ${{ steps.tags.outputs.main_branch_tag }}
       latest_tag: ${{ steps.tags.outputs.latest_tag }}
       sha_tag: ${{ steps.tags.outputs.sha_tag }}
+      semver_tag: ${{ steps.tags.outputs.semver_tag }}
+      publish_tags: ${{ steps.tags.outputs.publish_tags }}
+      publish_mode: ${{ steps.tags.outputs.publish_mode }}
 
     steps:
       - name: Checkout repository
@@ -45,9 +50,42 @@ jobs:
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
           echo "created=${created}" >> "$GITHUB_OUTPUT"
           echo "repository=${repository}" >> "$GITHUB_OUTPUT"
-          echo "branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "main_branch_tag=${repository}:main-${short_sha}" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${repository}:main-latest" >> "$GITHUB_OUTPUT"
           echo "sha_tag=${repository}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
+
+          publish_mode="none"
+          semver_tag=""
+          publish_tags="${repository}:sha-${short_sha}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            publish_mode="main"
+            publish_tags="${repository}:main-${short_sha}"$'\n'"${repository}:main-latest"$'\n'"${repository}:sha-${short_sha}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" =~ ^refs/tags/v[0-9].* ]]; then
+            tag_name="${GITHUB_REF#refs/tags/}"
+            if [[ ! "${tag_name}" =~ ^v[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Malformed release tag '${tag_name}'. Expected semver-like 'v<major>.<minor>.<patch>'." >&2
+              exit 1
+            fi
+            if [[ "${tag_name}" == *"/"* || "${tag_name}" == *":"* || "${tag_name}" == "." || "${tag_name}" == ".." ]]; then
+              echo "Unsafe Docker tag computed from '${tag_name}'." >&2
+              exit 1
+            fi
+            semver_tag="${repository}:${tag_name}"
+            publish_mode="tag"
+            publish_tags="${semver_tag}"$'\n'"${repository}:sha-${short_sha}"
+          fi
+
+          if [[ -z "${publish_tags}" ]]; then
+            echo "Refusing to continue: computed publish tags are empty." >&2
+            exit 1
+          fi
+
+          echo "semver_tag=${semver_tag}" >> "$GITHUB_OUTPUT"
+          echo "publish_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${publish_tags}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "publish_mode=${publish_mode}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -106,7 +144,7 @@ jobs:
     name: Publish relay image
     runs-on: ubuntu-latest
     needs: build-and-smoke
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read
       packages: write
@@ -138,10 +176,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           provenance: false
-          tags: |
-            ${{ needs.build-and-smoke.outputs.branch_tag }}
-            ${{ needs.build-and-smoke.outputs.latest_tag }}
-            ${{ needs.build-and-smoke.outputs.sha_tag }}
+          tags: ${{ needs.build-and-smoke.outputs.publish_tags }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ needs.build-and-smoke.outputs.short_sha }}
@@ -154,9 +189,15 @@ jobs:
           {
             echo "## Relay image tags"
             echo ""
-            echo "Immutable tag: \`${{ needs.build-and-smoke.outputs.branch_tag }}\`"
-            echo "Mutable tag: \`${{ needs.build-and-smoke.outputs.latest_tag }}\`"
-            echo "SHA tag: \`${{ needs.build-and-smoke.outputs.sha_tag }}\`"
+            echo "Publish mode: \`${{ needs.build-and-smoke.outputs.publish_mode }}\`"
+            echo "Source ref: \`${{ github.ref }}\`"
+            echo ""
+            echo "Pushed tags:"
+            while IFS= read -r tag; do
+              [ -n "$tag" ] && echo "- \`$tag\`"
+            done <<'EOF'
+            ${{ needs.build-and-smoke.outputs.publish_tags }}
+            EOF
             echo ""
             echo "Pushed: true"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
+- Preferred staging candidate tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
+- Canonical release tag after Git tag push (example): `v0.1.0` → `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Production can pin either validated `main-<shortsha>` or release `v0.1.0`; after tagging, `v0.1.0` is canonical
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -31,6 +31,8 @@ upgrade windows, set an explicit single-pod rollout strategy (for example `Recre
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Required sign-off tag style: immutable `main-<shortsha>`
+- Canonical release tag after Git tag push example: `v0.1.0` → `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Production may deploy either validated `main-<shortsha>` or release `v0.1.0`; release tag is canonical post-tag
 - `main-latest` is convenience-only and not production sign-off
 
 ## Deployment commands (run from Sugarkube repo)

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -32,6 +32,7 @@ operations, operators should configure a single-pod rollout policy (for example 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
+- Release tag publication example: Git tag `v0.1.0` publishes `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only
 
 ## Deployment commands (run from Sugarkube repo)

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -33,7 +33,9 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
+- Preferred deploy tag for staging candidate validation: immutable `main-<shortsha>`
+- Git release tag push example: `v0.1.0` also publishes `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Production can use validated `main-<shortsha>` or canonical release tag `v0.1.0` after tag push
 - `main-latest` is convenience-only and not production sign-off material
 
 > The `tokenplace.*` values/version files in command examples below are **Sugarkube-owned future


### PR DESCRIPTION
### Motivation
- The existing image workflow published `main-*` and `sha-*` tags but did not publish a matching semver image for a release Git tag (for example `v0.1.0`), blocking canonical release-image pinning. 
- The change ensures pushing a semver tag like `v0.1.0` produces `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` while preserving existing `main-*`, `main-latest`, and `sha-*` behavior.

### Description
- Added `push: tags: - v*` to `.github/workflows/ci-image.yml` and extended the `Compute image metadata and tags` step to compute `publish_mode`, `publish_tags`, and `semver_tag` based on the event/ref. 
- Kept `main` push behavior unchanged (publishes `main-<shortsha>`, `main-latest`, `sha-<shortsha>`) and implemented tag-push behavior to publish `<semver>` and `sha-<shortsha>`; the publish job condition was updated to run for `refs/heads/main` and `refs/tags/v*` only. 
- Added fail-closed validation for malformed/unsafe semver tags and centralized the docker `tags` input to use the computed `publish_tags`, and updated the workflow summary to list `publish_mode`, `github.ref`, and exact pushed tags. 
- Updated docs (`README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`) to document that staging candidates use `main-<shortsha>` and that pushing `v0.1.0` publishes `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` as the canonical release image tag.

### Testing
- Ran a local simulation of the tag-computation logic with: `python - <<'PY' ...` to validate cases for `push refs/heads/main`, `push refs/tags/v0.1.0`, and `pull_request refs/pull/*/merge`, and it produced the expected publish modes and tag lists (passed). 
- Searched references to tags and documentation with `rg -n "v0.1.0|main-<shortsha>|main-latest|tokenplace-relay"` and confirmed updates appear in the workflow and docs (passed). 
- Attempted `actionlint .github/workflows/ci-image.yml` but `actionlint` is not available in this environment (not run). 
- Ran `pre-commit run --all-files` which completed other hooks but failed due to pre-existing unrelated `check-yaml` errors in `charts/tokenplace/templates/*.yaml` (existing repo issue, not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154bfdc1e8832fb566d174f55f764d)