### PR TITLE
Harden API v1 relay long-poll registration/poll flow for desktop compute nodes

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,7 +103,9 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-MODEL_ALIASES: Dict[str, str] = {}
+MODEL_ALIASES: Dict[str, str] = {
+    "gpt-5-chat-latest": "llama-3-8b-instruct",
+}
 
 
 AVAILABLE_MODELS = [

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,10 +103,7 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-MODEL_ALIASES: Dict[str, str] = {
-    "gpt-3.5-turbo": "llama-3-8b-instruct",
-    "gpt-5-chat-latest": "llama-3-8b-instruct",
-}
+MODEL_ALIASES: Dict[str, str] = {}
 
 
 AVAILABLE_MODELS = [

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -104,6 +104,7 @@ if ENVIRONMENT != 'prod':
 
 # Available model metadata
 MODEL_ALIASES: Dict[str, str] = {
+    "gpt-3.5-turbo": "llama-3-8b-instruct",
     "gpt-5-chat-latest": "llama-3-8b-instruct",
 }
 

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,12 +103,7 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-MODEL_ALIASES: Dict[str, str] = {
-    # Provide compatibility with first-party integrations that still request
-    # OpenAI-branded model identifiers.
-    "gpt-3.5-turbo": "llama-3-8b-instruct",
-    "gpt-5-chat-latest": "llama-3-8b-instruct",
-}
+MODEL_ALIASES: Dict[str, str] = {}
 
 
 AVAILABLE_MODELS = [

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,7 +103,13 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-MODEL_ALIASES: Dict[str, str] = {}
+MODEL_ALIASES: Dict[str, str] = {
+    # Temporary OpenAI-client compatibility aliases that route to the fixed
+    # Meta Llama 3.1 8B backend; these are not first-class GPT model support.
+    # Any removal should happen in a dedicated compatibility/deprecation PR.
+    "gpt-3.5-turbo": "llama-3-8b-instruct",
+    "gpt-5-chat-latest": "llama-3-8b-instruct",
+}
 
 
 AVAILABLE_MODELS = [

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -363,6 +363,15 @@ def _handle_chat_completion_request(data):
         requested_model_id = data["model"]
         response_model_id = requested_model_id
         model_id = resolve_model_alias(requested_model_id) or requested_model_id
+        supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
+        if model_id not in supported_model_ids:
+            return format_error_response(
+                f"Model '{requested_model_id}' is not supported by API v1.",
+                error_type="invalid_request_error",
+                param="model",
+                code="model_not_supported",
+                status_code=400,
+            )
         if model_id != requested_model_id:
             log_info(
                 f"Routing alias model '{requested_model_id}' to canonical model '{model_id}' for compatibility"

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -363,15 +363,6 @@ def _handle_chat_completion_request(data):
         requested_model_id = data["model"]
         response_model_id = requested_model_id
         model_id = resolve_model_alias(requested_model_id) or requested_model_id
-        supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
-        if model_id not in supported_model_ids:
-            return format_error_response(
-                f"Model '{requested_model_id}' is not supported by API v1.",
-                error_type="invalid_request_error",
-                param="model",
-                code="model_not_supported",
-                status_code=400,
-            )
         if model_id != requested_model_id:
             log_info(
                 f"Routing alias model '{requested_model_id}' to canonical model '{model_id}' for compatibility"
@@ -488,6 +479,16 @@ def _handle_chat_completion_request(data):
             "api_v1_provider_selection provider_class=%s resolved_provider_path=%s stream_mode=non-streaming"
             % (resolved_provider_name, resolved_provider_path)
         )
+        if resolved_provider_path != "distributed":
+            supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
+            if model_id not in supported_model_ids:
+                return format_error_response(
+                    f"Model '{requested_model_id}' is not supported by API v1.",
+                    error_type="invalid_request_error",
+                    param="model",
+                    code="model_not_supported",
+                    status_code=400,
+                )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,
@@ -661,6 +662,16 @@ def _handle_text_completion_request(data):
             "api_v1_provider_selection provider_class=%s resolved_provider_path=%s stream_mode=non-streaming"
             % (resolved_provider_name, resolved_provider_path)
         )
+        if resolved_provider_path != "distributed":
+            supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
+            if model_id not in supported_model_ids:
+                return format_error_response(
+                    f"Model '{requested_model_id}' is not supported by API v1.",
+                    error_type="invalid_request_error",
+                    param="model",
+                    code="model_not_supported",
+                    status_code=400,
+                )
         assistant_message = provider.complete_chat(
             model_id=model_id,
             messages=messages,

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -308,6 +308,10 @@ def _estimate_token_length(text: str) -> int:
     return max(1, math.ceil(len(stripped) / 4))
 
 
+def _is_relay_capable_provider_path(resolved_provider_path: str) -> bool:
+    return resolved_provider_path in {"distributed", "distributed_with_local_fallback"}
+
+
 def _extract_chat_completion_options(data: dict) -> dict:
     """Pass through compatible OpenAI-style chat options to compute providers."""
 
@@ -479,7 +483,7 @@ def _handle_chat_completion_request(data):
             "api_v1_provider_selection provider_class=%s resolved_provider_path=%s stream_mode=non-streaming"
             % (resolved_provider_name, resolved_provider_path)
         )
-        if resolved_provider_path != "distributed":
+        if not _is_relay_capable_provider_path(resolved_provider_path):
             supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
             if model_id not in supported_model_ids:
                 return format_error_response(
@@ -662,7 +666,7 @@ def _handle_text_completion_request(data):
             "api_v1_provider_selection provider_class=%s resolved_provider_path=%s stream_mode=non-streaming"
             % (resolved_provider_name, resolved_provider_path)
         )
-        if resolved_provider_path != "distributed":
+        if not _is_relay_capable_provider_path(resolved_provider_path):
             supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
             if model_id not in supported_model_ids:
                 return format_error_response(

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -483,7 +483,7 @@ def _handle_chat_completion_request(data):
             supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
             if model_id not in supported_model_ids:
                 return format_error_response(
-                    f"Model '{requested_model_id}' is not supported by API v1.",
+                    f"Model '{model_id}' is not supported by API v1.",
                     error_type="invalid_request_error",
                     param="model",
                     code="model_not_supported",
@@ -666,7 +666,7 @@ def _handle_text_completion_request(data):
             supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
             if model_id not in supported_model_ids:
                 return format_error_response(
-                    f"Model '{requested_model_id}' is not supported by API v1.",
+                    f"Model '{model_id}' is not supported by API v1.",
                     error_type="invalid_request_error",
                     param="model",
                     code="model_not_supported",

--- a/relay.py
+++ b/relay.py
@@ -525,7 +525,7 @@ def _evict_stale_servers() -> list[str]:
         if isinstance(in_flight_requests, dict):
             active_in_flight_requests = {
                 request_id: expires_at
-                for request_id, expires_at in in_flight_requests.items()
+                for request_id, expires_at in list(in_flight_requests.items())
                 if isinstance(request_id, str)
                 and request_id
                 and isinstance(expires_at, (int, float))

--- a/relay.py
+++ b/relay.py
@@ -523,16 +523,18 @@ def _evict_stale_servers() -> list[str]:
             continue
         in_flight_requests = payload.get("api_v1_in_flight_requests")
         if isinstance(in_flight_requests, dict):
-            active_in_flight_requests = {
-                request_id: expires_at
-                for request_id, expires_at in list(in_flight_requests.items())
-                if isinstance(request_id, str)
-                and request_id
-                and isinstance(expires_at, (int, float))
-                and expires_at > now_monotonic
-            }
-            if active_in_flight_requests:
-                payload["api_v1_in_flight_requests"] = active_in_flight_requests
+            has_active_in_flight_requests = False
+            for request_id, expires_at in list(in_flight_requests.items()):
+                if not isinstance(request_id, str) or not request_id:
+                    continue
+                if isinstance(expires_at, (int, float)) and expires_at > now_monotonic:
+                    current_expires_at = in_flight_requests.get(request_id)
+                    if isinstance(current_expires_at, (int, float)) and current_expires_at > now_monotonic:
+                        has_active_in_flight_requests = True
+                    continue
+                if in_flight_requests.get(request_id) == expires_at:
+                    in_flight_requests.pop(request_id, None)
+            if has_active_in_flight_requests:
                 continue
             payload.pop("api_v1_in_flight_requests", None)
 

--- a/relay.py
+++ b/relay.py
@@ -536,9 +536,11 @@ def _evict_stale_servers() -> list[str]:
                     in_flight_requests.pop(request_id, None)
 
             has_active_in_flight_requests = any(
-                isinstance(in_flight_requests.get(request_id), (int, float))
-                and in_flight_requests[request_id] > now_monotonic
-                for request_id in active_request_ids
+                isinstance(current_expires_at, (int, float))
+                and current_expires_at > now_monotonic
+                for current_expires_at in (
+                    in_flight_requests.get(request_id) for request_id in active_request_ids
+                )
             )
             if has_active_in_flight_requests:
                 continue

--- a/relay.py
+++ b/relay.py
@@ -521,6 +521,21 @@ def _evict_stale_servers() -> list[str]:
         polling_until = payload.get("polling_until_monotonic")
         if isinstance(polling_until, (int, float)) and polling_until > now_monotonic:
             continue
+        in_flight_requests = payload.get("api_v1_in_flight_requests")
+        if isinstance(in_flight_requests, dict):
+            active_in_flight_requests = {
+                request_id: expires_at
+                for request_id, expires_at in in_flight_requests.items()
+                if isinstance(request_id, str)
+                and request_id
+                and isinstance(expires_at, (int, float))
+                and expires_at > now_monotonic
+            }
+            if active_in_flight_requests:
+                payload["api_v1_in_flight_requests"] = active_in_flight_requests
+                continue
+            payload.pop("api_v1_in_flight_requests", None)
+
         in_flight_until = payload.get("api_v1_in_flight_until_monotonic")
         if isinstance(in_flight_until, (int, float)) and in_flight_until > now_monotonic:
             continue
@@ -1069,8 +1084,11 @@ def api_v1_relay_servers_poll():
     queued_at = first_request.pop('_queued_at', None)
     if isinstance(queued_at, (int, float)):
         queue_wait_ms = round(max((time.time() - float(queued_at)) * 1000.0, 0.0), 3)
-    server_payload['api_v1_in_flight_request_id'] = first_request.get('request_id')
-    server_payload['api_v1_in_flight_until_monotonic'] = time.monotonic() + _api_v1_in_flight_ttl_seconds()
+    request_id = first_request.get('request_id')
+    if isinstance(request_id, str) and request_id:
+        in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
+        if isinstance(in_flight_requests, dict):
+            in_flight_requests[request_id] = time.monotonic() + _api_v1_in_flight_ttl_seconds()
 
     LOGGER.info(
         "relay.api_v1.request_dispatched",
@@ -1143,9 +1161,11 @@ def api_v1_relay_responses():
     request_id = envelope.get('request_id')
     if isinstance(request_id, str) and request_id:
         for server_payload in known_servers.values():
-            if server_payload.get('api_v1_in_flight_request_id') == request_id:
-                server_payload.pop('api_v1_in_flight_request_id', None)
-                server_payload.pop('api_v1_in_flight_until_monotonic', None)
+            in_flight_requests = server_payload.get('api_v1_in_flight_requests')
+            if isinstance(in_flight_requests, dict) and request_id in in_flight_requests:
+                in_flight_requests.pop(request_id, None)
+                if not in_flight_requests:
+                    server_payload.pop('api_v1_in_flight_requests', None)
                 break
 
     _queue_client_response(client_public_key, envelope)

--- a/relay.py
+++ b/relay.py
@@ -1041,7 +1041,11 @@ def api_v1_relay_servers_poll():
 
     if first_request is None:
         server_payload['last_ping'] = datetime.now()
-        return jsonify({'message': 'No requests available'}), 200
+        return jsonify({
+            'message': 'No requests available',
+            'next_ping_in_x_seconds': server_payload['last_ping_duration'],
+            'poll_wait_seconds': poll_wait_seconds,
+        }), 200
 
     queue_wait_ms = None
     queued_at = first_request.pop('_queued_at', None)

--- a/relay.py
+++ b/relay.py
@@ -428,6 +428,7 @@ API_V1_POLL_WAIT_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS"
 DEFAULT_API_V1_POLL_WAIT_SECONDS = 10
 API_V1_LEASE_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS"
 DEFAULT_API_V1_LEASE_SECONDS = 30
+API_V1_IN_FLIGHT_TTL_SECONDS_ENV = "TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS"
 
 
 def _server_ping_age_seconds(last_ping: Any) -> float:
@@ -467,6 +468,18 @@ def _api_v1_lease_seconds() -> int:
         return DEFAULT_API_V1_LEASE_SECONDS
     return max(value, 1)
 
+
+
+
+def _api_v1_in_flight_ttl_seconds() -> float:
+    raw = os.environ.get(API_V1_IN_FLIGHT_TTL_SECONDS_ENV)
+    if raw is None:
+        return max(float(_api_v1_lease_seconds()), 1.0)
+    try:
+        value = float(raw)
+    except ValueError:
+        return max(float(_api_v1_lease_seconds()), 1.0)
+    return max(value, 1.0)
 
 def _pop_next_api_v1_request(public_key: str):
     queued_requests = client_inference_requests.get(public_key, [])
@@ -508,6 +521,11 @@ def _evict_stale_servers() -> list[str]:
         polling_until = payload.get("polling_until_monotonic")
         if isinstance(polling_until, (int, float)) and polling_until > now_monotonic:
             continue
+        in_flight_until = payload.get("api_v1_in_flight_until_monotonic")
+        if isinstance(in_flight_until, (int, float)) and in_flight_until > now_monotonic:
+            continue
+        payload.pop("api_v1_in_flight_until_monotonic", None)
+        payload.pop("api_v1_in_flight_request_id", None)
         stale_after = payload.get("last_ping_duration", default_stale_after)
         if not isinstance(stale_after, (int, float)):
             stale_after = default_stale_after
@@ -1043,7 +1061,7 @@ def api_v1_relay_servers_poll():
         server_payload['last_ping'] = datetime.now()
         return jsonify({
             'message': 'No requests available',
-            'next_ping_in_x_seconds': server_payload['last_ping_duration'],
+            'next_ping_in_x_seconds': 0 if poll_wait_seconds > 0 else max(server_payload['last_ping_duration'], 1),
             'poll_wait_seconds': poll_wait_seconds,
         }), 200
 
@@ -1051,6 +1069,9 @@ def api_v1_relay_servers_poll():
     queued_at = first_request.pop('_queued_at', None)
     if isinstance(queued_at, (int, float)):
         queue_wait_ms = round(max((time.time() - float(queued_at)) * 1000.0, 0.0), 3)
+    server_payload['api_v1_in_flight_request_id'] = first_request.get('request_id')
+    server_payload['api_v1_in_flight_until_monotonic'] = time.monotonic() + _api_v1_in_flight_ttl_seconds()
+
     LOGGER.info(
         "relay.api_v1.request_dispatched",
         extra={
@@ -1118,6 +1139,14 @@ def api_v1_relay_responses():
     client_public_key = envelope.get('client_public_key')
     if not client_public_key:
         return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+
+    request_id = envelope.get('request_id')
+    if isinstance(request_id, str) and request_id:
+        for server_payload in known_servers.values():
+            if server_payload.get('api_v1_in_flight_request_id') == request_id:
+                server_payload.pop('api_v1_in_flight_request_id', None)
+                server_payload.pop('api_v1_in_flight_until_monotonic', None)
+                break
 
     _queue_client_response(client_public_key, envelope)
     return jsonify({'message': 'Response received and queued for client'}), 200

--- a/relay.py
+++ b/relay.py
@@ -523,17 +523,23 @@ def _evict_stale_servers() -> list[str]:
             continue
         in_flight_requests = payload.get("api_v1_in_flight_requests")
         if isinstance(in_flight_requests, dict):
-            has_active_in_flight_requests = False
+            active_request_ids: set[str] = set()
             for request_id, expires_at in list(in_flight_requests.items()):
                 if not isinstance(request_id, str) or not request_id:
                     continue
                 if isinstance(expires_at, (int, float)) and expires_at > now_monotonic:
                     current_expires_at = in_flight_requests.get(request_id)
                     if isinstance(current_expires_at, (int, float)) and current_expires_at > now_monotonic:
-                        has_active_in_flight_requests = True
+                        active_request_ids.add(request_id)
                     continue
                 if in_flight_requests.get(request_id) == expires_at:
                     in_flight_requests.pop(request_id, None)
+
+            has_active_in_flight_requests = any(
+                isinstance(in_flight_requests.get(request_id), (int, float))
+                and in_flight_requests[request_id] > now_monotonic
+                for request_id in active_request_ids
+            )
             if has_active_in_flight_requests:
                 continue
             payload.pop("api_v1_in_flight_requests", None)

--- a/relay.py
+++ b/relay.py
@@ -417,6 +417,7 @@ client_pending_request_ids_lock = threading.Lock()
 PENDING_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_PENDING_REQUEST_TTL_SECONDS", "300"))
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
+api_v1_in_flight_requests_lock = threading.Lock()
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -521,30 +522,24 @@ def _evict_stale_servers() -> list[str]:
         polling_until = payload.get("polling_until_monotonic")
         if isinstance(polling_until, (int, float)) and polling_until > now_monotonic:
             continue
-        in_flight_requests = payload.get("api_v1_in_flight_requests")
-        if isinstance(in_flight_requests, dict):
-            active_request_ids: set[str] = set()
-            for request_id, expires_at in list(in_flight_requests.items()):
-                if not isinstance(request_id, str) or not request_id:
-                    continue
-                if isinstance(expires_at, (int, float)) and expires_at > now_monotonic:
-                    current_expires_at = in_flight_requests.get(request_id)
-                    if isinstance(current_expires_at, (int, float)) and current_expires_at > now_monotonic:
-                        active_request_ids.add(request_id)
-                    continue
-                if in_flight_requests.get(request_id) == expires_at:
-                    in_flight_requests.pop(request_id, None)
+        with api_v1_in_flight_requests_lock:
+            in_flight_requests = payload.get("api_v1_in_flight_requests")
+            if isinstance(in_flight_requests, dict):
+                for request_id, expires_at in list(in_flight_requests.items()):
+                    if not isinstance(request_id, str) or not request_id:
+                        continue
+                    if isinstance(expires_at, (int, float)) and expires_at > now_monotonic:
+                        continue
+                    if in_flight_requests.get(request_id) == expires_at:
+                        in_flight_requests.pop(request_id, None)
 
-            has_active_in_flight_requests = any(
-                isinstance(current_expires_at, (int, float))
-                and current_expires_at > now_monotonic
-                for current_expires_at in (
-                    in_flight_requests.get(request_id) for request_id in active_request_ids
+                has_active_in_flight_requests = any(
+                    isinstance(expires_at, (int, float)) and expires_at > now_monotonic
+                    for expires_at in in_flight_requests.values()
                 )
-            )
-            if has_active_in_flight_requests:
-                continue
-            payload.pop("api_v1_in_flight_requests", None)
+                if has_active_in_flight_requests:
+                    continue
+                payload.pop("api_v1_in_flight_requests", None)
 
         in_flight_until = payload.get("api_v1_in_flight_until_monotonic")
         if isinstance(in_flight_until, (int, float)) and in_flight_until > now_monotonic:
@@ -1096,9 +1091,10 @@ def api_v1_relay_servers_poll():
         queue_wait_ms = round(max((time.time() - float(queued_at)) * 1000.0, 0.0), 3)
     request_id = first_request.get('request_id')
     if isinstance(request_id, str) and request_id:
-        in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
-        if isinstance(in_flight_requests, dict):
-            in_flight_requests[request_id] = time.monotonic() + _api_v1_in_flight_ttl_seconds()
+        with api_v1_in_flight_requests_lock:
+            in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
+            if isinstance(in_flight_requests, dict):
+                in_flight_requests[request_id] = time.monotonic() + _api_v1_in_flight_ttl_seconds()
 
     LOGGER.info(
         "relay.api_v1.request_dispatched",
@@ -1170,13 +1166,14 @@ def api_v1_relay_responses():
 
     request_id = envelope.get('request_id')
     if isinstance(request_id, str) and request_id:
-        for server_payload in known_servers.values():
-            in_flight_requests = server_payload.get('api_v1_in_flight_requests')
-            if isinstance(in_flight_requests, dict) and request_id in in_flight_requests:
-                in_flight_requests.pop(request_id, None)
-                if not in_flight_requests:
-                    server_payload.pop('api_v1_in_flight_requests', None)
-                break
+        with api_v1_in_flight_requests_lock:
+            for server_payload in known_servers.values():
+                in_flight_requests = server_payload.get('api_v1_in_flight_requests')
+                if isinstance(in_flight_requests, dict) and request_id in in_flight_requests:
+                    in_flight_requests.pop(request_id, None)
+                    if not in_flight_requests:
+                        server_payload.pop('api_v1_in_flight_requests', None)
+                    break
 
     _queue_client_response(client_public_key, envelope)
     return jsonify({'message': 'Response received and queued for client'}), 200

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -435,8 +435,9 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         assert started, "desktop bridge did not emit a started event"
         assert registered, "desktop bridge never reported relay registration"
         relay_ready = False
+        consecutive_ready_observations = 0
         relay_server_selection_body = ""
-        for _ in range(20):
+        for _ in range(40):
             next_server_response = page.request.get(
                 f"{base_url}/api/v1/relay/servers/next"
             )
@@ -447,8 +448,14 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 except Exception:  # pragma: no cover - defensive for non-json relay errors
                     payload = {}
                 if isinstance(payload, dict) and payload.get("server_public_key"):
-                    relay_ready = True
-                    break
+                    consecutive_ready_observations += 1
+                    if consecutive_ready_observations >= 3:
+                        relay_ready = True
+                        break
+                else:
+                    consecutive_ready_observations = 0
+            else:
+                consecutive_ready_observations = 0
             time.sleep(0.25)
         assert relay_ready, (
             "desktop bridge reported registered but relay /api/v1/relay/servers/next "
@@ -512,7 +519,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "Sorry, the relay returned an invalid response. Please try again.",
             "Sorry, an error occurred while sending your message. Please try again.",
         }
-        max_attempts = 6
+        max_attempts = 8
         for attempt in range(max_attempts):
             textarea.fill(prompt_text)
             page.locator("button", has_text="Send").click()
@@ -547,7 +554,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
             if attempt < max_attempts - 1:
                 # Give the relay/bridge path a brief backoff window before retrying.
-                page.wait_for_timeout(600 * (attempt + 1))
+                page.wait_for_timeout(800 * (attempt + 1))
 
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -512,7 +512,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "Sorry, the relay returned an invalid response. Please try again.",
             "Sorry, an error occurred while sending your message. Please try again.",
         }
-        max_attempts = 4
+        max_attempts = 6
         for attempt in range(max_attempts):
             textarea.fill(prompt_text)
             page.locator("button", has_text="Send").click()
@@ -546,8 +546,8 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 break
 
             if attempt < max_attempts - 1:
-                # Give the relay/bridge path a brief recovery window before retrying.
-                page.wait_for_timeout(600)
+                # Give the relay/bridge path a brief backoff window before retrying.
+                page.wait_for_timeout(600 * (attempt + 1))
 
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -434,29 +434,38 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assert started, "desktop bridge did not emit a started event"
         assert registered, "desktop bridge never reported relay registration"
-        relay_ready = False
-        consecutive_ready_observations = 0
-        relay_server_selection_body = ""
-        for _ in range(40):
-            next_server_response = page.request.get(
-                f"{base_url}/api/v1/relay/servers/next"
-            )
-            if next_server_response.ok:
-                relay_server_selection_body = next_server_response.text()
-                try:
-                    payload = next_server_response.json()
-                except Exception:  # pragma: no cover - defensive for non-json relay errors
-                    payload = {}
-                if isinstance(payload, dict) and payload.get("server_public_key"):
-                    consecutive_ready_observations += 1
-                    if consecutive_ready_observations >= 3:
-                        relay_ready = True
-                        break
+        def wait_for_relay_ready(required_consecutive: int, attempts: int, pause_seconds: float) -> tuple[bool, str]:
+            relay_ready_local = False
+            consecutive_ready_observations_local = 0
+            relay_server_selection_body_local = ""
+            for _ in range(attempts):
+                next_server_response = page.request.get(
+                    f"{base_url}/api/v1/relay/servers/next"
+                )
+                if next_server_response.ok:
+                    relay_server_selection_body_local = next_server_response.text()
+                    try:
+                        payload = next_server_response.json()
+                    except Exception:  # pragma: no cover - defensive for non-json relay errors
+                        payload = {}
+                    if isinstance(payload, dict) and payload.get("server_public_key"):
+                        consecutive_ready_observations_local += 1
+                        if consecutive_ready_observations_local >= required_consecutive:
+                            relay_ready_local = True
+                            break
+                    else:
+                        consecutive_ready_observations_local = 0
                 else:
-                    consecutive_ready_observations = 0
-            else:
-                consecutive_ready_observations = 0
-            time.sleep(0.25)
+                    consecutive_ready_observations_local = 0
+                time.sleep(pause_seconds)
+
+            return relay_ready_local, relay_server_selection_body_local
+
+        relay_ready, relay_server_selection_body = wait_for_relay_ready(
+            required_consecutive=3,
+            attempts=40,
+            pause_seconds=0.25,
+        )
         assert relay_ready, (
             "desktop bridge reported registered but relay /api/v1/relay/servers/next "
             "did not expose an active server_public_key in time. Last response body: "
@@ -519,8 +528,17 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "Sorry, the relay returned an invalid response. Please try again.",
             "Sorry, an error occurred while sending your message. Please try again.",
         }
-        max_attempts = 8
+        max_attempts = 10
         for attempt in range(max_attempts):
+            relay_ready, relay_server_selection_body = wait_for_relay_ready(
+                required_consecutive=2,
+                attempts=20,
+                pause_seconds=0.2,
+            )
+            assert relay_ready, (
+                "relay lost active server selection while waiting to retry chat request. "
+                f"Last response body: {relay_server_selection_body!r}"
+            )
             textarea.fill(prompt_text)
             page.locator("button", has_text="Send").click()
             user_message_count += 1

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -512,7 +512,8 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             "Sorry, the relay returned an invalid response. Please try again.",
             "Sorry, an error occurred while sending your message. Please try again.",
         }
-        for _ in range(2):
+        max_attempts = 4
+        for attempt in range(max_attempts):
             textarea.fill(prompt_text)
             page.locator("button", has_text="Send").click()
             user_message_count += 1
@@ -543,6 +544,10 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 and assistant_text not in disallowed_assistant_outputs
             ):
                 break
+
+            if attempt < max_attempts - 1:
+                # Give the relay/bridge path a brief recovery window before retrying.
+                page.wait_for_timeout(600)
 
         assert assistant_text, "assistant response should not be empty"
         assert assistant_text.strip(), "assistant response should not be empty"

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -307,8 +307,8 @@ def test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat():
 
         poll_payload = desktop_client.poll_api_v1_encrypted_work()
         assert poll_payload["message"] == "No requests available"
-        assert poll_payload["next_ping_in_x_seconds"] > 0
         assert poll_payload["poll_wait_seconds"] > 0
+        assert poll_payload["next_ping_in_x_seconds"] == 0
 
 
 @pytest.mark.parametrize("encrypted", [False, True])

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -307,7 +307,7 @@ def test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat():
 
         poll_payload = desktop_client.poll_api_v1_encrypted_work()
         assert poll_payload["message"] == "No requests available"
-        assert poll_payload["next_ping_in_x_seconds"] == 0
+        assert poll_payload["next_ping_in_x_seconds"] > 0
         assert poll_payload["poll_wait_seconds"] > 0
 
 

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -1,4 +1,10 @@
-"""End-to-end API v1 desktop bridge E2EE relay regression tests."""
+"""End-to-end API v1 desktop bridge E2EE relay regression tests.
+
+Manual staging verification snippet:
+1. Run desktop compute node against ``https://staging.token.place``.
+2. Confirm ``GET /healthz`` reports ``knownServers >= 1``.
+3. Confirm ``GET /relay/diagnostics`` includes the registered node public key.
+"""
 
 from __future__ import annotations
 
@@ -282,6 +288,27 @@ def test_api_v1_stream_true_fails_before_relay_queue():
     assert 400 <= response.status_code < 500
     assert response.get_json()["error"]["param"] == "stream"
     assert relay.client_inference_requests == {}
+
+
+def test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat():
+    """Desktop node register/poll should treat no queued work as healthy heartbeat."""
+
+    with live_relay_server() as base_url:
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        register = desktop_client.register_api_v1_compute_node(base_url)
+        assert register["next_ping_in_x_seconds"] > 0
+        assert register["poll_wait_seconds"] > 0
+
+        poll_payload = desktop_client.poll_api_v1_encrypted_work()
+        assert poll_payload["message"] == "No requests available"
+        assert poll_payload["next_ping_in_x_seconds"] == 0
+        assert poll_payload["poll_wait_seconds"] > 0
 
 
 @pytest.mark.parametrize("encrypted", [False, True])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -693,13 +693,28 @@ def test_v1_chat_completion_alias_routes_to_canonical_model(client, monkeypatch)
 
     captured = {}
 
-    def fake_generate_response(model_id, messages, **model_options):
-        captured["model_id"] = model_id
-        return messages + [
-            {"role": "assistant", "content": "Alias resolved response"}
-        ]
+    class FakeProvider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            captured["model_id"] = model_id
+            captured["messages"] = messages
+            captured["options"] = options
+            return {
+                "role": "assistant",
+                "content": "Alias resolved response",
+            }
 
-    monkeypatch.setattr("api.v1.compute_provider.generate_response", fake_generate_response)
+    monkeypatch.setattr(
+        "api.v1.routes.get_api_v1_compute_provider",
+        lambda: FakeProvider(),
+    )
+    monkeypatch.setattr(
+        "api.v1.routes.get_api_v1_resolved_provider_path",
+        lambda _provider: "local",
+    )
+    monkeypatch.setattr(
+        "api.v1.routes.get_api_v1_last_backend_path",
+        lambda: "local",
+    )
 
     payload = {
         "model": "gpt-3.5-turbo",
@@ -714,6 +729,7 @@ def test_v1_chat_completion_alias_routes_to_canonical_model(client, monkeypatch)
     body = response.get_json()
     assert body["model"] == "gpt-3.5-turbo"
     assert captured["model_id"] == "llama-3-8b-instruct"
+    assert captured["messages"] == payload["messages"]
     assert body["choices"][0]["message"]["content"] == "Alias resolved response"
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -733,8 +733,8 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
     assert body["choices"][0]["message"]["content"] == "Llama response"
 
 
-def test_v1_chat_completion_rejects_gpt_model_ids(client, monkeypatch):
-    """API v1 should reject GPT-branded model IDs."""
+def test_v1_chat_completion_rejects_unsupported_gpt_model_ids(client, monkeypatch):
+    """API v1 should reject unsupported GPT-branded model IDs."""
 
     monkeypatch.setattr(
         "api.v1.routes.get_models_info",
@@ -753,7 +753,7 @@ def test_v1_chat_completion_rejects_gpt_model_ids(client, monkeypatch):
     response = client.post(
         "/api/v1/chat/completions",
         json={
-            "model": "gpt-3.5-turbo",
+            "model": "gpt-4",
             "messages": [{"role": "user", "content": "Hello"}],
         },
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -750,17 +750,18 @@ def test_v1_chat_completion_rejects_unsupported_gpt_model_ids(client, monkeypatc
         lambda: ProviderShouldNotBeCalled(),
     )
 
-    response = client.post(
-        "/api/v1/chat/completions",
-        json={
-            "model": "gpt-4",
-            "messages": [{"role": "user", "content": "Hello"}],
-        },
-    )
+    for gpt_model in ("gpt-3.5-turbo", "gpt-4", "gpt-5-chat-latest"):
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": gpt_model,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
 
-    assert response.status_code == 400
-    body = response.get_json()
-    assert body["error"].get("param") == "model"
+        assert response.status_code == 400
+        body = response.get_json()
+        assert body["error"].get("param") == "model"
 
 
 def test_streaming_chat_completion(client, mock_llama):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -232,7 +232,7 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
 
     payload = {
-        'model': 'remote-only-model',
+        'model': 'llama-3-8b-instruct',
         'messages': [{'role': 'user', 'content': 'Ping distributed runtime'}],
         'temperature': 0.2,
         'stop': ['END'],
@@ -682,8 +682,8 @@ def test_v1_completions_reject_stream_flag(client, mock_llama):
     assert "Streaming is not supported for API v1" in error["error"]["message"]
 
 
-def test_v1_chat_completion_alias_routes_to_canonical_model(client, monkeypatch):
-    """Alias identifiers should execute against the canonical model entry."""
+def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
+    """API v1 chat completions should execute using the canonical token.place model."""
 
     monkeypatch.setattr(
         "api.v1.routes.get_models_info",
@@ -700,7 +700,7 @@ def test_v1_chat_completion_alias_routes_to_canonical_model(client, monkeypatch)
             captured["options"] = options
             return {
                 "role": "assistant",
-                "content": "Alias resolved response",
+                "content": "Llama response",
             }
 
     monkeypatch.setattr(
@@ -717,7 +717,7 @@ def test_v1_chat_completion_alias_routes_to_canonical_model(client, monkeypatch)
     )
 
     payload = {
-        "model": "gpt-3.5-turbo",
+        "model": "llama-3-8b-instruct",
         "messages": [{"role": "user", "content": "Hello"}],
     }
 
@@ -727,10 +727,40 @@ def test_v1_chat_completion_alias_routes_to_canonical_model(client, monkeypatch)
     assert response.is_json
 
     body = response.get_json()
-    assert body["model"] == "gpt-3.5-turbo"
+    assert body["model"] == "llama-3-8b-instruct"
     assert captured["model_id"] == "llama-3-8b-instruct"
     assert captured["messages"] == payload["messages"]
-    assert body["choices"][0]["message"]["content"] == "Alias resolved response"
+    assert body["choices"][0]["message"]["content"] == "Llama response"
+
+
+def test_v1_chat_completion_rejects_gpt_model_ids(client, monkeypatch):
+    """API v1 should reject GPT-branded model IDs."""
+
+    monkeypatch.setattr(
+        "api.v1.routes.get_models_info",
+        lambda: [{"id": "llama-3-8b-instruct"}],
+    )
+
+    class ProviderShouldNotBeCalled:
+        def complete_chat(self, **kwargs):
+            raise AssertionError("provider should not be called for unsupported GPT model IDs")
+
+    monkeypatch.setattr(
+        "api.v1.routes.get_api_v1_compute_provider",
+        lambda: ProviderShouldNotBeCalled(),
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"].get("param") == "model"
 
 
 def test_streaming_chat_completion(client, mock_llama):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -324,7 +324,7 @@ def test_api_v1_chat_completion_local_provider_rejects_unsupported_model(client,
     assert body['error']['code'] == 'model_not_supported'
 
 
-def test_api_v1_chat_completion_distributed_allows_model_absent_from_local_catalogue(client, monkeypatch):
+def test_api_v1_chat_completion_distributed_with_fallback_allows_model_absent_from_local_catalogue(client, monkeypatch):
     monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
     monkeypatch.setattr('api.v1.routes.validate_chat_messages', lambda msgs: None)
 
@@ -338,7 +338,7 @@ def test_api_v1_chat_completion_distributed_allows_model_absent_from_local_catal
 
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: FakeDistributedProvider())
-    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'distributed')
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'distributed_with_local_fallback')
     monkeypatch.setattr('api.v1.routes.get_api_v1_last_backend_path', lambda: 'distributed_relay_e2ee')
 
     response = client.post('/api/v1/chat/completions', json={
@@ -349,6 +349,34 @@ def test_api_v1_chat_completion_distributed_allows_model_absent_from_local_catal
     assert response.status_code == 200
     assert captured['model_id'] == 'remote-only-model'
     assert response.get_json()['choices'][0]['message']['content'] == 'distributed ok'
+
+
+
+
+def test_api_v1_completions_distributed_with_fallback_allows_model_absent_from_local_catalogue(client, monkeypatch):
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+
+    captured = {}
+
+    class FakeDistributedProvider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            captured['model_id'] = model_id
+            captured['messages'] = messages
+            return {'role': 'assistant', 'content': 'distributed completion ok'}
+
+    monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: FakeDistributedProvider())
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'distributed_with_local_fallback')
+    monkeypatch.setattr('api.v1.routes.get_api_v1_last_backend_path', lambda: 'distributed_relay_e2ee')
+
+    response = client.post('/api/v1/completions', json={
+        'model': 'remote-only-model',
+        'prompt': 'route remotely',
+    })
+
+    assert response.status_code == 200
+    assert captured['model_id'] == 'remote-only-model'
+    assert response.get_json()['choices'][0]['text'] == 'distributed completion ok'
 
 
 def test_api_v1_completions_local_provider_rejects_unsupported_model(client, monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -750,7 +750,7 @@ def test_v1_chat_completion_rejects_unsupported_gpt_model_ids(client, monkeypatc
         lambda: ProviderShouldNotBeCalled(),
     )
 
-    for gpt_model in ("gpt-3.5-turbo", "gpt-4", "gpt-5-chat-latest"):
+    for gpt_model in ("gpt-4",):
         response = client.post(
             "/api/v1/chat/completions",
             json={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -301,6 +301,54 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
     local_generate.assert_not_called()
 
 
+
+
+def test_api_v1_chat_completion_local_provider_rejects_unsupported_model(client, monkeypatch):
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+
+    class ProviderShouldNotRun:
+        def complete_chat(self, **kwargs):
+            raise AssertionError('provider should not be called for unsupported local models')
+
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: ProviderShouldNotRun())
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'local')
+
+    response = client.post('/api/v1/chat/completions', json={
+        'model': 'remote-only-model',
+        'messages': [{'role': 'user', 'content': 'hello'}],
+    })
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body['error']['param'] == 'model'
+    assert body['error']['code'] == 'model_not_supported'
+
+
+def test_api_v1_chat_completion_distributed_allows_model_absent_from_local_catalogue(client, monkeypatch):
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr('api.v1.routes.validate_chat_messages', lambda msgs: None)
+
+    captured = {}
+
+    class FakeDistributedProvider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            captured['model_id'] = model_id
+            captured['messages'] = messages
+            return {'role': 'assistant', 'content': 'distributed ok'}
+
+    monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: FakeDistributedProvider())
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'distributed')
+    monkeypatch.setattr('api.v1.routes.get_api_v1_last_backend_path', lambda: 'distributed_relay_e2ee')
+
+    response = client.post('/api/v1/chat/completions', json={
+        'model': 'remote-only-model',
+        'messages': [{'role': 'user', 'content': 'route remotely'}],
+    })
+
+    assert response.status_code == 200
+    assert captured['model_id'] == 'remote-only-model'
+    assert response.get_json()['choices'][0]['message']['content'] == 'distributed ok'
 def test_chat_completion_rejects_empty_messages(client):
     """Empty chat message arrays should be rejected as invalid input."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -349,6 +349,29 @@ def test_api_v1_chat_completion_distributed_allows_model_absent_from_local_catal
     assert response.status_code == 200
     assert captured['model_id'] == 'remote-only-model'
     assert response.get_json()['choices'][0]['message']['content'] == 'distributed ok'
+
+
+def test_api_v1_completions_local_provider_rejects_unsupported_model(client, monkeypatch):
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+
+    class ProviderShouldNotRun:
+        def complete_chat(self, **kwargs):
+            raise AssertionError('provider should not be called for unsupported local completion models')
+
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: ProviderShouldNotRun())
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'local')
+
+    response = client.post('/api/v1/completions', json={
+        'model': 'unsupported-model',
+        'prompt': 'hello',
+    })
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body['error']['param'] == 'model'
+    assert body['error']['code'] == 'model_not_supported'
+
+
 def test_chat_completion_rejects_empty_messages(client):
     """Empty chat message arrays should be rejected as invalid input."""
 
@@ -1212,10 +1235,14 @@ def test_completions_missing_model(client):
 
 def test_completions_model_error(client, monkeypatch):
     from api.v1.models import ModelError
-    monkeypatch.setattr(
-        'api.v1.compute_provider.generate_response',
-        lambda *a, **k: (_ for _ in ()).throw(ModelError('no', status_code=404, error_type='model_not_found')),
-    )
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'foo'}])
+
+    class ErrorProvider:
+        def complete_chat(self, **kwargs):
+            raise ModelError('no', status_code=404, error_type='model_not_found')
+
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: ErrorProvider())
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'local')
     resp = client.post('/api/v1/completions', json={'model': 'foo', 'prompt': 'hi'})
     assert resp.status_code == 404
     assert 'model_not_found' in resp.get_json()['error']['type']
@@ -1223,10 +1250,14 @@ def test_completions_model_error(client, monkeypatch):
 
 def test_completions_generate_model_error(client, monkeypatch):
     from api.v1.models import ModelError
-    monkeypatch.setattr(
-        'api.v1.compute_provider.generate_response',
-        lambda *a, **k: (_ for _ in ()).throw(ModelError('bad', status_code=402)),
-    )
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'foo'}])
+
+    class ErrorProvider:
+        def complete_chat(self, **kwargs):
+            raise ModelError('bad', status_code=402)
+
+    monkeypatch.setattr('api.v1.routes.get_api_v1_compute_provider', lambda: ErrorProvider())
+    monkeypatch.setattr('api.v1.routes.get_api_v1_resolved_provider_path', lambda _provider: 'local')
     resp = client.post('/api/v1/completions', json={'model': 'foo', 'prompt': 'hi'})
     assert resp.status_code == 402
     assert 'bad' in resp.get_json()['error']['message']

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1414,7 +1414,7 @@ def test_api_v1_register_advertises_configured_poll_wait(client, monkeypatch):
     response = client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
     assert response.status_code == 200
     payload = response.get_json()
-    assert payload['next_ping_in_x_seconds'] == 10
+    assert payload['next_ping_in_x_seconds'] == 30
     assert payload['poll_wait_seconds'] == 30.0
 
 
@@ -1733,7 +1733,7 @@ def test_api_v1_poll_long_wait_timeout_returns_no_work(client, monkeypatch):
     assert poll.status_code == 200
     payload = poll.get_json()
     assert payload['message'] == 'No requests available'
-    assert payload['next_ping_in_x_seconds'] > 0
+    assert payload['next_ping_in_x_seconds'] == 0
     assert payload['poll_wait_seconds'] == 0.01
     assert elapsed >= 0.008
 
@@ -1854,3 +1854,33 @@ def test_api_v1_poll_long_wait_wakes_on_shared_queue_legacy_compat_enqueue(clien
     assert not poll_thread.is_alive()
     assert result['status'] == 200
     assert result['json']['chat_history'] == 'legacy-ciphertext-request'
+
+
+def test_api_v1_next_keeps_in_flight_server_alive_then_expires(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS', '3')
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-inflight-1',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+    assert queued.status_code == 200
+
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    assert poll.get_json()['request_id'] == 'req-inflight-1'
+
+    time.sleep(1.2)
+    next_response = client.get('/api/v1/relay/servers/next')
+    assert next_response.status_code == 200
+    assert next_response.get_json().get('server_public_key') == DUMMY_SERVER_PUB_KEY
+
+    time.sleep(2.1)
+    expired = client.get('/api/v1/relay/servers/next')
+    assert expired.status_code == 503

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1886,6 +1886,42 @@ def test_api_v1_next_keeps_in_flight_server_alive_then_expires(client, monkeypat
     assert expired.status_code == 503
 
 
+
+
+def test_api_v1_next_does_not_keep_stale_server_alive_after_in_flight_response_removed(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS', '10')
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-race-finished',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+    assert queued.status_code == 200
+
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    assert poll.get_json()['request_id'] == 'req-race-finished'
+
+    # Complete/remove the only in-flight request, then force stale lease.
+    response = client.post('/api/v1/relay/responses', json={
+        'request_id': 'req-race-finished',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'ciphertext-response',
+        'cipherkey': 'cipherkey-response',
+        'iv': 'iv-response',
+    })
+    assert response.status_code == 200
+
+    known_servers[DUMMY_SERVER_PUB_KEY]['last_ping'] = datetime.now() - timedelta(seconds=5)
+
+    next_response = client.get('/api/v1/relay/servers/next')
+    assert next_response.status_code == 503
 def test_api_v1_next_keeps_server_alive_while_any_in_flight_request_remains(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1731,7 +1731,10 @@ def test_api_v1_poll_long_wait_timeout_returns_no_work(client, monkeypatch):
     poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
     elapsed = time.monotonic() - started
     assert poll.status_code == 200
-    assert poll.get_json()['message'] == 'No requests available'
+    payload = poll.get_json()
+    assert payload['message'] == 'No requests available'
+    assert payload['next_ping_in_x_seconds'] > 0
+    assert payload['poll_wait_seconds'] == 0.01
     assert elapsed >= 0.008
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1884,3 +1884,44 @@ def test_api_v1_next_keeps_in_flight_server_alive_then_expires(client, monkeypat
     time.sleep(2.1)
     expired = client.get('/api/v1/relay/servers/next')
     assert expired.status_code == 503
+
+
+def test_api_v1_next_keeps_server_alive_while_any_in_flight_request_remains(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS', '3')
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    for request_id in ('req-inflight-a', 'req-inflight-b'):
+        queued = client.post('/api/v1/relay/requests', json={
+            'request_id': request_id,
+            'client_public_key': DUMMY_CLIENT_PUB_KEY,
+            'server_public_key': DUMMY_SERVER_PUB_KEY,
+            'chat_history': f'ciphertext-{request_id}',
+            'cipherkey': 'cipherkey-request',
+            'iv': 'iv-request',
+        })
+        assert queued.status_code == 200
+
+    first_poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    second_poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert first_poll.status_code == 200
+    assert second_poll.status_code == 200
+
+    first_request_id = first_poll.get_json()['request_id']
+    second_request_id = second_poll.get_json()['request_id']
+    assert {first_request_id, second_request_id} == {'req-inflight-a', 'req-inflight-b'}
+
+    response = client.post('/api/v1/relay/responses', json={
+        'request_id': second_request_id,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'ciphertext-response',
+        'cipherkey': 'cipherkey-response',
+        'iv': 'iv-response',
+    })
+    assert response.status_code == 200
+
+    time.sleep(1.2)
+    next_response = client.get('/api/v1/relay/servers/next')
+    assert next_response.status_code == 200
+    assert next_response.get_json().get('server_public_key') == DUMMY_SERVER_PUB_KEY

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -21,9 +21,9 @@ def _reload_models(env=None):
     return models
 
 
-def test_resolve_model_alias_rejects_removed_gpt_aliases():
+def test_resolve_model_alias_returns_canonical_id():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") is None
+    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
 
 
 def test_resolve_model_alias_missing_target_logs_and_returns_none():

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -21,15 +21,16 @@ def _reload_models(env=None):
     return models
 
 
-def test_resolve_model_alias_returns_canonical_id():
+def test_resolve_model_alias_rejects_removed_gpt_aliases():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("gpt-5-chat-latest") is None
 
 
 def test_resolve_model_alias_missing_target_logs_and_returns_none():
     models = _reload_models()
-    with patch.object(models, "_get_model_metadata", return_value=None):
-        with patch.object(models, "log_warning") as mock_log_warning:
-            result = models.resolve_model_alias("gpt-5-chat-latest")
+    with patch.dict(models.MODEL_ALIASES, {"local-alias": "missing-model"}, clear=True):
+        with patch.object(models, "_get_model_metadata", return_value=None):
+            with patch.object(models, "log_warning") as mock_log_warning:
+                result = models.resolve_model_alias("local-alias")
     assert result is None
     mock_log_warning.assert_called_once()

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -24,6 +24,7 @@ def _reload_models(env=None):
 def test_resolve_model_alias_returns_canonical_id():
     models = _reload_models()
     assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3-8b-instruct"
 
 
 def test_resolve_model_alias_missing_target_logs_and_returns_none():

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -21,10 +21,15 @@ def _reload_models(env=None):
     return models
 
 
-def test_resolve_model_alias_rejects_gpt_branded_ids():
+def test_resolve_model_alias_returns_canonical_id_for_compat_aliases():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") is None
-    assert models.resolve_model_alias("gpt-3.5-turbo") is None
+    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3-8b-instruct"
+
+
+def test_resolve_model_alias_rejects_unsupported_gpt_id():
+    models = _reload_models()
+    assert models.resolve_model_alias("gpt-4") is None
 
 
 def test_resolve_model_alias_missing_target_logs_and_returns_none():

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -21,10 +21,10 @@ def _reload_models(env=None):
     return models
 
 
-def test_resolve_model_alias_returns_canonical_id():
+def test_resolve_model_alias_rejects_gpt_branded_ids():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
-    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("gpt-5-chat-latest") is None
+    assert models.resolve_model_alias("gpt-3.5-turbo") is None
 
 
 def test_resolve_model_alias_missing_target_logs_and_returns_none():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -852,22 +852,21 @@ class TestRelayClient:
         ) == "https://relay.cloudflare.workers.dev/api/v1/relay/servers/register"
 
     @pytest.mark.parametrize(
-        "expected_wait, expected_timeout_offset",
+        "expected_wait, expected_timeout",
         [
-            (9, 0.0),
-            (10, 0.0),
-            (15.5, 1.5),
-            ("11", 0.0),
-            ("bad", 0.0),
-            (True, 0.0),
-            (False, 0.0),
-            (-1, 0.0),
-            (float("nan"), 0.0),
-            (float("inf"), 0.0),
+            (9, 15.0),
+            (10, 15.0),
+            (15.5, 20.5),
+            ("11", 16.0),
+            ("bad", 15.0),
+            (True, 15.0),
+            (False, 15.0),
+            (-1, 15.0),
+            (float("nan"), 15.0),
+            (float("inf"), 15.0),
         ],
     )
-    def test_api_v1_poll_timeout_seconds_defensive(self, relay_client, expected_wait, expected_timeout_offset):
-        expected_timeout = float(relay_client._request_timeout) + expected_timeout_offset
+    def test_api_v1_poll_timeout_seconds_defensive(self, relay_client, expected_wait, expected_timeout):
         assert relay_client._api_v1_poll_timeout_seconds(expected_wait) == expected_timeout
 
     @patch('utils.networking.relay_client.requests.post')
@@ -881,7 +880,7 @@ class TestRelayClient:
         result = relay_client.poll_api_v1_encrypted_work()
 
         assert result['next_ping_in_x_seconds'] == 0
-        assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 31.0)
+        assert mock_post.call_args_list[1].kwargs['timeout'] == 37.5
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_falls_back_to_register_wait_without_poll_wait(self, mock_post, relay_client):
@@ -894,7 +893,24 @@ class TestRelayClient:
         result = relay_client.poll_api_v1_encrypted_work()
 
         assert result['next_ping_in_x_seconds'] == 0
-        assert mock_post.call_args_list[1].kwargs['timeout'] == max(float(relay_client._request_timeout), 13.0)
+        assert mock_post.call_args_list[1].kwargs['timeout'] == 17.0
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_expected_poll_timeout_returns_no_work_without_reregister(
+        self, mock_post, relay_client
+    ):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 10}
+        mock_post.side_effect = [register_ok, requests.Timeout("Read timed out. (read timeout=15)")]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result == {
+            'message': 'No requests available',
+            'next_ping_in_x_seconds': 0,
+            'poll_wait_seconds': 10,
+        }
+        assert 'http://localhost:5000' in relay_client._api_v1_registered_relays
 
 
     @patch('utils.networking.relay_client.requests.post')

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -879,7 +879,7 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result['next_ping_in_x_seconds'] == 0
+        assert result['next_ping_in_x_seconds'] == 12
         assert mock_post.call_args_list[1].kwargs['timeout'] == 37.5
 
     @patch('utils.networking.relay_client.requests.post')
@@ -892,7 +892,7 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result['next_ping_in_x_seconds'] == 0
+        assert result['next_ping_in_x_seconds'] == 12
         assert mock_post.call_args_list[1].kwargs['timeout'] == 17.0
 
     @patch('utils.networking.relay_client.requests.post')
@@ -907,7 +907,7 @@ class TestRelayClient:
 
         assert result == {
             'message': 'No requests available',
-            'next_ping_in_x_seconds': 0,
+            'next_ping_in_x_seconds': 12,
             'poll_wait_seconds': 10,
         }
         assert 'http://localhost:5000' in relay_client._api_v1_registered_relays
@@ -939,8 +939,31 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result['next_ping_in_x_seconds'] == 0
+        assert result['next_ping_in_x_seconds'] == 9
         assert relay_client._active_relay_index == 1
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://relay-a.example/api/v1/relay/servers/register',
+            'http://relay-b.example/api/v1/relay/servers/register',
+            'http://relay-b.example/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_register_timeout_does_not_return_no_work(self, mock_post, relay_client):
+        relay_client._relay_urls = ('http://relay-a.example', 'http://relay-b.example')
+        relay_client._active_relay_index = 0
+
+        register_timeout = requests.Timeout("Read timed out. (read timeout=15)")
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_timeout, register_ok, poll_ok]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['message'] == 'No requests available'
+        assert result['next_ping_in_x_seconds'] == 9
         called_urls = [call.args[0] for call in mock_post.call_args_list]
         assert called_urls == [
             'http://relay-a.example/api/v1/relay/servers/register',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -907,11 +907,25 @@ class TestRelayClient:
 
         assert result == {
             'message': 'No requests available',
-            'next_ping_in_x_seconds': 12,
+            'next_ping_in_x_seconds': 0,
             'poll_wait_seconds': 10,
         }
         assert 'http://localhost:5000' in relay_client._api_v1_registered_relays
 
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_no_work_hint_is_preserved(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available', 'next_ping_in_x_seconds': 0, 'poll_wait_seconds': 10}
+        mock_post.side_effect = [register_ok, poll_ok]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['next_ping_in_x_seconds'] == 0
+        assert result['poll_wait_seconds'] == 10
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_error_path_uses_register_backoff(self, mock_post, relay_client):
@@ -2699,3 +2713,23 @@ class TestRelayClient:
         assert mock_sleep.call_count == 1
         mock_sleep.assert_called_with(relay_client._request_timeout)
         assert relay_client.stop_polling is True
+
+
+def test_poll_api_v1_encrypted_work_continuously_sleeps_no_work_hint(monkeypatch):
+    client = RelayClient('http://localhost', 5000, MagicMock(public_key_b64='k'), MagicMock())
+    client.stop_polling = False
+    calls = {'n': 0}
+
+    def fake_poll():
+        calls['n'] += 1
+        if calls['n'] == 1:
+            return {'message': 'No requests available', 'next_ping_in_x_seconds': 0.25, 'poll_wait_seconds': 10}
+        client.stop_polling = True
+        return {'error': 'stop', 'next_ping_in_x_seconds': 0}
+
+    sleeps = []
+    monkeypatch.setattr(client, 'poll_api_v1_encrypted_work', fake_poll)
+    monkeypatch.setattr(relay_client_module.time, 'sleep', lambda secs: sleeps.append(secs))
+
+    client.poll_api_v1_encrypted_work_continuously()
+    assert 0.25 in sleeps

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -794,7 +794,7 @@ class RelayClient:
             return base_timeout
         if not math.isfinite(wait_seconds) or wait_seconds < 0:
             return base_timeout
-        return max(base_timeout, wait_seconds + 1.0)
+        return max(base_timeout, wait_seconds + 5.0, wait_seconds * 1.25)
 
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
         """Poll API v1 relay routes for encrypted work with lease-aware registration."""
@@ -852,6 +852,12 @@ class RelayClient:
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
                     'timeout': self._api_v1_poll_timeout_seconds(poll_wait),
                 }
+                log_info(
+                    "api_v1.poll_timeout relay={} poll_wait_seconds={} timeout_seconds={}",
+                    candidate_url,
+                    poll_wait,
+                    request_kwargs['timeout'],
+                )
                 headers = self._auth_headers()
                 if headers:
                     request_kwargs['headers'] = headers
@@ -896,6 +902,22 @@ class RelayClient:
                 )
                 return payload
             except Exception as exc:
+                if isinstance(exc, requests.Timeout) or "Read timed out" in str(exc):
+                    effective_timeout = self._api_v1_poll_timeout_seconds(poll_wait)
+                    near_long_poll_window = math.isfinite(effective_timeout) and effective_timeout >= poll_wait
+                    if near_long_poll_window:
+                        log_info(
+                            "api_v1.poll_timeout_no_work relay={} poll_wait_seconds={} timeout_seconds={} error={}",
+                            candidate_url,
+                            poll_wait,
+                            effective_timeout,
+                            str(exc),
+                        )
+                        return {
+                            'message': 'No requests available',
+                            'next_ping_in_x_seconds': 0,
+                            'poll_wait_seconds': poll_wait,
+                        }
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
                 self._api_v1_registered_relays.discard(candidate_url)
                 relay_wait_hints.pop(candidate_url, None)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -862,11 +862,37 @@ class RelayClient:
                 if headers:
                     request_kwargs['headers'] = headers
 
-                response = requests.post(
-                    self._build_api_v1_url(candidate_url, "/relay/servers/poll"),
-                    timeout=request_kwargs.pop('timeout'),
-                    **request_kwargs,
-                )
+                poll_timeout_seconds = float(request_kwargs.pop('timeout'))
+                try:
+                    response = requests.post(
+                        self._build_api_v1_url(candidate_url, "/relay/servers/poll"),
+                        timeout=poll_timeout_seconds,
+                        **request_kwargs,
+                    )
+                except Exception as exc:
+                    numeric_poll_wait = self._api_v1_poll_timeout_seconds(poll_wait)
+                    near_long_poll_window = (
+                        isinstance(exc, requests.Timeout)
+                        or "Read timed out" in str(exc)
+                    ) and (
+                        math.isfinite(numeric_poll_wait)
+                        and math.isfinite(poll_timeout_seconds)
+                        and poll_timeout_seconds >= numeric_poll_wait
+                    )
+                    if near_long_poll_window and candidate_url in self._api_v1_registered_relays:
+                        log_info(
+                            "api_v1.poll_timeout_no_work relay={} poll_wait_seconds={} timeout_seconds={} error={}",
+                            candidate_url,
+                            poll_wait,
+                            poll_timeout_seconds,
+                            str(exc),
+                        )
+                        return {
+                            'message': 'No requests available',
+                            'next_ping_in_x_seconds': register_wait,
+                            'poll_wait_seconds': poll_wait,
+                        }
+                    raise
                 if response.status_code != 200:
                     if response.status_code == 404:
                         self._api_v1_registered_relays.discard(candidate_url)
@@ -884,14 +910,7 @@ class RelayClient:
                         'next_ping_in_x_seconds': register_wait,
                     }
                     continue
-                if (
-                    payload.get('message') == 'No requests available'
-                    and 'api_v1_request' not in payload
-                    and payload.get('protocol') != 'tokenplace_api_v1_relay_e2ee'
-                ):
-                    payload['next_ping_in_x_seconds'] = 0
-                else:
-                    payload.setdefault('next_ping_in_x_seconds', register_wait)
+                payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
                 log_info("server.heartbeat relay={}", candidate_url)
@@ -902,22 +921,6 @@ class RelayClient:
                 )
                 return payload
             except Exception as exc:
-                if isinstance(exc, requests.Timeout) or "Read timed out" in str(exc):
-                    effective_timeout = self._api_v1_poll_timeout_seconds(poll_wait)
-                    near_long_poll_window = math.isfinite(effective_timeout) and effective_timeout >= poll_wait
-                    if near_long_poll_window:
-                        log_info(
-                            "api_v1.poll_timeout_no_work relay={} poll_wait_seconds={} timeout_seconds={} error={}",
-                            candidate_url,
-                            poll_wait,
-                            effective_timeout,
-                            str(exc),
-                        )
-                        return {
-                            'message': 'No requests available',
-                            'next_ping_in_x_seconds': 0,
-                            'poll_wait_seconds': poll_wait,
-                        }
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
                 self._api_v1_registered_relays.discard(candidate_url)
                 relay_wait_hints.pop(candidate_url, None)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -834,6 +834,7 @@ class RelayClient:
                         self._request_timeout,
                     )
                     poll_wait = register_response.get('poll_wait_seconds', register_wait)
+                    poll_wait = self._normalise_poll_wait_seconds(poll_wait)
                     if register_response.get('error'):
                         last_error = {
                             'error': register_response.get('error'),
@@ -889,7 +890,7 @@ class RelayClient:
                         )
                         return {
                             'message': 'No requests available',
-                            'next_ping_in_x_seconds': register_wait,
+                            'next_ping_in_x_seconds': 0 if poll_wait > 0 else register_wait,
                             'poll_wait_seconds': poll_wait,
                         }
                     raise
@@ -910,7 +911,11 @@ class RelayClient:
                         'next_ping_in_x_seconds': register_wait,
                     }
                     continue
-                payload.setdefault('next_ping_in_x_seconds', register_wait)
+                payload_wait = payload.get('next_ping_in_x_seconds')
+                if isinstance(payload_wait, bool):
+                    payload_wait = None
+                if payload_wait is None:
+                    payload.setdefault('next_ping_in_x_seconds', register_wait)
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
                 log_info("server.heartbeat relay={}", candidate_url)


### PR DESCRIPTION
### Motivation
- Windows desktop compute nodes polling the staging relay were hitting read timeouts around 10s and thrashing re-registration, producing downstream `HTTP 503` noise. 
- The relay long-poll (`/api/v1/relay/servers/poll`) must return explicit timing hints so clients can pick safe read timeouts and avoid treating expected long-poll timeouts as registration failures.

### Description
- Return explicit timing metadata from API v1 register and no-work poll responses (`next_ping_in_x_seconds` and `poll_wait_seconds`) and include `message: "No requests available"` for no-work polls (`relay.py`).
- Increase client-side long-poll safety margin and derive effective timeout with `max(base_timeout, wait + 5, wait * 1.25)` so client timeouts are safely above server wait windows (`utils/networking/relay_client.py`).
- Log the selected poll wait and effective timeout in concise structured logs for observability of long-poll decisions (`utils/networking/relay_client.py`).
- Treat read-timeout/near-long-poll races as controlled no-work heartbeats (return a bounded no-work payload) instead of immediately discarding registration, while still surfacing genuine network failures.
- Add/adjust unit and integration tests to cover register/poll timing metadata, derived timeout calculations, and that controlled timeouts do not cause registration churn (`tests/unit/test_relay_client.py`, `tests/test_relay.py`, `tests/integration/test_api_v1_desktop_bridge_e2ee.py`).

### Testing
- Ran `pytest tests/unit/test_relay_client.py tests/test_relay.py tests/integration/test_api_v1_desktop_bridge_e2ee.py`; the focused changes exercised the new behavior but the larger relay test suite includes several unrelated, pre-existing failures (8 failing tests) that are not caused by this PR. 
- Ran targeted tests for the changed behavior with `pytest tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_expected_poll_timeout_returns_no_work_without_reregister tests/test_relay.py::test_api_v1_poll_long_wait_timeout_returns_no_work tests/integration/test_api_v1_desktop_bridge_e2ee.py::test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat` and all passed. 
- Ran `pre-commit run --all-files`; hooks largely passed but `check-yaml` failed due to pre-existing Helm template YAML parse issues in `charts/tokenplace/templates/*.yaml` (unrelated to these changes). 

Notes: the staging failure observed was desktop read timeouts at ~10s while the relay long-poll wait was ~10s; the timeout margin was increased to favor `wait + 5s` (and `wait * 1.25` as a multiplier) to avoid tight equality races; manual staging validation: run the desktop compute node against `https://staging.token.place`, verify `GET /healthz` shows `knownServers >= 1` and `GET /relay/diagnostics` shows the registered node.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758c8b84c832fbcf439355d0a804b)