### PR TITLE
Keep desktop API v1 relay registration alive after no-work polls

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -17,6 +17,10 @@ from pathlib import Path
 from urllib.request import urlopen
 
 
+RELAY_STARTUP_TIMEOUT_SECONDS = 60.0
+RELAY_LIVEZ_REQUEST_TIMEOUT_SECONDS = 2.0
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -26,26 +30,49 @@ def reserve_free_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def wait_for_livez(relay: subprocess.Popen[str], port: int, timeout_seconds: float = 20.0) -> None:
+def _tail_text(path: Path, *, max_chars: int = 4000) -> str:
+    try:
+        return path.read_text(errors="replace")[-max_chars:]
+    except OSError as exc:
+        return f"<unable to read {path}: {exc}>"
+
+
+def wait_for_livez(
+    relay: subprocess.Popen[str],
+    port: int,
+    *,
+    timeout_seconds: float = RELAY_STARTUP_TIMEOUT_SECONDS,
+    request_timeout_seconds: float = RELAY_LIVEZ_REQUEST_TIMEOUT_SECONDS,
+    stdout_path: Path | None = None,
+    stderr_path: Path | None = None,
+) -> None:
     deadline = time.time() + timeout_seconds
     last_error: Exception | None = None
     while time.time() < deadline:
         try:
-            with urlopen(f"http://127.0.0.1:{port}/livez", timeout=1) as resp:  # noqa: S310
+            with urlopen(
+                f"http://127.0.0.1:{port}/livez",
+                timeout=request_timeout_seconds,
+            ) as resp:  # noqa: S310
                 if resp.status == 200:
                     return
         except Exception as exc:  # pragma: no cover - retry loop
             last_error = exc
 
         if relay.poll() is not None:
-            stderr = relay.stderr.read() if relay.stderr else ""
-            stdout = relay.stdout.read() if relay.stdout else ""
+            stderr = _tail_text(stderr_path) if stderr_path is not None else ""
+            stdout = _tail_text(stdout_path) if stdout_path is not None else ""
             raise RuntimeError(
                 f"relay exited early with code {relay.returncode}; stdout={stdout}; stderr={stderr}"
             )
         time.sleep(0.25)
 
-    raise RuntimeError(f"relay did not become live on port {port}: {last_error}")
+    stdout = _tail_text(stdout_path) if stdout_path is not None else ""
+    stderr = _tail_text(stderr_path) if stderr_path is not None else ""
+    raise RuntimeError(
+        f"relay did not become live on port {port} after {timeout_seconds:.1f}s: "
+        f"{last_error}; stdout={stdout}; stderr={stderr}"
+    )
 
 
 def create_packaged_layout(tmp_root: Path, *, resources_dir_name: str = "resources") -> Path:
@@ -408,6 +435,11 @@ def main() -> int:
 
         for probe_script, probe_resources_root, layout_label in probe_specs:
             relay_port = reserve_free_port()
+            relay_log_label = layout_label.replace(" ", "-").replace("/", "-")
+            relay_stdout = tmp_path / f"relay-{relay_log_label}-{relay_port}.stdout.log"
+            relay_stderr = tmp_path / f"relay-{relay_log_label}-{relay_port}.stderr.log"
+            relay_stdout_handle = relay_stdout.open("w", encoding="utf-8")
+            relay_stderr_handle = relay_stderr.open("w", encoding="utf-8")
             relay = subprocess.Popen(  # noqa: S603
                 [
                     sys.executable,
@@ -420,13 +452,18 @@ def main() -> int:
                 ],
                 cwd=REPO_ROOT,
                 env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=relay_stdout_handle,
+                stderr=relay_stderr_handle,
                 text=True,
             )
 
             try:
-                wait_for_livez(relay, relay_port)
+                wait_for_livez(
+                    relay,
+                    relay_port,
+                    stdout_path=relay_stdout,
+                    stderr_path=relay_stderr,
+                )
                 run_compute_bridge_startup_probe(
                     tmp_path,
                     probe_script,
@@ -436,7 +473,14 @@ def main() -> int:
                 )
             finally:
                 if relay.poll() is None:
-                    relay.kill()
+                    relay.terminate()
+                    try:
+                        relay.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        relay.kill()
+                        relay.wait(timeout=5)
+                relay_stdout_handle.close()
+                relay_stderr_handle.close()
 
     return 0
 

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import math
 import os
@@ -72,6 +73,32 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
+
+
+def _registration_fresh(relay_client: Any, relay_url: str) -> bool:
+    """Return whether bridge UI should report the relay registration as current."""
+
+    is_fresh = getattr(relay_client, "api_v1_registration_fresh", None)
+    if callable(is_fresh):
+        try:
+            return bool(is_fresh(relay_url))
+        except TypeError:
+            return bool(is_fresh())
+    return False
+
+
+def _poll_deadline_seconds(relay_client: Any, wait_seconds: float) -> float:
+    timeout_for_wait = getattr(relay_client, "_api_v1_poll_timeout_seconds", None)
+    if callable(timeout_for_wait):
+        try:
+            return float(timeout_for_wait(wait_seconds)) + 5.0
+        except (TypeError, ValueError):
+            pass
+    try:
+        request_timeout = float(getattr(relay_client, "_request_timeout", 1))
+    except (TypeError, ValueError):
+        request_timeout = 1.0
+    return max(request_timeout, wait_seconds) + 5.0
 
 
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
@@ -352,14 +379,17 @@ def run(args: argparse.Namespace) -> int:
     warm_load_duration_ms: Optional[int] = None
     warm_load_failed: Optional[str] = None
     warm_load_fatal = False
+    warm_load_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+    warm_load_future: Optional[concurrent.futures.Future] = None
 
     def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
+        fresh_registered = registered and _registration_fresh(runtime.relay_client, active_relay_url)
         diagnostics = compute_mode_diagnostics(runtime.model_manager)
         emit(
             {
                 "type": "status",
                 "running": True,
-                "registered": registered,
+                "registered": fresh_registered,
                 "active_relay_url": active_relay_url,
                 "requested_mode": diagnostics.get("requested_mode"),
                 "effective_mode": diagnostics.get("effective_mode"),
@@ -382,27 +412,41 @@ def run(args: argparse.Namespace) -> int:
             }
         )
 
-    def ensure_runtime_ready(reason: str, *, active_relay_url: str) -> bool:
+    def ensure_runtime_ready(reason: str, *, active_relay_url: str, block: bool = False) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
+        nonlocal warm_load_executor, warm_load_future
         if warm_load_state == "ready":
             return True
-        if warm_load_state == "warming":
+        if warm_load_state == "failed":
             return False
-        warm_load_state = "warming"
-        warm_load_failed = None
-        warm_load_duration_ms = None
-        warm_load_started_at = time.perf_counter()
-        emit_status_event(
-            registered=True,
-            active_relay_url=active_relay_url,
-            current_last_error=last_error,
-        )
-        print(
-            "desktop.compute_node_bridge.model_init.start "
-            f"reason={reason} state={warm_load_state}",
-            file=sys.stderr,
-        )
-        ready = runtime.ensure_api_v1_runtime_ready()
+        if warm_load_state == "not_started":
+            warm_load_state = "warming"
+            warm_load_failed = None
+            warm_load_duration_ms = None
+            warm_load_started_at = time.perf_counter()
+            if warm_load_executor is None:
+                warm_load_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="tokenplace-warm-load"
+                )
+            warm_load_future = warm_load_executor.submit(runtime.ensure_api_v1_runtime_ready)
+            emit_status_event(
+                registered=True,
+                active_relay_url=active_relay_url,
+                current_last_error=last_error,
+            )
+            print(
+                "desktop.compute_node_bridge.model_init.start "
+                f"reason={reason} state={warm_load_state}",
+                file=sys.stderr,
+            )
+        if warm_load_future is None:
+            return False
+        if block and not warm_load_future.done():
+            ready = bool(warm_load_future.result())
+        elif warm_load_future.done():
+            ready = bool(warm_load_future.result())
+        else:
+            return False
         warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
         if not ready:
             warm_load_state = "failed"
