### PR TITLE
Fix macOS Tauri compute-node startup failing on missing cryptography (preflight ordering)

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -48,8 +48,7 @@ def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: flo
     raise RuntimeError(f"relay did not become live on port {port}: {last_error}")
 
 
-def create_packaged_layout(tmp_root: Path) -> Path:
-    resources_root = tmp_root / "resources"
+def _populate_packaged_resources(resources_root: Path) -> Path:
     python_dir = resources_root / "python"
     python_dir.mkdir(parents=True, exist_ok=True)
 
@@ -75,8 +74,18 @@ def create_packaged_layout(tmp_root: Path) -> Path:
     return python_dir / "compute_node_bridge.py"
 
 
+def create_packaged_layout(tmp_root: Path) -> Path:
+    return _populate_packaged_resources(tmp_root / "resources")
+
+
+def create_macos_app_packaged_layout(tmp_root: Path) -> Path:
+    return _populate_packaged_resources(tmp_root / "token.place.app" / "Contents" / "Resources")
+
+
 def _packaged_env(tmp_root: Path) -> dict[str, str]:
     resources_root = tmp_root / "resources"
+    if not resources_root.exists():
+        resources_root = tmp_root / "Resources"
     home_dir = tmp_root / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
@@ -192,6 +201,8 @@ def run_compute_bridge_import_probe(tmp_root: Path) -> None:
     env = _packaged_env(tmp_root)
 
     compute_bridge = tmp_root / "resources" / "python" / "compute_node_bridge.py"
