### PR TITLE
Fix desktop API v1 relay response handling

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -73,6 +73,7 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
+API_V1_READY_WAIT_SECONDS_DEFAULT = "10"
 
 
 _POLL_CANCELLED = object()
@@ -281,6 +282,16 @@ def _env_enabled(name: str, default: str = "0") -> bool:
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
+def _env_float(name: str, default: str, *, minimum: float = 0.0) -> float:
+    value = os.getenv(name, default)
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = float(default)
+    if not math.isfinite(parsed) or parsed < minimum:
+        return float(default)
+    return parsed
+
 def _runtime_path_from_env() -> str:
     value = os.getenv("TOKENPLACE_DESKTOP_RUNTIME_PATH", RUNTIME_PATH_DEFAULT)
     if value.strip().lower() == "sidecar":
@@ -426,6 +437,11 @@ def run(args: argparse.Namespace) -> int:
     apply_compute_mode(runtime.model_manager, args.mode)
 
     warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)
+    api_v1_ready_wait_seconds = _env_float(
+        "TOKENPLACE_DESKTOP_API_V1_READY_WAIT_SECONDS",
+        API_V1_READY_WAIT_SECONDS_DEFAULT,
+        minimum=0.0,
+    )
     runtime_path = _runtime_path_from_env()
     dual_runtime_enabled = _env_enabled("TOKENPLACE_DESKTOP_DUAL_RUNTIME", "0")
     bridge_runtime_allowed = runtime_path == "bridge" or dual_runtime_enabled
@@ -468,12 +484,25 @@ def run(args: argparse.Namespace) -> int:
             }
         )
 
-    def ensure_runtime_ready(reason: str, *, active_relay_url: str, block: bool = False) -> bool:
+    def ensure_runtime_ready(
+        reason: str,
+        *,
+        active_relay_url: str,
+        block: bool = False,
+        max_wait_seconds: Optional[float] = None,
+        request_id: str = "none",
+    ) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
         nonlocal warm_load_executor, warm_load_future
         if warm_load_state == "ready":
             return True
         if warm_load_state == "failed":
+            print(
+                "desktop.compute_node_bridge.model_init.wait_result "
+                f"reason={reason} request_id={request_id} "
+                f"relay={_sanitize_relay_target(active_relay_url)} state={warm_load_state} ready=False",
+                file=sys.stderr,
+            )
             return False
         if warm_load_state == "not_started":
             warm_load_state = "warming"
@@ -498,7 +527,29 @@ def run(args: argparse.Namespace) -> int:
         if warm_load_future is None:
             return False
         if block and not warm_load_future.done():
-            ready = bool(warm_load_future.result())
+            wait_seconds = (
+                api_v1_ready_wait_seconds
+                if max_wait_seconds is None
+                else max_wait_seconds
+            )
+            print(
+                "desktop.compute_node_bridge.model_init.wait_start "
+                f"reason={reason} request_id={request_id} "
+                f"relay={_sanitize_relay_target(active_relay_url)} "
+                f"state={warm_load_state} timeout_seconds={wait_seconds}",
+                file=sys.stderr,
+            )
+            try:
+                ready = bool(warm_load_future.result(timeout=wait_seconds))
+            except concurrent.futures.TimeoutError:
+                print(
+                    "desktop.compute_node_bridge.model_init.wait_result "
+                    f"reason={reason} request_id={request_id} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"state={warm_load_state} ready=False timed_out=True",
+                    file=sys.stderr,
+                )
+                return False
         elif warm_load_future.done():
             ready = bool(warm_load_future.result())
         else:
@@ -509,14 +560,30 @@ def run(args: argparse.Namespace) -> int:
             warm_load_failed = "failed to initialize API v1 model runtime"
             print(
                 "desktop.compute_node_bridge.model_init.failed "
-                f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                f"reason={reason} request_id={request_id} "
+                f"relay={_sanitize_relay_target(active_relay_url)} "
+                f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                file=sys.stderr,
+            )
+            print(
+                "desktop.compute_node_bridge.model_init.wait_result "
+                f"reason={reason} request_id={request_id} "
+                f"relay={_sanitize_relay_target(active_relay_url)} state={warm_load_state} ready=False",
                 file=sys.stderr,
             )
             return False
         warm_load_state = "ready"
         print(
             "desktop.compute_node_bridge.model_init.ready "
-            f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+            f"reason={reason} request_id={request_id} "
+            f"relay={_sanitize_relay_target(active_relay_url)} "
+            f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
+            file=sys.stderr,
+        )
+        print(
+            "desktop.compute_node_bridge.model_init.wait_result "
+            f"reason={reason} request_id={request_id} "
+            f"relay={_sanitize_relay_target(active_relay_url)} state={warm_load_state} ready=True",
             file=sys.stderr,
         )
         print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
