### PR TITLE
Fix desktop API v1 relay work processing after payload dispatch

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -192,12 +192,18 @@ def _sanitize_relay_target(relay_url: Any) -> str:
     if not isinstance(relay_url, str):
         return "unknown"
 
-    parsed = urlsplit(relay_url.strip())
-    if not parsed.scheme or not parsed.hostname:
+    try:
+        parsed = urlsplit(relay_url.strip())
+        hostname = parsed.hostname
+        parsed_port = parsed.port
+    except ValueError:
         return "unknown"
 
-    port = f":{parsed.port}" if parsed.port is not None else ""
-    return urlunsplit((parsed.scheme, f"{parsed.hostname}{port}", "", "", ""))
+    if not parsed.scheme or not hostname:
+        return "unknown"
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    port = f":{parsed_port}" if parsed_port is not None else ""
+    return urlunsplit((parsed.scheme, f"{host}{port}", "", "", ""))
 
 
 def _safe_poll_wait_seconds(relay_response: Dict[str, Any], default: float = 1) -> float:
@@ -569,8 +575,33 @@ def run(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return False
+            except Exception as exc:
+                ready = False
+                warm_load_state = "failed"
+                warm_load_failed = "failed to initialize API v1 model runtime"
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.exception "
+                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                    f"state={warm_load_state} duration_ms={warm_load_duration_ms} "
+                    f"exc_type={type(exc).__name__}",
+                    file=sys.stderr,
+                )
         elif warm_load_future.done():
-            ready = bool(warm_load_future.result())
+            try:
+                ready = bool(warm_load_future.result())
+            except Exception as exc:
+                ready = False
+                warm_load_state = "failed"
+                warm_load_failed = "failed to initialize API v1 model runtime"
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                print(
+                    "desktop.compute_node_bridge.model_init.exception "
+                    f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state} "
+                    f"duration_ms={warm_load_duration_ms} exc_type={type(exc).__name__}",
+                    file=sys.stderr,
+                )
         else:
             return False
         warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
@@ -791,12 +822,13 @@ def run(args: argparse.Namespace) -> int:
                     )
                     try:
                         processed = runtime.process_relay_request(relay_response)
-                    except Exception:
+                    except Exception as exc:
                         processed = False
                         last_error = "failed to process relay request"
                         print(
                             "desktop.compute_node_bridge.process_request.exception "
-                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                            f"exc_type={type(exc).__name__}",
                             file=sys.stderr,
                         )
                     if not processed:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -73,6 +73,7 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
+API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 10.0
 
 
 _POLL_CANCELLED = object()
@@ -154,6 +155,21 @@ def _cached_poll_wait_seconds(relay_client: Any, relay_url: str, default: float)
     if not math.isfinite(normalised_wait) or normalised_wait < 0:
         return default
     return normalised_wait
+
+
+def _api_v1_warm_load_wait_seconds(default: float = API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS) -> float:
+    """Return bounded API v1 warm-load wait before fail-closed response submission."""
+
+    raw_value = os.environ.get("TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS")
+    if raw_value is None:
+        return default
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(value) or value < 0:
+        return default
+    return value
 
 
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
@@ -468,7 +484,43 @@ def run(args: argparse.Namespace) -> int:
             }
         )
 
-    def ensure_runtime_ready(reason: str, *, active_relay_url: str, block: bool = False) -> bool:
+    def submit_api_v1_error_response(
+        relay_response: Dict[str, Any],
+        *,
+        code: str,
+        message: str,
+        active_relay_url: str,
+        request_id: str,
+    ) -> bool:
+        submit_error = getattr(runtime, "submit_api_v1_error_response", None)
+        if not callable(submit_error):
+            relay_client = getattr(runtime, "relay_client", None)
+            submit_error = getattr(relay_client, "submit_api_v1_error_response", None)
+        if not callable(submit_error):
+            print(
+                "desktop.compute_node_bridge.api_v1_e2ee.error_response.unavailable "
+                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                f"code={code}",
+                file=sys.stderr,
+            )
+            return False
+        submitted = bool(submit_error(relay_response, code=code, message=message))
+        print(
+            "desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted "
+            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+            f"code={code} submitted={submitted}",
+            file=sys.stderr,
+        )
+        return submitted
+
+    def ensure_runtime_ready(
+        reason: str,
+        *,
+        active_relay_url: str,
+        block: bool = False,
+        request_id: str = "none",
+        block_timeout_seconds: Optional[float] = None,
+    ) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
         nonlocal warm_load_executor, warm_load_future
         if warm_load_state == "ready":
