### PR TITLE
Align v0.1.0 launch docs and add OCI immutability guard in Helm publish workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -150,7 +150,7 @@ jobs:
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
           if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Bump charts/tokenplace/Chart.yaml version before publishing." >&2
+            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Published OCI chart versions are immutable. Stop and resolve manually (verify whether existing 0.1.0 is stale) before any further publish action." >&2
             exit 1
           fi
           helm push "${package_file}" "${chart_registry}"

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -29,8 +29,19 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
+- v0.1.0 launch alignment: keep chart package `version: 0.1.0`, chart `appVersion: "0.1.0"`, Git tag `v0.1.0`, and release image tag `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only and not production sign-off
+
+
+Before publishing the launch chart, run:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- If chart `0.1.0` already exists with stale contents, stop and decide manually; never overwrite published OCI artifacts.
+- If it does not exist, publish `0.1.0`.
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -33,6 +33,25 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only
 
+
+### Pre-launch `v0.1.0` alignment
+
+Launch alignment for this phase keeps all release identifiers at `0.1.0`:
+
+- Git tag: `v0.1.0`
+- Chart package version: `0.1.0`
+- chart `appVersion`: `0.1.0`
+- Final release image: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate before final tag: `main-<shortsha>`
+
+Before publishing `0.1.0`, verify whether it already exists in OCI:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+If it exists with stale contents, stop and resolve manually; do not overwrite an immutable OCI artifact.
+
 ## Deployment commands (run from Sugarkube repo)
 
 > These commands run from a **Sugarkube checkout**, not from token.place.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -36,6 +36,28 @@ operator workflow.
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
 
+
+## Pre-launch v0.1.0 alignment contract
+
+For the `v0.1.0` launch, all token.place release identifiers stay aligned at `0.1.0`:
+
+- Git tag: `v0.1.0`
+- OCI Helm chart package version (`charts/tokenplace/Chart.yaml` `version`): `0.1.0`
+- chart `appVersion`: `0.1.0`
+- Final release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tag before final tagging: `main-<shortsha>`
+
+Do **not** bump the chart package version as part of this launch alignment work; keep launch alignment at 0.1.0.
+
+Before publishing the chart, verify whether `oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` already exists:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- If `0.1.0` already exists with stale contents, do **not** overwrite it; stop and decide manually.
+- If `0.1.0` does not exist, proceed with publishing `0.1.0`.
+
 ## Default hostnames
 
 - Staging default: `https://staging.token.place`


### PR DESCRIPTION
### Motivation

- Ensure the pre-launch release/story keeps all token.place release identifiers aligned at `0.1.0` (Git tag, chart package version, chart `appVersion`, and release image tag) and add clear pre-publish guardrails around immutable OCI charts.
- Make the Helm publish workflow and Sugarkube onboarding/runbooks explicit about not overwriting a published `0.1.0` chart and avoid suggesting an automatic bump to `0.1.1`.
- Preserve the strict single-pod Recreate rollout semantics and avoid any runtime behavior changes.

### Description

- Added a `Pre-launch v0.1.0 alignment` section to `docs/relay_sugarkube_onboarding.md` that documents the all-`0.1.0` launch story and a pre-publish check using `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` with explicit stop/manual resolution guidance if `0.1.0` already exists.
- Added matching pre-launch alignment guidance to `docs/k3s-sugarkube-staging.md` and `docs/k3s-sugarkube-prod.md` clarifying `main-<shortsha>` staging candidate usage and the immutable-OCI check before publishing `0.1.0`.
- Tightened `.github/workflows/ci-helm.yml` publish step messaging so the job fails if the chart already exists and clearly instructs manual resolution under immutable OCI semantics instead of recommending a version bump to `0.1.1`.
- Verified and left `charts/tokenplace/Chart.yaml` unchanged with `version: 0.1.0` and `appVersion: "0.1.0"` and did not introduce `0.1.1` anywhere in release/docs/workflows.
- Kept the strict single-pod rollout wording and chart defaults intact (`replicaCount: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1` references remain documented in runbooks).

### Testing

- Checked chart metadata: `grep -nE '^(version|appVersion):' charts/tokenplace/Chart.yaml` — returned `version: 0.1.0` and `appVersion: "0.1.0"` (pass).
- Searched for any `0.1.1` occurrences in release docs/workflows/charts: `rg -n "0\.1\.1" README.md docs charts .github/workflows || true` — no `0.1.1` found in docs/workflows/charts; matches that did appear are in `desktop-tauri` Cargo.lock (dependency lock entries) and are unrelated to release/chart/package versions (informational).
- Searched for alignment strings: `rg -n "0\.1\.0|v0\.1\.0|main-<shortsha>|Recreate|relay:v0\.1\.0|helm show chart|charts/tokenplace" README.md docs charts .github/workflows` — updated docs and workflow contain the expected guidance and terms (pass).
- Attempted Helm-based checks: `helm lint` / `helm template` / `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` were not executed because `helm` is not installed in this environment (`helm: command not found`), so OCI existence could not be verified here (blocked).
- Ran repository hooks: `pre-commit run --all-files` — most hooks passed; `check-yaml` failed due to Helm chart templates that include Go templating syntax (the YAML checker mis-parses Helm templates), consistent with existing repo behavior; this is a pre-existing, unrelated template parsing issue and not caused by the doc/workflow edits.

Note: The PR intentionally does not bump the chart package to `0.1.1`. The CI workflow now explicitly fails to publish if `chart_ref:0.1.0` already exists and instructs manual resolution so immutable OCI semantics are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165bdf1f18832f9f12db1819038c3d)