### PR TITLE
Harden API v1 relay long-poll registration and timeout handling for desktop compute nodes

### DIFF
--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -95,3 +95,18 @@ The migration roadmap follow-up phases own the implementation repair:
 4. add final guardrails proving active production paths no longer use legacy routes.
 
 This documentation baseline intentionally does **not** implement those code migrations.
+
+## Manual staging verification: desktop compute-node registration + long-poll heartbeat
+
+Use this when validating a desktop compute node against `https://staging.token.place`:
+
+1. Launch the desktop compute node with API v1 relay mode pointed at staging.
+2. Confirm relay health is green:
+   - `GET https://staging.token.place/healthz`
+   - verify `knownServers >= 1`.
+3. Confirm relay diagnostics sees the registered node:
+   - `GET https://staging.token.place/relay/diagnostics`
+   - verify the compute node public key appears in registered node diagnostics.
+4. Let the node idle with no queued requests for several poll intervals.
+   - expected behavior: repeated API v1 `No requests available` heartbeat responses,
+     no sustained registration churn, and no repeated desktop read-timeout storms.

--- a/relay.py
+++ b/relay.py
@@ -1041,7 +1041,11 @@ def api_v1_relay_servers_poll():
 
     if first_request is None:
         server_payload['last_ping'] = datetime.now()
-        return jsonify({'message': 'No requests available'}), 200
+        return jsonify({
+            'message': 'No requests available',
+            'next_ping_in_x_seconds': server_payload.get('last_ping_duration', _api_v1_lease_seconds()),
+            'poll_wait_seconds': poll_wait_seconds,
+        }), 200
 
     queue_wait_ms = None
     queued_at = first_request.pop('_queued_at', None)

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -169,6 +169,26 @@ def _start_fake_desktop_loop(base_url, done_event):
     return thread, model_manager
 
 
+def test_api_v1_desktop_bridge_registration_and_no_work_poll_heartbeat():
+    with live_relay_server() as base_url:
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+
+        register_payload = desktop_client.register_api_v1_compute_node()
+        assert register_payload["next_ping_in_x_seconds"] > 0
+        assert register_payload["poll_wait_seconds"] >= 0
+
+        poll_payload = desktop_client.poll_api_v1_encrypted_work()
+        assert poll_payload["message"] == "No requests available"
+        assert poll_payload["next_ping_in_x_seconds"] > 0
+        assert poll_payload["poll_wait_seconds"] >= 0
+
+
 def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     """Browser-shaped encrypted API v1 chat completes via relay-blind desktop bridge."""
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1731,7 +1731,10 @@ def test_api_v1_poll_long_wait_timeout_returns_no_work(client, monkeypatch):
     poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
     elapsed = time.monotonic() - started
     assert poll.status_code == 200
-    assert poll.get_json()['message'] == 'No requests available'
+    payload = poll.get_json()
+    assert payload['message'] == 'No requests available'
+    assert payload['next_ping_in_x_seconds'] > 0
+    assert payload['poll_wait_seconds'] == 0.01
     assert elapsed >= 0.008
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -852,22 +852,21 @@ class TestRelayClient:
         ) == "https://relay.cloudflare.workers.dev/api/v1/relay/servers/register"
 
     @pytest.mark.parametrize(
-        "expected_wait, expected_timeout_offset",
+        "expected_wait, expected_timeout",
         [
-            (9, 0.0),
-            (10, 0.0),
-            (15.5, 1.5),
-            ("11", 0.0),
-            ("bad", 0.0),
-            (True, 0.0),
-            (False, 0.0),
-            (-1, 0.0),
-            (float("nan"), 0.0),
-            (float("inf"), 0.0),
+            (9, 15.0),
+            (10, 15.0),
+            (15.5, 20.5),
+            ("11", 16.0),
+            ("bad", 15.0),
+            (True, 15.0),
+            (False, 15.0),
+            (-1, 15.0),
+            (float("nan"), 15.0),
+            (float("inf"), 15.0),
         ],
     )
