### PR TITLE
Exempt operational and relay control-plane routes from global API rate limits

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -15,6 +15,20 @@ from api.v2 import routes as v2_routes
 
 RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
 
+RATE_LIMIT_EXEMPT_PATHS = frozenset(
+    {
+        "/livez",
+        "/healthz",
+        "/metrics",
+        "/relay/diagnostics",
+        "/api/v1/relay/servers/register",
+        "/api/v1/relay/servers/poll",
+        "/api/v1/relay/servers/next",
+        "/api/v1/relay/responses",
+        "/api/v1/relay/responses/retrieve",
+    }
+)
+
 
 def _resolve_rate_limit_storage_uri() -> str | None:
     raw_value = os.environ.get(RATE_LIMIT_STORAGE_URI_ENV, "")
@@ -66,6 +80,10 @@ def init_app(app):
         app=app,
         **limiter_kwargs,
     )
+
+    @limiter.request_filter
+    def _exempt_operational_and_relay_control_plane_routes() -> bool:
+        return request.path.rstrip("/") in RATE_LIMIT_EXEMPT_PATHS
 
     @app.errorhandler(RateLimitExceeded)
     def _handle_rate_limit(exc: RateLimitExceeded):

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -234,7 +234,32 @@ Verification focus:
 - Validate end-to-end register/poll/request/reply path with an actual external node, not relay
   pod health alone.
 
-### 6) Health checks green before true relay flow validation
+### 6) Readiness probe exhausted public API rate limit
+
+Symptom:
+- Kubernetes readiness probes receive `429` from `/healthz`, causing the pod to become unready
+  and public health checks to return `503`.
+
+Cause:
+- A 10-second kube-probe cadence sends 360 `/healthz` requests per hour. The staging default
+  public API quota (`API_RATE_LIMIT=60/hour`) previously counted `/healthz`, so probes could
+  consume the public API quota even while the relay process was healthy.
+
+Expected behavior:
+- Operational endpoints (`/livez`, `/healthz`, `/metrics`, and `/relay/diagnostics`) and API v1
+  relay compute-node heartbeat/control-plane routes are exempt from the public user API quota.
+- Public chat/completions routes remain rate-limited and continue returning OpenAI-style rate-limit
+  errors for user traffic.
+
+Verification commands:
+
+```bash
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/metrics | head -n 20
+```
+
+### 7) Health checks green before true relay flow validation
 
 Warning:
 - `/livez`, `/healthz`, `/`, and `/metrics` are necessary checks but **not sufficient** for

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,28 @@ def _encrypt_messages_for_server(messages, server_public_key):
         'iv': base64.b64encode(iv).decode('utf-8'),
     }
 
+
+def test_api_public_chat_completion_rate_limit_regression(monkeypatch):
+    """Public chat completions should remain covered by the global API quota."""
+    from flask import Flask
+
+    from api import init_app
+
+    monkeypatch.setenv("API_RATE_LIMIT", "1/minute")
+    monkeypatch.delenv("API_DAILY_QUOTA", raising=False)
+    test_app = Flask(__name__)
+    init_app(test_app)
+
+    with test_app.test_client() as isolated_client:
+        first_response = isolated_client.post("/api/v1/chat/completions", json={})
+        limited_response = isolated_client.post("/api/v1/chat/completions", json={})
+
+    assert first_response.status_code != 429
+    assert limited_response.status_code == 429
+    payload = limited_response.get_json()
+    assert payload["error"]["code"] == "rate_limit_exceeded"
+
+
 def test_api_health(client):
     """Test the API health endpoint"""
     response = client.get("/api/v1/health")

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -794,6 +794,42 @@ def test_faucet_unknown_server(client):
     assert data['error'] == {'message': 'Server with the specified public key not found', 'code': 404}
 
 
+def test_healthz_ignores_public_api_rate_limit_under_probe_burst(client):
+    """Readiness probes should not be blocked by the global public API quota."""
+    responses = [
+        client.get("/healthz", headers={"User-Agent": "kube-probe/1.29"})
+        for _ in range(120)
+    ]
+
+    assert all(response.status_code != 429 for response in responses)
+    assert responses[-1].status_code in {200, 503}
+
+
+def test_relay_operational_diagnostics_ignore_public_api_rate_limit(client):
+    """Relay diagnostics should stay available during public API quota pressure."""
+    responses = [client.get("/relay/diagnostics") for _ in range(75)]
+
+    assert all(response.status_code == 200 for response in responses)
+
+
+def test_api_v1_register_and_poll_ignore_public_api_rate_limit(client, monkeypatch):
+    """Compute-node heartbeat routes should not inherit the public 60/hour quota."""
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0")
+    server_payload = {"server_public_key": DUMMY_SERVER_PUB_KEY}
+
+    register_responses = [
+        client.post("/api/v1/relay/servers/register", json=server_payload)
+        for _ in range(75)
+    ]
+    poll_responses = [
+        client.post("/api/v1/relay/servers/poll", json=server_payload)
+        for _ in range(75)
+    ]
+
+    assert all(response.status_code == 200 for response in register_responses)
+    assert all(response.status_code == 200 for response in poll_responses)
+
+
 def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monkeypatch):
     """Diagnostics should expose configured URLs and live compute registrations."""
     monkeypatch.delenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", raising=False)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -127,3 +127,104 @@ def test_production_with_rate_limit_storage_uri_uses_explicit_backend():
 
     assert limiter is limiter_instance
     assert limiter_cls.call_args.kwargs["storage_uri"] == "memcached://127.0.0.1:11211"
