### PR TITLE
Gate desktop relay registration on runtime readiness and eliminate warm-load race

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -700,6 +700,8 @@ def run(args: argparse.Namespace) -> int:
         )
 
     def warm_runtime_before_registration() -> bool:
+        nonlocal warm_load_duration_ms, warm_load_failed, warm_load_state
+        nonlocal last_error
         if not warm_load_enabled:
             print(
                 "desktop.compute_node_bridge.model_init.skipped "
@@ -707,10 +709,12 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return True
+        warm_load_deadline_seconds = _api_v1_warm_load_wait_seconds()
         print(
             "desktop.compute_node_bridge.registration.gate_wait_start "
             f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
-            f"runtime_path={runtime_path} relay_runtime_path={relay_runtime_path}",
+            f"runtime_path={runtime_path} relay_runtime_path={relay_runtime_path} "
+            f"timeout_seconds={warm_load_deadline_seconds}",
             file=sys.stderr,
         )
         ensure_runtime_ready(
@@ -718,13 +722,35 @@ def run(args: argparse.Namespace) -> int:
             active_relay_url=runtime.relay_client.relay_url,
             block=False,
         )
-        last_progress_log_at = time.monotonic()
+        wait_started_at = time.monotonic()
+        last_progress_log_at = wait_started_at
         while warm_load_state == "warming":
+            elapsed_seconds = time.monotonic() - wait_started_at
+            remaining_seconds = warm_load_deadline_seconds - elapsed_seconds
+            if remaining_seconds <= 0:
+                warm_load_state = "failed"
+                warm_load_failed = "timed out initializing API v1 model runtime before relay registration"
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                last_error = warm_load_failed
+                print(
+                    "desktop.compute_node_bridge.registration.gate_wait_timeout "
+                    f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+                    f"state={warm_load_state} duration_ms={warm_load_duration_ms} "
+                    f"timeout_seconds={warm_load_deadline_seconds}",
+                    file=sys.stderr,
+                )
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=runtime.relay_client.relay_url,
+                    current_last_error=last_error,
+                )
+                fail_on_warm_load_error(active_relay_url=runtime.relay_client.relay_url)
+                return False
             if ensure_runtime_ready(
                 "pre_registration",
                 active_relay_url=runtime.relay_client.relay_url,
                 block=True,
-                block_timeout_seconds=0.1,
+                block_timeout_seconds=min(0.1, remaining_seconds),
             ):
                 break
             now = time.monotonic()
@@ -734,7 +760,8 @@ def run(args: argparse.Namespace) -> int:
                 print(
                     "desktop.compute_node_bridge.model_init.still_warming "
                     f"reason=pre_registration relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
-                    f"state={warm_load_state} duration_ms={duration_ms}",
+                    f"state={warm_load_state} duration_ms={duration_ms} "
+                    f"timeout_seconds={warm_load_deadline_seconds}",
                     file=sys.stderr,
                 )
             emit_status_event(

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -80,6 +80,37 @@ PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
 _POLL_CANCELLED = object()
 
 
+class _DaemonWarmLoadFuture:
+    """Run warm-load work on a daemon thread so wedged init cannot keep the process alive."""
+
+    def __init__(self, fn: Any) -> None:
+        self._future: "concurrent.futures.Future[Any]" = concurrent.futures.Future()
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(fn,),
+            name="tokenplace-warm-load",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(self, fn: Any) -> None:
+        if not self._future.set_running_or_notify_cancel():
+            return
+        try:
+            self._future.set_result(fn())
+        except BaseException as exc:
+            self._future.set_exception(exc)
+
+    def done(self) -> bool:
+        return self._future.done()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        return self._future.result(timeout=timeout)
+
+    def cancel(self) -> bool:
+        return self._future.cancel()
+
+
 class _CancelablePollWorker:
     """Run one relay poll at a time while the bridge keeps checking for cancel."""
 
@@ -457,8 +488,7 @@ def run(args: argparse.Namespace) -> int:
     warm_load_duration_ms: Optional[int] = None
     warm_load_failed: Optional[str] = None
     warm_load_fatal = False
-    warm_load_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
-    warm_load_future: Optional[concurrent.futures.Future] = None
+    warm_load_future: Optional[_DaemonWarmLoadFuture] = None
     poll_worker = _CancelablePollWorker()
 
     def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
@@ -530,7 +560,7 @@ def run(args: argparse.Namespace) -> int:
         block_timeout_seconds: Optional[float] = None,
     ) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
-        nonlocal warm_load_executor, warm_load_future
+        nonlocal warm_load_future
         if warm_load_state == "ready":
             return True
         if warm_load_state == "failed":
@@ -540,11 +570,7 @@ def run(args: argparse.Namespace) -> int:
             warm_load_failed = None
             warm_load_duration_ms = None
             warm_load_started_at = time.perf_counter()
-            if warm_load_executor is None:
-                warm_load_executor = concurrent.futures.ThreadPoolExecutor(
-                    max_workers=1, thread_name_prefix="tokenplace-warm-load"
-                )
-            warm_load_future = warm_load_executor.submit(runtime.ensure_api_v1_runtime_ready)
+            warm_load_future = _DaemonWarmLoadFuture(runtime.ensure_api_v1_runtime_ready)
             emit_status_event(
                 registered=False,
                 active_relay_url=active_relay_url,
@@ -915,8 +941,8 @@ def run(args: argparse.Namespace) -> int:
     finally:
         print("desktop.compute_node_bridge.stop", file=sys.stderr)
         poll_worker.shutdown()
-        if warm_load_executor is not None:
-            warm_load_executor.shutdown(wait=False, cancel_futures=True)
+        if warm_load_future is not None and not warm_load_future.done():
+            warm_load_future.cancel()
         runtime.stop()
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -527,6 +527,7 @@ def run(args: argparse.Namespace) -> int:
         block: bool = False,
         request_id: str = "none",
         block_timeout_seconds: Optional[float] = None,
+        log_runtime_wait_progress: bool = True,
     ) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
         nonlocal warm_load_executor, warm_load_future
@@ -559,22 +560,24 @@ def run(args: argparse.Namespace) -> int:
             return False
         if block and not warm_load_future.done():
             timeout = block_timeout_seconds
-            print(
-                "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start "
-                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                f"state={warm_load_state} timeout_seconds={timeout}",
-                file=sys.stderr,
-            )
+            if log_runtime_wait_progress:
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start "
+                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                    f"state={warm_load_state} timeout_seconds={timeout}",
+                    file=sys.stderr,
+                )
             try:
                 ready = bool(warm_load_future.result(timeout=timeout))
             except concurrent.futures.TimeoutError:
                 warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
-                print(
-                    "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout "
-                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                    f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
-                    file=sys.stderr,
-                )
+                if log_runtime_wait_progress:
+                    print(
+                        "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                        f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                        file=sys.stderr,
+                    )
                 return False
             except Exception as exc:
                 ready = False
@@ -724,6 +727,8 @@ def run(args: argparse.Namespace) -> int:
         )
         wait_started_at = time.monotonic()
         last_progress_log_at = wait_started_at
+        last_status_emit_at = wait_started_at
+        progress_emit_interval_seconds = 30.0
         while warm_load_state == "warming":
             elapsed_seconds = time.monotonic() - wait_started_at
             remaining_seconds = warm_load_deadline_seconds - elapsed_seconds
@@ -751,10 +756,11 @@ def run(args: argparse.Namespace) -> int:
                 active_relay_url=runtime.relay_client.relay_url,
                 block=True,
                 block_timeout_seconds=min(0.1, remaining_seconds),
+                log_runtime_wait_progress=False,
             ):
                 break
             now = time.monotonic()