-    def test_api_v1_poll_timeout_seconds_defensive(self, relay_client, expected_wait, expected_timeout_offset):
-        expected_timeout = float(relay_client._request_timeout) + expected_timeout_offset
+    def test_api_v1_poll_timeout_seconds_defensive(self, relay_client, expected_wait, expected_timeout):
         assert relay_client._api_v1_poll_timeout_seconds(expected_wait) == expected_timeout
 
     @patch('utils.networking.relay_client.requests.post')
@@ -880,8 +879,9 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result['next_ping_in_x_seconds'] == 0
-        assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 31.0)
+        assert result['next_ping_in_x_seconds'] == 12
+        assert result['poll_wait_seconds'] == 30
+        assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 35.0, 37.5)
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_falls_back_to_register_wait_without_poll_wait(self, mock_post, relay_client):
@@ -893,8 +893,9 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result['next_ping_in_x_seconds'] == 0
-        assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 13.0)
+        assert result['next_ping_in_x_seconds'] == 12
+        assert result['poll_wait_seconds'] == 12
+        assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 17.0, 15.0)
 
 
     @patch('utils.networking.relay_client.requests.post')
@@ -923,7 +924,7 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result['next_ping_in_x_seconds'] == 0
+        assert result['next_ping_in_x_seconds'] == 9
         assert relay_client._active_relay_index == 1
         called_urls = [call.args[0] for call in mock_post.call_args_list]
         assert called_urls == [
@@ -1034,6 +1035,20 @@ class TestRelayClient:
         result = relay_client.poll_api_v1_encrypted_work()
 
         assert result == {'error': 'HTTP 429', 'next_ping_in_x_seconds': 11}
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_handles_expected_long_poll_timeout_without_reregistering(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 10, 'poll_wait_seconds': 10}
+        mock_post.side_effect = [register_ok, requests.Timeout("Read timed out.")]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['message'] == 'No requests available'
+        assert result['next_ping_in_x_seconds'] == 10
+        assert result['poll_wait_seconds'] == 10
+        assert relay_client.relay_url == 'http://localhost:5000'
+        assert 'http://localhost:5000' in relay_client._api_v1_registered_relays
 
     def test_process_client_request_missing_fields(self, relay_client):
         """Test processing a client request with missing fields."""

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -794,7 +794,7 @@ class RelayClient:
             return base_timeout
         if not math.isfinite(wait_seconds) or wait_seconds < 0:
             return base_timeout
-        return max(base_timeout, wait_seconds + 1.0)
+        return max(base_timeout, wait_seconds + 5.0, wait_seconds * 1.25)
 
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
         """Poll API v1 relay routes for encrypted work with lease-aware registration."""
@@ -852,9 +852,16 @@ class RelayClient:
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
                     'timeout': self._api_v1_poll_timeout_seconds(poll_wait),
                 }
+                poll_timeout_seconds = float(request_kwargs['timeout'])
                 headers = self._auth_headers()
                 if headers:
                     request_kwargs['headers'] = headers
+                log_info(
+                    "relay.poll_config relay={} poll_wait_seconds={} timeout_seconds={}",
+                    candidate_url,
+                    poll_wait,
+                    round(poll_timeout_seconds, 3),
+                )
 
                 response = requests.post(
                     self._build_api_v1_url(candidate_url, "/relay/servers/poll"),
@@ -883,7 +890,8 @@ class RelayClient:
                     and 'api_v1_request' not in payload
                     and payload.get('protocol') != 'tokenplace_api_v1_relay_e2ee'
                 ):
-                    payload['next_ping_in_x_seconds'] = 0
+                    payload.setdefault('next_ping_in_x_seconds', register_wait)
+                    payload.setdefault('poll_wait_seconds', poll_wait)
                 else:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
@@ -896,6 +904,24 @@ class RelayClient:
                 )
                 return payload
             except Exception as exc:
