### PR TITLE
Ensure desktop bridge always responds to API v1 E2EE work (process or encrypted error) and add diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -138,7 +138,6 @@ def _registration_fresh(relay_client: Any, relay_url: str) -> bool:
     return False
 
 
-
 def _cached_poll_wait_seconds(relay_client: Any, relay_url: str, default: float) -> float:
     """Return the relay-advertised long-poll wait used by the active client."""
 
@@ -275,6 +274,57 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
         f"kv_cache_device={diagnostics.get('kv_cache_device') or 'unknown'}"
     )
 
+
+def _api_v1_ready_wait_timeout_seconds(default: float = 15.0) -> float:
+    """Return a bounded warm-load wait for an in-flight API v1 relay request."""
+
+    raw_value = os.getenv("TOKENPLACE_DESKTOP_API_V1_READY_TIMEOUT_SECONDS")
+    if raw_value is None:
+        return default
+    try:
+        timeout = float(raw_value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(timeout) or timeout < 0:
+        return default
+    return timeout
+
+
+def _post_api_v1_error_response(
+    runtime: Any,
+    relay_response: Dict[str, Any],
+    *,
+    code: str,
+    message: str,
+    active_relay_url: str,
+) -> bool:
+    """Submit an encrypted API v1 error envelope when bridge readiness fails."""
+
+    request_id = relay_response.get("request_id") if isinstance(relay_response, dict) else None
+    safe_request_id = request_id if isinstance(request_id, str) and request_id else "none"
+    submit_error = getattr(getattr(runtime, "relay_client", None), "post_api_v1_error_response", None)
+    if not callable(submit_error):
+        print(
+            "desktop.compute_node_bridge.api_v1_e2ee.error_response_unavailable "
+            f"relay={_sanitize_relay_target(active_relay_url)} "
+            f"request_id={safe_request_id} code={code}",
+            file=sys.stderr,
+        )
+        return False
+    print(
+        "desktop.compute_node_bridge.api_v1_e2ee.error_response_submit.start "
+        f"relay={_sanitize_relay_target(active_relay_url)} "
+        f"request_id={safe_request_id} code={code}",
+        file=sys.stderr,
+    )
+    submitted = bool(submit_error(relay_response, code=code, message=message))
+    print(
+        "desktop.compute_node_bridge.api_v1_e2ee.error_response_submit.done "
+        f"relay={_sanitize_relay_target(active_relay_url)} "
+        f"request_id={safe_request_id} code={code} submitted={submitted}",
+        file=sys.stderr,
+    )
+    return submitted
 
 def _env_enabled(name: str, default: str = "0") -> bool:
     value = os.getenv(name, default)
@@ -468,12 +518,34 @@ def run(args: argparse.Namespace) -> int:
             }
         )
 
-    def ensure_runtime_ready(reason: str, *, active_relay_url: str, block: bool = False) -> bool:
+    def ensure_runtime_ready(
+        reason: str,
+        *,
+        active_relay_url: str,
+        block: bool = False,
+        timeout_seconds: Optional[float] = None,
+        request_id: str = "none",
+    ) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
         nonlocal warm_load_executor, warm_load_future
         if warm_load_state == "ready":
+            if reason == "api_v1_request":
+                print(
+                    "desktop.compute_node_bridge.model_init.wait.ready "
+                    f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state}",
+                    file=sys.stderr,
+                )
             return True
         if warm_load_state == "failed":
+            if reason == "api_v1_request":
+                print(
+                    "desktop.compute_node_bridge.model_init.wait.failed "
+                    f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state} "
+                    f"error={warm_load_failed or 'unknown'}",
+                    file=sys.stderr,
+                )
             return False
         if warm_load_state == "not_started":
             warm_load_state = "warming"
@@ -498,9 +570,52 @@ def run(args: argparse.Namespace) -> int:
         if warm_load_future is None:
             return False
         if block and not warm_load_future.done():
