### PR TITLE
Exempt operational and relay heartbeat endpoints from API rate limits

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -15,6 +15,26 @@ from api.v2 import routes as v2_routes
 
 RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
 
+_RATE_LIMIT_EXEMPT_PATHS = frozenset(
+    {
+        "/livez",
+        "/healthz",
+        "/metrics",
+        "/relay/diagnostics",
+        "/api/v1/relay/servers/register",
+        "/api/v1/relay/servers/poll",
+        "/api/v1/relay/servers/next",
+        "/api/v1/relay/responses",
+        "/api/v1/relay/responses/retrieve",
+    }
+)
+
+
+def _is_rate_limit_exempt_path() -> bool:
+    """Return True for operational and relay control-plane routes."""
+
+    return request.path.rstrip("/") in _RATE_LIMIT_EXEMPT_PATHS
+
 
 def _resolve_rate_limit_storage_uri() -> str | None:
     raw_value = os.environ.get(RATE_LIMIT_STORAGE_URI_ENV, "")
@@ -66,6 +86,7 @@ def init_app(app):
         app=app,
         **limiter_kwargs,
     )
+    limiter.request_filter(_is_rate_limit_exempt_path)
 
     @app.errorhandler(RateLimitExceeded)
     def _handle_rate_limit(exc: RateLimitExceeded):

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -237,8 +237,13 @@ Verification focus:
 ### 6) Health checks green before true relay flow validation
 
 Warning:
-- `/livez`, `/healthz`, `/`, and `/metrics` are necessary checks but **not sufficient** for
-  production sign-off.
+- `/livez`, `/healthz`, `/`, `/metrics`, and `/relay/diagnostics` are necessary checks but
+  **not sufficient** for production sign-off. These operational routes are exempt from the
+  public API quota so Kubernetes probes, such as `/healthz` every 10 seconds, do not exhaust
+  the default `60/hour` API rate limit and make an otherwise running pod unready.
+- API v1 relay compute-node heartbeat routes (`/api/v1/relay/servers/register` and
+  `/api/v1/relay/servers/poll`) are also exempt from the public user API quota; public
+  chat/completion endpoints remain rate limited.
 - Sign-off requires successful encrypted relay flow with a real external compute node.
 
 ### Required external compute node validation checklist (sign-off gate)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2082,3 +2082,59 @@ def test_api_v1_next_keeps_server_alive_while_any_in_flight_request_remains(clie
     next_response = client.get('/api/v1/relay/servers/next')
     assert next_response.status_code == 200
     assert next_response.get_json().get('server_public_key') == DUMMY_SERVER_PUB_KEY
+
+
+def test_healthz_rate_limit_exempt_for_kubernetes_probe_cadence(client):
+    """Kubernetes readiness probes should not exhaust the public API quota."""
+
+    responses = [
+        client.get(
+            "/healthz",
+            headers={"User-Agent": "kube-probe/1.30"},
+            environ_base={"REMOTE_ADDR": "10.42.2.1"},
+        )
+        for _ in range(65)
+    ]
+
+    assert all(response.status_code != 429 for response in responses)
+    assert responses[-1].status_code == 200
+
+
+def test_livez_metrics_and_diagnostics_rate_limit_exempt(client):
+    """Operational health, metrics, and diagnostics routes should bypass API quotas."""
+
+    for path in ("/livez", "/metrics", "/relay/diagnostics"):
+        responses = [
+            client.get(path, environ_base={"REMOTE_ADDR": "10.42.2.1"})
+            for _ in range(65)
+        ]
+        assert all(response.status_code != 429 for response in responses), path
+
+
+def test_api_v1_server_register_and_poll_rate_limit_exempt(client, monkeypatch):
+    """Compute-node heartbeat routes should not inherit the public 60/hour quota."""
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0")
+    payload = {"server_public_key": DUMMY_SERVER_PUB_KEY}
+
+    register_responses = [
+        client.post(
+            "/api/v1/relay/servers/register",
+            json=payload,
+            environ_base={"REMOTE_ADDR": "10.42.2.1"},
+        )
+        for _ in range(65)
+    ]
+    poll_responses = [
+        client.post(
+            "/api/v1/relay/servers/poll",
+            json=payload,
+            environ_base={"REMOTE_ADDR": "10.42.2.1"},
+        )
+        for _ in range(65)
+    ]
+
+    assert all(response.status_code != 429 for response in register_responses)
+    assert all(response.status_code != 429 for response in poll_responses)
+    assert register_responses[-1].status_code == 200
+    assert poll_responses[-1].status_code == 200

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -127,3 +127,103 @@ def test_production_with_rate_limit_storage_uri_uses_explicit_backend():
 
     assert limiter is limiter_instance
     assert limiter_cls.call_args.kwargs["storage_uri"] == "memcached://127.0.0.1:11211"
