### PR TITLE
Fix relay chart runtime for read-only root filesystem and duplicate env rendering

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -57,7 +57,23 @@ jobs:
           grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
           grep -n "type: Recreate" /tmp/tokenplace-render.yaml
           grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "1"'
+          grep -n "name: XDG_CONFIG_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.config"'
+          grep -n "name: XDG_DATA_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/share"'
+          grep -n "name: XDG_CACHE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.cache"'
+          grep -n "name: XDG_STATE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/state"'
           ! grep -n "rollingUpdate:" /tmp/tokenplace-render.yaml
+
+          python3 - <<'PY'
+          import collections
+          import yaml
+
+          docs = list(yaml.safe_load_all(open("/tmp/tokenplace-render.yaml", encoding="utf-8")))
+          deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+          env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+          names = [item["name"] for item in env]
+          dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+          assert not dupes, dupes
+          PY
 
           helm template tokenplace charts/tokenplace \
             --namespace tokenplace \

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -109,6 +109,8 @@ jobs:
           set -euo pipefail
 
           docker run -d --rm --name tokenplace-relay-smoke \
+            --read-only \
+            --tmpfs /tmp \
             -p 127.0.0.1:5010:5010 \
             -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
             tokenplace-relay:smoke

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -68,15 +68,11 @@ spec:
               value: "0.0.0.0"
             - name: RELAY_PORT
               value: "{{ .Values.containerPort }}"
-            - name: RELAY_WORKERS
-              value: "1"
-            - name: TOKENPLACE_FRONTEND_MODE
-              value: "production"
-            - name: TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH
-              value: "0"
-            {{- range $key, $val := .Values.env }}
+            {{- $defaultEnv := dict "RELAY_WORKERS" "1" "TOKENPLACE_FRONTEND_MODE" "production" "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "0" }}
+            {{- $mergedEnv := mergeOverwrite (deepCopy $defaultEnv) (.Values.env | default dict) }}
+            {{- range $key := keys $mergedEnv | sortAlpha }}
             - name: {{ $key }}
-              value: {{ $val | quote }}
+              value: {{ index $mergedEnv $key | quote }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -63,7 +63,11 @@ ingress:
     enabled: false
     secretName: ""
 
-env: {}
+env:
+  XDG_CONFIG_HOME: /tmp/.config
+  XDG_DATA_HOME: /tmp/.local/share
+  XDG_CACHE_HOME: /tmp/.cache
+  XDG_STATE_HOME: /tmp/.local/state
 extraEnv: []
 envFrom: []
 


### PR DESCRIPTION
### Motivation
- Staging pods crashed in a CrashLoop because the relay default XDG dirs fell under `/home/relay/.config` which is not writable when `readOnlyRootFilesystem: true`, requiring a manual Helm override to point XDG paths at `/tmp`.
- The chart also hardcoded defaults and then rendered `.Values.env`, producing duplicate environment-name warnings in Kubernetes manifests.

### Description
- Added chart-owned XDG defaults to `charts/tokenplace/values.yaml`: `XDG_CONFIG_HOME=/tmp/.config`, `XDG_DATA_HOME=/tmp/.local/share`, `XDG_CACHE_HOME=/tmp/.cache`, and `XDG_STATE_HOME=/tmp/.local/state` so default deployments work with a read-only root filesystem.
- Refactored `charts/tokenplace/templates/deployment.yaml` to merge chart default envs with `.Values.env` and render each env name once (chart defaults are overridable by `.Values.env` and overrides win); this preserves `RELAY_WORKERS=1`, `TOKENPLACE_FRONTEND_MODE=production`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0` unless explicitly changed.
- Kept the writable `/tmp` `emptyDir` volume mount in the pod spec so the XDG defaults resolve to a writable path at runtime.
- Strengthened CI checks in `.github/workflows/ci-helm.yml` to assert presence of the XDG env vars, `replicas: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`, and to fail if duplicate env names exist via a small Python manifest check.
- Hardened the image smoke test in `.github/workflows/ci-image.yml` to run the relay container as read-only with `--read-only --tmpfs /tmp` while validating `/livez`, `/healthz`, `/`, and `/metrics`.

### Testing
- Ran `pre-commit run --all-files`; hooks executed and project checks passed, but `check-yaml` failed on templated Helm YAML files due to Helm template markers (this is an expected local lint limitation for templated files).
- Attempted `helm lint` and `helm template` locally but the environment lacked Helm (`helm: command not found`), so those render-time validations are delegated to CI (the updated CI workflow will run them).
- Attempted `docker build`/`docker run` smoke commands locally but Docker was not available here (`docker: command not found`); the CI image job now exercises `docker run --read-only --tmpfs /tmp` to validate runtime behavior and endpoints.
- Residual info: templated Helm YAML can trip local YAML parsers; please run `helm template` and the CI jobs (which now include duplicate-env and XDG checks) in CI or a local environment with `helm`/`docker` installed to fully validate the rendered manifest and smoke test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a5735064832fa47402d69e1ccf15)