### PR TITLE
Clarify relay-only health diagnostics for staging

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -114,6 +114,19 @@ curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
 ```
 
+
+
+Health interpretation for relay-only staging:
+
+- `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0` means the relay reports process readiness even
+  when no compute nodes are registered yet.
+- `knownServers: 0` means no external compute nodes have registered; it does **not** mean relay
+  process health is degraded.
+- Relay-only Sugarkube does not require `TOKENPLACE_RELAY_UPSTREAM_URL` or an in-cluster GPU
+  service for `/healthz` to return `200`.
+- `/healthz` and `/relay/diagnostics` report `relayOnly: true` / `relay_only: true` and
+  `upstreamHealthRequired: false` / `upstream_health_required: false` in this mode.
+
 Optional note: true relay traffic validation requires a registered external compute node and an
 E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`).
 

--- a/relay.py
+++ b/relay.py
@@ -619,14 +619,23 @@ def healthz():
     _evict_stale_servers()
     gpu_host = app.config.get("gpu_host")
     configured_servers = app.config.get("relay_configured_servers", [])
+    require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
+    relay_only = not require_upstream_health
+
     status = {
         "status": "ok",
         "upstream": app.config.get("upstream_url"),
-        "configuredUpstreamServers": configured_servers,
         "gpuHost": gpu_host,
         "knownServers": len(known_servers),
         "registeredServers": _live_server_diagnostics(),
+        "upstreamHealthRequired": require_upstream_health,
+        "relayOnly": relay_only,
     }
+
+    if relay_only:
+        status["legacyConfiguredUpstreamServers"] = configured_servers
+    else:
+        status["configuredUpstreamServers"] = configured_servers
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -639,7 +648,6 @@ def healthz():
         response.headers.setdefault("Cache-Control", "no-store")
         return response
 
-    require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     if require_upstream_health and gpu_host and not _can_resolve_gpu_host(gpu_host):
         status["status"] = "degraded"
         status.setdefault("details", {})["gpuHostResolution"] = "failed"
@@ -790,11 +798,21 @@ def relay_diagnostics():
     """Live diagnostics for legacy relay registered compute nodes."""
     _evict_stale_servers()
     live_nodes = _live_server_diagnostics()
-    return jsonify({
-        "configured_upstream_servers": app.config.get("relay_configured_servers", []),
+    require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
+    relay_only = not require_upstream_health
+
+    diagnostics = {
         "registered_compute_nodes": live_nodes,
         "total_registered_compute_nodes": len(live_nodes),
-    })
+        "upstream_health_required": require_upstream_health,
+        "relay_only": relay_only,
+    }
+    if relay_only:
+        diagnostics["legacy_configured_upstream_servers"] = app.config.get("relay_configured_servers", [])
+    else:
+        diagnostics["configured_upstream_servers"] = app.config.get("relay_configured_servers", [])
+
+    return jsonify(diagnostics)
 
 
 @app.route('/relay/api/v1/chat/completions', methods=['POST'])

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -794,8 +794,8 @@ def test_faucet_unknown_server(client):
     assert data['error'] == {'message': 'Server with the specified public key not found', 'code': 404}
 
 
-def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client):
-    """Diagnostics should expose configured URLs and live compute registrations."""
+def test_relay_diagnostics_distinguishes_legacy_upstreams_and_live_nodes(client, monkeypatch):
+    """Diagnostics should expose relay-only posture separately from live compute registrations."""
     app.config["relay_configured_servers"] = [
         "https://configured-one.example.com:8000",
         "https://configured-two.example.com:8000",
@@ -809,18 +809,23 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client):
         {"chat_history": "pending", "client_public_key": "c", "cipherkey": "k", "iv": "i"}
     ]
 
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+
     response = client.get("/relay/diagnostics")
     assert response.status_code == 200
     payload = response.get_json()
 
-    assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
+    assert payload["relay_only"] is True
+    assert payload["upstream_health_required"] is False
+    assert payload["legacy_configured_upstream_servers"] == app.config["relay_configured_servers"]
+    assert "configured_upstream_servers" not in payload
     assert payload["total_registered_compute_nodes"] == 1
     assert payload["registered_compute_nodes"][0]["server_public_key"] == DUMMY_SERVER_PUB_KEY
     assert payload["registered_compute_nodes"][0]["queue_depth"] == 1
 
 