+                if isinstance(exc, requests.Timeout) or "timed out" in str(exc).lower():
+                    poll_timeout = self._api_v1_poll_timeout_seconds(poll_wait)
+                    if poll_wait and poll_timeout > 0 and abs(float(poll_timeout) - float(poll_wait)) <= 6.0:
+                        log_info(
+                            "relay.poll_timeout_near_wait relay={} poll_wait_seconds={} timeout_seconds={}",
+                            candidate_url,
+                            poll_wait,
+                            round(float(poll_timeout), 3),
+                        )
+                        self._active_relay_index = index
+                        return {
+                            'message': 'No requests available',
+                            'next_ping_in_x_seconds': register_wait,
+                            'poll_wait_seconds': poll_wait,
+                        }
+                    log_error("API v1 relay poll timed out for {}: {}", candidate_url, str(exc))
+                    last_error = {'error': str(exc), 'next_ping_in_x_seconds': self._request_timeout}
+                    continue
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
                 self._api_v1_registered_relays.discard(candidate_url)
                 relay_wait_hints.pop(candidate_url, None)


### PR DESCRIPTION
### Motivation
- Windows desktop compute nodes polling staging were experiencing repeated `Read timed out. (read timeout=10)` errors while the relay long-poll wait was ~10s, causing registration churn and later `HTTP 503` errors.
- Clients must be given explicit timing hints so they can pick safe read timeouts and avoid treating expected long-poll races as catastrophic registration loss. 
- The change aims to make no-work long-polls a healthy heartbeat and make client-side timeouts safely larger than server wait windows with an explicit margin.

### Description
- Relay server `/api/v1/relay/servers/register` and `/api/v1/relay/servers/poll` semantics: the poll no-work response now includes `message: "No requests available"`, `next_ping_in_x_seconds`, and `poll_wait_seconds` so clients can derive safe timeouts and heartbeats (changes in `relay.py`).
- Relay client timeout logic: `_api_v1_poll_timeout_seconds` now uses a larger safety margin `max(base_timeout, wait + 5, wait * 1.25)` so the client read timeout exceeds the server long-poll wait by a practical margin.
- Client logging and behavior: added concise structured log of effective `poll_wait_seconds` and computed `timeout_seconds`, and a controlled handling path that treats expected long-poll timeouts near the server wait as a no-work heartbeat instead of immediately discarding registration (changes in `utils/networking/relay_client.py`).
- Tests and docs: updated and added unit/integration tests to cover register response metadata, no-work poll metadata, derived timeout behavior, and controlled timeout heartbeat handling; added a small integration test exercising desktop-bridge registration + no-work poll against a local relay; added manual staging verification steps to `docs/architecture/api_v1_e2ee_relay.md`.

### Testing
- Ran unit tests for the relay client: `pytest tests/unit/test_relay_client.py -q` — all tests in that suite passed. (✅)
- Ran the combined smoke suites: `pytest tests/unit/test_relay_client.py -q && pytest tests/test_relay.py -q && pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — the unit and the new/changed integration tests that validate registration/no-work heartbeat passed, while `tests/test_relay.py` exposed 6 failing cases unrelated to the timing metadata changes (these failures appear tied to pre-existing API v1 model-path expectations in this runtime/test environment). (unit/integration: ✅, relay suite: ⚠️)
- Verified the tight-targeted trio of relay-client tests locally that validate the new timeout math and controlled timeout path: `pytest tests/unit/test_relay_client.py::TestRelayClient::test_api_v1_poll_timeout_seconds_defensive tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_fails_over_and_uses_register_interval tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_handles_expected_long_poll_timeout_without_reregistering -q` — all passed. (✅)

Notes and rationale
- Observed staging failure: desktop read timeout at 10s while server long-polls around 10s; client timeout margin was increased to avoid tight races and to prefer `wait + 5s` or `wait * 1.25`, whichever is larger, while always honoring `base_timeout` as a floor.
- Manual staging validation snippet was added to docs: run a desktop compute node against staging, verify `/healthz` shows `knownServers >= 1`, and check `/relay/diagnostics` for the registered node.
- The change preserves the relay-blind E2EE invariant (only ciphertext + routing metadata visible to relay) and does not change `server.py` or Helm defaults per scope.

Residual risks / follow-ups
- A subset of `tests/test_relay.py` (model-path and API v1 model expectations) failed in this invocation and should be investigated separately in the test environment that has the full model/runtime fixtures; the failures appear unrelated to the long-poll metadata/timeout changes introduced here.
- Consider tuning the acceptable "near-wait" threshold if additional production telemetry shows different timing distributions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758c8b84c832fbcf439355d0a804b)