@@ -582,6 +649,11 @@ def run(args: argparse.Namespace) -> int:
             active_relay_url = runtime.relay_client.relay_url
             relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
             if relay_response is _POLL_CANCELLED:
+                print(
+                    "desktop.compute_node_bridge.poll.cancelled "
+                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    file=sys.stderr,
+                )
                 break
             relay_response = relay_response if isinstance(relay_response, dict) else {}
             active_relay_url = runtime.relay_client.relay_url
@@ -633,11 +705,53 @@ def run(args: argparse.Namespace) -> int:
                         f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
                         file=sys.stderr,
                     )
-                elif not ensure_runtime_ready(
-                    "api_v1_request", active_relay_url=active_relay_url, block=True
-                ):
-                    fail_on_warm_load_error(active_relay_url=active_relay_url)
-                    break
+                else:
+                    ready = ensure_runtime_ready(
+                        "api_v1_request",
+                        active_relay_url=active_relay_url,
+                        block=True,
+                        max_wait_seconds=api_v1_ready_wait_seconds,
+                        request_id=request_id,
+                    )
+                    if not ready:
+                        last_error = (
+                            warm_load_failed or "API v1 runtime not ready for relay request"
+                        )
+                        submit_error = getattr(runtime, "submit_api_v1_error_response", None)
+                        submitted = False
+                        if callable(submit_error):
+                            submitted = bool(
+                                submit_error(
+                                    relay_response,
+                                    code="compute_node_runtime_not_ready",
+                                    message=(
+                                        "Desktop runtime was not ready before the "
+                                        "bounded API v1 wait elapsed"
+                                    ),
+                                )
+                            )
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.runtime_not_ready_response "
+                            f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)} "
+                            f"submitted={submitted} warm_load_state={warm_load_state}",
+                            file=sys.stderr,
+                        )
+                        if not submitted:
+                            fail_on_warm_load_error(active_relay_url=active_relay_url)
+                            break
+                        emit_status_event(
+                            registered=registered,
+                            active_relay_url=active_relay_url,
+                            current_last_error=last_error,
+                        )
+                        if _sleep_with_cancel(wait_seconds):
+                            print(
+                                "desktop.compute_node_bridge.sleep.cancelled "
+                                f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)}",
+                                file=sys.stderr,
+                            )
+                            break
+                        continue
 
             if not registered:
                 if relay_error is not None:
@@ -653,24 +767,28 @@ def run(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 print(
-                    "desktop.compute_node_bridge.process_request",
+                    "desktop.compute_node_bridge.process_request "
+                    f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)}",
                     file=sys.stderr,
                 )
                 print(
-                    "desktop.compute_node_bridge.api_v1_e2ee.work_received",
+                    "desktop.compute_node_bridge.api_v1_e2ee.work_received "
+                    f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)}",
                     file=sys.stderr,
                 )
                 processed = runtime.process_relay_request(relay_response)
                 if not processed:
                     last_error = "failed to process relay request"
                     print(
-                        "desktop.compute_node_bridge.process_request.failed",
+                        "desktop.compute_node_bridge.process_request.failed "
+                        f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)}",
                         file=sys.stderr,
                     )
                 else:
                     last_error = None
                     print(
-                        "desktop.compute_node_bridge.api_v1_e2ee.response_submitted",
+                        "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
+                        f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)}",
                         file=sys.stderr,
                     )
             else:
@@ -707,6 +825,11 @@ def run(args: argparse.Namespace) -> int:
             )
 
             if _sleep_with_cancel(wait_seconds):
+                print(
+                    "desktop.compute_node_bridge.sleep.cancelled "
+                    f"request_id={request_id} relay={_sanitize_relay_target(active_relay_url)}",
+                    file=sys.stderr,
+                )
                 break
     except KeyboardInterrupt:
         pass

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -180,6 +180,7 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     """Browser-shaped encrypted API v1 chat completes via relay-blind desktop bridge."""
 
     observed_posts = []
+    observed_retrieve_statuses = []
     real_request = requests.sessions.Session.request
     real_relay_post = relay_client_module.requests.post
 
@@ -187,12 +188,15 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
         path = urlparse(url).path
         if any(fragment in path for fragment in LEGACY_ROUTE_FRAGMENTS):
             raise AssertionError(f"legacy/API v2 route used in API v1 bridge: {path}")
+        response = real_request(self, method, url, **kwargs)
         if method.upper() == "POST" and path in {
             "/api/v1/relay/requests",
             "/api/v1/relay/responses",
         }:
             observed_posts.append((path, kwargs.get("json")))