+
+
+def _make_rate_limited_app_with_operational_routes():
+    app = Flask(__name__)
+    init_app(app)
+
+    app.add_url_rule("/healthz", "healthz", lambda: {"status": "ok"})
+    app.add_url_rule("/livez", "livez", lambda: {"status": "alive"})
+    app.add_url_rule(
+        "/relay/diagnostics",
+        "relay_diagnostics",
+        lambda: {"status": "ok"},
+    )
+    app.add_url_rule(
+        "/api/v1/relay/servers/register",
+        "api_v1_relay_servers_register",
+        lambda: {"registered": True},
+        methods=["POST"],
+    )
+    app.add_url_rule(
+        "/api/v1/relay/servers/poll",
+        "api_v1_relay_servers_poll",
+        lambda: {"message": "No requests available"},
+        methods=["POST"],
+    )
+    return app
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "60/hour"}, clear=True)
+def test_healthz_exempt_from_staging_default_rate_limit_after_many_calls():
+    """Staging default 60/hour must not exhaust Kubernetes readiness checks."""
+    app = _make_rate_limited_app_with_operational_routes()
+
+    with app.test_client() as client:
+        responses = [client.get("/healthz") for _ in range(120)]
+
+    assert all(response.status_code == 200 for response in responses)
+    assert not any(response.status_code == 429 for response in responses)
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "60/hour"}, clear=True)
+def test_kubernetes_probe_cadence_cannot_exhaust_healthz_quota():
+    """A 10s kube-probe cadence produces 360 hits/hour and should remain ready."""
+    app = _make_rate_limited_app_with_operational_routes()
+
+    with app.test_client() as client:
+        for _ in range(360):
+            response = client.get(
+                "/healthz",
+                headers={"User-Agent": "kube-probe/1.29", "Accept": "*/*"},
+            )
+            assert response.status_code == 200
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "60/hour"}, clear=True)
+def test_operational_routes_are_exempt_from_public_api_quota():
+    """Liveness, metrics, and relay diagnostics should not consume public API quota."""
+    app = _make_rate_limited_app_with_operational_routes()
+
+    with app.test_client() as client:
+        for path in ("/livez", "/metrics", "/relay/diagnostics"):
+            responses = [client.get(path) for _ in range(75)]
+            assert all(response.status_code != 429 for response in responses), path
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "1/minute"}, clear=True)
+def test_public_chat_completion_route_still_uses_default_rate_limit():
+    """Public chat completions should keep OpenAI-style rate limiting."""
+    app = _make_rate_limited_app_with_operational_routes()
+
+    with app.test_client() as client:
+        first_response = client.post("/api/v1/chat/completions", json={})
+        limited_response = client.post("/api/v1/chat/completions", json={})
+
+    assert first_response.status_code != 429
+    assert limited_response.status_code == 429
+    payload = limited_response.get_json()
+    assert payload["error"]["code"] == "rate_limit_exceeded"
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "60/hour"}, clear=True)
+def test_api_v1_compute_node_register_and_poll_exempt_from_public_quota():
+    """Compute-node heartbeat control-plane routes must not inherit 60/hour."""
+    app = _make_rate_limited_app_with_operational_routes()
+
+    with app.test_client() as client:
+        register_responses = [
+            client.post(
+                "/api/v1/relay/servers/register", json={"server_public_key": "node"}
+            )
+            for _ in range(75)
+        ]
+        poll_responses = [
+            client.post(
+                "/api/v1/relay/servers/poll", json={"server_public_key": "node"}
+            )
+            for _ in range(75)
+        ]
+
+    assert all(response.status_code == 200 for response in register_responses)
+    assert all(response.status_code == 200 for response in poll_responses)


### PR DESCRIPTION
### Motivation

- Staging readiness probes (kube-probe every 10s) could exhaust the default public API quota (`API_RATE_LIMIT=60/hour`), causing `/healthz` to return `429` and pods to become unready (public checks then saw `503`).
- Operational endpoints and API v1 compute-node heartbeat/control-plane routes must not consume the global public user quota to avoid this production-blocking readiness failure.

### Description

- Add a centralized exemption set `RATE_LIMIT_EXEMPT_PATHS` and a Flask-Limiter `@limiter.request_filter` to skip rate limiting for operational endpoints and API v1 relay control-plane routes (implemented in `api/__init__.py`).
- Add regression tests that assert `/livez`, `/healthz`, `/metrics`, and `/relay/diagnostics` are never blocked by the public quota, that kube-probe-like cadences cannot exhaust `/healthz`, that API v1 server `register`/`poll` do not inherit the public quota, and that public chat/completions remain rate-limited (tests added/updated under `tests/unit/test_rate_limit.py`, `tests/test_relay.py`, and `tests/test_api.py`).
- Document the staging incident symptom and before/after behavior in `docs/relay_sugarkube_onboarding.md`.

### Testing

- Ran `pytest tests/unit/test_rate_limit.py` and it passed (targeted rate-limit regression coverage executed successfully). 
- Ran `pytest tests/test_relay.py -k "health or relay"` and the relay health/diagnostics/relay-control tests passed. 
- Ran `pytest tests/test_api.py -k rate` and the public chat completion rate-limit regression passed. 
- Ran combined `python -m pytest tests/unit/test_rate_limit.py tests/test_relay.py` and the targeted suites passed. 
- Ran `pre-commit run --all-files` which completed hooks but failed the YAML checks due to pre-existing Helm template YAML (Chart templates contain Go template markers that the generic YAML validator flags), which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1876c37538832faa4b75020e8fa434)