### PR TITLE
Add desktop relay-client diagnostics for HTTP 403 / pre-app rejections

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -142,11 +142,30 @@ def _relay_response_summary(
     relay_error = _relay_error_message(relay_response)
     request_id = relay_response.get("request_id")
     safe_request_id = request_id if isinstance(request_id, str) and request_id else "none"
+    error_kind = relay_response.get("error_kind")
+    http_status = relay_response.get("http_status")
+    if isinstance(error_kind, str) and error_kind:
+        outcome = error_kind
+    elif relay_error and isinstance(http_status, int):
+        outcome = "http_status"
+    elif relay_error:
+        outcome = "relay_error"
+    elif api_v1_payload:
+        outcome = "api_v1_work"
+    elif has_heartbeat:
+        outcome = "heartbeat"
+    else:
+        outcome = "metadata_only"
+
+    cf_ray = relay_response.get("cf_ray")
+    safe_cf_ray = cf_ray if isinstance(cf_ray, str) and cf_ray else "none"
+    safe_http_status = http_status if isinstance(http_status, int) else "none"
 
     return (
-        f"keys={keys} api_v1_payload={api_v1_payload} "
+        f"outcome={outcome} keys={keys} api_v1_payload={api_v1_payload} "
         f"heartbeat={has_heartbeat} request_id={safe_request_id} "
-        f"wait={wait_seconds} error={relay_error or 'none'}"
+        f"wait={wait_seconds} http_status={safe_http_status} cf_ray={safe_cf_ray} "
+        f"error={relay_error or 'none'}"
     )
 
 

--- a/docs/relay-deploy.md
+++ b/docs/relay-deploy.md
@@ -192,3 +192,54 @@ Kubernetes continuously verifies the relay’s health:
 With the Windows host advertising `server.py` on the expected port and the Helm release pointing to
 that DNS record, pods inside the cluster can reach the GPU-backed server transparently through the
 `gpu-server` service.
+
+## Troubleshooting desktop API v1 compute-node HTTP 403 registration failures
+
+Desktop/Tauri compute nodes log API v1 register and poll failures with metadata only. If a desktop
+build reports `desktop.compute_node_bridge.api_v1_e2ee.register error=HTTP 403` while synthetic
+register/poll checks succeed and the relay app logs do not show matching `POST
+/api/v1/relay/servers/register` or `/api/v1/relay/servers/poll` requests, suspect a pre-app
+infrastructure rejection such as Cloudflare WAF.
+
+1. Compare desktop stderr with relay logs. A probable Cloudflare/pre-app rejection includes
+   `outcome=cloudflare_pre_app_rejection`, `http_status=403`, and often `cf_ray=<id>` in the desktop
+   `desktop.compute_node_bridge.relay_poll` summary. The shared relay client also emits a redacted
+   diagnostic like:
+   ```text
+   api_v1.relay_http_non_200 method=POST path=/api/v1/relay/servers/register status=403 token_sent=True headers={'server': 'cloudflare', 'cf-ray': 'abc123-IAD', 'content-type': 'text/html'} body_snippet=<html>... relay_json_error=none
+   api_v1.relay_pre_app_rejection probable=cloudflare_or_waf method=POST path=/api/v1/relay/servers/register status=403 cf_ray=abc123-IAD server=cloudflare token_sent=True
+   ```
+   The logs intentionally report only whether `X-Relay-Server-Token` was sent, never the token value,
+   keys, ciphertext, prompts, or model payload content.
+2. Use the `cf-ray` value from the desktop log to inspect Cloudflare **Security Events** for the
+   relevant zone and timeframe. Filter by Ray ID when available, then check the rule, action, source
+   IP, bot/WAF signal, and any managed challenge or block reason.
+3. Reproduce from the same desktop network with a metadata-only register call. Replace the token with
+   a real registration token only in your shell; do not paste it into tickets or logs:
+   ```bash
+   TOKEN_PLACE_RELAY_SERVER_TOKEN='<redacted>'
+   curl -i -X POST 'https://staging.token.place/api/v1/relay/servers/register' \
+     -H "X-Relay-Server-Token: ${TOKEN_PLACE_RELAY_SERVER_TOKEN}" \
+     -H 'Content-Type: application/json' \
+     --data '{"server_public_key":"diagnostic-public-key-placeholder"}'
+   ```
+   Or use Python requests:
+   ```bash
+   python - <<'PY'
+   import os, requests
+   url = 'https://staging.token.place/api/v1/relay/servers/register'
+   response = requests.post(
+       url,
+       headers={'X-Relay-Server-Token': os.environ['TOKEN_PLACE_RELAY_SERVER_TOKEN']},
+       json={'server_public_key': 'diagnostic-public-key-placeholder'},
+       timeout=15,
+   )
+   print(response.status_code)
+   print({k: response.headers.get(k) for k in ['server', 'cf-ray', 'cf-cache-status', 'content-type', 'x-request-id']})
+   print(response.text[:240])
+   PY
+   ```
+4. Compare timestamps across systems. If desktop logs show `cf-ray`/Cloudflare HTML for a 403 and
+   relay application logs have no matching POST for the same time window, debug Cloudflare or another
+   pre-app layer before changing relay application code. If relay logs do show the request and return a
+   JSON error (for example a 401 registration-token guard), inspect the relay app response instead.

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -346,3 +346,66 @@ def test_api_v1_image_content_fails_before_relay_queue(encrypted):
     assert 400 <= response.status_code < 500
     assert "image" in response.get_json()["error"]["message"].lower()
     assert relay.client_inference_requests == {}
+
+
+def test_desktop_bridge_relay_summary_classifies_http_error_kinds():
+    """Desktop summary logs distinguish relay JSON, HTTP, timeout, and pre-app failures."""
+
+    import importlib.util
+    from pathlib import Path
+
+    bridge_path = (
+        Path(__file__).resolve().parents[2]
+        / "desktop-tauri"
+        / "src-tauri"
+        / "python"
+        / "compute_node_bridge.py"
+    )
+    spec = importlib.util.spec_from_file_location("compute_node_bridge_summary_probe", bridge_path)
+    assert spec is not None and spec.loader is not None
+    bridge = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(bridge)
+
+    cloudflare_summary = bridge._relay_response_summary(
+        {
+            "error": "HTTP 403",
+            "error_kind": "cloudflare_pre_app_rejection",
+            "http_status": 403,
+            "cf_ray": "abc123-IAD",
+            "next_ping_in_x_seconds": 15,
+        },
+        wait_seconds=15,
+    )
+    relay_json_summary = bridge._relay_response_summary(
+        {
+            "error": "HTTP 401: invalid relay registration token",
+            "error_kind": "relay_json_error",
+            "http_status": 401,
+            "next_ping_in_x_seconds": 15,
+        },
+        wait_seconds=15,
+    )
+    timeout_summary = bridge._relay_response_summary(
+        {
+            "error": "Read timed out",
+            "error_kind": "request_timeout",
+            "next_ping_in_x_seconds": 15,
+        },
+        wait_seconds=15,
+    )
+    http_summary = bridge._relay_response_summary(
+        {
+            "error": "HTTP 503",
+            "error_kind": "http_status_without_json_body",
+            "http_status": 503,
+            "next_ping_in_x_seconds": 15,
+        },
+        wait_seconds=15,
+    )
+
+    assert "outcome=cloudflare_pre_app_rejection" in cloudflare_summary
+    assert "http_status=403" in cloudflare_summary
+    assert "cf_ray=abc123-IAD" in cloudflare_summary
+    assert "outcome=relay_json_error" in relay_json_summary
+    assert "outcome=request_timeout" in timeout_summary
+    assert "outcome=http_status_without_json_body" in http_summary

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -841,7 +841,114 @@ class TestRelayClient:
 
         result = relay_client.register_api_v1_compute_node('http://relay-a.example')
 
-        assert result == {'error': 'HTTP 503', 'next_ping_in_x_seconds': relay_client._request_timeout}
+        assert result['error'] == 'HTTP 503'
+        assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
+        assert result['error_kind'] == 'http_status_without_json_body'
+
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_register_api_v1_compute_node_403_html_logs_safe_cloudflare_diagnostic(
+        self, mock_post, relay_client, caplog
+    ):
+        relay_client._registration_token = 'super-secret-registration-token'
+        response = MagicMock(status_code=403)
+        response.headers = {
+            'server': 'cloudflare',
+            'cf-ray': 'abc123-IAD',
+            'cf-cache-status': 'DYNAMIC',
+            'content-type': 'text/html; charset=UTF-8',
+            'x-request-id': 'req-123',
+            'authorization': 'should-not-log',
+        }
+        response.text = (
+            '<html><body>blocked token=super-secret-registration-token '
+            'private_key=desktop-private-key ciphertext=encrypted-payload body></html>'
+        )
+        response.json.side_effect = ValueError('not json')
+        mock_post.return_value = response
+
+        with caplog.at_level('ERROR', logger='relay_client'):
+            result = relay_client.register_api_v1_compute_node(
+                'https://staging.token.place?token=do-not-log'
+            )
+
+        log_output = caplog.text
+        assert result['error'] == 'HTTP 403'
+        assert result['error_kind'] == 'cloudflare_pre_app_rejection'
+        assert result['pre_app_rejection'] is True
+        assert result['cf_ray'] == 'abc123-IAD'
+        assert 'api_v1.relay_http_non_200' in log_output
+        assert 'api_v1.relay_pre_app_rejection' in log_output
+        assert 'path=/api/v1/relay/servers/register' in log_output
+        assert 'status=403' in log_output
+        assert "'server': 'cloudflare'" in log_output
+        assert "'cf-ray': 'abc123-IAD'" in log_output
+        assert 'token_sent=True' in log_output
+        assert 'do-not-log' not in log_output
+        assert 'super-secret-registration-token' not in log_output
+        assert 'desktop-private-key' not in log_output
+        assert 'encrypted-payload' not in log_output
+        assert 'should-not-log' not in log_output
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_register_api_v1_compute_node_401_json_logs_relay_error_safely(
+        self, mock_post, relay_client, caplog
+    ):
+        relay_client._registration_token = 'super-secret-registration-token'
+        response = MagicMock(status_code=401)
+        response.headers = {
+            'server': 'gunicorn',
+            'content-type': 'application/json',
+            'x-request-id': 'relay-req-456',
+        }
+        response.text = '{"error":"invalid relay registration token"}'
+        response.json.return_value = {'error': 'invalid relay registration token'}
+        mock_post.return_value = response
+
+        with caplog.at_level('ERROR', logger='relay_client'):
+            result = relay_client.register_api_v1_compute_node('https://staging.token.place')
+
+        log_output = caplog.text
+        assert result['error'] == 'HTTP 401: invalid relay registration token'
+        assert result['error_kind'] == 'relay_json_error'
+        assert result['relay_json_error'] is True
+        assert result['pre_app_rejection'] is False
+        assert 'relay_json_error=invalid relay registration token' in log_output
+        assert 'api_v1.relay_pre_app_rejection' not in log_output
+        assert 'super-secret-registration-token' not in log_output
+        assert 'token_sent=True' in log_output
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_403_html_logs_safe_cloudflare_diagnostic(
+        self, mock_post, relay_client, caplog
+    ):
+        relay_client._registration_token = 'super-secret-registration-token'
+        relay_client._api_v1_registered_relays.add('http://localhost:5000')
+        relay_client._api_v1_relay_wait_hints = {
+            'http://localhost:5000': {
+                'next_ping_in_x_seconds': 7,
+                'poll_wait_seconds': 0,
+                'server_public_key': relay_client.crypto_manager.public_key_b64,
+            }
+        }
+        response = MagicMock(status_code=403)
+        response.headers = {'server': 'cloudflare', 'cf-ray': 'poll-ray-789'}
+        response.text = '<html>WAF blocked prompt=secret-user-prompt</html>'
+        response.json.side_effect = ValueError('not json')
+        mock_post.return_value = response
+
+        with caplog.at_level('ERROR', logger='relay_client'):
+            result = relay_client.poll_api_v1_encrypted_work()
+
+        log_output = caplog.text
+        assert result['error'] == 'HTTP 403'
+        assert result['error_kind'] == 'cloudflare_pre_app_rejection'
+        assert result['pre_app_rejection'] is True
+        assert result['cf_ray'] == 'poll-ray-789'
+        assert 'path=/api/v1/relay/servers/poll' in log_output
+        assert 'secret-user-prompt' not in log_output
+        assert 'super-secret-registration-token' not in log_output
 
     def test_build_api_v1_url_avoids_double_api_v1_suffix(self):
         assert RelayClient._build_api_v1_url(
@@ -1015,7 +1122,9 @@ class TestRelayClient:
         first = relay_client.poll_api_v1_encrypted_work()
         second = relay_client.poll_api_v1_encrypted_work()
 
-        assert first == {'error': 'HTTP 404', 'next_ping_in_x_seconds': 9}
+        assert first['error'] == 'HTTP 404'
+        assert first['next_ping_in_x_seconds'] == 9
+        assert first['error_kind'] == 'http_status_without_json_body'
         assert second['message'] == 'No requests available'
         called_urls = [call.args[0] for call in mock_post.call_args_list]
         assert called_urls == [
@@ -1086,7 +1195,9 @@ class TestRelayClient:
 
         result = relay_client.poll_api_v1_encrypted_work()
 
-        assert result == {'error': 'HTTP 429', 'next_ping_in_x_seconds': 11}
+        assert result['error'] == 'HTTP 429'
+        assert result['next_ping_in_x_seconds'] == 11
+        assert result['error_kind'] == 'http_status_without_json_body'
 
     def test_process_client_request_missing_fields(self, relay_client):
         """Test processing a client request with missing fields."""

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse, urlunparse
@@ -105,6 +106,195 @@ RELAY_RESPONSE_SCHEMA = {
 }
 
 
+_DIAGNOSTIC_BODY_SNIPPET_LIMIT = 240
+_DIAGNOSTIC_HEADERS = (
+    "server",
+    "cf-ray",
+    "cf-cache-status",
+    "content-type",
+    "x-request-id",
+)
+_SENSITIVE_DIAGNOSTIC_PATTERN = re.compile(
+    r"(?i)(x-relay-server-token|relay[-_ ]?server[-_ ]?token|registration[-_ ]?token|token|"
+    r"private[-_ ]?key|public[-_ ]?key|ciphertext|cipherkey|chat_history|prompt|messages?)"
+    r"([\"'\s:=]+)([^\s,;}<>&]+)"
+)
+_LONG_TOKEN_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9+/=_-])[A-Za-z0-9+/=_-]{48,}(?![A-Za-z0-9+/=_-])"
+)
+
+
+def _redact_diagnostic_text(
+    value: Any, *, limit: int = _DIAGNOSTIC_BODY_SNIPPET_LIMIT
+) -> str:
+    """Return a short, single-line response snippet with secret-like values removed."""
+
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace")
+    else:
+        text = str(value)
+    text = " ".join(text.replace("\x00", "�").split())
+    text = _SENSITIVE_DIAGNOSTIC_PATTERN.sub(r"\1\2[redacted]", text)
+    text = _LONG_TOKEN_PATTERN.sub("[redacted-long-value]", text)
+    if len(text) > limit:
+        return f"{text[:limit]}…"
+    return text
+
+
+def _safe_response_headers(response: Any) -> Dict[str, str]:
+    """Extract only infrastructure headers that are safe and useful for debugging."""
+
+    raw_headers = getattr(response, "headers", {}) or {}
+    safe_headers: Dict[str, str] = {}
+    for header in _DIAGNOSTIC_HEADERS:
+        value = None
+        try:
+            value = raw_headers.get(header)
+        except AttributeError:
+            value = None
+        if value is None:
+            try:
+                value = raw_headers.get(header.title())
+            except AttributeError:
+                value = None
+        if isinstance(value, (str, bytes, int, float)) and not isinstance(value, bool):
+            safe_headers[header] = _redact_diagnostic_text(value, limit=120)
+    return safe_headers
+
+
+def _parse_relay_error_json(response: Any) -> Tuple[Optional[Dict[str, Any]], bool]:
+    """Parse relay JSON error bodies without requiring every non-200 body to be JSON."""
+
+    try:
+        payload = response.json()
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None, False
+    except Exception:
+        return None, False
+    if isinstance(payload, dict):
+        return payload, True
+    return None, True
+
+
+def _probable_cloudflare_pre_app_rejection(
+    *, status_code: int, headers: Dict[str, str], has_json_relay_body: bool
+) -> bool:
+    """Identify 403s that likely came from Cloudflare/WAF before the relay app."""
+
+    if status_code != 403 or has_json_relay_body:
+        return False
+    server = headers.get("server", "").strip().lower()
+    return server == "cloudflare" or bool(headers.get("cf-ray"))
+
+
+
+def _log_api_v1_non_200_response(
+    *,
+    method: str,
+    url: str,
+    response: Any,
+    token_sent: bool,
+) -> Dict[str, Any]:
+    """Log concise, safe diagnostics for non-200 API v1 relay responses."""
+
+    parsed = urlparse(url)
+    path = parsed.path or "/"
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    headers = _safe_response_headers(response)
+    body_snippet = _redact_diagnostic_text(getattr(response, "text", ""))
+    relay_error_body, json_body_present = _parse_relay_error_json(response)
+    has_json_relay_body = bool(
+        isinstance(relay_error_body, dict)
+        and ("error" in relay_error_body or "message" in relay_error_body)
+    )
+    probable_pre_app = _probable_cloudflare_pre_app_rejection(
+        status_code=status_code,
+        headers=headers,
+        has_json_relay_body=has_json_relay_body,
+    )
+    relay_error_snippet = "none"
+    if isinstance(relay_error_body, dict):
+        raw_relay_error = (
+            relay_error_body.get("error")
+            or relay_error_body.get("message")
+            or relay_error_body
+        )
+        relay_error_snippet = _redact_diagnostic_text(raw_relay_error, limit=160)
+
+    log_error(
+        "api_v1.relay_http_non_200 method={} path={} status={} token_sent={} "
+        "headers={} body_snippet={} relay_json_error={}",
+        method.upper(),
+        path,
+        status_code,
+        bool(token_sent),
+        headers,
+        body_snippet or "none",
+        relay_error_snippet,
+    )
+    if probable_pre_app:
+        log_error(
+            "api_v1.relay_pre_app_rejection probable=cloudflare_or_waf method={} path={} "
+            "status={} cf_ray={} server={} token_sent={}",
+            method.upper(),
+            path,
+            status_code,
+            headers.get("cf-ray", "none"),
+            headers.get("server", "none"),
+            bool(token_sent),
+        )
+
+    return {
+        "headers": headers,
+        "relay_error_body": relay_error_body if has_json_relay_body else None,
+        "pre_app_rejection": probable_pre_app,
+        "json_body_present": json_body_present,
+    }
+
+
+def _api_v1_error_result(
+    *,
+    status_code: int,
+    wait_seconds: float,
+    headers: Dict[str, str],
+    relay_error_body: Optional[Dict[str, Any]],
+    pre_app_rejection: bool,
+) -> Dict[str, Any]:
+    """Build a metadata-only API v1 relay error response for callers."""
+
+    relay_error = None
+    if isinstance(relay_error_body, dict):
+        raw_error = relay_error_body.get("error") or relay_error_body.get("message")
+        if raw_error is not None:
+            relay_error = _redact_diagnostic_text(raw_error, limit=160)
+
+    if pre_app_rejection:
+        error_kind = "cloudflare_pre_app_rejection"
+    elif relay_error is not None:
+        error_kind = "relay_json_error"
+    else:
+        error_kind = "http_status_without_json_body"
+
+    result: Dict[str, Any] = {
+        "error": (
+            f"HTTP {status_code}"
+            if relay_error is None
+            else f"HTTP {status_code}: {relay_error}"
+        ),
+        "next_ping_in_x_seconds": wait_seconds,
+        "error_kind": error_kind,
+        "http_status": status_code,
+        "relay_json_error": relay_error is not None,
+        "pre_app_rejection": pre_app_rejection,
+    }
+    cf_ray = headers.get("cf-ray")
+    if cf_ray:
+        result["cf_ray"] = cf_ray
+    return result
+
+
 def _normalise_registration_token(value: Optional[str]) -> Optional[str]:
     """Normalise optional registration tokens from config or environment."""
 
