### PR TITLE
docs: add v0.1.0 staging failure-mode and runbook guidance

### DIFF
--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -97,6 +97,11 @@ curl -fsS https://token.place/
 Optional note: true relay traffic validation requires a registered external compute node plus an
 E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
 
+> ⚠️ Production sign-off warning: `/livez`, `/healthz`, `/`, and `/metrics` are necessary but not
+> sufficient. Run the external compute-node validation checklist in
+> [`docs/relay_sugarkube_onboarding.md`](relay_sugarkube_onboarding.md#external-compute-node-validation-checklist-required-sign-off-gate)
+> before final `v0.1.0` production approval.
+
 If operators override hostname/routing, use the equivalent production host in the same checks.
 
 ## Rollback

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -94,6 +94,11 @@ curl -fsS https://staging.token.place/
 Optional note: true relay traffic validation requires a registered external compute node plus an
 E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
 
+> ⚠️ Sign-off warning: `/livez`, `/healthz`, `/`, and `/metrics` are necessary but not sufficient.
+> Run the external compute-node validation checklist in
+> [`docs/relay_sugarkube_onboarding.md`](relay_sugarkube_onboarding.md#external-compute-node-validation-checklist-required-sign-off-gate)
+> before promoting staging artifacts.
+
 If operators use a non-default staging hostname, apply the same checks with that host.
 
 ## Rollback

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -117,6 +117,93 @@ curl -fsS https://token.place/
 Optional note: true relay traffic validation requires a registered external compute node and an
 E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`).
 
+## v0.1.0 staging failure modes and fast triage runbook
+
+This section captures failures seen during `v0.1.0` staging so operators can quickly detect and
+correct them without changing launch identifiers away from `0.1.0`.
+
+### Critical distinction: image tag vs chart version vs Git tag
+
+- App image tag (example): `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Chart package version: `0.1.0`
+- Git tag: `v0.1.0`
+
+All three identifiers can drift independently; verify each explicitly before sign-off.
+
+### Failure modes observed in staging
+
+1. **Stale OCI chart `0.1.0` in GHCR**
+   - Symptom: rendered OCI manifest did not include `strategy.type: Recreate` while local chart did.
+   - Why it matters: relay is operationally stateful in-memory; non-`Recreate` rollout can overlap pods and lose/duplicate relay state transitions.
+2. **Pre-launch `0.1.0` chart delete/re-publish decision**
+   - Symptom: GHCR chart `0.1.0` existed but package contents were stale for launch requirements.
+   - Decision rule for pre-launch only: if `0.1.0` is stale before launch sign-off, delete stale package and re-publish corrected `0.1.0` so launch artifacts remain aligned at `0.1.0`.
+3. **Read-only root filesystem crash in relay container**
+   - Symptom: container CrashLoop when runtime attempted writes under default XDG paths on read-only root.
+   - Fix: redirect XDG write paths to writable tmpfs locations (`/tmp`).
+4. **Duplicate environment warnings**
+   - Symptom: Helm/Kubernetes warnings for duplicate env keys when both chart defaults and values overlays set the same variable.
+   - Fix: keep each env key defined once in final rendered manifest.
+5. **Desktop external compute-node long-poll timeout**
+   - Symptom: desktop compute node registration appears successful, but long-poll request/response path times out against staging.
+   - Fix approach: validate API v1 register/poll flow against live staging relay, then confirm queued client request is received and replied to by the external compute node.
+6. **Health checks green without true relay flow validation**
+   - Symptom: `/livez`, `/healthz`, `/`, and `/metrics` all green while end-to-end relay compute path is still broken.
+   - Required interpretation: these endpoints are necessary readiness checks, but they are not sufficient for production sign-off.
+
+### Fast verification commands (staging incident playbook)
+
+```bash
+# 1) Compare local chart render vs OCI chart render for the same values/tag.
+helm template tokenplace ./deploy/charts/tokenplace-relay \
+  --namespace tokenplace \
+  -f PATH/TO/tokenplace.values.dev.yaml \
+  -f PATH/TO/tokenplace.values.staging.yaml \
+  --set image.tag=v0.1.0 > /tmp/tokenplace-local-render.yaml
+
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace \
+  --version 0.1.0 \
+  --namespace tokenplace \
+  -f PATH/TO/tokenplace.values.dev.yaml \
+  -f PATH/TO/tokenplace.values.staging.yaml \
+  --set image.tag=v0.1.0 > /tmp/tokenplace-oci-render.yaml
+
+# 2) Confirm Recreate strategy exists in OCI render.
+rg -n "strategy:|type: Recreate" /tmp/tokenplace-oci-render.yaml
+
+# 3) Confirm XDG paths are redirected away from read-only root into /tmp.
+rg -n "XDG_CONFIG_HOME|XDG_CACHE_HOME|XDG_DATA_HOME|XDG_STATE_HOME|/tmp" /tmp/tokenplace-oci-render.yaml
+
+# 4) Detect duplicate env keys in rendered Deployment env block (should be empty output).
+python - <<'PY'
+from collections import Counter
+from pathlib import Path
+import re
+
+text = Path("/tmp/tokenplace-oci-render.yaml").read_text()
+env_lines = re.findall(r"^\s*- name:\s*([A-Z0-9_]+)\s*$", text, flags=re.M)
+dupes = [k for k, c in Counter(env_lines).items() if c > 1]
+print("\n".join(dupes))
+PY
+
+# 5) Confirm staging candidate image tag exists in GHCR (example v0.1.0).
+docker manifest inspect ghcr.io/futuroptimist/tokenplace-relay:v0.1.0 >/dev/null && echo "image tag exists"
+```
+
+### External compute-node validation checklist (required sign-off gate)
+
+Do not promote based only on relay self-health endpoints. For `v0.1.0`, sign-off requires all of:
+
+1. External compute node registers with staging relay.
+2. `/healthz` shows `knownServers` incremented from `0` to `>=1`.
+3. `/relay/diagnostics` includes the registered compute node identity/route metadata.
+4. Client request is accepted and queued on relay (API v1 path).
+5. External compute node receives queued request via long-poll.
+6. Client successfully retrieves encrypted response produced by the compute node.
+
+If any checklist step fails, do not sign off release readiness even when `/livez`, `/healthz`, `/`,
+and `/metrics` are green.
+
 ### Relay-only health output expectations (staging and production)
 
 For Sugarkube relay-only deployments, healthy relay readiness does **not** require


### PR DESCRIPTION
### Motivation

- Capture and document the failure modes discovered during the `v0.1.0` staging run so operators can triage quickly without changing launch identifiers. 
- Make explicit the distinction between app image tag, chart package version, and Git tag to avoid drift at release time. 
- Ensure operators understand that `/livez`, `/healthz`, `/`, and `/metrics` are necessary but not sufficient and require an external compute-node validation gate for true relay sign-off.

### Description

- Added a new “v0.1.0 staging failure modes and fast triage runbook” section to `docs/relay_sugarkube_onboarding.md` that documents the observed issues (stale OCI chart `0.1.0`, GHCR chart delete/re-publish guidance, read-only root/XDG crash, duplicate env warnings, desktop long-poll timeout, and health-check vs real-flow caveat). 
- Added practical verification commands for operators including `helm template` comparisons (local vs OCI), `rg` checks for `strategy.type: Recreate`, XDG env redirection checks, a small Python snippet to detect duplicate env keys in rendered manifests, and `docker manifest inspect` to confirm image tag existence. 
- Added an explicit external compute-node validation checklist (register -> `knownServers` increment -> `/relay/diagnostics` visibility -> queue/poll/response path) as a required sign-off gate for `v0.1.0`. 
- Touched only docs: `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md`, and kept all launch identifiers pinned to `0.1.0` / `v0.1.0`.

### Testing

- Searched for the new guidance keys with `rg -n "stale OCI|Recreate|XDG_CONFIG_HOME|read-only|duplicate env|long-poll|knownServers|relay/diagnostics|v0.1.0|0.1.0" docs README.md` which returned the new locations and related mentions (success). 
- Ran `pre-commit run --all-files` which executed multiple hooks successfully but failed on `check-yaml` due to pre-existing YAML parse issues in chart templates unrelated to this docs-only change (hooks other than `check-yaml` passed). 
- Committed the changes as `docs: add v0.1.0 staging failure-mode runbook` and generated PR metadata via the repo helper; this is a documentation-only change with no code/runtime modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e3b80c0c832fa8ec951f7dcc86a6)