-            ready = bool(warm_load_future.result())
+            bounded_timeout = timeout_seconds
+            print(
+                "desktop.compute_node_bridge.model_init.wait.start "
+                f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} state={warm_load_state} "
+                f"timeout_seconds={bounded_timeout if bounded_timeout is not None else 'unbounded'}",
+                file=sys.stderr,
+            )
+            try:
+                ready = bool(warm_load_future.result(timeout=bounded_timeout))
+            except concurrent.futures.TimeoutError:
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                warm_load_failed = "timed out waiting for API v1 model runtime warm-load"
+                print(
+                    "desktop.compute_node_bridge.model_init.wait.timeout "
+                    f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state} "
+                    f"duration_ms={warm_load_duration_ms} timeout_seconds={bounded_timeout}",
+                    file=sys.stderr,
+                )
+                return False
+            except Exception:
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                warm_load_state = "failed"
+                warm_load_failed = "API v1 model runtime warm-load raised an exception"
+                print(
+                    "desktop.compute_node_bridge.model_init.failed "
+                    f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                    file=sys.stderr,
+                )
+                return False
         elif warm_load_future.done():
-            ready = bool(warm_load_future.result())
+            try:
+                ready = bool(warm_load_future.result())
+            except Exception:
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                warm_load_state = "failed"
+                warm_load_failed = "API v1 model runtime warm-load raised an exception"
+                print(
+                    "desktop.compute_node_bridge.model_init.failed "
+                    f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"request_id={request_id} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                    file=sys.stderr,
+                )
+                return False
         else:
             return False
         warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
@@ -509,14 +624,16 @@ def run(args: argparse.Namespace) -> int:
             warm_load_failed = "failed to initialize API v1 model runtime"
             print(
                 "desktop.compute_node_bridge.model_init.failed "
-                f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} state={warm_load_state} duration_ms={warm_load_duration_ms}",
                 file=sys.stderr,
             )
             return False
         warm_load_state = "ready"
         print(
             "desktop.compute_node_bridge.model_init.ready "
-            f"reason={reason} state={warm_load_state} duration_ms={warm_load_duration_ms}",
+            f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+            f"request_id={request_id} state={warm_load_state} duration_ms={warm_load_duration_ms}",
             file=sys.stderr,
         )
         print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
@@ -624,20 +741,32 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
 
+            api_v1_error_response_submitted = False
             if registered and api_v1_payload and warm_load_enabled and warm_load_state != "ready":
                 if not bridge_runtime_allowed:
                     warm_load_state = "not_started"
                     print(
                         "desktop.compute_node_bridge.model_init.skipped "
-                        f"reason=api_v1_request runtime_path={runtime_path} "
+                        f"reason=api_v1_request relay={_sanitize_relay_target(active_relay_url)} "
+                        f"request_id={request_id} runtime_path={runtime_path} "
                         f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
                         file=sys.stderr,
                     )
                 elif not ensure_runtime_ready(
-                    "api_v1_request", active_relay_url=active_relay_url, block=True
+                    "api_v1_request",
+                    active_relay_url=active_relay_url,
+                    block=True,
+                    timeout_seconds=_api_v1_ready_wait_timeout_seconds(),
+                    request_id=request_id,
                 ):
-                    fail_on_warm_load_error(active_relay_url=active_relay_url)
-                    break
+                    last_error = warm_load_failed or "failed to initialize API v1 model runtime"
+                    api_v1_error_response_submitted = _post_api_v1_error_response(
+                        runtime,
+                        relay_response,
+                        code="compute_node_runtime_not_ready",
+                        message="Desktop runtime was not ready to process API v1 relay work",
+                        active_relay_url=active_relay_url,
+                    )
 
             if not registered:
                 if relay_error is not None:
@@ -648,31 +777,52 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
             elif api_v1_payload:
-                print(
-                    f"desktop.compute_node_bridge.request_route runtime_path={runtime_path}",
-                    file=sys.stderr,
-                )
-                print(
-                    "desktop.compute_node_bridge.process_request",
-                    file=sys.stderr,
-                )
-                print(
-                    "desktop.compute_node_bridge.api_v1_e2ee.work_received",
-                    file=sys.stderr,
-                )
-                processed = runtime.process_relay_request(relay_response)
-                if not processed:
-                    last_error = "failed to process relay request"
+                if api_v1_error_response_submitted:
                     print(
-                        "desktop.compute_node_bridge.process_request.failed",
+                        "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                        "submitted=True response_kind=error",
                         file=sys.stderr,
                     )
                 else:
-                    last_error = None
+                    if stop_requested():
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.cancel_before_process "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            file=sys.stderr,
+                        )
                     print(
-                        "desktop.compute_node_bridge.api_v1_e2ee.response_submitted",
+                        "desktop.compute_node_bridge.request_route "
+                        f"relay={_sanitize_relay_target(active_relay_url)} "
+                        f"request_id={request_id} runtime_path={runtime_path}",
                         file=sys.stderr,
                     )