@@ -134,6 +324,7 @@ def _coerce_optional_bool(value: Optional[Any]) -> Optional[bool]:
             return False
 
     return None
+
 
 def _log(level: str, message: str, *args, exc_info: Optional[bool] = None) -> None:
     """Log a message with environment-aware behaviour.
@@ -765,19 +956,36 @@ class RelayClient:
         headers = self._auth_headers()
         if headers:
             request_kwargs['headers'] = headers
+        register_url = self._build_api_v1_url(target_url, "/relay/servers/register")
         response = requests.post(
-            self._build_api_v1_url(target_url, "/relay/servers/register"),
+            register_url,
             timeout=request_kwargs.pop('timeout'),
             **request_kwargs,
         )
         if response.status_code != 200:
-            return {'error': f'HTTP {response.status_code}', 'next_ping_in_x_seconds': self._request_timeout}
+            diagnostics = _log_api_v1_non_200_response(
+                method="POST",
+                url=register_url,
+                response=response,
+                token_sent=bool(headers),
+            )
+            return _api_v1_error_result(
+                status_code=response.status_code,
+                wait_seconds=self._request_timeout,
+                headers=diagnostics["headers"],
+                relay_error_body=diagnostics["relay_error_body"],
+                pre_app_rejection=diagnostics["pre_app_rejection"],
+            )
         return response.json()
 
     @staticmethod
     def _build_api_v1_url(relay_url: str, route: str) -> str:
         """Build API v1 URLs without duplicating a pre-existing /api/v1 suffix."""
-        base = relay_url.rstrip("/")
+        parsed = urlparse(relay_url.strip())
+        if parsed.scheme and parsed.netloc:
+            base = urlunparse((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+        else:
+            base = relay_url.split("?", 1)[0].split("#", 1)[0].rstrip("/")
         normalized_route = route if route.startswith("/") else f"/{route}"
         if base.endswith("/api/v1"):
             return f"{base}{normalized_route}"
@@ -899,10 +1107,19 @@ class RelayClient:
                         self._api_v1_registered_relays.discard(candidate_url)
                         relay_wait_hints.pop(candidate_url, None)
                         log_info("server.reregister reason=unknown_node relay={}", candidate_url)
-                    last_error = {
-                        'error': f'HTTP {response.status_code}',
-                        'next_ping_in_x_seconds': register_wait,
-                    }
+                    diagnostics = _log_api_v1_non_200_response(
+                        method="POST",
+                        url=self._build_api_v1_url(candidate_url, "/relay/servers/poll"),
+                        response=response,
+                        token_sent=bool(headers),
+                    )
+                    last_error = _api_v1_error_result(
+                        status_code=response.status_code,
+                        wait_seconds=register_wait,
+                        headers=diagnostics["headers"],
+                        relay_error_body=diagnostics["relay_error_body"],
+                        pre_app_rejection=diagnostics["pre_app_rejection"],
+                    )
                     continue
                 payload = response.json()
                 if not isinstance(payload, dict):
@@ -929,7 +1146,12 @@ class RelayClient:
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
                 self._api_v1_registered_relays.discard(candidate_url)
                 relay_wait_hints.pop(candidate_url, None)
-                last_error = {'error': str(exc), 'next_ping_in_x_seconds': self._request_timeout}
+                error_kind = "request_timeout" if isinstance(exc, requests.Timeout) else "request_exception"
+                last_error = {
+                    'error': str(exc),
+                    'next_ping_in_x_seconds': self._request_timeout,
+                    'error_kind': error_kind,
+                }
 
         return last_error or {
             'error': 'No relay targets responded',


### PR DESCRIPTION
### Motivation

- A Windows 11 desktop build targeting `https://staging.token.place` repeatedly logged `desktop.compute_node_bridge.api_v1_e2ee.register error=HTTP 403` while synthetic `curl` register/poll succeeded and the relay app showed no matching `POST /api/v1/relay/servers/register` or `/api/v1/relay/servers/poll`, indicating a likely pre-app (Cloudflare/WAF) rejection rather than a relay JSON token guard (which returns 401).
- Make desktop/Tauri compute-node registration failures diagnosable without leaking secrets and without changing Cloudflare or `server.py`.

### Description

- Add safe non-200 API v1 diagnostics in `utils/networking/relay_client.py` that log method, path-only URL, status, a capped/redacted response body snippet, selected infrastructure headers (`server`, `cf-ray`, `cf-cache-status`, `content-type`, `x-request-id`), and whether `X-Relay-Server-Token` was sent (boolean only). 
- Classify and return metadata-only error results (`error_kind`, `http_status`, `relay_json_error`, `pre_app_rejection`, optional `cf_ray`) for register/poll failures and emit a distinct `api_v1.relay_pre_app_rejection` event when a 403 looks like a Cloudflare/WAF pre-app rejection.
- Improve desktop bridge summary in `desktop-tauri/src-tauri/python/compute_node_bridge.py` to include `outcome` (distinct for `relay_json_error`, `http_status_without_json_body`, `request_timeout`, `cloudflare_pre_app_rejection`), `http_status`, and `cf_ray` for easier correlation.
- Add unit tests in `tests/unit/test_relay_client.py` and an integration probe in `tests/integration/test_api_v1_desktop_bridge_e2ee.py` to assert safe redaction (no tokens/keys/ciphertext/prompts in logs) and correct classification of non-JSON 403 and JSON 401 failures, and add a troubleshooting snippet to `docs/relay-deploy.md` describing how to use `cf-ray` with Cloudflare Security Events and reproduce with `curl`/`python requests`.
- Example redacted diagnostic output: `api_v1.relay_http_non_200 method=POST path=/api/v1/relay/servers/register status=403 token_sent=True headers={'server': 'cloudflare', 'cf-ray': 'abc123-IAD', 'content-type': 'text/html'} body_snippet=<html>... relay_json_error=none` and `api_v1.relay_pre_app_rejection probable=cloudflare_or_waf method=POST path=/api/v1/relay/servers/register status=403 cf_ray=abc123-IAD server=cloudflare token_sent=True`.

### Testing

- Ran unit tests with `pytest tests/unit/test_relay_client.py -q` and observed `114 passed`.
- Ran integration tests with `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and observed `6 passed` (integration probe asserting bridge summary classification included).
- Ran `pre-commit run --all-files`; project checks executed, but the generic `check-yaml` hook reports pre-existing parsing failures in Helm template files under `charts/tokenplace/templates/*.yaml` (these are unrelated to this change and stem from Go-template delimiters being non-parseable by the generic YAML checker).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18772862b0832f998185ce3144f41f)