### PR TITLE
docs: add v0.1.0 staging failure-mode and release runbook guidance

### DIFF
--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -96,6 +96,8 @@ curl -fsS https://token.place/
 
 Optional note: true relay traffic validation requires a registered external compute node plus an
 E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
+See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" and run
+the same external compute-node validation pattern against production hostnames before sign-off.
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -93,6 +93,10 @@ curl -fsS https://staging.token.place/
 
 Optional note: true relay traffic validation requires a registered external compute node plus an
 E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
+See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" for
+required checks covering stale OCI chart detection, Recreate strategy verification, XDG
+read-only-root safeguards, duplicate env detection, and external compute-node long-poll flow
+validation.
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -141,12 +141,12 @@ Verification commands:
 
 ```bash
 # Compare local chart metadata with OCI package metadata.
-helm show chart ./deploy/charts/tokenplace-relay
+helm show chart ./charts/tokenplace
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 
 # Render local and OCI manifests, then diff strategy/env sections.
-helm template tokenplace ./deploy/charts/tokenplace-relay --namespace tokenplace > /tmp/tokenplace-local.yaml
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace > /tmp/tokenplace-oci.yaml
+helm template tokenplace ./charts/tokenplace --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=main-REPLACE_SHORTSHA > /tmp/tokenplace-local.yaml
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=main-REPLACE_SHORTSHA > /tmp/tokenplace-oci.yaml
 diff -u /tmp/tokenplace-local.yaml /tmp/tokenplace-oci.yaml | less
 ```
 
@@ -180,12 +180,12 @@ Required fix:
 Verification commands:
 
 ```bash
-kubectl -n tokenplace get deploy tokenplace -o yaml | grep -n "XDG_CONFIG_HOME\\|XDG_CACHE_HOME\\|XDG_DATA_HOME" -A1 -B1
+kubectl -n tokenplace get deploy tokenplace -o yaml | grep -n "XDG_CONFIG_HOME\\|XDG_CACHE_HOME\\|XDG_DATA_HOME\\|XDG_STATE_HOME" -A1 -B1
 kubectl -n tokenplace logs deploy/tokenplace --tail=200
 ```
 
 Expected:
-- `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `XDG_DATA_HOME` are set under container env.
+- `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` are set under container env.
 - No read-only filesystem write failure appears in logs after rollout.
 
 ### 4) Duplicate environment variable rendering warnings
@@ -198,7 +198,22 @@ Verification commands:
 
 ```bash
 grep -n "name: TOKENPLACE_" -A1 /tmp/tokenplace-oci.yaml
-awk '/env:/{flag=1;next}/imagePullPolicy:/{flag=0}flag' /tmp/tokenplace-oci.yaml | grep "name:" | sort | uniq -d
+python - <<'PY'
+import sys, yaml
+from collections import Counter
+
+with open('/tmp/tokenplace-oci.yaml', 'r', encoding='utf-8') as f:
+    docs=[d for d in yaml.safe_load_all(f) if isinstance(d, dict)]
+
+for d in docs:
+    if d.get('kind') != 'Deployment':
+        continue
+    for c in d.get('spec', {}).get('template', {}).get('spec', {}).get('containers', []):
+        names=[e.get('name') for e in c.get('env', []) if isinstance(e, dict) and e.get('name')]
+        dupes=[k for k,v in Counter(names).items() if v>1]
+        if dupes:
+            print(f"{d.get('metadata', {}).get('name','<unknown>')}:{c.get('name','<unknown>')} duplicates: {', '.join(dupes)}")
+PY
 helm upgrade --install tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace --dry-run=client
 ```
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -117,6 +117,144 @@ curl -fsS https://token.place/
 Optional note: true relay traffic validation requires a registered external compute node and an
 E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`).
 
