### PR TITLE
Keep desktop API v1 relay registration fresh after no-work polls

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -486,7 +486,11 @@ def run(args: argparse.Namespace) -> int:
             has_heartbeat = (
                 isinstance(relay_response, dict) and "next_ping_in_x_seconds" in relay_response
             )
-            registered = relay_error is None and (has_heartbeat or api_v1_payload)
+            locally_fresh = False
+            if relay_error is None and (has_heartbeat or api_v1_payload):
+                freshness_check = getattr(runtime.relay_client, "is_api_v1_registration_fresh", None)
+                locally_fresh = bool(freshness_check(active_relay_url)) if callable(freshness_check) else True
+            registered = relay_error is None and (has_heartbeat or api_v1_payload) and locally_fresh
             wait_seconds = _safe_poll_wait_seconds(
                 relay_response, getattr(runtime.relay_client, "_request_timeout", 1)
             )
@@ -572,19 +576,12 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
 
-            if registered and warm_load_enabled and warm_load_state == "not_started":
-                if not bridge_runtime_allowed:
-                    warm_load_state = "not_started"
-                    print(
-                        "desktop.compute_node_bridge.model_init.skipped "
-                        f"reason=post_registration runtime_path={runtime_path} "
-                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
-                        file=sys.stderr,
-                    )
-                else:
-                    if not ensure_runtime_ready("post_registration", active_relay_url=active_relay_url):
-                        fail_on_warm_load_error(active_relay_url=active_relay_url)
-                        break
+            if registered and warm_load_enabled and warm_load_state == "not_started" and not api_v1_payload:
+                print(
+                    "desktop.compute_node_bridge.model_init.deferred "
+                    "reason=heartbeat_only state=not_started next_poll_required=True",
+                    file=sys.stderr,
+                )
             emit_status_event(
                 registered=registered,
                 active_relay_url=active_relay_url,

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -311,6 +311,51 @@ def test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat():
         assert poll_payload["next_ping_in_x_seconds"] == 0
 
 
+def test_api_v1_desktop_bridge_idle_no_work_poll_keeps_node_available(monkeypatch):
+    """A no-work desktop poll must be followed by a lease-safe heartbeat before API work arrives."""
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS", "2")
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0.01")
+    with live_relay_server() as base_url:
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        desktop_client._request_timeout = 1
+
+        first_poll = desktop_client.poll_api_v1_encrypted_work()
+        assert first_poll["message"] == "No requests available"
+        assert desktop_client.is_api_v1_registration_fresh(base_url) is True
+
+        time.sleep(1.7)
+        second_poll = desktop_client.poll_api_v1_encrypted_work()
+        assert second_poll["message"] == "No requests available"
+        assert desktop_client.is_api_v1_registration_fresh(base_url) is True
+
+        time.sleep(0.6)
+        request_id = "req-after-idle-heartbeat"
+        queued = requests.post(
+            f"{base_url}/api/v1/relay/requests",
+            json={
+                "request_id": request_id,
+                "client_public_key": "client-public-key",
+                "server_public_key": desktop_client.crypto_manager.public_key_b64,
+                "ciphertext": "ciphertext-request",
+                "cipherkey": "cipherkey-request",
+                "iv": "iv-request",
+            },
+            timeout=2,
+        )
+        assert queued.status_code == 200
+
+        work = desktop_client.poll_api_v1_encrypted_work()
+        assert work["request_id"] == request_id
+        assert work.get("e2ee_v1") is True
+
+
 @pytest.mark.parametrize("encrypted", [False, True])
 def test_api_v1_image_content_fails_before_relay_queue(encrypted):
     messages = [

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1178,6 +1178,80 @@ class TestRelayClient:
         assert result['next_ping_in_x_seconds'] == 0
         assert result['poll_wait_seconds'] == 10
 
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_before_lease_expiry_risk(
+        self, mock_post, monkeypatch, relay_client
+    ):
+        now = {'value': 1000.0}
+        monkeypatch.setattr(relay_client_module.time, 'monotonic', lambda: now['value'])
+        register_first = MagicMock(status_code=200)
+        register_first.json.return_value = {'next_ping_in_x_seconds': 30, 'poll_wait_seconds': 10}
+        poll_first = MagicMock(status_code=200)
+        poll_first.json.return_value = {
+            'message': 'No requests available',
+            'next_ping_in_x_seconds': 0,
+            'poll_wait_seconds': 10,
+        }
+        register_second = MagicMock(status_code=200)
+        register_second.json.return_value = {'next_ping_in_x_seconds': 30, 'poll_wait_seconds': 10}
+        poll_second = MagicMock(status_code=200)
+        poll_second.json.return_value = {
+            'message': 'No requests available',
+            'next_ping_in_x_seconds': 0,
+            'poll_wait_seconds': 10,
+        }
+        mock_post.side_effect = [register_first, poll_first, register_second, poll_second]
+
+        relay_client.poll_api_v1_encrypted_work()
+        assert relay_client.is_api_v1_registration_fresh('http://localhost:5000') is True
+
+        now['value'] += 23.0
+        relay_client.poll_api_v1_encrypted_work()
+
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_api_v1_registration_freshness_expires_after_lease(
+        self, mock_post, monkeypatch, relay_client
+    ):
+        now = {'value': 2000.0}
+        monkeypatch.setattr(relay_client_module.time, 'monotonic', lambda: now['value'])
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 5, 'poll_wait_seconds': 1}
+        mock_post.return_value = register_ok
+
+        relay_client.register_api_v1_compute_node('http://localhost:5000')
+        assert relay_client.is_api_v1_registration_fresh('http://localhost:5000') is True
+
+        now['value'] += 5.5
+        assert relay_client.is_api_v1_registration_fresh('http://localhost:5000') is False
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_unknown_node_retries_without_sleeping_lease(
+        self, mock_post, relay_client
+    ):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 30, 'poll_wait_seconds': 10}
+        poll_missing = MagicMock(status_code=404)
+        poll_missing.json.return_value = {
+            'error': {'message': 'Server with the specified public key not found', 'code': 404}
+        }
+        mock_post.side_effect = [register_ok, poll_missing]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['http_status'] == 404
+        assert result['next_ping_in_x_seconds'] == 0
+        assert relay_client.is_api_v1_registration_fresh('http://localhost:5000') is False
+
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_error_path_uses_register_backoff(self, mock_post, relay_client):
         register_ok = MagicMock(status_code=200)