+
+
+@patch.dict(
+    os.environ,
+    {"API_RATE_LIMIT": "60/hour", "API_DAILY_QUOTA": "10000/day"},
+    clear=True,
+)
+def test_operational_endpoints_are_exempt_from_staging_default_rate_limit():
+    """Staging health, metrics, and diagnostics routes must not consume API quota."""
+
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.get("/healthz")
+    def healthz():
+        return {"status": "ok"}
+
+    @app.get("/livez")
+    def livez():
+        return {"status": "alive"}
+
+    @app.get("/relay/diagnostics")
+    def relay_diagnostics():
+        return {"registered_compute_nodes": []}
+
+    with app.test_client() as client:
+        for path in ("/healthz", "/livez", "/metrics", "/relay/diagnostics"):
+            responses = [client.get(path) for _ in range(65)]
+            assert all(response.status_code != 429 for response in responses), path
+
+
+@patch.dict(
+    os.environ,
+    {"API_RATE_LIMIT": "60/hour", "API_DAILY_QUOTA": "10000/day"},
+    clear=True,
+)
+def test_public_chat_completion_route_still_uses_staging_default_rate_limit():
+    """Public API traffic should still receive OpenAI-style 429s after quota exhaustion."""
+
+    app = Flask(__name__)
+    init_app(app)
+    payload = {}
+
+    with app.test_client() as client:
+        for _ in range(60):
+            response = client.post("/api/v1/chat/completions", json=payload)
+            assert response.status_code != 429
+        limited_response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert limited_response.status_code == 429
+    body = limited_response.get_json()
+    assert body is not None
+    assert body["error"]["code"] == "rate_limit_exceeded"
+
+
+@patch.dict(
+    os.environ,
+    {"API_RATE_LIMIT": "60/hour", "API_DAILY_QUOTA": "10000/day"},
+    clear=True,
+)
+def test_api_v1_relay_control_plane_routes_are_exempt_from_public_api_quota():
+    """Compute-node heartbeat/control-plane routes should not inherit public user limits."""
+
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/servers/register")
+    def register():
+        return {"next_ping_in_x_seconds": 10}
+
+    @app.post("/api/v1/relay/servers/poll")
+    def poll():
+        return {"message": "No requests available"}
+
+    @app.get("/api/v1/relay/servers/next")
+    def next_server():
+        return {"server_public_key": "test"}
+
+    @app.post("/api/v1/relay/responses")
+    def responses():
+        return {"message": "Response received and queued for client"}
+
+    @app.post("/api/v1/relay/responses/retrieve")
+    def responses_retrieve():
+        return {"status": "pending"}, 202
+
+    with app.test_client() as client:
+        route_calls = (
+            ("post", "/api/v1/relay/servers/register"),
+            ("post", "/api/v1/relay/servers/poll"),
+            ("get", "/api/v1/relay/servers/next"),
+            ("post", "/api/v1/relay/responses"),
+            ("post", "/api/v1/relay/responses/retrieve"),
+        )
+        for method, path in route_calls:
+            responses = [
+                getattr(client, method)(path, json={})
+                for _ in range(65)
+            ]
+            assert all(response.status_code != 429 for response in responses), path


### PR DESCRIPTION
### Motivation

- Staging was blocked when Kubernetes readiness probes hit `/healthz` every 10s and exhausted the default `API_RATE_LIMIT=60/hour`, causing Flask-Limiter to return `429` and pods to become unready (public health checks saw `503`).

### Description

- Added a centralized Flask-Limiter request filter in `api/__init__.py` that exempts operational endpoints and relay control-plane paths from the public API quota: `/livez`, `/healthz`, `/metrics`, `/relay/diagnostics`, and API v1 relay routes (`/api/v1/relay/servers/register`, `/api/v1/relay/servers/poll`, `/api/v1/relay/servers/next`, `/api/v1/relay/responses`, `/api/v1/relay/responses/retrieve`).
- Preserved OpenAI-style rate-limit error responses and existing public user rate limits for chat/completions routes (`/api/v1/chat/completions`, v2 chat routes, streaming limits, etc.).
- Added regression tests to prove the fix: unit tests in `tests/unit/test_rate_limit.py` (staging-default `60/hour` behavior, operational route exemption, public chat route still rate-limited, relay control-plane exemption) and relay integration-like tests in `tests/test_relay.py` (Kubernetes-like probe cadence exempt, `/livez`/`/metrics`/`/relay/diagnostics` exempt, and compute-node register/poll exempt).
- Documented the incident and the exemption behavior in `docs/relay_sugarkube_onboarding.md`.

### Testing

- Ran `pytest tests/unit/test_rate_limit.py` and the new/updated unit tests passed (all tests in that file succeeded).
- Ran `pytest tests/test_relay.py -k "health or relay"` and the relay tests exercising health/diagnostics/register/poll behavior passed.
- Ran `pytest tests/test_api.py -k rate` and the selected API rate-related test passed.
- Ran `python -m pytest tests/unit/test_rate_limit.py tests/test_relay.py` and the combined run passed (all included tests passed).
- Ran `pre-commit run --all-files`; hooks executed but the repo contains pre-existing Helm template YAML files that trigger `check-yaml` failures (`charts/tokenplace/templates/{serviceaccount,deployment,ingress,service}.yaml`) because Helm templates are not valid standalone YAML for that hook; this is an unrelated pre-existing failure and does not affect the rate-limit logic or tests.

Residual notes: this change only exempts the listed operational and API v1 relay control-plane routes from the global public quota; public-facing chat/completion routes remain rate-limited. Follow-ups may include adding storage-backed rate-limit backend for production and auditing any additional operational endpoints that should be exempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1876c37538832faa4b75020e8fa434)