### PR TITLE
Gate desktop relay registration on API v1 runtime readiness

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -73,7 +73,7 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
-API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 10.0
+API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 
 
 _POLL_CANCELLED = object()
@@ -544,14 +544,15 @@ def run(args: argparse.Namespace) -> int:
                 )
             warm_load_future = warm_load_executor.submit(runtime.ensure_api_v1_runtime_ready)
             emit_status_event(
-                registered=True,
+                registered=False,
                 active_relay_url=active_relay_url,
                 current_last_error=last_error,
             )
             print(
                 "desktop.compute_node_bridge.model_init.start "
                 f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
-                f"request_id={request_id} state={warm_load_state}",
+                f"request_id={request_id} state={warm_load_state} "
+                f"runtime_path={runtime_path}",
                 file=sys.stderr,
             )
         if warm_load_future is None:
@@ -645,7 +646,7 @@ def run(args: argparse.Namespace) -> int:
         nonlocal last_error, warm_load_fatal
         last_error = warm_load_failed or "failed to initialize API v1 model runtime"
         emit_status_event(
-            registered=True,
+            registered=False,
             active_relay_url=active_relay_url,
             current_last_error=last_error,
         )
@@ -695,9 +696,40 @@ def run(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    if warm_load_enabled and bridge_runtime_allowed:
+        print(
+            "desktop.compute_node_bridge.operator_start.warm_load_requested "
+            f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+            f"runtime_path={runtime_path}",
+            file=sys.stderr,
+        )
+        if not ensure_runtime_ready(
+            "pre_registration",
+            active_relay_url=runtime.relay_client.relay_url,
+            block=True,
+        ):
+            fail_on_warm_load_error(active_relay_url=runtime.relay_client.relay_url)
+        else:
+            emit_status_event(
+                registered=False,
+                active_relay_url=runtime.relay_client.relay_url,
+                current_last_error=last_error,
+            )
+    elif warm_load_enabled and not bridge_runtime_allowed:
+        print(
+            "desktop.compute_node_bridge.operator_start.warm_load_skipped "
+            f"runtime_path={runtime_path} dual_runtime_enabled={dual_runtime_enabled}",
+            file=sys.stderr,
+        )
+
     try:
-        while not stop_requested():
-            print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
+        while not warm_load_fatal and not stop_requested():
+            print(
+                "desktop.compute_node_bridge.api_v1_e2ee.register "
+                f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+                f"runtime_ready={warm_load_state == 'ready'}",
+                file=sys.stderr,
+            )
             active_relay_url = runtime.relay_client.relay_url
             relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
             if relay_response is _POLL_CANCELLED:
@@ -862,7 +894,7 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
 
-            if registered and warm_load_enabled and warm_load_state == "not_started":
+            if registered and warm_load_enabled and warm_load_state == "not_started" and not bridge_runtime_allowed:
                 if not bridge_runtime_allowed:
                     warm_load_state = "not_started"
                     print(

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -420,6 +420,8 @@ describe('desktop app start failure handling', () => {
         type: 'status',
         running: true,
         registered: true,
+        warm_load_state: 'ready',
+        runtime_path: 'bridge',
         last_error: null,
       },
     });
@@ -427,6 +429,29 @@ describe('desktop app start failure handling', () => {
     await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
     await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
     expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
+  it('does not display registered yes while relay runtime is still warming', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        warm_load_state: 'warming',
+        runtime_path: 'bridge',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('warming');
+    expect(screen.getByText(/Registered:/).textContent).not.toContain('yes');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
   });
 
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -31,6 +31,9 @@ interface ComputeNodeStatus {
   fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
+  warm_load_state: string | null;
+  runtime_path: string | null;
+  warm_load_enabled: boolean | null;
 }
 
 interface ModelArtifactInfo {
@@ -63,6 +66,9 @@ const defaultComputeStatus: ComputeNodeStatus = {
   fallback_reason: null,
   model_path: '',
   last_error: null,
+  warm_load_state: null,
+  runtime_path: null,
+  warm_load_enabled: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -194,6 +200,16 @@ export function App() {
               : typeof payload.message === 'string'
                 ? payload.message
                 : prev.last_error,
+        warm_load_state:
+          typeof payload.warm_load_state === 'string'
+            ? payload.warm_load_state
+            : prev.warm_load_state,
+        runtime_path:
+          typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
+        warm_load_enabled:
+          typeof payload.warm_load_enabled === 'boolean'
+            ? payload.warm_load_enabled
+            : prev.warm_load_enabled,
       }));
       if (payload.type === 'started' || payload.type === 'error') {
         setIsStartingComputeNode(false);
@@ -235,6 +251,16 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
     [config.model_path, computeStatus.running, isStartingComputeNode]
   );
+  const relayRuntimeReady =
+    computeStatus.warm_load_enabled === false ||
+    computeStatus.warm_load_state === 'ready' ||
+    computeStatus.warm_load_state === null;
+  const displaysRegistered = computeStatus.registered && relayRuntimeReady;
+  const registrationLabel = displaysRegistered
+    ? 'yes'
+    : computeStatus.running && computeStatus.warm_load_state === 'warming'
+      ? 'warming'
+      : 'no';
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
 
@@ -331,6 +357,9 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        warm_load_state: 'not_started',
+        runtime_path: 'bridge',
+        warm_load_enabled: true,
       }));
       await invoke('start_compute_node', {
         request: {
@@ -450,7 +479,9 @@ export function App() {
           </button>
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Registered: <strong>{registrationLabel}</strong></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{computeStatus.warm_load_state ?? 'not reported'}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{computeStatus.runtime_path ?? 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode ?? 'pending'}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -807,7 +807,7 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
 
 
-def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload(
+def test_run_api_v1_payload_waits_for_startup_warm_load_without_error_response(
     capsys, monkeypatch
 ):
     _reset_cancel_queue()
@@ -834,25 +834,27 @@ def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload
     runtime = WarmingTimeoutApiV1Runtime.last_instance
     assert runtime is not None
     assert runtime.ready_started.is_set()
-    assert runtime._processed == []
+    assert [payload['request_id'] for payload in runtime._processed] == ['req-1']
     assert runtime.relay_client.endpoint_calls == [
         (
             '/api/v1/relay/responses',
             {
+                'protocol': 'tokenplace_api_v1_relay_e2ee',
+                'version': 1,
                 'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_not_ready',
-                    'message': 'API v1 model runtime is not ready',
-                },
+                'client_public_key': 'client-key',
+                'chat_history': 'ciphertext',
+                'cipherkey': 'key',
+                'iv': 'iv',
+                'next_ping_in_x_seconds': 0,
             },
         )
     ]
 
     output = capsys.readouterr()
     assert 'api_v1_payload=True' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout' in output.err
-    assert 'desktop.compute_node_bridge.process_request.skipped_runtime_not_ready' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.ready' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' not in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):
@@ -917,8 +919,11 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert status_events[0]['registered'] is False
+    assert status_events[0]['warm_load_state'] == 'warming'
+    registered_events = [event for event in status_events if event.get('registered') is True]
+    assert registered_events
+    assert registered_events[0]['last_error'] is None
     stderr = output.err
     assert 'desktop.compute_node_bridge.start' in stderr
     assert 'desktop.compute_node_bridge.relay_target.resolved' in stderr
@@ -952,8 +957,10 @@ def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert status_events[0]['registered'] is False
+    registered_events = [event for event in status_events if event.get('registered') is True]
+    assert registered_events
+    assert registered_events[0]['last_error'] is None
 
 
 def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch):
@@ -1013,8 +1020,8 @@ def test_run_ignores_legacy_shaped_processing_failure(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event.get('registered') is True for event in status_events)
+    assert status_events[-1]['last_error'] is None
 
 
 def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
@@ -1471,7 +1478,7 @@ def test_run_reports_stale_registration_status_after_missed_heartbeat(capsys, mo
     )
 
 
-def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypatch):
+def test_run_warms_runtime_before_first_successful_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1490,21 +1497,18 @@ def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypat
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     _ = capsys.readouterr()
 
 
-def test_run_does_not_wait_for_active_warmup_before_runtime_stop(capsys, monkeypatch):
+def test_run_waits_for_pre_registration_warmup_before_polling(capsys, monkeypatch):
     _reset_cancel_queue()
     events = []
-    warm_started = threading.Event()
-    release_warmup = threading.Event()
 
     class SlowWarmupRuntime(FakeRuntime):
         def ensure_api_v1_runtime_ready(self):
             events.append("warm-start")
-            warm_started.set()
-            release_warmup.wait(timeout=1.0)
+            time.sleep(0.05)
             events.append("warm-done")
             return True
 
@@ -1516,30 +1520,15 @@ def test_run_does_not_wait_for_active_warmup_before_runtime_stop(capsys, monkeyp
             events.append("stop")
 
     _install_fake_runtime_module(monkeypatch, runtime_cls=SlowWarmupRuntime)
-    stop_calls = {"count": 0}
-
-    def fake_stop_requested():
-        stop_calls["count"] += 1
-        if stop_calls["count"] == 1:
-            return False
-        assert warm_started.wait(timeout=1.0)
-        return True
-
-    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: events.count("poll") > 0)
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
 
-    started_at = time.perf_counter()
     status = compute_node_bridge.run(args)
-    elapsed = time.perf_counter() - started_at
 
-    try:
-        assert status == 0
-        assert elapsed < 0.5
-        assert "stop" in events
-        assert "warm-done" not in events[: events.index("stop") + 1]
-    finally:
-        release_warmup.set()
+    assert status == 0
+    assert events[:3] == ["warm-start", "warm-done", "poll"]
+    assert "stop" in events
     _ = capsys.readouterr()
 
 
@@ -1585,7 +1574,7 @@ def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatc
     _ = capsys.readouterr()
 
 
-def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypatch):
+def test_run_stops_before_registration_when_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
@@ -1603,7 +1592,7 @@ def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypat
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     status = compute_node_bridge.run(args)
     assert status == 1