-            if now - last_progress_log_at >= 30:
+            if now - last_progress_log_at >= progress_emit_interval_seconds:
                 last_progress_log_at = now
                 duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
                 print(
@@ -764,11 +770,13 @@ def run(args: argparse.Namespace) -> int:
                     f"timeout_seconds={warm_load_deadline_seconds}",
                     file=sys.stderr,
                 )
-            emit_status_event(
-                registered=False,
-                active_relay_url=runtime.relay_client.relay_url,
-                current_last_error=last_error,
-            )
+            if now - last_status_emit_at >= progress_emit_interval_seconds:
+                last_status_emit_at = now
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=runtime.relay_client.relay_url,
+                    current_last_error=last_error,
+                )
             if stop_requested():
                 return False
             time.sleep(0.01)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -73,7 +73,7 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
-API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 10.0
+API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 
 
 _POLL_CANCELLED = object()
@@ -450,7 +450,7 @@ def run(args: argparse.Namespace) -> int:
     warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)
     runtime_path = _runtime_path_from_env()
     dual_runtime_enabled = _env_enabled("TOKENPLACE_DESKTOP_DUAL_RUNTIME", "0")
-    bridge_runtime_allowed = runtime_path == "bridge" or dual_runtime_enabled
+    relay_runtime_path = "bridge"
     warm_load_state = "not_started"
     warm_load_started_at = 0.0
     warm_load_duration_ms: Optional[int] = None
@@ -487,6 +487,7 @@ def run(args: argparse.Namespace) -> int:
                 "warm_load_enabled": warm_load_enabled,
                 "warm_load_duration_ms": warm_load_duration_ms,
                 "runtime_path": runtime_path,
+                "relay_runtime_path": relay_runtime_path,
             }
         )
 
@@ -544,7 +545,7 @@ def run(args: argparse.Namespace) -> int:
                 )
             warm_load_future = warm_load_executor.submit(runtime.ensure_api_v1_runtime_ready)
             emit_status_event(
-                registered=True,
+                registered=False,
                 active_relay_url=active_relay_url,
                 current_last_error=last_error,
             )
@@ -645,7 +646,7 @@ def run(args: argparse.Namespace) -> int:
         nonlocal last_error, warm_load_fatal
         last_error = warm_load_failed or "failed to initialize API v1 model runtime"
         emit_status_event(
-            registered=True,
+            registered=False,
             active_relay_url=active_relay_url,
             current_last_error=last_error,
         )
@@ -657,6 +658,7 @@ def run(args: argparse.Namespace) -> int:
                 "warm_load_state": warm_load_state,
                 "warm_load_duration_ms": warm_load_duration_ms,
                 "runtime_path": runtime_path,
+                "relay_runtime_path": relay_runtime_path,
             }
         )
         warm_load_fatal = True
@@ -686,81 +688,132 @@ def run(args: argparse.Namespace) -> int:
             "warm_load_state": warm_load_state,
             "warm_load_enabled": warm_load_enabled,
             "runtime_path": runtime_path,
+            "relay_runtime_path": relay_runtime_path,
         }
     )
-    if runtime_path == "sidecar" and dual_runtime_enabled:
+    if runtime_path == "sidecar":
         print(
-            "desktop.compute_node_bridge.runtime_path.dual_mode_enabled "
-            "runtime_path=sidecar dual_runtime_enabled=True",
+            "desktop.compute_node_bridge.runtime_path.relay_uses_bridge "
+            f"runtime_path={runtime_path} relay_runtime_path={relay_runtime_path} "
+            f"dual_runtime_enabled={dual_runtime_enabled}",
             file=sys.stderr,
         )
 
-    try:
-        while not stop_requested():
-            print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
-            active_relay_url = runtime.relay_client.relay_url
-            relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
-            if relay_response is _POLL_CANCELLED:
+    def warm_runtime_before_registration() -> bool:
+        if not warm_load_enabled:
+            print(
+                "desktop.compute_node_bridge.model_init.skipped "
+                "reason=warm_load_disabled relay_runtime_path=bridge",
+                file=sys.stderr,
+            )
+            return True
+        print(
+            "desktop.compute_node_bridge.registration.gate_wait_start "
+            f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+            f"runtime_path={runtime_path} relay_runtime_path={relay_runtime_path}",
+            file=sys.stderr,
+        )
+        ensure_runtime_ready(
+            "pre_registration",
+            active_relay_url=runtime.relay_client.relay_url,
+            block=False,
+        )
+        last_progress_log_at = time.monotonic()
+        while warm_load_state == "warming":
+            if ensure_runtime_ready(
+                "pre_registration",
+                active_relay_url=runtime.relay_client.relay_url,
+                block=True,
+                block_timeout_seconds=0.1,
+            ):
+                break
+            now = time.monotonic()
+            if now - last_progress_log_at >= 30:
+                last_progress_log_at = now
+                duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
                 print(
-                    "desktop.compute_node_bridge.poll.cancelled "
-                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    "desktop.compute_node_bridge.model_init.still_warming "
+                    f"reason=pre_registration relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+                    f"state={warm_load_state} duration_ms={duration_ms}",
                     file=sys.stderr,
                 )
-                break
-            relay_response = relay_response if isinstance(relay_response, dict) else {}
-            active_relay_url = runtime.relay_client.relay_url
-            api_v1_payload = is_api_v1_relay_payload(relay_response)
-            relay_error = _relay_error_message(relay_response)
-            has_heartbeat = (
-                isinstance(relay_response, dict) and "next_ping_in_x_seconds" in relay_response
+            emit_status_event(
+                registered=False,
+                active_relay_url=runtime.relay_client.relay_url,
+                current_last_error=last_error,
             )
-            registered = (
-                relay_error is None
-                and (has_heartbeat or api_v1_payload)
-                and _registration_fresh(runtime.relay_client, active_relay_url)
-            )
-            wait_seconds = _safe_poll_wait_seconds(
-                relay_response, getattr(runtime.relay_client, "_request_timeout", 1)
-            )
-            request_id = (
-                relay_response.get("request_id")
-                if isinstance(relay_response, dict)
-                and isinstance(relay_response.get("request_id"), str)
-                else "none"
-            )
-            summary = _relay_response_summary(
-                relay_response, api_v1_payload=api_v1_payload, wait_seconds=wait_seconds
-            )
+            if stop_requested():
+                return False
+            time.sleep(0.01)
+        if warm_load_state == "failed":
+            fail_on_warm_load_error(active_relay_url=runtime.relay_client.relay_url)
+            return False
+        ready = warm_load_state == "ready"
+        print(
+            "desktop.compute_node_bridge.registration.gate_wait_done "
+            f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+            f"state={warm_load_state} ready={ready}",
+            file=sys.stderr,
+        )
+        return ready
 
-            print(
-                "desktop.compute_node_bridge.relay_poll "
-                f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
-                f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
-                f"request_id={request_id} wait={wait_seconds} summary={summary}",
-                file=sys.stderr,
-            )
-
-            print(
-                "desktop.compute_node_bridge.api_v1_e2ee.poll "
-                f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
-                f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
-                f"request_id={request_id} wait={wait_seconds} summary={summary}",
-                file=sys.stderr,
-            )
-
-            api_v1_runtime_ready_for_request = True
-            terminate_after_api_v1_error = False
-            if registered and api_v1_payload and warm_load_enabled and warm_load_state != "ready":
-                if not bridge_runtime_allowed:
-                    warm_load_state = "not_started"
+    try:
+        if warm_runtime_before_registration():
+            while not stop_requested():
+                print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
+                active_relay_url = runtime.relay_client.relay_url
+                relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
+                if relay_response is _POLL_CANCELLED:
                     print(
-                        "desktop.compute_node_bridge.model_init.skipped "
-                        f"reason=api_v1_request runtime_path={runtime_path} "
-                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state} "
-                        f"request_id={request_id}",
+                        "desktop.compute_node_bridge.poll.cancelled "
+                        f"relay={_sanitize_relay_target(active_relay_url)}",
                         file=sys.stderr,
                     )