+## v0.1.0 staging failure modes and operator runbook
+
+The following failure modes were observed during v0.1.0 staging and should be treated as a
+pre-launch runbook for future operators.
+
+### 1) Stale OCI chart package (`0.1.0`) in GHCR
+
+Symptom:
+- Deployed manifests from OCI chart `0.1.0` do not include expected rollout safety defaults
+  (especially `strategy.type: Recreate`), even though local chart sources do.
+
+Why this matters:
+- For relay's in-memory queue/registration state, rollout behavior must stay single-pod-safe.
+- A stale chart can silently remove safety defaults and invalidate staging confidence.
+
+Decision rule for v0.1.0:
+- Because launch identifiers are intentionally pinned at `0.1.0`, pre-launch chart package
+  deletion/re-publish may be required when GHCR `0.1.0` content is stale or incorrect.
+- Keep this as a deliberate operator action with notes (who/when/why), not an automatic overwrite.
+
+Verification commands:
+
+```bash
+# Compare local chart metadata with OCI package metadata.
+helm show chart ./deploy/charts/tokenplace-relay
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+
+# Render local and OCI manifests, then diff strategy/env sections.
+helm template tokenplace ./deploy/charts/tokenplace-relay --namespace tokenplace > /tmp/tokenplace-local.yaml
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace > /tmp/tokenplace-oci.yaml
+diff -u /tmp/tokenplace-local.yaml /tmp/tokenplace-oci.yaml | less
+```
+
+### 2) Missing `Recreate` strategy in deployed chart output
+
+Symptom:
+- Deployment renders/rolls out without `spec.strategy.type: Recreate`.
+
+Verification commands:
+
+```bash
+grep -n "strategy:" -A4 /tmp/tokenplace-local.yaml
+grep -n "strategy:" -A4 /tmp/tokenplace-oci.yaml
+kubectl -n tokenplace get deploy tokenplace -o yaml | grep -n "strategy:" -A4
+```
+
+Expected:
+- Deployment strategy shows `type: Recreate`.
+
+### 3) Relay crash under read-only root filesystem (XDG paths)
+
+Symptom:
+- Relay container restarts/crashes when chart enforces read-only root filesystem.
+
+Cause:
+- Runtime attempted to write default XDG/config/cache data to unwritable filesystem locations.
+
+Required fix:
+- Redirect runtime write paths to `/tmp` using XDG env vars in the deployment.
+
+Verification commands:
+
+```bash
+kubectl -n tokenplace get deploy tokenplace -o yaml | grep -n "XDG_CONFIG_HOME\\|XDG_CACHE_HOME\\|XDG_DATA_HOME" -A1 -B1
+kubectl -n tokenplace logs deploy/tokenplace --tail=200
+```
+
+Expected:
+- `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `XDG_DATA_HOME` are set under container env.
+- No read-only filesystem write failure appears in logs after rollout.
+
+### 4) Duplicate environment variable rendering warnings
+
+Symptom:
+- Warnings/errors indicate duplicate env entries rendered from both chart defaults and values
+  overlays.
+
+Verification commands:
+
+```bash
+grep -n "name: TOKENPLACE_" -A1 /tmp/tokenplace-oci.yaml
+awk '/env:/{flag=1;next}/imagePullPolicy:/{flag=0}flag' /tmp/tokenplace-oci.yaml | grep "name:" | sort | uniq -d
+helm upgrade --install tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace --dry-run=client
+```
+
+Expected:
+- No duplicated env variable names in rendered manifest.
+- Dry-run output has no duplicate-env warnings.
+
+### 5) Desktop external compute node long-poll timeout (staging)
+
+Symptom:
+- Compute node fails or stalls during register/poll loop against `https://staging.token.place`.
+
+Verification focus:
+- Validate end-to-end register/poll/request/reply path with an actual external node, not relay
+  pod health alone.
+
+### 6) Health checks green before true relay flow validation
+
+Warning:
+- `/livez`, `/healthz`, `/`, and `/metrics` are necessary checks but **not sufficient** for
+  production sign-off.
+- Sign-off requires successful encrypted relay flow with a real external compute node.
+
+### Required external compute node validation checklist (sign-off gate)
+
+Run this in staging before production promotion:
+
+1. External compute node registers successfully to relay.
+2. Relay `/healthz` `knownServers` increments from `0` to `>=1`.
+3. `/relay/diagnostics` lists the registered compute node.
+4. Client encrypted request is accepted/queued by relay.
+5. Compute node receives and processes the queued request.
+6. Client retrieves encrypted response successfully.
+
+Example checks:
+
+```bash
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
+curl -fsS https://staging.token.place/metrics | head -n 40
+```
+
+### Image tag, chart version, and Git tag must be validated independently
+
+For v0.1.0 launch readiness, verify all three identifiers explicitly:
+
+- Git release tag: `v0.1.0`
+- Chart package version: `0.1.0` (with chart `appVersion: "0.1.0"`)
+- Relay image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+
+Example image-tag existence check:
+
+```bash
+docker manifest inspect ghcr.io/futuroptimist/tokenplace-relay:v0.1.0 >/dev/null
+```
+
 ### Relay-only health output expectations (staging and production)
 
 For Sugarkube relay-only deployments, healthy relay readiness does **not** require

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -145,8 +145,8 @@ helm show chart ./charts/tokenplace
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 
 # Render local and OCI manifests, then diff strategy/env sections.
