### PR TITLE
Fix macOS compute-node bridge early cryptography import crash in packaged startup

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -275,12 +275,15 @@ def run(args: argparse.Namespace) -> int:
             ComputeNodeRuntime,
             ComputeNodeRuntimeConfig,
             is_api_v1_relay_payload,
+            normalize_compute_mode,
             resolve_relay_port,
             resolve_relay_url,
         )
     except ModuleNotFoundError as exc:
         emit({"type": "error", "message": f"runtime unavailable: {exc}"})
         return 1
+
+    args.mode = normalize_compute_mode(args.mode)
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
     relay_port = resolve_relay_port(args.relay_port, relay_url)
@@ -599,9 +602,6 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        from utils.compute_node_runtime import normalize_compute_mode
-
-        args.mode = normalize_compute_mode(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
         emit({"type": "error", "message": f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"})

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -594,6 +594,7 @@ def _resolve_desktop_requirements_path(repo_root: Path) -> Path:
     candidates = [
         repo_root / "python" / "requirements_desktop_runtime.txt",
         repo_root / "resources" / "python" / "requirements_desktop_runtime.txt",
+        repo_root / "Resources" / "python" / "requirements_desktop_runtime.txt",
         Path(__file__).resolve().parent / "requirements_desktop_runtime.txt",
     ]
     for candidate in candidates:

--- a/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json
+++ b/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-27",
+  "slug": "desktop-macos-compute-node-cryptography-missing",
+  "summary": "macOS packaged desktop compute-node startup could fail before first bridge event with No module named 'cryptography'.",
+  "impact": "Desktop users could not start compute-node operator in clean packaged environments, and received early-exit messaging instead of structured dependency preflight diagnostics.",
+  "fix": "Moved compute runtime mode normalization behind dependency preflight in compute_node_bridge, added macOS Contents/Resources requirements path support, and added regression tests for startup ordering and bundle layout requirements discovery.",
+  "lessons": "Any imports reachable before bridge dependency preflight must stay free of runtime dependency requirements, and packaged macOS resource path coverage must mirror real .app Contents/Resources layouts."
+}

--- a/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md
+++ b/outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.md
@@ -1,0 +1,34 @@
+# Outage: desktop macOS compute-node bridge cryptography missing before startup event
+
+- **Date:** 2026-05-27
+- **Slug:** `desktop-macos-compute-node-cryptography-missing`
+- **Affected area:** desktop-tauri compute-node operator startup in packaged macOS app bundles
+
+## Summary
+On macOS desktop release bundles, starting the compute-node operator could fail with `compute-node bridge exited before emitting a startup event: No module named 'cryptography'`.
+The bridge terminated too early in startup ordering, preventing a normal startup/status/error event sequence.
+
+## Impact
+- Users could not start the compute node operator from the desktop UI in clean packaged environments.
+- The UI surfaced an early-exit startup message instead of structured dependency diagnostics.
+
+## Root cause
+- `compute_node_bridge.main()` imported `utils.compute_node_runtime.normalize_compute_mode` before dependency preflight.
+- That import chain reached modules that require `cryptography`, so `ModuleNotFoundError` occurred before `ensure_desktop_python_dependencies()` ran.
+- Desktop requirements discovery also omitted macOS `Contents/Resources/python/requirements_desktop_runtime.txt` as an explicit candidate path.
+
+## Fix
+- Moved compute mode normalization into `run()` after dependency preflight and after runtime module imports are guarded.
+- Kept early failure handling eventized so startup paths emit structured `error` events rather than raw crashes.
+- Added macOS `Contents/Resources/python/requirements_desktop_runtime.txt` path resolution coverage in runtime setup.
+- Added targeted regression tests to lock startup ordering and macOS requirements path behavior.
+
+## Verification
+- Unit tests for compute-node bridge startup ordering and dependency preflight behavior.
+- Unit tests for desktop runtime requirements discovery in macOS bundle layout.
+- Packaged operator e2e checks with `PYTHONNOUSERSITE=1` and clean temp HOME continue to validate bridge behavior.
+
+## Prevention
+- Keep bridge imports dependency-safe before desktop dependency preflight.
+- Maintain explicit tests for real/release-like macOS bundle layout (`.app/Contents/Resources`).
+- Continue asserting that early startup failures are emitted as structured events.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -999,21 +999,17 @@ def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkey
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload['type'] == 'error'
-    assert payload['message'].startswith(
-        'compute-node bridge exited before emitting a startup event:'
-    )
+    assert payload['message'].startswith('runtime unavailable:')
 
 
-def test_main_normalizes_mode_before_run(monkeypatch):
+def test_main_does_not_import_compute_runtime_before_run(monkeypatch):
     captured = {}
 
     def fake_run(args):
         captured['mode'] = args.mode
         return 0
 
-    module = ModuleType('utils.compute_node_runtime')
-    module.normalize_compute_mode = lambda mode: {'cuda': 'gpu'}.get(str(mode).lower(), 'auto')
-    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
+    monkeypatch.delitem(sys.modules, 'utils.compute_node_runtime', raising=False)
     monkeypatch.setattr(compute_node_bridge, 'run', fake_run)
     monkeypatch.setattr(
         sys,
@@ -1023,17 +1019,7 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 
     status = compute_node_bridge.main()
     assert status == 0
-    assert captured['mode'] == 'gpu'
-
-    monkeypatch.setattr(
-        sys,
-        'argv',
-        ['compute_node_bridge.py', '--model', '/tmp/model.gguf', '--mode', 'unsupported'],
-    )
-
-    status = compute_node_bridge.main()
-    assert status == 0
-    assert captured['mode'] == 'auto'
+    assert captured['mode'] == 'CUDA'
 
 
 def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):
@@ -1454,6 +1440,49 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monk
     assert error_event["warm_load_state"] == "failed"
 
 
+
+
+def test_run_normalizes_mode_after_dependency_preflight(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class _Runtime:
+        def __init__(self, *_args, **_kwargs):
+            relay_client = SimpleNamespace(relay_url='https://token.place', _request_timeout=1)
+            model_manager = SimpleNamespace(model_path='', use_mock_llm=False)
+            self.relay_client = relay_client
+            self.model_manager = model_manager
+
+        def stop(self):
+            return None
+
+        def register_and_poll_once(self):
+            return {'next_ping_in_x_seconds': 0}
+
+    runtime_module = ModuleType('utils.compute_node_runtime')
+    runtime_module.normalize_compute_mode = lambda mode: {'cuda': 'gpu'}.get(str(mode).lower(), 'auto')
+    runtime_module.apply_compute_mode = lambda manager, mode: setattr(manager, 'applied_mode', mode)
+    runtime_module.compute_mode_diagnostics = lambda _manager: {}
+    runtime_module.ComputeNodeRuntime = _Runtime
+    runtime_module.ComputeNodeRuntimeConfig = lambda **kwargs: kwargs
+    runtime_module.is_api_v1_relay_payload = lambda _payload: False
+    runtime_module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    runtime_module.resolve_relay_url = lambda relay_url, prefer_cli=True: relay_url
+    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', runtime_module)
+
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_llama_runtime', lambda _mode: {})
+    monkeypatch.setattr(compute_node_bridge, 'maybe_reexec_for_runtime_refresh', lambda _setup: None)
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_python_dependencies', lambda: {'ok': 'true'})
+    monkeypatch.setattr(compute_node_bridge, 'desktop_gpu_runtime_failure_message', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(compute_node_bridge, '_is_repo_llama_cpp_shim', lambda _path: False)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='CUDA', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert args.mode == 'gpu'
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert events[0]['type'] == 'started'
 def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -771,6 +771,17 @@ def test_resolve_requirements_path_prefers_packaged_resources_when_repo_root_mis
     assert resolved == packaged_requirements
 
 
+
+
+def test_resolve_desktop_requirements_path_supports_macos_contents_resources(tmp_path):
+    runtime_root = tmp_path / 'Token Place.app' / 'Contents'
+    requirements = runtime_root / 'Resources' / 'python' / 'requirements_desktop_runtime.txt'
+    requirements.parent.mkdir(parents=True)
+    requirements.write_text('cryptography==46.0.1\n', encoding='utf-8')
+
+    resolved = desktop_runtime_setup._resolve_desktop_requirements_path(runtime_root)
+
+    assert resolved == requirements
 def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_unpinned_fallback(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop launches could crash the compute-node bridge before emitting any startup event with errors like `No module named 'cryptography'`, preventing structured diagnostics. 
- The immediate cause was startup ordering: `main()` imported `utils.compute_node_runtime` (to normalize mode) before the desktop dependency preflight (`ensure_desktop_python_dependencies()`) completed. 
- The desktop runtime requirements discovery also missed a common macOS layout variant under `.app/Contents/Resources/python`, allowing a release bundle to skip the expected `requirements_desktop_runtime.txt` candidate.

### Description
- Move compute mode normalization into `run()` so `normalize_compute_mode` is imported/used only after dependency preflight and guarded runtime imports in `desktop-tauri/src-tauri/python/compute_node_bridge.py`. 
- Add explicit macOS bundle support by checking `Contents/Resources/python/requirements_desktop_runtime.txt` in `_resolve_desktop_requirements_path` in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`. 
- Make early runtime-import failures emit structured bridge errors (e.g. `runtime unavailable: ...`) so the bridge emits an actionable JSON `error` event instead of crashing before the first event. 
- Add/update unit tests to lock the regression: ensure `main()` does not import the compute runtime before `run()`, ensure `run()` normalizes mode after dependency preflight and still emits a `started` event, and add a test for macOS `Contents/Resources` requirements discovery. 
- Add outage documentation files `outages/2026-05-27-desktop-macos-compute-node-cryptography-missing.{md,json}` describing the incident, root cause, fix, and verification steps.

### Testing
- Ran unit test suite: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_model_bridge.py tests/unit/test_desktop_packaged_layout.py -q`, which completed with `108 passed, 1 skipped` (all modified/added regression tests passed). 
- Ran focused typing/guard tests: `python -m pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py -q`, which passed (`3 passed`). 
- Exercised packaged-operator e2e checks with `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, which executed (packaged-layout checks exercised the bridge import/preflight paths). 
- Frontend unit tests `cd desktop-tauri && npm test -- --run` passed and reported the JS tests OK. 
- `cd desktop-tauri/src-tauri && cargo test` was attempted but failed in this CI environment due to missing system `glib-2.0`/`pkg-config` development libs and is environment-specific rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165277acd8832fbca284c7df588e0b)