-    assert calls == ["poll", "warm"]
+    assert calls == ["warm"]
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload["type"] == "error"
@@ -1682,7 +1671,7 @@ def test_run_sidecar_runtime_path_with_dual_mode_warms_and_logs_opt_in(capsys, m
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     output = capsys.readouterr()
     assert "dual_mode_enabled" in output.err
 
@@ -1798,25 +1787,14 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, mon
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
+    assert "request_id=none" in output.err
     assert "runtime_wait.exception" in output.err or "model_init.exception" in output.err
-    assert "error_response.submitted" in output.err
-    assert "code=compute_node_runtime_unavailable" in output.err
+    assert "error_response.submitted" not in output.err
+    assert "code=compute_node_runtime_unavailable" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive model init failure details" not in output.err
     assert ApiPayloadWarmRaiseRuntime.last_instance is not None
-    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1854,24 +1832,13 @@ def test_run_first_api_v1_payload_fails_closed_when_blocking_warm_load_raises(ca
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
+    assert "request_id=none" in output.err
     assert "runtime_wait.exception" in output.err
-    assert "error_response.submitted" in output.err
+    assert "error_response.submitted" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive delayed model init details" not in output.err
     assert BlockingWarmRaiseRuntime.last_instance is not None
-    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"


### PR DESCRIPTION
### Motivation
- Prevent the desktop compute-node operator from advertising itself as a registered/available relay server before the API v1 E2EE runtime used to process relay work is actually warmed and ready.
- Hide benign warm-start races from browser clients so they don't receive `compute_node_runtime_not_ready` failures while the local runtime is still starting.

### Description
- Pre-registration warm-up: the bridge now attempts a pre-registration warm-load (`ensure_api_v1_runtime_ready`) when `TOKENPLACE_DESKTOP_WARM_LOAD` and the bridge runtime path are enabled and will emit warming/ready/failure diagnostics before registering with the relay; registration is gated on that readiness. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Defensive behavior: during warm-up the bridge reports `registered=false` in status events, increases the default API v1 warm-load wait budget, avoids submitting `compute_node_runtime_not_ready` for normal pre-registration warm-up races, and fails closed (actionable error) if warm-load truly fails. (`compute_node_bridge.py`)
- UI changes: the desktop UI now tracks `warm_load_state`, `runtime_path`, and `warm_load_enabled` and only displays `Registered: yes` when the relay runtime is actually ready; while warming the UI shows `warming` instead of `yes`. (`desktop-tauri/src/App.tsx`, `desktop-tauri/src/App.test.tsx`)
- Tests updated: unit tests for the bridge and UI were added/adjusted to cover pre-registration warm-up ordering, slow successful warm-ups, warm-up failures, and to assert the UI does not show `Registered: yes` while relay runtime is warming. (`tests/unit/test_desktop_compute_node_bridge.py`, `desktop-tauri/src/App.test.tsx`)

### Testing
- Ran the updated compute-node bridge unit suite: `pytest tests/unit/test_desktop_compute_node_bridge.py -q` (all tests passed).
- Ran related unit and integration suites: `pytest tests/unit/test_desktop_model_bridge.py -q`, `pytest tests/unit/test_relay_client.py -k "api_v1 or response or e2ee or register or warm" -q`, `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and `pytest tests/test_relay.py -k "api_v1 or responses" -q` (all passed).
- Ran desktop UI tests: `npm test` inside `desktop-tauri/` (Vitest tests passed).
- Pre-commit checks: `pre-commit run --all-files` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195402c01c832f873299a9ca142655)