### PR TITLE
Fix staging distributed API v1 relay target selection

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -14,6 +14,7 @@ import uuid
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
+from urllib.parse import urlparse
 
 import requests
 
@@ -21,6 +22,109 @@ from api.v1.models import generate_response
 from utils.crypto.crypto_manager import CryptoManager
 
 logger = logging.getLogger("api.v1.compute_provider")
+
+_PRODUCTION_RELAY_TARGET = "https://token.place"
+_EXPLICIT_DISTRIBUTED_TARGET_ENV_VARS = (
+    "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+    "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+)
+_RELAY_PUBLIC_URL_ENV_VARS = (
+    "TOKENPLACE_RELAY_PUBLIC_URL",
+    "TOKEN_PLACE_RELAY_PUBLIC_URL",
+    "RELAY_PUBLIC_URL",
+)
+
+
+@dataclass(frozen=True)
+class DistributedRelayTargetSelection:
+    """Resolved distributed relay target plus diagnostics about why it was selected."""
+
+    url: str
+    source: str
+    relay_only: bool = False
+
+
+def _normalise_relay_target_url(value: str | None) -> str:
+    """Return a normalized HTTP(S) relay target base URL, or an empty string."""
+
+    candidate = (value or "").strip().rstrip("/")
+    if not candidate:
+        return ""
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    return candidate
+
+
+def _current_token_place_env() -> str:
+    """Return the normalized deployment environment name."""
+
+    return (
+        os.environ.get("TOKEN_PLACE_ENV")
+        or os.environ.get("ENVIRONMENT")
+        or "development"
+    ).strip().lower()
+
+
+def _select_distributed_relay_target() -> DistributedRelayTargetSelection:
+    """Resolve the API v1 distributed relay target with staging-safe precedence."""
+
+    for env_var in _EXPLICIT_DISTRIBUTED_TARGET_ENV_VARS:
+        target = _normalise_relay_target_url(os.environ.get(env_var))
+        if target:
+            return DistributedRelayTargetSelection(target, f"env:{env_var}")
+
+    for env_var in _RELAY_PUBLIC_URL_ENV_VARS:
+        target = _normalise_relay_target_url(os.environ.get(env_var))
+        if target:
+            return DistributedRelayTargetSelection(
+                target,
+                f"relay_public_url:{env_var}",
+                relay_only=True,
+            )
+
+    config_target = _select_configured_distributed_relay_target()
+    if config_target.url:
+        return config_target
+
+    if _current_token_place_env() == "production":
+        return DistributedRelayTargetSelection(
+            _PRODUCTION_RELAY_TARGET,
+            "production_default",
+        )
+
+    return DistributedRelayTargetSelection("", "unconfigured")
+
+
+def _select_configured_distributed_relay_target() -> DistributedRelayTargetSelection:
+    """Return a non-default configured relay target when config explicitly provides one."""
+
+    try:
+        from config import get_config
+        from utils.config_schema import DEFAULT_CONFIG
+
+        config = get_config()
+    except Exception:
+        return DistributedRelayTargetSelection("", "config_unavailable")
+
+    config_candidates = (
+        ("api.relay_url", config.get("api.relay_url", "")),
+        ("relay.server_url", config.get("relay.server_url", "")),
+    )
+    default_candidates = {
+        _normalise_relay_target_url(DEFAULT_CONFIG["api"].get("relay_url", "")),
+        _normalise_relay_target_url(DEFAULT_CONFIG["relay"].get("server_url", "")),
+    }
+
+    for key, value in config_candidates:
+        target = _normalise_relay_target_url(value if isinstance(value, str) else "")
+        if not target:
+            continue
+        if target not in default_candidates or _current_token_place_env() == "production":
+            return DistributedRelayTargetSelection(target, f"config:{key}")
+
+    return DistributedRelayTargetSelection("", "config_default_ignored")
+
 _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
     "api_v1_last_backend_path",
     default="unknown",
