### PR TITLE
Fix relay chart runtime for read-only root filesystem and duplicate env rendering

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -80,6 +80,63 @@ jobs:
           assert not dupes, dupes
           PY
 
+
+      - name: Template list-style env render check
+        run: |
+          cat > /tmp/tokenplace-list-env-values.yaml <<'YAML'
+          env:
+            - name: FOO
+              value: bar
+          YAML
+
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            -f /tmp/tokenplace-list-env-values.yaml > /tmp/tokenplace-render-list-env.yaml
+
+          python3 - <<'PY'
+          import collections
+          import yaml
+
+          docs = list(yaml.safe_load_all(open("/tmp/tokenplace-render-list-env.yaml", encoding="utf-8")))
+          deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+          env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+          names = [item["name"] for item in env]
+          dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+          assert not dupes, dupes
+          values = {item["name"]: item.get("value") for item in env}
+          assert values["FOO"] == "bar"
+          assert values["XDG_CONFIG_HOME"] == "/tmp/.config"
+          assert values["XDG_DATA_HOME"] == "/tmp/.local/share"
+          assert values["XDG_CACHE_HOME"] == "/tmp/.cache"
+          assert values["XDG_STATE_HOME"] == "/tmp/.local/state"
+          PY
+
+      - name: Template extraEnv valueFrom render check
+        run: |
+          cat > /tmp/tokenplace-extra-env-values.yaml <<'YAML'
+          extraEnv:
+            - name: SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: relay-secret
+                  key: token
+          YAML
+
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            -f /tmp/tokenplace-extra-env-values.yaml > /tmp/tokenplace-render-extra-env.yaml
+
+          python3 - <<'PY'
+          import yaml
+
+          docs = list(yaml.safe_load_all(open("/tmp/tokenplace-render-extra-env.yaml", encoding="utf-8")))
+          deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+          env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+          secret = next(item for item in env if item["name"] == "SECRET_TOKEN")
+          assert secret["valueFrom"]["secretKeyRef"]["name"] == "relay-secret"
+          assert secret["valueFrom"]["secretKeyRef"]["key"] == "token"
+          PY
+
       - name: Template strategy-empty fallback smoke render
         run: |
 

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -63,6 +63,11 @@ jobs:
           grep -n "name: XDG_STATE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/state"'
           ! grep -n "rollingUpdate:" /tmp/tokenplace-render.yaml
 
+      - name: Install Python dependency for duplicate-env check
+        run: pip3 install PyYAML
+
+      - name: Duplicate-env validation
+        run: |
           python3 - <<'PY'
           import collections
           import yaml
@@ -74,6 +79,9 @@ jobs:
           dupes = [name for name, count in collections.Counter(names).items() if count > 1]
           assert not dupes, dupes
           PY
+
+      - name: Template strategy-empty fallback smoke render
+        run: |
 
           helm template tokenplace charts/tokenplace \
             --namespace tokenplace \
@@ -97,6 +105,10 @@ jobs:
           docker run -d --rm --name tokenplace-relay-readonly --read-only --tmpfs /tmp \
             -p 127.0.0.1:5010:5010 \
             -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
+            -e XDG_CONFIG_HOME=/tmp/.config \
+            -e XDG_DATA_HOME=/tmp/.local/share \
+            -e XDG_CACHE_HOME=/tmp/.cache \
+            -e XDG_STATE_HOME=/tmp/.local/state \
             tokenplace-relay:chart-smoke
           trap 'docker logs tokenplace-relay-readonly || true; docker stop tokenplace-relay-readonly || true' EXIT
           for _ in $(seq 1 30); do

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -98,30 +98,6 @@ jobs:
           grep -n 'else if and (eq $strategyType "Recreate") $existingHasRollingUpdate' charts/tokenplace/templates/deployment.yaml
           grep -n 'rollingUpdate: null' charts/tokenplace/templates/deployment.yaml
 