-        return real_request(self, method, url, **kwargs)
+        if method.upper() == "POST" and path == "/api/v1/relay/responses/retrieve":
+            observed_retrieve_statuses.append(response.status_code)
+        return response
 
     def guard_relay_client_post(url, *args, **kwargs):
         path = urlparse(url).path
@@ -268,10 +272,64 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     ]
     assert len(request_posts) == 1
     assert len(response_posts) == 1
+    assert 200 in observed_retrieve_statuses
+    assert response.status_code != 504
     _assert_ciphertext_only(request_posts[0], forbidden_text=user_text)
     _assert_ciphertext_only(request_posts[0], forbidden_text="pong from desktop")
     _assert_ciphertext_only(response_posts[0], forbidden_text=user_text)
     _assert_ciphertext_only(response_posts[0], forbidden_text="pong from desktop")
+
+
+def test_api_v1_chat_times_out_without_desktop_response_post(monkeypatch):
+    """Repeated relay response 202s without a desktop post must not look successful."""
+
+    with live_relay_server() as base_url:
+        monkeypatch.setattr(
+            routes,
+            "get_api_v1_compute_provider_for_mode",
+            lambda **_kwargs: compute_provider.DistributedApiV1ComputeProvider(
+                base_url=base_url,
+                timeout_seconds=0.25,
+            ),
+        )
+
+        idle_desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        register = idle_desktop_client.register_api_v1_compute_node(base_url)
+        assert register["next_ping_in_x_seconds"] > 0
+
+        browser_crypto = EncryptionManager()
+        payload = {
+            "model": "llama-3-8b-instruct",
+            "encrypted": True,
+            "client_public_key": browser_crypto.public_key_b64,
+            "messages": _encrypt_browser_messages(
+                [{"role": "user", "content": "ping that no desktop answers"}]
+            ),
+            "metadata": {
+                "inference_target": "desktop_bridge_api_v1_e2ee",
+                "relay_path": "api_v1_e2ee",
+            },
+        }
+
+        response = requests.post(
+            f"{base_url}/api/v1/chat/completions",
+            json=payload,
+            timeout=5,
+        )
+
+    assert response.status_code == 504
+    body = response.json()
+    assert body["error"]["code"] in {
+        "distributed_compute_timeout",
+        "compute_timeout",
+        "compute_node_timeout",
+    }
 
 
 def test_api_v1_stream_true_fails_before_relay_queue():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -37,7 +37,14 @@ class FakeModelManager:
 class FakeRelayClient:
     relay_url = 'https://token.place'
 
+    def __init__(self):
+        self.error_responses = []
+
     def api_v1_registration_fresh(self, _relay_url=None):
+        return True
+
+    def submit_api_v1_error_response(self, payload, *, code, message):
+        self.error_responses.append((payload, code, message))
         return True
 
 
@@ -48,6 +55,7 @@ class StaleRelayClient(FakeRelayClient):
 
 class FakeRelayClientRouting(FakeRelayClient):
     def __init__(self):
+        super().__init__()
         self.endpoint_calls = []
 
     def process_client_request(self, payload):
@@ -92,6 +100,11 @@ class FakeRuntime:
     def process_relay_request(self, payload):
         self._processed.append(payload)
         return True
+
+    def submit_api_v1_error_response(self, payload, *, code, message):
+        return self.relay_client.submit_api_v1_error_response(
+            payload, code=code, message=message
+        )
 
     def stop(self):
         return None
@@ -1591,11 +1604,17 @@ def test_run_api_v1_payload_not_dropped_when_warm_not_started(capsys, monkeypatc
     assert "runtime_path=bridge" in output.err
 
 
-def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monkeypatch):
+def test_run_first_api_v1_payload_posts_error_when_warm_load_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
     class ApiPayloadWarmFailRuntime(FakeRuntime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            ApiPayloadWarmFailRuntime.last_instance = self
+
         def ensure_api_v1_runtime_ready(self):
             calls.append("warm")
             return False
@@ -1618,14 +1637,92 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monk
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=ApiPayloadWarmFailRuntime)
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: bool(
+            ApiPayloadWarmFailRuntime.last_instance
+            and ApiPayloadWarmFailRuntime.last_instance.relay_client.error_responses
+        ),
+    )
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
-    assert status == 1
+    assert status == 0
     assert calls == ["warm"]