@@ -479,14 +523,51 @@ def run(args: argparse.Namespace) -> int:
     try:
         while not stop_requested():
             print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
-            relay_response = runtime.register_and_poll_once()
+            active_relay_url = runtime.relay_client.relay_url
+            poll_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="tokenplace-relay-poll"
+            )
+            poll_started = time.monotonic()
+            poll_future = poll_executor.submit(runtime.register_and_poll_once)
+            poll_deadline = _poll_deadline_seconds(
+                runtime.relay_client, getattr(runtime.relay_client, "_request_timeout", 1)
+            )
+            relay_response: Dict[str, Any]
+            while True:
+                try:
+                    relay_response = poll_future.result(timeout=0.25)
+                    break
+                except concurrent.futures.TimeoutError:
+                    active_relay_url = runtime.relay_client.relay_url
+                    if not _registration_fresh(runtime.relay_client, active_relay_url):
+                        emit_status_event(
+                            registered=False,
+                            active_relay_url=active_relay_url,
+                            current_last_error="relay registration heartbeat is stale; reconnecting",
+                        )
+                    if poll_future.running() and (
+                        time.monotonic() - poll_started
+                    ) > poll_deadline:
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.poll_timeout "
+                            f"relay={_sanitize_relay_target(active_relay_url)} deadline={poll_deadline}",
+                            file=sys.stderr,
+                        )
+                    if stop_requested():
+                        poll_executor.shutdown(wait=False, cancel_futures=True)
+                        raise KeyboardInterrupt
+            poll_executor.shutdown(wait=False)
             active_relay_url = runtime.relay_client.relay_url
             api_v1_payload = is_api_v1_relay_payload(relay_response)
             relay_error = _relay_error_message(relay_response)
             has_heartbeat = (
                 isinstance(relay_response, dict) and "next_ping_in_x_seconds" in relay_response
             )
-            registered = relay_error is None and (has_heartbeat or api_v1_payload)
+            registered = (
+                relay_error is None
+                and (has_heartbeat or api_v1_payload)
+                and _registration_fresh(runtime.relay_client, active_relay_url)
+            )
             wait_seconds = _safe_poll_wait_seconds(
                 relay_response, getattr(runtime.relay_client, "_request_timeout", 1)
             )
@@ -525,7 +606,9 @@ def run(args: argparse.Namespace) -> int:
                         f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
                         file=sys.stderr,
                     )
-                elif not ensure_runtime_ready("api_v1_request", active_relay_url=active_relay_url):
+                elif not ensure_runtime_ready(
+                    "api_v1_request", active_relay_url=active_relay_url, block=True
+                ):
                     fail_on_warm_load_error(active_relay_url=active_relay_url)
                     break
 
@@ -582,7 +665,12 @@ def run(args: argparse.Namespace) -> int:
                         file=sys.stderr,
                     )
                 else:
-                    if not ensure_runtime_ready("post_registration", active_relay_url=active_relay_url):
+                    if (
+                        not ensure_runtime_ready(
+                            "post_registration", active_relay_url=active_relay_url, block=False
+                        )
+                        and warm_load_state == "failed"
+                    ):
                         fail_on_warm_load_error(active_relay_url=active_relay_url)
                         break
             emit_status_event(
@@ -593,8 +681,12 @@ def run(args: argparse.Namespace) -> int:
 
             if _sleep_with_cancel(wait_seconds):
                 break
+    except KeyboardInterrupt:
+        pass
     finally:
         print("desktop.compute_node_bridge.stop", file=sys.stderr)
+        if warm_load_executor is not None:
+            warm_load_executor.shutdown(wait=False, cancel_futures=True)
         runtime.stop()
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -75,6 +75,57 @@ WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
 
 
+_POLL_CANCELLED = object()
+
+
+class _CancelablePollWorker:
+    """Run one relay poll at a time while the bridge keeps checking for cancel."""
+
+    def __init__(self) -> None:
+        self._tasks: "queue.Queue[Any]" = queue.Queue()
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name="tokenplace-relay-poll",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            task = self._tasks.get()
+            if task is None:
+                return
+            fn, result_queue = task
+            try:
+                result_queue.put((True, fn()))
+            except BaseException as exc:  # pragma: no cover - exercised via call() re-raise
+                result_queue.put((False, exc))
+
+    def call(self, fn: Any, should_cancel: Any, *, poll_interval: float = 0.1) -> Any:
+        if self._closed:
+            return _POLL_CANCELLED
+        result_queue: "queue.Queue[Any]" = queue.Queue(maxsize=1)
+        self._tasks.put((fn, result_queue))
+        while True:
+            try:
+                ok, value = result_queue.get(timeout=poll_interval)
+            except queue.Empty:
+                if should_cancel():
+                    return _POLL_CANCELLED
+                continue
+            if ok:
+                return value
+            raise value
+
+    def shutdown(self) -> None:
+        self._closed = True
+        try:
+            self._tasks.put_nowait(None)
+        except queue.Full:  # pragma: no cover - unbounded queue is not expected to fill
+            pass
+
+
 def _registration_fresh(relay_client: Any, relay_url: str) -> bool:
     """Return whether bridge UI should report the relay registration as current."""
 
@@ -385,6 +436,7 @@ def run(args: argparse.Namespace) -> int:
     warm_load_fatal = False
     warm_load_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
     warm_load_future: Optional[concurrent.futures.Future] = None
+    poll_worker = _CancelablePollWorker()
 
     def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
         fresh_registered = registered and _registration_fresh(runtime.relay_client, active_relay_url)
@@ -528,7 +580,10 @@ def run(args: argparse.Namespace) -> int:
         while not stop_requested():
             print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
             active_relay_url = runtime.relay_client.relay_url
-            relay_response: Dict[str, Any] = runtime.register_and_poll_once()
+            relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
+            if relay_response is _POLL_CANCELLED:
+                break
+            relay_response = relay_response if isinstance(relay_response, dict) else {}
             active_relay_url = runtime.relay_client.relay_url
             api_v1_payload = is_api_v1_relay_payload(relay_response)
             relay_error = _relay_error_message(relay_response)
@@ -657,8 +712,9 @@ def run(args: argparse.Namespace) -> int:
         pass
     finally:
         print("desktop.compute_node_bridge.stop", file=sys.stderr)
+        poll_worker.shutdown()
         if warm_load_executor is not None:
-            warm_load_executor.shutdown(wait=True, cancel_futures=True)
+            warm_load_executor.shutdown(wait=False, cancel_futures=True)
         runtime.stop()
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -87,19 +87,6 @@ def _registration_fresh(relay_client: Any, relay_url: str) -> bool:
     return False
 
 
-def _poll_deadline_seconds(relay_client: Any, wait_seconds: float) -> float:
-    timeout_for_wait = getattr(relay_client, "_api_v1_poll_timeout_seconds", None)
-    if callable(timeout_for_wait):
-        try:
-            return float(timeout_for_wait(wait_seconds)) + 5.0
-        except (TypeError, ValueError):
-            pass
-    try:
-        request_timeout = float(getattr(relay_client, "_request_timeout", 1))
-    except (TypeError, ValueError):
-        request_timeout = 1.0
-    return max(request_timeout, wait_seconds) + 5.0
-
 
 def _cached_poll_wait_seconds(relay_client: Any, relay_url: str, default: float) -> float:
     """Return the relay-advertised long-poll wait used by the active client."""
@@ -541,42 +528,7 @@ def run(args: argparse.Namespace) -> int:
         while not stop_requested():
             print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
             active_relay_url = runtime.relay_client.relay_url
-            poll_executor = concurrent.futures.ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="tokenplace-relay-poll"
-            )
-            poll_started = time.monotonic()
-            poll_future = poll_executor.submit(runtime.register_and_poll_once)
-            poll_wait_seconds = _cached_poll_wait_seconds(
-                runtime.relay_client,
-                active_relay_url,
-                getattr(runtime.relay_client, "_request_timeout", 1),
-            )
-            poll_deadline = _poll_deadline_seconds(runtime.relay_client, poll_wait_seconds)
-            relay_response: Dict[str, Any]
-            while True:
-                try:
-                    relay_response = poll_future.result(timeout=0.25)
-                    break
-                except concurrent.futures.TimeoutError:
-                    active_relay_url = runtime.relay_client.relay_url
-                    if not _registration_fresh(runtime.relay_client, active_relay_url):
-                        emit_status_event(
-                            registered=False,
-                            active_relay_url=active_relay_url,
-                            current_last_error="relay registration heartbeat is stale; reconnecting",
-                        )
-                    if poll_future.running() and (
-                        time.monotonic() - poll_started
-                    ) > poll_deadline:
-                        print(
-                            "desktop.compute_node_bridge.api_v1_e2ee.poll_timeout "
-                            f"relay={_sanitize_relay_target(active_relay_url)} deadline={poll_deadline}",
-                            file=sys.stderr,
-                        )
-                    if stop_requested():
-                        poll_executor.shutdown(wait=False, cancel_futures=True)
-                        raise KeyboardInterrupt
-            poll_executor.shutdown(wait=False)
+            relay_response: Dict[str, Any] = runtime.register_and_poll_once()
             active_relay_url = runtime.relay_client.relay_url
             api_v1_payload = is_api_v1_relay_payload(relay_response)
             relay_error = _relay_error_message(relay_response)