@@ -492,13 +544,31 @@ def run(args: argparse.Namespace) -> int:
             )
             print(
                 "desktop.compute_node_bridge.model_init.start "
-                f"reason={reason} state={warm_load_state}",
+                f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} state={warm_load_state}",
                 file=sys.stderr,
             )
         if warm_load_future is None:
             return False
         if block and not warm_load_future.done():
-            ready = bool(warm_load_future.result())
+            timeout = block_timeout_seconds
+            print(
+                "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start "
+                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                f"state={warm_load_state} timeout_seconds={timeout}",
+                file=sys.stderr,
+            )
+            try:
+                ready = bool(warm_load_future.result(timeout=timeout))
+            except concurrent.futures.TimeoutError:
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout "
+                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                    f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                    file=sys.stderr,
+                )
+                return False
         elif warm_load_future.done():
             ready = bool(warm_load_future.result())
         else:
@@ -509,16 +579,34 @@ def run(args: argparse.Namespace) -> int:
             warm_load_failed = "failed to initialize API v1 model runtime"
             print(
                 "desktop.compute_node_bridge.model_init.failed "
-                f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} state={warm_load_state} "
+                f"duration_ms={warm_load_duration_ms}",
                 file=sys.stderr,
             )
+            if block:
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.failed "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state}",
+                    file=sys.stderr,
+                )
             return False
         warm_load_state = "ready"
         print(
             "desktop.compute_node_bridge.model_init.ready "
-            f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+            f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+            f"request_id={request_id} state={warm_load_state} "
+            f"duration_ms={warm_load_duration_ms}",
             file=sys.stderr,
         )
+        if block:
+            print(
+                "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.ready "
+                f"relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} state={warm_load_state}",
+                file=sys.stderr,
+            )
         print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
         return True
 
@@ -582,6 +670,11 @@ def run(args: argparse.Namespace) -> int:
             active_relay_url = runtime.relay_client.relay_url
             relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
             if relay_response is _POLL_CANCELLED:
+                print(
+                    "desktop.compute_node_bridge.poll.cancelled "
+                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    file=sys.stderr,
+                )
                 break
             relay_response = relay_response if isinstance(relay_response, dict) else {}
             active_relay_url = runtime.relay_client.relay_url
@@ -624,20 +717,45 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
 
+            api_v1_runtime_ready_for_request = True
+            terminate_after_api_v1_error = False
             if registered and api_v1_payload and warm_load_enabled and warm_load_state != "ready":
                 if not bridge_runtime_allowed:
                     warm_load_state = "not_started"
                     print(
                         "desktop.compute_node_bridge.model_init.skipped "
                         f"reason=api_v1_request runtime_path={runtime_path} "
-                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
+                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state} "
+                        f"request_id={request_id}",
                         file=sys.stderr,
                     )
-                elif not ensure_runtime_ready(
-                    "api_v1_request", active_relay_url=active_relay_url, block=True
-                ):
-                    fail_on_warm_load_error(active_relay_url=active_relay_url)
-                    break
+                else:
+                    api_v1_runtime_ready_for_request = ensure_runtime_ready(
+                        "api_v1_request",
+                        active_relay_url=active_relay_url,
+                        block=True,
+                        request_id=request_id,
+                        block_timeout_seconds=_api_v1_warm_load_wait_seconds(),
+                    )
+                    if not api_v1_runtime_ready_for_request:
+                        code = (
+                            "compute_node_runtime_not_ready"
+                            if warm_load_state == "warming"
+                            else "compute_node_runtime_unavailable"
+                        )
+                        last_error = warm_load_failed or "API v1 model runtime is not ready"
+                        submit_api_v1_error_response(
+                            relay_response,
+                            code=code,
+                            message=last_error,
+                            active_relay_url=active_relay_url,
+                            request_id=request_id,
+                        )
+                        terminate_after_api_v1_error = warm_load_state == "failed"
+
+            if terminate_after_api_v1_error:
+                fail_on_warm_load_error(active_relay_url=active_relay_url)
+                break
 
             if not registered:
                 if relay_error is not None:
@@ -648,31 +766,61 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
             elif api_v1_payload:
-                print(
-                    f"desktop.compute_node_bridge.request_route runtime_path={runtime_path}",
-                    file=sys.stderr,
-                )
-                print(
-                    "desktop.compute_node_bridge.process_request",
-                    file=sys.stderr,
-                )
-                print(
-                    "desktop.compute_node_bridge.api_v1_e2ee.work_received",
-                    file=sys.stderr,
-                )
-                processed = runtime.process_relay_request(relay_response)
-                if not processed:
-                    last_error = "failed to process relay request"
+                if not api_v1_runtime_ready_for_request:
                     print(
-                        "desktop.compute_node_bridge.process_request.failed",
+                        "desktop.compute_node_bridge.process_request.skipped_runtime_not_ready "
+                        f"relay={_sanitize_relay_target(active_relay_url)} "
+                        f"request_id={request_id} state={warm_load_state}",
                         file=sys.stderr,
                     )
                 else:
-                    last_error = None
                     print(
-                        "desktop.compute_node_bridge.api_v1_e2ee.response_submitted",
+                        f"desktop.compute_node_bridge.request_route runtime_path={runtime_path} "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
                         file=sys.stderr,
                     )
+                    print(
+                        "desktop.compute_node_bridge.process_request "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "desktop.compute_node_bridge.api_v1_e2ee.work_received "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    try:
+                        processed = runtime.process_relay_request(relay_response)
+                    except Exception:
+                        processed = False
+                        last_error = "failed to process relay request"
+                        print(
+                            "desktop.compute_node_bridge.process_request.exception "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            file=sys.stderr,
+                        )
+                    if not processed:
+                        last_error = "failed to process relay request"
+                        print(
+                            "desktop.compute_node_bridge.process_request.failed "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            file=sys.stderr,
+                        )
+                        submit_api_v1_error_response(
+                            relay_response,
+                            code="compute_node_process_failed",
+                            message=last_error,
+                            active_relay_url=active_relay_url,
+                            request_id=request_id,
+                        )
+                    else:
+                        last_error = None
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            f"request_id={request_id}",
+                            file=sys.stderr,
+                        )
             else:
                 if has_heartbeat:
                     last_error = None
@@ -707,6 +855,11 @@ def run(args: argparse.Namespace) -> int:
             )
 
             if _sleep_with_cancel(wait_seconds):
+                print(
+                    "desktop.compute_node_bridge.stop_requested "
+                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                    file=sys.stderr,
+                )
                 break
     except KeyboardInterrupt:
         pass

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -180,6 +180,7 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     """Browser-shaped encrypted API v1 chat completes via relay-blind desktop bridge."""
 
     observed_posts = []
+    observed_retrieve_statuses = []
     real_request = requests.sessions.Session.request
     real_relay_post = relay_client_module.requests.post
 
@@ -187,12 +188,15 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
         path = urlparse(url).path
         if any(fragment in path for fragment in LEGACY_ROUTE_FRAGMENTS):
             raise AssertionError(f"legacy/API v2 route used in API v1 bridge: {path}")
+        response = real_request(self, method, url, **kwargs)
         if method.upper() == "POST" and path in {
             "/api/v1/relay/requests",
             "/api/v1/relay/responses",
         }:
             observed_posts.append((path, kwargs.get("json")))
-        return real_request(self, method, url, **kwargs)
+        if method.upper() == "POST" and path == "/api/v1/relay/responses/retrieve":
+            observed_retrieve_statuses.append(response.status_code)
+        return response
 
     def guard_relay_client_post(url, *args, **kwargs):
         path = urlparse(url).path
@@ -268,10 +272,73 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     ]
     assert len(request_posts) == 1
     assert len(response_posts) == 1
+    assert 200 in observed_retrieve_statuses
     _assert_ciphertext_only(request_posts[0], forbidden_text=user_text)
     _assert_ciphertext_only(request_posts[0], forbidden_text="pong from desktop")
     _assert_ciphertext_only(response_posts[0], forbidden_text=user_text)
     _assert_ciphertext_only(response_posts[0], forbidden_text="pong from desktop")