-                else:
+                    break
+                relay_response = relay_response if isinstance(relay_response, dict) else {}
+                active_relay_url = runtime.relay_client.relay_url
+                api_v1_payload = is_api_v1_relay_payload(relay_response)
+                relay_error = _relay_error_message(relay_response)
+                has_heartbeat = (
+                    isinstance(relay_response, dict) and "next_ping_in_x_seconds" in relay_response
+                )
+                registered = (
+                    relay_error is None
+                    and (has_heartbeat or api_v1_payload)
+                    and _registration_fresh(runtime.relay_client, active_relay_url)
+                )
+                wait_seconds = _safe_poll_wait_seconds(
+                    relay_response, getattr(runtime.relay_client, "_request_timeout", 1)
+                )
+                request_id = (
+                    relay_response.get("request_id")
+                    if isinstance(relay_response, dict)
+                    and isinstance(relay_response.get("request_id"), str)
+                    else "none"
+                )
+                summary = _relay_response_summary(
+                    relay_response, api_v1_payload=api_v1_payload, wait_seconds=wait_seconds
+                )
+
+                print(
+                    "desktop.compute_node_bridge.relay_poll "
+                    f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
+                    f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
+                    f"request_id={request_id} wait={wait_seconds} summary={summary}",
+                    file=sys.stderr,
+                )
+
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.poll "
+                    f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
+                    f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
+                    f"request_id={request_id} wait={wait_seconds} summary={summary}",
+                    file=sys.stderr,
+                )
+
+                api_v1_runtime_ready_for_request = True
+                terminate_after_api_v1_error = False
+                if registered and api_v1_payload and warm_load_enabled and warm_load_state != "ready":
                     api_v1_runtime_ready_for_request = ensure_runtime_ready(
                         "api_v1_request",
                         active_relay_url=active_relay_url,
@@ -769,109 +822,103 @@ def run(args: argparse.Namespace) -> int:
                         block_timeout_seconds=_api_v1_warm_load_wait_seconds(),
                     )
                     if not api_v1_runtime_ready_for_request:
-                        code = (
-                            "compute_node_runtime_not_ready"
-                            if warm_load_state == "warming"
-                            else "compute_node_runtime_unavailable"
-                        )
                         last_error = warm_load_failed or "API v1 model runtime is not ready"
-                        submit_api_v1_error_response(
-                            relay_response,
-                            code=code,
-                            message=last_error,
-                            active_relay_url=active_relay_url,
-                            request_id=request_id,
+                        if warm_load_state == "failed":
+                            submit_api_v1_error_response(
+                                relay_response,
+                                code="compute_node_runtime_unavailable",
+                                message=last_error,
+                                active_relay_url=active_relay_url,
+                                request_id=request_id,
+                            )
+                            terminate_after_api_v1_error = True
+                        else:
+                            print(
+                                "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.deferred "
+                                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                                f"state={warm_load_state}",
+                                file=sys.stderr,
+                            )
+
+                if terminate_after_api_v1_error:
+                    fail_on_warm_load_error(active_relay_url=active_relay_url)
+                    break
+
+                if not registered:
+                    if relay_error is not None:
+                        last_error = relay_error
+                    else:
+                        last_error = (
+                            "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
+                            "operator; update relay.py to repo HEAD"
                         )
-                        terminate_after_api_v1_error = warm_load_state == "failed"
-
-            if terminate_after_api_v1_error:
-                fail_on_warm_load_error(active_relay_url=active_relay_url)
-                break
-
-            if not registered:
-                if relay_error is not None:
-                    last_error = relay_error
-                else:
-                    last_error = (
-                        "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
-                        "operator; update relay.py to repo HEAD"
-                    )
-            elif api_v1_payload:
-                if not api_v1_runtime_ready_for_request:
-                    print(
-                        "desktop.compute_node_bridge.process_request.skipped_runtime_not_ready "
-                        f"relay={_sanitize_relay_target(active_relay_url)} "
-                        f"request_id={request_id} state={warm_load_state}",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(
-                        f"desktop.compute_node_bridge.request_route runtime_path={runtime_path} "
-                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                        file=sys.stderr,
-                    )
-                    print(
-                        "desktop.compute_node_bridge.process_request "
-                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                        file=sys.stderr,
-                    )
-                    print(
-                        "desktop.compute_node_bridge.api_v1_e2ee.work_received "
-                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                        file=sys.stderr,
-                    )
-                    try:
-                        processed = runtime.process_relay_request(relay_response)
-                    except Exception as exc:
-                        processed = False
-                        last_error = "failed to process relay request"
+                elif api_v1_payload:
+                    if not api_v1_runtime_ready_for_request:
                         print(
-                            "desktop.compute_node_bridge.process_request.exception "
-                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                            f"exc_type={type(exc).__name__}",
+                            "desktop.compute_node_bridge.process_request.skipped_runtime_not_ready "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            f"request_id={request_id} state={warm_load_state}",
                             file=sys.stderr,
                         )
-                    if not processed:
-                        last_error = "failed to process relay request"
+                    else:
                         print(
-                            "desktop.compute_node_bridge.process_request.failed "
+                            f"desktop.compute_node_bridge.request_route runtime_path={runtime_path} "
                             f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
                             file=sys.stderr,
                         )
-                        submit_api_v1_error_response(
-                            relay_response,
-                            code="compute_node_process_failed",
-                            message=last_error,
-                            active_relay_url=active_relay_url,
-                            request_id=request_id,
-                        )
-                    else:
-                        last_error = None
                         print(
-                            "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
-                            f"relay={_sanitize_relay_target(active_relay_url)} "
-                            f"request_id={request_id}",
+                            "desktop.compute_node_bridge.process_request "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
                             file=sys.stderr,
                         )
-            else:
-                if has_heartbeat:
-                    last_error = None
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.work_received "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            file=sys.stderr,
+                        )
+                        try:
+                            processed = runtime.process_relay_request(relay_response)
+                        except Exception as exc:
+                            processed = False
+                            last_error = "failed to process relay request"
+                            print(
+                                "desktop.compute_node_bridge.process_request.exception "
+                                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                                f"exc_type={type(exc).__name__}",
+                                file=sys.stderr,
+                            )
+                        if not processed:
+                            last_error = "failed to process relay request"
+                            print(
+                                "desktop.compute_node_bridge.process_request.failed "
+                                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                                file=sys.stderr,
+                            )
+                            submit_api_v1_error_response(
+                                relay_response,
+                                code="compute_node_process_failed",
+                                message=last_error,
+                                active_relay_url=active_relay_url,
+                                request_id=request_id,
+                            )
+                        else:
+                            last_error = None
+                            print(
+                                "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
+                                f"relay={_sanitize_relay_target(active_relay_url)} "
+                                f"request_id={request_id}",
+                                file=sys.stderr,
+                            )
                 else:
-                    last_error = (
-                        "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
-                        "operator; update relay.py to repo HEAD"
-                    )
+                    if has_heartbeat:
+                        last_error = None
+                    else:
+                        last_error = (
+                            "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
+                            "operator; update relay.py to repo HEAD"
+                        )
 
-            if registered and warm_load_enabled and warm_load_state == "not_started":
-                if not bridge_runtime_allowed:
-                    warm_load_state = "not_started"
-                    print(
-                        "desktop.compute_node_bridge.model_init.skipped "
-                        f"reason=post_registration runtime_path={runtime_path} "
-                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
-                        file=sys.stderr,
-                    )
-                else:
+                if registered and warm_load_enabled and warm_load_state == "not_started":
                     if (
                         not ensure_runtime_ready(
                             "post_registration", active_relay_url=active_relay_url, block=False
@@ -880,19 +927,19 @@ def run(args: argparse.Namespace) -> int:
                     ):
                         fail_on_warm_load_error(active_relay_url=active_relay_url)
                         break
-            emit_status_event(
-                registered=registered,
-                active_relay_url=active_relay_url,
-                current_last_error=last_error,
-            )
-
-            if _sleep_with_cancel(wait_seconds):
-                print(
-                    "desktop.compute_node_bridge.stop_requested "
-                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                    file=sys.stderr,
+                emit_status_event(
+                    registered=registered,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
                 )
-                break
+
+                if _sleep_with_cancel(wait_seconds):
+                    print(
+                        "desktop.compute_node_bridge.stop_requested "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    break
     except KeyboardInterrupt:
         pass
     finally:
@@ -925,6 +972,7 @@ def run(args: argparse.Namespace) -> int:
             "warm_load_enabled": warm_load_enabled,
             "warm_load_duration_ms": warm_load_duration_ms,
             "runtime_path": runtime_path,
+            "relay_runtime_path": relay_runtime_path,
         }
     )
     return 1 if warm_load_fatal else 0

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -74,6 +74,7 @@ EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
 API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
+PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
 
 
 _POLL_CANCELLED = object()
@@ -527,7 +528,6 @@ def run(args: argparse.Namespace) -> int:
         block: bool = False,
         request_id: str = "none",
         block_timeout_seconds: Optional[float] = None,
-        log_runtime_wait_progress: bool = True,
     ) -> bool:
         nonlocal warm_load_state, warm_load_started_at, warm_load_duration_ms, warm_load_failed
         nonlocal warm_load_executor, warm_load_future
@@ -560,24 +560,10 @@ def run(args: argparse.Namespace) -> int:
             return False
         if block and not warm_load_future.done():
             timeout = block_timeout_seconds
-            if log_runtime_wait_progress:
-                print(
-                    "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start "
-                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                    f"state={warm_load_state} timeout_seconds={timeout}",
-                    file=sys.stderr,
-                )
             try:
                 ready = bool(warm_load_future.result(timeout=timeout))
             except concurrent.futures.TimeoutError:
                 warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
-                if log_runtime_wait_progress:
-                    print(
-                        "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout "
-                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                        f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
-                        file=sys.stderr,
-                    )
                 return False
             except Exception as exc:
                 ready = False
@@ -728,7 +714,7 @@ def run(args: argparse.Namespace) -> int:
         wait_started_at = time.monotonic()
         last_progress_log_at = wait_started_at
         last_status_emit_at = wait_started_at
-        progress_emit_interval_seconds = 30.0
+        progress_emit_interval_seconds = PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS
         while warm_load_state == "warming":
             elapsed_seconds = time.monotonic() - wait_started_at
             remaining_seconds = warm_load_deadline_seconds - elapsed_seconds
@@ -756,7 +742,6 @@ def run(args: argparse.Namespace) -> int:
                 active_relay_url=runtime.relay_client.relay_url,
                 block=True,
                 block_timeout_seconds=min(0.1, remaining_seconds),
-                log_runtime_wait_progress=False,
             ):
                 break
             now = time.monotonic()