@@ -706,7 +658,7 @@ def run(args: argparse.Namespace) -> int:
     finally:
         print("desktop.compute_node_bridge.stop", file=sys.stderr)
         if warm_load_executor is not None:
-            warm_load_executor.shutdown(wait=False, cancel_futures=True)
+            warm_load_executor.shutdown(wait=True, cancel_futures=True)
         runtime.stop()
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -101,6 +101,23 @@ def _poll_deadline_seconds(relay_client: Any, wait_seconds: float) -> float:
     return max(request_timeout, wait_seconds) + 5.0
 
 
+def _cached_poll_wait_seconds(relay_client: Any, relay_url: str, default: float) -> float:
+    """Return the relay-advertised long-poll wait used by the active client."""
+
+    hints_by_relay = getattr(relay_client, "_api_v1_relay_wait_hints", {})
+    hints = hints_by_relay.get(relay_url, {}) if isinstance(hints_by_relay, dict) else {}
+    wait_seconds = hints.get("poll_wait_seconds", default) if isinstance(hints, dict) else default
+    if isinstance(wait_seconds, bool):
+        return default
+    try:
+        normalised_wait = float(wait_seconds)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(normalised_wait) or normalised_wait < 0:
+        return default
+    return normalised_wait
+
+
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
     """Return a normalized relay error message if the response includes one."""
 
@@ -529,9 +546,12 @@ def run(args: argparse.Namespace) -> int:
             )
             poll_started = time.monotonic()
             poll_future = poll_executor.submit(runtime.register_and_poll_once)
-            poll_deadline = _poll_deadline_seconds(
-                runtime.relay_client, getattr(runtime.relay_client, "_request_timeout", 1)
+            poll_wait_seconds = _cached_poll_wait_seconds(
+                runtime.relay_client,
+                active_relay_url,
+                getattr(runtime.relay_client, "_request_timeout", 1),
             )
+            poll_deadline = _poll_deadline_seconds(runtime.relay_client, poll_wait_seconds)
             relay_response: Dict[str, Any]
             while True:
                 try:

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -12,6 +12,7 @@ import base64
 import json
 import threading
 import time
+from datetime import datetime, timedelta
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
@@ -309,6 +310,86 @@ def test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat():
         assert poll_payload["message"] == "No requests available"
         assert poll_payload["poll_wait_seconds"] > 0
         assert poll_payload["next_ping_in_x_seconds"] == 0
+
+
+
+def test_api_v1_desktop_bridge_reregisters_after_idle_no_work_before_browser_request(monkeypatch):
+    """A desktop node that idled after no-work polling should renew before browser work."""
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0.01")
+
+    with live_relay_server() as base_url:
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        desktop_client._request_timeout = 1
+        server_key = desktop_client.crypto_manager.public_key_b64
+
+        first_no_work = desktop_client.poll_api_v1_encrypted_work()
+        assert first_no_work["message"] == "No requests available"
+        assert server_key in relay.known_servers
+
+        relay.known_servers[server_key]["last_ping"] = datetime.now() - timedelta(seconds=60)
+        desktop_client._api_v1_last_heartbeat_at[base_url] -= 25.0
+
+        renewed_no_work = desktop_client.poll_api_v1_encrypted_work()
+        assert renewed_no_work["message"] == "No requests available"
+        assert server_key in relay.known_servers
+        assert requests.get(f"{base_url}/api/v1/relay/servers/next", timeout=2).status_code == 200
+
+        monkeypatch.setattr(
+            routes,
+            "get_api_v1_compute_provider_for_mode",
+            lambda **_kwargs: compute_provider.DistributedApiV1ComputeProvider(
+                base_url=base_url,
+                timeout_seconds=5,
+            ),
+        )
+        browser_crypto = EncryptionManager()
+        user_text = "ping after idle no-work"
+        payload = {
+            "model": "llama-3-8b-instruct",
+            "encrypted": True,
+            "client_public_key": browser_crypto.public_key_b64,
+            "messages": _encrypt_browser_messages(
+                [{"role": "user", "content": user_text}]
+            ),
+            "metadata": {
+                "inference_target": "desktop_bridge_api_v1_e2ee",
+                "relay_path": "api_v1_e2ee",
+            },
+        }
+        response_holder = {}
+
+        def _browser_request():
+            response_holder["response"] = requests.post(
+                f"{base_url}/api/v1/chat/completions", json=payload, timeout=10
+            )
+
+        browser_thread = threading.Thread(target=_browser_request, daemon=True)
+        browser_thread.start()
+
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            relay_payload = desktop_client.poll_api_v1_encrypted_work()
+            if relay_payload.get("protocol") == "tokenplace_api_v1_relay_e2ee":
+                assert desktop_client.process_client_request(relay_payload) is True
+                break
+            time.sleep(0.02)
+        else:  # pragma: no cover - diagnostic failure path
+            pytest.fail("desktop did not receive queued API v1 E2EE request after idle renewal")
+
+        browser_thread.join(timeout=5)
+
+    response = response_holder.get("response")
+    assert response is not None
+    assert response.status_code == 200, response.text
+    completion = _decrypt_browser_response(browser_crypto, response.json())
+    assert completion["choices"][0]["message"]["content"] == "pong from desktop"
 
 
 @pytest.mark.parametrize("encrypted", [False, True])

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1351,16 +1351,17 @@ def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypat
     _ = capsys.readouterr()
 
 
-def test_run_waits_for_active_warmup_before_runtime_stop(capsys, monkeypatch):
+def test_run_does_not_wait_for_active_warmup_before_runtime_stop(capsys, monkeypatch):
     _reset_cancel_queue()
     events = []
     warm_started = threading.Event()
+    release_warmup = threading.Event()
 
     class SlowWarmupRuntime(FakeRuntime):
         def ensure_api_v1_runtime_ready(self):
             events.append("warm-start")
             warm_started.set()
-            time.sleep(0.05)
+            release_warmup.wait(timeout=1.0)
             events.append("warm-done")
             return True
 
@@ -1387,8 +1388,54 @@ def test_run_waits_for_active_warmup_before_runtime_stop(capsys, monkeypatch):
 
     status = compute_node_bridge.run(args)
 
-    assert status == 0
-    assert events.index("warm-done") < events.index("stop")
+    try:
+        assert status == 0
+        assert "stop" in events
+        assert "warm-done" not in events[: events.index("stop") + 1]
+    finally:
+        release_warmup.set()
+    _ = capsys.readouterr()
+
+
+def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatch):
+    _reset_cancel_queue()
+    events = []
+    poll_started = threading.Event()
+    release_poll = threading.Event()
+
+    class BlockingPollRuntime(FakeRuntime):
+        def register_and_poll_once(self):
+            events.append("poll-start")
+            poll_started.set()
+            release_poll.wait(timeout=1.0)
+            events.append("poll-done")
+            return {"next_ping_in_x_seconds": 0}
+
+        def stop(self):
+            events.append("stop")
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=BlockingPollRuntime)
+    stop_calls = {"count": 0}
+
+    def fake_stop_requested():
+        stop_calls["count"] += 1
+        if stop_calls["count"] == 1:
+            return False
+        assert poll_started.wait(timeout=1.0)
+        return True
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    try:
+        assert status == 0
+        assert "stop" in events
+        assert "poll-done" not in events[: events.index("stop") + 1]
+    finally:
+        release_poll.set()
     _ = capsys.readouterr()
 
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -6,6 +6,8 @@ import os
 import queue
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -32,6 +34,14 @@ class FakeModelManager:
 
 class FakeRelayClient:
     relay_url = 'https://token.place'
