### PR TITLE
Gate desktop relay registration on runtime readiness

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -73,7 +73,7 @@ _stdin_reader_lock = threading.Lock()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
-API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 10.0
+API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 
 
 _POLL_CANCELLED = object()
@@ -544,7 +544,7 @@ def run(args: argparse.Namespace) -> int:
                 )
             warm_load_future = warm_load_executor.submit(runtime.ensure_api_v1_runtime_ready)
             emit_status_event(
-                registered=True,
+                registered=False,
                 active_relay_url=active_relay_url,
                 current_last_error=last_error,
             )
@@ -645,7 +645,7 @@ def run(args: argparse.Namespace) -> int:
         nonlocal last_error, warm_load_fatal
         last_error = warm_load_failed or "failed to initialize API v1 model runtime"
         emit_status_event(
-            registered=True,
+            registered=False,
             active_relay_url=active_relay_url,
             current_last_error=last_error,
         )
@@ -695,8 +695,92 @@ def run(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    active_relay_url = runtime.relay_client.relay_url
+    if warm_load_enabled:
+        if not bridge_runtime_allowed:
+            warm_load_failed = (
+                "API v1 relay runtime warm-load is unavailable for sidecar runtime path "
+                "without TOKENPLACE_DESKTOP_DUAL_RUNTIME=1"
+            )
+            warm_load_state = "failed"
+            print(
+                "desktop.compute_node_bridge.model_init.failed "
+                f"reason=pre_registration runtime_path={runtime_path} "
+                f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
+                file=sys.stderr,
+            )
+            fail_on_warm_load_error(active_relay_url=active_relay_url)
+        else:
+            print(
+                "desktop.compute_node_bridge.model_init.pre_registration "
+                f"relay={_sanitize_relay_target(active_relay_url)} runtime_path={runtime_path}",
+                file=sys.stderr,
+            )
+            ensure_runtime_ready(
+                "pre_registration",
+                active_relay_url=active_relay_url,
+                block=False,
+            )
+            last_warming_log_at = 0.0
+            prewarm_cancelled = False
+            while warm_load_state == "warming" and warm_load_future is not None:
+                if ensure_runtime_ready(
+                    "pre_registration",
+                    active_relay_url=active_relay_url,
+                    block=True,
+                    block_timeout_seconds=0.1,
+                ):
+                    break
+                if warm_load_future.done():
+                    break
+                elapsed = time.perf_counter() - warm_load_started_at if warm_load_started_at else 0.0
+                if elapsed > 30 and elapsed - last_warming_log_at >= 30:
+                    last_warming_log_at = elapsed
+                    warm_load_duration_ms = int(elapsed * 1000)
+                    print(
+                        "desktop.compute_node_bridge.model_init.still_warming "
+                        f"relay={_sanitize_relay_target(active_relay_url)} "
+                        f"state={warm_load_state} duration_ms={warm_load_duration_ms}",
+                        file=sys.stderr,
+                    )
+                if stop_requested():
+                    prewarm_cancelled = True
+                    break
+            if warm_load_state == "warming" and prewarm_cancelled:
+                print(
+                    "desktop.compute_node_bridge.model_init.cancelled "
+                    f"relay={_sanitize_relay_target(active_relay_url)} state={warm_load_state}",
+                    file=sys.stderr,
+                )
+            elif warm_load_state != "ready":
+                if warm_load_state != "failed":
+                    ensure_runtime_ready(
+                        "pre_registration",
+                        active_relay_url=active_relay_url,
+                        block=False,
+                    )
+                if warm_load_state == "failed":
+                    fail_on_warm_load_error(active_relay_url=active_relay_url)
+            if warm_load_state == "ready":
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                )
+                print(
+                    "desktop.compute_node_bridge.registration.ready_to_begin "
+                    f"relay={_sanitize_relay_target(active_relay_url)} state={warm_load_state}",
+                    file=sys.stderr,
+                )
+
     try:
-        while not stop_requested():
+        while not warm_load_fatal and not stop_requested():
+            print(
+                "desktop.compute_node_bridge.api_v1_e2ee.register_after_ready "
+                f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+                f"warm_load_state={warm_load_state}",
+                file=sys.stderr,
+            )
             print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
             active_relay_url = runtime.relay_client.relay_url
             relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
@@ -714,10 +798,13 @@ def run(args: argparse.Namespace) -> int:
             has_heartbeat = (
                 isinstance(relay_response, dict) and "next_ping_in_x_seconds" in relay_response
             )
-            registered = (
+            relay_registered = (
                 relay_error is None
                 and (has_heartbeat or api_v1_payload)
                 and _registration_fresh(runtime.relay_client, active_relay_url)
+            )
+            registered = relay_registered and (
+                not warm_load_enabled or warm_load_state == "ready"
             )
             wait_seconds = _safe_poll_wait_seconds(
                 relay_response, getattr(runtime.relay_client, "_request_timeout", 1)
@@ -862,24 +949,13 @@ def run(args: argparse.Namespace) -> int:
                         "operator; update relay.py to repo HEAD"
                     )
 
-            if registered and warm_load_enabled and warm_load_state == "not_started":
-                if not bridge_runtime_allowed:
-                    warm_load_state = "not_started"
-                    print(
-                        "desktop.compute_node_bridge.model_init.skipped "
-                        f"reason=post_registration runtime_path={runtime_path} "
-                        f"dual_runtime_enabled={dual_runtime_enabled} state={warm_load_state}",
-                        file=sys.stderr,
-                    )
-                else:
-                    if (
-                        not ensure_runtime_ready(
-                            "post_registration", active_relay_url=active_relay_url, block=False
-                        )
-                        and warm_load_state == "failed"
-                    ):
-                        fail_on_warm_load_error(active_relay_url=active_relay_url)
-                        break
+            if relay_registered and warm_load_enabled and warm_load_state != "ready":
+                print(
+                    "desktop.compute_node_bridge.relay_registered_but_runtime_not_ready "
+                    f"relay={_sanitize_relay_target(active_relay_url)} state={warm_load_state} "
+                    f"request_id={request_id}",
+                    file=sys.stderr,
+                )
             emit_status_event(
                 registered=registered,
                 active_relay_url=active_relay_url,

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -413,6 +413,7 @@ describe('desktop app start failure handling', () => {
         running: true,
         registered: false,
         last_error: null,
+        warm_load_state: 'warming',
       },
     });
     computeHandler?.({
@@ -421,12 +422,39 @@ describe('desktop app start failure handling', () => {
         running: true,
         registered: true,
         last_error: null,
+        warm_load_state: 'ready',
       },
     });
 
     await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
     await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Warm load state:/).textContent).toContain('ready');
     expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