-helm template tokenplace ./charts/tokenplace --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=main-REPLACE_SHORTSHA > /tmp/tokenplace-local.yaml
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=main-REPLACE_SHORTSHA > /tmp/tokenplace-oci.yaml
+helm template tokenplace ./charts/tokenplace --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-local.yaml
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-oci.yaml
 diff -u /tmp/tokenplace-local.yaml /tmp/tokenplace-oci.yaml | less
 ```
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -145,8 +145,12 @@ helm show chart ./charts/tokenplace
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 
 # Render local and OCI manifests, then diff strategy/env sections.
-helm template tokenplace ./charts/tokenplace --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-local.yaml
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-oci.yaml
+# For staging candidate validation, set this to the immutable image tag deployed by Sugarkube.
+IMAGE_TAG=main-REPLACE_SHORTSHA
+
+
+helm template tokenplace ./charts/tokenplace --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag="$IMAGE_TAG" > /tmp/tokenplace-local.yaml
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml --set image.tag="$IMAGE_TAG" > /tmp/tokenplace-oci.yaml
 diff -u /tmp/tokenplace-local.yaml /tmp/tokenplace-oci.yaml | less
 ```
 
@@ -258,15 +262,21 @@ curl -fsS https://staging.token.place/metrics | head -n 40
 
 ### Image tag, chart version, and Git tag must be validated independently
 
-For v0.1.0 launch readiness, verify all three identifiers explicitly:
+For final v0.1.0 release readiness, verify all four identifiers explicitly (separate from staging candidate validation):
 
 - Git release tag: `v0.1.0`
 - Chart package version: `0.1.0` (with chart `appVersion: "0.1.0"`)
+- Chart appVersion: `"0.1.0"`
 - Relay image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 
-Example image-tag existence check:
+Example image-tag existence checks:
 
 ```bash
+# Staging candidate validation (use the same candidate tag as IMAGE_TAG above).
+IMAGE_TAG=main-REPLACE_SHORTSHA
+docker manifest inspect "ghcr.io/futuroptimist/tokenplace-relay:${IMAGE_TAG}" >/dev/null
+
+# Final release-tag validation.
 docker manifest inspect ghcr.io/futuroptimist/tokenplace-relay:v0.1.0 >/dev/null
 ```
 


### PR DESCRIPTION
### Motivation
- Staging uncovered several v0.1.0-specific failure modes (stale OCI chart, missing `Recreate` strategy, read-only-root crashes, duplicate env rendering, desktop long-poll timeouts, and misleading health checks) that can cause false-positive readiness during pre-launch validation. 
- Operators need a concise runbook to detect these issues and a required external compute-node validation gate before promoting staging to production. 

### Description
- Added a new `v0.1.0 staging failure modes and operator runbook` section to `docs/relay_sugarkube_onboarding.md` that documents the observed failure modes, decision guidance for pre-launch OCI chart re-publish, and practical verification commands (local vs OCI render diff, `Recreate` strategy checks, XDG env checks, duplicate env detection, image tag existence). 
- Cross-referenced the new runbook from `docs/k3s-sugarkube-staging.md` and `docs/k3s-sugarkube-prod.md` so staging and prod validation steps point operators to the same sign-off checklist. 
- Kept all identifiers pinned to `v0.1.0` and included an explicit checklist that requires an external compute node to register and complete end-to-end encrypted request/response flows (including `/healthz` `knownServers`, `/relay/diagnostics`, queue/poll/response validation). 

### Testing
- Ran a targeted grep to verify the new text is discoverable: `rg -n "stale OCI|Recreate|XDG_CONFIG_HOME|read-only|duplicate env|long-poll|knownServers|relay/diagnostics|v0.1.0|0.1.0" docs README.md` which found the new guidance (exit: success). 
- Ran `pre-commit run --all-files`, which returned a failure from the existing `check-yaml` hook due to pre-existing YAML parse issues in `charts/tokenplace/templates/*.yaml`; this is unrelated to the docs-only changes and did not block this docs patch. 
- No code or runtime changes were made; the PR is documentation-only and includes explicit verification commands operators can run manually (for example `helm show chart`, `helm template`, `diff -u`, `grep` checks, and `docker manifest inspect`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e3b80c0c832fa8ec951f7dcc86a6)