+
+    def api_v1_registration_fresh(self, _relay_url=None):
+        return True
+
+
+class StaleRelayClient(FakeRelayClient):
+    def api_v1_registration_fresh(self, _relay_url=None):
+        return False
 
 
 class FakeRelayClientRouting(FakeRelayClient):
@@ -1282,6 +1292,42 @@ def test_relay_error_message_normalizes_non_string_truthy_values():
     assert compute_node_bridge._relay_error_message({"error": 503}) == "503"
 
 
+def test_run_reports_stale_registration_status_after_missed_heartbeat(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class StaleHeartbeatRuntime(FakeRuntime):
+        def __init__(self, _config):
+            self.model_manager = FakeModelManager()
+            self.relay_client = StaleRelayClient()
+            self._processed = []
+
+        def register_and_poll_once(self):
+            return {"next_ping_in_x_seconds": 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StaleHeartbeatRuntime)
+    stop_calls = {"count": 0}
+
+    def fake_stop_requested():
+        stop_calls["count"] += 1
+        return stop_calls["count"] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get("type") == "status"]
+    assert status_events
+    assert all(event["registered"] is False for event in status_events)
+    assert any(
+        "relay appears unreachable" in (event.get("last_error") or "")
+        for event in status_events
+    )
+
+
 def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
@@ -1302,6 +1348,47 @@ def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypat
     status = compute_node_bridge.run(args)
     assert status == 0
     assert call_order[:3] == ["poll", "warm", "poll"]