-      - name: Relay container read-only rootfs smoke test
-        run: |
-          set -euo pipefail
-          docker build -t tokenplace-relay:chart-smoke .
-          docker run -d --rm --name tokenplace-relay-readonly --read-only --tmpfs /tmp \
-            -p 127.0.0.1:5010:5010 \
-            -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
-            -e XDG_CONFIG_HOME=/tmp/.config \
-            -e XDG_DATA_HOME=/tmp/.local/share \
-            -e XDG_CACHE_HOME=/tmp/.cache \
-            -e XDG_STATE_HOME=/tmp/.local/state \
-            tokenplace-relay:chart-smoke
-          trap 'docker logs tokenplace-relay-readonly || true; docker stop tokenplace-relay-readonly || true' EXIT
-          for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:5010/livez >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-          curl -fsS http://127.0.0.1:5010/livez
-          curl -fsS http://127.0.0.1:5010/healthz
-          curl -fsS http://127.0.0.1:5010/
-          curl -fsS http://127.0.0.1:5010/metrics
-
       - name: Capture chart metadata
         id: chart_meta
         run: |

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -57,7 +57,23 @@ jobs:
           grep -n "strategy:" -A4 /tmp/tokenplace-render.yaml
           grep -n "type: Recreate" /tmp/tokenplace-render.yaml
           grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "1"'
+          grep -n "name: XDG_CONFIG_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.config"'
+          grep -n "name: XDG_DATA_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/share"'
+          grep -n "name: XDG_CACHE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.cache"'
+          grep -n "name: XDG_STATE_HOME" -A2 /tmp/tokenplace-render.yaml | grep -n 'value: "/tmp/.local/state"'
           ! grep -n "rollingUpdate:" /tmp/tokenplace-render.yaml
+
+          python3 - <<'PY'
+          import collections
+          import yaml
+
+          docs = list(yaml.safe_load_all(open("/tmp/tokenplace-render.yaml", encoding="utf-8")))
+          deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+          env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+          names = [item["name"] for item in env]
+          dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+          assert not dupes, dupes
+          PY
 
           helm template tokenplace charts/tokenplace \
             --namespace tokenplace \
@@ -73,6 +89,26 @@ jobs:
           # when switching live defaulted RollingUpdate Deployments to Recreate.
           grep -n 'else if and (eq $strategyType "Recreate") $existingHasRollingUpdate' charts/tokenplace/templates/deployment.yaml
           grep -n 'rollingUpdate: null' charts/tokenplace/templates/deployment.yaml
+
+      - name: Relay container read-only rootfs smoke test
+        run: |
+          set -euo pipefail
+          docker build -t tokenplace-relay:chart-smoke .
+          docker run -d --rm --name tokenplace-relay-readonly --read-only --tmpfs /tmp \
+            -p 127.0.0.1:5010:5010 \
+            -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
+            tokenplace-relay:chart-smoke
+          trap 'docker logs tokenplace-relay-readonly || true; docker stop tokenplace-relay-readonly || true' EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5010/livez >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl -fsS http://127.0.0.1:5010/livez
+          curl -fsS http://127.0.0.1:5010/healthz
+          curl -fsS http://127.0.0.1:5010/
+          curl -fsS http://127.0.0.1:5010/metrics
 
       - name: Capture chart metadata
         id: chart_meta

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -137,6 +137,43 @@ jobs:
 
           docker exec tokenplace-relay-smoke sh -c "tr '\\0' ' ' < /proc/1/cmdline" | grep -F -- '--workers 1'
 
