### PR TITLE
Exempt operational and relay heartbeat endpoints from global API rate limits

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -15,11 +15,31 @@ from api.v2 import routes as v2_routes
 
 RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
 
+PUBLIC_API_RATE_LIMIT_EXEMPT_PATHS = frozenset(
+    {
+        "/livez",
+        "/healthz",
+        "/metrics",
+        "/relay/diagnostics",
+        "/api/v1/relay/servers/register",
+        "/api/v1/relay/servers/poll",
+        "/api/v1/relay/servers/next",
+        "/api/v1/relay/responses",
+        "/api/v1/relay/responses/retrieve",
+    }
+)
+
 
 def _resolve_rate_limit_storage_uri() -> str | None:
     raw_value = os.environ.get(RATE_LIMIT_STORAGE_URI_ENV, "")
     storage_uri = raw_value.strip()
     return storage_uri or None
+
+
+def _is_public_api_rate_limit_exempt() -> bool:
+    """Return True when a route should not consume public API quota."""
+
+    return request.path.rstrip("/") in PUBLIC_API_RATE_LIMIT_EXEMPT_PATHS
 
 
 def _build_rate_limit_response(exc: RateLimitExceeded):
@@ -56,7 +76,8 @@ def init_app(app):
         "default_limits": [
             os.environ.get("API_RATE_LIMIT", "60/hour"),
             os.environ.get("API_DAILY_QUOTA", "1000/day"),
-        ]
+        ],
+        "default_limits_exempt_when": _is_public_api_rate_limit_exempt,
     }
     if limiter_storage_uri:
         limiter_kwargs["storage_uri"] = limiter_storage_uri

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -260,6 +260,11 @@ curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/metrics | head -n 40
 ```
 
+Operational note: `/healthz`, `/livez`, `/metrics`, `/relay/diagnostics`, and API v1 relay
+compute-node heartbeat endpoints are exempt from the public API quota. Kubernetes readiness probes
+may hit `/healthz` every 10 seconds; those probes must not exhaust the default `60/hour` user API
+limit or make an otherwise-running pod unready.
+
 ### Image tag, chart version, and Git tag must be validated independently
 
 For final v0.1.0 release readiness, verify all four identifiers explicitly (separate from staging candidate validation):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2082,3 +2082,34 @@ def test_api_v1_next_keeps_server_alive_while_any_in_flight_request_remains(clie
     next_response = client.get('/api/v1/relay/servers/next')
     assert next_response.status_code == 200
     assert next_response.get_json().get('server_public_key') == DUMMY_SERVER_PUB_KEY
+
+
+def test_healthz_not_limited_by_staging_default_public_quota(client):
+    """Repeated readiness probes should not exhaust the public API limit."""
+
+    for _ in range(105):
+        response = client.get("/healthz", headers={"User-Agent": "kube-probe/1.30"})
+        assert response.status_code == 200
+
+
+def test_api_v1_relay_register_and_poll_not_limited_by_public_quota(client, monkeypatch):
+    """Compute-node heartbeat routes should not inherit the public 60/hour limit."""
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "-1")
+    server_payload = {"server_public_key": DUMMY_SERVER_PUB_KEY}
+
+    for _ in range(65):
+        register = client.post("/api/v1/relay/servers/register", json=server_payload)
+        assert register.status_code == 200
+
+    for _ in range(65):
+        poll = client.post("/api/v1/relay/servers/poll", json=server_payload)
+        assert poll.status_code == 200
+
+
+def test_relay_operational_diagnostics_not_limited_by_public_quota(client):
+    """Relay diagnostics must remain available under public API quota pressure."""
+
+    for _ in range(105):
+        response = client.get("/relay/diagnostics")
+        assert response.status_code == 200

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -127,3 +127,65 @@ def test_production_with_rate_limit_storage_uri_uses_explicit_backend():
 
     assert limiter is limiter_instance
     assert limiter_cls.call_args.kwargs["storage_uri"] == "memcached://127.0.0.1:11211"
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "60/hour"}, clear=True)
+def test_staging_default_rate_limit_exempts_operational_routes():
+    """Operational routes should not consume the public API quota."""
+
+    app = Flask(__name__)
+
+    @app.get("/healthz")
+    def healthz():
+        return {"status": "ok"}
+
+    @app.get("/livez")
+    def livez():
+        return {"status": "alive"}
+
+    @app.get("/relay/diagnostics")
+    def relay_diagnostics():
+        return {"registered_compute_nodes": []}
+
+    init_app(app)
+
+    with app.test_client() as client:
+        for path in ("/healthz", "/livez", "/metrics", "/relay/diagnostics"):
+            responses = [client.get(path) for _ in range(105)]
+            assert all(response.status_code != 429 for response in responses), path
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "60/hour"}, clear=True)
+def test_kubernetes_probe_cadence_cannot_exhaust_healthz_quota():
+    """A kube-probe hitting /healthz every 10s should not exhaust 60/hour."""
+
+    app = Flask(__name__)
+
+    @app.get("/healthz")
+    def healthz():
+        return {"status": "ok"}
+
+    init_app(app)
+
+    with app.test_client() as client:
+        for _ in range(72):
+            response = client.get("/healthz", headers={"User-Agent": "kube-probe/1.30"})
+            assert response.status_code == 200
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "1/hour"}, clear=True)
+def test_public_chat_completion_route_still_uses_public_rate_limit():
+    """Public chat completions must keep OpenAI-style public API rate limits."""
+
+    app = Flask(__name__)
+    init_app(app)
+
+    with app.test_client() as client:
+        first_response = client.post("/api/v1/chat/completions", json={})
+        limited_response = client.post("/api/v1/chat/completions", json={})
+
+    assert first_response.status_code != 429
+    assert limited_response.status_code == 429
+    body = limited_response.get_json()
+    assert body is not None
+    assert body["error"]["code"] == "rate_limit_exceeded"


### PR DESCRIPTION
### Motivation

- Staging revealed a production-blocking readiness failure where Kubernetes kube-probes hit `/healthz` every 10s and exhausted the default `API_RATE_LIMIT=60/hour`, causing `flask-limiter` to return `429` and the pod to become unready (503 observed by public checks). 
- The intent is to keep operational/liveness/metrics and API v1 relay control-plane endpoints available to probes and compute-node heartbeats while preserving public API quotas for user-facing completions.

### Description

- Add a path-based exemption set `PUBLIC_API_RATE_LIMIT_EXEMPT_PATHS` and predicate `_is_public_api_rate_limit_exempt()` in `api/__init__.py` and wire it into `Limiter` via `default_limits_exempt_when` to exempt operational paths. 
- Exempted routes include `/livez`, `/healthz`, `/metrics`, `/relay/diagnostics` and API v1 relay control-plane endpoints (`/api/v1/relay/servers/register`, `/api/v1/relay/servers/poll`, `/api/v1/relay/servers/next`, `/api/v1/relay/responses`, `/api/v1/relay/responses/retrieve`). 
- Preserve existing OpenAI-style rate-limit error payloads and keep public user-facing chat/completion limits unchanged. 
- Add regression tests proving operational routes and API v1 relay heartbeats are not rate-limited and that public chat completions remain rate-limited, and add an operational note to `docs/relay_sugarkube_onboarding.md` describing the before/after `/healthz` behavior.

### Testing

- `pytest tests/unit/test_rate_limit.py` — passed (new rate-limit exemption and public-rate-limit checks exercised). 
- `pytest tests/test_relay.py -k "health or relay"` — passed (repeated `/healthz`, `/relay/diagnostics`, register/poll heartbeat loops verified). 
- `pytest tests/test_api.py -k rate` — passed (public completion rate-limit behavior preserved). 
- `python -m pytest tests/unit/test_rate_limit.py tests/test_relay.py` — passed (combined verification). 
- `pre-commit run --all-files` — partially ran; hooks passed except for `check-yaml` failures caused by pre-existing Helm chart template YAML parsing errors in `charts/tokenplace/templates/*.yaml` (unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1876c37538832faa4b75020e8fa434)