### PR TITLE
Gate desktop relay registration on runtime readiness

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -73,7 +73,8 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
-API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 10.0
+API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 60.0
+WARM_LOAD_STALLED_LOG_SECONDS = 30.0
 
 
 _POLL_CANCELLED = object()
@@ -459,6 +460,8 @@ def run(args: argparse.Namespace) -> int:
     warm_load_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
     warm_load_future: Optional[concurrent.futures.Future] = None
     poll_worker = _CancelablePollWorker()
+    warm_load_last_stalled_log_at = 0.0
+    registration_ready_logged = False
 
     def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
         fresh_registered = registered and _registration_fresh(runtime.relay_client, active_relay_url)
@@ -544,14 +547,22 @@ def run(args: argparse.Namespace) -> int:
                 )
             warm_load_future = warm_load_executor.submit(runtime.ensure_api_v1_runtime_ready)
             emit_status_event(
-                registered=True,
+                registered=False,
                 active_relay_url=active_relay_url,
                 current_last_error=last_error,
             )
             print(
                 "desktop.compute_node_bridge.model_init.start "
                 f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
-                f"request_id={request_id} state={warm_load_state}",
+                f"request_id={request_id} state={warm_load_state} "
+                f"runtime_path={runtime_path}",
+                file=sys.stderr,
+            )
+            print(
+                "desktop.compute_node_bridge.model_init.runtime_path_selected "
+                f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} runtime_path={runtime_path} "
+                f"dual_runtime_enabled={dual_runtime_enabled}",
                 file=sys.stderr,
             )
         if warm_load_future is None:
@@ -645,7 +656,7 @@ def run(args: argparse.Namespace) -> int:
         nonlocal last_error, warm_load_fatal
         last_error = warm_load_failed or "failed to initialize API v1 model runtime"
         emit_status_event(
-            registered=True,
+            registered=False,
             active_relay_url=active_relay_url,
             current_last_error=last_error,
         )
@@ -696,9 +707,67 @@ def run(args: argparse.Namespace) -> int:
         )
 
     try:
-        while not stop_requested():
-            print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
+        active_relay_url = runtime.relay_client.relay_url
+        if warm_load_enabled and not bridge_runtime_allowed:
+            warm_load_state = "failed"
+            warm_load_failed = (
+                "API v1 relay work requires the bridge runtime; "
+                "TOKENPLACE_DESKTOP_RUNTIME_PATH=sidecar is only supported with "
+                "TOKENPLACE_DESKTOP_DUAL_RUNTIME=1"
+            )
+            fail_on_warm_load_error(active_relay_url=active_relay_url)
+
+        while not warm_load_fatal and not stop_requested():
             active_relay_url = runtime.relay_client.relay_url
+            if warm_load_enabled and bridge_runtime_allowed and warm_load_state != "ready":
+                ready = ensure_runtime_ready(
+                    "operator_start" if warm_load_state == "not_started" else "pre_registration",
+                    active_relay_url=active_relay_url,
+                    block=False,
+                )
+                if warm_load_state == "failed":
+                    fail_on_warm_load_error(active_relay_url=active_relay_url)
+                    break
+                if not ready:
+                    warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                    now = time.monotonic()
+                    if (
+                        warm_load_duration_ms >= int(WARM_LOAD_STALLED_LOG_SECONDS * 1000)
+                        and now - warm_load_last_stalled_log_at >= WARM_LOAD_STALLED_LOG_SECONDS
+                    ):
+                        warm_load_last_stalled_log_at = now
+                        print(
+                            "desktop.compute_node_bridge.model_init.still_warming "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            f"state={warm_load_state} duration_ms={warm_load_duration_ms} "
+                            f"runtime_path={runtime_path}",
+                            file=sys.stderr,
+                        )
+                    emit_status_event(
+                        registered=False,
+                        active_relay_url=active_relay_url,
+                        current_last_error=last_error,
+                    )
+                    if _sleep_with_cancel(0.25):
+                        print(
+                            "desktop.compute_node_bridge.stop_requested "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            "state=warming",
+                            file=sys.stderr,
+                        )
+                        break
+                    continue
+
+            if warm_load_enabled and warm_load_state == "ready" and not registration_ready_logged:
+                registration_ready_logged = True
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.registration.begin_after_ready "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"state={warm_load_state} runtime_path={runtime_path}",
+                    file=sys.stderr,
+                )
+
+            print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
             relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
             if relay_response is _POLL_CANCELLED:
                 print(
@@ -769,20 +838,23 @@ def run(args: argparse.Namespace) -> int:
                         block_timeout_seconds=_api_v1_warm_load_wait_seconds(),
                     )
                     if not api_v1_runtime_ready_for_request:
-                        code = (
-                            "compute_node_runtime_not_ready"
-                            if warm_load_state == "warming"
-                            else "compute_node_runtime_unavailable"
-                        )
                         last_error = warm_load_failed or "API v1 model runtime is not ready"
-                        submit_api_v1_error_response(
-                            relay_response,
-                            code=code,
-                            message=last_error,
-                            active_relay_url=active_relay_url,
-                            request_id=request_id,
-                        )
-                        terminate_after_api_v1_error = warm_load_state == "failed"
+                        if warm_load_state == "warming":
+                            print(
+                                "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.defer_response "
+                                f"relay={_sanitize_relay_target(active_relay_url)} "
+                                f"request_id={request_id} state={warm_load_state}",
+                                file=sys.stderr,
+                            )
+                        else:
+                            submit_api_v1_error_response(
+                                relay_response,
+                                code="compute_node_runtime_unavailable",
+                                message=last_error,
+                                active_relay_url=active_relay_url,
+                                request_id=request_id,
+                            )
+                            terminate_after_api_v1_error = warm_load_state == "failed"
 
             if terminate_after_api_v1_error:
                 fail_on_warm_load_error(active_relay_url=active_relay_url)

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -429,6 +429,35 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last error:/).textContent).toContain('none');
   });
 
+  it('shows warming instead of registered yes while relay runtime is warming', async () => {
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: false,
+        warm_load_state: 'warming',
+        warm_load_enabled: true,
+        runtime_path: 'bridge',
+        effective_mode: 'pending',
+        backend_available: 'unknown',
+        backend_selected: 'unknown',
+        backend_used: 'unknown',
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('warming');
+    expect(screen.getByText(/Registered:/).textContent).not.toContain('yes');
+    expect(screen.getByText(/Relay runtime readiness:/).textContent).toContain('warming');
+  });
+
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -31,6 +31,9 @@ interface ComputeNodeStatus {
   fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
+  warm_load_state: string | null;
+  warm_load_enabled: boolean | null;
+  runtime_path: string | null;
 }
 
 interface ModelArtifactInfo {
@@ -63,6 +66,9 @@ const defaultComputeStatus: ComputeNodeStatus = {
   fallback_reason: null,
   model_path: '',
   last_error: null,
+  warm_load_state: null,
+  warm_load_enabled: null,
+  runtime_path: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -194,6 +200,13 @@ export function App() {
               : typeof payload.message === 'string'
                 ? payload.message
                 : prev.last_error,
+        warm_load_state:
+          typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
+        warm_load_enabled:
+          typeof payload.warm_load_enabled === 'boolean'
+            ? payload.warm_load_enabled
+            : prev.warm_load_enabled,
+        runtime_path: typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
       }));
       if (payload.type === 'started' || payload.type === 'error') {
         setIsStartingComputeNode(false);
@@ -331,6 +344,9 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        warm_load_state: 'not_started',
+        warm_load_enabled: true,
+        runtime_path: 'bridge',
       }));
       await invoke('start_compute_node', {
         request: {
@@ -450,7 +466,7 @@ export function App() {
           </button>
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : computeStatus.warm_load_state === 'warming' ? 'warming' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode ?? 'pending'}</code></p>
@@ -458,6 +474,8 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Backend selected: <code>{computeStatus.backend_selected ?? 'pending'}</code></p>
         <p style={{ marginBottom: 0 }}>Backend used: <code>{computeStatus.backend_used ?? 'pending'}</code></p>
         <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime readiness: <code>{computeStatus.warm_load_state ?? 'pending'}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{computeStatus.runtime_path ?? 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -780,10 +780,16 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     stop_counter = {'count': 0}
 
     def fake_stop_requested():
+        runtime = WarmingThenApiV1Runtime.last_instance
+        if runtime is not None and runtime._processed:
+            return True
         stop_counter['count'] += 1
-        return stop_counter['count'] > 2
+        return stop_counter['count'] > 50
 
     monkeypatch.setattr(concurrent.futures.ThreadPoolExecutor, 'submit', releasing_submit)
+    monkeypatch.setattr(
+        compute_node_bridge, '_sleep_with_cancel', lambda _seconds: (time.sleep(0.01) or False)
+    )
     monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
 
     args = SimpleNamespace(
@@ -801,18 +807,16 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     assert runtime.relay_client.endpoint_calls[0][0] == '/api/v1/relay/responses'
 
     output = capsys.readouterr()
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.ready' in output.err
+    assert 'desktop.compute_node_bridge.model_init.start' in output.err
+    assert 'desktop.compute_node_bridge.model_init.ready' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.registration.begin_after_ready' in output.err
     assert 'desktop.compute_node_bridge.process_request relay=https://token.place request_id=req-1' in output.err
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
 
 
-def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload(
-    capsys, monkeypatch
-):
+def test_run_slow_warm_load_does_not_poll_or_submit_runtime_not_ready(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingTimeoutApiV1Runtime)
-    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.01')
 
     stop_counter = {'count': 0}
 
@@ -835,24 +839,16 @@ def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload
     assert runtime is not None
     assert runtime.ready_started.is_set()
     assert runtime._processed == []
-    assert runtime.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_not_ready',
-                    'message': 'API v1 model runtime is not ready',
-                },
-            },
-        )
-    ]
+    assert runtime.relay_client.endpoint_calls == []
 
     output = capsys.readouterr()
-    assert 'api_v1_payload=True' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout' in output.err
-    assert 'desktop.compute_node_bridge.process_request.skipped_runtime_not_ready' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' in output.err
+    assert 'desktop.compute_node_bridge.model_init.start' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.register' not in output.err
+    assert 'compute_node_runtime_not_ready' not in output.err
+    events = [json.loads(line) for line in output.out.splitlines()]
+    warming_status = [event for event in events if event.get('warm_load_state') == 'warming']
+    assert warming_status
+    assert all(event.get('registered') is False for event in warming_status)
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):
@@ -900,7 +896,7 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
 
     def fake_stop_requested():
         call_count['n'] += 1