+      - name: Smoke test relay container on read-only rootfs
+        run: |
+          set -euo pipefail
+
+          docker run -d --rm --name tokenplace-relay-smoke-readonly \
+            --read-only --tmpfs /tmp \
+            -p 127.0.0.1:5011:5010 \
+            -e TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0 \
+            -e XDG_CONFIG_HOME=/tmp/.config \
+            -e XDG_DATA_HOME=/tmp/.local/share \
+            -e XDG_CACHE_HOME=/tmp/.cache \
+            -e XDG_STATE_HOME=/tmp/.local/state \
+            tokenplace-relay:smoke
+
+          cleanup() {
+            echo "--- readonly container logs ---"
+            docker logs tokenplace-relay-smoke-readonly || true
+            docker stop tokenplace-relay-smoke-readonly >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5011/livez \
+              && curl -fsS http://127.0.0.1:5011/healthz \
+              && curl -fsS http://127.0.0.1:5011/ >/dev/null \
+              && curl -fsS http://127.0.0.1:5011/metrics >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          curl -fsS http://127.0.0.1:5011/livez >/dev/null
+          curl -fsS http://127.0.0.1:5011/healthz >/dev/null
+          curl -fsS http://127.0.0.1:5011/ >/dev/null
+          curl -fsS http://127.0.0.1:5011/metrics >/dev/null
+          docker exec tokenplace-relay-smoke-readonly sh -c "tr '\\0' ' ' < /proc/1/cmdline" | grep -F -- '--workers 1'
+
   publish:
     name: Publish relay image
     runs-on: ubuntu-latest

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -58,24 +58,22 @@ spec:
       containers:
         - name: relay
           {{- $defaultEnv := dict
-                "RELAY_HOST" "0.0.0.0"
-                "RELAY_PORT" (printf "%v" .Values.containerPort)
-                "RELAY_WORKERS" "1"
-                "TOKENPLACE_FRONTEND_MODE" "production"
-                "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "0"
+                "RELAY_HOST" (dict "name" "RELAY_HOST" "value" "0.0.0.0")
+                "RELAY_PORT" (dict "name" "RELAY_PORT" "value" (printf "%v" .Values.containerPort))
+                "RELAY_WORKERS" (dict "name" "RELAY_WORKERS" "value" "1")
+                "TOKENPLACE_FRONTEND_MODE" (dict "name" "TOKENPLACE_FRONTEND_MODE" "value" "production")
+                "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" (dict "name" "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "value" "0")
           }}
           {{- $mergedEnv := deepCopy $defaultEnv }}
           {{- if kindIs "map" .Values.env }}
           {{- range $key, $val := .Values.env }}
-          {{- $_ := set $mergedEnv (printf "%v" $key) (printf "%v" $val) }}
+          {{- $_ := set $mergedEnv (printf "%v" $key) (dict "name" (printf "%v" $key) "value" (printf "%v" $val)) }}
           {{- end }}
           {{- else if kindIs "slice" .Values.env }}
           {{- range $item := .Values.env }}
           {{- if and (kindIs "map" $item) (hasKey $item "name") }}
           {{- $name := (printf "%v" (get $item "name")) }}
-          {{- if hasKey $item "value" }}
-          {{- $_ := set $mergedEnv $name (printf "%v" (get $item "value")) }}
-          {{- end }}
+          {{- $_ := set $mergedEnv $name (deepCopy $item) }}
           {{- end }}
           {{- end }}
           {{- end }}
@@ -83,9 +81,7 @@ spec:
           {{- range $item := .Values.extraEnv }}
           {{- if and (kindIs "map" $item) (hasKey $item "name") }}
           {{- $name := (printf "%v" (get $item "name")) }}
-          {{- if hasKey $item "value" }}
-          {{- $_ := set $mergedEnv $name (printf "%v" (get $item "value")) }}
-          {{- end }}
+          {{- $_ := set $mergedEnv $name (deepCopy $item) }}
           {{- end }}
           {{- end }}
           {{- end }}
@@ -97,8 +93,16 @@ spec:
               protocol: TCP
           env:
             {{- range $key := keys $mergedEnv | sortAlpha }}
+            {{- $entry := get $mergedEnv $key }}
             - name: {{ $key }}
-              value: {{ get $mergedEnv $key | quote }}
+              {{- if and (kindIs "map" $entry) (hasKey $entry "valueFrom") }}
+              valueFrom:
+                {{- toYaml (get $entry "valueFrom") | nindent 16 }}
+              {{- else if and (kindIs "map" $entry) (hasKey $entry "value") }}
+              value: {{ get $entry "value" | quote }}
+              {{- else }}
+              value: ""
+              {{- end }}
             {{- end }}
           {{- with .Values.envFrom }}
           envFrom:

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -65,8 +65,29 @@ spec:
                 "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "0"
           }}
           {{- $mergedEnv := deepCopy $defaultEnv }}
