### PR TITLE
Clarify mandatory E2EE messaging on relay landing page and add guard test

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -1171,9 +1171,9 @@ def faucet():
     with a list of chat messages between the user and the assistant. Clients and servers may implement
     diffing mechanisms to determine if conversations were altered, but this is intentionally built in a
     stateless manner to minimize complexity and maximize scalability. It's trivially easy to identify
-    tampering from either party, so enforcing it on the relay is a non-goal, especially since communication
-    between the client and the server is intended to be end-to-end-encrypted. Servers and clients can choose
-    how to handle this as they see fit.
+    tampering from either party, so enforcing it on the relay is a non-goal. Communication between
+    clients and servers is expected to remain end-to-end encrypted by design, with relay-managed transport
+    carrying ciphertext envelopes and routing metadata rather than plaintext chat content.
 
     Example request:
 

--- a/static/index.html
+++ b/static/index.html
@@ -441,14 +441,14 @@
 }</pre>
         </div>
 
-        <h3>Encrypted API Usage</h3>
-        <p>For enhanced privacy, you can use end-to-end encryption with the API:</p>
+        <h3>End-to-End Encryption (Always On)</h3>
+        <p>End-to-end encryption is mandatory across token.place and enabled by design for all client↔relay↔server communication paths.</p>
         <ol>
             <li>Get the server's public key from <code>/api/v1/public-key</code></li>
             <li>Generate your own RSA key pair on the client</li>
-            <li>Encrypt your messages with the server's public key</li>
-            <li>Send the encrypted request with <code>"encrypted": true</code> flag</li>
-            <li>The server will encrypt its response with your public key</li>
+            <li>Encrypt your payload with the server's public key before sending to the relay</li>
+            <li>Include your client public key so the server can encrypt its response for your client</li>
+            <li>Treat this flow as required protocol behavior (not an optional privacy mode)</li>
         </ol>
 
         <p><strong>Example Encrypted Request:</strong></p>
@@ -478,7 +478,7 @@
         <p>Learn more about our goals and how you can be a part of this initiative on our <a href="https://github.com/futuroptimist/token.place">GitHub repository</a>.</p>
 
         <h3>Privacy Notice</h3>
-        <p><strong>All communications are now end-to-end encrypted for enhanced privacy. For maximum security, consider self-hosting by following the README on the GitHub repository.</strong></p>
+        <p><strong>All communications are end-to-end encrypted by default and by requirement. For maximum security, consider self-hosting by following the README on the GitHub repository.</strong></p>
 
         <div class="mode-toggle-container">
             <button id="toggleMode"></button>

--- a/tests/unit/test_relay_index_e2ee_copy.py
+++ b/tests/unit/test_relay_index_e2ee_copy.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_relay_index_e2ee_copy_states_mandatory_encryption():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    assert "End-to-End Encryption (Always On)" in index_html
+    assert "enabled by design for all client↔relay↔server communication paths" in index_html
+    assert "not an optional privacy mode" in index_html
+    assert "For enhanced privacy, you can use end-to-end encryption with the API:" not in index_html


### PR DESCRIPTION
### Motivation
- The landing-page wording implied end-to-end encryption could be optional, which conflicts with the repo invariant that relay paths must remain ciphertext-only and fail closed for plaintext relay dispatch. 
- Make the contract explicit in user-facing docs and add a regression guard so the messaging cannot be accidentally reverted.

### Description
- Update `static/index.html` to reword the “Encrypted API Usage” section to `End-to-End Encryption (Always On)` and state that E2EE is mandatory across client↔relay↔server paths. 
- Tweak the legacy `/faucet` docstring in `relay.py` to clarify the relay carries ciphertext envelopes and routing metadata rather than plaintext. 
- Add `tests/unit/test_relay_index_e2ee_copy.py` to assert the landing-page contains the required mandatory-E2EE phrasing and that the old optional-privacy copy was removed.

### Testing
- Ran `pytest -q tests/unit/test_relay_index_e2ee_copy.py tests/unit/test_e2ee_relay_invariant.py`, which passed (`7 passed`). 
- Ran `pre-commit run --all-files`, which failed on existing unrelated YAML parse errors in Helm templates under `charts/tokenplace/templates/*.yaml` (these failures are pre-existing and not caused by this change). 
- Existing E2EE invariant tests were exercised and continue to enforce that plaintext is not stored, routed, or logged by relay paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a4b3f2a4832fa70e87a09a1e5ede)