### PR TITLE
Align token.place v0.1.0 launch artifacts and immutable chart publish guardrails

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -150,7 +150,7 @@ jobs:
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
           if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Bump charts/tokenplace/Chart.yaml version before publishing." >&2
+            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Refusing to overwrite immutable OCI artifact; stop and resolve manually." >&2
             exit 1
           fi
           helm push "${package_file}" "${chart_registry}"

--- a/README.md
+++ b/README.md
@@ -263,8 +263,10 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- v0.1.0 launch alignment: Git tag `v0.1.0`, chart package version `0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
 - Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Pre-publish check: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (do not overwrite)
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Artifact references:
 - v0.1.0 launch alignment: Git tag `v0.1.0`, chart package version `0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - Preferred staging/prod tag: immutable `main-<shortsha>` (`main-latest` is convenience-only)
 - Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- Pre-publish check: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (do not overwrite)
+- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if chart `0.1.0` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.0` does not exist, proceed with publishing chart package version `0.1.0`.
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo.
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -32,7 +32,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only and not production sign-off
-- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (never overwrite OCI chart contents).
+- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if chart `0.1.0` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.0` does not exist, proceed with publishing chart package version `0.1.0`.
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -28,9 +28,11 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch version alignment for v0.1.0: Git tag `v0.1.0`, chart package version `0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only and not production sign-off
+- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (never overwrite OCI chart contents).
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -29,9 +29,11 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch version alignment for v0.1.0: Git tag `v0.1.0`, chart package version `0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only
+- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (never overwrite OCI chart contents).
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -33,7 +33,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only
-- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (never overwrite OCI chart contents).
+- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if chart `0.1.0` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.0` does not exist, proceed with publishing chart package version `0.1.0`.
 
 ## Deployment commands (run from Sugarkube repo)
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -36,7 +36,7 @@ operator workflow.
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
-- Before publishing the chart, run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (do not overwrite immutable OCI artifacts).
+- Before publishing, run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if chart `0.1.0` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.0` does not exist, proceed with publishing chart package version `0.1.0`.
 
 ## Default hostnames
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -32,9 +32,11 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Launch version alignment for v0.1.0: Git tag `v0.1.0`, chart package version `0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
+- Before publishing the chart, run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`; if it already exists with stale contents, stop and resolve manually (do not overwrite immutable OCI artifacts).
 
 ## Default hostnames
 


### PR DESCRIPTION
### Motivation
- Ensure all token.place release identifiers remain 0.1.0 for the v0.1.0 launch and add clear pre-publish guardrails so an already-published OCI chart version is never accidentally overwritten. 
- Preserve strict single-pod Recreate rollout semantics for the stateful relay phase and avoid any chart or image bumps to 0.1.1.

### Description
- Added explicit v0.1.0 launch alignment language (Git tag `v0.1.0`, chart package `0.1.0`, chart `appVersion: "0.1.0"`, final image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`, staging candidates `main-<shortsha>`) to `README.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md`.
- Tightened pre-publish wording in those docs to require running `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` and to stop and resolve manually if the chart version already exists (do not overwrite immutable OCI artifacts).
- Updated `.github/workflows/ci-helm.yml` to make the publish failure message explicit about immutable OCI semantics and to refuse to overwrite an existing chart version (preserving the existing exit-on-exist behavior but clarifying intent).
- Verified `charts/tokenplace/Chart.yaml` remains unchanged with `version: 0.1.0` and `appVersion: "0.1.0"`; no 0.1.1 versions were introduced in the release/workflow/docs paths touched.

### Testing
- `grep -nE '^(version|appVersion):' charts/tokenplace/Chart.yaml` — passed and shows `version: 0.1.0` and `appVersion: "0.1.0"`.
- `rg -n "0\.1\.1" .` — ran; matches found only in unrelated dependency lockfiles and not in altered docs/workflows (no 0.1.1 introduced by this PR).
- `rg -n "0\.1\.0|v0\.1\.0|main-<shortsha>|Recreate|relay:v0\.1\.0|helm show chart|charts/tokenplace" README.md docs charts .github/workflows` — passed and confirms README/docs/workflows include the v0.1.0 alignment and pre-publish guidance.
- `helm lint charts/tokenplace` and `helm template ...` and `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` — not run because `helm` is not installed in this execution environment (`helm: command not found`).
- `pre-commit run --all-files` — started and executed hooks; `check-yaml` failed on existing Helm template files in `charts/tokenplace/templates/*` (existing repo issues unrelated to the docs/workflow changes), so the full pre-commit suite did not complete cleanly in this environment.

Files changed:
- `.github/workflows/ci-helm.yml` (publish message clarified; behavior unchanged)
- `README.md` (v0.1.0 launch alignment + pre-publish check)
- `docs/relay_sugarkube_onboarding.md` (v0.1.0 launch alignment + pre-publish check)
- `docs/k3s-sugarkube-staging.md` (v0.1.0 launch alignment + pre-publish gate)
- `docs/k3s-sugarkube-prod.md` (v0.1.0 launch alignment + pre-publish gate)

Notes and residual risks:
- This PR intentionally does not bump the chart package or appVersion and does not attempt to publish or overwrite any OCI artifacts.
- Live verification of whether `oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0` already exists must be performed in an environment with `helm` available; CI will refuse to publish if the version already exists.
- Existing `check-yaml` failures in chart templates were observed by `pre-commit` and should be investigated separately if they block CI in your environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165bdf1f18832f9f12db1819038c3d)