### PR TITLE
Fix desktop operator Stop lifecycle, relay unregister, and polling shutdown

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -70,6 +70,7 @@ def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+_stop_event = threading.Event()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
@@ -153,10 +154,12 @@ class _CancelablePollWorker:
 
     def shutdown(self) -> None:
         self._closed = True
+        print("desktop.compute_node_bridge.poll_worker.stop_requested", file=sys.stderr)
         try:
             self._tasks.put_nowait(None)
         except queue.Full:  # pragma: no cover - unbounded queue is not expected to fill
             pass
+        print("desktop.compute_node_bridge.poll_worker.stopped", file=sys.stderr)
 
 
 def _registration_fresh(relay_client: Any, relay_url: str) -> bool:
@@ -367,6 +370,8 @@ def _start_stdin_reader() -> None:
 
 
 def stop_requested() -> bool:
+    if _stop_event.is_set():
+        return True
     _start_stdin_reader()
     while True:
         try:
@@ -380,6 +385,11 @@ def stop_requested() -> bool:
         except json.JSONDecodeError:
             continue
         if payload.get("type") == "cancel":
+            _stop_event.set()
+            print(
+                "desktop.compute_node_bridge.stop_requested signal=stdin_cancel",
+                file=sys.stderr,
+            )
             return True
 
 
@@ -398,6 +408,7 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
+    _stop_event.clear()
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -939,11 +950,36 @@ def run(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         pass
     finally:
-        print("desktop.compute_node_bridge.stop", file=sys.stderr)
+        _stop_event.set()
+        relay_url_for_stop = _sanitize_relay_target(
+            getattr(runtime.relay_client, 'relay_url', 'unknown')
+        )
+        key_fingerprint_fn = getattr(
+            runtime.relay_client, '_api_v1_public_key_fingerprint', None
+        )
+        public_key = getattr(getattr(runtime, 'relay_client', None), 'crypto_manager', None)
+        public_key_value = getattr(public_key, 'public_key_b64', None)
+        key_fingerprint = (
+            key_fingerprint_fn(public_key_value)
+            if callable(key_fingerprint_fn)
+            else 'unknown'
+        )
+        print(
+            "desktop.compute_node_bridge.stop relay={} key_fingerprint={}".format(
+                relay_url_for_stop, key_fingerprint
+            ),
+            file=sys.stderr,
+        )
         poll_worker.shutdown()
         if warm_load_future is not None and not warm_load_future.done():
             warm_load_future.cancel()
         runtime.stop()
+        print(
+            "desktop.compute_node_bridge.stopped_idle relay={} key_fingerprint={}".format(
+                relay_url_for_stop, key_fingerprint
+            ),
+            file=sys.stderr,
+        )
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     emit(

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -580,8 +580,11 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         stdin_lock.take()
     };
     if let Some(stdin) = stdin_handle.as_mut() {
+        eprintln!("desktop.compute_node.stop_requested sending_cancel=true");
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
+    } else {
+        eprintln!("desktop.compute_node.stop_requested sending_cancel=false");
     }
 
     let mut owned_child = None;
@@ -604,8 +607,12 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
 
         if !exited {
+            eprintln!("desktop.compute_node.bridge_process.kill_after_cancel_timeout");
             let _ = child.kill().await;
             let _ = child.wait().await;
+            eprintln!("desktop.compute_node.bridge_process.exited_after_kill");
+        } else {
+            eprintln!("desktop.compute_node.bridge_process.exited_after_cancel");
         }
     }
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -314,6 +314,42 @@ describe('desktop app start failure handling', () => {
     resolveStart?.();
   });
 
+
+  it('clicking Stop operator invokes backend stop and reflects stopped event', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        warm_load_state: 'ready',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.some(([command]) => command === 'stop_compute_node')).toBe(true)
+    );
+
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+  });
+
   it('keeps model path blank on first launch when config has no persisted model path', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'detect_backend') {

--- a/relay.py
+++ b/relay.py
@@ -1134,6 +1134,26 @@ def api_v1_relay_servers_register():
     }), 200
 
 