+    if not compute_bridge.exists():
+        compute_bridge = tmp_root / "Resources" / "python" / "compute_node_bridge.py"
     result = subprocess.run(  # noqa: S603
         [
             sys.executable,
@@ -242,6 +253,9 @@ def main() -> int:
         run_desktop_dependency_preflight(Path(tmpdir))
         run_model_bridge_inspect_probe(Path(tmpdir))
         run_compute_bridge_import_probe(Path(tmpdir))
+        macos_root = Path(tmpdir) / "macos-layout"
+        create_macos_app_packaged_layout(macos_root)
+        run_compute_bridge_import_probe(macos_root / "token.place.app" / "Contents")
 
         if os.environ.get("TOKEN_PLACE_INSPECT_ONLY") == "1":
             return 0

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -275,12 +275,18 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_api_v1_relay_payload,
+            normalize_compute_mode,
             resolve_relay_port,
             resolve_relay_url,
         )
     except ModuleNotFoundError as exc:
         emit({"type": "error", "message": f"runtime unavailable: {exc}"})
         return 1
+    except ImportError as exc:
+        emit({"type": "error", "message": f"runtime unavailable: {exc}"})
+        return 1
+
+    args.mode = normalize_compute_mode(args.mode)
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
@@ -599,9 +605,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        from utils.compute_node_runtime import normalize_compute_mode
-
-        args.mode = normalize_compute_mode(args.mode)
+        args.mode = str(args.mode or "auto").strip().lower() or "auto"
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
         emit({"type": "error", "message": f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"})

--- a/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json
+++ b/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-27",
+  "slug": "desktop-macos-compute-node-cryptography-missing",
+  "summary": "macOS desktop compute-node startup imported runtime modules before dependency preflight, causing cryptography missing errors before startup events.",
+  "impact": "Start operator failed before started/status lifecycle; UI showed compute-node bridge exited before emitting startup event with No module named 'cryptography'.",
+  "fix": "Moved compute mode normalization out of early main() imports and into run() after dependency preflight/runtime setup, and added macOS .app/Contents/Resources packaged e2e coverage.",
+  "lessons": "Desktop bridge entrypoints must avoid importing dependency-heavy runtime modules before preflight; packaged regression tests must include real macOS bundle layout, not only synthetic resources roots."
+}

--- a/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md
+++ b/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md
@@ -1,0 +1,25 @@
+# 2026-05-27 — macOS desktop compute-node bridge failed before startup event on missing `cryptography`
+
+## Summary
+The macOS Tauri desktop app failed to start the compute node operator in release-like environments because `compute_node_bridge.py` attempted to import runtime modules before dependency preflight completed, surfacing `No module named 'cryptography'` and exiting before a startup event.
+
+## User impact
+Users clicking **Start operator** saw:
+`Last error: compute-node bridge exited before emitting a startup event: No module named 'cryptography'`.
+Operator startup never reached stable `started`/`status` events.
+
+## Root cause
+`compute_node_bridge.main()` imported `normalize_compute_mode` from `utils.compute_node_runtime` before `run()` executed desktop runtime dependency bootstrap. In clean packaged Python environments (`PYTHONNOUSERSITE=1`, clean HOME), that early import chain reached modules requiring `cryptography` before `ensure_desktop_python_dependencies()` had a chance to install/validate desktop runtime prerequisites.
+
+## Fix
+- Moved compute mode normalization off the preflight path in `main()` and into `run()` after runtime preflight/import setup.
+- Kept startup failure handling structured (`type=error`) so bridge exits no longer fail silently before first JSON event.
+- Extended packaged e2e coverage to include a release-like macOS `.app/Contents/Resources` layout, preventing synthetic layout-only regressions.
+
+## Verification
+- Unit bridge tests validate run-path mode normalization and structured startup failure semantics.
+- Packaged e2e now probes compute bridge import behavior under both `resources/` and macOS `Contents/Resources` layouts in isolated env (`PYTHONNOUSERSITE=1`, temp HOME).
+
+## Prevention
+- Preserve dependency preflight-before-runtime-import ordering for desktop bridge entrypoints.
+- Keep macOS `.app` layout checks in packaged e2e to mirror real bundle resource resolution.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -999,21 +999,16 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload['type'] == 'error'
-    assert payload['message'].startswith(
-        'compute-node bridge exited before emitting a startup event:'
-    )
+    assert payload['message'].startswith('runtime unavailable:')
 
 
-def test_main_normalizes_mode_before_run(monkeypatch):
+def test_main_sanitizes_mode_before_run(monkeypatch):
     captured = {}
 
     def fake_run(args):
         captured['mode'] = args.mode
         return 0
 
-    module = ModuleType('utils.compute_node_runtime')
-    module.normalize_compute_mode = lambda mode: {'cuda': 'gpu'}.get(str(mode).lower(), 'auto')
-    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
     monkeypatch.setattr(compute_node_bridge, 'run', fake_run)
     monkeypatch.setattr(
         sys,
@@ -1023,7 +1018,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'gpu'
+    assert captured['mode'] == 'cuda'
 
     monkeypatch.setattr(
         sys,
@@ -1033,7 +1028,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'auto'
+    assert captured['mode'] == 'unsupported'
 
 
 def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):


### PR DESCRIPTION
### Motivation
- The macOS release Tauri app could fail to start the compute-node operator with `No module named 'cryptography'` because runtime-heavy imports happened before the desktop dependency preflight completed.  The bridge exited before emitting any structured startup event.
- The goal is to ensure dependency preflight runs (and emits a structured error if it fails) before importing modules that may require `cryptography` or other desktop runtime packages in a clean, packaged Python environment (`PYTHONNOUSERSITE=1`).

### Description
- Move compute-mode normalization out of the early `main()` import path and perform it inside `run()` after runtime preflight and safe imports, to avoid importing `utils.compute_node_runtime` before dependencies are validated; changes in `desktop-tauri/src-tauri/python/compute_node_bridge.py`.
- Add explicit `ImportError` handling alongside `ModuleNotFoundError` for runtime import failures and emit structured bridge error events instead of crashing silently; changes in `desktop-tauri/src-tauri/python/compute_node_bridge.py`.
- Extend the packaged operator e2e probe to exercise a real macOS `.app/Contents/Resources` layout in addition to the synthetic `resources/` layout, and make the probe tolerant of `resources` vs `Resources` roots; changes in `desktop-tauri/scripts/test_packaged_operator_e2e.py`.
- Update unit test expectations to match the new startup ordering and structured error surface; changes in `tests/unit/test_desktop_compute_node_bridge.py`.
- Add an outage record documenting the incident and the fix at `outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md` and `.json`.
- Files changed: `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/scripts/test_packaged_operator_e2e.py`, `tests/unit/test_desktop_compute_node_bridge.py`, `outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md`, `outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json`.

### Testing
- Ran unit test suites: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_packaged_layout.py -q` — result: all tests passed (`106 passed, 1 skipped` in the local run).
- Ran additional guard tests: `python -m pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py -q` — result: passed (`3 passed`).
- Exercised packaged operator e2e probes: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python desktop-tauri/scripts/test_packaged_operator_e2e.py` to validate both synthetic `resources/` and macOS `.app/Contents/Resources` layouts under isolated env (`PYTHONNOUSERSITE=1`, temporary `HOME`) — result: passed locally.
- Notes: JS and Rust test targets (`cd desktop-tauri && npm test -- --run`, `cd desktop-tauri/src-tauri && cargo test`) were not run in this pass because changes are Python-side only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165277acd8832fbca284c7df588e0b)