@@ -1267,7 +1341,7 @@ class TestRelayClient:
         second = relay_client.poll_api_v1_encrypted_work()
 
         assert first['error'] == 'HTTP 404'
-        assert first['next_ping_in_x_seconds'] == 9
+        assert first['next_ping_in_x_seconds'] == 0
         assert first['relay_error_kind'] == 'http_status_no_json_body'
         assert second['message'] == 'No requests available'
         called_urls = [call.args[0] for call in mock_post.call_args_list]

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 import importlib
 import ipaddress
 import json
@@ -591,6 +592,7 @@ class RelayClient:
         self._sink_start_index = 0
         self._last_api_v1_work_relay_url: Optional[str] = None
         self._api_v1_registered_relays: Set[str] = set()
+        self._api_v1_registration_state: Dict[str, Dict[str, Any]] = {}
 
     @staticmethod
     def _compose_relay_url(base_url: str, port: Optional[int]) -> str:
@@ -711,6 +713,121 @@ class RelayClient:
         if not self._registration_token:
             return {}
         return {"X-Relay-Server-Token": self._registration_token}
+
+    @staticmethod
+    def _api_v1_public_key_fingerprint(public_key: Any) -> str:
+        """Return a short diagnostic fingerprint for a public key without logging it."""
+
+        if not isinstance(public_key, str) or not public_key:
+            return "unknown"
+        return hashlib.sha256(public_key.encode("utf-8")).hexdigest()[:12]
+
+    @staticmethod
+    def _api_v1_lease_refresh_seconds(lease_seconds: Any) -> float:
+        """Return the local age at which a registration should be renewed early."""
+
+        try:
+            lease = float(lease_seconds)
+        except (TypeError, ValueError):
+            return 1.0
+        if not math.isfinite(lease) or lease <= 0:
+            return 1.0
+        if lease <= 2.0:
+            return max(lease * 0.5, 0.1)
+        return max(min(lease * 0.75, lease - 1.0), 1.0)
+
+    def _api_v1_record_registration_heartbeat(
+        self,
+        relay_url: str,
+        *,
+        lease_seconds: Any,
+        poll_wait_seconds: Any,
+        server_public_key: str,
+    ) -> None:
+        """Track the latest locally confirmed API v1 relay registration heartbeat."""
+
+        try:
+            lease = float(lease_seconds)
+        except (TypeError, ValueError):
+            lease = float(self._request_timeout)
+        if not math.isfinite(lease) or lease <= 0:
+            lease = float(self._request_timeout)
+        poll_wait = self._normalise_poll_wait_seconds(poll_wait_seconds)
+        now = time.monotonic()
+        self._api_v1_registration_state[relay_url] = {
+            'last_confirmed_monotonic': now,
+            'lease_seconds': lease,
+            'poll_wait_seconds': poll_wait,
+            'server_public_key': server_public_key,
+        }
+        self._api_v1_registered_relays.add(relay_url)
+        refresh_in = self._api_v1_lease_refresh_seconds(lease)
+        log_info(
+            "server.heartbeat_state relay={} key_fp={} lease_seconds={} poll_wait_seconds={} refresh_in_seconds={}",
+            relay_url,
+            self._api_v1_public_key_fingerprint(server_public_key),
+            lease,
+            poll_wait,
+            refresh_in,
+        )
+
+    def _api_v1_clear_registration_state(self, relay_url: str) -> None:
+        self._api_v1_registered_relays.discard(relay_url)
+        self._api_v1_registration_state.pop(relay_url, None)
+
+    def api_v1_registration_age_seconds(self, relay_url: Optional[str] = None) -> Optional[float]:
+        """Return the age of the latest confirmed API v1 relay heartbeat, if known."""
+
+        target_url = relay_url or self.relay_url
+        state = self._api_v1_registration_state.get(target_url)
+        if not isinstance(state, dict):
+            return None
+        last_confirmed = state.get('last_confirmed_monotonic')
+        if not isinstance(last_confirmed, (int, float)):
+            return None
+        return max(time.monotonic() - float(last_confirmed), 0.0)
+
+    def is_api_v1_registration_fresh(self, relay_url: Optional[str] = None) -> bool:
+        """Return whether local state reflects a relay-confirmed registration within its lease."""
+
+        target_url = relay_url or self.relay_url
+        if target_url not in self._api_v1_registered_relays:
+            return False
+        state = self._api_v1_registration_state.get(target_url)
+        if not isinstance(state, dict):
+            return False
+        if state.get('server_public_key') != self.crypto_manager.public_key_b64:
+            return False
+        age = self.api_v1_registration_age_seconds(target_url)
+        if age is None:
+            return False
+        lease = state.get('lease_seconds', self._request_timeout)
+        try:
+            lease_value = float(lease)
+        except (TypeError, ValueError):
+            lease_value = float(self._request_timeout)
+        if not math.isfinite(lease_value) or lease_value <= 0:
+            lease_value = float(self._request_timeout)
+        return age <= lease_value
+
+    def _api_v1_registration_refresh_reason(self, relay_url: str, server_public_key: str) -> Optional[str]:
+        """Return why an API v1 relay registration should be renewed before polling."""
+
+        if relay_url not in self._api_v1_registered_relays:
+            return "not_registered"
+        state = self._api_v1_registration_state.get(relay_url)
+        if not isinstance(state, dict):
+            return "missing_local_heartbeat"
+        if state.get('server_public_key') != server_public_key:
+            return "public_key_changed"
+        age = self.api_v1_registration_age_seconds(relay_url)
+        if age is None:
+            return "missing_local_heartbeat"
+        lease = state.get('lease_seconds', self._request_timeout)
+        refresh_after = self._api_v1_lease_refresh_seconds(lease)
+        if age >= refresh_after:
+            return "lease_expiry_risk"
+        return None
 
     def start(self):
         """Start the polling loop by setting stop_polling to False"""