@@ -846,39 +831,6 @@ def run(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
 
-                api_v1_runtime_ready_for_request = True
-                terminate_after_api_v1_error = False
-                if registered and api_v1_payload and warm_load_enabled and warm_load_state != "ready":
-                    api_v1_runtime_ready_for_request = ensure_runtime_ready(
-                        "api_v1_request",
-                        active_relay_url=active_relay_url,
-                        block=True,
-                        request_id=request_id,
-                        block_timeout_seconds=_api_v1_warm_load_wait_seconds(),
-                    )
-                    if not api_v1_runtime_ready_for_request:
-                        last_error = warm_load_failed or "API v1 model runtime is not ready"
-                        if warm_load_state == "failed":
-                            submit_api_v1_error_response(
-                                relay_response,
-                                code="compute_node_runtime_unavailable",
-                                message=last_error,
-                                active_relay_url=active_relay_url,
-                                request_id=request_id,
-                            )
-                            terminate_after_api_v1_error = True
-                        else:
-                            print(
-                                "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.deferred "
-                                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                                f"state={warm_load_state}",
-                                file=sys.stderr,
-                            )
-
-                if terminate_after_api_v1_error:
-                    fail_on_warm_load_error(active_relay_url=active_relay_url)
-                    break
-
                 if not registered:
                     if relay_error is not None:
                         last_error = relay_error
@@ -888,62 +840,54 @@ def run(args: argparse.Namespace) -> int:
                             "operator; update relay.py to repo HEAD"
                         )
                 elif api_v1_payload:
-                    if not api_v1_runtime_ready_for_request:
+                    print(
+                        f"desktop.compute_node_bridge.request_route runtime_path={runtime_path} "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "desktop.compute_node_bridge.process_request "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "desktop.compute_node_bridge.api_v1_e2ee.work_received "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    try:
+                        processed = runtime.process_relay_request(relay_response)
+                    except Exception as exc:
+                        processed = False
+                        last_error = "failed to process relay request"
                         print(
-                            "desktop.compute_node_bridge.process_request.skipped_runtime_not_ready "
-                            f"relay={_sanitize_relay_target(active_relay_url)} "
-                            f"request_id={request_id} state={warm_load_state}",
+                            "desktop.compute_node_bridge.process_request.exception "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                            f"exc_type={type(exc).__name__}",
                             file=sys.stderr,
+                        )
+                    if not processed:
+                        last_error = "failed to process relay request"
+                        print(
+                            "desktop.compute_node_bridge.process_request.failed "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            file=sys.stderr,
+                        )
+                        submit_api_v1_error_response(
+                            relay_response,
+                            code="compute_node_process_failed",
+                            message=last_error,
+                            active_relay_url=active_relay_url,
+                            request_id=request_id,
                         )
                     else:
+                        last_error = None
                         print(
-                            f"desktop.compute_node_bridge.request_route runtime_path={runtime_path} "
-                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                            "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            f"request_id={request_id}",
                             file=sys.stderr,
                         )
-                        print(
-                            "desktop.compute_node_bridge.process_request "
-                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                            file=sys.stderr,
-                        )
-                        print(
-                            "desktop.compute_node_bridge.api_v1_e2ee.work_received "
-                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                            file=sys.stderr,
-                        )
-                        try:
-                            processed = runtime.process_relay_request(relay_response)
-                        except Exception as exc:
-                            processed = False
-                            last_error = "failed to process relay request"
-                            print(
-                                "desktop.compute_node_bridge.process_request.exception "
-                                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
-                                f"exc_type={type(exc).__name__}",
-                                file=sys.stderr,
-                            )
-                        if not processed:
-                            last_error = "failed to process relay request"
-                            print(
-                                "desktop.compute_node_bridge.process_request.failed "
-                                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
-                                file=sys.stderr,
-                            )
-                            submit_api_v1_error_response(
-                                relay_response,
-                                code="compute_node_process_failed",
-                                message=last_error,
-                                active_relay_url=active_relay_url,
-                                request_id=request_id,
-                            )
-                        else:
-                            last_error = None
-                            print(
-                                "desktop.compute_node_bridge.api_v1_e2ee.response_submitted "
-                                f"relay={_sanitize_relay_target(active_relay_url)} "
-                                f"request_id={request_id}",
-                                file=sys.stderr,
-                            )
                 else:
                     if has_heartbeat:
                         last_error = None
@@ -953,15 +897,6 @@ def run(args: argparse.Namespace) -> int:
                             "operator; update relay.py to repo HEAD"
                         )
 
