### PR TITLE
Fix macOS relay quickstart packaging resolver conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ source .venv/bin/activate   # Windows: .\.venv\Scripts\Activate.ps1
 
 python -m pip install --upgrade pip
 python -m pip install -r config/requirements_relay.txt
+
+# macOS/Homebrew note: if `python3` still resolves to Apple Python (often 3.9),
+# recreate the venv with Homebrew Python explicitly:
+#   deactivate 2>/dev/null || true
+#   rm -rf .venv
+#   /opt/homebrew/bin/python3 -m venv .venv
+#   source .venv/bin/activate
+#   python -V   # should show 3.11+
 ```
 
 **Relay only (fast path):** after activating `.venv`, run `python relay.py` and open `http://127.0.0.1:5010/api/v1/health`. Or run `./scripts/setup-relay-venv.sh` to create the venv and install relay dependencies in one step.
@@ -63,6 +71,8 @@ pre-commit run --all-files
 ```
 
 On macOS, use `python3` / `pip3` (or the venv’s `python` / `pip` after activation) if the unversioned `python` / `pip` commands are not on your `PATH`.
+
+On macOS, always verify the interpreter used to create the venv (`python -V` after activation). If it reports Python 3.9, remove `.venv` and recreate it with `/opt/homebrew/bin/python3` so dependency resolution matches CI and pinned requirements.
 
 ### Developer workflow quick reference
 

--- a/config/requirements_relay.txt
+++ b/config/requirements_relay.txt
@@ -20,7 +20,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 jsonschema==4.25.1
 MarkupSafe==3.0.3
-packaging==25.0
+packaging==24.2
 Pillow>=10.4.0
 psutil==7.1.0
 python-dotenv==1.1.1

--- a/outages/2026-05-27-macos-relay-requirements-packaging-conflict.json
+++ b/outages/2026-05-27-macos-relay-requirements-packaging-conflict.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-27",
+  "slug": "macos-relay-requirements-packaging-conflict",
+  "summary": "Fresh macOS relay quickstart installs failed because requirements_relay pinned packaging==25.0 while Flask-Limiter transitively required limits packages constrained to packaging<25.",
+  "impact": "pip install -r config/requirements_relay.txt failed with ResolutionImpossible and relay.py could not start due to missing Flask.",
+  "fix": "Pinned packaging to 24.2 in relay requirements and documented macOS Homebrew Python venv recreation guidance in README quickstart.",
+  "lessons": "Dependency pins must be checked against transitive upper bounds and quickstart should explicitly verify interpreter version in fresh macOS venvs."
+}

--- a/outages/2026-05-27-macos-relay-requirements-packaging-conflict.md
+++ b/outages/2026-05-27-macos-relay-requirements-packaging-conflict.md
@@ -1,0 +1,26 @@
+# Outage: macOS relay quickstart dependency resolution failure (packaging conflict)
+
+- **Date:** 2026-05-27
+- **Status:** Resolved
+- **Severity:** Medium
+
+## Summary
+Fresh macOS quickstart relay installs failed because `config/requirements_relay.txt` pinned `packaging==25.0`, while `Flask-Limiter==3.11.0` depends on `limits` versions that require `packaging<25`.
+
+## Impact
+- `python -m pip install -r config/requirements_relay.txt` failed with `ResolutionImpossible`.
+- `python relay.py` then failed with `ModuleNotFoundError: No module named 'flask'` because dependencies were not installed.
+- Affected new local setups, especially on macOS where users often bootstrap from a clean virtual environment.
+
+## Root cause
+A transitive compatibility mismatch was introduced between:
+- direct pin: `packaging==25.0`
+- transitive constraint via `Flask-Limiter` -> `limits` requiring `packaging<25`
+
+## Fix
+- Pinned relay dependency to `packaging==24.2` (compatible with the `limits` constraint chain).
+- Updated quickstart documentation with macOS guidance to ensure the venv is created from Homebrew Python when `python3` still resolves to Apple-provided Python 3.9.
+
+## Prevention
+- Keep relay requirements aligned with resolver constraints of transitives used by pinned top-level packages.
+- Validate quickstart in a clean venv on macOS for each dependency pin update.


### PR DESCRIPTION
### Motivation

- Fresh macOS quickstart installs failed because `config/requirements_relay.txt` pinned `packaging==25.0` while `Flask-Limiter` (via `limits`) requires `packaging<25`, causing `pip` dependency resolution to fail and leaving `flask` uninstalled so `python relay.py` crashed.
- Provide a minimal, low-risk fix to unblock macOS developers following the Quickstart and document the incident for future visibility.

### Description

- Relax the relay stack to a compatible packaging version by changing `packaging==25.0` → `packaging==24.2` in `config/requirements_relay.txt` to satisfy `limits` transitive constraints.
- Add explicit macOS/Homebrew venv guidance to the Quickstart in `README.md` explaining how to recreate the venv with Homebrew Python (`/opt/homebrew/bin/python3`) and to verify the interpreter with `python -V`.
- Add an outage entry (`outages/2026-05-27-macos-relay-requirements-packaging-conflict.md` and `.json`) documenting the symptom, root cause, applied fix, and prevention guidance.
- Changes touch `config/requirements_relay.txt`, `README.md`, and the new `outages/2026-05-27-*` files.

### Testing

- Ran `pytest -q tests/unit/test_relay_requirements.py`, which passed (1 test) and verified the relay requirements list includes required API-stack packages. ✅
- Ran `pre-commit run --all-files`; this failed due to pre-existing YAML parse errors in Helm chart templates under `charts/tokenplace/templates/*.yaml`, which is unrelated to these changes. ⚠️
- Manual reproduction steps that motivated the fix: follow the Quickstart venv creation and `python -m pip install -r config/requirements_relay.txt` on macOS; after the change the dependency resolution no longer produces the previous `ResolutionImpossible` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169581362c832fba69be4c2088b1c5)