+@app.route('/api/v1/relay/servers/unregister', methods=['POST'])
+def api_v1_relay_servers_unregister():
+    """Explicitly unregister an API v1 compute node and clear relay state."""
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+
+    public_key = data.get('server_public_key')
+    if not isinstance(public_key, str) or not public_key.strip():
+        return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
+
+    removed = _unregister_server(public_key)
+    LOGGER.info("server.unregistered", extra={"server_public_key": public_key, "removed": removed})
+    return jsonify({'message': 'Server unregistered', 'removed': removed}), 200
+
+
 @app.route('/api/v1/relay/servers/poll', methods=['POST'])
 def api_v1_relay_servers_poll():
     """Claim the next queued encrypted workload for a registered compute node."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2100,6 +2100,40 @@ def test_api_v1_poll_long_wait_wakes_on_shared_queue_legacy_compat_enqueue(clien
     assert result['json']['chat_history'] == 'legacy-ciphertext-request'
 
 
+def test_api_v1_unregister_removes_server_and_is_idempotent(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    assert client.get('/api/v1/relay/servers/next').status_code == 200
+
+    first = client.post('/api/v1/relay/servers/unregister', json=server_payload)
+    assert first.status_code == 200
+    assert first.get_json()['removed'] is True
+    assert client.get('/api/v1/relay/servers/next').status_code == 503
+
+    second = client.post('/api/v1/relay/servers/unregister', json=server_payload)
+    assert second.status_code == 200
+    assert second.get_json()['removed'] is False
+
+
+def test_api_v1_unregister_prevents_dispatch_to_stopped_node(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    assert client.post('/api/v1/relay/servers/unregister', json=server_payload).status_code == 200
+
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-after-unregister',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+    assert queued.status_code == 404
+
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 404
+
+
 def test_api_v1_next_keeps_in_flight_server_alive_then_expires(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -107,6 +107,57 @@ class FakeRuntime:
         return None
 
 
+
+
+class BlockingPollRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        BlockingPollRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClient()
+        self.poll_started = threading.Event()
+        self.release_poll = threading.Event()
+        self.poll_calls = 0
+        self.stop_calls = 0
+
+    def register_and_poll_once(self):
+        self.poll_calls += 1
+        self.poll_started.set()
+        self.release_poll.wait(timeout=2)
+        return {'next_ping_in_x_seconds': 0}
+
+    def stop(self):
+        self.stop_calls += 1
+        self.release_poll.set()
+
+
+class StopDuringWarmLoadRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        StopDuringWarmLoadRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClient()
+        self.ready_started = threading.Event()
+        self.release_ready = threading.Event()
+        self.poll_calls = 0
+        self.stop_calls = 0
+
+    def ensure_api_v1_runtime_ready(self):
+        self.ready_started.set()
+        self.release_ready.wait(timeout=2)
+        return True
+
+    def register_and_poll_once(self):
+        self.poll_calls += 1
+        return {'next_ping_in_x_seconds': 0}
+
+    def stop(self):
+        self.stop_calls += 1
+        self.release_ready.set()
+
+
 class StreamingRuntime(FakeRuntime):
     last_instance = None
 
@@ -376,6 +427,7 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
 def _reset_cancel_queue():
     compute_node_bridge._stdin_lines = queue.Queue()
     compute_node_bridge._stdin_reader_started = True
+    compute_node_bridge._stop_event.clear()
 
 
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
@@ -2104,3 +2156,91 @@ def test_run_handles_keyboard_interrupt_from_poll_worker(capsys, monkeypatch):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     assert events[-1]["type"] == "stopped"
+
+
+def test_poll_worker_returns_cancelled_without_starting_new_poll_after_shutdown():
+    worker = compute_node_bridge._CancelablePollWorker()
+    called = []
+    worker.shutdown()
+
+    result = worker.call(lambda: called.append(True), lambda: False, poll_interval=0.01)
+
+    assert result is compute_node_bridge._POLL_CANCELLED
+    assert called == []
+
+
+def test_run_stop_during_long_poll_cancels_promptly_and_stops_runtime(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=BlockingPollRuntime)
+
+    def fake_stop_requested():
+        runtime = BlockingPollRuntime.last_instance
+        if runtime is not None and runtime.poll_started.is_set():
+            return True
+        return False
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    started = time.monotonic()
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert time.monotonic() - started < 1.0
+    runtime = BlockingPollRuntime.last_instance
+    assert runtime is not None
+    assert runtime.poll_calls == 1
+    assert runtime.stop_calls == 1
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.poll.cancelled' in output.err
+    assert 'desktop.compute_node_bridge.poll_worker.stopped' in output.err
+
+
+def test_run_stop_during_sleep_does_not_poll_again(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    runtime_holder = {}
+
+    class SleepStopRuntime(FakeRuntime):
+        def __init__(self, config):
+            super().__init__(config)
+            self._responses = [{'next_ping_in_x_seconds': 5}]
+            self.poll_calls = 0
+            runtime_holder['runtime'] = self
+
+        def register_and_poll_once(self):
+            self.poll_calls += 1
+            return super().register_and_poll_once()
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=SleepStopRuntime)
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', lambda _seconds: True)
+
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert runtime_holder['runtime'].poll_calls == 1
+    assert 'desktop.compute_node_bridge.stop_requested' in capsys.readouterr().err
+
+
+def test_run_stop_during_warm_load_does_not_register_afterward(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StopDuringWarmLoadRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '1')
+
+    def fake_stop_requested():
+        runtime = StopDuringWarmLoadRuntime.last_instance
+        return runtime is not None and runtime.ready_started.is_set()
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    runtime = StopDuringWarmLoadRuntime.last_instance
+    assert runtime is not None
+    assert runtime.poll_calls == 0
+    assert runtime.stop_calls == 1
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.register' not in output.err

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -374,7 +374,7 @@ class TestRelayClient:
 
     @patch('utils.networking.relay_client.requests.post')
     def test_unregister_from_relay_success(self, mock_post, relay_client):
-        """Unregister should post to /unregister and return True on success."""
+        """Unregister should post to the API v1 unregister route and return True on success."""
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -384,9 +384,9 @@ class TestRelayClient:
 
         assert result is True
         mock_post.assert_called_once_with(
-            'http://localhost:5000/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
             json={'server_public_key': 'mock_public_key_b64'},
-            timeout=relay_client._request_timeout,
+            timeout=min(float(relay_client._request_timeout), 2.0),
         )
 
     def test_unregister_from_relay_attempts_all_configured_relays(
@@ -426,8 +426,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/unregister',
-            'http://backup-relay:6000/unregister',
+            'http://primary-relay:5000/api/v1/relay/servers/unregister',
+            'http://backup-relay:6000/api/v1/relay/servers/unregister',
         ]
 
     @patch('utils.networking.relay_client.requests.post')
@@ -465,6 +465,16 @@ class TestRelayClient:
         mock_post.assert_called_once()
         call = mock_post.call_args
         assert call.kwargs['headers'] == {'X-Relay-Server-Token': 'alpha-token'}
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_poll_api_v1_encrypted_work_skips_register_after_stop(self, mock_post, relay_client):
+        relay_client.stop()
+
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['message'] == 'Relay polling stopped'
+        assert mock_post.call_count == 0
 
     @patch('utils.networking.relay_client.requests.post')
     def test_ping_relay_success(self, mock_post, relay_client, mock_crypto_manager):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -280,6 +280,8 @@ class ComputeNodeRuntime:
             ]
         else:
             self.request_adapters = list(request_adapters)
+        self._stopped = False
+        self._stop_lock = threading.Lock()
 
     def ensure_model_ready(self) -> bool:
         """Initialize model runtime and report readiness."""
@@ -381,13 +383,22 @@ class ComputeNodeRuntime:
         return bool(submit_error(request_data, code=code, message=message))
 
     def stop(self) -> None:
-        """Stop relay polling and network activity."""
+        """Stop relay polling and best-effort unregister exactly once."""
+        with self._stop_lock:
+            if self._stopped:
+                return
+            self._stopped = True
+
         try:
+            _log_info("Compute node runtime stop requested; cancelling relay polling")
             self.relay_client.stop()
             unregister_fn = getattr(self.relay_client, "unregister_from_relay", None)
             if callable(unregister_fn):
+                _log_info("Attempting compute node relay unregister during shutdown")
                 if not unregister_fn():
                     _log_warning("Relay unregister request failed during shutdown")
+            else:
+                _log_warning("Relay client does not expose unregister_from_relay during shutdown")
         except Exception:
             _log_warning(
                 "Relay unregister request raised during shutdown; continuing stop",

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -519,6 +519,7 @@ class RelayClient:
         self.crypto_manager = crypto_manager
         self.model_manager = model_manager
         self.stop_polling = True  # Flag to control polling loop - starts as True so loop won't run until explicitly started
+        self._shutdown_requested = False
         self._registration_token: Optional[str] = None
         configured_servers: List[Any] = []
         self._cluster_only = False
@@ -779,11 +780,16 @@ class RelayClient:
 
     def start(self):
         """Start the polling loop by setting stop_polling to False"""
+        self._shutdown_requested = False
         self.stop_polling = False
 
     def stop(self):
         """Stop the polling loop by setting stop_polling to True"""
-        log_info("Stopping relay polling")
+        log_info(
+            "Stopping relay polling key_fingerprint={}",
+            self._api_v1_public_key_fingerprint(getattr(self.crypto_manager, 'public_key_b64', None)),
+        )
+        self._shutdown_requested = True
         self.stop_polling = True
 
     def unregister_from_relay(self) -> bool:
@@ -806,20 +812,34 @@ class RelayClient:
                 if headers:
                     request_kwargs['headers'] = headers
 
+                unregister_url = self._build_api_v1_url(candidate_url, "/relay/servers/unregister")
+                unregister_timeout = min(float(self._request_timeout), 2.0)
+                log_info(
+                    "server.unregister.attempt relay={} key_fingerprint={}",
+                    candidate_url,
+                    self._api_v1_public_key_fingerprint(self.crypto_manager.public_key_b64),
+                )
                 response = requests.post(
-                    f'{candidate_url}/unregister',
-                    timeout=self._request_timeout,
+                    unregister_url,
+                    timeout=unregister_timeout,
                     **request_kwargs,
                 )
                 if response.status_code == 200:
                     self._active_relay_index = index
-                    log_info("Unregistered compute node from relay {}", candidate_url)
+                    self._api_v1_registered_relays.discard(candidate_url)
+                    self._api_v1_last_heartbeat_at.pop(candidate_url, None)
+                    relay_wait_hints.pop(candidate_url, None)
+                    log_info(
+                        "server.unregister.succeeded relay={} key_fingerprint={}",
+                        candidate_url,
+                        self._api_v1_public_key_fingerprint(self.crypto_manager.public_key_b64),
+                    )
                     had_success = True
                     continue
 
                 last_error = f"HTTP {response.status_code}"
                 log_error(
-                    "Failed to unregister compute node from {}: {}",
+                    "server.unregister.failed relay={} error={}",
                     candidate_url,
                     last_error,
                 )
@@ -1131,6 +1151,17 @@ class RelayClient:
         relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
         self._api_v1_relay_wait_hints = relay_wait_hints
 
+        if getattr(self, '_shutdown_requested', False):
+            log_info(
+                "api_v1.poll.skipped_after_stop key_fingerprint={}",
+                self._api_v1_public_key_fingerprint(getattr(self.crypto_manager, 'public_key_b64', None)),
+            )
+            return {
+                'message': 'Relay polling stopped',
+                'next_ping_in_x_seconds': self._request_timeout,
+                'poll_wait_seconds': 0,
+            }
+
         for offset in range(len(self._relay_urls)):
             index = (self._active_relay_index + offset) % len(self._relay_urls)
             candidate_url = self._relay_urls[index]
@@ -1176,6 +1207,17 @@ class RelayClient:
                             self._api_v1_public_key_fingerprint(current_public_key),
                         )
                     register_response = self.register_api_v1_compute_node(candidate_url)
+                    if getattr(self, '_shutdown_requested', False):
+                        log_info(
+                            "server.register.discarded_after_stop relay={} key_fingerprint={}",
+                            candidate_url,
+                            self._api_v1_public_key_fingerprint(current_public_key),
+                        )
+                        return {
+                            'message': 'Relay polling stopped',
+                            'next_ping_in_x_seconds': self._request_timeout,
+                            'poll_wait_seconds': 0,
+                        }
                     if not isinstance(register_response, dict):
                         last_error = {
                             'error': 'Invalid register response format: expected object payload',
@@ -1232,6 +1274,17 @@ class RelayClient:
                         timeout=poll_timeout_seconds,
                         **request_kwargs,
                     )
+                    if getattr(self, '_shutdown_requested', False):
+                        log_info(
+                            "server.heartbeat.discarded_after_stop relay={} key_fingerprint={}",
+                            candidate_url,
+                            self._api_v1_public_key_fingerprint(current_public_key),
+                        )
+                        return {
+                            'message': 'Relay polling stopped',
+                            'next_ping_in_x_seconds': self._request_timeout,
+                            'poll_wait_seconds': 0,
+                        }
                 except Exception as exc:
                     elapsed_seconds = time.monotonic() - poll_started
                     timeout_exception = (


### PR DESCRIPTION
### Motivation
- Stopping the desktop operator could leave the bridge/relay polling and heartbeats running, causing the relay to keep a fresh `knownServers` entry and the UI/relay state to diverge.
- Make Stop a clean, observable lifecycle transition that cancels in-flight polls, prevents re-registration, best-effort unregisters from API v1 relays, and avoids orphan bridge processes.

### Description
- Bridge cancellation: latch a bridge-side stop event, surface poll-worker stop/stop-requested diagnostics, ensure `_CancelablePollWorker` shuts down and returns `_POLL_CANCELLED` instead of spawning new polls, and cancel warm-load futures on shutdown (`desktop-tauri/src-tauri/python/compute_node_bridge.py`).
- Runtime stop ordering/idempotency: make `ComputeNodeRuntime.stop()` idempotent and stop relay polling before calling the relay-client unregister path (`utils/compute_node_runtime.py`).
- Relay client shutdown & unregister: add a `_shutdown_requested` flag to `RelayClient`, skip/register/poll bookkeeping after stop is requested, call a new API v1 unregister route with a bounded timeout, and redact key fingerprints in logs (`utils/networking/relay_client.py`, `relay.py`).
- Relay API: add `/api/v1/relay/servers/unregister` that removes a compute node from `known_servers` safely and is idempotent (`relay.py`).
- Rust/Tauri & UI: emit clearer stderr diagnostics when sending cancel to the bridge and when the bridge exits/killed, and add a UI test that clicking Stop invokes the backend and reflects stopped status (`desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src/App.test.tsx`).
- Tests: add and update unit/regression tests covering bridge cancel behavior, stop during long polls/sleep/warm-load, relay-client unregister/stop semantics, and relay unregister/time-to-expiry effects (`tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_relay_client.py`, `tests/test_relay.py`).

### Testing
- `pytest tests/unit/test_desktop_compute_node_bridge.py -q` — passed (all tests in file passed).
- `pytest tests/unit/test_relay_client.py -k "unregister or stop or api_v1 or relay" -q` — passed (targeted relay-client tests passed).
- `pytest tests/test_relay.py -k "unregister or servers or api_v1" -q` — passed (relay unregister and servers/api_v1 tests passed).
- `cd desktop-tauri && npm test` — passed (`vitest` desktop UI tests passed).
- `cd desktop-tauri/src-tauri && cargo test compute_node --quiet` — not run / blocked due to missing system dependency (`glib-2.0.pc`) in the environment; this is an external native dependency and needs system pkg-config / glib installed to run Rust UI integration tests locally.
- `pre-commit run --all-files` — passed (formatting, linting, and project checks succeeded).

Residual risk & follow-ups: the Rust `cargo test` step requires native `glib`/`pkg-config` on CI or contributors' machines; consider documenting or adding CI image support for that dependency in a follow-up if Rust integration tests are required in all CI lanes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a136dcf24832fbf9b1b89b31c81a9)