-        return call_count['n'] > 1
+        return call_count['n'] > 3
 
     monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
 
@@ -917,8 +913,10 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is False for event in status_events if event.get('warm_load_state') == 'warming')
+    registered_events = [event for event in status_events if event['registered'] is True]
+    assert registered_events
+    assert registered_events[-1]['last_error'] is None
     stderr = output.err
     assert 'desktop.compute_node_bridge.start' in stderr
     assert 'desktop.compute_node_bridge.relay_target.resolved' in stderr
@@ -936,7 +934,7 @@ def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):
 
     def fake_stop_requested():
         call_count['n'] += 1
-        return call_count['n'] > 1
+        return call_count['n'] > 3
 
     monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
 
@@ -952,8 +950,10 @@ def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is False for event in status_events if event.get('warm_load_state') == 'warming')
+    registered_events = [event for event in status_events if event['registered'] is True]
+    assert registered_events
+    assert registered_events[-1]['last_error'] is None
 
 
 def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch):
@@ -997,7 +997,7 @@ def test_run_ignores_legacy_shaped_processing_failure(capsys, monkeypatch):
 
     def fake_stop_requested():
         call_count['n'] += 1
-        return call_count['n'] > 1
+        return call_count['n'] > 3
 
     monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
 
@@ -1013,8 +1013,10 @@ def test_run_ignores_legacy_shaped_processing_failure(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is False for event in status_events if event.get('warm_load_state') == 'warming')
+    registered_events = [event for event in status_events if event['registered'] is True]
+    assert registered_events
+    assert registered_events[-1]['last_error'] is None
 
 
 def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
@@ -1471,7 +1473,7 @@ def test_run_reports_stale_registration_status_after_missed_heartbeat(capsys, mo
     )
 
 
-def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypatch):
+def test_run_warms_runtime_before_first_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1490,7 +1492,7 @@ def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypat
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     _ = capsys.readouterr()
 
 
@@ -1603,7 +1605,7 @@ def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypat
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     status = compute_node_bridge.run(args)
     assert status == 1
