### PR TITLE
Fix macOS packaged compute-node startup: run dependency preflight before crypto-dependent imports

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -48,8 +48,8 @@ def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: flo
     raise RuntimeError(f"relay did not become live on port {port}: {last_error}")
 
 
-def create_packaged_layout(tmp_root: Path) -> Path:
-    resources_root = tmp_root / "resources"
+def create_packaged_layout(tmp_root: Path, *, resources_dir_name: str = "resources") -> Path:
+    resources_root = tmp_root / resources_dir_name
     python_dir = resources_root / "python"
     python_dir.mkdir(parents=True, exist_ok=True)
 
@@ -75,8 +75,13 @@ def create_packaged_layout(tmp_root: Path) -> Path:
     return python_dir / "compute_node_bridge.py"
 
 
-def _packaged_env(tmp_root: Path) -> dict[str, str]:
-    resources_root = tmp_root / "resources"
+def create_macos_bundle_layout(tmp_root: Path) -> Path:
+    resources_tmp_root = tmp_root / "TokenPlace.app" / "Contents"
+    return create_packaged_layout(resources_tmp_root, resources_dir_name="Resources")
+
+
+def _packaged_env(tmp_root: Path, resources_root: Path | None = None) -> dict[str, str]:
+    resources_root = resources_root or (tmp_root / "resources")
     home_dir = tmp_root / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
@@ -87,9 +92,9 @@ def _packaged_env(tmp_root: Path) -> dict[str, str]:
     return env
 
 