-                if registered and warm_load_enabled and warm_load_state == "not_started":
-                    if (
-                        not ensure_runtime_ready(
-                            "post_registration", active_relay_url=active_relay_url, block=False
-                        )
-                        and warm_load_state == "failed"
-                    ):
-                        fail_on_warm_load_error(active_relay_url=active_relay_url)
-                        break
                 emit_status_event(
                     registered=registered,
                     active_relay_url=active_relay_url,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -38,6 +38,8 @@ pub struct ComputeNodeStatus {
     pub model_path: String,
     pub last_error: Option<String>,
     pub warm_load_state: Option<String>,
+    pub warm_load_enabled: Option<bool>,
+    pub warm_load_duration_ms: Option<u64>,
     pub runtime_path: Option<String>,
     pub relay_runtime_path: Option<String>,
 }
@@ -198,6 +200,8 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
         warm_load_state: Some("failed".into()),
+        warm_load_enabled: Some(true),
+        warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
     }
@@ -248,6 +252,12 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
             .get("warm_load_state")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+    }
+    if payload.get("warm_load_enabled").is_some() {
+        status.warm_load_enabled = payload.get("warm_load_enabled").and_then(Value::as_bool);
+    }
+    if payload.get("warm_load_duration_ms").is_some() {
+        status.warm_load_duration_ms = payload.get("warm_load_duration_ms").and_then(Value::as_u64);
     }
     if payload.get("runtime_path").is_some() {
         status.runtime_path = payload
@@ -474,6 +484,8 @@ pub async fn start_compute_node(
                 model_path: request.model_path.clone(),
                 last_error: None,
                 warm_load_state: Some("not_started".into()),
+                warm_load_enabled: Some(true),
+                warm_load_duration_ms: None,
                 runtime_path: Some("bridge".into()),
                 relay_runtime_path: Some("bridge".into()),
             };
@@ -755,6 +767,8 @@ mod tests {
             running: true,
             registered: true,
             warm_load_state: Some("ready".into()),
+            warm_load_enabled: Some(true),
+            warm_load_duration_ms: Some(125),
             runtime_path: Some("bridge".into()),
             relay_runtime_path: Some("bridge".into()),
             ..ComputeNodeStatus::default()
@@ -764,6 +778,8 @@ mod tests {
             "type": "status",
             "registered": true,
             "warm_load_state": "warming",
+            "warm_load_enabled": true,
+            "warm_load_duration_ms": 250,
             "runtime_path": "sidecar",
             "relay_runtime_path": "bridge"
         });
@@ -772,8 +788,37 @@ mod tests {
 
         assert!(status.registered);
         assert_eq!(status.warm_load_state.as_deref(), Some("warming"));
+        assert_eq!(status.warm_load_enabled, Some(true));
+        assert_eq!(status.warm_load_duration_ms, Some(250));
         assert_eq!(status.runtime_path.as_deref(), Some("sidecar"));
         assert_eq!(status.relay_runtime_path.as_deref(), Some("bridge"));
+    }
+
+    #[test]
+    fn compute_node_status_cache_replays_warming_relay_runtime_fields() {
+        let state = ComputeNodeState::default();
+        let cached_status = ComputeNodeStatus {
+            running: true,
+            registered: false,
+            warm_load_state: Some("warming".into()),
+            warm_load_enabled: Some(true),
+            warm_load_duration_ms: Some(42),
+            runtime_path: Some("sidecar".into()),
+            relay_runtime_path: Some("bridge".into()),
+            ..ComputeNodeStatus::default()
+        };
+
+        let mut status = state.status.blocking_lock();
+        *status = cached_status.clone();
+
+        assert_eq!(status.warm_load_state, cached_status.warm_load_state);
+        assert_eq!(status.warm_load_enabled, cached_status.warm_load_enabled);
+        assert_eq!(
+            status.warm_load_duration_ms,
+            cached_status.warm_load_duration_ms
+        );
+        assert_eq!(status.runtime_path, cached_status.runtime_path);
+        assert_eq!(status.relay_runtime_path, cached_status.relay_runtime_path);
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -37,6 +37,9 @@ pub struct ComputeNodeStatus {
     pub fallback_reason: Option<String>,
     pub model_path: String,
     pub last_error: Option<String>,
+    pub warm_load_state: Option<String>,
+    pub runtime_path: Option<String>,
+    pub relay_runtime_path: Option<String>,
 }
 
 #[derive(Clone, Default)]
@@ -194,6 +197,9 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         fallback_reason: None,
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
+        warm_load_state: Some("failed".into()),
+        runtime_path: Some("bridge".into()),
+        relay_runtime_path: Some("bridge".into()),
     }
 }
 
@@ -234,6 +240,24 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
     if payload.get("last_error").is_some() {
         status.last_error = payload
             .get("last_error")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("warm_load_state").is_some() {
+        status.warm_load_state = payload
+            .get("warm_load_state")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("runtime_path").is_some() {
+        status.runtime_path = payload
+            .get("runtime_path")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("relay_runtime_path").is_some() {
+        status.relay_runtime_path = payload
+            .get("relay_runtime_path")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
     }
@@ -449,6 +473,9 @@ pub async fn start_compute_node(
                 fallback_reason: None,
                 model_path: request.model_path.clone(),
                 last_error: None,
+                warm_load_state: Some("not_started".into()),
+                runtime_path: Some("bridge".into()),
+                relay_runtime_path: Some("bridge".into()),
             };
             true
         }
@@ -708,12 +735,45 @@ mod tests {
         let observed_cancel = std::fs::read_to_string(&observed_cancel_path)
             .expect("cancel message should be recorded");
         assert_eq!(observed_cancel, "{\"type\":\"cancel\"}");
-        assert!(state.child.lock().await.is_none(), "child handle should be cleared");
-        assert!(state.stdin.lock().await.is_none(), "stdin handle should be cleared");
+        assert!(
+            state.child.lock().await.is_none(),
+            "child handle should be cleared"
+        );
+        assert!(
+            state.stdin.lock().await.is_none(),
+            "stdin handle should be cleared"
+        );
 
         let final_status = state.status.lock().await.clone();
         assert!(!final_status.running);
         assert!(!final_status.registered);
+    }
+
+    #[test]
+    fn update_status_from_event_preserves_relay_runtime_readiness_fields() {
+        let mut status = ComputeNodeStatus {
+            running: true,
+            registered: true,
+            warm_load_state: Some("ready".into()),
+            runtime_path: Some("bridge".into()),
+            relay_runtime_path: Some("bridge".into()),
+            ..ComputeNodeStatus::default()
+        };
+
+        let payload = serde_json::json!({
+            "type": "status",
+            "registered": true,
+            "warm_load_state": "warming",
+            "runtime_path": "sidecar",
+            "relay_runtime_path": "bridge"
+        });
+
+        update_status_from_event(&mut status, &payload);
+
+        assert!(status.registered);
+        assert_eq!(status.warm_load_state.as_deref(), Some("warming"));
+        assert_eq!(status.runtime_path.as_deref(), Some("sidecar"));
+        assert_eq!(status.relay_runtime_path.as_deref(), Some("bridge"));
     }
 
     #[test]

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -420,6 +420,7 @@ describe('desktop app start failure handling', () => {
         type: 'status',
         running: true,
         registered: true,
+        warm_load_state: 'ready',
         last_error: null,
       },
     });
@@ -427,6 +428,32 @@ describe('desktop app start failure handling', () => {
     await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
     await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
     expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
+
+  it('does not display registered yes while relay runtime is warming', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        warm_load_state: 'warming',
+        effective_mode: 'pending',
+        backend_available: 'unknown',
+        backend_selected: 'unknown',
+        backend_used: 'unknown',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
   });
 
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -78,6 +78,55 @@ describe('desktop app start failure handling', () => {
     });
   });
 
