### PR TITLE
Fix relay chart runtime defaults for read-only filesystem and dedupe env rendering

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -57,7 +57,23 @@ jobs:
           grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
           grep -n "type: Recreate" /tmp/tokenplace-render.yaml
           grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "1"'
+          grep -n "name: XDG_CONFIG_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.config"'
+          grep -n "name: XDG_DATA_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/share"'
+          grep -n "name: XDG_CACHE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.cache"'
+          grep -n "name: XDG_STATE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/state"'
           ! grep -n "rollingUpdate:" /tmp/tokenplace-render.yaml
+
+          python3 - <<'PY'
+          import collections
+          import yaml
+
+          docs = list(yaml.safe_load_all(open('/tmp/tokenplace-render.yaml', encoding='utf-8')))
+          deploy = next(d for d in docs if d and d.get('kind') == 'Deployment')
+          env = deploy['spec']['template']['spec']['containers'][0]['env']
+          names = [item['name'] for item in env]
+          dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+          assert not dupes, f'duplicate env names found: {dupes}'
+          PY
 
           helm template tokenplace charts/tokenplace \
             --namespace tokenplace \

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -109,6 +109,8 @@ jobs:
           set -euo pipefail
 
           docker run -d --rm --name tokenplace-relay-smoke \
+            --read-only \
+            --tmpfs /tmp \
             -p 127.0.0.1:5010:5010 \
             -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
             tokenplace-relay:smoke

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -68,12 +68,6 @@ spec:
               value: "0.0.0.0"
             - name: RELAY_PORT
               value: "{{ .Values.containerPort }}"
-            - name: RELAY_WORKERS
-              value: "1"
-            - name: TOKENPLACE_FRONTEND_MODE
-              value: "production"
-            - name: TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH
-              value: "0"
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -63,7 +63,14 @@ ingress:
     enabled: false
     secretName: ""
 
-env: {}
+env:
+  RELAY_WORKERS: "1"
+  TOKENPLACE_FRONTEND_MODE: "production"
+  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"
+  XDG_CONFIG_HOME: /tmp/.config
+  XDG_DATA_HOME: /tmp/.local/share
+  XDG_CACHE_HOME: /tmp/.cache
+  XDG_STATE_HOME: /tmp/.local/state
 extraEnv: []
 envFrom: []
 


### PR DESCRIPTION
### Motivation
- Staging relay pods crashed under `readOnlyRootFilesystem: true` because the Python relay attempted to create XDG config/data directories under the non-writable home (`~/.config`) and required chart-owned defaults that point to writable `/tmp` locations.
- The Deployment template previously hardcoded default env vars and then rendered `.Values.env`, which produced duplicate env-name warnings for `RELAY_WORKERS`, `TOKENPLACE_FRONTEND_MODE`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH`.

### Description
- Added chart-owned runtime defaults to `charts/tokenplace/values.yaml` for `RELAY_WORKERS=1`, `TOKENPLACE_FRONTEND_MODE=production`, `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0`, and XDG variables `XDG_CONFIG_HOME=/tmp/.config`, `XDG_DATA_HOME=/tmp/.local/share`, `XDG_CACHE_HOME=/tmp/.cache`, and `XDG_STATE_HOME=/tmp/.local/state` so the container can run with a read-only root filesystem.
- Refactored `charts/tokenplace/templates/deployment.yaml` to keep fixed `RELAY_HOST`/`RELAY_PORT` entries and render `.Values.env` exactly once to avoid duplicate env names while preserving override behavior.
- Kept the writable `/tmp` `emptyDir` volume and `/tmp` mount intact so the relay can use `/tmp` when the filesystem is read-only.
- Strengthened CI checks in `.github/workflows/ci-helm.yml` to assert presence of the XDG env vars, `RELAY_WORKERS=1`, `replicas: 1`, `strategy.type: Recreate`, and a Python YAML-based duplicate-env name assertion, and hardened the image smoke test in `.github/workflows/ci-image.yml` to launch the relay with `--read-only --tmpfs /tmp` and validate `/livez`, `/healthz`, `/`, and `/metrics`.

### Testing
- Verified chart metadata lines with `grep -nE '^(version|appVersion):' charts/tokenplace/Chart.yaml` and confirmed `version: 0.1.0` and `appVersion: "0.1.0"`.
- Ran `pre-commit run --all-files`; most hooks passed but the run failed due to `check-yaml` detecting templated Helm manifests as invalid YAML (static YAML check on Helm templates), which is a pre-existing hook behavior and unrelated to the env dedupe logic change.
- Attempts to run `helm lint` / `helm template` and the Docker smoke run were blocked in this environment because `helm` and `docker` are not available here, so those validations will be exercised by CI (the workflow changes add explicit assertions for these checks).
- All changes committed and pushed in a single focused update touching `charts/tokenplace/values.yaml`, `charts/tokenplace/templates/deployment.yaml`, `.github/workflows/ci-helm.yml`, and `.github/workflows/ci-image.yml`; CI will run the full Helm render and container smoke tests to validate acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a5735064832fa47402d69e1ccf15)