### PR TITLE
docs: add v0.1.0 staging failure-mode and release runbook guidance

### DIFF
--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -99,6 +99,21 @@ E2EE client-flow probe; health/root checks alone do not prove register/poll/requ
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 
+## Required v0.1.0 failure-mode runbook checks
+
+Before production promotion/sign-off, execute the v0.1.0 troubleshooting runbook in
+[`relay_sugarkube_onboarding.md`](./relay_sugarkube_onboarding.md#v010-staging-failure-modes-and-fast-triage-runbook),
+especially:
+
+- OCI chart `0.1.0` drift detection (local vs GHCR render),
+- explicit `strategy.type: Recreate` confirmation,
+- read-only root XDG env checks (`XDG_*` redirected to `/tmp`),
+- duplicate env warning prevention,
+- release image tag availability validation,
+- external compute-node register/poll/queue/retrieve encrypted-response validation.
+
+Warning: `/livez`, `/healthz`, `/`, and `/metrics` alone do not prove end-to-end relay readiness.
+
 ## Rollback
 
 - Record baseline revision: `helm history tokenplace -n tokenplace`

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -96,6 +96,21 @@ E2EE client-flow probe; health/root checks alone do not prove register/poll/requ
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 
+## Required v0.1.0 failure-mode runbook checks
+
+Before declaring staging ready, run the v0.1.0 troubleshooting checks in
+[`relay_sugarkube_onboarding.md`](./relay_sugarkube_onboarding.md#v010-staging-failure-modes-and-fast-triage-runbook),
+including:
+
+- stale OCI `0.1.0` chart detection vs local render,
+- `strategy.type: Recreate` verification,
+- XDG `/tmp` env verification for read-only root operation,
+- duplicate env detection in rendered manifests,
+- staging image tag existence check,
+- external compute-node long-poll + queue/retrieve flow validation.
+
+Warning: `/livez`, `/healthz`, `/`, and `/metrics` are necessary but not sufficient for sign-off.
+
 ## Rollback
 
 - Record baseline revision: `helm history tokenplace -n tokenplace`

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -117,6 +117,104 @@ curl -fsS https://token.place/
 Optional note: true relay traffic validation requires a registered external compute node and an
 E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`).
 
+## v0.1.0 staging failure modes and fast triage runbook
+
+The v0.1.0 staging incident exposed six recurring operator failure modes. Treat this section as
+required pre-release triage for both staging and production promotion.
+
+### 1) Stale OCI chart `0.1.0` (missing `strategy.type: Recreate`)
+
+Symptom: rendered manifests from GHCR chart `0.1.0` do not include `strategy.type: Recreate`
+even though local chart files do.
+
+```bash
+# Local chart render (token.place repo)
+helm template tokenplace ./deploy/charts/tokenplace-relay -f docs/examples/tokenplace.values.dev.yaml > /tmp/tokenplace-local-render.yaml
+grep -n "strategy:" -A4 /tmp/tokenplace-local-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-local-render.yaml
+
+# OCI chart render (published package)
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 -f docs/examples/tokenplace.values.dev.yaml > /tmp/tokenplace-oci-render.yaml
+grep -n "strategy:" -A4 /tmp/tokenplace-oci-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-oci-render.yaml
+```
+
+If local and OCI renders diverge, stop rollout.
+
+### 2) GHCR package delete/re-publish decision for pre-launch `0.1.0`
+
+Before public launch, if `0.1.0` in GHCR is stale and operators must keep all launch identifiers
+at `0.1.0`, the fix is to delete the bad `0.1.0` chart package and re-publish corrected `0.1.0`.
+Do **not** imply `0.1.1` is required for this pre-launch correction.
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+Keep identifiers aligned: Git tag `v0.1.0`, chart package version `0.1.0`, chart
+`appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
+
+### 3) Relay crash with read-only root filesystem (XDG paths)
+
+Symptom: relay container exits on startup when runtime/user cache/config paths point to
+unwritable root locations.
+
+Required mitigation: redirect XDG/runtime temp paths to `/tmp`.
+
+```bash
+# Render-time verification
+grep -n "XDG_CONFIG_HOME\\|XDG_CACHE_HOME\\|XDG_DATA_HOME\\|XDG_STATE_HOME\\|XDG_RUNTIME_DIR" /tmp/tokenplace-oci-render.yaml
+
+# Runtime verification (cluster)
+kubectl -n tokenplace exec deploy/tokenplace -- env | grep -E '^XDG_(CONFIG_HOME|CACHE_HOME|DATA_HOME|STATE_HOME|RUNTIME_DIR)='
+```
+
+### 4) Duplicate env warnings (chart + values overlap)
+
+Symptom: deployment warnings about duplicate environment variable keys due to values overlays
+redeclaring env vars already emitted by chart defaults.
+
+```bash
+# Render and inspect env block
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 -f PATH/TO/tokenplace.values.dev.yaml -f PATH/TO/tokenplace.values.staging.yaml > /tmp/tokenplace-staging-render.yaml
+awk '/env:/,/imagePullPolicy:/' /tmp/tokenplace-staging-render.yaml
+```
+
+Expected: one declaration per env key. Remove duplicates from values overlays instead of patching
+around warnings.
+
+### 5) Desktop compute node long-poll timeout against staging
+
+Symptom: external desktop compute node can register, then poll times out or loops without
+delivering queued relay work.
+
+Verify staging image/tag and relay poll behavior before release sign-off:
+
+```bash
+# Verify intended image tag exists before deploy/promotion
+docker manifest inspect ghcr.io/futuroptimist/tokenplace-relay:v0.1.0 >/dev/null
+
+# Verify active cluster image
+kubectl -n tokenplace get deploy tokenplace -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+If long-poll still times out, block release until external compute-node poll/queue/retrieve flow
+passes end-to-end.
+
+### 6) Green health endpoints before real relay path validation
+
+`/livez`, `/healthz`, `/`, and `/metrics` are necessary baseline checks but are **not sufficient**
+for production sign-off. They validate relay process health, not full distributed relay inference.
+
+Required external compute-node validation checklist:
+
+- [ ] Compute node registers with relay.
+- [ ] `/healthz` `knownServers` increments from `0` to `>=1`.
+- [ ] `/relay/diagnostics` shows the registered node.
+- [ ] Client request is accepted and queued at relay.
+- [ ] External compute node receives that request via poll.
+- [ ] Client retrieves encrypted response successfully.
+
 ### Relay-only health output expectations (staging and production)
 
 For Sugarkube relay-only deployments, healthy relay readiness does **not** require


### PR DESCRIPTION
### Motivation
- Capture the v0.1.0 staging failure modes observed during validation so operators can triage and avoid regressions. 
- Make clear that process-level health checks are necessary but not sufficient and require an external compute node for end-to-end relay validation. 
- Preserve launch identifier alignment at `0.1.0` and provide a safe pre-publish decision path when the GHCR chart package is stale.

### Description
- Add a new `v0.1.0 staging failure modes and fast triage runbook` section to `docs/relay_sugarkube_onboarding.md` containing six failure-mode descriptions and concrete commands to reproduce/verify each issue. 
- Link and require the runbook checks from both `docs/k3s-sugarkube-staging.md` and `docs/k3s-sugarkube-prod.md` so staging and promotion flows include the checklist. 
- Provide practical verification commands for: local chart render vs OCI chart render, confirming `strategy.type: Recreate`, checking XDG env vars for read-only root operation, detecting duplicate env declarations, and validating staging/release image tag existence. 
- Capture the staging failure-mode list explicitly: stale OCI chart `0.1.0` missing `strategy.type: Recreate`, GHCR package delete/re-publish decision while keeping `0.1.0`, relay crash under read-only root until XDG paths redirected to `/tmp`, duplicate env warnings from chart+values overlap, desktop compute-node long-poll timeout, and health endpoints green before real relay path validation.

### Testing
- Ran `rg -n "stale OCI|Recreate|XDG_CONFIG_HOME|read-only|duplicate env|long-poll|knownServers|relay/diagnostics|v0.1.0|0.1.0" docs README.md` to verify inserted references and it returned matches in the updated docs. 
- Ran `pre-commit run --all-files`; doc-related hooks such as `codespell`, `vulture`, and `bandit` passed, but `check-yaml` failed due to pre-existing YAML parsing issues in `charts/tokenplace/templates/*.yaml` which are unrelated to these documentation-only changes. 
- Committed the docs-only changes and created the PR; no runtime/application code was modified and all runbook commands are included verbatim for operator verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e3b80c0c832fa8ec951f7dcc86a6)