+
+  const mockInitialComputeStatus = (statusOverrides: Record<string, unknown>) => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'detect_backend') {
+        return Promise.resolve({
+          platform_label: 'macos',
+          preferred_mode: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
+        });
+      }
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: false,
+          registered: false,
+          active_relay_url: '',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '',
+          last_error: null,
+          ...statusOverrides,
+        });
+      }
+      if (command === 'inspect_model_artifact') {
+        return Promise.resolve({
+          canonical_family_url: 'https://example.test/models',
+          filename: 'model.gguf',
+          url: 'https://example.test/model.gguf',
+          models_dir: '/tmp',
+          resolved_model_path: '/tmp/model.gguf',
+          exists: true,
+          size_bytes: 1,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+  };
+
   it('moves local inference from starting to failed when invoke rejects', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'start_inference') {
@@ -454,6 +503,67 @@ describe('desktop app start failure handling', () => {
     await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
     expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
+  });
+
+
+  it('replays cached warming readiness and relay runtime path without showing registered yes', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      model_path: '/tmp/model.gguf',
+      warm_load_state: 'warming',
+      warm_load_enabled: true,
+      warm_load_duration_ms: 25,
+      runtime_path: 'sidecar',
+      relay_runtime_path: 'bridge',
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
+    expect(screen.getByText(/Relay runtime path:/).textContent).toContain('bridge');
+  });
+
+  it('allows cached ready relay runtime status to display registered yes', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      model_path: '/tmp/model.gguf',
+      warm_load_state: 'ready',
+      warm_load_enabled: true,
+      warm_load_duration_ms: 25,
+      runtime_path: 'bridge',
+      relay_runtime_path: 'bridge',
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('ready');
+  });
+
+  it('does not display registered yes for stopped cached compute node status', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      model_path: '/tmp/model.gguf',
+      warm_load_state: 'ready',
+      warm_load_enabled: true,
+      warm_load_duration_ms: 25,
+      runtime_path: 'bridge',
+      relay_runtime_path: 'bridge',
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
   });
 
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -547,6 +547,26 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Relay runtime state:/).textContent).toContain('ready');
   });
 
