### PR TITLE
Fix staging relay target selection for distributed API v1 compute provider

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -14,6 +14,7 @@ import uuid
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
+from urllib.parse import urlparse
 
 import requests
 
@@ -49,7 +50,7 @@ class ComputeProviderError(Exception):
 _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
     "no_registered_compute_nodes": {
         "error_type": "service_unavailable_error",
-        "public_message": "No LLM servers are available right now.",
+        "public_message": "No registered compute nodes are available on this relay.",
         "status_code": 503,
     },
     "compute_node_timeout": {
@@ -88,6 +89,103 @@ def _error_from_code(code: str, *, message: str) -> ComputeProviderError:
         error_type=mapped.get("error_type", "server_error"),
         public_message=mapped.get("public_message", "Unable to generate a response right now."),
         status_code=int(mapped.get("status_code", 502)),
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedDistributedRelayTarget:
+    """Normalized distributed relay target plus diagnostics metadata."""
+
+    url: str
+    source: str
+    relay_only: bool = False
+
+
+def _normalise_relay_target_url(value: str) -> str:
+    """Normalize a configured HTTP(S) relay target URL."""
+
+    candidate = (value or "").strip().rstrip("/")
+    if not candidate:
+        return ""
+
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    return candidate
+
+
+def _configured_public_relay_url() -> ResolvedDistributedRelayTarget | None:
+    """Return the relay public URL when this process is configured as a relay."""
+
+    for env_var in (
+        "TOKENPLACE_RELAY_PUBLIC_URL",
+        "TOKEN_PLACE_RELAY_PUBLIC_URL",
+        "RELAY_PUBLIC_URL",
+    ):
+        target = _normalise_relay_target_url(os.environ.get(env_var, ""))
+        if target:
+            return ResolvedDistributedRelayTarget(
+                url=target,
+                source=env_var,
+                relay_only=True,
+            )
+    return None
+
+
+def _explicit_distributed_relay_target_from_env() -> ResolvedDistributedRelayTarget | None:
+    """Return explicit API v1 distributed relay target env overrides."""
+
+    for env_var in (
+        "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+    ):
+        target = _normalise_relay_target_url(os.environ.get(env_var, ""))
+        if target:
+            return ResolvedDistributedRelayTarget(url=target, source=env_var)
+    return None
+
+
+def _explicit_distributed_relay_target_from_config() -> ResolvedDistributedRelayTarget | None:
+    """Return an explicit distributed relay target from config."""
+
+    try:
+        from config import get_config
+
+        config = get_config()
+        raw_value = config.get("api.distributed_relay_url", "")
+        target = _normalise_relay_target_url(raw_value if isinstance(raw_value, str) else "")
+        if target:
+            return ResolvedDistributedRelayTarget(url=target, source="config:api.distributed_relay_url")
+    except Exception as exc:  # pragma: no cover - defensive config fallback
+        logger.debug("unable to inspect distributed relay target config: %s", exc)
+    return None
+
+
+def _production_default_distributed_relay_target() -> ResolvedDistributedRelayTarget | None:
+    """Return the production default only for explicit production environments."""
+
+    env_name = (
+        os.environ.get("TOKEN_PLACE_ENV")
+        or os.environ.get("ENVIRONMENT")
+        or ""
+    ).strip().lower()
+    if env_name in {"prod", "production"}:
+        return ResolvedDistributedRelayTarget(
+            url="https://token.place",
+            source="production_default",
+        )
+    return None
+
+
+def _resolve_distributed_relay_target() -> ResolvedDistributedRelayTarget:
+    """Resolve distributed relay target with staging-safe precedence rules."""
+
+    return (
+        _explicit_distributed_relay_target_from_env()
+        or _explicit_distributed_relay_target_from_config()
+        or _configured_public_relay_url()
+        or _production_default_distributed_relay_target()
+        or ResolvedDistributedRelayTarget(url="", source="unset")
     )
 
 
@@ -177,6 +275,31 @@ class DistributedApiV1ComputeProvider:
                 message=f"unable to reach relay next_server endpoint: {exc}",
             ) from exc
 
+        try:
+            next_server_payload = next_server_response.json()
+        except ValueError as exc:
+            if next_server_response.status_code >= 500:
+                raise _error_from_code(
+                    "compute_node_unreachable",
+                    message=(
+                        "relay next_server endpoint returned "
+                        f"unexpected status {next_server_response.status_code}"
+                    ),
+                ) from exc
+            raise _error_from_code(
+                "compute_node_invalid_payload",
+                message="relay next_server response was not valid JSON",
+            ) from exc
+
+        if next_server_response.status_code == 503:
+            relay_error = next_server_payload.get("error") if isinstance(next_server_payload, dict) else None
+            relay_error_code = relay_error.get("code") if isinstance(relay_error, dict) else None
+            if relay_error_code in {503, "503", "no_registered_compute_nodes"}:
+                raise _error_from_code(
+                    "no_registered_compute_nodes",
+                    message="relay reported no registered compute nodes are available",
+                )
+
         if next_server_response.status_code >= 500:
             raise _error_from_code(
                 "compute_node_unreachable",
@@ -185,14 +308,6 @@ class DistributedApiV1ComputeProvider:
                     f"unexpected status {next_server_response.status_code}"
                 ),
             )