+
+
+def test_api_v1_desktop_bridge_without_response_post_times_out_instead_of_passing(
+    monkeypatch,
+):
+    """Repeated retrieve 202 without a desktop /responses post is a failure signal."""
+
+    retrieve_statuses = []
+    real_request = requests.sessions.Session.request
+
+    def observe_retrieve_pending(self, method, url, **kwargs):
+        response = real_request(self, method, url, **kwargs)
+        if (
+            method.upper() == "POST"
+            and urlparse(url).path == "/api/v1/relay/responses/retrieve"
+        ):
+            retrieve_statuses.append(response.status_code)
+        return response
+
+    monkeypatch.setattr(requests.sessions.Session, "request", observe_retrieve_pending)
+
+    with live_relay_server() as base_url:
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        assert desktop_client.register_api_v1_compute_node(base_url)["next_ping_in_x_seconds"] > 0
+
+        monkeypatch.setattr(
+            routes,
+            "get_api_v1_compute_provider_for_mode",
+            lambda **_kwargs: compute_provider.DistributedApiV1ComputeProvider(
+                base_url=base_url,
+                timeout_seconds=1,
+            ),
+        )
+
+        browser_crypto = EncryptionManager()
+        response = requests.post(
+            f"{base_url}/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "encrypted": True,
+                "client_public_key": browser_crypto.public_key_b64,
+                "messages": _encrypt_browser_messages(
+                    [{"role": "user", "content": "never answered"}]
+                ),
+                "metadata": {
+                    "inference_target": "desktop_bridge_api_v1_e2ee",
+                    "relay_path": "api_v1_e2ee",
+                },
+            },
+            timeout=5,
+        )
+
+    assert response.status_code == 504
+    assert response.json()["error"]["code"] == "compute_node_timeout"
+    assert retrieve_statuses
+    assert set(retrieve_statuses) == {202}
 
 
 def test_api_v1_stream_true_fails_before_relay_queue():

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -806,6 +806,58 @@ def test_relay_client_api_v1_posts_encrypted_internal_error_for_invalid_inferenc
     assert encrypted_payload["request_id"] == "req-invalid-inference-output"
     assert encrypted_payload["api_v1_response"]["error"]["code"] == "compute_node_invalid_model_output"
 
+
+def test_relay_client_submit_api_v1_error_response_posts_ciphertext_only(monkeypatch):
+    crypto_stub = _RelayClientApiV1CryptoStub({})
+    relay_client = _build_relay_client_for_api_v1_tests(crypto_stub)
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None, **_kwargs):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["timeout"] = timeout
+
+        class _Response:
+            status_code = 200
+
+        return _Response()
+
+    monkeypatch.setattr("utils.networking.relay_client.requests.post", fake_post)
+
+    request_data = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "request_id": "req-runtime-not-ready",
+        "client_public_key": DUMMY_CLIENT_PUB_KEY,
+        "chat_history": "opaque",
+        "cipherkey": "opaque",
+        "iv": "opaque",
+    }
+
+    assert relay_client.submit_api_v1_error_response(
+        request_data,
+        code="compute_node_runtime_not_ready",
+        message="API v1 model runtime is not ready",
+    ) is True
+
+    assert captured["url"] == "https://relay.example/api/v1/relay/responses"
+    assert captured["timeout"] == relay_client._request_timeout
+    posted = captured["payload"]
+    assert posted["request_id"] == "req-runtime-not-ready"
+    assert posted["protocol"] == "tokenplace_api_v1_relay_e2ee"
+    assert posted["version"] == 1
+    assert "chat_history" in posted and "cipherkey" in posted and "iv" in posted
+    assert "api_v1_response" not in posted
+    assert "API v1 model runtime is not ready" not in json.dumps(posted)
+
+    encrypted_payload = crypto_stub.last_encrypted_payload
+    assert encrypted_payload["request_id"] == "req-runtime-not-ready"
+    assert encrypted_payload["api_v1_response"]["error"] == {
+        "code": "compute_node_runtime_not_ready",
+        "message": "API v1 model runtime is not ready",
+    }
+
+
 # --- Test /faucet ---
 
 def test_faucet_submit_request(client):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -297,6 +297,60 @@ def test_compute_node_runtime_request_flow_delegates_to_relay_client():
     relay_client.process_client_request.assert_called_once_with(payload)
 
 
