### PR TITLE
Stop operator: cancel bridge poll, stop/retry unregister, and halt relay heartbeats

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -70,6 +70,7 @@ def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
 _stdin_reader_lock = threading.Lock()
+_stop_requested_latched = threading.Event()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
@@ -135,16 +136,27 @@ class _CancelablePollWorker:
             except BaseException as exc:  # pragma: no cover - exercised via call() re-raise
                 result_queue.put((False, exc))
 
-    def call(self, fn: Any, should_cancel: Any, *, poll_interval: float = 0.1) -> Any:
+    def call(
+        self,
+        fn: Any,
+        should_cancel: Any,
+        *,
+        poll_interval: float = 0.1,
+        on_cancel: Optional[Any] = None,
+    ) -> Any:
         if self._closed:
             return _POLL_CANCELLED
         result_queue: "queue.Queue[Any]" = queue.Queue(maxsize=1)
         self._tasks.put((fn, result_queue))
+        cancel_notified = False
         while True:
             try:
                 ok, value = result_queue.get(timeout=poll_interval)
             except queue.Empty:
                 if should_cancel():
+                    if not cancel_notified and callable(on_cancel):
+                        cancel_notified = True
+                        on_cancel()
                     return _POLL_CANCELLED
                 continue
             if ok:
@@ -236,6 +248,22 @@ def _sanitize_relay_target(relay_url: Any) -> str:
     host = f"[{hostname}]" if ":" in hostname else hostname
     port = f":{parsed_port}" if parsed_port is not None else ""
     return urlunsplit((parsed.scheme, f"{host}{port}", "", "", ""))
+
+
+def _relay_key_fingerprint(relay_client: Any) -> str:
+    """Return a safe short fingerprint for the compute-node relay key."""
+
+    crypto_manager = getattr(relay_client, "crypto_manager", None)
+    public_key = getattr(crypto_manager, "public_key_b64", None)
+    if not isinstance(public_key, str) or not public_key:
+        return "unknown"
+    fingerprint = getattr(relay_client, "_api_v1_public_key_fingerprint", None)
+    if callable(fingerprint):
+        try:
+            return str(fingerprint(public_key))
+        except Exception:
+            return "unknown"
+    return f"{public_key[:8]}...{public_key[-4:]}" if len(public_key) > 12 else "unknown"
 
 
 def _safe_poll_wait_seconds(relay_response: Dict[str, Any], default: float = 1) -> float:
@@ -367,6 +395,9 @@ def _start_stdin_reader() -> None:
 
 
 def stop_requested() -> bool:
+    if _stop_requested_latched.is_set():
+        return True
+
     _start_stdin_reader()
     while True:
         try:
@@ -380,6 +411,7 @@ def stop_requested() -> bool:
         except json.JSONDecodeError:
             continue
         if payload.get("type") == "cancel":
+            _stop_requested_latched.set()
             return True
 
 
@@ -398,6 +430,7 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
+    _stop_requested_latched.clear()
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -803,12 +836,69 @@ def run(args: argparse.Namespace) -> int:
         )
         return ready
 
+    poll_cancel_requested = False
+
+    def request_poll_cancel(active_relay_url: str) -> None:
+        nonlocal poll_cancel_requested
+        if poll_cancel_requested:
+            return
+        poll_cancel_requested = True
+        relay_client = getattr(runtime, "relay_client", None)
+        print(
+            "desktop.compute_node_bridge.poll.cancel_requested "
+            f"relay={_sanitize_relay_target(active_relay_url)} "
+            f"key_fingerprint={_relay_key_fingerprint(relay_client)}",
+            file=sys.stderr,
+        )
+        relay_stop = getattr(relay_client, "stop", None)
+        if callable(relay_stop):
+            relay_stop()
+        unregister = getattr(relay_client, "unregister_from_relay", None)
+        if callable(unregister):
+            print(
+                "desktop.compute_node_bridge.unregister.attempted "
+                f"relay={_sanitize_relay_target(active_relay_url)} "
+                f"key_fingerprint={_relay_key_fingerprint(relay_client)}",
+                file=sys.stderr,
+            )
+            try:
+                unregistered = bool(unregister())
+            except Exception as exc:
+                print(
+                    "desktop.compute_node_bridge.unregister.failed "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                    f"exc_type={type(exc).__name__}",
+                    file=sys.stderr,
+                )
+            else:
+                unregister_event = (
+                    "desktop.compute_node_bridge.unregister.succeeded"
+                    if unregistered
+                    else "desktop.compute_node_bridge.unregister.failed"
+                )
+                print(
+                    f"{unregister_event} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                    f"success={unregistered}",
+                    file=sys.stderr,
+                )
+
     try:
         if warm_runtime_before_registration():
             while not stop_requested():
-                print("desktop.compute_node_bridge.api_v1_e2ee.register", file=sys.stderr)
                 active_relay_url = runtime.relay_client.relay_url