-    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
-    error_event = next(event for event in events if event.get("type") == "error")
-    assert error_event["warm_load_state"] == "failed"
+    runtime = ApiPayloadWarmFailRuntime.last_instance
+    assert runtime is not None
+    assert len(runtime.relay_client.error_responses) == 1
+    payload, code, message = runtime.relay_client.error_responses[0]
+    assert payload["request_id"] == "req-bridge-fail-1"
+    assert code == "compute_node_runtime_not_ready"
+    assert "not ready" in message
+    output = capsys.readouterr()
+    assert "desktop.compute_node_bridge.model_init.wait_result" in output.err
+    assert "runtime_not_ready_response request_id=req-bridge-fail-1" in output.err
+    assert "submitted=True" in output.err
 
+
+
+def test_run_api_v1_payload_posts_error_when_warm_load_times_out(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = []
+
+    class ApiPayloadWarmTimeoutRuntime(FakeRuntime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            ApiPayloadWarmTimeoutRuntime.last_instance = self
+
+        def ensure_api_v1_runtime_ready(self):
+            calls.append("warm")
+            time.sleep(0.25)
+            return True
+
+        def register_and_poll_once(self):
+            return {
+                "protocol": "tokenplace_api_v1_relay_e2ee",
+                "version": 1,
+                "request_id": "req-bridge-timeout-1",
+                "client_public_key": "abc",
+                "chat_history": "ciphertext",
+                "cipherkey": "key",
+                "iv": "iv",
+                "next_ping_in_x_seconds": 0,
+            }
+
+        def process_relay_request(self, _payload):
+            calls.append("process")
+            return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiPayloadWarmTimeoutRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_API_V1_READY_WAIT_SECONDS", "0.01")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: bool(
+            ApiPayloadWarmTimeoutRuntime.last_instance
+            and ApiPayloadWarmTimeoutRuntime.last_instance.relay_client.error_responses
+        ),
+    )
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert calls == ["warm"]
+    runtime = ApiPayloadWarmTimeoutRuntime.last_instance
+    assert runtime is not None
+    assert len(runtime.relay_client.error_responses) == 1
+    payload, code, _message = runtime.relay_client.error_responses[0]
+    assert payload["request_id"] == "req-bridge-timeout-1"
+    assert code == "compute_node_runtime_not_ready"
+    output = capsys.readouterr()
+    assert "request_id=req-bridge-timeout-1" in output.err
+    assert "timed_out=True" in output.err
+    assert "runtime_not_ready_response request_id=req-bridge-timeout-1" in output.err
+    assert "desktop.compute_node_bridge.process_request request_id=req-bridge-timeout-1" not in output.err
 
 def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):
     _reset_cancel_queue()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1957,6 +1957,48 @@ class TestRelayClient:
             'https://relay-that-polled.example/api/v1/relay/responses'
         )
 
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_submit_api_v1_error_response_posts_encrypted_error_without_decrypting_payload(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        """Bridge warm-load failures can be answered as encrypted API v1 errors."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        request_data.update({
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-runtime-not-ready",
+        })
+        relay_client._last_api_v1_work_relay_url = "https://relay-that-polled.example"
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.submit_api_v1_error_response(
+            request_data,
+            code="compute_node_runtime_not_ready",
+            message="Desktop runtime was not ready",
+        ) is True
+
+        mock_crypto_manager.decrypt_message.assert_not_called()
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["request_id"] == "req-runtime-not-ready"
+        assert encrypted_envelope["api_v1_response"]["error"] == {
+            "code": "compute_node_runtime_not_ready",
+            "message": "Desktop runtime was not ready",
+        }
+        assert mock_post.call_args.args[0] == (
+            "https://relay-that-polled.example/api/v1/relay/responses"
+        )
+        relay_visible_payload = mock_post.call_args.kwargs["json"]
+        assert relay_visible_payload["request_id"] == "req-runtime-not-ready"
+        assert relay_visible_payload["protocol"] == "tokenplace_api_v1_relay_e2ee"
+        assert relay_visible_payload["version"] == 1
+
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_e2ee_rejects_mismatched_bound_key(
         self,

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -364,6 +364,21 @@ class ComputeNodeRuntime:
         )
         return False
 
+    def submit_api_v1_error_response(
+        self,
+        request_data: Dict[str, Any],
+        *,
+        code: str,
+        message: str,
+    ) -> bool:
+        """Submit an encrypted API v1 error envelope for unprocessed relay work."""
+
+        submit_error = getattr(self.relay_client, "submit_api_v1_error_response", None)
+        if not callable(submit_error):
+            _log_error("Relay client cannot submit API v1 error responses")
+            return False
+        return bool(submit_error(request_data, code=code, message=message))
+
     def register_and_poll_once(self) -> Dict[str, Any]:
         """Poll relay for one encrypted API v1 work item."""
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1353,6 +1353,53 @@ class RelayClient:
             "api_v1_response": api_v1_response,
         }
 
+    def submit_api_v1_error_response(
+        self,
+        request_data: Dict[str, Any],
+        *,
+        code: str,
+        message: str,
+    ) -> bool:
+        """Encrypt and submit an API v1 error for work that cannot be processed."""
+
+        if not isinstance(request_data, dict):
+            log_error("Cannot submit API v1 error response: request payload is not an object")
+            return False
+        request_id = request_data.get("request_id")
+        if not isinstance(request_id, str) or not request_id.strip():
+            log_error("Cannot submit API v1 error response: missing request_id")
+            return False
+        client_pub_key_b64 = _normalize_client_public_key_b64(
+            request_data.get("client_public_key")
+        )
+        if client_pub_key_b64 is None:
+            log_error(
+                "Cannot submit API v1 error response request_id={}: invalid client_public_key",
+                request_id,
+            )
+            return False
+        try:
+            client_pub_key = base64.b64decode(client_pub_key_b64, validate=True)
+        except (AttributeError, binascii.Error, ValueError):
+            log_error(
+                "Cannot submit API v1 error response request_id={}: invalid client_public_key encoding",
+                request_id,
+            )
+            return False
+
+        response_envelope = self._api_v1_response_envelope(
+            request_id,
+            error={
+                "code": code,
+                "message": message,
+            },
+        )
+        return self._post_api_v1_response(
+            response_envelope,
+            client_pub_key_b64=client_pub_key_b64,
+            client_pub_key=client_pub_key,
+        )
+
     def _post_api_v1_response(
         self,
         response_envelope: Dict[str, Any],


### PR DESCRIPTION
### Motivation
- Staging showed API v1 E2EE work was queued and dispatched to desktops but the desktop bridge sometimes never posted back to `/api/v1/relay/responses`, causing repeated `/responses/retrieve` 202s and final `/api/v1/chat/completions` 504s. 
- The bridge could silently stall while waiting for runtime warm-load/readiness, leaving requests unanswered and violating the requirement that dispatched API v1 work must be either answered or responded-to with an encrypted error envelope.

### Description
- Bound warm-load readiness waits with a new env-driven timeout `TOKENPLACE_DESKTOP_API_V1_READY_WAIT_SECONDS` (default `10s`) and added diagnostic logs before/after entering the wait, on timeout, and on success/failure; logs include `request_id` and a sanitized relay target but redact raw keys.
- If the bounded warm-load wait fails, the bridge will attempt to submit an encrypted API v1 error envelope back to the relay instead of silently swallowing the request; this is implemented via `ComputeNodeRuntime.submit_api_v1_error_response()` and `RelayClient.submit_api_v1_error_response()` which build and post a ciphertext-only error envelope to `/api/v1/relay/responses`.
- Added explicit logging around poll cancellation, processing start, processing failures, and response submission success/failure with `request_id` and sanitized relay target to make the lifecycle observable (`process_request`, `work_received`, `response_submitted`, `runtime_not_ready_response`, `model_init.wait_start/result`, and cancellation events).
- Kept relay-blind E2EE invariants: bridge does not decrypt or expose plaintext when posting error envelopes; posted payloads remain ciphertext-only and only include safe routing metadata in logs.
- Tests updated/added to cover: successful API v1 desktop round-trip, warm-load failure posting an encrypted error, bounded warm-load timeout posting an encrypted error, and the negative/integration case where repeated relay `responses/retrieve` 202s without a desktop post results in a timed-out 504 (no silent swallow). Small adaptions made to unit relay-client tests to validate `submit_api_v1_error_response` behavior.

### Testing
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py` and all tests passed (48 passed). 
- Ran `pytest tests/unit/test_relay_client.py -k "api_v1 or response or e2ee"` and targeted tests passed (74 selected -> 74 passed for the filtered run). 
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and all integration tests passed (9 passed after the new negative timeout test was added). 
- Ran `pytest tests/test_relay.py -k "api_v1 or responses"` and relay tests covering API v1 paths passed (42 passed for the selection). 
- Ran `pre-commit run --all-files` and the repository checks completed successfully (hooks and project checks passed).

All automated tests exercised the new warm-load timeout/error-submission paths and the positive API v1 flow; they passed locally. Follow-ups: monitor staging logs to ensure the new `runtime_not_ready_response` and related diagnostics appear in real-world dispatches and adjust `TOKENPLACE_DESKTOP_API_V1_READY_WAIT_SECONDS` if operational tuning is needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921dfe69c832f945b9affe9bc0d54)