### PR TITLE
Align token.place v0.1.0 launch version guardrails without chart bump

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -150,7 +150,8 @@ jobs:
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
           if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Bump charts/tokenplace/Chart.yaml version before publishing." >&2
+            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Refusing publish to preserve immutable OCI semantics; do not overwrite an existing chart artifact." >&2
+            echo "For v0.1.0 launch alignment, stop and verify whether the existing 0.1.0 artifact already matches approved release contents before any manual follow-up." >&2
             exit 1
           fi
           helm push "${package_file}" "${chart_registry}"

--- a/README.md
+++ b/README.md
@@ -263,8 +263,15 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch chart package version: `0.1.0`
+- Launch chart `appVersion`: `"0.1.0"`
 - Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
-- Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Canonical release image tag for Git tag `v0.1.0`: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+
+Release guardrail: before publishing chart `0.1.0`, check whether it already exists in GHCR with:
+`helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`. If it exists,
+do not overwrite/re-push the artifact; stop and verify manually whether existing contents are the
+approved launch chart.
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -28,9 +28,26 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch chart package version: `0.1.0`
+- Launch chart `appVersion`: `"0.1.0"`
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
-- Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Canonical release image tag for Git tag `v0.1.0`: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off
+
+### v0.1.0 chart publish pre-check
+
+For launch, keep all token.place release identifiers at `0.1.0` (Git tag `v0.1.0`, chart package
+version `0.1.0`, chart `appVersion: "0.1.0"`, and image tag
+`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`).
+
+Before any chart publish, verify whether chart `0.1.0` already exists:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+If it already exists, do not overwrite the OCI artifact; stop and decide manually. If it does not
+exist, proceed with publishing `0.1.0`.
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -29,9 +29,14 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch chart package version: `0.1.0`
+- Launch chart `appVersion`: `"0.1.0"`
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
-- Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Final release image tag for Git tag `v0.1.0`: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only
+
+For launch alignment, keep staging candidate deploys on immutable `main-<shortsha>` until final
+release tagging. Do not switch staging sign-off to semver tags before release cut.
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -32,9 +32,27 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch chart package version: `0.1.0`
+- Launch chart `appVersion`: `"0.1.0"`
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
-- Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Canonical release image tag after pushing Git tag `v0.1.0`: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
+
+### v0.1.0 publish guardrail (must check before chart publish)
+
+For the v0.1.0 launch, token.place release identifiers intentionally stay aligned at `0.1.0`:
+Git tag `v0.1.0`, chart package version `0.1.0`, chart `appVersion: "0.1.0"`, and release
+image tag `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
+
+Before publishing chart `0.1.0`, verify whether that OCI chart version already exists:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- If it **does not exist**, publish `0.1.0`.
+- If it **already exists**, do **not** overwrite/re-push from code or CI. Stop and decide manually
+  whether the existing artifact already matches the approved launch contents.
 
 ## Default hostnames
 


### PR DESCRIPTION
### Motivation

- Ensure the v0.1.0 launch story keeps all token.place release identifiers at `0.1.0` and prevent accidental overwrites of an immutable OCI Helm chart artifact.  
- Make the pre-publish guardrails explicit in docs and CI so operators manually verify any pre-existing `0.1.0` chart before publishing.  
- Preserve the strict single-pod Recreate rollout semantics and avoid any automatic chart-package version bump to `0.1.1`.

### Description

- Tightened CI publish messaging in ` .github/workflows/ci-helm.yml` to explicitly refuse overwriting an existing OCI chart and instruct manual verification for an existing `0.1.0` artifact.  
- Added explicit v0.1.0 launch alignment and pre-publish guidance to `README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md`, including the recommended check `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`.  
- Left `charts/tokenplace/Chart.yaml` unchanged so it remains `version: 0.1.0` and `appVersion: "0.1.0"`, and preserved single-pod rollout wording and templates that render `replicaCount: 1` and `strategy.type: Recreate`.  
- Did not modify any runtime code (`server.py`, desktop/Tauri, or relay runtime behavior) and did not introduce `0.1.1` anywhere in the scoped docs or workflows.

### Testing

- Verified chart metadata lines with `grep -nE '^(version|appVersion):' charts/tokenplace/Chart.yaml` which shows `version: 0.1.0` and `appVersion: "0.1.0"`.  
- Searched for `0.1.1` with `rg -n "0\.1\.1" README.md docs charts .github/workflows` and found no `0.1.1` usages in the scoped files.  
- Ran `rg` to confirm presence of the aligned release story and guardrail text across `README.md`, `docs`, `charts`, and workflows and observed the expected `0.1.0`/`v0.1.0`/`main-<shortsha>` references.  
- Attempted `helm`-based validation (`helm lint` / `helm template` / `helm show chart`) but `helm` was not available in the local environment so those commands could not be executed here; the CI workflow still performs these checks and now refuses to publish when the exact chart version already exists.  
- Ran `pre-commit run --all-files` which completed other hooks but failed the existing `check-yaml` hook against Helm template YAML files (an unrelated pre-existing repo-wide YAML formatting issue), and this failure is unrelated to the documentation/workflow message changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165bdf1f18832f9f12db1819038c3d)