-def run_desktop_dependency_preflight(tmp_root: Path) -> None:
-    resources_root = tmp_root / "resources"
-    env = _packaged_env(tmp_root)
+def run_desktop_dependency_preflight(tmp_root: Path, *, resources_root: Path | None = None) -> None:
+    resources_root = resources_root or (tmp_root / "resources")
+    env = _packaged_env(tmp_root, resources_root)
 
     result = subprocess.run(  # noqa: S603
         [
@@ -114,10 +119,11 @@ def run_desktop_dependency_preflight(tmp_root: Path) -> None:
     assert payload.get("ok") == "true", combined
 
 
-def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
-    env = _packaged_env(tmp_root)
+def run_model_bridge_inspect_probe(tmp_root: Path, *, resources_root: Path | None = None) -> None:
+    resources_root = resources_root or (tmp_root / "resources")
+    env = _packaged_env(tmp_root, resources_root)
 
-    model_bridge = tmp_root / "resources" / "python" / "model_bridge.py"
+    model_bridge = resources_root / "python" / "model_bridge.py"
     result = subprocess.run(  # noqa: S603
         [sys.executable, str(model_bridge), "inspect"],
         cwd=tmp_root,
@@ -188,10 +194,11 @@ def run_model_bridge_inspect_probe(tmp_root: Path) -> None:
 
 
 
-def run_compute_bridge_import_probe(tmp_root: Path) -> None:
-    env = _packaged_env(tmp_root)
+def run_compute_bridge_import_probe(tmp_root: Path, *, resources_root: Path | None = None) -> None:
+    resources_root = resources_root or (tmp_root / "resources")
+    env = _packaged_env(tmp_root, resources_root)
 
-    compute_bridge = tmp_root / "resources" / "python" / "compute_node_bridge.py"
+    compute_bridge = resources_root / "python" / "compute_node_bridge.py"
     result = subprocess.run(  # noqa: S603
         [
             sys.executable,
@@ -238,10 +245,17 @@ def main() -> int:
     env["USE_MOCK_LLM"] = "1"
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
-        bridge_script = create_packaged_layout(Path(tmpdir))
-        run_desktop_dependency_preflight(Path(tmpdir))
-        run_model_bridge_inspect_probe(Path(tmpdir))
-        run_compute_bridge_import_probe(Path(tmpdir))
+        tmp_path = Path(tmpdir)
+        bridge_script = create_packaged_layout(tmp_path)
+        run_desktop_dependency_preflight(tmp_path)
+        run_model_bridge_inspect_probe(tmp_path)
+        run_compute_bridge_import_probe(tmp_path)
+
+        create_macos_bundle_layout(tmp_path)
+        mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
+        run_desktop_dependency_preflight(tmp_path, resources_root=mac_resources_root)
+        run_model_bridge_inspect_probe(tmp_path, resources_root=mac_resources_root)
+        run_compute_bridge_import_probe(tmp_path, resources_root=mac_resources_root)
 
         if os.environ.get("TOKEN_PLACE_INSPECT_ONLY") == "1":
             return 0

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -420,8 +420,8 @@ def main() -> int:
                 ],
                 cwd=REPO_ROOT,
                 env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
             )
 

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -290,14 +290,20 @@ def run_compute_bridge_startup_probe(
             daemon=True,
         ).start()
 
-        deadline = time.time() + 20
+        start_deadline = time.time() + 20
+        registration_deadline = time.time() + 45
         buffered = ""
-        while time.time() < deadline:
-            timeout = max(0.0, min(0.25, deadline - time.time()))
+        while time.time() < registration_deadline:
+            active_deadline = start_deadline if not saw_started else registration_deadline
+            timeout = max(0.0, min(0.25, active_deadline - time.time()))
+            if timeout <= 0 and not saw_started:
+                break
             try:
                 chunk = output_queue.get(timeout=timeout)
             except queue.Empty:
                 if bridge.poll() is not None:
+                    break
+                if saw_started and time.time() >= registration_deadline:
                     break
                 continue
 

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -291,7 +291,7 @@ def run_compute_bridge_startup_probe(
         ).start()
 
         start_deadline = time.time() + 20
-        registration_deadline = time.time() + 45
+        registration_deadline = time.time() + 90
         buffered = ""
         while time.time() < registration_deadline:
             active_deadline = start_deadline if not saw_started else registration_deadline

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -266,9 +266,11 @@ def run_compute_bridge_startup_probe(
         text=False,
     )
     bridge_output = ""
-    saw_structured_event = False
+    saw_started = False
+    saw_registered = False
     try:
         assert bridge.stdout is not None
+        assert bridge.stdin is not None
         output_queue: queue.Queue[bytes] = queue.Queue()
         threading.Thread(
             target=enqueue_bridge_stdout,
@@ -300,21 +302,49 @@ def run_compute_bridge_startup_probe(
                     payload = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if payload.get("type") in {"started", "status", "error"}:
-                    saw_structured_event = True
+                if payload.get("type") == "error":
+                    raise RuntimeError(f"bridge emitted error event: {payload}")
+                if payload.get("type") == "started" and payload.get("running") is True:
+                    saw_started = True
+                if payload.get("registered") is True:
+                    saw_registered = True
+                if saw_started and saw_registered:
+                    bridge.stdin.write(b'{"type":"cancel"}\n')
+                    bridge.stdin.flush()
                     break
-            if saw_structured_event:
+            if saw_started and saw_registered:
                 break
 
-        assert saw_structured_event, (
-            "compute-node bridge exited before emitting a startup event; output="
-            f"{bridge_output[-2000:]}"
-        )
+        if not saw_started:
+            raise RuntimeError(
+                "bridge did not emit started/running event; output="
+                f"{bridge_output[-2000:]}"
+            )
+        if not saw_registered:
+            raise RuntimeError(
+                "bridge never reported registered=true (relay connection missing); output="
+                f"{bridge_output[-2000:]}"
+            )
+
+        try:
+            bridge.stdin.close()
+        except OSError:
+            pass
+
+        try:
+            bridge.wait(timeout=90)
+        except subprocess.TimeoutExpired:
+            bridge.terminate()
+            bridge.wait(timeout=15)
+        if bridge.returncode != 0:
+            raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
+
         forbidden_output = (
             "No module named 'cryptography'",
             "ModuleNotFoundError",
             "ImportError",
             "compute-node bridge exited before emitting a startup event",
+            "desktop_runtime_setup module missing",
         )
         for marker in forbidden_output:
             assert marker not in bridge_output, bridge_output

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -323,6 +323,12 @@ def run_compute_bridge_startup_probe(
                 if saw_started and saw_registered:
                     bridge.stdin.write(b'{"type":"cancel"}\n')
                     bridge.stdin.flush()
+                    cancel_deadline = time.time() + 5
+                    while time.time() < cancel_deadline and bridge.poll() is None:
+                        try:
+                            bridge_output += output_queue.get(timeout=0.1).decode("utf-8", errors="replace")
+                        except queue.Empty:
+                            pass
                     break
             if saw_started and saw_registered:
                 break

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -382,7 +382,6 @@ def run_compute_bridge_startup_probe(
 
 
 def main() -> int:
-    relay_port = reserve_free_port()
     env = os.environ.copy()
     env["USE_MOCK_LLM"] = "1"
 
@@ -402,42 +401,42 @@ def main() -> int:
         if os.environ.get("TOKEN_PLACE_INSPECT_ONLY") == "1":
             return 0
 
-        relay = subprocess.Popen(  # noqa: S603
-            [
-                sys.executable,
-                str(REPO_ROOT / "relay.py"),
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(relay_port),
-                "--use_mock_llm",
-            ],
-            cwd=REPO_ROOT,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        probe_specs = (
+            (bridge_script, None, "standard resources"),
+            (mac_bridge_script, mac_resources_root, "macOS Contents/Resources"),
         )
 
-        try:
-            wait_for_livez(relay, relay_port)
-            run_compute_bridge_startup_probe(
-                tmp_path,
-                bridge_script,
-                relay_port=relay_port,
-                layout_label="standard resources",
-            )
-            run_compute_bridge_startup_probe(
-                tmp_path,
-                mac_bridge_script,
-                relay_port=relay_port,
-                resources_root=mac_resources_root,
-                layout_label="macOS Contents/Resources",
+        for probe_script, probe_resources_root, layout_label in probe_specs:
+            relay_port = reserve_free_port()
+            relay = subprocess.Popen(  # noqa: S603
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "relay.py"),
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(relay_port),
+                    "--use_mock_llm",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
             )
 
-        finally:
-            if relay.poll() is None:
-                relay.kill()
+            try:
+                wait_for_livez(relay, relay_port)
+                run_compute_bridge_startup_probe(
+                    tmp_path,
+                    probe_script,
+                    relay_port=relay_port,
+                    resources_root=probe_resources_root,
+                    layout_label=layout_label,
+                )
+            finally:
+                if relay.poll() is None:
+                    relay.kill()
 
     return 0
 

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -80,7 +80,12 @@ def create_macos_bundle_layout(tmp_root: Path) -> Path:
     return create_packaged_layout(resources_tmp_root, resources_dir_name="Resources")
 
 
-def _packaged_env(tmp_root: Path, resources_root: Path | None = None) -> dict[str, str]:
+def _packaged_env(
+    tmp_root: Path,
+    resources_root: Path | None = None,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, str]:
     resources_root = resources_root or (tmp_root / "resources")
     home_dir = tmp_root / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
@@ -89,6 +94,8 @@ def _packaged_env(tmp_root: Path, resources_root: Path | None = None) -> dict[st
     env["PYTHONNOUSERSITE"] = "1"
     env["TOKEN_PLACE_PYTHON_IMPORT_ROOT"] = str(resources_root)
     env["PYTHONPATH"] = str(resources_root / "python")
+    if extra_env:
+        env.update(extra_env)
     return env
 
 
@@ -245,8 +252,13 @@ def run_compute_bridge_startup_probe(
     *,
     relay_port: int,
     resources_root: Path | None = None,
+    layout_label: str = "standard resources",
 ) -> None:
-    env = _packaged_env(tmp_root, resources_root)
+    env = _packaged_env(tmp_root, resources_root, extra_env={"USE_MOCK_LLM": "1"})
+    log_dir = REPO_ROOT / ".desktop-e2e-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    safe_layout_label = layout_label.replace(" ", "_").replace("/", "_")
+    log_file = log_dir / f"packaged-bridge-startup-{safe_layout_label}.log"
     bridge = subprocess.Popen(  # noqa: S603
         [
             sys.executable,
@@ -317,13 +329,13 @@ def run_compute_bridge_startup_probe(
 
         if not saw_started:
             raise RuntimeError(
-                "bridge did not emit started/running event; output="
-                f"{bridge_output[-2000:]}"
+                f"[{layout_label}] bridge did not emit started/running event; output="
+                f"{bridge_output[-4000:]}"
             )
         if not saw_registered:
             raise RuntimeError(
-                "bridge never reported registered=true (relay connection missing); output="
-                f"{bridge_output[-2000:]}"
+                f"[{layout_label}] bridge never reported registered=true "
+                f"(relay connection missing); output={bridge_output[-4000:]}"
             )
 
         try:
@@ -337,7 +349,10 @@ def run_compute_bridge_startup_probe(
             bridge.terminate()
             bridge.wait(timeout=15)
         if bridge.returncode != 0:
-            raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
+            raise RuntimeError(
+                f"[{layout_label}] bridge exited non-zero ({bridge.returncode}): "
+                f"{bridge_output[-4000:]}"
+            )
 
         forbidden_output = (
             "No module named 'cryptography'",
@@ -349,6 +364,7 @@ def run_compute_bridge_startup_probe(
         for marker in forbidden_output:
             assert marker not in bridge_output, bridge_output
     finally:
+        log_file.write_text(bridge_output, encoding="utf-8")
         if bridge.poll() is None:
             bridge.kill()
 
@@ -393,12 +409,18 @@ def main() -> int:
 
         try:
             wait_for_livez(relay, relay_port)
-            run_compute_bridge_startup_probe(tmp_path, bridge_script, relay_port=relay_port)
+            run_compute_bridge_startup_probe(
+                tmp_path,
+                bridge_script,
+                relay_port=relay_port,
+                layout_label="standard resources",
+            )
             run_compute_bridge_startup_probe(
                 tmp_path,
                 mac_bridge_script,
                 relay_port=relay_port,
                 resources_root=mac_resources_root,
+                layout_label="macOS Contents/Resources",
             )
 
         finally:

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -239,6 +239,90 @@ def enqueue_bridge_stdout(stdout: object, output_queue: queue.Queue[bytes]) -> N
         output_queue.put(chunk)
 
 
+def run_compute_bridge_startup_probe(
+    tmp_root: Path,
+    bridge_script: Path,
+    *,
+    relay_port: int,
+    resources_root: Path | None = None,
+) -> None:
+    env = _packaged_env(tmp_root, resources_root)
+    bridge = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            str(bridge_script),
+            "--model",
+            "mock.gguf",
+            "--mode",
+            "cpu",
+            "--relay-url",
+            f"http://127.0.0.1:{relay_port}",
+        ],
+        cwd=tmp_root,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=False,
+    )
+    bridge_output = ""
+    saw_structured_event = False
+    try:
+        assert bridge.stdout is not None
+        output_queue: queue.Queue[bytes] = queue.Queue()
+        threading.Thread(
+            target=enqueue_bridge_stdout,
+            args=(bridge.stdout, output_queue),
+            daemon=True,
+        ).start()
+
+        deadline = time.time() + 20
+        buffered = ""
+        while time.time() < deadline:
+            timeout = max(0.0, min(0.25, deadline - time.time()))
+            try:
+                chunk = output_queue.get(timeout=timeout)
+            except queue.Empty:
+                if bridge.poll() is not None:
+                    break
+                continue
+
+            text = chunk.decode("utf-8", errors="replace")
+            bridge_output += text
+            buffered += text
+
+            while "\n" in buffered:
+                line, buffered = buffered.split("\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") in {"started", "status", "error"}:
+                    saw_structured_event = True
+                    break
+            if saw_structured_event:
+                break
+
+        assert saw_structured_event, (
+            "compute-node bridge exited before emitting a startup event; output="
+            f"{bridge_output[-2000:]}"
+        )
+        forbidden_output = (
+            "No module named 'cryptography'",
+            "ModuleNotFoundError",
+            "ImportError",
+            "compute-node bridge exited before emitting a startup event",
+        )
+        for marker in forbidden_output:
+            assert marker not in bridge_output, bridge_output
+    finally:
+        if bridge.poll() is None:
+            bridge.kill()
+
+
 def main() -> int:
     relay_port = reserve_free_port()
     env = os.environ.copy()
@@ -251,7 +335,7 @@ def main() -> int:
         run_model_bridge_inspect_probe(tmp_path)
         run_compute_bridge_import_probe(tmp_path)
 
-        create_macos_bundle_layout(tmp_path)
+        mac_bridge_script = create_macos_bundle_layout(tmp_path)
         mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
         run_desktop_dependency_preflight(tmp_path, resources_root=mac_resources_root)
         run_model_bridge_inspect_probe(tmp_path, resources_root=mac_resources_root)
@@ -277,117 +361,17 @@ def main() -> int:
             text=True,
         )
 
-        bridge: subprocess.Popen[bytes] | None = None
-        bridge_output = ""
-        output_queue: queue.Queue[bytes] | None = None
         try:
             wait_for_livez(relay, relay_port)
-            bridge = subprocess.Popen(  # noqa: S603
-                [
-                    sys.executable,
-                    str(bridge_script),
-                    "--model",
-                    "mock.gguf",
-                    "--mode",
-                    "cpu",
-                    "--relay-url",
-                    f"http://127.0.0.1:{relay_port}",
-                ],
-                cwd=tmpdir,
-                env=env,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=False,
+            run_compute_bridge_startup_probe(tmp_path, bridge_script, relay_port=relay_port)
+            run_compute_bridge_startup_probe(
+                tmp_path,
+                mac_bridge_script,
+                relay_port=relay_port,
+                resources_root=mac_resources_root,
             )
-
-            assert bridge.stdout is not None
-            assert bridge.stdin is not None
-
-            output_queue = queue.Queue()
-            threading.Thread(
-                target=enqueue_bridge_stdout,
-                args=(bridge.stdout, output_queue),
-                daemon=True,
-            ).start()
-
-            saw_started = False
-            saw_registered = False
-            buffered = ""
-            deadline = time.time() + 20
-
-            while time.time() < deadline:
-                timeout = max(0.0, min(0.25, deadline - time.time()))
-                try:
-                    chunk = output_queue.get(timeout=timeout)
-                except queue.Empty:
-                    if bridge.poll() is not None:
-                        break
-                    continue
-
-                text = chunk.decode("utf-8", errors="replace")
-                bridge_output += text
-                buffered += text
-
-                while "\n" in buffered:
-                    line, buffered = buffered.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        payload = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if payload.get("type") == "error":
-                        raise RuntimeError(f"bridge emitted error event: {payload}")
-                    if payload.get("type") == "started" and payload.get("running") is True:
-                        saw_started = True
-                    if payload.get("registered") is True:
-                        saw_registered = True
-                    if saw_started and saw_registered:
-                        bridge.stdin.write(b'{"type":"cancel"}\n')
-                        bridge.stdin.flush()
-                        break
-
-                if saw_started and saw_registered:
-                    break
-
-            if not saw_started:
-                raise RuntimeError(
-                    "bridge did not emit started/running event; output="
-                    f"{bridge_output[-2000:]}"
-                )
-            if not saw_registered:
-                raise RuntimeError(
-                    "bridge never reported registered=true (relay connection missing); output="
-                    f"{bridge_output[-2000:]}"
-                )
-
-            try:
-                bridge.stdin.close()
-            except OSError:
-                pass
-
-            try:
-                bridge.wait(timeout=90)
-            except subprocess.TimeoutExpired:
-                bridge.terminate()
-                bridge.wait(timeout=15)
-            if bridge.returncode != 0:
-                raise RuntimeError(f"bridge exited non-zero ({bridge.returncode}): {bridge_output}")
-            forbidden_output = (
-                "No module named",
-                "ModuleNotFoundError",
-                "ImportError",
-                "compute-node bridge exited before emitting a startup event",
-                "desktop_runtime_setup module missing",
-            )
-            for marker in forbidden_output:
-                assert marker not in bridge_output, bridge_output
 
         finally:
-            if bridge is not None and bridge.poll() is None:
-                bridge.kill()
             if relay.poll() is None:
                 relay.kill()
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -22,6 +22,8 @@ if __package__ in (None, ""):
 
 from path_bootstrap import ensure_runtime_import_paths
 
+ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
+
 try:
     from desktop_runtime_setup import (
         desktop_gpu_runtime_failure_message,
@@ -55,8 +57,6 @@ except ModuleNotFoundError:
         _runtime_setup: Dict[str, str], *, allow_reexec: bool = True
     ) -> None:
         return
-
-ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
@@ -176,6 +176,12 @@ def _runtime_path_from_env() -> str:
     if value.strip().lower() == "sidecar":
         return "sidecar"
     return "bridge"
+
+
+def _normalize_compute_mode_local(mode: Any) -> str:
+    supported_modes = {"auto", "cpu", "gpu", "hybrid"}
+    normalized = {"cuda": "gpu", "metal": "gpu"}.get(str(mode).lower(), str(mode).lower())
+    return normalized if normalized in supported_modes else "auto"
 
 
 def _start_stdin_reader() -> None:
@@ -599,9 +605,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        from utils.compute_node_runtime import normalize_compute_mode
-
-        args.mode = normalize_compute_mode(args.mode)
+        args.mode = _normalize_compute_mode_local(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
         emit({"type": "error", "message": f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"})

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -180,7 +180,8 @@ def _runtime_path_from_env() -> str:
 
 def _normalize_compute_mode_local(mode: Any) -> str:
     supported_modes = {"auto", "cpu", "gpu", "hybrid"}
-    normalized = {"cuda": "gpu", "metal": "gpu"}.get(str(mode).lower(), str(mode).lower())
+    selected = (mode or "auto").strip().lower()
+    normalized = {"cuda": "gpu", "metal": "gpu"}.get(selected, selected)
     return normalized if normalized in supported_modes else "auto"
 
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,8 +1,8 @@
 mod backend;
 mod compute_node;
 mod config;
-mod forward;
-mod keygen;
+pub mod forward;
+pub mod keygen;
 mod logging;
 mod python_runtime;
 mod sidecar;

--- a/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json
+++ b/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-27",
+  "slug": "desktop-macos-compute-node-cryptography-missing",
+  "summary": "Desktop macOS packaged compute-node startup could fail before first bridge event with No module named 'cryptography' because compute runtime imports ran before dependency preflight.",
+  "impact": "Desktop UI Start operator could immediately fail in clean packaged-like environments, preventing compute-node startup and surfacing only bridge-exited diagnostics.",
+  "fix": "Moved bridge path bootstrap earlier, removed early compute runtime import from main mode normalization path, and expanded packaged e2e/unit coverage for macOS .app/Contents/Resources dependency preflight and import ordering.",
+  "lessons": "Bridge startup ordering is critical: dependency preflight and packaged import-root resolution must happen before crypto-dependent runtime imports, and regression tests must mirror real macOS bundle layouts."
+}

--- a/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md
+++ b/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md
@@ -1,0 +1,30 @@
+# Outage: desktop macOS compute-node bridge missing cryptography preflight
+
+- **Date:** 2026-05-27
+- **Slug:** `desktop-macos-compute-node-cryptography-missing`
+- **Affected area:** desktop-tauri compute-node startup in packaged macOS layout
+
+## Summary
+Desktop macOS packaged startup could fail with `compute-node bridge exited before emitting a startup event: No module named 'cryptography'`.
+The failure happened before the bridge emitted its first startup/status event, so the UI only surfaced a bridge-exited error.
+
+## Impact
+On clean packaged-like environments (`PYTHONNOUSERSITE=1`, empty HOME), starting the operator from desktop UI could fail immediately, blocking local compute-node bring-up.
+
+## Root cause
+- `compute_node_bridge.py` imported `utils.compute_node_runtime` in `main()` just to normalize mode **before** runtime dependency preflight.
+- That early import reached crypto-dependent modules prior to `ensure_desktop_python_dependencies()`, so missing `cryptography` raised `ModuleNotFoundError` too early.
+- Existing packaged tests covered `resources/python` layout but not a release-like macOS `.app/Contents/Resources` path in the same dependency preflight + bridge startup flow.
+
+## Fix
+- Moved runtime path bootstrap (`ensure_runtime_import_paths`) to execute before importing desktop runtime setup helpers.
+- Removed early compute-runtime import from `main()` and replaced it with a local mode normalizer so dependency preflight executes first inside `run()`.
+- Extended packaged operator e2e to validate both standard `resources/` and macOS `.app/Contents/Resources` layouts with dependency preflight and bridge import probes under isolated env (`PYTHONNOUSERSITE=1`, clean HOME).
+- Added unit coverage for macOS requirements file discovery path and startup ordering guard (no early compute-runtime import in `main()`).
+
+## Verification
+- Targeted desktop unit suites pass for runtime setup, compute bridge, and model bridge.
+- Packaged operator e2e inspect path now validates macOS release-like layout and rejects `No module named`, `ModuleNotFoundError`, and `ImportError` regressions.
+
+## Prevention
+Keep compute-node bridge startup contract explicit: path bootstrap and dependency preflight must run before imports that can transitively require `cryptography`, and packaged e2e must include real macOS bundle path shapes.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -999,9 +999,7 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload['type'] == 'error'
-    assert payload['message'].startswith(
-        'compute-node bridge exited before emitting a startup event:'
-    )
+    assert payload['message'] == "runtime unavailable: No module named 'utils.compute_node_runtime'"
 
 
 def test_main_normalizes_mode_before_run(monkeypatch):
@@ -1011,9 +1009,6 @@ def test_main_normalizes_mode_before_run(monkeypatch):
         captured['mode'] = args.mode
         return 0
 
-    module = ModuleType('utils.compute_node_runtime')
-    module.normalize_compute_mode = lambda mode: {'cuda': 'gpu'}.get(str(mode).lower(), 'auto')
-    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
     monkeypatch.setattr(compute_node_bridge, 'run', fake_run)
     monkeypatch.setattr(
         sys,
@@ -1034,6 +1029,25 @@ def test_main_normalizes_mode_before_run(monkeypatch):
     status = compute_node_bridge.main()
     assert status == 0
     assert captured['mode'] == 'auto'
+
+
+def test_main_does_not_import_compute_runtime_for_mode_normalization(monkeypatch):
+    monkeypatch.setattr(compute_node_bridge, 'run', lambda _args: 0)
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'utils.compute_node_runtime':
+            raise AssertionError('main() should not import compute runtime before run()')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'CUDA'],
+    )
+
+    assert compute_node_bridge.main() == 0
 
 
 def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1023,6 +1023,26 @@ def test_main_normalizes_mode_before_run(monkeypatch):
     monkeypatch.setattr(
         sys,
         'argv',
+        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', ' CUDA '],
+    )
+
+    status = compute_node_bridge.main()
+    assert status == 0
+    assert captured['mode'] == 'gpu'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', ' cpu '],
+    )
+
+    status = compute_node_bridge.main()
+    assert status == 0
+    assert captured['mode'] == 'cpu'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
         ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'unsupported'],
     )
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -858,6 +858,17 @@ def test_ensure_desktop_python_dependencies_reports_requirements_missing(monkeyp
     assert result['missing'] == 'psutil,requests,dotenv,cryptography'
 
 
+def test_resolve_desktop_requirements_path_prefers_macos_resources_layout(tmp_path):
+    runtime_root = tmp_path / 'TokenPlace.app' / 'Contents' / 'Resources'
+    requirements = runtime_root / 'python' / 'requirements_desktop_runtime.txt'
+    requirements.parent.mkdir(parents=True)
+    requirements.write_text('cryptography==46.0.1\n', encoding='utf-8')
+
+    resolved = desktop_runtime_setup._resolve_desktop_requirements_path(runtime_root)
+
+    assert resolved == requirements
+
+
 def test_ensure_desktop_python_dependencies_reports_install_failed(monkeypatch, tmp_path):
     requirements = tmp_path / 'requirements_desktop_runtime.txt'
     requirements.write_text('psutil\nrequests\npython-dotenv\ncryptography\n', encoding='utf-8')


### PR DESCRIPTION
### Motivation
- Prevent compute-node bridge from exiting before its first startup event with `ModuleNotFoundError: No module named 'cryptography'` when launched from a macOS `.app/Contents/Resources` packaged layout. 
- Ensure dependency preflight and import-root bootstrap run early in release-like layouts so desktop runtime deps listed in `requirements_desktop_runtime.txt` are available to the bridge. 
- Add regression coverage that mirrors a real macOS bundle layout and rejects the exact failure signatures (`No module named 'cryptography'`, `ModuleNotFoundError`, `ImportError`, `compute-node bridge exited before emitting a startup event`).

### Description
- Move runtime import-root bootstrap earlier by calling `ensure_runtime_import_paths(__file__, ...)` immediately in `compute_node_bridge.py` so packaged import roots are visible before runtime helper imports. 
- Avoid importing `utils.compute_node_runtime` in `main()` solely to normalize mode; add a local `_normalize_compute_mode_local()` and perform dependency preflight inside `run()` before importing compute-runtime modules. 
- Extend `desktop-tauri/scripts/test_packaged_operator_e2e.py` to exercise both `resources/` and macOS `TokenPlace.app/Contents/Resources` layouts, run dependency preflight under `PYTHONNOUSERSITE=1` + clean `HOME`, and assert the bridge emits startup/status/error JSON rather than crashing. 
- Add unit tests: `test_main_does_not_import_compute_runtime_for_mode_normalization` to prevent reintroducing early imports and `test_resolve_desktop_requirements_path_prefers_macos_resources_layout` to lock macOS `.app` requirements discovery. 
- Add outage documentation `outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.{md,json}` describing symptom, root cause, fix, and prevention.

### Testing
- Ran targeted unit suites: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_packaged_layout.py -q` which completed with `108 passed, 1 skipped`.
- Verified PEP604/runtime alias guard tests with `python -m pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py -q` which passed (`3 passed`).
- Ran packaged operator e2e probes: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` and full `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, both completed successfully in this environment and validated the macOS-style layout probe and dependency preflight. 
- Frontend unit tests: `cd desktop-tauri && npm test -- --run` passed (`1 test file, 8 tests`).
- `cd desktop-tauri/src-tauri && cargo test` is expected but failed in this CI/container due to a missing system dependency (`glib-2.0` / `pkg-config`), so Rust tests were not completed here (environment limitation).
- All automated checks that exercise the Python dependency preflight and compute-bridge import ordering passed; cargo tests are blocked by host library requirements and should be re-run in a macOS/CI environment with `glib-2.0` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165277acd8832fbca284c7df588e0b)