@@ -1014,7 +1131,17 @@ class RelayClient:
                 token_sent=token_sent,
                 next_ping_in_x_seconds=self._request_timeout,
             )
-        return response.json()
+        payload = response.json()
+        if isinstance(payload, dict) and not payload.get('error'):
+            lease_seconds = payload.get('next_ping_in_x_seconds', self._request_timeout)
+            poll_wait_seconds = payload.get('poll_wait_seconds', lease_seconds)
+            self._api_v1_record_registration_heartbeat(
+                target_url,
+                lease_seconds=lease_seconds,
+                poll_wait_seconds=poll_wait_seconds,
+                server_public_key=self.crypto_manager.public_key_b64,
+            )
+        return payload
 
     @staticmethod
     def _build_api_v1_url(relay_url: str, route: str) -> str:
@@ -1055,15 +1182,26 @@ class RelayClient:
                 poll_wait = cached_hints.get('poll_wait_seconds', register_wait)
                 current_public_key = self.crypto_manager.public_key_b64
                 registered_public_key = cached_hints.get('server_public_key')
-                requires_register = candidate_url not in self._api_v1_registered_relays
+                refresh_reason = self._api_v1_registration_refresh_reason(
+                    candidate_url, current_public_key
+                )
+                requires_register = refresh_reason is not None
                 if (
                     not requires_register
                     and isinstance(registered_public_key, str)
                     and registered_public_key != current_public_key
                 ):
