### PR TITLE
Fix staging relay target selection for distributed API v1 compute provider

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -49,7 +49,7 @@ class ComputeProviderError(Exception):
 _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
     "no_registered_compute_nodes": {
         "error_type": "service_unavailable_error",
-        "public_message": "No LLM servers are available right now.",
+        "public_message": "No registered compute nodes are available on this relay.",
         "status_code": 503,
     },
     "compute_node_timeout": {
@@ -78,6 +78,15 @@ _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
         "status_code": 502,
     },
 }
+
+
+@dataclass(frozen=True)
+class DistributedRelayTarget:
+    """Resolved distributed relay target and diagnostics metadata."""
+
+    url: str
+    source: str
+    relay_only: bool = False
 
 
 def _error_from_code(code: str, *, message: str) -> ComputeProviderError:
@@ -156,6 +165,7 @@ class DistributedApiV1ComputeProvider:
         relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
         deadline = time.time() + relay_timeout
         relay_request_id = f"api-v1-{uuid.uuid4().hex}"
+        _last_backend_path.set("distributed_relay_e2ee_pending")
 
         def _remaining_timeout() -> float:
             remaining = deadline - time.time()
@@ -174,14 +184,14 @@ class DistributedApiV1ComputeProvider:
         except requests.RequestException as exc:
             raise _error_from_code(
                 "compute_node_unreachable",
-                message=f"unable to reach relay next_server endpoint: {exc}",
+                message=f"unable to reach API v1 relay compute-node selection endpoint: {exc}",
             ) from exc
 
         if next_server_response.status_code >= 500:
             raise _error_from_code(
                 "compute_node_unreachable",
                 message=(
-                    "relay next_server endpoint returned "
+                    "API v1 relay compute-node selection endpoint returned "
                     f"unexpected status {next_server_response.status_code}"
                 ),
             )
@@ -191,20 +201,20 @@ class DistributedApiV1ComputeProvider:
         except ValueError as exc:
             raise _error_from_code(
                 "compute_node_invalid_payload",
-                message="relay next_server response was not valid JSON",
+                message="API v1 relay compute-node selection response was not valid JSON",
             ) from exc
 
         if not isinstance(next_server_payload, dict):
             raise _error_from_code(
                 "compute_node_invalid_payload",
-                message="relay next_server response must be an object",
+                message="API v1 relay compute-node selection response must be an object",
             )
 
         server_public_key = next_server_payload.get("server_public_key")
         if not isinstance(server_public_key, str) or not server_public_key.strip():
             raise _error_from_code(
                 "no_registered_compute_nodes",
-                message="relay reported no registered compute nodes",
+                message="no registered compute nodes are available on this relay",
             )
 
         plaintext_envelope = {
@@ -396,9 +406,13 @@ class FallbackApiV1ComputeProvider:
             return message
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=16)
 def _build_api_v1_compute_provider(
-    mode: str, distributed_url: str, distributed_fallback_enabled: bool
+    mode: str,
+    distributed_url: str,
+    distributed_fallback_enabled: bool,
+    target_source: str = "unset",
+    relay_only: bool = False,
 ) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
