### PR TITLE
Fix macOS relay quickstart dependency conflict (packaging pin + docs + outage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Secure peer-to-peer generative AI platform
 
 **Prerequisites**
 
-- **Python 3.11 or 3.12** (matches CI and Docker images; see [macOS relay setup](#macos-relay-only-quick-start) below)
+- **Python 3.11+** (3.11/3.12 are CI baseline; Homebrew currently installs 3.14 on macOS)
 - **Node.js 18+** (`nvm use` respects the included `.nvmrc`)
 
 Create and activate a virtual environment before installing Python packages (recommended on all platforms, especially macOS where `pip` may be missing but `pip3` is available):
@@ -43,9 +43,17 @@ python3.12 -m venv .venv || python3 -m venv .venv
 # Windows PowerShell alternative: py -3.12 -m venv .venv
 source .venv/bin/activate   # Windows: .\.venv\Scripts\Activate.ps1
 
+# If .venv was created before you installed/updated Homebrew Python, recreate it:
+# deactivate 2>/dev/null || true
+# rm -rf .venv
+# /opt/homebrew/bin/python3 -m venv .venv
+# source .venv/bin/activate
+
 python -m pip install --upgrade pip
 python -m pip install -r config/requirements_relay.txt
 ```
+
+On macOS, if `python -m pip install -r config/requirements_relay.txt` fails with a solver error mentioning `Flask-Limiter`, `limits`, and `packaging==25.0`, update to latest main (or set `packaging==24.2` in `config/requirements_relay.txt`) and reinstall into a freshly recreated `.venv`.
 
 **Relay only (fast path):** after activating `.venv`, run `python relay.py` and open `http://127.0.0.1:5010/api/v1/health`. Or run `./scripts/setup-relay-venv.sh` to create the venv and install relay dependencies in one step.
 

--- a/config/requirements_relay.txt
+++ b/config/requirements_relay.txt
@@ -20,7 +20,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 jsonschema==4.25.1
 MarkupSafe==3.0.3
-packaging==25.0
+packaging==24.2
 Pillow>=10.4.0
 psutil==7.1.0
 python-dotenv==1.1.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,3 +50,7 @@ testing, and deploying token.place. For an expanded overview of every directory,
 - [Implement](prompts/codex/implement.md)
 - [Automation](prompts/codex/automation.md)
 - [Polish](prompts/codex/polish.md)
+
+## Troubleshooting quick links
+
+- Relay dependency resolver conflict on macOS fresh setup (`Flask-Limiter`/`limits` vs `packaging`): see [README Quickstart](../README.md#quickstart) and outage record `outages/2026-05-27-macos-relay-requirements-packaging-conflict.md`.

--- a/outages/2026-05-27-macos-relay-requirements-packaging-conflict.json
+++ b/outages/2026-05-27-macos-relay-requirements-packaging-conflict.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-27",
+  "slug": "macos-relay-requirements-packaging-conflict",
+  "summary": "Fresh macOS relay quickstart installs failed because requirements_relay pinned packaging==25.0 while Flask-Limiter's limits dependency requires packaging<25.",
+  "impact": "Users could not install relay dependencies and relay.py failed to start due to missing Flask.",
+  "fix": "Pinned packaging to 24.2 in relay requirements and updated quickstart/docs troubleshooting guidance including venv recreation after Python upgrades.",
+  "lessons": "Pin changes in shared transitive dependency surfaces must be validated with clean resolver installs for each supported setup path, especially macOS Homebrew quickstart flows."
+}

--- a/outages/2026-05-27-macos-relay-requirements-packaging-conflict.md
+++ b/outages/2026-05-27-macos-relay-requirements-packaging-conflict.md
@@ -1,0 +1,23 @@
+# Outage: macOS relay quickstart dependency resolution conflict
+
+- **Date:** 2026-05-27
+- **Slug:** `macos-relay-requirements-packaging-conflict`
+- **Affected area:** Relay quickstart dependency install (`config/requirements_relay.txt`) on fresh macOS/Homebrew Python environments
+
+## Summary
+Fresh relay setup on macOS failed during `python -m pip install -r config/requirements_relay.txt` with `ResolutionImpossible`.
+The resolver reported `Flask-Limiter -> limits` requiring `packaging<25` while the file pinned `packaging==25.0`.
+
+## Impact
+Quickstart users could not finish relay dependency installation, so `python relay.py` failed early with `ModuleNotFoundError: No module named 'flask'`.
+
+## Root cause
+`config/requirements_relay.txt` pinned `packaging==25.0`, which conflicts with the `limits` versions allowed by `Flask-Limiter==3.11.0`.
+
+## Fix
+- Updated relay requirements to pin `packaging==24.2` so the dependency graph satisfies `Flask-Limiter` + `limits` constraints.
+- Updated setup docs to call out recreating `.venv` after Python upgrades on macOS.
+- Added explicit troubleshooting guidance in docs and README quickstart.
+
+## Prevention
+When bumping pinned shared dependencies, run a clean-environment relay install check (`python -m pip install -r config/requirements_relay.txt`) to catch resolver conflicts before release.


### PR DESCRIPTION
### Motivation
- Fresh macOS/Homebrew quickstart installs failed when `python -m pip install -r config/requirements_relay.txt` produced a `ResolutionImpossible` due to a transitive dependency mismatch. 
- The failure prevented `python relay.py` from running (observed `ModuleNotFoundError: No module named 'flask'`) for new users following Quickstart. 
- Provide a minimal, low-risk fix and document the incident so future maintainers and users can reproduce and avoid the issue. 

### Description
- Relaxed the conflicting packaging pin by changing `packaging==25.0` to `packaging==24.2` in `config/requirements_relay.txt`. 
- Updated the Quickstart section in `README.md` to reflect modern macOS/Homebrew Python behaviour, add `.venv` recreation guidance, and call out the resolver conflict workaround. 
- Added a troubleshooting pointer in `docs/README.md` linking to the outage record. 
- Added outage records `outages/2026-05-27-macos-relay-requirements-packaging-conflict.md` and `.json` describing the incident, root cause, fix, and prevention. 

### Testing
- Ran `pre-commit run --all-files` which auto-fixed an EOF issue but failed `check-yaml` on unrelated Helm chart templates, so pre-commit is partially green (existing repo YAML templates outside this change). 
- Verified a clean install by running `python3 -m venv /tmp/tpvenv && source /tmp/tpvenv/bin/activate && python -m pip install -U pip && python -m pip install -r config/requirements_relay.txt` which completed successfully. 
- Verified runtime import by activating the test venv and running `python -c "import flask, relay; print('ok')"`, which printed `ok` and showed the relay app initialized log entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169581362c832fba69be4c2088b1c5)