+def test_compute_node_runtime_submit_api_v1_error_response_delegates_to_relay_client():
+    relay_client = MagicMock()
+    relay_client.submit_api_v1_error_response.return_value = True
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+    )
+    payload = {"request_id": "req-runtime-error", "chat_history": "ciphertext"}
+
+    assert (
+        runtime.submit_api_v1_error_response(
+            payload,
+            code="compute_node_runtime_unavailable",
+            message="failed to initialize API v1 model runtime",
+        )
+        is True
+    )
+    relay_client.submit_api_v1_error_response.assert_called_once_with(
+        payload,
+        code="compute_node_runtime_unavailable",
+        message="failed to initialize API v1 model runtime",
+    )
+
+
+def test_compute_node_runtime_submit_api_v1_error_response_fails_closed_without_helper():
+    relay_client = MagicMock()
+    relay_client.submit_api_v1_error_response = None
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+    )
+
+    assert (
+        runtime.submit_api_v1_error_response(
+            {"request_id": "req-runtime-error"},
+            code="compute_node_runtime_unavailable",
+            message="failed to initialize API v1 model runtime",
+        )
+        is False
+    )
+
+
 def test_compute_node_runtime_process_relay_request_returns_false_for_unknown_payload():
     relay_client = MagicMock()
     model_manager = MagicMock()

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1,5 +1,6 @@
 """Unit tests for the desktop compute-node bridge."""
 
+import concurrent.futures
 import importlib.util
 import json
 import os
@@ -59,6 +60,16 @@ class FakeRelayClientRouting(FakeRelayClient):
 
     def process_api_v1_chat_request(self, payload):
         self.endpoint_calls.append(('/api/v1/relay/responses', payload))
+        return True
+
+    def submit_api_v1_error_response(self, payload, *, code, message):
+        self.endpoint_calls.append((
+            '/api/v1/relay/responses',
+            {
+                'request_id': payload.get('request_id'),
+                'error': {'code': code, 'message': message},
+            },
+        ))
         return True
 
 
@@ -148,6 +159,35 @@ class ApiV1Runtime(FakeRuntime):
     def process_relay_request(self, payload):
         self._processed.append(payload)
         return self.relay_client.process_api_v1_chat_request(payload)
+
+
+class WarmingThenApiV1Runtime(ApiV1Runtime):
+    last_instance = None
+
+    def __init__(self, _config):
+        super().__init__(_config)
+        WarmingThenApiV1Runtime.last_instance = self
+        self.ready_started = threading.Event()
+        self.ready_release = threading.Event()
+
+    def ensure_api_v1_runtime_ready(self):
+        self.ready_started.set()
+        self.ready_release.wait(timeout=1)
+        return True
+
+
+class WarmingTimeoutApiV1Runtime(ApiV1Runtime):
+    last_instance = None
+
+    def __init__(self, _config):
+        super().__init__(_config)
+        WarmingTimeoutApiV1Runtime.last_instance = self
+        self.ready_started = threading.Event()
+
+    def ensure_api_v1_runtime_ready(self):
+        self.ready_started.set()
+        time.sleep(0.2)
+        return True
 
 
 class MalformedWaitThenApiV1Runtime(ApiV1Runtime):