+          {{- if kindIs "map" .Values.env }}
           {{- range $key, $val := .Values.env }}
-          {{- $_ := set $mergedEnv $key (printf "%v" $val) }}
+          {{- $_ := set $mergedEnv (printf "%v" $key) (printf "%v" $val) }}
+          {{- end }}
+          {{- else if kindIs "slice" .Values.env }}
+          {{- range $item := .Values.env }}
+          {{- if and (kindIs "map" $item) (hasKey $item "name") }}
+          {{- $name := (printf "%v" (get $item "name")) }}
+          {{- if hasKey $item "value" }}
+          {{- $_ := set $mergedEnv $name (printf "%v" (get $item "value")) }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if kindIs "slice" .Values.extraEnv }}
+          {{- range $item := .Values.extraEnv }}
+          {{- if and (kindIs "map" $item) (hasKey $item "name") }}
+          {{- $name := (printf "%v" (get $item "name")) }}
+          {{- if hasKey $item "value" }}
+          {{- $_ := set $mergedEnv $name (printf "%v" (get $item "value")) }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           image: {{ include "tokenplace.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -78,9 +99,6 @@ spec:
             {{- range $key := keys $mergedEnv | sortAlpha }}
             - name: {{ $key }}
               value: {{ get $mergedEnv $key | quote }}
-            {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.envFrom }}
           envFrom:

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -67,7 +67,16 @@ spec:
           {{- $mergedEnv := deepCopy $defaultEnv }}
           {{- if kindIs "map" .Values.env }}
           {{- range $key, $val := .Values.env }}
-          {{- $_ := set $mergedEnv (printf "%v" $key) (dict "name" (printf "%v" $key) "value" (printf "%v" $val)) }}
+          {{- $name := (printf "%v" $key) }}
+          {{- if kindIs "map" $val }}
+          {{- $entry := deepCopy $val }}
+          {{- if not (hasKey $entry "name") }}
+          {{- $_ := set $entry "name" $name }}
+          {{- end }}
+          {{- $_ := set $mergedEnv $name $entry }}
+          {{- else }}
+          {{- $_ := set $mergedEnv $name (dict "name" $name "value" (printf "%v" $val)) }}
+          {{- end }}
           {{- end }}
           {{- else if kindIs "slice" .Values.env }}
           {{- range $item := .Values.env }}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -57,6 +57,17 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: relay
+          {{- $defaultEnv := dict
+                "RELAY_HOST" "0.0.0.0"
+                "RELAY_PORT" (printf "%v" .Values.containerPort)
+                "RELAY_WORKERS" "1"
+                "TOKENPLACE_FRONTEND_MODE" "production"
+                "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "0"
+          }}
+          {{- $mergedEnv := deepCopy $defaultEnv }}
+          {{- range $key, $val := .Values.env }}
+          {{- $_ := set $mergedEnv $key (printf "%v" $val) }}
+          {{- end }}
           image: {{ include "tokenplace.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -64,19 +75,9 @@ spec:
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           env:
-            - name: RELAY_HOST
-              value: "0.0.0.0"
-            - name: RELAY_PORT
-              value: "{{ .Values.containerPort }}"
-            - name: RELAY_WORKERS
-              value: "1"
-            - name: TOKENPLACE_FRONTEND_MODE
-              value: "production"
-            - name: TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH
-              value: "0"
-            {{- range $key, $val := .Values.env }}
+            {{- range $key := keys $mergedEnv | sortAlpha }}
             - name: {{ $key }}
-              value: {{ $val | quote }}
+              value: {{ get $mergedEnv $key | quote }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
                 "RELAY_WORKERS" (dict "name" "RELAY_WORKERS" "value" "1")
                 "TOKENPLACE_FRONTEND_MODE" (dict "name" "TOKENPLACE_FRONTEND_MODE" "value" "production")
                 "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" (dict "name" "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "value" "0")
+                "XDG_CONFIG_HOME" (dict "name" "XDG_CONFIG_HOME" "value" "/tmp/.config")
+                "XDG_DATA_HOME" (dict "name" "XDG_DATA_HOME" "value" "/tmp/.local/share")
+                "XDG_CACHE_HOME" (dict "name" "XDG_CACHE_HOME" "value" "/tmp/.cache")
+                "XDG_STATE_HOME" (dict "name" "XDG_STATE_HOME" "value" "/tmp/.local/state")
           }}
           {{- $mergedEnv := deepCopy $defaultEnv }}
           {{- if kindIs "map" .Values.env }}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -63,7 +63,11 @@ ingress:
     enabled: false
     secretName: ""
 
-env: {}
+env:
+  XDG_CONFIG_HOME: /tmp/.config
+  XDG_DATA_HOME: /tmp/.local/share
+  XDG_CACHE_HOME: /tmp/.cache
+  XDG_STATE_HOME: /tmp/.local/state
 extraEnv: []
 envFrom: []
 


### PR DESCRIPTION
### Motivation
- Relay pods in staging CrashLooped because runtime XDG paths defaulted under the container home and could not be created with `readOnlyRootFilesystem: true`.
- The chart rendered hardcoded envs plus `.Values.env`, producing duplicate environment names and Kubernetes warnings.
- The goal is to provide safe chart defaults so the relay runs with a read-only rootfs and to ensure env variables are emitted exactly once and remain overridable.

### Description
- Added chart-owned XDG defaults in `charts/tokenplace/values.yaml`: `XDG_CONFIG_HOME=/tmp/.config`, `XDG_DATA_HOME=/tmp/.local/share`, `XDG_CACHE_HOME=/tmp/.cache`, and `XDG_STATE_HOME=/tmp/.local/state`.
- Refactored `charts/tokenplace/templates/deployment.yaml` to merge chart default envs with `.Values.env` into a single deduplicated map and render env entries once (preserving override semantics); kept the writable `/tmp` `emptyDir` mount.
- Extended the Helm CI workflow `.github/workflows/ci-helm.yml` to assert presence of the XDG envs, ensure `replicas: 1`, `strategy.type: Recreate`, `RELAY_WORKERS=1`, and to check for duplicate env names via an inline Python check in the template smoke step.
- Added a CI smoke step to run the relay image with `--read-only --tmpfs /tmp` and validate `/livez`, `/healthz`, `/`, and `/metrics` (Docker-based smoke test in CI job).

### Testing
- `grep -nE '^(version|appVersion):' charts/tokenplace/Chart.yaml` — passed and reports `version: 0.1.0` and `appVersion: "0.1.0"` as required.
- `helm lint charts/tokenplace` and `helm template ... > /tmp/tokenplace-render.yaml` — not run locally because `helm` is not available in the execution environment (`helm: command not found`).
- Duplicate-env render check (`python3` parsing `/tmp/tokenplace-render.yaml`) and the render greps for XDG vars are exercised in the updated CI smoke render step and therefore will run in CI; they could not be executed locally for the same reason as above.
- Docker smoke test (`docker build` / `docker run --read-only --tmpfs /tmp ...` and `curl` probes) is included in CI but could not be run locally because `docker` is not available in this environment (`docker: command not found`).
- `pre-commit run --all-files` was executed and existing repository `check-yaml` hooks failed on Helm template YAML parsing errors in `charts/tokenplace/templates/*` (hook output shows `check-yaml` failed while other hooks passed); this is a pre-existing validation guard that surfaced during the run and should be resolved by CI templating or by running `helm template` in CI where template fragments are valid YAML post-render.

Notes: CI will run the Helm template and Docker smoke steps as part of the updated workflow where `helm` and Docker are available; local execution of those commands is blocked in this environment. The change preserves chart `version` / `appVersion` and the single-pod Recreate behavior while removing the need for ad-hoc staging overrides to make relay work on a read-only root filesystem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a5735064832fa47402d69e1ccf15)