@@ -49,7 +153,7 @@ class ComputeProviderError(Exception):
 _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
     "no_registered_compute_nodes": {
         "error_type": "service_unavailable_error",
-        "public_message": "No LLM servers are available right now.",
+        "public_message": "No registered compute nodes are available on this relay.",
         "status_code": 503,
     },
     "compute_node_timeout": {
@@ -176,6 +280,12 @@ class DistributedApiV1ComputeProvider:
                 "compute_node_unreachable",
                 message=f"unable to reach relay next_server endpoint: {exc}",
             ) from exc
+
+        if next_server_response.status_code == 503:
+            raise _error_from_code(
+                "no_registered_compute_nodes",
+                message="relay reported no registered compute nodes are available",
+            )
 
         if next_server_response.status_code >= 500:
             raise _error_from_code(
@@ -396,9 +506,13 @@ class FallbackApiV1ComputeProvider:
             return message
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=16)
 def _build_api_v1_compute_provider(
-    mode: str, distributed_url: str, distributed_fallback_enabled: bool
+    mode: str,
+    distributed_url: str,
+    distributed_fallback_enabled: bool,
+    target_source: str = "explicit",
+    relay_only: bool = False,
 ) -> ApiV1ComputeProvider:
     """Create a compute provider for the normalized environment inputs."""
 