-    assert calls == ["poll", "warm"]
+    assert calls == ["warm"]
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload["type"] == "error"
@@ -1652,10 +1654,10 @@ def test_run_sidecar_runtime_path_skips_bridge_warm_load_without_dual_opt_in(cap
     monkeypatch.delenv("TOKENPLACE_DESKTOP_DUAL_RUNTIME", raising=False)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
-    assert status == 0
-    assert call_order == ["poll", "poll"]
+    assert status == 1
+    assert call_order == []
     output = capsys.readouterr()
-    assert "model_init.skipped" in output.err
+    assert "API v1 relay work requires the bridge runtime" in output.out
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     started = next(event for event in events if event.get("type") == "started")
     assert started["runtime_path"] == "sidecar"
@@ -1682,7 +1684,7 @@ def test_run_sidecar_runtime_path_with_dual_mode_warms_and_logs_opt_in(capsys, m
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     output = capsys.readouterr()
     assert "dual_mode_enabled" in output.err
 
@@ -1798,25 +1800,13 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, mon
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
-    assert "runtime_wait.exception" in output.err or "model_init.exception" in output.err
-    assert "error_response.submitted" in output.err
-    assert "code=compute_node_runtime_unavailable" in output.err
+    assert "request_id=none" in output.err
+    assert "model_init.exception" in output.err
+    assert "error_response.submitted" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive model init failure details" not in output.err
     assert ApiPayloadWarmRaiseRuntime.last_instance is not None
-    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1854,24 +1844,13 @@ def test_run_first_api_v1_payload_fails_closed_when_blocking_warm_load_raises(ca
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
-    assert "runtime_wait.exception" in output.err
-    assert "error_response.submitted" in output.err
+    assert "request_id=none" in output.err
+    assert "model_init.exception" in output.err
+    assert "error_response.submitted" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive delayed model init details" not in output.err
     assert BlockingWarmRaiseRuntime.last_instance is not None
-    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1978,10 +1957,10 @@ def test_run_sidecar_api_v1_payload_skips_bridge_warm_load_without_dual_opt_in(c
 
     status = compute_node_bridge.run(args)
 
-    assert status == 0
-    assert calls == ["process"]
+    assert status == 1
+    assert calls == []
     output = capsys.readouterr()
-    assert "model_init.skipped reason=api_v1_request" in output.err
+    assert "API v1 relay work requires the bridge runtime" in output.out
 
 
 def test_run_reports_api_v1_processing_failure(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent the desktop operator from advertising API v1 availability before the API v1 E2EE runtime used for relay work is warmed and ready so browser chat requests are not dispatched to an unready node.
- Avoid spuriously submitting `compute_node_runtime_not_ready` encrypted errors for normal warm-up races and provide clearer diagnostics for warm-load progress/failure.

### Description
- Bridge runtime gating: change `desktop-tauri/src-tauri/python/compute_node_bridge.py` to warm the API v1 runtime before starting regular register/poll loops, keep `registered=false` while warming, delay/deflect response handling until `warm_load_state == 'ready'`, and add stalled-warm logging and a larger warm-wait default (`API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS`).
- Fail-closed sidecar guard: refuse to register/poll for API v1 relay work when `TOKENPLACE_DESKTOP_RUNTIME_PATH=sidecar` without `TOKENPLACE_DESKTOP_DUAL_RUNTIME=1` and surface an actionable local error instead of advertising availability.
- Defer vs. submit semantics: when a request arrives while the runtime is warming, defer responding (do not immediately send `compute_node_runtime_not_ready`) and only submit an encrypted error when warm-load truly fails.
- UI updates: extend `ComputeNodeStatus` in `desktop-tauri/src/App.tsx` with `warm_load_state`, `warm_load_enabled`, and `runtime_path`; display `Registered: warming` and expose relay runtime readiness/path in the operator UI.
- Tests: update/add unit tests in `tests/unit/test_desktop_compute_node_bridge.py` and add a UI test `desktop-tauri/src/App.test.tsx` to cover pre-registration warm-up, slow warm-load behavior, warm-load failures, sidecar/bridge selection, and the `Registered: warming` UI state.

### Testing
- Ran desktop bridge unit suite: `pytest tests/unit/test_desktop_compute_node_bridge.py -q` — passed.
- Ran model bridge unit suite: `pytest tests/unit/test_desktop_model_bridge.py -q` — passed.
- Ran relay-client focused unit tests: `pytest tests/unit/test_relay_client.py -k "api_v1 or response or e2ee or register or warm" -q` — passed.
- Ran integration API v1 desktop bridge e2ee tests: `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — passed.
- Ran relay server tests: `pytest tests/test_relay.py -k "api_v1 or responses" -q` — passed.
- Ran desktop UI tests: `cd desktop-tauri && npm test -- --run src/App.test.tsx` — passed.
- Ran repository checks: `pre-commit run --all-files` — passed.

All automated tests listed above succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195402c01c832f873299a9ca142655)