-                relay_response = poll_worker.call(runtime.register_and_poll_once, stop_requested)
+                print(
+                    "desktop.compute_node_bridge.api_v1_e2ee.register "
+                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    file=sys.stderr,
+                )
+                relay_response = poll_worker.call(
+                    runtime.register_and_poll_once,
+                    stop_requested,
+                    on_cancel=lambda relay=active_relay_url: request_poll_cancel(relay),
+                )
                 if relay_response is _POLL_CANCELLED:
                     print(
                         "desktop.compute_node_bridge.poll.cancelled "
@@ -939,11 +1029,27 @@ def run(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         pass
     finally:
-        print("desktop.compute_node_bridge.stop", file=sys.stderr)
+        active_relay_url = getattr(getattr(runtime, "relay_client", None), "relay_url", relay_url)
+        print(
+            "desktop.compute_node_bridge.stop "
+            f"relay={_sanitize_relay_target(active_relay_url)}",
+            file=sys.stderr,
+        )
+        request_poll_cancel(active_relay_url)
         poll_worker.shutdown()
+        print(
+            "desktop.compute_node_bridge.poll.worker_stopped "
+            f"relay={_sanitize_relay_target(active_relay_url)}",
+            file=sys.stderr,
+        )
         if warm_load_future is not None and not warm_load_future.done():
             warm_load_future.cancel()
         runtime.stop()
+        print(
+            "desktop.compute_node_bridge.stopped_idle "
+            f"relay={_sanitize_relay_target(active_relay_url)}",
+            file=sys.stderr,
+        )
 
     diagnostics = compute_mode_diagnostics(runtime.model_manager)
     emit(

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -852,7 +852,16 @@ def run(args: argparse.Namespace) -> int:
         )
         relay_stop = getattr(relay_client, "stop", None)
         if callable(relay_stop):
-            relay_stop()
+            try:
+                relay_stop()
+            except Exception as exc:
+                print(
+                    "desktop.compute_node_bridge.relay.stop_failed "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                    f"exc_type={type(exc).__name__}",
+                    file=sys.stderr,
+                )
         unregister = getattr(relay_client, "unregister_from_relay", None)
         if callable(unregister):
             print(

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -575,11 +575,13 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
+    eprintln!("desktop.compute_node.stop_requested");
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
     };
     if let Some(stdin) = stdin_handle.as_mut() {
+        eprintln!("desktop.compute_node.cancel_requested");
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
     }
@@ -604,8 +606,12 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
 
         if !exited {
+            eprintln!("desktop.compute_node.bridge_kill_requested");
             let _ = child.kill().await;
             let _ = child.wait().await;
+            eprintln!("desktop.compute_node.bridge_process_exited killed=true");
+        } else {
+            eprintln!("desktop.compute_node.bridge_process_exited killed=false");
         }
     }
 
@@ -759,6 +765,44 @@ mod tests {
         let final_status = state.status.lock().await.clone();
         assert!(!final_status.running);
         assert!(!final_status.registered);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn repeated_start_stop_start_does_not_leave_stale_child_handle() {
+        let state = ComputeNodeState::default();
+        let mut first_child = Command::new("sh")
+            .args(["-c", "IFS= read -r _line; exit 0"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn first bridge");
+        let first_stdin = first_child.stdin.take().expect("first stdin");
+        let first_pid = first_child.id().expect("first child pid");
+        *state.child.lock().await = Some(first_child);
+        *state.stdin.lock().await = Some(first_stdin);
+
+        stop_compute_node(state.clone()).await.expect("first stop");
+        assert!(state.child.lock().await.is_none());
+        assert!(state.stdin.lock().await.is_none());
+
+        let mut second_child = Command::new("sh")
+            .args(["-c", "IFS= read -r _line; exit 0"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn second bridge");
+        let second_stdin = second_child.stdin.take().expect("second stdin");
+        let second_pid = second_child.id().expect("second child pid");
+        *state.child.lock().await = Some(second_child);
+        *state.stdin.lock().await = Some(second_stdin);
+
+        assert_ne!(first_pid, second_pid);
+        stop_compute_node(state.clone()).await.expect("second stop");
+        assert!(state.child.lock().await.is_none());
+        assert!(state.stdin.lock().await.is_none());
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -779,7 +779,6 @@ mod tests {
             .spawn()
             .expect("spawn first bridge");
         let first_stdin = first_child.stdin.take().expect("first stdin");
-        let first_pid = first_child.id().expect("first child pid");
         *state.child.lock().await = Some(first_child);
         *state.stdin.lock().await = Some(first_stdin);
 
@@ -795,11 +794,9 @@ mod tests {
             .spawn()
             .expect("spawn second bridge");
         let second_stdin = second_child.stdin.take().expect("second stdin");
-        let second_pid = second_child.id().expect("second child pid");
         *state.child.lock().await = Some(second_child);
         *state.stdin.lock().await = Some(second_stdin);
 
-        assert_ne!(first_pid, second_pid);
         stop_compute_node(state.clone()).await.expect("second stop");
         assert!(state.child.lock().await.is_none());
         assert!(state.stdin.lock().await.is_none());

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -586,6 +586,42 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
   });
 
+
+  it('invokes backend stop and reflects stopped operator event', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      warm_load_state: 'ready',
+      warm_load_enabled: true,
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+
+    const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+    fireEvent.click(stopOperatorButton);
+
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.some(([command]) => command === 'stop_compute_node')).toBe(true)
+    );
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        active_relay_url: 'https://token.place',
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+  });
+
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2205,3 +2205,30 @@ def test_api_v1_next_keeps_server_alive_while_any_in_flight_request_remains(clie
     next_response = client.get('/api/v1/relay/servers/next')
     assert next_response.status_code == 200
     assert next_response.get_json().get('server_public_key') == DUMMY_SERVER_PUB_KEY
+
+
+def test_api_v1_unregister_removes_known_server_and_next_skips_it(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    assert client.get('/api/v1/relay/servers/next').status_code == 200
+
+    unregistered = client.post('/unregister', json=server_payload)
+
+    assert unregistered.status_code == 200
+    assert unregistered.get_json()['removed'] is True
+    diagnostics = client.get('/relay/diagnostics').get_json()
+    assert diagnostics['total_registered_compute_nodes'] == 0
+    next_response = client.get('/api/v1/relay/servers/next')
+    assert next_response.status_code == 503
+
+
+def test_api_v1_unregister_is_idempotent_when_server_already_gone(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+
+    first = client.post('/unregister', json=server_payload)
+    second = client.post('/unregister', json=server_payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.get_json()['removed'] is False
+    assert second.get_json()['removed'] is False

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -376,6 +376,7 @@ def _install_fake_runtime_module(monkeypatch, runtime_cls=FakeRuntime):
 def _reset_cancel_queue():
     compute_node_bridge._stdin_lines = queue.Queue()
     compute_node_bridge._stdin_reader_started = True
+    compute_node_bridge._stop_requested_latched.clear()
 
 
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
@@ -2104,3 +2105,139 @@ def test_run_handles_keyboard_interrupt_from_poll_worker(capsys, monkeypatch):
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     assert events[-1]["type"] == "stopped"
+
+
+class ShutdownTrackingRelayClient(FakeRelayClient):
+    def __init__(self):
+        self.stop_calls = 0
+        self.unregister_calls = 0
+        self._unregistered = False
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def unregister_from_relay(self):
+        if self._unregistered:
+            return True
+        self._unregistered = True
+        self.unregister_calls += 1
+        return True
+
+
+class ShutdownTrackingRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        ShutdownTrackingRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = ShutdownTrackingRelayClient()
+        self.poll_calls = 0
+        self.stop_calls = 0
+        self._processed = []
+
+    def register_and_poll_once(self):
+        self.poll_calls += 1
+        return {'next_ping_in_x_seconds': 60}
+
+    def stop(self):
+        self.stop_calls += 1
+        self.relay_client.stop()
+        self.relay_client.unregister_from_relay()
+
+
+def test_run_unregisters_once_and_does_not_poll_after_cancel(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ShutdownTrackingRuntime)
+    stop_calls = {'count': 0}
+
+    def fake_stop_requested():
+        stop_calls['count'] += 1
+        return stop_calls['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    runtime = ShutdownTrackingRuntime.last_instance
+    assert runtime.poll_calls == 1
+    assert runtime.stop_calls == 1
+    assert runtime.relay_client.stop_calls >= 1
+    assert runtime.relay_client.unregister_calls == 1
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.poll.cancel_requested' in output.err
+    assert 'desktop.compute_node_bridge.unregister.succeeded' in output.err
+    assert 'desktop.compute_node_bridge.poll.worker_stopped' in output.err
+
+
+def test_cancelable_poll_worker_invokes_cancel_callback_promptly_during_long_poll():
+    worker = compute_node_bridge._CancelablePollWorker()
+    call_started = threading.Event()
+    release_call = threading.Event()
+    cancel_calls = []
+
+    def long_poll():
+        call_started.set()
+        release_call.wait(timeout=1.0)
+        return {'ok': True}
+
+    try:
+        result = worker.call(
+            long_poll,
+            lambda: call_started.is_set(),
+            poll_interval=0.01,
+            on_cancel=lambda: cancel_calls.append('cancelled'),
+        )
+    finally:
+        release_call.set()
+        worker.shutdown()
+
+    assert result is compute_node_bridge._POLL_CANCELLED
+    assert cancel_calls == ['cancelled']
+
+
+def test_stop_requested_latches_cancel_from_stdin_queue():
+    _reset_cancel_queue()
+    compute_node_bridge._stdin_lines.put(json.dumps({'type': 'cancel'}))
+
+    assert compute_node_bridge.stop_requested() is True
+    assert compute_node_bridge.stop_requested() is True
+
+
+def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingThenApiV1Runtime)
+    stop_after_warm_started = {'armed': False}
+
+    def fake_stop_requested():
+        instance = WarmingThenApiV1Runtime.last_instance
+        if instance is not None and instance.ready_started.is_set():
+            stop_after_warm_started['armed'] = True
+            return True
+        return False
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '1')
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    runtime = WarmingThenApiV1Runtime.last_instance
+    assert stop_after_warm_started['armed'] is True
+    assert runtime._processed == []
+    assert runtime._responses == [
+        {
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'version': 1,
+            'request_id': 'req-1',
+            'client_public_key': 'client-key',
+            'chat_history': 'ciphertext',
+            'cipherkey': 'key',
+            'iv': 'iv',
+            'next_ping_in_x_seconds': 0,
+        }
+    ]
+    assert capsys.readouterr().out.splitlines()[-1]

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1420,6 +1420,36 @@ def test_sanitize_relay_target_preserves_ipv6_brackets():
     assert sanitized == 'http://[::1]:8000'
 
 
+def test_relay_key_fingerprint_uses_safe_helper_and_fallbacks():
+    class CryptoManager:
+        public_key_b64 = 'abcdefghijklmno'
+
+    class RelayClient:
+        crypto_manager = CryptoManager()
+
+        def _api_v1_public_key_fingerprint(self, public_key):
+            assert public_key == 'abcdefghijklmno'
+            return 'fp:abcd'
+
+    assert compute_node_bridge._relay_key_fingerprint(RelayClient()) == 'fp:abcd'
+
+    class BrokenFingerprintRelay(RelayClient):
+        def _api_v1_public_key_fingerprint(self, _public_key):
+            raise RuntimeError('fingerprint failed')
+
+    assert compute_node_bridge._relay_key_fingerprint(BrokenFingerprintRelay()) == 'unknown'
+
+    class NoHelperRelay:
+        crypto_manager = CryptoManager()
+
+    assert compute_node_bridge._relay_key_fingerprint(NoHelperRelay()) == 'abcdefgh...lmno'
+
+    class ShortKeyRelay:
+        crypto_manager = SimpleNamespace(public_key_b64='short')
+
+    assert compute_node_bridge._relay_key_fingerprint(ShortKeyRelay()) == 'unknown'
+
+
 def test_relay_response_summary_handles_non_dict_payloads():
     summary = compute_node_bridge._relay_response_summary(["unexpected"])
     assert summary == "non-dict response type=list"

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2172,6 +2172,121 @@ def test_run_unregisters_once_and_does_not_poll_after_cancel(capsys, monkeypatch
     assert 'desktop.compute_node_bridge.poll.worker_stopped' in output.err
 
 
+class StopFailureRelayClient(FakeRelayClient):
+    def __init__(self):
+        self.stop_calls = 0
+        self.unregister_calls = 0
+
+    def stop(self):
+        self.stop_calls += 1
+        raise RuntimeError('relay stop failed')
+
+    def unregister_from_relay(self):
+        self.unregister_calls += 1
+        return True
+
+
+class StopFailureRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        StopFailureRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = StopFailureRelayClient()
+        self.stop_calls = 0
+        self._processed = []
+
+    def register_and_poll_once(self):
+        return {'next_ping_in_x_seconds': 60}
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+def test_run_continues_shutdown_when_relay_stop_raises(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StopFailureRuntime)
+    stop_calls = {'count': 0}
+
+    def fake_stop_requested():
+        stop_calls['count'] += 1
+        return stop_calls['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    runtime = StopFailureRuntime.last_instance
+    assert runtime.stop_calls == 1
+    assert runtime.relay_client.stop_calls == 1
+    assert runtime.relay_client.unregister_calls == 1
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.relay.stop_failed' in output.err
+    assert 'exc_type=RuntimeError' in output.err
+    assert 'desktop.compute_node_bridge.unregister.succeeded' in output.err
+    assert json.loads(output.out.splitlines()[-1])['type'] == 'stopped'
+
+
+class UnregisterFailureRelayClient(FakeRelayClient):
+    def __init__(self):
+        self.stop_calls = 0
+        self.unregister_calls = 0
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def unregister_from_relay(self):
+        self.unregister_calls += 1
+        raise TimeoutError('relay unregister timed out')
+
+
+class UnregisterFailureRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        UnregisterFailureRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = UnregisterFailureRelayClient()
+        self.stop_calls = 0
+        self._processed = []
+
+    def register_and_poll_once(self):
+        return {'next_ping_in_x_seconds': 60}
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+def test_run_continues_shutdown_when_unregister_raises(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=UnregisterFailureRuntime)
+    stop_calls = {'count': 0}
+
+    def fake_stop_requested():
+        stop_calls['count'] += 1
+        return stop_calls['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    runtime = UnregisterFailureRuntime.last_instance
+    assert runtime.stop_calls == 1
+    assert runtime.relay_client.stop_calls == 1
+    assert runtime.relay_client.unregister_calls == 1
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.unregister.failed' in output.err
+    assert 'exc_type=TimeoutError' in output.err
+    assert 'desktop.compute_node_bridge.poll.worker_stopped' in output.err
+    assert json.loads(output.out.splitlines()[-1])['type'] == 'stopped'
+
+
 def test_cancelable_poll_worker_invokes_cancel_callback_promptly_during_long_poll():
     worker = compute_node_bridge._CancelablePollWorker()
     call_started = threading.Event()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -3176,3 +3176,67 @@ def test_poll_api_v1_encrypted_work_continuously_sleeps_no_work_hint(monkeypatch
 
     client.poll_api_v1_encrypted_work_continuously()
     assert 0.25 in sleeps
+
+
+def _standalone_relay_client():
+    crypto = MagicMock()
+    crypto.public_key_b64 = 'mock_public_key_b64'
+    model = MagicMock()
+    config = MagicMock()
+    config.is_production = False
+    config.get.side_effect = lambda key, default=None: {'relay.request_timeout': 15}.get(key, default)
+    with patch('utils.networking.relay_client.get_config_lazy', return_value=config):
+        return RelayClient('http://localhost', 5000, crypto, model)
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_unregister_from_relay_is_idempotent_and_clears_api_v1_registration(mock_post):
+    client = _standalone_relay_client()
+    client._api_v1_registered_relays.add('http://localhost:5000')
+    client._api_v1_last_heartbeat_at['http://localhost:5000'] = 123.0
+    client._api_v1_relay_wait_hints = {'http://localhost:5000': {'next_ping_in_x_seconds': 30}}
+    mock_post.return_value = MagicMock(status_code=200)
+
+    assert client.unregister_from_relay() is True
+    assert client.unregister_from_relay() is True
+
+    mock_post.assert_called_once_with(
+        'http://localhost:5000/unregister',
+        json={'server_public_key': 'mock_public_key_b64'},
+        timeout=15,
+    )
+    assert client._api_v1_registered_relays == set()
+    assert client._api_v1_last_heartbeat_at == {}
+    assert client._api_v1_relay_wait_hints == {}
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_poll_api_v1_encrypted_work_stop_prevents_register_and_poll(mock_post):
+    client = _standalone_relay_client()
+    client.stop()
+
+    result = client.poll_api_v1_encrypted_work()
+
+    assert result == {
+        'error': 'Relay polling stopped',
+        'next_ping_in_x_seconds': 0,
+        'poll_wait_seconds': 0,
+    }
+    mock_post.assert_not_called()
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_start_after_stop_allows_api_v1_registration_again(mock_post):
+    client = _standalone_relay_client()
+    client.stop()
+    client.start()
+    register_ok = MagicMock(status_code=200)
+    register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+    poll_ok = MagicMock(status_code=200)
+    poll_ok.json.return_value = {'message': 'No requests available'}
+    mock_post.side_effect = [register_ok, poll_ok]
+
+    result = client.poll_api_v1_encrypted_work()
+
+    assert result['next_ping_in_x_seconds'] == 12
+    assert mock_post.call_count == 2

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -422,13 +422,91 @@ class TestRelayClient:
 
         with patch('utils.networking.relay_client.requests.post') as mock_post:
             mock_post.side_effect = [success_response, failure_response]
-            assert client.unregister_from_relay() is True
+            assert client.unregister_from_relay() is False
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
             'http://primary-relay:5000/unregister',
             'http://backup-relay:6000/unregister',
         ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_retries_after_transient_failure(self, mock_post, relay_client):
+        """A failed unregister attempt should not make later attempts no-ops."""
+
+        failure_response = MagicMock()
+        failure_response.status_code = 503
+        success_response = MagicMock()
+        success_response.status_code = 200
+        mock_post.side_effect = [failure_response, success_response]
+
+        assert relay_client.unregister_from_relay() is False
+        assert relay_client.unregister_from_relay() is True
+
+        requested_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert requested_urls == [
+            'http://localhost:5000/unregister',
+            'http://localhost:5000/unregister',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_keeps_failed_registered_relay_for_retry(
+        self,
+        mock_post,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Partial multi-relay unregisters should retain only failed local state."""
+
+        config_values = {
+            'relay.request_timeout': 15,
+            'relay.additional_servers': ['http://backup-relay:6000'],
+        }
+
+        with patch('utils.networking.relay_client.get_config_lazy') as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.is_production = False
+            mock_config.get.side_effect = lambda key, default=None: config_values.get(key, default)
+            mock_get_config.return_value = mock_config
+
+            client = RelayClient(
+                base_url="http://primary-relay",
+                port=5000,
+                crypto_manager=mock_crypto_manager,
+                model_manager=mock_model_manager,
+            )
+
+        primary = 'http://primary-relay:5000'
+        backup = 'http://backup-relay:6000'
+        client._api_v1_registered_relays.update({primary, backup})
+        client._api_v1_last_heartbeat_at.update({primary: 1.0, backup: 2.0})
+        client._api_v1_relay_wait_hints = {
+            primary: {'next_ping_in_x_seconds': 30},
+            backup: {'next_ping_in_x_seconds': 30},
+        }
+        success_response = MagicMock(status_code=200)
+        failure_response = MagicMock(status_code=503)
+        retry_success_response = MagicMock(status_code=200)
+        mock_post.side_effect = [success_response, failure_response, retry_success_response]
+
+        assert client.unregister_from_relay() is False
+        assert client._api_v1_registered_relays == {backup}
+        assert primary not in client._api_v1_last_heartbeat_at
+        assert primary not in client._api_v1_relay_wait_hints
+        assert backup in client._api_v1_last_heartbeat_at
+        assert backup in client._api_v1_relay_wait_hints
+
+        assert client.unregister_from_relay() is True
+
+        requested_urls = [call.args[0] for call in mock_post.call_args_list]
+        assert requested_urls == [
+            f'{primary}/unregister',
+            f'{backup}/unregister',
+            f'{backup}/unregister',
+        ]
+        assert client._api_v1_registered_relays == set()
+        assert client._api_v1_last_heartbeat_at == {}
+        assert client._api_v1_relay_wait_hints == {}
 
     @patch('utils.networking.relay_client.requests.post')
     def test_unregister_from_relay_uses_registration_token(
@@ -3223,6 +3301,28 @@ def test_poll_api_v1_encrypted_work_stop_prevents_register_and_poll(mock_post):
         'poll_wait_seconds': 0,
     }
     mock_post.assert_not_called()
+
+
+def test_poll_api_v1_encrypted_work_continuously_clears_previous_stop_request(monkeypatch):
+    client = _standalone_relay_client()
+    client.stop()
+    client._unregister_attempted = True
+    observed_stop_flags = []
+
+    def fake_poll():
+        observed_stop_flags.append(client._polling_stopped_by_request)
+        client.stop()
+        return {'message': 'No requests available', 'next_ping_in_x_seconds': 0}
+
+    monkeypatch.setattr(client, 'poll_api_v1_encrypted_work', fake_poll)
+    monkeypatch.setattr(relay_client_module.time, 'sleep', lambda _seconds: None)
+
+    client.poll_api_v1_encrypted_work_continuously()
+
+    assert observed_stop_flags == [False]
+    assert client.stop_polling is True
+    assert client._polling_stopped_by_request is True
+    assert client._unregister_attempted is False
 
 
 @patch('utils.networking.relay_client.requests.post')

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -3303,6 +3303,44 @@ def test_poll_api_v1_encrypted_work_stop_prevents_register_and_poll(mock_post):
     mock_post.assert_not_called()
 
 
+@patch('utils.networking.relay_client.requests.post')
+def test_poll_api_v1_encrypted_work_stop_after_register_retries_unregister(mock_post):
+    client = _standalone_relay_client()
+    client.start()
+    client._unregister_attempted = True
+    client._unregister_complete = True
+
+    register_response = MagicMock(status_code=200)
+    register_response.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+    unregister_response = MagicMock(status_code=200)
+
+    def fake_post(url, *args, **kwargs):
+        if url.endswith('/relay/servers/register'):
+            client.stop()
+            return register_response
+        if url.endswith('/unregister'):
+            return unregister_response
+        raise AssertionError(f'Unexpected relay request: {url}')
+
+    mock_post.side_effect = fake_post
+
+    result = client.poll_api_v1_encrypted_work()
+
+    assert result == {
+        'error': 'Relay polling stopped',
+        'next_ping_in_x_seconds': 0,
+        'poll_wait_seconds': 0,
+    }
+    requested_urls = [call.args[0] for call in mock_post.call_args_list]
+    assert requested_urls == [
+        'http://localhost:5000/api/v1/relay/servers/register',
+        'http://localhost:5000/unregister',
+    ]
+    assert client._api_v1_registered_relays == set()
+    assert client._api_v1_last_heartbeat_at == {}
+    assert client._unregister_complete is True
+
+
 def test_poll_api_v1_encrypted_work_continuously_clears_previous_stop_request(monkeypatch):
     client = _standalone_relay_client()
     client.stop()

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -614,6 +614,8 @@ class RelayClient:
         self._last_api_v1_work_relay_url: Optional[str] = None
         self._api_v1_registered_relays: Set[str] = set()
         self._api_v1_last_heartbeat_at: Dict[str, float] = {}
+        self._unregister_attempted = False
+        self._unregister_complete = False
 
 
     @staticmethod
@@ -783,6 +785,7 @@ class RelayClient:
         self.stop_polling = False
         self._polling_stopped_by_request = False
         self._unregister_attempted = False
+        self._unregister_complete = False
 
     def stop(self):
         """Stop the polling loop by setting stop_polling to True"""
@@ -793,20 +796,36 @@ class RelayClient:
     def unregister_from_relay(self) -> bool:
         """Best-effort unregister call for graceful compute-node shutdown."""
 
-        if getattr(self, "_unregister_attempted", False):
-            log_info("Compute node unregister already attempted; skipping duplicate request")
+        if (
+            getattr(self, "_unregister_attempted", False)
+            and getattr(self, "_unregister_complete", False)
+        ):
+            log_info("Compute node unregister already completed; skipping duplicate request")
             return True
+
         self._unregister_attempted = True
 
         last_error: Optional[str] = None
-        had_success = False
+        failed_relays: Set[str] = set()
+        unregistered_relays: Set[str] = set()
 
         relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
         self._api_v1_relay_wait_hints = relay_wait_hints
+        registered_relays = getattr(self, "_api_v1_registered_relays", set())
 
-        for offset in range(len(self._relay_urls)):
-            index = (self._active_relay_index + offset) % len(self._relay_urls)
-            candidate_url = self._relay_urls[index]
+        ordered_relay_urls = [
+            self._relay_urls[(self._active_relay_index + offset) % len(self._relay_urls)]
+            for offset in range(len(self._relay_urls))
+        ]
+        if registered_relays:
+            target_urls = [url for url in ordered_relay_urls if url in registered_relays]
+            target_urls.extend(sorted(url for url in registered_relays if url not in set(target_urls)))
+        else:
+            target_urls = ordered_relay_urls
+
+        relay_index_by_url = {url: index for index, url in enumerate(self._relay_urls)}
+
+        for candidate_url in target_urls:
             try:
                 request_kwargs = {
                     'json': {'server_public_key': self.crypto_manager.public_key_b64},
@@ -821,11 +840,16 @@ class RelayClient:
                     **request_kwargs,
                 )
                 if response.status_code == 200:
-                    self._active_relay_index = index
+                    if candidate_url in relay_index_by_url:
+                        self._active_relay_index = relay_index_by_url[candidate_url]
                     log_info("Unregistered compute node from relay {}", candidate_url)
-                    had_success = True
+                    unregistered_relays.add(candidate_url)
+                    self._api_v1_registered_relays.discard(candidate_url)
+                    self._api_v1_last_heartbeat_at.pop(candidate_url, None)
+                    relay_wait_hints.pop(candidate_url, None)
                     continue
 
+                failed_relays.add(candidate_url)
                 last_error = f"HTTP {response.status_code}"
                 log_error(
                     "Failed to unregister compute node from {}: {}",
@@ -833,6 +857,7 @@ class RelayClient:
                     last_error,
                 )
             except requests.RequestException as exc:
+                failed_relays.add(candidate_url)
                 last_error = str(exc)
                 log_error(
                     "Error unregistering compute node from {}: {}",
@@ -841,6 +866,7 @@ class RelayClient:
                     exc_info=True,
                 )
             except Exception as exc:  # pragma: no cover - unexpected edge cases
+                failed_relays.add(candidate_url)
                 last_error = str(exc)
                 log_error(
                     "Unexpected error unregistering compute node from {}: {}",
@@ -849,15 +875,18 @@ class RelayClient:
                     exc_info=True,
                 )
 
-        if had_success:
+        if failed_relays:
+            self._unregister_complete = False
+            if last_error:
+                log_error("Unable to unregister compute node from relay: {}", last_error)
+            return False
+
+        self._unregister_complete = True
+        if len(unregistered_relays) == len(target_urls):
             self._api_v1_registered_relays.clear()
             self._api_v1_last_heartbeat_at.clear()
             relay_wait_hints.clear()
-            return True
-
-        if last_error:
-            log_error("Unable to unregister compute node from relay: {}", last_error)
-        return False
+        return True
 
     def ping_relay(self) -> Dict[str, Any]:
         """
@@ -2188,7 +2217,7 @@ class RelayClient:
     def poll_api_v1_encrypted_work_continuously(self):  # pragma: no cover
         """Continuously poll API v1 E2EE relay routes and process encrypted work."""
 
-        self.stop_polling = False
+        self.start()
         consecutive_failures = 0
         max_failures = _max_poll_failures_before_stop()
         log_info("Starting API v1 E2EE relay polling loop")

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1260,6 +1260,7 @@ class RelayClient:
                     }
                     self._api_v1_registered_relays.add(candidate_url)
                     self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
+                    self._unregister_complete = False
                     if getattr(self, "_polling_stopped_by_request", False):
                         self.unregister_from_relay()
                         return {

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -519,6 +519,7 @@ class RelayClient:
         self.crypto_manager = crypto_manager
         self.model_manager = model_manager
         self.stop_polling = True  # Flag to control polling loop - starts as True so loop won't run until explicitly started
+        self._polling_stopped_by_request = False
         self._registration_token: Optional[str] = None
         configured_servers: List[Any] = []
         self._cluster_only = False
@@ -780,14 +781,22 @@ class RelayClient:
     def start(self):
         """Start the polling loop by setting stop_polling to False"""
         self.stop_polling = False
+        self._polling_stopped_by_request = False
+        self._unregister_attempted = False
 
     def stop(self):
         """Stop the polling loop by setting stop_polling to True"""
         log_info("Stopping relay polling")
         self.stop_polling = True
+        self._polling_stopped_by_request = True
 
     def unregister_from_relay(self) -> bool:
         """Best-effort unregister call for graceful compute-node shutdown."""
+
+        if getattr(self, "_unregister_attempted", False):
+            log_info("Compute node unregister already attempted; skipping duplicate request")
+            return True
+        self._unregister_attempted = True
 
         last_error: Optional[str] = None
         had_success = False
@@ -841,6 +850,9 @@ class RelayClient:
                 )
 
         if had_success:
+            self._api_v1_registered_relays.clear()
+            self._api_v1_last_heartbeat_at.clear()
+            relay_wait_hints.clear()
             return True
 
         if last_error:
@@ -1127,6 +1139,13 @@ class RelayClient:
     def poll_api_v1_encrypted_work(self) -> Dict[str, Any]:
         """Poll API v1 relay routes for encrypted work with lease-aware registration."""
 
+        if getattr(self, "_polling_stopped_by_request", False):
+            return {
+                'error': 'Relay polling stopped',
+                'next_ping_in_x_seconds': 0,
+                'poll_wait_seconds': 0,
+            }
+
         last_error: Optional[Dict[str, Any]] = None
         relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
         self._api_v1_relay_wait_hints = relay_wait_hints
@@ -1167,7 +1186,20 @@ class RelayClient:
                         requires_register = True
                         reregister_reason = "lease_expiry_risk"
 
+                if getattr(self, "_polling_stopped_by_request", False):
+                    return {
+                        'error': 'Relay polling stopped',
+                        'next_ping_in_x_seconds': 0,
+                        'poll_wait_seconds': 0,
+                    }
+
                 if requires_register:
+                    if getattr(self, "_polling_stopped_by_request", False):
+                        return {
+                            'error': 'Relay polling stopped',
+                            'next_ping_in_x_seconds': 0,
+                            'poll_wait_seconds': 0,
+                        }
                     if reregister_reason and reregister_reason != "not_registered":
                         log_info(
                             "server.reregister reason={} relay={} key_fingerprint={}",
@@ -1199,6 +1231,13 @@ class RelayClient:
                     }
                     self._api_v1_registered_relays.add(candidate_url)
                     self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
+                    if getattr(self, "_polling_stopped_by_request", False):
+                        self.unregister_from_relay()
+                        return {
+                            'error': 'Relay polling stopped',
+                            'next_ping_in_x_seconds': 0,
+                            'poll_wait_seconds': 0,
+                        }
                     next_refresh = self._api_v1_refresh_threshold_seconds(register_wait)
                     log_info(
                         "server.registered relay={} lease_seconds={} next_refresh_seconds={} key_fingerprint={}",
@@ -1221,6 +1260,13 @@ class RelayClient:
                 headers = self._auth_headers()
                 if headers:
                     request_kwargs['headers'] = headers
+
+                if getattr(self, "_polling_stopped_by_request", False):
+                    return {
+                        'error': 'Relay polling stopped',
+                        'next_ping_in_x_seconds': 0,
+                        'poll_wait_seconds': 0,
+                    }
 
                 poll_timeout_seconds = float(request_kwargs.pop('timeout'))
                 poll_url = self._build_api_v1_url(candidate_url, "/relay/servers/poll")
@@ -2221,6 +2267,7 @@ class RelayClient:
         if self.stop_polling:
             log_info("Starting relay polling")
             self.stop_polling = False
+            self._polling_stopped_by_request = False
 
         consecutive_failures = 0
         max_failures = _max_poll_failures_before_stop()


### PR DESCRIPTION
### Motivation
- Ensure clicking Stop actually cancels the desktop compute-node bridge polling loop, prevents further register/heartbeat activity, and best-effort unregisters the node from the relay to avoid stale/stuck registrations.
- Add clear diagnostics and small defensive guards so the bridge/relay lifecycle cannot re-register or keep heartbeating after a stop is requested.

### Description
- Desktop bridge (Python): updated `desktop-tauri/src-tauri/python/compute_node_bridge.py` to reliably latch a stop request and surface stronger shutdown hooks by:
  - Adding a `_stop_requested_latched` `threading.Event` so `stop_requested()` latches the cancel event and remains true thereafter.
  - Extending `_CancelablePollWorker.call()` with an optional `on_cancel` callback and making it return `_POLL_CANCELLED` if cancellation is observed before/during the worker call.
  - Introducing `request_poll_cancel()` which is invoked when a poll is cancelled and which best-effort calls `relay_client.stop()` and `relay_client.unregister_from_relay()` while emitting structured diagnostic logs (attempted/succeeded/failed) with sanitized relay targets.
  - Improving finalization to call `request_poll_cancel()` in `finally`, shutdown the poll worker, cancel warm-load futures, call `runtime.stop()`, and emit explicit poll/worker/idle logs.
  - Keeping existing behavior: not blocking shutdown indefinitely on unregister failures and preserving E2EE invariants.
- Relay client (Python): updated `utils/networking/relay_client.py` to make client-side polling stoppable and unregister idempotent by:
  - Introducing per-client flags to stop polling early and short-circuit registration/poll codepaths when `stop()` has been invoked.
  - Making `unregister_from_relay()` safe to call multiple times (idempotent) and clearing local registration/heartbeat state on success so diagnostics reflect that the node is removed.
- Tests and harness updates:
  - Added unit tests and small test fixes to assert that stop cancels active polls, `on_cancel` callback fires, unregister is attempted exactly once, and poll/register calls do not occur after stop.
  - Updated `tests/unit/test_desktop_compute_node_bridge.py` with new scenarios exercising stop during long poll, warm load, and ensuring unregister/logging is emitted.
  - Added/adjusted tests in `tests/unit/test_relay_client.py` and `tests/test_relay.py` to assert idempotent unregister behavior and that `poll_api_v1_encrypted_work()` respects `stop()`.
  - Added a UI test in `desktop-tauri/src/App.test.tsx` that clicks the Stop operator button, verifies the backend stop invoke is sent, then verifies a stopped `compute_node_event` updates Running/Registered fields.
- Logging: added explicit stderr lines in the bridge (e.g., `poll.cancel_requested`, `unregister.attempted/succeeded/failed`, `poll.worker_stopped`, `stopped_idle`) that include sanitized relay URL and key fingerprint metadata only.

### Testing
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py` and obtained: all tests passed (`58 passed`).
- Ran targeted relay client tests: `pytest tests/unit/test_relay_client.py -k "unregister or stop or api_v1 or relay"` after a small test adjustment and obtained all targeted tests passing (selection passed).
- Ran targeted relay server tests: `pytest tests/test_relay.py -k "unregister or servers or api_v1"` and relevant new tests passed in the CI-local run.
- Notes about JS/desktop tests: the added/updated UI test in `desktop-tauri/src/App.test.tsx` was added but `npm`/`vitest` was not executed here due to the local environment choice; CI should run `npm test` / `npm run test:ci` as part of the normal pipeline to validate the TypeScript test suite.

Residual risks and follow-ups
- This PR focuses on lifecycle/cancellation; Prompt 2 (UI state fidelity) and Prompt 3 (multi-desktop dispatch) remain out of scope and should be addressed in follow-ups.
- Please run full JS test pipeline (`npm run test:ci` or `npm test -- --runInBand`) and `pre-commit run --all-files` in CI to ensure lint/type/test coverage across the whole repo before merging to main.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a136dcf24832fbf9b1b89b31c81a9)