@@ -720,6 +760,99 @@ def test_run_api_v1_payload_uses_relay_api_v1_response_endpoint(capsys, monkeypa
     assert 'desktop.compute_node_bridge.api_v1_e2ee.work_received' in output.err
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
     assert "ModuleNotFoundError: No module named 'api'" not in output.err
+
+
+def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingThenApiV1Runtime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
+
+    real_submit = concurrent.futures.ThreadPoolExecutor.submit
+
+    def releasing_submit(self, fn, *args, **kwargs):
+        future = real_submit(self, fn, *args, **kwargs)
+        runtime = WarmingThenApiV1Runtime.last_instance
+        assert runtime is not None
+        assert runtime.ready_started.wait(timeout=0.5)
+        runtime.ready_release.set()
+        return future
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(concurrent.futures.ThreadPoolExecutor, 'submit', releasing_submit)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+
+    runtime = WarmingThenApiV1Runtime.last_instance
+    assert runtime is not None
+    assert [payload['request_id'] for payload in runtime._processed] == ['req-1']
+    assert runtime.relay_client.endpoint_calls[0][0] == '/api/v1/relay/responses'
+
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.ready' in output.err
+    assert 'desktop.compute_node_bridge.process_request relay=https://token.place request_id=req-1' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
+
+
+def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload(
+    capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingTimeoutApiV1Runtime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.01')
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+
+    runtime = WarmingTimeoutApiV1Runtime.last_instance
+    assert runtime is not None
+    assert runtime.ready_started.is_set()
+    assert runtime._processed == []
+    assert runtime.relay_client.endpoint_calls == [
+        (
+            '/api/v1/relay/responses',
+            {
+                'request_id': 'req-1',
+                'error': {
+                    'code': 'compute_node_runtime_not_ready',
+                    'message': 'API v1 model runtime is not ready',
+                },
+            },
+        )
+    ]
+
+    output = capsys.readouterr()
+    assert 'api_v1_payload=True' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout' in output.err
+    assert 'desktop.compute_node_bridge.process_request.skipped_runtime_not_ready' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1416,6 +1416,14 @@ def test_sanitize_relay_target_redacts_credentials_query_and_fragment():
 def test_sanitize_relay_target_returns_unknown_for_invalid_values():
     assert compute_node_bridge._sanitize_relay_target(None) == 'unknown'
     assert compute_node_bridge._sanitize_relay_target('not-a-valid-url') == 'unknown'
+    assert compute_node_bridge._sanitize_relay_target('https://token.place:bad') == 'unknown'
+    assert compute_node_bridge._sanitize_relay_target('http://[::1') == 'unknown'
+
+
+def test_sanitize_relay_target_preserves_ipv6_brackets():
+    sanitized = compute_node_bridge._sanitize_relay_target('http://[::1]:8000/path?token=abc')
+
+    assert sanitized == 'http://[::1]:8000'
 
 
 def test_relay_response_summary_handles_non_dict_payloads():
@@ -1760,6 +1768,57 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monk
     assert error_event["warm_load_state"] == "failed"
 
 
+def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class ApiPayloadWarmRaiseRuntime(ApiV1Runtime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            ApiPayloadWarmRaiseRuntime.last_instance = self
+
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            raise RuntimeError("sensitive model init failure details")
+
+        def process_relay_request(self, _payload):
+            calls.append("process")
+            return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiPayloadWarmRaiseRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 1
+    assert calls == ["warm"]
+    assert "runtime_wait.exception" in output.err or "model_init.exception" in output.err
+    assert "exc_type=RuntimeError" in output.err
+    assert "sensitive model init failure details" not in output.err
+    assert ApiPayloadWarmRaiseRuntime.last_instance is not None
+    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
+        (
+            '/api/v1/relay/responses',
+            {
+                'request_id': 'req-1',
+                'error': {
+                    'code': 'compute_node_runtime_unavailable',
+                    'message': 'failed to initialize API v1 model runtime',
+                },
+            },
+        )
+    ]
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get("type") == "error")
+    assert error_event["warm_load_state"] == "failed"
+
+
 def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)
