### PR TITLE
Enforce mandatory E2EE and reject plaintext fields on relay routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,7 +1135,7 @@ Example response:
 
 ### End-to-End Encryption
 
-For enhanced privacy, you can use end-to-end encryption with the API:
+End-to-end encryption is mandatory across token.place. Relay paths only accept encrypted envelopes and reject plaintext payload fields:
 
 1. Get the server's public key:
 ```

--- a/relay.py
+++ b/relay.py
@@ -807,8 +807,8 @@ def relay_api_v1_chat_completions():
                 'type': 'service_unavailable_error',
                 'code': 'distributed_api_v1_relay_disabled',
                 'message': (
-                    'Distributed relay API v1 chat completions are disabled pending '
-                    'an end-to-end encrypted relay design.'
+                    'Distributed relay API v1 chat completions must use encrypted API v1 relay envelopes; '
+                    'plaintext relay dispatch is forbidden by design.'
                 ),
             }
         }
@@ -825,8 +825,8 @@ def relay_api_v1_source():
                 'type': 'service_unavailable_error',
                 'code': 'distributed_api_v1_relay_disabled',
                 'message': (
-                    'Distributed relay API v1 source dispatch is disabled pending '
-                    'an end-to-end encrypted relay design.'
+                    'Distributed relay API v1 source dispatch must use encrypted API v1 relay envelopes; '
+                    'plaintext relay dispatch is forbidden by design.'
                 ),
             }
         }
@@ -843,6 +843,12 @@ def _extract_ciphertext_envelope(payload, *, require_server_key=False):
         return None, ('Invalid request data', 400)
     if require_server_key:
         required.insert(0, 'server_public_key')
+
+    forbidden_plaintext_fields = {'messages', 'prompt', 'input', 'content'}
+    present_plaintext_fields = sorted(forbidden_plaintext_fields.intersection(payload))
+    if present_plaintext_fields:
+        return None, ('Plaintext fields are not allowed on encrypted relay routes', 400)
+
     missing = [field for field in required if field not in payload]
     if missing:
         return None, ('Invalid request data', 400)

--- a/static/index.html
+++ b/static/index.html
@@ -442,13 +442,13 @@
         </div>
 
         <h3>Encrypted API Usage</h3>
-        <p>For enhanced privacy, you can use end-to-end encryption with the API:</p>
+        <p>End-to-end encryption is required across token.place. The relay only accepts encrypted envelopes and never plaintext payloads:</p>
         <ol>
             <li>Get the server's public key from <code>/api/v1/public-key</code></li>
             <li>Generate your own RSA key pair on the client</li>
             <li>Encrypt your messages with the server's public key</li>
-            <li>Send the encrypted request with <code>"encrypted": true</code> flag</li>
-            <li>The server will encrypt its response with your public key</li>
+            <li>Send the encrypted request envelope (<code>ciphertext</code> + encrypted symmetric key + IV)</li>
+            <li>The server returns an encrypted envelope for client-side decryption</li>
         </ol>
 
         <p><strong>Example Encrypted Request:</strong></p>

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1345,7 +1345,7 @@ def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(clie
     assert DUMMY_CLIENT_PUB_KEY not in client_responses
 
 
-def test_api_v1_relay_plaintext_messages_not_stored(client):
+def test_api_v1_relay_plaintext_fields_rejected(client):
     client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
 
     plaintext = 'PLAINTEXT_SENTINEL_DO_NOT_STORE'
@@ -1360,12 +1360,12 @@ def test_api_v1_relay_plaintext_messages_not_stored(client):
         'prompt': plaintext,
     }
     response = client.post('/api/v1/relay/requests', json=payload)
-    assert response.status_code == 200
+    assert response.status_code == 400
+    assert response.get_json() == {
+        'error': {'message': 'Plaintext fields are not allowed on encrypted relay routes', 'code': 400}
+    }
 
-    queued_payload = client_inference_requests[DUMMY_SERVER_PUB_KEY][0]
-    assert 'messages' not in queued_payload
-    assert 'prompt' not in queued_payload
-    assert plaintext not in json.dumps(queued_payload)
+    assert DUMMY_SERVER_PUB_KEY not in client_inference_requests
 
 
 def test_api_v1_relay_requests_requires_client_public_key(client):


### PR DESCRIPTION
### Motivation
- The relay docs and some error messaging implied encryption was optional, which conflicts with the repo-wide relay-blind E2EE invariant requiring ciphertext-only relay state.
- Harden runtime behavior so encrypted relay routes never accept or store plaintext fields to prevent accidental plaintext leakage.

### Description
- Updated relay fail-closed messages to explicitly state API v1 relay dispatch must use encrypted API v1 relay envelopes and that plaintext relay dispatch is forbidden by design in `relay.py`.
- Added payload validation in `_extract_ciphertext_envelope` to reject plaintext-oriented fields (`messages`, `prompt`, `input`, `content`) on encrypted relay routes and return HTTP 400 when present in `relay.py`.
- Rewrote the landing-page docs and README wording (`static/index.html` and `README.md`) to declare E2EE as mandatory and to clarify envelope-based request/response behavior.
- Replaced the plaintext-acceptance test with a stricter test in `tests/test_relay.py` that asserts plaintext fields are rejected with a 400 and are not queued.

### Testing
- Ran the focused relay tests with `pytest -q tests/test_relay.py -k "plaintext_fields_rejected or relay_api_v1_chat_completions"` and the targeted test `test_api_v1_relay_plaintext_fields_rejected` passed (1 passed, deselected others). 
- Ran the single-test invocation `pytest -q tests/test_relay.py -k plaintext_fields_rejected` and it passed (1 passed, deselected others). 
- Ran repository hooks with `pre-commit run --all-files`, which completed but failed the `check-yaml` hook due to pre-existing invalid chart YAML files in `charts/tokenplace/templates/{serviceaccount,deployment,ingress,service}.yaml`; these YAML failures are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a4b3f2a4832fa70e87a09a1e5ede)