+                    refresh_reason = "public_key_changed"
                     requires_register = True
 
                 if requires_register:
+                    if refresh_reason not in {None, "not_registered"}:
+                        log_info(
+                            "server.reregister reason={} relay={} key_fp={}",
+                            refresh_reason,
+                            candidate_url,
+                            self._api_v1_public_key_fingerprint(current_public_key),
+                        )
                     register_response = self.register_api_v1_compute_node(candidate_url)
                     if not isinstance(register_response, dict):
                         last_error = {
@@ -1086,8 +1224,13 @@ class RelayClient:
                         'poll_wait_seconds': poll_wait,
                         'server_public_key': current_public_key,
                     }
-                    self._api_v1_registered_relays.add(candidate_url)
-                    log_info("server.registered relay={}", candidate_url)
+                    log_info(
+                        "server.registered relay={} key_fp={} lease_seconds={} poll_wait_seconds={}",
+                        candidate_url,
+                        self._api_v1_public_key_fingerprint(current_public_key),
+                        register_wait,
+                        poll_wait,
+                    )
 
                 request_kwargs: Dict[str, Any] = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
@@ -1138,15 +1281,19 @@ class RelayClient:
                     raise
                 if response.status_code != 200:
                     if response.status_code == 404:
-                        self._api_v1_registered_relays.discard(candidate_url)
+                        self._api_v1_clear_registration_state(candidate_url)
                         relay_wait_hints.pop(candidate_url, None)
-                        log_info("server.reregister reason=unknown_node relay={}", candidate_url)
+                        log_info(
+                            "server.reregister reason=unknown_node relay={} key_fp={}",
+                            candidate_url,
+                            self._api_v1_public_key_fingerprint(current_public_key),
+                        )
                     last_error = self._api_v1_http_error_result(
                         response,
                         method="POST",
                         url=poll_url,
                         token_sent=token_sent,
-                        next_ping_in_x_seconds=register_wait,
+                        next_ping_in_x_seconds=0 if response.status_code == 404 else register_wait,
                     )
                     continue
                 payload = response.json()
@@ -1161,9 +1308,21 @@ class RelayClient:
                     payload_wait = None
                 if payload_wait is None:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