-
-        try:
-            next_server_payload = next_server_response.json()
-        except ValueError as exc:
-            raise _error_from_code(
-                "compute_node_invalid_payload",
-                message="relay next_server response was not valid JSON",
-            ) from exc
 
         if not isinstance(next_server_payload, dict):
             raise _error_from_code(
@@ -396,9 +511,13 @@ class FallbackApiV1ComputeProvider:
             return message
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=16)
 def _build_api_v1_compute_provider(
-    mode: str, distributed_url: str, distributed_fallback_enabled: bool
+    mode: str,
+    distributed_url: str,
+    distributed_fallback_enabled: bool,
+    distributed_url_source: str = "unset",
+    relay_only_mode: bool = False,
 ) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
@@ -412,7 +531,7 @@ def _build_api_v1_compute_provider(
         if not distributed_fallback_enabled:
             message = (
                 "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed requires "
-                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL when "
+                "a configured distributed relay target when "
                 "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK is disabled"
             )
             logger.error(
@@ -423,9 +542,11 @@ def _build_api_v1_compute_provider(
             raise ComputeProviderError(message)
         logger.warning(
             "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed set without "
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback "
-            "(fallback_enabled=%s)",
+            "a configured distributed relay target; using local fallback "
+            "(fallback_enabled=%s target_source=%s relay_only=%s)",
             distributed_fallback_enabled,
+            distributed_url_source,
+            relay_only_mode,
         )
         return local_provider
 
@@ -433,17 +554,21 @@ def _build_api_v1_compute_provider(
     if not distributed_fallback_enabled:
         logger.info(
             "api_v1.compute_provider.selected provider=distributed mode=%s "
-            "fallback_enabled=false target=%s",
+            "fallback_enabled=false target=%s target_source=%s relay_only=%s",
             mode,
             distributed_url.rstrip("/"),
+            distributed_url_source,
+            relay_only_mode,
         )
         return distributed_provider
 
     logger.info(
         "api_v1.compute_provider.selected provider=distributed_with_local_fallback "
-        "mode=%s fallback_enabled=true target=%s",
+        "mode=%s fallback_enabled=true target=%s target_source=%s relay_only=%s",
         mode,
         distributed_url.rstrip("/"),
+        distributed_url_source,
+        relay_only_mode,
     )
     return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
 
@@ -451,20 +576,26 @@ def _build_api_v1_compute_provider(
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     """Resolve the active provider based on environment configuration."""
 
-    mode, distributed_url, distributed_fallback_enabled = _read_api_v1_provider_env()
-    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
+    mode, target, distributed_fallback_enabled = _read_api_v1_provider_env()
+    return _build_api_v1_compute_provider(
+        mode,
+        target.url,
+        distributed_fallback_enabled,
+        target.source,
+        target.relay_only,
+    )
 
 
-def _read_api_v1_provider_env() -> tuple[str, str, bool]:
+def _read_api_v1_provider_env() -> tuple[str, ResolvedDistributedRelayTarget, bool]:
     """Read and normalize API v1 provider environment configuration."""
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
-    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    distributed_target = _resolve_distributed_relay_target()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return mode, distributed_url, distributed_fallback_enabled
+    return mode, distributed_target, distributed_fallback_enabled
 
 
 def get_api_v1_compute_provider_for_mode(
@@ -476,14 +607,22 @@ def get_api_v1_compute_provider_for_mode(
     """Resolve provider with an explicit mode override for request-scoped routing."""
 
     normalized_mode = (mode or "local").strip().lower()
-    _, env_distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
+    _, env_distributed_target, fallback_enabled_from_env = _read_api_v1_provider_env()
     if distributed_fallback_enabled is None:
         distributed_fallback_enabled = fallback_enabled_from_env
-    selected_distributed_url = distributed_url if distributed_url is not None else env_distributed_url
+    if distributed_url is not None:
+        selected_target = ResolvedDistributedRelayTarget(
+            url=_normalise_relay_target_url(distributed_url),
+            source="request_override",
+        )
+    else:
+        selected_target = env_distributed_target
     return _build_api_v1_compute_provider(
         normalized_mode,
-        selected_distributed_url.strip(),
+        selected_target.url,
         bool(distributed_fallback_enabled),
+        selected_target.source,
+        selected_target.relay_only,
     )
 
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -497,7 +497,7 @@ new Vue({
             const fallbackMessage = ASSISTANT_GENERIC_FALLBACK_MESSAGE;
 
             const codeToMessage = {
-                no_registered_compute_nodes: 'No LLM servers are available right now.',
+                no_registered_compute_nodes: 'No registered compute nodes are available on this relay.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_bridge_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_unreachable: 'The LLM server is unavailable right now. Please try again.',

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -302,7 +302,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
-    assert "No LLM servers are available right now." in assistant_message.inner_text()
+    assert "No registered compute nodes are available on this relay." in assistant_message.inner_text()
 
 
 @pytest.mark.e2e

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -226,6 +226,101 @@ def test_unencrypted_chat_completion(client, client_keys, mock_llama):
     assert 'Mock response' in data['choices'][0]['message']['content']
 
 
+
+def _clear_distributed_target_env(monkeypatch):
+    for env_var in (
+        "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+        "TOKENPLACE_RELAY_PUBLIC_URL",
+        "TOKEN_PLACE_RELAY_PUBLIC_URL",
+        "RELAY_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_api_v1_distributed_provider_staging_uses_public_relay_url(monkeypatch, caplog):
+    from api.v1 import compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    caplog.set_level(logging.INFO, logger="api.v1.compute_provider")
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+    assert provider.base_url == "https://staging.token.place"
+    assert provider.base_url != "https://token.place"
+    assert (
+        "api_v1.compute_provider.selected provider=distributed mode=distributed "
+        "fallback_enabled=false target=https://staging.token.place "
+        "target_source=TOKENPLACE_RELAY_PUBLIC_URL relay_only=True"
+    ) in caplog.text
+
+
+def test_api_v1_distributed_provider_production_uses_production_default(monkeypatch):
+    from api.v1 import compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "production")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+    assert provider.base_url == "https://token.place"
+
+
+def test_api_v1_staging_distributed_no_compute_nodes_reports_relay_error(client, monkeypatch):
+    from api.v1 import compute_provider
+
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+
+    next_server_response = MagicMock()
+    next_server_response.status_code = 503
+    next_server_response.json.return_value = {
+        "error": {"message": "No servers available", "code": 503}
+    }
+
+    def fake_get(url, timeout):
+        assert url == "https://staging.token.place/api/v1/relay/servers/next"
+        assert timeout > 0
+        return next_server_response
+
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        response = client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hello staging"}],
+            },
+        )
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    assert response.status_code == 503
+    error = response.get_json()["error"]
+    assert error["type"] == "service_unavailable_error"
+    assert error["code"] == "no_registered_compute_nodes"
+    assert "No registered compute nodes are available on this relay" in error["message"]
+
 def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_nodes(client, monkeypatch):
     monkeypatch.setenv('TOKENPLACE_API_V1_COMPUTE_PROVIDER', 'distributed')
     monkeypatch.setenv('TOKENPLACE_DISTRIBUTED_COMPUTE_URL', 'https://compute.example')

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -572,7 +572,7 @@ def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monk
             compute_provider.get_api_v1_compute_provider()
             raise AssertionError("expected ComputeProviderError")
         except ComputeProviderError as exc:
-            assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+            assert "requires a configured distributed relay target" in str(exc)
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
@@ -760,7 +760,7 @@ def test_get_api_v1_compute_provider_for_mode_distributed_without_url_raises(mon
         get_api_v1_compute_provider_for_mode(mode="distributed", distributed_fallback_enabled=False)
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
-        assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+        assert "requires a configured distributed relay target" in str(exc)
 
 
 def test_get_api_v1_compute_provider_for_mode_reads_fallback_from_env(monkeypatch):

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -52,7 +52,7 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "compute_node_bridge_timeout" in chat_js
     assert "compute_node_unreachable" in chat_js
     assert "compute_node_invalid_payload" in chat_js
-    assert "No LLM servers are available right now." in chat_js
+    assert "No registered compute nodes are available on this relay." in chat_js
     assert "The LLM server took too long to respond. Please try again." in chat_js
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -38,6 +38,7 @@ class APISettings(TypedDict, total=False):
     host: str
     port: int
     relay_url: str
+    distributed_relay_url: str
     cors_origins: List[str]
 
 
@@ -122,6 +123,7 @@ DEFAULT_CONFIG: AppConfig = {
         "host": "127.0.0.1",
         "port": 3000,
         "relay_url": "https://token.place",
+        "distributed_relay_url": "",
         "cors_origins": ["*"],
     },
     "security": {


### PR DESCRIPTION
### Motivation

- Staging relay-only runs were resolving the distributed compute provider target as `https://token.place`, making staging appear to call production and producing confusing `next_server` errors. 
- The goal is to make distributed relay target precedence explicit and testable so staging uses its own public URL and does not silently fall back to the production host.

### Description

- Add a typed `ResolvedDistributedRelayTarget` and `_resolve_distributed_relay_target()` with explicit precedence: 1) explicit env (`TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL` / `TOKENPLACE_DISTRIBUTED_COMPUTE_URL`), 2) `api.distributed_relay_url` from config, 3) relay public URL envs (`TOKENPLACE_RELAY_PUBLIC_URL` / `TOKEN_PLACE_RELAY_PUBLIC_URL` / `RELAY_PUBLIC_URL`) (relay-only), and 4) `https://token.place` only when the environment is production. 
- Wire the resolved target into provider construction and make provider-selection logging include the `target`, `target_source`, and `relay_only` flags so logs clearly show staging vs prod selection (before: `target=https://token.place`; after: `target=https://staging.token.place target_source=TOKENPLACE_RELAY_PUBLIC_URL relay_only=True`).
- Map relay `GET /api/v1/relay/servers/next` 503/no-node responses to `no_registered_compute_nodes` with a clearer public message (`No registered compute nodes are available on this relay.`) and preserve existing E2EE behavior.
- Add `api.distributed_relay_url` to the typed config schema and update browser UI copy and tests to reflect the clearer no-compute-node message.
- Add staging/production target-selection unit tests and a staging-like API test that asserts staging chooses `https://staging.token.place` and that a staging 503 returns the new `no_registered_compute_nodes` 503 error.

### Testing

- Ran `pytest tests/test_api.py -k "distributed or provider or staging"` and all relevant tests passed (11 passed, 59 deselected in selection run). 
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and all integration tests passed (5 passed). 
- Ran `pytest tests/test_relay.py -k next` and relay `/next_server` tests passed (7 passed). 
- Ran `pytest tests/unit/test_api_v1_compute_provider.py -q` and `pytest tests/unit/test_touch_ui.py -q` and unit suites for the provider and UI updates passed (22 and 5 passed respectively). 
- Verified Python compilation: `python -m py_compile api/v1/compute_provider.py utils/config_schema.py tests/test_api.py` succeeded. 
- `pre-commit run --all-files` passed most hooks but failed on existing Helm template YAML parsing in `charts/tokenplace/templates/*.yaml` (these are pre-existing unrelated YAML template parsing issues and not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18773b0b2c832fa81b702b2a53d0a7)