+    _ = capsys.readouterr()
+
+
+def test_run_waits_for_active_warmup_before_runtime_stop(capsys, monkeypatch):
+    _reset_cancel_queue()
+    events = []
+    warm_started = threading.Event()
+
+    class SlowWarmupRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            events.append("warm-start")
+            warm_started.set()
+            time.sleep(0.05)
+            events.append("warm-done")
+            return True
+
+        def register_and_poll_once(self):
+            events.append("poll")
+            return {"next_ping_in_x_seconds": 0}
+
+        def stop(self):
+            events.append("stop")
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=SlowWarmupRuntime)
+    stop_calls = {"count": 0}
+
+    def fake_stop_requested():
+        stop_calls["count"] += 1
+        if stop_calls["count"] == 1:
+            return False
+        assert warm_started.wait(timeout=1.0)
+        return True
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert events.index("warm-done") < events.index("stop")
     _ = capsys.readouterr()
 
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1388,10 +1388,13 @@ def test_run_does_not_wait_for_active_warmup_before_runtime_stop(capsys, monkeyp
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
 
+    started_at = time.perf_counter()
     status = compute_node_bridge.run(args)
+    elapsed = time.perf_counter() - started_at
 
     try:
         assert status == 0
+        assert elapsed < 0.5
         assert "stop" in events
         assert "warm-done" not in events[: events.index("stop") + 1]
     finally:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 import threading
 import time
+
+import pytest
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -1643,3 +1645,150 @@ def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert "dependency preflight failed" in error_event["message"]
+
+
+def test_cancelable_poll_worker_returns_after_empty_poll_and_reraises():
+    worker = compute_node_bridge._CancelablePollWorker()
+    call_started = threading.Event()
+    release_call = threading.Event()
+
+    def delayed_result():
+        call_started.set()
+        release_call.wait(timeout=1.0)
+        return {"ok": True}
+
+    try:
+        def cancel_after_first_empty_poll():
+            if call_started.is_set():
+                release_call.set()
+            return False
+
+        assert worker.call(
+            delayed_result, cancel_after_first_empty_poll, poll_interval=0.01
+        ) == {"ok": True}
+
+        with pytest.raises(RuntimeError, match="poll exploded"):
+            worker.call(lambda: (_ for _ in ()).throw(RuntimeError("poll exploded")), lambda: False)
+    finally:
+        worker.shutdown()
+
+    assert worker.call(lambda: {"ok": False}, lambda: False) is compute_node_bridge._POLL_CANCELLED
+
+
+def test_registration_fresh_supports_legacy_no_arg_helper_and_missing_helper():
+    class LegacyFreshClient:
+        def api_v1_registration_fresh(self):
+            return True
+
+    assert compute_node_bridge._registration_fresh(LegacyFreshClient(), "https://relay.example") is True
+    assert compute_node_bridge._registration_fresh(object(), "https://relay.example") is False
+
+
+def test_cached_poll_wait_seconds_normalizes_hints_and_rejects_bad_values():
+    class RelayClient:
+        _api_v1_relay_wait_hints = {
+            "https://relay.example": {"poll_wait_seconds": "12.5"},
+            "https://bool.example": {"poll_wait_seconds": True},
+            "https://negative.example": {"poll_wait_seconds": -1},
+            "https://nan.example": {"poll_wait_seconds": float("nan")},
+            "https://bad.example": {"poll_wait_seconds": "soon"},
+        }
+
+    client = RelayClient()
+    assert compute_node_bridge._cached_poll_wait_seconds(client, "https://relay.example", 3) == 12.5
+    assert compute_node_bridge._cached_poll_wait_seconds(client, "https://bool.example", 3) == 3
+    assert compute_node_bridge._cached_poll_wait_seconds(client, "https://negative.example", 3) == 3
+    assert compute_node_bridge._cached_poll_wait_seconds(client, "https://nan.example", 3) == 3
+    assert compute_node_bridge._cached_poll_wait_seconds(client, "https://bad.example", 3) == 3
+    assert compute_node_bridge._cached_poll_wait_seconds(object(), "https://relay.example", 3) == 3
+
+
+def test_run_sidecar_api_v1_payload_skips_bridge_warm_load_without_dual_opt_in(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class SidecarApiPayloadRuntime(ApiV1Runtime):
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            return True
+
+        def process_relay_request(self, payload):
+            calls.append("process")
+            return super().process_relay_request(payload)
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=SidecarApiPayloadRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_RUNTIME_PATH", "sidecar")
+    monkeypatch.delenv("TOKENPLACE_DESKTOP_DUAL_RUNTIME", raising=False)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: bool(calls))
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert calls == ["process"]
+    output = capsys.readouterr()
+    assert "model_init.skipped reason=api_v1_request" in output.err
+
+
+def test_run_reports_api_v1_processing_failure(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class ApiV1ProcessingFailureRuntime(ApiV1Runtime):
+        def process_relay_request(self, payload):
+            self._processed.append(payload)
+            return False
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1ProcessingFailureRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: bool(ApiV1ProcessingFailureRuntime.last_instance._processed))
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get("type") == "status"]
+    assert status_events[-1]["last_error"] == "failed to process relay request"
+
+
+def test_run_reports_unreachable_for_non_heartbeat_response(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class NonHeartbeatRuntime(FakeRuntime):
+        def register_and_poll_once(self):
+            return {"relay_version": "desktop-v0.1.0"}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=NonHeartbeatRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', lambda _seconds: True)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    status_event = next(event for event in events if event.get("type") == "status")
+    assert status_event["registered"] is False
+    assert "relay appears unreachable" in status_event["last_error"]
+
+
+def test_run_handles_keyboard_interrupt_from_poll_worker(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class KeyboardInterruptRuntime(FakeRuntime):
+        def register_and_poll_once(self):
+            raise KeyboardInterrupt
+
+        def stop(self):
+            self.stopped = True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=KeyboardInterruptRuntime)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert events[-1]["type"] == "stopped"

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -96,6 +96,20 @@ def test_desktop_bridge_registration_fresh_helper_accepts_recent_heartbeat(monke
 
     assert bridge._registration_fresh(client, "https://staging.token.place") is True
 
+
+def test_desktop_bridge_cached_poll_wait_helper_uses_relay_hint(monkeypatch):
+    bridge = _load_compute_node_bridge_module()
+    client = MagicMock()
+    client._api_v1_relay_wait_hints = {
+        "https://staging.token.place": {"poll_wait_seconds": "30"}
+    }
+
+    assert (
+        bridge._cached_poll_wait_seconds(client, "https://staging.token.place", 15)
+        == 30.0
+    )
+
+
 def test_validate_with_fallback_accepts_message_schema_without_jsonschema():
     payload = {
         "client_public_key": "abc",
@@ -1165,11 +1179,20 @@ class TestRelayClient:
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_expected_poll_timeout_returns_no_work_without_reregister(
-        self, mock_post, relay_client
+        self, mock_post, relay_client, monkeypatch
     ):
+        clock_values = iter([1000.0, 1000.0, 1010.0, 1010.0])
+        monkeypatch.setattr(
+            relay_client_module.time,
+            'monotonic',
+            lambda: next(clock_values),
+        )
         register_ok = MagicMock(status_code=200)
         register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 10}
-        mock_post.side_effect = [register_ok, requests.Timeout("Read timed out. (read timeout=15)")]
+        mock_post.side_effect = [
+            register_ok,
+            requests.Timeout("Read timed out. (read timeout=15)"),
+        ]
 
         result = relay_client.poll_api_v1_encrypted_work()
 
@@ -1249,6 +1272,40 @@ class TestRelayClient:
         called_urls = [call.args[0] for call in mock_post.call_args_list]
         assert called_urls == [
             'http://relay-a.example/api/v1/relay/servers/register',
+            'http://relay-b.example/api/v1/relay/servers/register',
+            'http://relay-b.example/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_poll_timeout_fails_over_to_backup(
+        self, mock_post, relay_client
+    ):
+        relay_client._relay_urls = ('http://relay-a.example', 'http://relay-b.example')
+        relay_client._active_relay_index = 0
+
+        register_a = MagicMock(status_code=200)
+        register_a.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        register_b = MagicMock(status_code=200)
+        register_b.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [
+            register_a,
+            requests.Timeout("Read timed out. (read timeout=15)"),
+            register_b,
+            poll_ok,
+        ]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['message'] == 'No requests available'
+        assert result['next_ping_in_x_seconds'] == 12
+        assert 'http://relay-a.example' not in relay_client._api_v1_registered_relays
+        assert relay_client._active_relay_index == 1
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://relay-a.example/api/v1/relay/servers/register',
+            'http://relay-a.example/api/v1/relay/servers/poll',
             'http://relay-b.example/api/v1/relay/servers/register',
             'http://relay-b.example/api/v1/relay/servers/poll',
         ]
@@ -1341,6 +1398,27 @@ class TestRelayClient:
 
         clock["now"] += 31.0
         assert relay_client.api_v1_registration_fresh('http://localhost:5000') is False
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_normalises_string_lease_hint(
+        self, mock_post, relay_client
+    ):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 9, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {
+            'message': 'No requests available',
+            'next_ping_in_x_seconds': '30',
+            'poll_wait_seconds': '10',
+        }
+        mock_post.side_effect = [register_ok, poll_ok]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['next_ping_in_x_seconds'] == 30.0
+        hints = relay_client._api_v1_relay_wait_hints['http://localhost:5000']
+        assert hints['next_ping_in_x_seconds'] == 30.0
+        assert hints['poll_wait_seconds'] == 10.0
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_cached_poll_wait_reused(self, mock_post, relay_client):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1224,7 +1224,9 @@ class TestRelayClient:
         result = relay_client.poll_api_v1_encrypted_work()
 
         assert 'Read timed out' in result['error']
+        assert result.get('message') != 'No requests available'
         assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
+        assert relay_client._api_v1_last_heartbeat_at == {}
         assert relay_client.api_v1_registration_fresh() is False
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -79,6 +79,23 @@ def test_max_poll_failures_honours_override(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_MAX_POLL_FAILURES", "3")
     assert relay_client_module._max_poll_failures_before_stop() == 3
 
+
+def test_desktop_bridge_registration_fresh_helper_rejects_stale_client_state(monkeypatch):
+    bridge = _load_compute_node_bridge_module()
+    client = MagicMock()
+    client.api_v1_registration_fresh.return_value = False
+
+    assert bridge._registration_fresh(client, "https://staging.token.place") is False
+    client.api_v1_registration_fresh.assert_called_once_with("https://staging.token.place")
+
+
+def test_desktop_bridge_registration_fresh_helper_accepts_recent_heartbeat(monkeypatch):
+    bridge = _load_compute_node_bridge_module()
+    client = MagicMock()
+    client.api_v1_registration_fresh.return_value = True
+
+    assert bridge._registration_fresh(client, "https://staging.token.place") is True
+
 def test_validate_with_fallback_accepts_message_schema_without_jsonschema():
     payload = {
         "client_public_key": "abc",
@@ -1277,6 +1294,53 @@ class TestRelayClient:
             'http://localhost:5000/api/v1/relay/servers/register',
             'http://localhost:5000/api/v1/relay/servers/poll',
         ]
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_reregisters_before_cached_lease_expires(
+        self, mock_post, relay_client, monkeypatch
+    ):
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(relay_client_module.time, "monotonic", lambda: clock["now"])
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 30, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available', 'next_ping_in_x_seconds': 0, 'poll_wait_seconds': 10}
+        mock_post.side_effect = [register_ok, poll_ok, register_ok, poll_ok]
+
+        first = relay_client.poll_api_v1_encrypted_work()
+        assert first['message'] == 'No requests available'
+        assert relay_client.api_v1_registration_fresh('http://localhost:5000') is True
+
+        clock["now"] += 25.0
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert second['message'] == 'No requests available'
+        called_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert called_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_api_v1_registration_fresh_expires_after_lease_window(
+        self, mock_post, relay_client, monkeypatch
+    ):
+        clock = {"now": 2000.0}
+        monkeypatch.setattr(relay_client_module.time, "monotonic", lambda: clock["now"])
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 30, 'poll_wait_seconds': 10}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available', 'next_ping_in_x_seconds': 0, 'poll_wait_seconds': 10}
+        mock_post.side_effect = [register_ok, poll_ok]
+
+        relay_client.poll_api_v1_encrypted_work()
+        assert relay_client.api_v1_registration_fresh('http://localhost:5000') is True
+
+        clock["now"] += 31.0
+        assert relay_client.api_v1_registration_fresh('http://localhost:5000') is False
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_cached_poll_wait_reused(self, mock_post, relay_client):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1338,11 +1338,17 @@ class TestRelayClient:
         mock_post.side_effect = [register_ok, poll_404, register_ok, poll_ok]
 
         first = relay_client.poll_api_v1_encrypted_work()
-        second = relay_client.poll_api_v1_encrypted_work()
 
         assert first['error'] == 'HTTP 404'
-        assert first['next_ping_in_x_seconds'] == 9
+        assert first['next_ping_in_x_seconds'] == 0
         assert first['relay_error_kind'] == 'http_status_no_json_body'
+        assert relay_client.api_v1_registration_fresh('http://localhost:5000') is False
+        assert 'http://localhost:5000' not in relay_client._api_v1_registered_relays
+        assert 'http://localhost:5000' not in relay_client._api_v1_last_heartbeat_at
+        assert 'http://localhost:5000' not in relay_client._api_v1_relay_wait_hints
+
+        second = relay_client.poll_api_v1_encrypted_work()
+
         assert second['message'] == 'No requests available'
         called_urls = [call.args[0] for call in mock_post.call_args_list]
         assert called_urls == [

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1204,6 +1204,29 @@ class TestRelayClient:
         assert 'http://localhost:5000' in relay_client._api_v1_registered_relays
 
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_zero_poll_wait_timeout_is_failure(
+        self, mock_post, relay_client, monkeypatch
+    ):
+        clock_values = iter([1000.0, 1000.0, 1000.1])
+        monkeypatch.setattr(
+            relay_client_module.time,
+            'monotonic',
+            lambda: next(clock_values),
+        )
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+        mock_post.side_effect = [
+            register_ok,
+            requests.Timeout("Read timed out. (read timeout=5)"),
+        ]
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert 'Read timed out' in result['error']
+        assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
+        assert relay_client.api_v1_registration_fresh() is False
+
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_no_work_hint_is_preserved(self, mock_post, relay_client):

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import os
+import hashlib
 import re
 import time
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -591,6 +592,50 @@ class RelayClient:
         self._sink_start_index = 0
         self._last_api_v1_work_relay_url: Optional[str] = None
         self._api_v1_registered_relays: Set[str] = set()
+        self._api_v1_last_heartbeat_at: Dict[str, float] = {}
+
+
+    @staticmethod
+    def _api_v1_public_key_fingerprint(public_key: Any) -> str:
+        """Return a short stable fingerprint for diagnostics without logging raw keys."""
+
+        if not isinstance(public_key, str) or not public_key:
+            return "unknown"
+        digest = hashlib.sha256(public_key.encode("utf-8", errors="ignore")).hexdigest()
+        return digest[:12]
+
+    @staticmethod
+    def _api_v1_refresh_threshold_seconds(lease_seconds: Any) -> float:
+        """Return the local age at which a relay lease should be proactively renewed."""
+
+        if isinstance(lease_seconds, bool):
+            return 0.0
+        try:
+            lease = float(lease_seconds)
+        except (TypeError, ValueError):
+            return 0.0
+        if not math.isfinite(lease) or lease <= 0:
+            return 0.0
+        return max(min(lease * 0.8, lease - 1.0), lease * 0.5)
+
+    def api_v1_registration_fresh(self, relay_url: Optional[str] = None) -> bool:
+        """Return whether the selected API v1 relay registration was recently confirmed."""
+
+        candidate_url = relay_url or self.relay_url
+        if candidate_url not in self._api_v1_registered_relays:
+            return False
+        hints = getattr(self, "_api_v1_relay_wait_hints", {}).get(candidate_url, {})
+        last_heartbeat_at = self._api_v1_last_heartbeat_at.get(candidate_url)
+        if not isinstance(last_heartbeat_at, (int, float)):
+            return False
+        lease_seconds = hints.get("next_ping_in_x_seconds", self._request_timeout)
+        try:
+            lease = float(lease_seconds)
+        except (TypeError, ValueError):
+            lease = float(self._request_timeout)
+        if not math.isfinite(lease) or lease <= 0:
+            lease = float(self._request_timeout)
+        return (time.monotonic() - float(last_heartbeat_at)) < lease
 
     @staticmethod
     def _compose_relay_url(base_url: str, port: Optional[int]) -> str:
@@ -1056,14 +1101,35 @@ class RelayClient:
                 current_public_key = self.crypto_manager.public_key_b64
                 registered_public_key = cached_hints.get('server_public_key')
                 requires_register = candidate_url not in self._api_v1_registered_relays
+                reregister_reason: Optional[str] = None
+                if requires_register:
+                    reregister_reason = "not_registered"
                 if (
                     not requires_register
                     and isinstance(registered_public_key, str)
                     and registered_public_key != current_public_key
                 ):
                     requires_register = True
+                    reregister_reason = "public_key_changed"
+                if not requires_register:
+                    last_heartbeat_at = self._api_v1_last_heartbeat_at.get(candidate_url)
+                    refresh_threshold = self._api_v1_refresh_threshold_seconds(register_wait)
+                    if (
+                        not isinstance(last_heartbeat_at, (int, float))
+                        or refresh_threshold <= 0
+                        or time.monotonic() - float(last_heartbeat_at) >= refresh_threshold
+                    ):
+                        requires_register = True
+                        reregister_reason = "lease_expiry_risk"
 
                 if requires_register:
+                    if reregister_reason and reregister_reason != "not_registered":
+                        log_info(
+                            "server.reregister reason={} relay={} key_fingerprint={}",
+                            reregister_reason,
+                            candidate_url,
+                            self._api_v1_public_key_fingerprint(current_public_key),
+                        )
                     register_response = self.register_api_v1_compute_node(candidate_url)
                     if not isinstance(register_response, dict):
                         last_error = {
@@ -1087,7 +1153,15 @@ class RelayClient:
                         'server_public_key': current_public_key,
                     }
                     self._api_v1_registered_relays.add(candidate_url)
-                    log_info("server.registered relay={}", candidate_url)
+                    self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
+                    next_refresh = self._api_v1_refresh_threshold_seconds(register_wait)
+                    log_info(
+                        "server.registered relay={} lease_seconds={} next_refresh_seconds={} key_fingerprint={}",
+                        candidate_url,
+                        register_wait,
+                        round(next_refresh, 3),
+                        self._api_v1_public_key_fingerprint(current_public_key),
+                    )
 
                 request_kwargs: Dict[str, Any] = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
@@ -1123,11 +1197,22 @@ class RelayClient:
                         and poll_timeout_seconds >= numeric_poll_wait
                     )
                     if near_long_poll_window and candidate_url in self._api_v1_registered_relays:
+                        self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
+                        relay_wait_hints[candidate_url] = {
+                            'next_ping_in_x_seconds': register_wait,
+                            'poll_wait_seconds': poll_wait,
+                            'server_public_key': current_public_key,
+                        }
+                        next_refresh = self._api_v1_refresh_threshold_seconds(register_wait)
                         log_info(
-                            "api_v1.poll_timeout_no_work relay={} poll_wait_seconds={} timeout_seconds={} error={}",
+                            "api_v1.poll_timeout_no_work relay={} poll_wait_seconds={} timeout_seconds={} "
+                            "lease_seconds={} next_refresh_seconds={} key_fingerprint={} error={}",
                             candidate_url,
                             poll_wait,
                             poll_timeout_seconds,
+                            register_wait,
+                            round(next_refresh, 3),
+                            self._api_v1_public_key_fingerprint(current_public_key),
                             str(exc),
                         )
                         return {
@@ -1139,8 +1224,13 @@ class RelayClient:
                 if response.status_code != 200:
                     if response.status_code == 404:
                         self._api_v1_registered_relays.discard(candidate_url)
+                        self._api_v1_last_heartbeat_at.pop(candidate_url, None)
                         relay_wait_hints.pop(candidate_url, None)
-                        log_info("server.reregister reason=unknown_node relay={}", candidate_url)
+                        log_info(
+                            "server.reregister reason=unknown_node relay={} key_fingerprint={}",
+                            candidate_url,
+                            self._api_v1_public_key_fingerprint(current_public_key),
+                        )
                     last_error = self._api_v1_http_error_result(
                         response,
                         method="POST",
@@ -1161,9 +1251,26 @@ class RelayClient:
                     payload_wait = None
                 if payload_wait is None:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
+                elif isinstance(payload_wait, (int, float)) and payload_wait > 0:
+                    register_wait = payload_wait
+                payload_poll_wait = payload.get('poll_wait_seconds', poll_wait)
+                poll_wait = self._normalise_poll_wait_seconds(payload_poll_wait)
+                relay_wait_hints[candidate_url] = {
+                    'next_ping_in_x_seconds': register_wait,
+                    'poll_wait_seconds': poll_wait,
+                    'server_public_key': current_public_key,
+                }
+                self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
                 self._active_relay_index = index
                 self._last_api_v1_work_relay_url = candidate_url
-                log_info("server.heartbeat relay={}", candidate_url)
+                next_refresh = self._api_v1_refresh_threshold_seconds(register_wait)
+                log_info(
+                    "server.heartbeat relay={} lease_seconds={} next_refresh_seconds={} key_fingerprint={}",
+                    candidate_url,
+                    register_wait,
+                    round(next_refresh, 3),
+                    self._api_v1_public_key_fingerprint(current_public_key),
+                )
                 log_info(
                     "API v1 relay poll route=/api/v1/relay/servers/poll api_v1_payload={} request_id={}",
                     payload.get('protocol') == 'tokenplace_api_v1_relay_e2ee',
@@ -1173,6 +1280,7 @@ class RelayClient:
             except Exception as exc:
                 log_error("API v1 relay poll failed for {}: {}", candidate_url, str(exc), exc_info=True)
                 self._api_v1_registered_relays.discard(candidate_url)
+                self._api_v1_last_heartbeat_at.pop(candidate_url, None)
                 relay_wait_hints.pop(candidate_url, None)
                 last_error = {'error': str(exc), 'next_ping_in_x_seconds': self._request_timeout}
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1083,6 +1083,27 @@ class RelayClient:
             return base_timeout
         return max(base_timeout, wait_seconds + 5.0, wait_seconds * 1.25)
 
+    def _normalise_positive_seconds(self, seconds: Any, fallback: Any) -> float:
+        """Return a finite positive numeric hint, accepting numeric strings."""
+
+        if isinstance(seconds, bool):
+            seconds = None
+        try:
+            normalised = float(seconds)
+        except (TypeError, ValueError):
+            try:
+                normalised = float(fallback)
+            except (TypeError, ValueError):
+                normalised = float(self._request_timeout)
+        if not math.isfinite(normalised) or normalised <= 0:
+            try:
+                normalised = float(fallback)
+            except (TypeError, ValueError):
+                normalised = float(self._request_timeout)
+        if not math.isfinite(normalised) or normalised <= 0:
+            normalised = float(self._request_timeout)
+        return normalised
+
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
         """Poll API v1 relay routes for encrypted work with lease-aware registration."""
 
@@ -1096,8 +1117,12 @@ class RelayClient:
 
             try:
                 cached_hints = relay_wait_hints.get(candidate_url, {})
-                register_wait = cached_hints.get('next_ping_in_x_seconds', self._request_timeout)
+                register_wait = self._normalise_positive_seconds(
+                    cached_hints.get('next_ping_in_x_seconds'),
+                    self._request_timeout,
+                )
                 poll_wait = cached_hints.get('poll_wait_seconds', register_wait)
+                poll_wait = self._normalise_poll_wait_seconds(poll_wait)
                 current_public_key = self.crypto_manager.public_key_b64
                 registered_public_key = cached_hints.get('server_public_key')
                 requires_register = candidate_url not in self._api_v1_registered_relays
@@ -1137,8 +1162,8 @@ class RelayClient:
                             'next_ping_in_x_seconds': self._request_timeout,
                         }
                         continue
-                    register_wait = register_response.get(
-                        'next_ping_in_x_seconds',
+                    register_wait = self._normalise_positive_seconds(
+                        register_response.get('next_ping_in_x_seconds'),
                         self._request_timeout,
                     )
                     poll_wait = register_response.get('poll_wait_seconds', register_wait)
@@ -1180,6 +1205,7 @@ class RelayClient:
                 poll_timeout_seconds = float(request_kwargs.pop('timeout'))
                 poll_url = self._build_api_v1_url(candidate_url, "/relay/servers/poll")
                 token_sent = bool(headers)
+                poll_started = time.monotonic()
                 try:
                     response = requests.post(
                         poll_url,
@@ -1187,16 +1213,19 @@ class RelayClient:
                         **request_kwargs,
                     )
                 except Exception as exc:
-                    numeric_poll_wait = self._api_v1_poll_timeout_seconds(poll_wait)
-                    near_long_poll_window = (
+                    elapsed_seconds = time.monotonic() - poll_started
+                    timeout_exception = (
                         isinstance(exc, requests.Timeout)
                         or "Read timed out" in str(exc)
-                    ) and (
-                        math.isfinite(numeric_poll_wait)
-                        and math.isfinite(poll_timeout_seconds)
-                        and poll_timeout_seconds >= numeric_poll_wait
                     )
-                    if near_long_poll_window and candidate_url in self._api_v1_registered_relays:
+                    can_try_another_relay = len(self._relay_urls) > 1
+                    reached_server_long_poll = (
+                        timeout_exception
+                        and not can_try_another_relay
+                        and math.isfinite(float(poll_wait))
+                        and elapsed_seconds >= max(0.0, float(poll_wait) - 0.5)
+                    )
+                    if reached_server_long_poll and candidate_url in self._api_v1_registered_relays:
                         self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
                         relay_wait_hints[candidate_url] = {
                             'next_ping_in_x_seconds': register_wait,
@@ -1247,12 +1276,19 @@ class RelayClient:
                     }
                     continue
                 payload_wait = payload.get('next_ping_in_x_seconds')
-                if isinstance(payload_wait, bool):
-                    payload_wait = None
-                if payload_wait is None:
+                normalised_payload_wait: Optional[float] = None
+                if not isinstance(payload_wait, bool):
+                    try:
+                        candidate_payload_wait = float(payload_wait)
+                    except (TypeError, ValueError):
+                        candidate_payload_wait = math.nan
+                    if math.isfinite(candidate_payload_wait) and candidate_payload_wait > 0:
+                        normalised_payload_wait = candidate_payload_wait
+                if normalised_payload_wait is None:
                     payload.setdefault('next_ping_in_x_seconds', register_wait)
-                elif isinstance(payload_wait, (int, float)) and payload_wait > 0:
-                    register_wait = payload_wait
+                else:
+                    register_wait = normalised_payload_wait
+                    payload['next_ping_in_x_seconds'] = normalised_payload_wait
                 payload_poll_wait = payload.get('poll_wait_seconds', poll_wait)
                 poll_wait = self._normalise_poll_wait_seconds(payload_poll_wait)
                 relay_wait_hints[candidate_url] = {
@@ -2027,10 +2063,12 @@ class RelayClient:
     def _normalise_poll_wait_seconds(self, wait_seconds: Any) -> float:
         """Return a safe non-negative polling delay for relay-provided wait values."""
 
-        if isinstance(wait_seconds, bool) or not isinstance(wait_seconds, (int, float)):
+        if isinstance(wait_seconds, bool):
             return float(self._request_timeout)
-
-        normalised_wait = float(wait_seconds)
+        try:
+            normalised_wait = float(wait_seconds)
+        except (TypeError, ValueError):
+            return float(self._request_timeout)
         if not math.isfinite(normalised_wait) or normalised_wait < 0:
             return float(self._request_timeout)
         return normalised_wait

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1224,6 +1224,7 @@ class RelayClient:
                         timeout_exception
                         and not can_try_another_relay
                         and math.isfinite(float(poll_wait))
+                        and float(poll_wait) > 0
                         and elapsed_seconds >= max(0.0, float(poll_wait) - 0.5)
                     )
                     if reached_server_long_poll and candidate_url in self._api_v1_registered_relays:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -19,6 +19,7 @@ from utils.networking.http_requests_compat import requests
 
 # Configure logging
 logger = logging.getLogger('relay_client')
+DEFAULT_API_V1_LEASE_SECONDS = 30.0
 
 
 def _load_jsonschema():
@@ -628,13 +629,13 @@ class RelayClient:
         last_heartbeat_at = self._api_v1_last_heartbeat_at.get(candidate_url)
         if not isinstance(last_heartbeat_at, (int, float)):
             return False
-        lease_seconds = hints.get("next_ping_in_x_seconds", self._request_timeout)
+        lease_seconds = hints.get("next_ping_in_x_seconds", DEFAULT_API_V1_LEASE_SECONDS)
         try:
             lease = float(lease_seconds)
         except (TypeError, ValueError):
-            lease = float(self._request_timeout)
+            lease = DEFAULT_API_V1_LEASE_SECONDS
         if not math.isfinite(lease) or lease <= 0:
-            lease = float(self._request_timeout)
+            lease = DEFAULT_API_V1_LEASE_SECONDS
         return (time.monotonic() - float(last_heartbeat_at)) < lease
 
     @staticmethod
@@ -1265,7 +1266,7 @@ class RelayClient:
                         method="POST",
                         url=poll_url,
                         token_sent=token_sent,
-                        next_ping_in_x_seconds=register_wait,
+                        next_ping_in_x_seconds=0 if response.status_code == 404 else register_wait,
                     )
                     continue
                 payload = response.json()


### PR DESCRIPTION
### Motivation

- Staging showed a desktop compute node register and report a successful no-work poll, then be evicted ~30s later so a subsequent browser API v1 chat saw `/api/v1/relay/servers/next` return 503. 
- The root cause was the bridge treating a single no-work poll as sufficient and allowing model warmup/long-poll timing to delay heartbeats so the relay lease expired.

### Description

- Track per-relay heartbeat timestamps and cached lease hints in `RelayClient` and expose `api_v1_registration_fresh()` to detect stale local registration state. (file: `utils/networking/relay_client.py`)
- Compute a conservative refresh threshold from the relay-provided lease and proactively re-register when the local heartbeat age approaches that threshold, and clear cached registration state on `404` or network failures, using short public-key fingerprints in new diagnostics to avoid logging raw keys. (file: `utils/networking/relay_client.py`)
- Preserve and update heartbeat timing on no-work long-poll timeouts so a no-work response does not let the node age out. (file: `utils/networking/relay_client.py`)
- Make bridge status (`Registered: yes`) reflect recently confirmed relay heartbeats instead of a stale local flag, and emit a reconnecting/stale status while an outstanding long poll risks lease expiry. (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Move API v1 runtime warmup (post-registration) into a background executor so warmup does not block the polling/heartbeat cadence, while still blocking for runtime readiness when actual API-v1 work arrives. (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Add targeted unit and integration regressions that reproduce the staging symptom and verify that the client re-registers before a queued browser API v1 E2EE request arrives and that UI/bridge registration becomes stale when heartbeats are missed. (files: `tests/unit/test_relay_client.py`, `tests/integration/test_api_v1_desktop_bridge_e2ee.py`)

### Testing

- Ran `python -m py_compile desktop-tauri/src-tauri/python/compute_node_bridge.py utils/networking/relay_client.py` which succeeded.
- Ran `pytest tests/unit/test_relay_client.py -q`, `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and `pytest tests/test_relay.py -k "api_v1 or relay or lease or heartbeat" -q`, and these test runs passed (unit, integration, and relay tests shown passing in the transcript).
- Attempted `pre-commit run --all-files`; the hooks were executed but `check-yaml` failed on unrelated Helm chart template YAML under `charts/tokenplace/templates/*.yaml` (pre-existing parsing issues), so full pre-commit succeeded only for code fixes but the YAML failures are unrelated to the heartbeat changes and require chart-template fixes outside this PR.
- Notes: `git diff --check` and other quick sanity checks were run during development; summary logs and added diagnostics appear in tests' live logs demonstrating lease/refresh timing and re-register reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18e56dd160832fb7eb50847933e64a)