@@ -1886,6 +1945,34 @@ def test_run_reports_api_v1_processing_failure(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     status_events = [event for event in events if event.get("type") == "status"]
     assert status_events[-1]["last_error"] == "failed to process relay request"
+
+
+def test_run_logs_api_v1_processing_exception_type(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class ApiV1ProcessingExceptionRuntime(ApiV1Runtime):
+        def process_relay_request(self, payload):
+            self._processed.append(payload)
+            raise ValueError("sensitive payload details")
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1ProcessingExceptionRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: bool(ApiV1ProcessingExceptionRuntime.last_instance._processed),
+    )
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert "process_request.exception" in output.err
+    assert "exc_type=ValueError" in output.err
+    assert "sensitive payload details" not in output.err
 
 
 def test_run_reports_unreachable_for_non_heartbeat_response(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1798,7 +1798,10 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, mon
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
+    assert "request_id=req-1" in output.err
     assert "runtime_wait.exception" in output.err or "model_init.exception" in output.err
+    assert "error_response.submitted" in output.err
+    assert "code=compute_node_runtime_unavailable" in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive model init failure details" not in output.err
     assert ApiPayloadWarmRaiseRuntime.last_instance is not None

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1822,6 +1822,61 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, mon
     assert error_event["warm_load_state"] == "failed"
 
 
+def test_run_first_api_v1_payload_fails_closed_when_blocking_warm_load_raises(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class BlockingWarmRaiseRuntime(ApiV1Runtime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            BlockingWarmRaiseRuntime.last_instance = self
+
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            time.sleep(0.05)
+            raise RuntimeError("sensitive delayed model init details")
+
+        def process_relay_request(self, _payload):
+            calls.append("process")
+            return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=BlockingWarmRaiseRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS", "1")
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 1
+    assert calls == ["warm"]
+    assert "request_id=req-1" in output.err
+    assert "runtime_wait.exception" in output.err
+    assert "error_response.submitted" in output.err
+    assert "exc_type=RuntimeError" in output.err
+    assert "sensitive delayed model init details" not in output.err
+    assert BlockingWarmRaiseRuntime.last_instance is not None
+    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
+        (
+            '/api/v1/relay/responses',
+            {
+                'request_id': 'req-1',
+                'error': {
+                    'code': 'compute_node_runtime_unavailable',
+                    'message': 'failed to initialize API v1 model runtime',
+                },
+            },
+        )
+    ]
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get("type") == "error")
+    assert error_event["warm_load_state"] == "failed"
+
+
 def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -59,6 +59,21 @@ def _load_compute_node_bridge_module():
     return module
 
 
+def test_sanitize_relay_target_handles_malformed_ports_and_ipv6():
+    assert relay_client_module._sanitize_relay_target('https://relay.example:bad') == 'unknown'
+    assert relay_client_module._sanitize_relay_target('http://[::1') == 'unknown'
+    assert (
+        relay_client_module._sanitize_relay_target('http://[::1]:8000/path?token=abc#debug')
+        == 'http://[::1]:8000'
+    )
+    assert (
+        relay_client_module._sanitize_relay_target(
+            'https://user:pass@[2001:db8::1]:9443/source?token=abc'
+        )
+        == 'https://[2001:db8::1]:9443'
+    )
+
+
 def test_load_jsonschema_returns_none_on_import_error(monkeypatch):
     import importlib
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -369,6 +369,17 @@ class ComputeNodeRuntime:
 
         return self.relay_client.poll_api_v1_encrypted_work()
 
+    def submit_api_v1_error_response(
+        self, request_data: Dict[str, Any], *, code: str, message: str
+    ) -> bool:
+        """Submit an encrypted API v1 error envelope without exposing plaintext to relay state."""
+
+        submit_error = getattr(self.relay_client, "submit_api_v1_error_response", None)
+        if not callable(submit_error):
+            _log_error("Relay client cannot submit API v1 encrypted error responses")
+            return False
+        return bool(submit_error(request_data, code=code, message=message))
+
     def stop(self) -> None:
         """Stop relay polling and network activity."""
         try:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -241,11 +241,18 @@ def _sanitize_relay_target(relay_url: Any) -> str:
 
     if not isinstance(relay_url, str):
         return "unknown"
-    parsed = urlparse(relay_url.strip() if relay_url.strip() else "")
-    if not parsed.scheme or not parsed.hostname:
+    try:
+        parsed = urlparse(relay_url.strip() if relay_url.strip() else "")
+        hostname = parsed.hostname
+        parsed_port = parsed.port
+    except ValueError:
         return "unknown"
-    port = f":{parsed.port}" if parsed.port is not None else ""
-    return urlunparse((parsed.scheme, f"{parsed.hostname}{port}", "", "", "", ""))
+
+    if not parsed.scheme or not hostname:
+        return "unknown"
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    port = f":{parsed_port}" if parsed_port is not None else ""
+    return urlunparse((parsed.scheme, f"{host}{port}", "", "", "", ""))
 
 
 def _normalise_registration_token(value: Optional[str]) -> Optional[str]:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -236,6 +236,18 @@ def _api_v1_response_headers(response: Any) -> Dict[str, str]:
     return diagnostic_headers
 
 
+def _sanitize_relay_target(relay_url: Any) -> str:
+    """Return a relay target safe for diagnostics without userinfo, query, or fragment."""
+
+    if not isinstance(relay_url, str):
+        return "unknown"
+    parsed = urlparse(relay_url.strip() if relay_url.strip() else "")
+    if not parsed.scheme or not parsed.hostname:
+        return "unknown"
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunparse((parsed.scheme, f"{parsed.hostname}{port}", "", "", "", ""))
+
+
 def _normalise_registration_token(value: Optional[str]) -> Optional[str]:
     """Normalise optional registration tokens from config or environment."""
 
@@ -1385,10 +1397,12 @@ class RelayClient:
             if headers:
                 request_kwargs["headers"] = headers
 
+            response_relay_url = self._api_v1_response_relay_url()
             response_url = self._build_api_v1_url(
-                self._api_v1_response_relay_url(),
+                response_relay_url,
                 "/relay/responses",
             )
+            relay_target = _sanitize_relay_target(response_relay_url)
             source_response = requests.post(
                 response_url,
                 timeout=self._request_timeout,
@@ -1399,18 +1413,20 @@ class RelayClient:
             protocol = "tokenplace_api_v1_relay_e2ee"
             if submitted:
                 log_info(
-                    "API v1 E2EE response submission request_id={} protocol={} route={} submitted={}",
+                    "API v1 E2EE response submission request_id={} protocol={} route={} relay={} submitted={}",
                     response_envelope["request_id"],
                     protocol,
                     route,
+                    relay_target,
                     submitted,
                 )
             else:
                 log_error(
-                    "API v1 E2EE response submission failed request_id={} protocol={} route={} http_status={}",
+                    "API v1 E2EE response submission failed request_id={} protocol={} route={} relay={} http_status={}",
                     response_envelope["request_id"],
                     protocol,
                     route,
+                    relay_target,
                     source_response.status_code,
                 )
             return submitted
@@ -1423,6 +1439,47 @@ class RelayClient:
                 exc_info=True,
             )
             return False
+
+
+    def submit_api_v1_error_response(
+        self,
+        request_data: Dict[str, Any],
+        *,
+        code: str,
+        message: str,
+    ) -> bool:
+        """Submit a structured encrypted API v1 error response for an unprocessed work item."""
+
+        required_string_fields = ("request_id", "client_public_key", "chat_history", "cipherkey", "iv")
+        if (
+            not isinstance(request_data, dict)
+            or request_data.get("protocol") != "tokenplace_api_v1_relay_e2ee"
+            or request_data.get("version") != 1
+            or not all(isinstance(request_data.get(field), str) for field in required_string_fields)
+        ):
+            log_error("Cannot submit API v1 error response for invalid relay payload")
+            return False
+
+        client_pub_key_b64 = _normalize_client_public_key_b64(request_data.get("client_public_key"))
+        if client_pub_key_b64 is None:
+            log_error("Cannot submit API v1 error response: invalid client_public_key metadata")
+            return False
+
+        try:
+            client_pub_key = base64.b64decode(client_pub_key_b64, validate=True)
+        except (AttributeError, binascii.Error, ValueError):
+            log_error("Cannot submit API v1 error response: invalid client_public_key encoding")
+            return False
+
+        response_envelope = self._api_v1_response_envelope(
+            request_data["request_id"],
+            error={"code": code, "message": message},
+        )
+        return self._post_api_v1_response(
+            response_envelope,
+            client_pub_key_b64=client_pub_key_b64,
+            client_pub_key=client_pub_key,
+        )
 
     @staticmethod
     def _valid_api_v1_assistant_message(message: Any) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
### Motivation
- Staging was dispatching API v1 E2EE work to the desktop compute node but the desktop bridge sometimes never posted to `/api/v1/relay/responses`, causing repeated `/responses/retrieve` 202s and eventual `504` from `/api/v1/chat/completions`; the bridge was silently blocked by warm-load/readiness gating.

### Description
- Add a bounded warm-load wait for API v1 requests: `API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS` and `_api_v1_warm_load_wait_seconds`, and extend `ensure_runtime_ready` to accept `request_id` and a `block_timeout_seconds` so warm-load waits are logged and bounded.
- If warm-load does not become ready in the bounded time the bridge now posts a structured encrypted API v1 error envelope instead of dropping the payload, via a new `submit_api_v1_error_response` helper on `RelayClient` and a passthrough on `ComputeNodeRuntime`.
- Ensure API v1 payloads are never silently swallowed: add explicit logs before/after readiness waits, immediately before calling `runtime.process_relay_request`, on exceptions, and on response-submission success/failure; include `request_id` and a sanitized relay target (no raw public keys) in diagnostics.
- Add cancellation/stop diagnostics so `Stop operator` or poll cancellation paths are logged and do not leave an in-flight API v1 request silently stuck when practical.
- Add regression tests and integration coverage exercising: warm-ready processing, warming-timeout error submission, successful desktop round-trip posting to `/api/v1/relay/responses`, and the negative case where repeated `202` retrieves time out.

### Testing
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py` and it passed (49 passed).
- Ran `pytest tests/unit/test_relay_client.py -k "api_v1 or response or e2ee"` and it passed (73 passed in the selected set).
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and it passed (9 passed).
- Ran `pytest tests/test_relay.py -k "api_v1 or responses"` and it passed (43 passed in the selected set).
- Ran `pre-commit run --all-files` and all configured checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921dfe69c832f945b9affe9bc0d54)