@@ -411,21 +525,24 @@ def _build_api_v1_compute_provider(
     if not distributed_url:
         if not distributed_fallback_enabled:
             message = (
-                "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed requires "
-                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL when "
-                "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK is disabled"
+                "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed requires an "
+                "explicit distributed relay target or TOKENPLACE_RELAY_PUBLIC_URL "
+                "when TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK is disabled"
             )
             logger.error(
-                "%s (fallback_enabled=%s)",
+                "%s (fallback_enabled=%s target_source=%s relay_only=%s)",
                 message,
                 distributed_fallback_enabled,
+                target_source,
+                relay_only,
             )
             raise ComputeProviderError(message)
         logger.warning(
             "TOKENPLACE_API_V1_COMPUTE_PROVIDER=distributed set without "
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL; using local fallback "
-            "(fallback_enabled=%s)",
+            "an explicit distributed relay target or TOKENPLACE_RELAY_PUBLIC_URL; "
+            "using local fallback (fallback_enabled=%s target_source=%s)",
             distributed_fallback_enabled,
+            target_source,
         )
         return local_provider
 
@@ -433,17 +550,21 @@ def _build_api_v1_compute_provider(
     if not distributed_fallback_enabled:
         logger.info(
             "api_v1.compute_provider.selected provider=distributed mode=%s "
-            "fallback_enabled=false target=%s",
+            "fallback_enabled=false target=%s target_source=%s relay_only=%s",
             mode,
             distributed_url.rstrip("/"),
+            target_source,
+            relay_only,
         )
         return distributed_provider
 
     logger.info(
         "api_v1.compute_provider.selected provider=distributed_with_local_fallback "
-        "mode=%s fallback_enabled=true target=%s",
+        "mode=%s fallback_enabled=true target=%s target_source=%s relay_only=%s",
         mode,
         distributed_url.rstrip("/"),
+        target_source,
+        relay_only,
     )
     return FallbackApiV1ComputeProvider(primary=distributed_provider, fallback=local_provider)
 
@@ -451,20 +572,38 @@ def _build_api_v1_compute_provider(
 def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     """Resolve the active provider based on environment configuration."""
 
-    mode, distributed_url, distributed_fallback_enabled = _read_api_v1_provider_env()
-    return _build_api_v1_compute_provider(mode, distributed_url, distributed_fallback_enabled)
+    (
+        mode,
+        distributed_url,
+        distributed_fallback_enabled,
+        target_source,
+        relay_only,
+    ) = _read_api_v1_provider_env()
+    return _build_api_v1_compute_provider(
+        mode,
+        distributed_url,
+        distributed_fallback_enabled,
+        target_source,
+        relay_only,
+    )
 
 
-def _read_api_v1_provider_env() -> tuple[str, str, bool]:
+def _read_api_v1_provider_env() -> tuple[str, str, bool, str, bool]:
     """Read and normalize API v1 provider environment configuration."""
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
-    distributed_url = os.environ.get("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "").strip()
+    target_selection = _select_distributed_relay_target()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return mode, distributed_url, distributed_fallback_enabled
+    return (
+        mode,
+        target_selection.url,
+        distributed_fallback_enabled,
+        target_selection.source,
+        target_selection.relay_only,
+    )
 
 
 def get_api_v1_compute_provider_for_mode(
@@ -476,14 +615,24 @@ def get_api_v1_compute_provider_for_mode(
     """Resolve provider with an explicit mode override for request-scoped routing."""
 
     normalized_mode = (mode or "local").strip().lower()
-    _, env_distributed_url, fallback_enabled_from_env = _read_api_v1_provider_env()
+    (
+        _,
+        env_distributed_url,
+        fallback_enabled_from_env,
+        env_target_source,
+        env_relay_only,
+    ) = _read_api_v1_provider_env()
     if distributed_fallback_enabled is None:
         distributed_fallback_enabled = fallback_enabled_from_env
     selected_distributed_url = distributed_url if distributed_url is not None else env_distributed_url
+    target_source = "request_override" if distributed_url is not None else env_target_source
+    relay_only = False if distributed_url is not None else env_relay_only
     return _build_api_v1_compute_provider(
         normalized_mode,
         selected_distributed_url.strip(),
         bool(distributed_fallback_enabled),
+        target_source,
+        relay_only,
     )
 
 

--- a/relay.py
+++ b/relay.py
@@ -843,7 +843,12 @@ def _legacy_route_deprecated_response(route_name: str):
 def _select_next_server_payload():
     _evict_stale_servers()
     if not known_servers:
-        return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
+        return jsonify({
+            'error': {
+                'message': 'No registered compute nodes are available on this relay.',
+                'code': 'no_registered_compute_nodes',
+            }
+        }), 503
     server_public_key = secrets.choice(list(known_servers.keys()))
     return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -241,7 +241,8 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     assert response.status_code == 503
     data = response.get_json()
     assert data['error']['type'] == 'service_unavailable_error'
-    assert data['error']['code'] in {'no_registered_compute_nodes', 'compute_node_unreachable'}
+    assert data['error']['code'] == 'no_registered_compute_nodes'
+    assert data['error']['message'] == 'No registered compute nodes are available on this relay.'
 
 
 def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client, monkeypatch):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -75,8 +75,8 @@ def test_next_server_no_servers(client):
     assert response.status_code == 503
     data = response.get_json()
     assert 'error' in data
-    assert data['error']['message'] == 'No servers available'
-    assert data['error']['code'] == 503
+    assert data['error']['message'] == 'No registered compute nodes are available on this relay.'
+    assert data['error']['code'] == 'no_registered_compute_nodes'
 
 def test_next_server_one_server(client):
     """Test /next_server when one server is registered."""
@@ -108,7 +108,7 @@ def test_next_server_evicts_stale_nodes(client):
     payload = response.get_json()
 
     assert response.status_code == 503
-    assert payload["error"]["message"] == "No servers available"
+    assert payload["error"]["message"] == "No registered compute nodes are available on this relay."
     assert DUMMY_SERVER_PUB_KEY not in known_servers
 
 # --- Test /sink ---

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -396,8 +396,8 @@ def test_distributed_compute_provider_maps_next_server_5xx(monkeypatch):
         )
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
-        assert exc.code == "compute_node_unreachable"
-        assert "unexpected status 503" in str(exc)
+        assert exc.code == "no_registered_compute_nodes"
+        assert "no registered compute nodes are available" in str(exc)
 
 
 def test_distributed_compute_provider_applies_end_to_end_timeout_budget(monkeypatch):
@@ -561,6 +561,73 @@ def test_get_provider_disables_local_fallback_when_configured(monkeypatch):
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
+
+def test_get_provider_uses_staging_public_relay_url_without_prod_fallback(monkeypatch):
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.delenv("TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        selection = compute_provider._select_distributed_relay_target()
+        provider = compute_provider.get_api_v1_compute_provider()
+
+        assert selection.url == "https://staging.token.place"
+        assert selection.source == "relay_public_url:TOKENPLACE_RELAY_PUBLIC_URL"
+        assert selection.relay_only is True
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://staging.token.place"
+        assert provider.base_url != "https://token.place"
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_get_provider_keeps_production_default_target(monkeypatch):
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "production")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.delenv("TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("RELAY_PUBLIC_URL", raising=False)
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        selection = compute_provider._select_distributed_relay_target()
+        provider = compute_provider.get_api_v1_compute_provider()
+
+        assert selection.url == "https://token.place"
+        assert selection.source in {"config:api.relay_url", "production_default"}
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://token.place"
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_get_provider_explicit_api_v1_distributed_relay_url_precedes_public_url(monkeypatch):
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "0")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL", "https://explicit.example/")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.delenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", raising=False)
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        selection = compute_provider._select_distributed_relay_target()
+        provider = compute_provider.get_api_v1_compute_provider()
+
+        assert selection.url == "https://explicit.example"
+        assert selection.source == "env:TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL"
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://explicit.example"
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
 def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "distributed")
     monkeypatch.setenv("TOKENPLACE_DISTRIBUTED_COMPUTE_URL", "")
@@ -572,7 +639,7 @@ def test_get_provider_raises_when_distributed_fallback_disabled_without_url(monk
             compute_provider.get_api_v1_compute_provider()
             raise AssertionError("expected ComputeProviderError")
         except ComputeProviderError as exc:
-            assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+            assert "requires an explicit distributed relay target" in str(exc)
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
@@ -760,7 +827,7 @@ def test_get_api_v1_compute_provider_for_mode_distributed_without_url_raises(mon
         get_api_v1_compute_provider_for_mode(mode="distributed", distributed_fallback_enabled=False)
         raise AssertionError("expected ComputeProviderError")
     except ComputeProviderError as exc:
-        assert "requires TOKENPLACE_DISTRIBUTED_COMPUTE_URL" in str(exc)
+        assert "requires an explicit distributed relay target" in str(exc)
 
 
 def test_get_api_v1_compute_provider_for_mode_reads_fallback_from_env(monkeypatch):


### PR DESCRIPTION
### Motivation

- Staging deployments using a relay-only public base URL could appear to select the production relay (`https://token.place`) for API v1 distributed compute, which is confusing and unsafe for staging validation.
- Make distributed relay target selection explicit and deterministic so staging resolves to its staging relay and production still falls back to `https://token.place` only when appropriate.

### Description

- Add explicit relay-target resolution with clear precedence: explicit API distributed env (`TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL`), legacy `TOKENPLACE_DISTRIBUTED_COMPUTE_URL`, relay public URL envs (`TOKENPLACE_RELAY_PUBLIC_URL` and compat aliases), explicit non-default config values, and production default only when `TOKEN_PLACE_ENV=production`.
- Emit selection diagnostics (`target_source` and `relay_only`) and include them in provider selection logs so entries like `target=https://token.place` are replaced by explicit logs such as `target=https://staging.token.place target_source=relay_public_url:TOKENPLACE_RELAY_PUBLIC_URL relay_only=True`.
- Map relay `/api/v1/relay/servers/next` 503 responses to a structured `no_registered_compute_nodes` error with a clearer public message `No registered compute nodes are available on this relay.`, and update the relay `_select_next_server_payload` responses to match.
- Add unit tests for staging target selection, production default, and explicit-distributed URL precedence, and update existing relay/API tests to expect the clearer no-compute-node error and message.

### Testing

- Ran `pytest tests/unit/test_api_v1_compute_provider.py -k "provider or staging or distributed" -q` and it passed (selected provider logs now include `target_source` and `relay_only`).
- Ran `pytest tests/test_api.py -k "distributed or provider or staging" -q`, `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and `pytest tests/test_relay.py -k next -q` and they all passed.
- Ran `pre-commit run --all-files` which passed project hooks but failed `check-yaml` on existing Helm templates under `charts/tokenplace/templates/*.yaml` (pre-existing parsing issues unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18773b0b2c832fa81b702b2a53d0a7)