@@ -412,20 +426,25 @@ def _build_api_v1_compute_provider(
         if not distributed_fallback_enabled:
             message = (
                 "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed requires "
-                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL when "
-                "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK is disabled"
+                "an explicit distributed relay target, TOKENPLACE_RELAY_PUBLIC_URL, "
+                "or a production relay default when TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK "
+                "is disabled"
             )
             logger.error(
-                "%s (fallback_enabled=%s)",
+                "%s (fallback_enabled=%s target_source=%s relay_only=%s)",
                 message,
                 distributed_fallback_enabled,
+                target_source,
+                relay_only,
             )
             raise ComputeProviderError(message)
         logger.warning(
             "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed set without "
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback "
-            "(fallback_enabled=%s)",
+            "a distributed relay target; using local fallback "
+            "(fallback_enabled=%s target_source=%s relay_only=%s)",
             distributed_fallback_enabled,
+            target_source,
+            relay_only,
         )
         return local_provider
 
@@ -433,17 +452,21 @@ def _build_api_v1_compute_provider(
     if not distributed_fallback_enabled:
         logger.info(
             "api_v1.compute_provider.selected provider=distributed mode=%s "
-            "fallback_enabled=false target=%s",
+            "fallback_enabled=false target=%s target_source=%s relay_only=%s",
             mode,
             distributed_url.rstrip("/"),
+            target_source,
+            relay_only,
         )
         return distributed_provider
 
     logger.info(
         "api_v1.compute_provider.selected provider=distributed_with_local_fallback "
-        "mode=%s fallback_enabled=true target=%s",
+        "mode=%s fallback_enabled=true target=%s target_source=%s relay_only=%s",
         mode,
         distributed_url.rstrip("/"),
+        target_source,
+        relay_only,
     )
     return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
 
@@ -451,20 +474,98 @@ def _build_api_v1_compute_provider(
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     """Resolve the active provider based on environment configuration."""
 
-    mode, distributed_url, distributed_fallback_enabled = _read_api_v1_provider_env()
-    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
+    mode, distributed_target, distributed_fallback_enabled = _read_api_v1_provider_env()
+    return _build_api_v1_compute_provider(
+        mode,
+        distributed_target.url,
+        distributed_fallback_enabled,
+        distributed_target.source,
+        distributed_target.relay_only,
+    )
 
 
-def _read_api_v1_provider_env() -> tuple[str, str, bool]:
+def _normalise_distributed_relay_target(value: str | None) -> str:
+    """Return a normalized relay target URL string."""
+
+    return (value or "").strip().rstrip("/")
+
+
+def _get_config_value(key: str) -> str:
+    """Read a string config value without allowing config failures to break routing."""
+
+    try:
+        from config import get_config
+
+        value = get_config().get(key, "")
+    except Exception as exc:  # pragma: no cover - defensive guard for config bootstrapping
+        logger.debug("api_v1.compute_provider.config_lookup_failed key=%s", key, exc_info=exc)
+        return ""
+    return value if isinstance(value, str) else ""
+
+
+def _resolve_distributed_relay_target() -> DistributedRelayTarget:
+    """Resolve distributed relay target with explicit staging-safe precedence."""
+
+    explicit_env_candidates = (
+        (
+            "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+            os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL"),
+        ),
+        (
+            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+            os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL"),
+        ),
+    )
+    for source, raw_value in explicit_env_candidates:
+        target = _normalise_distributed_relay_target(raw_value)
+        if target:
+            return DistributedRelayTarget(url=target, source=source, relay_only=False)
+
+    explicit_config = _normalise_distributed_relay_target(
+        _get_config_value("api.v1_distributed_relay_url")
+    )
+    if explicit_config:
+        return DistributedRelayTarget(
+            url=explicit_config,
+            source="config.api.v1_distributed_relay_url",
+            relay_only=False,
+        )
+
+    public_url_candidates = (
+        ("TOKENPLACE_RELAY_PUBLIC_URL", os.environ.get("TOKENPLACE_RELAY_PUBLIC_URL")),
+        ("TOKEN_PLACE_RELAY_PUBLIC_URL", os.environ.get("TOKEN_PLACE_RELAY_PUBLIC_URL")),
+        ("RELAY_PUBLIC_URL", os.environ.get("RELAY_PUBLIC_URL")),
+    )
+    for source, raw_value in public_url_candidates:
+        target = _normalise_distributed_relay_target(raw_value)
+        if target:
+            return DistributedRelayTarget(url=target, source=source, relay_only=True)
+
+    token_place_env = os.environ.get("TOKEN_PLACE_ENV", "development").strip().lower()
+    if token_place_env == "production":
+        configured_target = _normalise_distributed_relay_target(
+            _get_config_value("relay.server_url") or _get_config_value("api.relay_url")
+        )
+        if configured_target:
+            return DistributedRelayTarget(
+                url=configured_target,
+                source="production_config.relay.server_url",
+                relay_only=False,
+            )
+
+    return DistributedRelayTarget(url="", source="unset", relay_only=False)
+
+
+def _read_api_v1_provider_env() -> tuple[str, DistributedRelayTarget, bool]:
     """Read and normalize API v1 provider environment configuration."""
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
-    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    distributed_target = _resolve_distributed_relay_target()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return mode, distributed_url, distributed_fallback_enabled
+    return mode, distributed_target, distributed_fallback_enabled
 
 
 def get_api_v1_compute_provider_for_mode(
@@ -476,14 +577,23 @@ def get_api_v1_compute_provider_for_mode(
     """Resolve provider with an explicit mode override for request-scoped routing."""
 
     normalized_mode = (mode or "local").strip().lower()
-    _, env_distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
+    _, env_distributed_target, fallback_enabled_from_env = _read_api_v1_provider_env()
     if distributed_fallback_enabled is None:
         distributed_fallback_enabled = fallback_enabled_from_env
-    selected_distributed_url = distributed_url if distributed_url is not None else env_distributed_url
+    if distributed_url is not None:
+        selected_distributed_target = DistributedRelayTarget(
+            url=_normalise_distributed_relay_target(distributed_url),
+            source="request_override",
+            relay_only=False,
+        )
+    else:
+        selected_distributed_target = env_distributed_target
     return _build_api_v1_compute_provider(
         normalized_mode,
-        selected_distributed_url.strip(),
+        selected_distributed_target.url,
         bool(distributed_fallback_enabled),
+        selected_distributed_target.source,
+        selected_distributed_target.relay_only,
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -244,6 +244,45 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     assert data['error']['code'] in {'no_registered_compute_nodes', 'compute_node_unreachable'}
 
 
+def test_api_v1_chat_completion_staging_relay_public_url_no_nodes_clear_503(client, monkeypatch):
+    compute_provider_module = importlib.import_module('api.v1.compute_provider')
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'staging')
+    monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
+    monkeypatch.delenv('TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL', raising=False)
+    monkeypatch.delenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', raising=False)
+    monkeypatch.setenv('TOKENPLACE_RELAY_PUBLIC_URL', 'https://staging.token.place')
+    monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
+
+    requested_urls = []
+
+    class FakeNoNodeResponse:
+        status_code = 200
+
+        def json(self):
+            return {'error': {'code': 'no_registered_compute_nodes'}}
+
+    monkeypatch.setattr(
+        compute_provider_module.requests,
+        'get',
+        lambda url, timeout: requested_urls.append(url) or FakeNoNodeResponse(),
+    )
+    compute_provider_module._build_api_v1_compute_provider.cache_clear()
+    try:
+        response = client.post('/api/v1/chat/completions', json={
+            'model': 'llama-3-8b-instruct',
+            'messages': [{'role': 'user', 'content': 'Ping staging distributed runtime'}],
+        })
+    finally:
+        compute_provider_module._build_api_v1_compute_provider.cache_clear()
+
+    assert requested_urls == ['https://staging.token.place/api/v1/relay/servers/next']
+    assert response.status_code == 503
+    data = response.get_json()
+    assert data['error']['type'] == 'service_unavailable_error'
+    assert data['error']['code'] == 'no_registered_compute_nodes'
+    assert data['error']['message'] == 'No registered compute nodes are available on this relay.'
+
+
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):
     fallback_message = {
         'role': 'assistant',

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -371,7 +371,7 @@ def test_distributed_compute_provider_maps_next_server_json_error(monkeypatch):
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
         assert exc.code == "compute_node_invalid_payload"
-        assert "next_server response was not valid JSON" in str(exc)
+        assert "compute-node selection response was not valid JSON" in str(exc)
 
 
 def test_distributed_compute_provider_maps_next_server_5xx(monkeypatch):
@@ -561,6 +561,47 @@ def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
+def test_get_provider_uses_staging_relay_public_url_without_prod_fallback(monkeypatch, caplog):
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.delenv("TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        with caplog.at_level("INFO", logger="api.v1.compute_provider"):
+            provider = compute_provider.get_api_v1_compute_provider()
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://staging.token.place"
+        assert "target=https://staging.token.place" in caplog.text
+        assert "target_source=TOKENPLACE_RELAY_PUBLIC_URL" in caplog.text
+        assert "relay_only=True" in caplog.text
+        assert "target=https://token.place" not in caplog.text
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_get_provider_uses_production_relay_default(monkeypatch):
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "production")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.delenv("TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("RELAY_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://token.place"
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
 def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "")
@@ -572,7 +613,7 @@ def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monk
             compute_provider.get_api_v1_compute_provider()
             raise AssertionError("expected ComputeProviderError")
         except ComputeProviderError as exc:
-            assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+            assert "requires an explicit distributed relay target" in str(exc)
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
@@ -673,7 +714,7 @@ def test_distributed_compute_provider_maps_next_server_request_exception(monkeyp
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
         assert exc.code == "compute_node_unreachable"
-        assert "unable to reach relay next_server endpoint" in str(exc)
+        assert "unable to reach API v1 relay compute-node selection endpoint" in str(exc)
 
 
 def test_distributed_compute_provider_maps_faucet_request_exception(monkeypatch):
@@ -760,7 +801,7 @@ def test_get_api_v1_compute_provider_for_mode_distributed_without_url_raises(mon
         get_api_v1_compute_provider_for_mode(mode="distributed", distributed_fallback_enabled=False)
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
-        assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+        assert "requires an explicit distributed relay target" in str(exc)
 
 
 def test_get_api_v1_compute_provider_for_mode_reads_fallback_from_env(monkeypatch):


### PR DESCRIPTION
### Motivation
- Staging runs were being observed selecting `https://token.place` as the distributed relay target which is confusing and incorrect for relay-only staging where `TOKENPLACE_RELAY_PUBLIC_URL` should be used. 
- Make distributed relay target selection explicit and testable with a clear precedence so staging never silently looks like production.

### Description
- Add `DistributedRelayTarget` and a resolver with explicit precedence: `TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL` -> `TOKENPLACE_DISTRIBUTED_COMPUTE_URL` -> config override -> relay public URL envs -> production-only config default; non-production no longer falls back to production silently. (file: `api/v1/compute_provider.py`)
- Propagate resolved target metadata (`target_source`, `relay_only`) into provider construction and include them in provider-selection logs for clearer diagnostics. (file: `api/v1/compute_provider.py`)
- Change error/public message for no-node case to: `No registered compute nodes are available on this relay.` and reword compute-node selection errors to avoid legacy `/next_server` phrasing. (file: `api/v1/compute_provider.py`)
- Mark pending relay state early (`distributed_relay_e2ee_pending`) for clearer per-request backend path diagnostics. (file: `api/v1/compute_provider.py`)
- Add unit and integration regression tests that assert staging uses `https://staging.token.place` when `TOKENPLACE_RELAY_PUBLIC_URL` is set and that production still resolves to `https://token.place`. (files: `tests/unit/test_api_v1_compute_provider.py`, `tests/test_api.py`)

### Testing
- `pytest tests/unit/test_api_v1_compute_provider.py -q` succeeded (24 passed). 
- `pytest tests/test_api.py -k "distributed or provider or staging"` succeeded (9 passed). 
- `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` succeeded (5 passed). 
- `pytest tests/test_relay.py -k next` succeeded (7 passed). 
- `python -m py_compile api/v1/compute_provider.py tests/test_api.py tests/unit/test_api_v1_compute_provider.py` succeeded (syntax check passed). 
- `pre-commit run --all-files` ran project checks but failed `check-yaml` on existing Helm templates (`charts/tokenplace/templates/*.yaml`), which are unrelated pre-existing failures and not caused by these changes.

Provider selection logs (before / after):
- Before: `api_v1.compute_provider.selected provider=distributed mode=distributed fallback_enabled=false target=https://token.place`
- After (staging): `api_v1.compute_provider.selected provider=distributed mode=distributed fallback_enabled=false target=https://staging.token.place target_source=TOKENPLACE_RELAY_PUBLIC_URL relay_only=True`
- After (production): `api_v1.compute_provider.selected provider=distributed mode=distributed fallback_enabled=false target=https://token.place target_source=production_config.relay.server_url relay_only=False`

Files changed: `api/v1/compute_provider.py`, `tests/test_api.py`, `tests/unit/test_api_v1_compute_provider.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18773b0b2c832fa81b702b2a53d0a7)