### PR TITLE
Make distributed API v1 relay target selection explicit and staging-safe

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -11,9 +11,10 @@ import logging
 import os
 import time
 import uuid
-from functools import lru_cache
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Dict, Optional, Protocol
+from urllib.parse import urlparse
 
 import requests
 
@@ -444,6 +445,22 @@ def _normalise_target_url(value: str | None) -> str:
     return (value or "").strip().rstrip("/")
 
 
+def _validated_target_url(value: str | None, *, source: str) -> str:
+    """Return a normalized absolute HTTP(S) target or fail clearly."""
+
+    target = _normalise_target_url(value)
+    if not target:
+        return ""
+
+    parsed = urlparse(target)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ComputeProviderError(
+            f"Invalid distributed relay target from {source}: target must be an "
+            "absolute HTTP(S) URL."
+        )
+    return target
+
+
 def _current_token_place_env() -> str:
     """Return the active token.place deployment environment label."""
 
@@ -477,7 +494,10 @@ def _select_distributed_target() -> DistributedTargetSelection:
     """
 
     for env_name in _EXPLICIT_DISTRIBUTED_TARGET_ENVS:
-        target = _normalise_target_url(os.environ.get(env_name))
+        target = _validated_target_url(
+            os.environ.get(env_name),
+            source=f"env:{env_name}",
+        )
         if target:
             return DistributedTargetSelection(
                 url=target,
@@ -486,7 +506,10 @@ def _select_distributed_target() -> DistributedTargetSelection:
             )
 
     for env_name in _RELAY_PUBLIC_URL_ENVS:
-        target = _normalise_target_url(os.environ.get(env_name))
+        target = _validated_target_url(
+            os.environ.get(env_name),
+            source=f"env:{env_name}",
+        )
         if target:
             return DistributedTargetSelection(
                 url=target,
@@ -496,7 +519,10 @@ def _select_distributed_target() -> DistributedTargetSelection:
 
     env_name = _current_token_place_env()
     for config_key in ("api.relay_url", "relay.server_url"):
-        target = _normalise_target_url(_config_value(config_key))
+        target = _validated_target_url(
+            _config_value(config_key),
+            source=f"config:{config_key}",
+        )
         if not target or target == _DEFAULT_PRODUCTION_RELAY_URL:
             continue
         return DistributedTargetSelection(

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -497,16 +497,18 @@ def _select_distributed_target() -> DistributedTargetSelection:
     env_name = _current_token_place_env()
     for config_key in ("api.relay_url", "relay.server_url"):
         target = _normalise_target_url(_config_value(config_key))
-        if not target:
+        if not target or target == _DEFAULT_PRODUCTION_RELAY_URL:
             continue
-        if target == _DEFAULT_PRODUCTION_RELAY_URL and env_name != "production":
-            continue
-        source = f"config:{config_key}"
-        if target == _DEFAULT_PRODUCTION_RELAY_URL:
-            source = "production_default"
         return DistributedTargetSelection(
             url=target,
-            source=source,
+            source=f"config:{config_key}",
+            relay_only=False,
+        )
+
+    if env_name == "production":
+        return DistributedTargetSelection(
+            url=_DEFAULT_PRODUCTION_RELAY_URL,
+            source="production_default",
             relay_only=False,
         )
 

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -27,6 +27,28 @@ _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
 )
 
 
+_DEFAULT_PRODUCTION_RELAY_URL = "https://token.place"
+_EXPLICIT_DISTRIBUTED_TARGET_ENVS = (
+    "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+    "TOKENPLACE_DISTRIBUTED_RELAY_URL",
+    "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+)
+_RELAY_PUBLIC_URL_ENVS = (
+    "TOKENPLACE_RELAY_PUBLIC_URL",
+    "TOKEN_PLACE_RELAY_PUBLIC_URL",
+    "RELAY_PUBLIC_URL",
+)
+
+
+@dataclass(frozen=True)
+class DistributedTargetSelection:
+    """Resolved distributed relay target and diagnostics for provider logs."""
+
+    url: str
+    source: str
+    relay_only: bool = False
+
+
 class ComputeProviderError(Exception):
     """Raised when a compute provider cannot satisfy a request."""
 
@@ -49,7 +71,7 @@ class ComputeProviderError(Exception):
 _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
     "no_registered_compute_nodes": {
         "error_type": "service_unavailable_error",
-        "public_message": "No LLM servers are available right now.",
+        "public_message": "No registered compute nodes are available on this relay.",
         "status_code": 503,
     },
     "compute_node_timeout": {
@@ -152,6 +174,7 @@ class DistributedApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
+        _last_backend_path.set("distributed_relay_e2ee_pending")
         crypto_manager = self._build_request_crypto_manager()
         relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
         deadline = time.time() + relay_timeout
@@ -177,6 +200,24 @@ class DistributedApiV1ComputeProvider:
                 message=f"unable to reach relay next_server endpoint: {exc}",
             ) from exc
 
+        next_server_payload: Any | None = None
+        if next_server_response.status_code == 503:
+            try:
+                next_server_payload = next_server_response.json()
+            except ValueError:
+                next_server_payload = None
+            error_payload = (
+                next_server_payload.get("error")
+                if isinstance(next_server_payload, dict)
+                else None
+            )
+            error_code = error_payload.get("code") if isinstance(error_payload, dict) else None
+            if error_code == "no_registered_compute_nodes":
+                raise _error_from_code(
+                    "no_registered_compute_nodes",
+                    message="relay reported no registered compute nodes",
+                )
+
         if next_server_response.status_code >= 500:
             raise _error_from_code(
                 "compute_node_unreachable",
@@ -187,7 +228,8 @@ class DistributedApiV1ComputeProvider:
             )
 
         try:
-            next_server_payload = next_server_response.json()
+            if next_server_payload is None:
+                next_server_payload = next_server_response.json()
         except ValueError as exc:
             raise _error_from_code(
                 "compute_node_invalid_payload",
@@ -396,9 +438,88 @@ class FallbackApiV1ComputeProvider:
             return message
 
 
-@lru_cache(maxsize=8)
+def _normalise_target_url(value: str | None) -> str:
+    """Normalize configured relay URLs for stable selection and cache keys."""
+
+    return (value or "").strip().rstrip("/")
+
+
+def _current_token_place_env() -> str:
+    """Return the active token.place deployment environment label."""
+
+    return os.environ.get("TOKEN_PLACE_ENV", "development").strip().lower()
+
+
+def _config_value(key: str) -> str:
+    """Read a string config value without making provider selection depend on imports."""
+
+    try:
+        from config import get_config
+
+        value = get_config().get(key, "")
+    except Exception as exc:  # pragma: no cover - defensive against early bootstrap cycles
+        logger.debug("api_v1.compute_provider.config_read_failed key=%s", key, exc_info=exc)
+        return ""
+    return value if isinstance(value, str) else ""
+
+
+def _select_distributed_target() -> DistributedTargetSelection:
+    """Resolve the distributed API v1 relay target with explicit staging-safe precedence.
+
+    Precedence:
+    1. Explicit API v1/distributed relay target environment variables.
+    2. Relay public URL environment variables when this process is the public relay.
+    3. Explicit non-default config relay URLs.
+    4. Production default only when TOKEN_PLACE_ENV=production.
+
+    Non-production environments intentionally do not silently fall back to
+    https://token.place because that makes staging appear to call production.
+    """
+
+    for env_name in _EXPLICIT_DISTRIBUTED_TARGET_ENVS:
+        target = _normalise_target_url(os.environ.get(env_name))
+        if target:
+            return DistributedTargetSelection(
+                url=target,
+                source=f"env:{env_name}",
+                relay_only=False,
+            )
+
+    for env_name in _RELAY_PUBLIC_URL_ENVS:
+        target = _normalise_target_url(os.environ.get(env_name))
+        if target:
+            return DistributedTargetSelection(
+                url=target,
+                source=f"env:{env_name}",
+                relay_only=True,
+            )
+
+    env_name = _current_token_place_env()
+    for config_key in ("api.relay_url", "relay.server_url"):
+        target = _normalise_target_url(_config_value(config_key))
+        if not target:
+            continue
+        if target == _DEFAULT_PRODUCTION_RELAY_URL and env_name != "production":
+            continue
+        source = f"config:{config_key}"
+        if target == _DEFAULT_PRODUCTION_RELAY_URL:
+            source = "production_default"
+        return DistributedTargetSelection(
+            url=target,
+            source=source,
+            relay_only=False,
+        )
+
+    return DistributedTargetSelection(url="", source="unset", relay_only=False)
+
+
+@lru_cache(maxsize=16)
 def _build_api_v1_compute_provider(
-    mode: str, distributed_url: str, distributed_fallback_enabled: bool
+    mode: str,
+    distributed_url: str,
+    distributed_fallback_enabled: bool,
+    target_source: str = "unknown",
+    relay_only: bool = False,
 ) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
@@ -412,38 +533,49 @@ def _build_api_v1_compute_provider(
         if not distributed_fallback_enabled:
             message = (
                 "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed requires "
-                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL when "
-                "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK is disabled"
+                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL or another explicit distributed "
+                "relay target outside production. Set one of "
+                f"{', '.join(_EXPLICIT_DISTRIBUTED_TARGET_ENVS)} or TOKENPLACE_RELAY_PUBLIC_URL."
             )
             logger.error(
-                "%s (fallback_enabled=%s)",
-                message,
+                "api_v1.compute_provider.target_unset mode=%s fallback_enabled=%s "
+                "target_source=%s relay_only=%s",
+                mode,
                 distributed_fallback_enabled,
+                target_source,
+                relay_only,
             )
             raise ComputeProviderError(message)
         logger.warning(
-            "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed set without "
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback "
-            "(fallback_enabled=%s)",
+            "api_v1.compute_provider.target_unset mode=%s fallback_enabled=%s "
+            "target_source=%s relay_only=%s; using local fallback",
+            mode,
             distributed_fallback_enabled,
+            target_source,
+            relay_only,
         )
         return local_provider
 
-    distributed_provider = DistributedApiV1ComputeProvider(base_url=distributed_url)
+    selected_target = distributed_url.rstrip("/")
+    distributed_provider = DistributedApiV1ComputeProvider(base_url=selected_target)
     if not distributed_fallback_enabled:
         logger.info(
             "api_v1.compute_provider.selected provider=distributed mode=%s "
-            "fallback_enabled=false target=%s",
+            "fallback_enabled=false target=%s target_source=%s relay_only=%s",
             mode,
-            distributed_url.rstrip("/"),
+            selected_target,
+            target_source,
+            relay_only,
         )
         return distributed_provider
 
     logger.info(
         "api_v1.compute_provider.selected provider=distributed_with_local_fallback "
-        "mode=%s fallback_enabled=true target=%s",
+        "mode=%s fallback_enabled=true target=%s target_source=%s relay_only=%s",
         mode,
-        distributed_url.rstrip("/"),
+        selected_target,
+        target_source,
+        relay_only,
     )
     return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
 
@@ -451,20 +583,25 @@ def _build_api_v1_compute_provider(
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     """Resolve the active provider based on environment configuration."""
 
-    mode, distributed_url, distributed_fallback_enabled = _read_api_v1_provider_env()
-    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
+    mode, target_selection, distributed_fallback_enabled = _read_api_v1_provider_env()
+    return _build_api_v1_compute_provider(
+        mode,
+        target_selection.url,
+        distributed_fallback_enabled,
+        target_selection.source,
+        target_selection.relay_only,
+    )
 
 
-def _read_api_v1_provider_env() -> tuple[str, str, bool]:
+def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
     """Read and normalize API v1 provider environment configuration."""
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
-    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return mode, distributed_url, distributed_fallback_enabled
+    return mode, _select_distributed_target(), distributed_fallback_enabled
 
 
 def get_api_v1_compute_provider_for_mode(
@@ -476,14 +613,23 @@ def get_api_v1_compute_provider_for_mode(
     """Resolve provider with an explicit mode override for request-scoped routing."""
 
     normalized_mode = (mode or "local").strip().lower()
-    _, env_distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
+    _, env_target_selection, fallback_enabled_from_env = _read_api_v1_provider_env()
     if distributed_fallback_enabled is None:
         distributed_fallback_enabled = fallback_enabled_from_env
-    selected_distributed_url = distributed_url if distributed_url is not None else env_distributed_url
+    if distributed_url is not None:
+        target_selection = DistributedTargetSelection(
+            url=_normalise_target_url(distributed_url),
+            source="request_override",
+            relay_only=False,
+        )
+    else:
+        target_selection = env_target_selection
     return _build_api_v1_compute_provider(
         normalized_mode,
-        selected_distributed_url.strip(),
+        target_selection.url,
         bool(distributed_fallback_enabled),
+        target_selection.source,
+        target_selection.relay_only,
     )
 
 

--- a/relay.py
+++ b/relay.py
@@ -840,9 +840,16 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
-def _select_next_server_payload():
+def _select_next_server_payload(*, api_v1: bool = False):
     _evict_stale_servers()
     if not known_servers:
+        if api_v1:
+            return jsonify({
+                'error': {
+                    'message': 'No registered compute nodes are available on this relay.',
+                    'code': 'no_registered_compute_nodes',
+                }
+            }), 503
         return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
     server_public_key = secrets.choice(list(known_servers.keys()))
     return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
@@ -865,7 +872,7 @@ def next_server():
 @app.route('/api/v1/relay/servers/next', methods=['GET'])
 def api_v1_relay_servers_next():
     """Get a registered compute node public key for API v1 encrypted relay requests."""
-    return _select_next_server_payload()
+    return _select_next_server_payload(api_v1=True)
 
 
 @app.route('/relay/diagnostics', methods=['GET'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -324,6 +324,35 @@ def test_api_v1_distributed_provider_staging_fails_without_target(monkeypatch):
     assert "outside production" in str(exc_info.value)
 
 
+def test_api_v1_distributed_provider_staging_rejects_malformed_relay_public_url(
+    monkeypatch,
+):
+    import api.v1.compute_provider as compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "staging.token.place")
+
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("Distributed provider should not be constructed")
+
+    monkeypatch.setattr(
+        compute_provider,
+        "DistributedApiV1ComputeProvider",
+        fail_if_constructed,
+    )
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    with pytest.raises(compute_provider.ComputeProviderError) as exc_info:
+        compute_provider.get_api_v1_compute_provider()
+
+    message = str(exc_info.value)
+    assert "env:TOKENPLACE_RELAY_PUBLIC_URL" in message
+    assert "absolute HTTP(S) URL" in message
+
+
 def test_api_v1_chat_completion_staging_no_nodes_returns_clear_503(client, monkeypatch):
     import api.v1.compute_provider as compute_provider
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -278,6 +278,37 @@ def test_api_v1_distributed_provider_production_uses_default_target(monkeypatch,
     assert "relay_only=False" in caplog.text
 
 
+def test_api_v1_distributed_provider_production_prefers_non_default_relay_config(
+    monkeypatch, caplog
+):
+    import api.v1.compute_provider as compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "production")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    config_values = {
+        "api.relay_url": "https://token.place",
+        "relay.server_url": "https://configured-relay.example",
+    }
+    monkeypatch.setattr(
+        compute_provider,
+        "_config_value",
+        lambda key: config_values.get(key, ""),
+    )
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    with caplog.at_level(logging.INFO, logger="api.v1.compute_provider"):
+        provider = compute_provider.get_api_v1_compute_provider()
+
+    assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+    assert provider.base_url == "https://configured-relay.example"
+    assert "target=https://configured-relay.example" in caplog.text
+    assert "target_source=config:relay.server_url" in caplog.text
+    assert "target_source=production_default" not in caplog.text
+
+
 def test_api_v1_distributed_provider_staging_fails_without_target(monkeypatch):
     import api.v1.compute_provider as compute_provider
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -290,7 +290,7 @@ def test_api_v1_distributed_provider_production_prefers_non_default_relay_config
 
     config_values = {
         "api.relay_url": "https://token.place",
-        "relay.server_url": "https://configured-relay.example",
+        "relay.server_url": "https://prod-relay.example",
     }
     monkeypatch.setattr(
         compute_provider,
@@ -303,8 +303,8 @@ def test_api_v1_distributed_provider_production_prefers_non_default_relay_config
         provider = compute_provider.get_api_v1_compute_provider()
 
     assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
-    assert provider.base_url == "https://configured-relay.example"
-    assert "target=https://configured-relay.example" in caplog.text
+    assert provider.base_url == "https://prod-relay.example"
+    assert "target=https://prod-relay.example" in caplog.text
     assert "target_source=config:relay.server_url" in caplog.text
     assert "target_source=production_default" not in caplog.text
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -226,6 +226,116 @@ def test_unencrypted_chat_completion(client, client_keys, mock_llama):
     assert 'Mock response' in data['choices'][0]['message']['content']
 
 
+def _clear_distributed_target_env(monkeypatch):
+    for env_name in (
+        "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+        "TOKENPLACE_RELAY_PUBLIC_URL",
+        "TOKEN_PLACE_RELAY_PUBLIC_URL",
+        "RELAY_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+
+def test_api_v1_distributed_provider_uses_staging_relay_public_url(monkeypatch, caplog):
+    import api.v1.compute_provider as compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    with caplog.at_level(logging.INFO, logger="api.v1.compute_provider"):
+        provider = compute_provider.get_api_v1_compute_provider()
+
+    assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+    assert provider.base_url == "https://staging.token.place"
+    assert provider.base_url != "https://token.place"
+    assert "target=https://staging.token.place" in caplog.text
+    assert "target_source=env:TOKENPLACE_RELAY_PUBLIC_URL" in caplog.text
+    assert "relay_only=True" in caplog.text
+
+
+def test_api_v1_distributed_provider_production_uses_default_target(monkeypatch, caplog):
+    import api.v1.compute_provider as compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "production")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    with caplog.at_level(logging.INFO, logger="api.v1.compute_provider"):
+        provider = compute_provider.get_api_v1_compute_provider()
+
+    assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+    assert provider.base_url == "https://token.place"
+    assert "target=https://token.place" in caplog.text
+    assert "target_source=production_default" in caplog.text
+    assert "relay_only=False" in caplog.text
+
+
+def test_api_v1_distributed_provider_staging_fails_without_target(monkeypatch):
+    import api.v1.compute_provider as compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    with pytest.raises(compute_provider.ComputeProviderError) as exc_info:
+        compute_provider.get_api_v1_compute_provider()
+
+    assert "outside production" in str(exc_info.value)
+
+
+def test_api_v1_chat_completion_staging_no_nodes_returns_clear_503(client, monkeypatch):
+    import api.v1.compute_provider as compute_provider
+
+    class NoNodesResponse:
+        status_code = 503
+
+        def json(self):
+            return {
+                "error": {
+                    "message": "No registered compute nodes are available on this relay.",
+                    "code": "no_registered_compute_nodes",
+                }
+            }
+
+    def fake_get(url, timeout):
+        assert url == "https://staging.token.place/api/v1/relay/servers/next"
+        return NoNodesResponse()
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "hello staging"}],
+        },
+    )
+
+    assert response.status_code == 503
+    data = response.get_json()
+    assert data["error"]["code"] == "no_registered_compute_nodes"
+    assert (
+        data["error"]["message"]
+        == "No registered compute nodes are available on this relay."
+    )
+
+
 def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_nodes(client, monkeypatch):
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -78,6 +78,20 @@ def test_next_server_no_servers(client):
     assert data['error']['message'] == 'No servers available'
     assert data['error']['code'] == 503
 
+
+def test_api_v1_next_server_no_registered_compute_nodes_message(client):
+    """API v1 relay reports no registered compute nodes with a stable error code."""
+
+    response = client.get("/api/v1/relay/servers/next")
+    assert response.status_code == 503
+    data = response.get_json()
+    assert data["error"]["code"] == "no_registered_compute_nodes"
+    assert (
+        data["error"]["message"]
+        == "No registered compute nodes are available on this relay."
+    )
+
+
 def test_next_server_one_server(client):
     """Test /next_server when one server is registered."""
     # Simulate server registration (directly modifying state for setup)


### PR DESCRIPTION
### Motivation
- Staging runs sometimes surfaced `target=https://token.place` in API v1 distributed logs which made staging look like it was calling production and confused operators.
- The selection of a distributed relay target was implicit and could silently fall back to the production default in non-production environments.
- The goal is to make target precedence explicit, prevent non-production from defaulting to production, and return clearer 503s when no compute nodes are registered on a relay.

### Description
- Add explicit distributed target resolution with precedence and diagnostics by introducing `DistributedTargetSelection` and `_select_distributed_target()` in `api/v1/compute_provider.py`, which reads targets from (1) explicit API/distributed envs, (2) relay public URL envs, (3) trusted config values, and (4) the production default only when `TOKEN_PLACE_ENV=production`.
- Change provider builder to accept and log `target_source` and `relay_only` metadata and to refuse silent production fallbacks in staging when no explicit target is set, raising `ComputeProviderError` when `TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed` and no allowed target exists.
- Improve API v1 relay error shape and messages by returning a clear 503 with `code: no_registered_compute_nodes` and `message: "No registered compute nodes are available on this relay."` from the API v1 `/api/v1/relay/servers/next` path and by mapping relay 503 payloads to that error code in the distributed provider path.
- Update `relay.py` to make `_select_next_server_payload()` provide API v1-specific error payloads and to call it with `api_v1=True` for `/api/v1/relay/servers/next`.
- Add staging-like unit/integration tests: `tests/test_api.py` new tests assert staging uses `TOKENPLACE_RELAY_PUBLIC_URL`, production uses the default `https://token.place`, staging without a target fails when fallback is disabled, and a staged API v1 chat returns the clear 503 payload; `tests/test_relay.py` adds an API v1 `/servers/next` no-nodes test.
- Minor diagnostics: set `_last_backend_path` to a pending state for distributed requests so logs indicate in-flight relay activity and update public-facing error text for no-registered-nodes.

### Testing
- Ran targeted API/provider/staging tests: `pytest tests/test_api.py -k "distributed or provider or staging"` and `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py`, which passed (new provider-selection tests and desktop-bridge integration tests passed). Example provider-selection logs produced during tests: `api_v1.compute_provider.selected provider=distributed mode=distributed fallback_enabled=false target=https://staging.token.place target_source=env:TOKENPLACE_RELAY_PUBLIC_URL relay_only=True` and for production: `api_v1.compute_provider.selected provider=distributed mode=distributed fallback_enabled=false target=https://token.place target_source=production_default relay_only=False`.
- Ran relay tests for next-server behavior: `pytest tests/test_relay.py -k next`, which passed and validates the new `no_registered_compute_nodes` 503 payload on the API v1 next-server route.
- Ran broader suites used in the rollout (unit, integration, API subsets and crypto/JS checks) as shown in the transcript; the focused tests covering distributed/provider/staging behavior passed.
- `pre-commit run --all-files` was executed, and pre-commit reported an unrelated `check-yaml` failure in chart templates (CI/helm YAML formatting) which is pre-existing to this change and not caused by the provider/relay logic updates.

Residual risks and follow-ups: update any operator runbooks that previously interpreted staging logs referencing `https://token.place` and consider a follow-up to canonicalize relay public URL env var names across deployment manifests; charts YAML lint failures are unrelated and should be fixed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18773b0b2c832fa81b702b2a53d0a7)