### PR TITLE
Enforce mandatory relay-blind E2EE wording on relay landing page, add regression test and outage record

### DIFF
--- a/outages/2026-05-27-relay-landing-page-e2ee-optional-wording.json
+++ b/outages/2026-05-27-relay-landing-page-e2ee-optional-wording.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-05-27",
+  "slug": "relay-landing-page-e2ee-optional-wording",
+  "summary": "The relay landing page documented E2EE as an optional enhanced-privacy mode and included optional \"encrypted\": true guidance, which conflicted with token.place's mandatory relay-blind E2EE invariant.",
+  "impact": "Users and integrators could incorrectly infer that plaintext relay payloads were acceptable, increasing regression risk toward non-E2EE implementations.",
+  "fix": "Updated relay-served / route documentation to state E2EE is always on, removed optional-encryption wording, and reinforced ciphertext-only request examples.",
+  "lessons": "Security invariants must be expressed as mandatory language in user-facing docs and guarded by tests to prevent policy drift."
+}

--- a/outages/2026-05-27-relay-landing-page-e2ee-optional-wording.md
+++ b/outages/2026-05-27-relay-landing-page-e2ee-optional-wording.md
@@ -1,0 +1,17 @@
+# Outage: relay landing-page E2EE optional wording
+
+## Summary
+The relay landing page (`/`) described end-to-end encryption as an optional enhancement and showed an optional `"encrypted": true` pattern. That contradicted token.place policy: relay traffic must be relay-blind E2EE by design.
+
+## Impact
+- Risked implementers building against misleading guidance.
+- Increased chance of future plaintext regressions by normalizing optional-E2EE language.
+
+## Fix
+- Rewrote the relay landing-page encryption section to state E2EE is always on.
+- Replaced optional wording with ciphertext-only envelope guidance.
+- Added regression test coverage asserting the mandatory-E2EE wording and guarding against optional-encryption text.
+
+## Prevention
+- Keep security-critical docs under test when they define protocol invariants.
+- Treat plaintext examples on relay/API pages as release-blocking violations.

--- a/static/index.html
+++ b/static/index.html
@@ -422,14 +422,18 @@
 
         <div class="api-endpoint">
             <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/completions</span></h3>
-            <p>Creates a completion for the prompt (traditional completion API).</p>
-            <p><strong>Request Body:</strong></p>
+            <p>Creates a completion request envelope (content must remain encrypted end-to-end).</p>
+            <p><strong>Request Body (ciphertext envelope):</strong></p>
             <pre>{
   "model": "llama-3-8b-instruct",
-  "prompt": "Write a poem about AI",
-  "max_tokens": 256
+  "client_public_key": "YOUR_PUBLIC_KEY_HERE",
+  "prompt": {
+    "ciphertext": "ENCRYPTED_DATA_HERE",
+    "cipherkey": "ENCRYPTED_AES_KEY_HERE",
+    "iv": "INITIALIZATION_VECTOR_HERE"
+  }
 }</pre>
-            <p><strong>Example Response:</strong> (Same format as chat/completions)</p>
+            <p><strong>Example Response:</strong> (ciphertext envelope shape matches chat/completions)</p>
         </div>
 
         <div class="api-endpoint">
@@ -441,20 +445,19 @@
 }</pre>
         </div>
 
-        <h3>Encrypted API Usage</h3>
-        <p>For enhanced privacy, you can use end-to-end encryption with the API:</p>
+        <h3>End-to-End Encryption (always on)</h3>
+        <p>token.place relay traffic is relay-blind E2EE by design. Plaintext payloads are not a supported mode.</p>
         <ol>
-            <li>Get the server's public key from <code>/api/v1/public-key</code></li>
-            <li>Generate your own RSA key pair on the client</li>
-            <li>Encrypt your messages with the server's public key</li>
-            <li>Send the encrypted request with <code>"encrypted": true</code> flag</li>
-            <li>The server will encrypt its response with your public key</li>
+            <li>Fetch the server key material from <code>/api/v1/public-key</code></li>
+            <li>Generate a client key pair on-device</li>
+            <li>Encrypt message content into a ciphertext envelope (<code>ciphertext</code>, <code>cipherkey</code>, <code>iv</code>)</li>
+            <li>Include your <code>client_public_key</code> so only your client can decrypt the response envelope</li>
+            <li>Send ciphertext-only payloads through relay routes; if E2EE cannot be preserved, relay fails closed</li>
         </ol>
 
-        <p><strong>Example Encrypted Request:</strong></p>
+        <p><strong>Example Chat Request (ciphertext-only):</strong></p>
         <pre>{
   "model": "llama-3-8b-instruct",
-  "encrypted": true,
   "client_public_key": "YOUR_PUBLIC_KEY_HERE",
   "messages": {
     "ciphertext": "ENCRYPTED_DATA_HERE",

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -67,6 +67,18 @@ def test_inference_endpoint_removed(client):
     response = client.post("/inference", json={})
     assert response.status_code == 404
 
+
+
+def test_index_documents_e2ee_as_mandatory(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+
+    assert 'End-to-End Encryption (always on)' in body
+    assert 'Plaintext payloads are not a supported mode' in body
+    assert 'For enhanced privacy, you can use end-to-end encryption with the API' not in body
+    assert '"encrypted": true' not in body
+
 # --- Test /next_server ---
 
 def test_next_server_no_servers(client):


### PR DESCRIPTION
### Motivation
- The relay landing page implied end-to-end encryption was optional and showed an `"encrypted": true` opt-in pattern, which conflicts with the repo-wide relay-blind E2EE invariant that relay-owned state must be ciphertext-only. 
- Make the landing-page documentation unambiguous that E2EE is always-on and ensure future wording regressions are caught by tests.

### Description
- Rewrote the landing-page encryption section in `static/index.html` to state E2EE is always-on, remove the optional `"encrypted": true` guidance, and replace plaintext examples with ciphertext-envelope request/response examples (fields: `ciphertext`, `cipherkey`, `iv`, `client_public_key`).
- Updated the `/api/v1/completions` example on the same page to show a ciphertext envelope rather than a plaintext `prompt` field.
- Added a regression test `test_index_documents_e2ee_as_mandatory` to `tests/test_relay.py` that asserts the `/` page contains mandatory-E2EE wording and does not contain the old optional-encryption language.
- Created an outage record documenting the mismatch and the remediation as `outages/2026-05-27-relay-landing-page-e2ee-optional-wording.md` and a JSON sidecar `outages/2026-05-27-relay-landing-page-e2ee-optional-wording.json`.

### Testing
- Ran the focused pytest command: `pytest -q tests/test_relay.py -k "index_documents_e2ee_as_mandatory or plaintext"`, which executed the new wording test plus related plaintext-guard tests and returned `3 passed, 64 deselected` (with warnings). 
- Ran repository hooks: `pre-commit run --all-files` which executed hooks successfully except `check-yaml` failed on unrelated existing YAML parsing issues in `charts/tokenplace/templates/*.yaml`; other pre-commit hooks passed. 
- Performed repository scan/searches for plaintext/sentinel strings in relay surfaces (used `rg`/searches across `relay.py`, `static/chat.js`, tests) and left the server-side relay behavior unchanged because relay already fails-closed for plaintext API v1 distributed paths; added the landing-page test to prevent future doc drift.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a4b3f2a4832fa70e87a09a1e5ede)