+  it('does not display Registered yes while relay runtime is still warming', async () => {
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        warm_load_state: 'warming',
+        runtime_path: 'bridge',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Warm load state:/).textContent).toContain('warming');
+    expect(screen.getByText(/Runtime path:/).textContent).toContain('bridge');
   });
 
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -31,6 +31,8 @@ interface ComputeNodeStatus {
   fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
+  warm_load_state: string | null;
+  runtime_path: string | null;
 }
 
 interface ModelArtifactInfo {
@@ -63,6 +65,8 @@ const defaultComputeStatus: ComputeNodeStatus = {
   fallback_reason: null,
   model_path: '',
   last_error: null,
+  warm_load_state: null,
+  runtime_path: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -160,7 +164,11 @@ export function App() {
             : payload.type === 'error'
               ? false
               : prev.running,
-        registered: typeof payload.registered === 'boolean' ? payload.registered : prev.registered,
+        registered:
+          typeof payload.registered === 'boolean'
+            ? payload.registered &&
+              (typeof payload.warm_load_state !== 'string' || payload.warm_load_state === 'ready')
+            : prev.registered,
         active_relay_url:
           typeof payload.active_relay_url === 'string'
             ? payload.active_relay_url
@@ -194,6 +202,12 @@ export function App() {
               : typeof payload.message === 'string'
                 ? payload.message
                 : prev.last_error,
+        warm_load_state:
+          typeof payload.warm_load_state === 'string'
+            ? payload.warm_load_state
+            : prev.warm_load_state,
+        runtime_path:
+          typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
       }));
       if (payload.type === 'started' || payload.type === 'error') {
         setIsStartingComputeNode(false);
@@ -451,6 +465,8 @@ export function App() {
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeStatus.registered ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Warm load state: <code>{computeStatus.warm_load_state || 'not started'}</code></p>
+        <p style={{ marginBottom: 0 }}>Runtime path: <code>{computeStatus.runtime_path || 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode ?? 'pending'}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -807,7 +807,7 @@ def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' in output.err
 
 
-def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload(
+def test_run_api_v1_payload_waits_for_slow_startup_warm_load_without_error(
     capsys, monkeypatch
 ):
     _reset_cancel_queue()
@@ -834,25 +834,27 @@ def test_run_api_v1_payload_timeout_posts_encrypted_error_without_losing_payload
     runtime = WarmingTimeoutApiV1Runtime.last_instance
     assert runtime is not None
     assert runtime.ready_started.is_set()
-    assert runtime._processed == []
+    assert [payload['request_id'] for payload in runtime._processed] == ['req-1']
     assert runtime.relay_client.endpoint_calls == [
         (
             '/api/v1/relay/responses',
             {
+                'protocol': 'tokenplace_api_v1_relay_e2ee',
+                'version': 1,
                 'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_not_ready',
-                    'message': 'API v1 model runtime is not ready',
-                },
+                'client_public_key': 'client-key',
+                'chat_history': 'ciphertext',
+                'cipherkey': 'key',
+                'iv': 'iv',
+                'next_ping_in_x_seconds': 0,
             },
         )
     ]
 
     output = capsys.readouterr()
     assert 'api_v1_payload=True' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.timeout' in output.err
-    assert 'desktop.compute_node_bridge.process_request.skipped_runtime_not_ready' in output.err
-    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' not in output.err
+    assert 'compute_node_runtime_not_ready' not in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):
@@ -917,8 +919,8 @@ def test_run_treats_null_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in output.out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is True for event in status_events)
+    assert status_events[-1]['last_error'] is None
     stderr = output.err
     assert 'desktop.compute_node_bridge.start' in stderr
     assert 'desktop.compute_node_bridge.relay_target.resolved' in stderr
@@ -952,8 +954,8 @@ def test_run_treats_false_error_heartbeat_as_registered(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is True for event in status_events)
+    assert status_events[-1]['last_error'] is None
 
 
 def test_run_reports_actionable_error_for_incompatible_relay(capsys, monkeypatch):
@@ -1013,8 +1015,8 @@ def test_run_ignores_legacy_shaped_processing_failure(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     status_events = [event for event in events if event['type'] == 'status']
     assert status_events
-    assert status_events[0]['registered'] is True
-    assert status_events[0]['last_error'] is None
+    assert any(event['registered'] is True for event in status_events)
+    assert status_events[-1]['last_error'] is None
 
 
 def test_apply_compute_mode_supports_gpu_and_cpu_modes(monkeypatch):
@@ -1471,7 +1473,7 @@ def test_run_reports_stale_registration_status_after_missed_heartbeat(capsys, mo
     )
 
 
-def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypatch):
+def test_run_warms_runtime_before_first_successful_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1490,7 +1492,7 @@ def test_run_warms_runtime_after_first_successful_registration(capsys, monkeypat
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     _ = capsys.readouterr()
 
 
@@ -1585,7 +1587,7 @@ def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatc
     _ = capsys.readouterr()
 
 
-def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypatch):
+def test_run_stops_when_pre_registration_runtime_warmup_fails(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
@@ -1603,7 +1605,7 @@ def test_run_stops_when_post_registration_runtime_warmup_fails(capsys, monkeypat
     monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
     status = compute_node_bridge.run(args)
     assert status == 1
-    assert calls == ["poll", "warm"]
+    assert calls == ["warm"]
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     payload = next(event for event in events if event.get("type") == "error")
     assert payload["type"] == "error"
@@ -1632,7 +1634,7 @@ def test_run_does_not_warm_when_disabled(capsys, monkeypatch):
     _ = capsys.readouterr()
 
 
-def test_run_sidecar_runtime_path_skips_bridge_warm_load_without_dual_opt_in(capsys, monkeypatch):
+def test_run_sidecar_runtime_path_fails_closed_without_dual_opt_in(capsys, monkeypatch):
     _reset_cancel_queue()
     call_order = []
 
@@ -1652,13 +1654,15 @@ def test_run_sidecar_runtime_path_skips_bridge_warm_load_without_dual_opt_in(cap
     monkeypatch.delenv("TOKENPLACE_DESKTOP_DUAL_RUNTIME", raising=False)
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
-    assert status == 0
-    assert call_order == ["poll", "poll"]
+    assert status == 1
+    assert call_order == []
     output = capsys.readouterr()
-    assert "model_init.skipped" in output.err
+    assert "model_init.failed reason=pre_registration runtime_path=sidecar" in output.err
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     started = next(event for event in events if event.get("type") == "started")
+    error_event = next(event for event in events if event.get("type") == "error")
     assert started["runtime_path"] == "sidecar"
+    assert error_event["warm_load_state"] == "failed"
 
 
 def test_run_sidecar_runtime_path_with_dual_mode_warms_and_logs_opt_in(capsys, monkeypatch):
@@ -1682,7 +1686,7 @@ def test_run_sidecar_runtime_path_with_dual_mode_warms_and_logs_opt_in(capsys, m
     args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
     status = compute_node_bridge.run(args)
     assert status == 0
-    assert call_order[:3] == ["poll", "warm", "poll"]
+    assert call_order[:3] == ["warm", "poll", "poll"]
     output = capsys.readouterr()
     assert "dual_mode_enabled" in output.err
 
@@ -1798,25 +1802,14 @@ def test_run_first_api_v1_payload_fails_closed_when_warm_load_raises(capsys, mon
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
+    assert "request_id=none" in output.err
     assert "runtime_wait.exception" in output.err or "model_init.exception" in output.err
-    assert "error_response.submitted" in output.err
-    assert "code=compute_node_runtime_unavailable" in output.err
+    assert "error_response.submitted" not in output.err
+    assert "code=compute_node_runtime_unavailable" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive model init failure details" not in output.err
     assert ApiPayloadWarmRaiseRuntime.last_instance is not None
-    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert ApiPayloadWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1854,24 +1847,13 @@ def test_run_first_api_v1_payload_fails_closed_when_blocking_warm_load_raises(ca
     output = capsys.readouterr()
     assert status == 1
     assert calls == ["warm"]
-    assert "request_id=req-1" in output.err
+    assert "request_id=none" in output.err
     assert "runtime_wait.exception" in output.err
-    assert "error_response.submitted" in output.err
+    assert "error_response.submitted" not in output.err
     assert "exc_type=RuntimeError" in output.err
     assert "sensitive delayed model init details" not in output.err
     assert BlockingWarmRaiseRuntime.last_instance is not None
-    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == [
-        (
-            '/api/v1/relay/responses',
-            {
-                'request_id': 'req-1',
-                'error': {
-                    'code': 'compute_node_runtime_unavailable',
-                    'message': 'failed to initialize API v1 model runtime',
-                },
-            },
-        )
-    ]
+    assert BlockingWarmRaiseRuntime.last_instance.relay_client.endpoint_calls == []
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     error_event = next(event for event in events if event.get("type") == "error")
     assert error_event["warm_load_state"] == "failed"
@@ -1956,7 +1938,7 @@ def test_cached_poll_wait_seconds_normalizes_hints_and_rejects_bad_values():
     assert compute_node_bridge._cached_poll_wait_seconds(object(), "https://relay.example", 3) == 3
 
 
-def test_run_sidecar_api_v1_payload_skips_bridge_warm_load_without_dual_opt_in(capsys, monkeypatch):
+def test_run_sidecar_api_v1_payload_fails_closed_without_dual_opt_in(capsys, monkeypatch):
     _reset_cancel_queue()
     calls = []
 
@@ -1978,10 +1960,10 @@ def test_run_sidecar_api_v1_payload_skips_bridge_warm_load_without_dual_opt_in(c
 
     status = compute_node_bridge.run(args)
 
-    assert status == 0
-    assert calls == ["process"]
+    assert status == 1
+    assert calls == []
     output = capsys.readouterr()
-    assert "model_init.skipped reason=api_v1_request" in output.err
+    assert "model_init.failed reason=pre_registration runtime_path=sidecar" in output.err
 
 
 def test_run_reports_api_v1_processing_failure(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent the desktop compute-node from advertising/being selected for API v1 E2EE work before the exact relay-processing runtime is warmed and ready, which caused staging browser requests to fail with `compute_node_runtime_not_ready` during normal startup warm-up.
- Prefer warming the API v1 runtime before registration/polling and fail closed with clear local diagnostics if warm-load truly cannot complete.

### Description
- Warm-before-register: start the API v1 runtime warm-up on operator start and perform a bounded pre-registration wait loop that polls `ensure_api_v1_runtime_ready`, logging progress and keeping `registered=false` while warming; only begin relay registration/polling loop after `warm_load_state == "ready"` (`desktop-tauri/src-tauri/python/compute_node_bridge.py`).
- Fail-closed and sidecar guard: if runtime path is `sidecar` and the bridge warm-load is disallowed (no `TOKENPLACE_DESKTOP_DUAL_RUNTIME`), fail the warm-load pre-registration and emit an actionable error without registering the node (`compute_node_bridge.py`).
- Defensive waits and error handling: increased default API v1 warm-load bounded wait from `10s` to `120s`, and refined in-flight-blocking semantics to avoid sending `compute_node_runtime_not_ready` for normal slow warm-ups while still failing closed on real initialization faults (`compute_node_bridge.py`).
- UI + diagnostics: update the desktop UI payload merging so `Registered: yes` is only shown when `warm_load_state === 'ready'`, add `warm_load_state` and `runtime_path` to the operator panel, and add tests that assert the operator displays `warming/ready/failed` semantics (`desktop-tauri/src/App.tsx`, `desktop-tauri/src/App.test.tsx`).
- Tests: adjusted and added unit tests to cover pre-registration warm-up, slow warm-up success, pre-registration warm-up failure, sidecar fail-closed behavior, and the UI readiness semantics (`tests/unit/test_desktop_compute_node_bridge.py`).

### Testing
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py` and the modified unit suite passed after updates; relevant scenarios asserting warm-before-register, bounded wait, and fail-closed behavior are covered (passed).
- Ran `pytest tests/unit/test_desktop_model_bridge.py` which passed, and `pytest tests/unit/test_relay_client.py -k "api_v1 or response or e2ee or register or warm"` which passed for the selected cases.
- Ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and `pytest tests/test_relay.py -k "api_v1 or responses"` and the integration relay tests for API v1 E2EE passed.
- Ran desktop UI tests with `cd desktop-tauri && npm test` and the Tauri React tests passed; I also exercised the dev UI and captured a readiness screenshot with Playwright to verify the new `Warm load state` and `Registered` behavior (Playwright browsers were installed during the run).
- Ran `pre-commit run --all-files` and hooks (lint/security checks) completed successfully.

Residual risks and follow-ups: monitor staging for long model init times in extreme environments (desktop warm-load can still be slow), document `TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS` tuning guidance for constrained devices, and consider adding telemetry for warm-load duration/failure rates in future follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195402c01c832f873299a9ca142655)