### PR TITLE
Align token.place v0.1.0 launch chart/release guardrails

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -150,7 +150,7 @@ jobs:
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
           if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Bump charts/tokenplace/Chart.yaml version before publishing." >&2
+            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Do not overwrite published OCI artifacts; stop and perform a manual release decision." >&2
             exit 1
           fi
           helm push "${package_file}" "${chart_registry}"

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -32,6 +32,30 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only and not production sign-off
 
+
+## v0.1.0 launch alignment
+
+For the `v0.1.0` launch, keep all token.place release identifiers aligned at `0.1.0`:
+
+- Git tag: `v0.1.0`
+- OCI Helm chart package version: `0.1.0`
+- Helm chart `appVersion`: `"0.1.0"`
+- Final GHCR release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tag before final tagging: `main-<shortsha>`
+
+Keep chart package/version alignment pinned to `0.1.0` for this launch track.
+
+## Pre-publish OCI chart safety check (required)
+
+Before publishing the chart, check whether chart version `0.1.0` already exists:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- If it does **not** exist, proceed with publishing `0.1.0`.
+- If it **does** exist and contents are stale/mismatched, do **not** overwrite it; stop and decide the release path manually.
+
 ## Deployment commands (run from Sugarkube repo)
 
 > Run from a **Sugarkube checkout**, not from token.place.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -33,6 +33,30 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only
 
+
+## v0.1.0 launch alignment
+
+For the `v0.1.0` launch, keep all token.place release identifiers aligned at `0.1.0`:
+
+- Git tag: `v0.1.0`
+- OCI Helm chart package version: `0.1.0`
+- Helm chart `appVersion`: `"0.1.0"`
+- Final GHCR release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tag before final tagging: `main-<shortsha>`
+
+Keep chart package/version alignment pinned to `0.1.0` for this launch track.
+
+## Pre-publish OCI chart safety check (required)
+
+Before publishing the chart, check whether chart version `0.1.0` already exists:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- If it does **not** exist, proceed with publishing `0.1.0`.
+- If it **does** exist and contents are stale/mismatched, do **not** overwrite it; stop and decide the release path manually.
+
 ## Deployment commands (run from Sugarkube repo)
 
 > These commands run from a **Sugarkube checkout**, not from token.place.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -36,6 +36,30 @@ operator workflow.
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
 
+
+## v0.1.0 launch alignment
+
+For the `v0.1.0` launch, keep all token.place release identifiers aligned at `0.1.0`:
+
+- Git tag: `v0.1.0`
+- OCI Helm chart package version: `0.1.0`
+- Helm chart `appVersion`: `"0.1.0"`
+- Final GHCR release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tag before final tagging: `main-<shortsha>`
+
+Keep chart package/version alignment pinned to `0.1.0` for this launch track.
+
+## Pre-publish OCI chart safety check (required)
+
+Before publishing the chart, check whether chart version `0.1.0` already exists:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- If it does **not** exist, proceed with publishing `0.1.0`.
+- If it **does** exist and contents are stale/mismatched, do **not** overwrite it; stop and decide the release path manually.
+
 ## Default hostnames
 
 - Staging default: `https://staging.token.place`


### PR DESCRIPTION
### Motivation
- Ensure the v0.1.0 launch story keeps all release identifiers consistently pinned to `0.1.0` and avoid accidental chart-version churn. 
- Prevent accidental overwrites of immutable OCI Helm artifacts by adding explicit pre-publish guardrails. 
- Preserve the strict single-pod Recreate rollout semantics for the relay and make that explicit in docs and CI guardrails.

### Description
- Kept `charts/tokenplace/Chart.yaml` pinned at `version: 0.1.0` and `appVersion: "0.1.0"` and did not introduce any `0.1.1` references. 
- Updated `.github/workflows/ci-helm.yml` to fail publishing when the chart already exists and to print an immutable-OCI guidance message: do not overwrite published OCI artifacts; stop and perform a manual release decision. 
- Added a `v0.1.0 launch alignment` section and a required pre-publish OCI chart safety check to `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md` that explain the all-0.1.0 launch story and include the `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` check and the “do not overwrite” guidance. 
- Left strict single-pod wording and guards intact (chart defaults/rendering for `replicaCount: 1`, `RELAY_WORKERS=1` references in templates, and `strategy.type: Recreate` remain in the chart and docs). 

### Testing
- Ran `grep -nE '^(version|appVersion):' charts/tokenplace/Chart.yaml` and confirmed `version: 0.1.0` and `appVersion: "0.1.0"` (pass). 
- Ran `rg -n "0\.1\.1" README.md docs charts .github/workflows` and verified there are no `0.1.1` occurrences in the targeted scope (pass). 
- Ran `rg -n "0\.1\.0|v0\.1\.0|main-<shortsha>|Recreate|relay:v0\.1\.0|helm show chart|charts/tokenplace" README.md docs charts .github/workflows` and confirmed the expected alignment text and Recreate/single-pod references are present (pass). 
- Attempted `helm lint`, `helm template`, and `helm show chart ... --version 0.1.0` but the environment lacked the `helm` binary so these commands could not be executed here and are marked as not-run (`helm: command not found`). 
- Ran `pre-commit run --all-files` which passed most hooks but failed on the repository's `check-yaml` hook due to existing Helm template parsing (pre-existing template YAML parsing errors); other hooks passed (partial). 

Notes and follow-ups
- The PR intentionally does not bump to `0.1.1`. 
- The CI guardrail already prevents publishing an existing chart version by running `helm show chart <chart_ref> --version <version>` and `exit 1` if found, and the failure message was clarified to avoid implying an automatic bump. 
- Because `helm` was not available in this execution environment, the `helm show chart ... --version 0.1.0` existence check should be run from a CI runner or a local environment with Helm installed before performing a publish operation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165bdf1f18832f9f12db1819038c3d)