+                    print(
+                        "desktop.compute_node_bridge.process_request "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "desktop.compute_node_bridge.api_v1_e2ee.work_received "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    processed = runtime.process_relay_request(relay_response)
+                    if not processed:
+                        last_error = "failed to process relay request"
+                        print(
+                            "desktop.compute_node_bridge.process_request.failed "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        last_error = None
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                            "submitted=True",
+                            file=sys.stderr,
+                        )
             else:
                 if has_heartbeat:
                     last_error = None

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -22,6 +22,7 @@ from werkzeug.serving import make_server
 
 import relay
 from api.v1 import compute_provider, routes
+from api.v1.compute_provider import ComputeProviderError
 from api.v1.encryption import EncryptionManager, encryption_manager
 from utils.crypto.crypto_manager import CryptoManager
 from utils.networking import relay_client as relay_client_module
@@ -272,6 +273,122 @@ def test_api_v1_encrypted_desktop_bridge_round_trip(monkeypatch):
     _assert_ciphertext_only(request_posts[0], forbidden_text="pong from desktop")
     _assert_ciphertext_only(response_posts[0], forbidden_text=user_text)
     _assert_ciphertext_only(response_posts[0], forbidden_text="pong from desktop")
+
+
+def test_api_v1_desktop_bridge_posts_structured_error_instead_of_timeout(monkeypatch):
+    """Desktop can answer dispatched work with encrypted non-timeout compute-node error."""
+
+    with live_relay_server() as base_url:
+        monkeypatch.setattr(
+            routes,
+            "get_api_v1_compute_provider_for_mode",
+            lambda **_kwargs: compute_provider.DistributedApiV1ComputeProvider(
+                base_url=base_url,
+                timeout_seconds=5,
+            ),
+        )
+
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        desktop_client._request_timeout = 1
+        browser_crypto = EncryptionManager()
+        payload = {
+            "model": "llama-3-8b-instruct",
+            "encrypted": True,
+            "client_public_key": browser_crypto.public_key_b64,
+            "messages": _encrypt_browser_messages([{"role": "user", "content": "ping"}]),
+            "metadata": {
+                "inference_target": "desktop_bridge_api_v1_e2ee",
+                "relay_path": "api_v1_e2ee",
+            },
+        }
+        response_holder = {}
+
+        def _browser_request():
+            response_holder["response"] = requests.post(
+                f"{base_url}/api/v1/chat/completions", json=payload, timeout=10
+            )
+
+        browser_thread = threading.Thread(target=_browser_request, daemon=True)
+        browser_thread.start()
+
+        deadline = time.time() + 5
+        relay_payload = None
+        while time.time() < deadline:
+            candidate = desktop_client.poll_api_v1_encrypted_work()
+            if candidate.get("protocol") == "tokenplace_api_v1_relay_e2ee":
+                relay_payload = candidate
+                break
+            time.sleep(0.02)
+        assert relay_payload is not None
+        assert desktop_client.post_api_v1_error_response(
+            relay_payload,
+            code="compute_node_runtime_not_ready",
+            message="Desktop runtime was not ready to process API v1 relay work",
+        ) is True
+
+        browser_thread.join(timeout=5)
+
+    response = response_holder.get("response")
+    assert response is not None
+    assert response.status_code != 504
+    assert response.status_code >= 500
+    body = response.json()
+    assert body["error"]["code"] == "compute_node_bridge_error"
+    assert "timed out" not in body["error"]["message"].lower()
+
+
+def test_api_v1_desktop_bridge_fails_if_dispatched_work_is_not_posted(monkeypatch):
+    """Repeated retrieve 202 without a desktop /responses post must surface as timeout."""
+
+    with live_relay_server() as base_url:
+        provider = compute_provider.DistributedApiV1ComputeProvider(
+            base_url=base_url,
+            timeout_seconds=1,
+        )
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        response_retrieve_calls = {"count": 0}
+        real_post = compute_provider.requests.post
+
+        def counted_post(url, *args, **kwargs):
+            if url.endswith("/api/v1/relay/responses/retrieve"):
+                response_retrieve_calls["count"] += 1
+            return real_post(url, *args, **kwargs)
+
+        monkeypatch.setattr(compute_provider.requests, "post", counted_post)
+        register_payload = desktop_client.register_api_v1_compute_node(base_url)
+        assert register_payload["next_ping_in_x_seconds"] > 0
+        error_holder = {}
+
+        def _browser_provider_request():
+            try:
+                provider.complete_chat(
+                    model_id="llama-3-8b-instruct",
+                    messages=[{"role": "user", "content": "ping without post"}],
+                )
+            except ComputeProviderError as exc:
+                error_holder["error"] = exc
+
+        browser_thread = threading.Thread(target=_browser_provider_request, daemon=True)
+        browser_thread.start()
+
+        # Intentionally do not poll/process work or call /api/v1/relay/responses.
+        browser_thread.join(timeout=3)
+
+    assert "error" in error_holder
+    assert error_holder["error"].code == "compute_node_timeout"
+    assert response_retrieve_calls["count"] > 1
 
 
 def test_api_v1_stream_true_fails_before_relay_queue():

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -50,6 +50,16 @@ class FakeRelayClientRouting(FakeRelayClient):
     def __init__(self):
         self.endpoint_calls = []
 
+    def post_api_v1_error_response(self, payload, *, code, message):
+        self.endpoint_calls.append((
+            '/api/v1/relay/responses',
+            {
+                'request_id': payload.get('request_id'),
+                'api_v1_response': {'error': {'code': code, 'message': message}},
+            },
+        ))
+        return True
+
     def process_client_request(self, payload):
         endpoint = '/source'
         if payload.get('stream') is True and payload.get('stream_session_id'):
@@ -148,6 +158,25 @@ class ApiV1Runtime(FakeRuntime):
     def process_relay_request(self, payload):
         self._processed.append(payload)
         return self.relay_client.process_api_v1_chat_request(payload)
+
+
+
+
+class HangingWarmLoadApiV1Runtime(ApiV1Runtime):
+    last_instance = None
+
+    def __init__(self, _config):
+        super().__init__(_config)
+        HangingWarmLoadApiV1Runtime.last_instance = self
+        self.ready_started = threading.Event()
+
+    def ensure_api_v1_runtime_ready(self):
+        self.ready_started.set()
+        time.sleep(10)
+        return True
+
+    def process_relay_request(self, payload):
+        raise AssertionError('timed-out warm-load work should get encrypted error response')
 
 
 class MalformedWaitThenApiV1Runtime(ApiV1Runtime):
@@ -720,6 +749,45 @@ def test_run_api_v1_payload_uses_relay_api_v1_response_endpoint(capsys, monkeypa
     assert 'desktop.compute_node_bridge.api_v1_e2ee.work_received' in output.err
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
     assert "ModuleNotFoundError: No module named 'api'" not in output.err
+
+
+def test_run_api_v1_payload_posts_error_when_warm_load_times_out(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=HangingWarmLoadApiV1Runtime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_READY_TIMEOUT_SECONDS', '0.01')
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+    assert status == 0
+
+    runtime = HangingWarmLoadApiV1Runtime.last_instance
+    assert runtime is not None
+    assert runtime.ready_started.is_set()
+    assert runtime._processed == []
+    assert len(runtime.relay_client.endpoint_calls) == 1
+    endpoint, payload = runtime.relay_client.endpoint_calls[0]
+    assert endpoint == '/api/v1/relay/responses'
+    assert payload['request_id'] == 'req-1'
+    assert payload['api_v1_response']['error']['code'] == 'compute_node_runtime_not_ready'
+
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.model_init.wait.start' in output.err
+    assert 'desktop.compute_node_bridge.model_init.wait.timeout' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response_submit.done' in output.err
+    assert 'submitted=True response_kind=error' in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):
@@ -1596,11 +1664,22 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monk
     calls = []
 
     class ApiPayloadWarmFailRuntime(FakeRuntime):
+        last_instance = None
+
+        def __init__(self, _config):
+            ApiPayloadWarmFailRuntime.last_instance = self
+            self.model_manager = FakeModelManager()
+            self.relay_client = FakeRelayClientRouting()
+            self._processed = []
+
         def ensure_api_v1_runtime_ready(self):
             calls.append("warm")
             return False
 
         def register_and_poll_once(self):
+            if getattr(self, "_sent", False):
+                return {"next_ping_in_x_seconds": 0}
+            self._sent = True
             return {
                 "protocol": "tokenplace_api_v1_relay_e2ee",
                 "version": 1,
@@ -1617,14 +1696,29 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_fails(capsys, monk
             return True
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=ApiPayloadWarmFailRuntime)
+    stop_counter = {"n": 0}
+
+    def fake_stop_requested():
+        stop_counter["n"] += 1
+        return stop_counter["n"] > 3
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
-    assert status == 1
+    assert status == 0
     assert calls == ["warm"]
-    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
-    error_event = next(event for event in events if event.get("type") == "error")
-    assert error_event["warm_load_state"] == "failed"
+    runtime = ApiPayloadWarmFailRuntime.last_instance
+    assert runtime is not None
+    assert runtime._processed == []
+    assert runtime.relay_client.endpoint_calls[0][0] == '/api/v1/relay/responses'
+    assert runtime.relay_client.endpoint_calls[0][1]['request_id'] == 'req-bridge-fail-1'
+    assert runtime.relay_client.endpoint_calls[0][1]['api_v1_response']['error']['code'] == (
+        'compute_node_runtime_not_ready'
+    )
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.model_init.failed' in output.err
+    assert 'submitted=True response_kind=error' in output.err
 
 
 def test_run_fails_fast_when_dependency_preflight_fails(capsys, monkeypatch):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1958,6 +1958,44 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_post_api_v1_error_response_encrypts_structured_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+    ):
+        request_data = {
+            **TEST_VALID_RESPONSE,
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-runtime-not-ready",
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        result = relay_client.post_api_v1_error_response(
+            request_data,
+            code="compute_node_runtime_not_ready",
+            message="Desktop runtime was not ready",
+        )
+
+        assert result is True
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["request_id"] == "req-runtime-not-ready"
+        assert encrypted_envelope["client_public_key"] == request_data["client_public_key"]
+        assert encrypted_envelope["api_v1_response"]["error"] == {
+            "code": "compute_node_runtime_not_ready",
+            "message": "Desktop runtime was not ready",
+        }
+        relay_visible_payload = mock_post.call_args.kwargs["json"]
+        assert relay_visible_payload["request_id"] == "req-runtime-not-ready"
+        assert relay_visible_payload["protocol"] == "tokenplace_api_v1_relay_e2ee"
+        assert relay_visible_payload["version"] == 1
+        assert "compute_node_runtime_not_ready" not in json.dumps(relay_visible_payload)
+
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_e2ee_rejects_mismatched_bound_key(
         self,
         mock_post,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -22,6 +22,18 @@ logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
 
 
+def _sanitize_relay_url_for_log(relay_url: Any) -> str:
+    """Return scheme/host/port only for relay diagnostics."""
+
+    if not isinstance(relay_url, str):
+        return "unknown"
+    parsed = urlparse(relay_url.strip())
+    if not parsed.scheme or not parsed.hostname:
+        return "unknown"
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunparse((parsed.scheme, f"{parsed.hostname}{port}", "", "", "", ""))
+
+
 def _load_jsonschema():
     """Lazy-load jsonschema; return ``None`` when unavailable in packaged runtimes."""
     try:
@@ -1397,32 +1409,78 @@ class RelayClient:
             submitted = source_response.status_code == 200
             route = "/api/v1/relay/responses"
             protocol = "tokenplace_api_v1_relay_e2ee"
+            relay_target = _sanitize_relay_url_for_log(self._api_v1_response_relay_url())
             if submitted:
                 log_info(
-                    "API v1 E2EE response submission request_id={} protocol={} route={} submitted={}",
+                    "API v1 E2EE response submission request_id={} protocol={} route={} relay={} submitted={}",
                     response_envelope["request_id"],
                     protocol,
                     route,
+                    relay_target,
                     submitted,
                 )
             else:
                 log_error(
-                    "API v1 E2EE response submission failed request_id={} protocol={} route={} http_status={}",
+                    "API v1 E2EE response submission failed request_id={} protocol={} route={} relay={} http_status={} submitted={}",
                     response_envelope["request_id"],
                     protocol,
                     route,
+                    relay_target,
                     source_response.status_code,
+                    submitted,
                 )
             return submitted
         except Exception:
             log_error(
-                "Failed to encrypt or post API v1 response request_id={} protocol={} route={}",
+                "Failed to encrypt or post API v1 response request_id={} protocol={} route={} relay={}",
                 response_envelope.get("request_id"),
                 response_envelope.get("protocol", "tokenplace_api_v1_relay_e2ee"),
                 "/api/v1/relay/responses",
+                _sanitize_relay_url_for_log(self._api_v1_response_relay_url()),
                 exc_info=True,
             )
             return False
+
+
+    def post_api_v1_error_response(
+        self,
+        request_data: Dict[str, Any],
+        *,
+        code: str,
+        message: str,
+    ) -> bool:
+        """Encrypt and submit a structured API v1 error response for queued work."""
+
+        request_id = request_data.get("request_id") if isinstance(request_data, dict) else None
+        if not isinstance(request_id, str) or not request_id.strip():
+            log_error("API v1 error response missing request_id; cannot submit structured error")
+            return False
+
+        try:
+            client_pub_key_b64 = _normalize_client_public_key_b64(request_data["client_public_key"])
+            if client_pub_key_b64 is None:
+                log_error(
+                    "API v1 error response invalid client key metadata request_id={}",
+                    request_id,
+                )
+                return False
+            client_pub_key = base64.b64decode(client_pub_key_b64, validate=True)
+        except (KeyError, AttributeError, binascii.Error, ValueError):
+            log_error(
+                "API v1 error response could not decode client key metadata request_id={}",
+                request_id,
+            )
+            return False
+
+        response_envelope = self._api_v1_response_envelope(
+            request_id,
+            error={"code": code, "message": message},
+        )
+        return self._post_api_v1_response(
+            response_envelope,
+            client_pub_key_b64=client_pub_key_b64,
+            client_pub_key=client_pub_key,
+        )
 
     @staticmethod
     def _valid_api_v1_assistant_message(message: Any) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
### Motivation
- Staging showed API v1 E2EE work was queued and dispatched to desktop nodes but the desktop sometimes never posted a response to `/api/v1/relay/responses`, causing the client to poll `/responses/retrieve` repeatedly (202) and eventually get 504. 
- Root cause appeared to be the bridge blocking indefinitely while waiting for the API v1 runtime warm-load, effectively swallowing dispatched payloads instead of answering them.

### Description
- Add bounded warm-load wait and explicit error-path response: introduce `_api_v1_ready_wait_timeout_seconds` and make `ensure_runtime_ready` accept `timeout_seconds` and `request_id`, performing a bounded `.result(timeout=...)` and emitting clear logs around enter/exit/timeout/error of the warm-load wait. 
- When the warm-load fails or times out for an in-flight API v1 payload, attempt to submit a structured encrypted API v1 error envelope back to the relay via a new `_post_api_v1_error_response` bridge helper (which calls `RelayClient.post_api_v1_error_response`), and mark the request as answered instead of silently dropping it. 
- Improve diagnostics: add logs immediately before/after runtime readiness wait, before calling `runtime.process_relay_request`, and log success/failure of response submissions; include `request_id` and a sanitized relay target (no full public keys) in new logs. 
- Make the bridge avoid silently swallowing API v1 payloads during warm-load; if error-response was posted, the bridge records `response_submitted` (response_kind=error) and skips processing. 
- Relay client enhancements: add `_sanitize_relay_url_for_log`, surface relay target in `_post_api_v1_response` logs, and implement `post_api_v1_error_response` to encrypt+post a structured `api_v1_response.error` envelope back to the relay. 
- Tests: add and update unit and integration tests to cover both successful processing and the bounded-warm-load / structured-error fallback paths, including: `tests/unit/test_desktop_compute_node_bridge.py` (new warm-hang runtime and error-posting test), `tests/unit/test_relay_client.py` (test for `post_api_v1_error_response`), and `tests/integration/test_api_v1_desktop_bridge_e2ee.py` (integration verification that desktop posts structured error instead of causing a client timeout). 
- Non-functional: reformat a few touched files with `black`.

### Testing
- Ran desktop bridge unit tests: `pytest tests/unit/test_desktop_compute_node_bridge.py` — all tests passed (`48 passed`).
- Ran relay-client unit tests filtered for API v1/response/e2ee: `pytest tests/unit/test_relay_client.py -k "api_v1 or response or e2ee"` — all selected tests passed (`74 passed, 51 deselected`).
- Ran integration suite for the desktop bridge: `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` — all tests passed (`10 passed`).
- Ran relay tests relevant to API v1 responses: `pytest tests/test_relay.py -k "api_v1 or responses"` — passed (`42 passed, 35 deselected`).
- Ran project checks: `pre-commit run --all-files` completed successfully in this environment (formatters and hooks ran and reformatting applied where needed).

All automated tests above passed after the changes; these tests validate that the bridge either processes API v1 payloads end-to-end or posts an encrypted structured error when warm-load readiness cannot be satisfied within the bounded wait, and that relay-side response posting logs include sanitized relay targets and request ids.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921dfe69c832f945b9affe9bc0d54)