+                self._api_v1_record_registration_heartbeat(
+                    candidate_url,
+                    lease_seconds=register_wait,
+                    poll_wait_seconds=payload.get('poll_wait_seconds', poll_wait),
+                    server_public_key=current_public_key,
+                )
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
-                log_info("server.heartbeat relay={}", candidate_url)
+                log_info(
+                    "server.heartbeat relay={} key_fp={} lease_seconds={} next_heartbeat_seconds={}",
+                    candidate_url,
+                    self._api_v1_public_key_fingerprint(current_public_key),
+                    register_wait,
+                    payload.get('next_ping_in_x_seconds'),
+                )
                 log_info(
                     "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
                     payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',
@@ -1171,8 +1330,13 @@ class RelayClient:
                 )
                 return payload
             except Exception as exc:
-                log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
-                self._api_v1_registered_relays.discard(candidate_url)
+                log_error(
+                    "API v1 relay poll failed for {}: {}",
+                    candidate_url,
+                    str(exc),
+                    exc_info=True,
+                )
+                self._api_v1_clear_registration_state(candidate_url)
                 relay_wait_hints.pop(candidate_url, None)
                 last_error = {'error': str(exc), 'next_ping_in_x_seconds': self._request_timeout}
 


### PR DESCRIPTION
### Motivation
- Fix the Sugarkube staging symptom where a desktop compute node registered successfully and returned a single no-work poll, then aged out before a later browser/API request (relay `/api/v1/relay/servers/next` returned 503). 
- Root cause: the desktop bridge treated a successful register/no-work poll as sufficient and did not ensure continuous lease-preserving heartbeats while warmup or idle periods could delay polling. 
- Goal: keep desktop registration alive (heartbeat/re-register proactively), make the UI/bridge reflect recent confirmed registration, and add regression tests reproducing the idle/no-work race.

### Description
- Added lease-aware local registration state tracking to `RelayClient` with short public-key fingerprints, heartbeat timestamps, and an early-refresh threshold to decide when to reregister before lease expiry (new helpers `_api_v1_record_registration_heartbeat`, `_api_v1_registration_refresh_reason`, `is_api_v1_registration_fresh`, and fingerprinting). (file: `utils/networking/relay_client.py`)
- Updated API v1 register/poll flow to record successful register heartbeats, reregister when local state indicates lease-expiry risk or public-key change, clear local registration state on relay 404 (unknown-node), and use 0/lease-adjusted next-ping hints so the client retries promptly instead of sleeping a full lease interval. (file: `utils/networking/relay_client.py`)
- Changed desktop bridge `registered` semantics to require a recently confirmed relay heartbeat (`is_api_v1_registration_fresh`) and deferred post-registration model warmup for heartbeat-only/no-work polls so warmup does not block the next poll/heartbeat. (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Added targeted regression tests covering: idle no-work polls followed by work arrival, lease-expiry early reregister, unknown-node re-register cadence, and registration freshness expiry. (files: `tests/unit/test_relay_client.py`, `tests/integration/test_api_v1_desktop_bridge_e2ee.py`)
- Added compact diagnostic logs that avoid printing raw public keys (use 12-char SHA256 fingerprint) and record lease/next-heartbeat timing for operators. (file: `utils/networking/relay_client.py`)

### Testing
- `python -m py_compile utils/networking/relay_client.py desktop-tauri/src-tauri/python/compute_node_bridge.py` — passed. 
- `pytest tests/unit/test_relay_client.py -q` — all unit tests passed (119 passed). 
- `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — integration tests passed (8 passed). 
- `pytest tests/test_relay.py -k "api_v1 or relay or lease or heartbeat" -q` — relay tests passed (77 passed). 
- `pre-commit run --all-files` — started but `check-yaml` failed on pre-existing Helm template YAML under `charts/tokenplace/templates/*` (these are pre-existing template parse issues unrelated to the change), so the full pre-commit sweep was not completed; CI-level `check-yaml` failures should be addressed separately. 

Residual risks / follow-ups: validate Helm/Chart YAML in a separate PR (Prompt 2 handles staging/prod relay target defaults), and run repository-wide `pre-commit` once Helm templates are fixed in CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18e56dd160832fb7eb50847933e64a)