-def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
-    """Healthz should separate configured upstream URLs from live registered nodes."""
+def test_healthz_reports_legacy_upstreams_and_live_queue_depth_in_relay_only_mode(client, monkeypatch):
+    """Healthz should expose relay-only posture while separating legacy upstream URLs from live nodes."""
     monkeypatch.setitem(app.config, "gpu_host", None)
     configured_servers = [
         "https://configured-one.example.com:8000",
@@ -842,11 +847,16 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
         }
     ]
 
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+
     response = client.get("/healthz")
     assert response.status_code == 200
     payload = response.get_json()
 
-    assert payload["configuredUpstreamServers"] == configured_servers
+    assert payload["relayOnly"] is True
+    assert payload["upstreamHealthRequired"] is False
+    assert payload["legacyConfiguredUpstreamServers"] == configured_servers
+    assert "configuredUpstreamServers" not in payload
     assert payload["registeredServers"][0]["server_public_key"] == live_server_key
     assert payload["registeredServers"][0]["age_seconds"] >= 0
     assert payload["registeredServers"][0]["queue_depth"] == 1
@@ -854,6 +864,30 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
         node["server_public_key"] for node in payload["registeredServers"]
     }
 
+
+
+
+def test_healthz_staging_relay_only_no_registered_servers_is_healthy(client, monkeypatch):
+    """Staging relay-only health should not imply required in-cluster upstream dependencies."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+    monkeypatch.setitem(app.config, "public_base_url", "https://staging.token.place")
+    monkeypatch.setitem(app.config, "upstream_url", "http://gpu-server:3000")
+    monkeypatch.setitem(app.config, "gpu_host", "gpu-server")
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+
+    response = client.get("/healthz")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["status"] == "ok"
+    assert payload["publicBaseUrl"] == "https://staging.token.place"
+    assert payload["knownServers"] == 0
+    assert payload["details"]["knownServers"] == "empty"
+    assert payload["relayOnly"] is True
+    assert payload["upstreamHealthRequired"] is False
+    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert "configuredUpstreamServers" not in payload
 
 def test_healthz_returns_draining_when_shutdown_flag_set(client):
     """healthz should switch to draining status and 503 during shutdown."""


### PR DESCRIPTION
### Motivation
- Staging relay-only deployments were reporting `configuredUpstreamServers` and `upstream` in a way that read like a hard dependency on production or an in-cluster GPU service.
- The intent is to make relay-only Sugarkube posture unambiguous when `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0` so `knownServers: 0` is not mistaken for degraded app health.

### Description
- `healthz` now exposes `relayOnly` and `upstreamHealthRequired` and only shows `configuredUpstreamServers` when upstream health is required; in relay-only mode the same list is surfaced as `legacyConfiguredUpstreamServers` to avoid implying a required upstream dependency.
- `/relay/diagnostics` mirrors the same semantics and fields as `healthz` using `relay_only`, `upstream_health_required`, `configured_upstream_servers` or `legacy_configured_upstream_servers` accordingly.
- Added unit tests in `tests/test_relay.py` to cover: relay-only diagnostics keys, relay-only `/healthz` with live nodes, and a staging-like case (`TOKENPLACE_RELAY_PUBLIC_URL=https://staging.token.place`, `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH=0`, no registered servers) ensuring 200 and non-misleading output.
- Updated `docs/relay_sugarkube_onboarding.md` to document that relay-only staging can be healthy with `knownServers: 0` and that relay-only Sugarkube does not require `TOKENPLACE_RELAY_UPSTREAM_URL` or an in-cluster GPU service for readiness.
- Before/after `/healthz` example (relay-only): before showed `configuredUpstreamServers` pointing at `https://token.place`; after shows `relayOnly: true`, `upstreamHealthRequired: false`, and `legacyConfiguredUpstreamServers` so staging does not look wired to production.

### Testing
- Ran `pytest tests/test_relay.py` (full file) and observed tests pass (all relevant relay tests passed).
- Ran `pytest tests/unit -k health` and observed the unit health tests passed (`5 passed` in the focused run).
- Ran `pre-commit run --all-files`; this reported failures in YAML template parsing under `charts/tokenplace/templates/*.yaml` which are pre-existing Helm/template issues unrelated to these changes (pre-commit run did not fail due to the modified Python/tests/docs files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c96bfa60832fba2f4e36b904a630)