+  it('allows cached registered status when warm-load is disabled', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      model_path: '/tmp/model.gguf',
+      warm_load_state: 'not_started',
+      warm_load_enabled: false,
+      warm_load_duration_ms: null,
+      runtime_path: 'bridge',
+      relay_runtime_path: 'bridge',
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('not_started');
+  });
+
   it('does not display registered yes for stopped cached compute node status', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -32,6 +32,8 @@ interface ComputeNodeStatus {
   model_path: string;
   last_error: string | null;
   warm_load_state: string | null;
+  warm_load_enabled: boolean | null;
+  warm_load_duration_ms: number | null;
   runtime_path: string | null;
   relay_runtime_path: string | null;
 }
@@ -67,6 +69,8 @@ const defaultComputeStatus: ComputeNodeStatus = {
   model_path: '',
   last_error: null,
   warm_load_state: null,
+  warm_load_enabled: null,
+  warm_load_duration_ms: null,
   runtime_path: null,
   relay_runtime_path: null,
 };
@@ -103,7 +107,7 @@ export function App() {
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
   const relayRuntimeReady = computeStatus.warm_load_state === null || computeStatus.warm_load_state === 'ready';
-  const computeNodeRegistered = computeStatus.registered && relayRuntimeReady;
+  const computeNodeRegistered = computeStatus.running && computeStatus.registered && relayRuntimeReady;
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');
 
@@ -196,6 +200,14 @@ export function App() {
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         warm_load_state:
           typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
+        warm_load_enabled:
+          typeof payload.warm_load_enabled === 'boolean'
+            ? payload.warm_load_enabled
+            : prev.warm_load_enabled,
+        warm_load_duration_ms:
+          typeof payload.warm_load_duration_ms === 'number'
+            ? payload.warm_load_duration_ms
+            : prev.warm_load_duration_ms,
         runtime_path: typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
         relay_runtime_path:
           typeof payload.relay_runtime_path === 'string'

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -106,7 +106,10 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
-  const relayRuntimeReady = computeStatus.warm_load_state === null || computeStatus.warm_load_state === 'ready';
+  const relayRuntimeReady =
+    computeStatus.warm_load_enabled === false ||
+    computeStatus.warm_load_state === null ||
+    computeStatus.warm_load_state === 'ready';
   const computeNodeRegistered = computeStatus.running && computeStatus.registered && relayRuntimeReady;
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -31,6 +31,9 @@ interface ComputeNodeStatus {
   fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
+  warm_load_state: string | null;
+  runtime_path: string | null;
+  relay_runtime_path: string | null;
 }
 
 interface ModelArtifactInfo {
@@ -63,6 +66,9 @@ const defaultComputeStatus: ComputeNodeStatus = {
   fallback_reason: null,
   model_path: '',
   last_error: null,
+  warm_load_state: null,
+  runtime_path: null,
+  relay_runtime_path: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -96,6 +102,8 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const relayRuntimeReady = computeStatus.warm_load_state === null || computeStatus.warm_load_state === 'ready';
+  const computeNodeRegistered = computeStatus.registered && relayRuntimeReady;
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');
 
@@ -186,6 +194,13 @@ export function App() {
               ? payload.fallback_reason
               : prev.fallback_reason,
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
+        warm_load_state:
+          typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
+        runtime_path: typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
+        relay_runtime_path:
+          typeof payload.relay_runtime_path === 'string'
+            ? payload.relay_runtime_path
+            : prev.relay_runtime_path,
         last_error:
           payload.last_error === null
             ? null
@@ -450,7 +465,10 @@ export function App() {
           </button>
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeNodeRegistered ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{computeStatus.warm_load_state || 'idle'}</code></p>
+        <p style={{ marginBottom: 0 }}>Runtime path: <code>{computeStatus.runtime_path || 'bridge'}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{computeStatus.relay_runtime_path || 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode ?? 'pending'}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -801,8 +801,10 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     assert runtime.relay_client.endpoint_calls[0][0] == '/api/v1/relay/responses'
 
     output = capsys.readouterr()
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.ready' in output.err
+    assert 'desktop.compute_node_bridge.registration.gate_wait_start' in output.err
+    assert 'desktop.compute_node_bridge.registration.gate_wait_done' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.start' not in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout' not in output.err
     assert 'desktop.compute_node_bridge.process_request relay=https://token.place request_id=req-1' in output.err
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
 
@@ -1577,7 +1579,15 @@ def test_run_pre_registration_warmup_times_out_without_registering(capsys, monke
         error_event = next(event for event in output_events if event.get("type") == "error")
         assert error_event["warm_load_state"] == "failed"
         assert "timed out" in error_event["message"]
+        warming_status_events = [
+            event
+            for event in output_events
+            if event.get("type") == "status" and event.get("warm_load_state") == "warming"
+        ]
+        assert len(warming_status_events) == 1
         assert "registration.gate_wait_timeout" in captured.err
+        assert "api_v1_e2ee.runtime_wait.start" not in captured.err
+        assert "api_v1_e2ee.runtime_wait.timeout" not in captured.err
     finally:
         release_warmup.set()
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1,6 +1,5 @@
 """Unit tests for the desktop compute-node bridge."""
 
-import concurrent.futures
 import importlib.util
 import json
 import os
@@ -767,23 +766,16 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingThenApiV1Runtime)
     monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
 
-    real_submit = concurrent.futures.ThreadPoolExecutor.submit
-
-    def releasing_submit(self, fn, *args, **kwargs):
-        future = real_submit(self, fn, *args, **kwargs)
-        runtime = WarmingThenApiV1Runtime.last_instance
-        assert runtime is not None
-        assert runtime.ready_started.wait(timeout=0.5)
-        runtime.ready_release.set()
-        return future
-
     stop_counter = {'count': 0}
 
     def fake_stop_requested():
         stop_counter['count'] += 1
+        runtime = WarmingThenApiV1Runtime.last_instance
+        assert runtime is not None
+        assert runtime.ready_started.wait(timeout=0.5)
+        runtime.ready_release.set()
         return stop_counter['count'] > 2
 
-    monkeypatch.setattr(concurrent.futures.ThreadPoolExecutor, 'submit', releasing_submit)
     monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
 
     args = SimpleNamespace(
@@ -1548,13 +1540,13 @@ def test_run_pre_registration_warmup_times_out_without_registering(capsys, monke
     _reset_cancel_queue()
     events = []
     warm_started = threading.Event()
-    release_warmup = threading.Event()
+    never_release_warmup = threading.Event()
 
     class StuckWarmupRuntime(FakeRuntime):
         def ensure_api_v1_runtime_ready(self):
             events.append("warm-start")
             warm_started.set()
-            release_warmup.wait(timeout=1.0)
+            never_release_warmup.wait()
             events.append("warm-done")
             return True
 
@@ -1577,28 +1569,31 @@ def test_run_pre_registration_warmup_times_out_without_registering(capsys, monke
     status = compute_node_bridge.run(args)
     elapsed = time.perf_counter() - started_at
 
-    try:
-        assert status == 1
-        assert elapsed < 0.5
-        assert warm_started.is_set()
-        assert "poll" not in events
-        assert "stop" in events
-        captured = capsys.readouterr()
-        output_events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
-        error_event = next(event for event in output_events if event.get("type") == "error")
-        assert error_event["warm_load_state"] == "failed"
-        assert "timed out" in error_event["message"]
-        warming_status_events = [
-            event
-            for event in output_events
-            if event.get("type") == "status" and event.get("warm_load_state") == "warming"
-        ]
-        assert len(warming_status_events) == 1
-        assert "registration.gate_wait_timeout" in captured.err
-        assert "api_v1_e2ee.runtime_wait.start" not in captured.err
-        assert "api_v1_e2ee.runtime_wait.timeout" not in captured.err
-    finally:
-        release_warmup.set()
+    assert status == 1
+    assert elapsed < 0.5
+    assert warm_started.is_set()
+    assert any(
+        thread.daemon
+        for thread in threading.enumerate()
+        if thread.name == "tokenplace-warm-load" and thread.is_alive()
+    )
+    assert "poll" not in events
+    assert "warm-done" not in events
+    assert "stop" in events
+    captured = capsys.readouterr()
+    output_events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+    error_event = next(event for event in output_events if event.get("type") == "error")
+    assert error_event["warm_load_state"] == "failed"
+    assert "timed out" in error_event["message"]
+    warming_status_events = [
+        event
+        for event in output_events
+        if event.get("type") == "status" and event.get("warm_load_state") == "warming"
+    ]
+    assert len(warming_status_events) == 1
+    assert "registration.gate_wait_timeout" in captured.err
+    assert "api_v1_e2ee.runtime_wait.start" not in captured.err
+    assert "api_v1_e2ee.runtime_wait.timeout" not in captured.err
 
 
 def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -815,6 +815,7 @@ def test_run_slow_pre_registration_warm_load_processes_without_runtime_not_ready
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingTimeoutApiV1Runtime)
     monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
+    monkeypatch.setattr(compute_node_bridge, 'PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS', 0.01)
 
     stop_counter = {'count': 0}
 
@@ -843,6 +844,14 @@ def test_run_slow_pre_registration_warm_load_processes_without_runtime_not_ready
     output = capsys.readouterr()
     assert 'api_v1_payload=True' in output.err
     assert 'desktop.compute_node_bridge.registration.gate_wait_start' in output.err
+    assert 'desktop.compute_node_bridge.model_init.still_warming' in output.err
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    warming_status_events = [
+        event
+        for event in events
+        if event.get('type') == 'status' and event.get('warm_load_state') == 'warming'
+    ]
+    assert len(warming_status_events) >= 2
     assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' not in output.err
     assert 'compute_node_runtime_not_ready' not in output.err
 
@@ -1634,7 +1643,7 @@ def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatc
     _ = capsys.readouterr()
 
 
-def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypatch):
+def test_run_stops_when_pre_registration_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -812,7 +812,7 @@ def test_run_slow_pre_registration_warm_load_processes_without_runtime_not_ready
 ):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingTimeoutApiV1Runtime)
-    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.01')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
 
     stop_counter = {'count': 0}
 
@@ -1531,6 +1531,55 @@ def test_run_does_not_wait_for_active_warmup_before_runtime_stop(capsys, monkeyp
     finally:
         release_warmup.set()
     _ = capsys.readouterr()
+
+
+def test_run_pre_registration_warmup_times_out_without_registering(capsys, monkeypatch):
+    _reset_cancel_queue()
+    events = []
+    warm_started = threading.Event()
+    release_warmup = threading.Event()
+
+    class StuckWarmupRuntime(FakeRuntime):
+        def ensure_api_v1_runtime_ready(self):
+            events.append("warm-start")
+            warm_started.set()
+            release_warmup.wait(timeout=1.0)
+            events.append("warm-done")
+            return True
+
+        def register_and_poll_once(self):
+            events.append("poll")
+            return {"next_ping_in_x_seconds": 0}
+
+        def stop(self):
+            events.append("stop")
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StuckWarmupRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS", "0.05")
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    started_at = time.perf_counter()
+    status = compute_node_bridge.run(args)
+    elapsed = time.perf_counter() - started_at
+
+    try:
+        assert status == 1
+        assert elapsed < 0.5
+        assert warm_started.is_set()
+        assert "poll" not in events
+        assert "stop" in events
+        captured = capsys.readouterr()
+        output_events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+        error_event = next(event for event in output_events if event.get("type") == "error")
+        assert error_event["warm_load_state"] == "failed"
+        assert "timed out" in error_event["message"]
+        assert "registration.gate_wait_timeout" in captured.err
+    finally:
+        release_warmup.set()
 
 
 def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -807,7 +807,7 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
 
 
-def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload(
+def test_run_slow_pre_registration_warm_load_processes_without_runtime_not_ready_error(
     capsys, monkeypatch
 ):
     _reset_cancel_queue()
@@ -834,25 +834,15 @@ def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload
     runtime = WarmingTimeoutApiV1Runtime.last_instance
     assert runtime is not None
     assert runtime.ready_started.is_set()
-    assert runtime._processed == []
-    assert runtime.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_not_ready',
-                    'message': 'API v1 model runtime is not ready',
-                },
-            },
-        )
-    ]
+    assert [payload['request_id'] for payload in runtime._processed] == ['req-1']
+    assert runtime.relay_client.endpoint_calls[0][0] == '/api/v1/relay/responses'
+    assert runtime.relay_client.endpoint_calls[0][1]['request_id'] == 'req-1'
 
     output = capsys.readouterr()
     assert 'api_v1_payload=True' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout' in output.err
-    assert 'desktop.compute_node_bridge.process_request.skipped_runtime_not_ready' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' in output.err
+    assert 'desktop.compute_node_bridge.registration.gate_wait_start' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' not in output.err
+    assert 'compute_node_runtime_not_ready' not in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):
@@ -917,8 +907,8 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is False and event.get('warm_load_state') == 'warming' for event in status_events)
+    assert any(event['registered'] is True and event['last_error'] is None for event in status_events)
     stderr = output.err
     assert 'desktop.compute_node_bridge.start' in stderr
     assert 'desktop.compute_node_bridge.relay_target.resolved' in stderr
@@ -952,8 +942,8 @@ def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is False and event.get('warm_load_state') == 'warming' for event in status_events)
+    assert any(event['registered'] is True and event['last_error'] is None for event in status_events)
 
 
 def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch):
@@ -1013,8 +1003,8 @@ def test_run_ignores_legacy_shaped_processing_failure(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is False and event.get('warm_load_state') == 'warming' for event in status_events)
+    assert any(event['registered'] is True and event['last_error'] is None for event in status_events)
 
 
 def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
@@ -1490,7 +1480,7 @@ def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypat
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     _ = capsys.readouterr()
 
 
@@ -1603,7 +1593,7 @@ def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypat
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     status = compute_node_bridge.run(args)
     assert status == 1
-    assert calls == ["poll", "warm"]
+    assert calls == ["warm"]
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload["type"] == "error"
@@ -1632,7 +1622,7 @@ def test_run_does_not_warm_when_disabled(capsys, monkeypatch):
     _ = capsys.readouterr()
 
 
-def test_run_sidecar_runtime_path_skips_bridge_warm_load_without_dual_opt_in(capsys, monkeypatch):
+def test_run_sidecar_runtime_path_warms_bridge_before_registration_without_dual_opt_in(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1653,9 +1643,9 @@ def test_run_sidecar_runtime_path_skips_bridge_warm_load_without_dual_opt_in(cap
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order == ["poll", "poll"]
+    assert call_order == ["warm", "poll"]
     output = capsys.readouterr()
-    assert "model_init.skipped" in output.err
+    assert "runtime_path.relay_uses_bridge" in output.err
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     started = next(event for event in events if event.get("type") == "started")
     assert started["runtime_path"] == "sidecar"
@@ -1682,9 +1672,9 @@ def test_run_sidecar_runtime_path_with_dual_mode_warms_and_logs_opt_in(capsys, m
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     output = capsys.readouterr()
-    assert "dual_mode_enabled" in output.err
+    assert "runtime_path.relay_uses_bridge" in output.err
 
 
 def test_run_api_v1_payload_not_dropped_when_warm_not_started(capsys, monkeypatch):
@@ -1798,25 +1788,14 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, mon
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
+    assert "request_id=none" in output.err
     assert "runtime_wait.exception" in output.err or "model_init.exception" in output.err
-    assert "error_response.submitted" in output.err
-    assert "code=compute_node_runtime_unavailable" in output.err
+    assert "error_response.submitted" not in output.err
+    assert "code=compute_node_runtime_unavailable" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive model init failure details" not in output.err
     assert ApiPayloadWarmRaiseRuntime.last_instance is not None
-    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1854,24 +1833,13 @@ def test_run_first_api_v1_payload_fails_closed_when_blocking_warm_load_raises(ca
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
+    assert "request_id=none" in output.err
     assert "runtime_wait.exception" in output.err
-    assert "error_response.submitted" in output.err
+    assert "error_response.submitted" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive delayed model init details" not in output.err
     assert BlockingWarmRaiseRuntime.last_instance is not None
-    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1956,7 +1924,7 @@ def test_cached_poll_wait_seconds_normalizes_hints_and_rejects_bad_values():
     assert compute_node_bridge._cached_poll_wait_seconds(object(), "https://relay.example", 3) == 3
 
 
-def test_run_sidecar_api_v1_payload_skips_bridge_warm_load_without_dual_opt_in(capsys, monkeypatch):
+def test_run_sidecar_api_v1_payload_warms_bridge_before_polling_without_dual_opt_in(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
@@ -1973,15 +1941,15 @@ def test_run_sidecar_api_v1_payload_skips_bridge_warm_load_without_dual_opt_in(c
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     monkeypatch.setenv("TOKENPLACE_DESKTOP_RUNTIME_PATH", "sidecar")
     monkeypatch.delenv("TOKENPLACE_DESKTOP_DUAL_RUNTIME", raising=False)
-    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: bool(calls))
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: 'process' in calls)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
 
     status = compute_node_bridge.run(args)
 
     assert status == 0
-    assert calls == ["process"]
+    assert calls == ["warm", "process"]
     output = capsys.readouterr()
-    assert "model_init.skipped reason=api_v1_request" in output.err
+    assert "runtime_path.relay_uses_bridge" in output.err
 
 
 def test_run_reports_api_v1_processing_failure(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent a desktop compute node from registering/polling with the API v1 relay before the exact relay-processing runtime is ready, avoiding early dispatch of API v1 work that returns `compute_node_runtime_not_ready` and causes 502/503 user failures.  
- Prefer warming the bridge runtime before advertising availability so local sidecar vs bridge runtime mismatches do not produce misleading UI states.  
- Surface clear diagnostics and fail-closed behavior if warm-load truly fails while preserving relay-blind E2EE invariants.

### Description
- Warm-before-register: added a `warm_runtime_before_registration()` gate that attempts/monitors the API v1 runtime warm-load before entering the register/poll loop and keeps `registered=false` while warming.  
- Deferred in-flight handling: changed in-flight API v1 handling to block/wait or defer rather than immediately submit `compute_node_runtime_not_ready` when the runtime is still warming; only a genuine warm-load failure submits an unavailable error.  
- Status & diagnostics: added `relay_runtime_path` diagnostic and richer warm-load logs (`registration.gate_wait_start/ done`, `model_init.still_warming`) and ensured emitted status events mark `registered=false` while warming/failing.  
- UI changes: updated compute status shape and the operator UI so `Registered: yes` is only shown when the relay-processing runtime is confirmed ready, and surfaced `Relay runtime state/runtime path/relay_runtime_path`.  
- Tests: updated and added unit/UI tests to cover pre-registration warm wait, slow warm-load success that processes queued API v1 payloads, warm-load failure without registering, sidecar-vs-bridge relay runtime diagnostics, and the UI suppression of misleading `Registered: yes` during warming.

### Testing
- `pytest tests/unit/test_desktop_compute_node_bridge.py -q` — 53 passed.  
- `pytest tests/unit/test_desktop_model_bridge.py -q` — 23 passed.  
- `pytest tests/unit/test_relay_client.py -q -k "api_v1 or response or e2ee or register or warm"` — selected relay-client tests passed.  
- `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — integration API v1 desktop bridge tests passed.  
- `pytest tests/test_relay.py -q -k "api_v1 or responses"` — relay integration tests passed.  
- `pytest` (full selected suites above) — summary: unit + integration suites covering the bridge/relay changes passed (see above commands).  
- Frontend: `npm --prefix desktop-tauri test` — UI tests passed; `npm --prefix desktop-tauri run build` — build succeeded.  
- Lint/hooks: `pre-commit run --all-files` — passed.  
- Note: attempted a Playwright screenshot to illustrate the updated UI, but Playwright Chromium was not installed in this environment (`npx playwright install` required) so no screenshot artifact was produced.

All automated checks described above passed in this environment after the changes; follow-up acceptance/staging steps described in the task should be used for manual staging validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195402c01c832f873299a9ca142655)