### PR TITLE
Make desktop compute-node UI fields accurate across lifecycle states

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -76,6 +76,7 @@ WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
 API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
+_STATUS_SEQUENCE = 0
 
 
 _POLL_CANCELLED = object()
@@ -416,6 +417,21 @@ def stop_requested() -> bool:
 
 
 def emit(payload: Dict[str, Any]) -> None:
+    """Emit a structured bridge event.
+
+    Operator status payloads are the single contract consumed by Rust and the
+    React UI. They include lifecycle booleans plus relay runtime diagnostics:
+    running, registered, relay_runtime_state, runtime_path, relay_runtime_path,
+    active_relay_url, requested/effective mode, backend availability/selection/use,
+    fallback_reason, model_path, last_error, status_sequence, and emitted_at_ms.
+    """
+    if payload.get("type") in {"started", "status", "stopped"}:
+        global _STATUS_SEQUENCE
+        _STATUS_SEQUENCE += 1
+        payload.setdefault("status_sequence", _STATUS_SEQUENCE)
+        payload.setdefault("emitted_at_ms", int(time.time() * 1000))
+    if "relay_runtime_state" not in payload and "warm_load_state" in payload:
+        payload["relay_runtime_state"] = payload.get("warm_load_state")
     sys.stdout.write(json.dumps(payload) + "\n")
     sys.stdout.flush()
 
@@ -548,6 +564,7 @@ def run(args: argparse.Namespace) -> int:
                 "model_path": args.model,
                 "last_error": current_last_error,
                 "warm_load_state": warm_load_state,
+                "relay_runtime_state": warm_load_state,
                 "warm_load_enabled": warm_load_enabled,
                 "warm_load_duration_ms": warm_load_duration_ms,
                 "runtime_path": runtime_path,
@@ -734,6 +751,7 @@ def run(args: argparse.Namespace) -> int:
             "model_path": args.model,
             "last_error": None,
             "warm_load_state": warm_load_state,
+            "relay_runtime_state": warm_load_state,
             "warm_load_enabled": warm_load_enabled,
             "runtime_path": runtime_path,
             "relay_runtime_path": relay_runtime_path,
@@ -1080,6 +1098,7 @@ def run(args: argparse.Namespace) -> int:
             "model_path": args.model,
             "last_error": last_error,
             "warm_load_state": warm_load_state,
+            "relay_runtime_state": warm_load_state,
             "warm_load_enabled": warm_load_enabled,
             "warm_load_duration_ms": warm_load_duration_ms,
             "runtime_path": runtime_path,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -38,10 +38,13 @@ pub struct ComputeNodeStatus {
     pub model_path: String,
     pub last_error: Option<String>,
     pub warm_load_state: Option<String>,
+    pub relay_runtime_state: Option<String>,
     pub warm_load_enabled: Option<bool>,
     pub warm_load_duration_ms: Option<u64>,
     pub runtime_path: Option<String>,
     pub relay_runtime_path: Option<String>,
+    pub session_id: u64,
+    pub status_sequence: u64,
 }
 
 #[derive(Clone, Default)]
@@ -50,6 +53,7 @@ pub struct ComputeNodeState {
     pub stdin: Arc<Mutex<Option<ChildStdin>>>,
     pub status: Arc<Mutex<ComputeNodeStatus>>,
     pub lifecycle_lock: Arc<Mutex<()>>,
+    pub session_id: Arc<Mutex<u64>>,
 }
 
 fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error> {
@@ -200,11 +204,21 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
         warm_load_state: Some("failed".into()),
+        relay_runtime_state: Some("failed".into()),
         warm_load_enabled: Some(true),
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
+        session_id: 0,
+        status_sequence: 0,
     }
+}
+
+fn is_current_session_payload(payload: &Value, current_session_id: u64) -> bool {
+    payload
+        .get("session_id")
+        .and_then(Value::as_u64)
+        .is_none_or(|payload_session_id| payload_session_id == current_session_id)
 }
 
 fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
@@ -252,6 +266,23 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
             .get("warm_load_state")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+    }
+    if payload.get("relay_runtime_state").is_some() {
+        status.relay_runtime_state = payload
+            .get("relay_runtime_state")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    } else if payload.get("warm_load_state").is_some() {
+        status.relay_runtime_state = payload
+            .get("warm_load_state")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if let Some(session_id) = payload.get("session_id").and_then(Value::as_u64) {
+        status.session_id = session_id;
+    }
+    if let Some(status_sequence) = payload.get("status_sequence").and_then(Value::as_u64) {
+        status.status_sequence = status_sequence;
     }
     if payload.get("warm_load_enabled").is_some() {
         status.warm_load_enabled = payload.get("warm_load_enabled").and_then(Value::as_bool);
@@ -335,6 +366,9 @@ fn finalize_bridge_exit(
             "running": false,
             "registered": false,
             "last_error": last_error,
+            "relay_runtime_state": status.relay_runtime_state.clone(),
+            "session_id": status.session_id,
+            "status_sequence": status.status_sequence,
         })
     })
 }
@@ -372,6 +406,12 @@ pub async fn start_compute_node(
         *child_slot = None;
         *state.stdin.lock().await = None;
     }
+
+    let session_id = {
+        let mut session_id = state.session_id.lock().await;
+        *session_id += 1;
+        *session_id
+    };
 
     let bridge_script = resolve_bridge_script(&app);
     let launcher = if is_python_script(&bridge_script) {
@@ -483,11 +523,14 @@ pub async fn start_compute_node(
                 fallback_reason: None,
                 model_path: request.model_path.clone(),
                 last_error: None,
-                warm_load_state: Some("not_started".into()),
+                warm_load_state: Some("starting".into()),
+                relay_runtime_state: Some("starting".into()),
                 warm_load_enabled: Some(true),
                 warm_load_duration_ms: None,
                 runtime_path: Some("bridge".into()),
                 relay_runtime_path: Some("bridge".into()),
+                session_id,
+                status_sequence: 0,
             };
             true
         }
@@ -517,7 +560,7 @@ pub async fn start_compute_node(
     let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
         match parse_compute_node_event_line(&line) {
-            Ok(payload) => {
+            Ok(mut payload) => {
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
                     if event_type == "error" {
                         saw_error_event = true;
@@ -525,6 +568,11 @@ pub async fn start_compute_node(
                     if event_type == "started" || event_type == "status" {
                         saw_startup_event = true;
                     }
+                }
+                payload["session_id"] = serde_json::json!(session_id);
+                let current_session_id = *state.session_id.lock().await;
+                if !is_current_session_payload(&payload, current_session_id) {
+                    continue;
                 }
                 {
                     let mut status = state.status.lock().await;
@@ -576,6 +624,10 @@ pub async fn start_compute_node(
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
     eprintln!("desktop.compute_node.stop_requested");
+    {
+        let mut session_id = state.session_id.lock().await;
+        *session_id += 1;
+    }
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
@@ -619,6 +671,9 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         let mut status = state.status.lock().await;
         status.running = false;
         status.registered = false;
+        status.relay_runtime_state = Some("stopped".into());
+        status.warm_load_state = Some("stopped".into());
+        status.last_error = None;
     }
     Ok(())
 }
@@ -697,6 +752,25 @@ mod tests {
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[test]
+    fn stale_session_payloads_are_rejected() {
+        let stale = serde_json::json!({
+            "type": "status",
+            "session_id": 1,
+            "running": true,
+            "registered": true,
+        });
+        let current = serde_json::json!({
+            "type": "status",
+            "session_id": 2,
+            "running": true,
+            "registered": false,
+        });
+
+        assert!(!is_current_session_payload(&stale, 2));
+        assert!(is_current_session_payload(&current, 2));
     }
 
     #[tokio::test]

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -667,4 +667,135 @@ describe('desktop app start failure handling', () => {
     );
     expect(screen.getByText(/Error:/).textContent).toContain('event failure path');
   });
+  it('renders compute-node lifecycle status fields from bridge payloads', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        status_sequence: 1,
+        running: true,
+        registered: false,
+        relay_runtime_state: 'warming',
+        runtime_path: 'sidecar',
+        relay_runtime_path: 'bridge',
+        active_relay_url: 'https://relay.example',
+        requested_mode: 'gpu',
+        effective_mode: null,
+        backend_available: 'unknown',
+        backend_selected: 'unknown',
+        backend_used: 'unknown',
+        fallback_reason: null,
+        model_path: '/models/relay.gguf',
+        last_error: null,
+        warm_load_enabled: true,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
+    expect(screen.getByText(/Runtime path:/).textContent).toContain('sidecar');
+    expect(screen.getByText(/Relay runtime path:/).textContent).toContain('bridge');
+    expect(screen.getByText(/Active relay URL:/).textContent).toContain('https://relay.example');
+    expect(screen.getByText(/Requested mode:/).textContent).toContain('gpu');
+    expect(screen.getByText(/Effective mode:/).textContent).toContain('pending');
+    expect(screen.getByText(/Backend available:/).textContent).toContain('unknown');
+    expect(screen.getByText(/Model path:/).textContent).toContain('/models/relay.gguf');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        status_sequence: 2,
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        effective_mode: 'cuda',
+        backend_available: 'cuda',
+        backend_selected: 'cuda',
+        backend_used: 'cuda',
+        fallback_reason: null,
+        last_error: null,
+        warm_load_enabled: true,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('ready');
+    expect(screen.getByText(/Backend available:/).textContent).toContain('cuda');
+    expect(screen.getByText(/Backend selected:/).textContent).toContain('cuda');
+    expect(screen.getByText(/Backend used:/).textContent).toContain('cuda');
+    expect(screen.getByText(/Fallback reason:/).textContent).toContain('none');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        status_sequence: 3,
+        running: true,
+        registered: true,
+        relay_runtime_state: 'processing',
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Relay runtime state:/).textContent).toContain('processing'));
+
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        session_id: 1,
+        status_sequence: 4,
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: null,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+  });
+
+  it('ignores stale compute-node events from a prior bridge session', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 2,
+        status_sequence: 1,
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        warm_load_enabled: true,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        status_sequence: 99,
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        last_error: 'old bridge failed after restart',
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.getByText(/Running:/).textContent).toContain('yes');
+    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -32,10 +32,13 @@ interface ComputeNodeStatus {
   model_path: string;
   last_error: string | null;
   warm_load_state: string | null;
+  relay_runtime_state: string | null;
   warm_load_enabled: boolean | null;
   warm_load_duration_ms: number | null;
   runtime_path: string | null;
   relay_runtime_path: string | null;
+  session_id: number | null;
+  status_sequence: number | null;
 }
 
 interface ModelArtifactInfo {
@@ -69,10 +72,13 @@ const defaultComputeStatus: ComputeNodeStatus = {
   model_path: '',
   last_error: null,
   warm_load_state: null,
+  relay_runtime_state: null,
   warm_load_enabled: null,
   warm_load_duration_ms: null,
   runtime_path: null,
   relay_runtime_path: null,
+  session_id: null,
+  status_sequence: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -106,13 +112,16 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const relayRuntimeState = computeStatus.relay_runtime_state ?? computeStatus.warm_load_state;
   const relayRuntimeReady =
     computeStatus.warm_load_enabled === false ||
-    computeStatus.warm_load_state === null ||
-    computeStatus.warm_load_state === 'ready';
+    relayRuntimeState === 'ready' ||
+    relayRuntimeState === 'processing';
   const computeNodeRegistered = computeStatus.running && computeStatus.registered && relayRuntimeReady;
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');
+  const computeSessionIdRef = useRef<number | null>(null);
+  const computeStatusSequenceRef = useRef<number | null>(null);
 
   useEffect(() => {
     invoke<BackendInfo>('detect_backend')
@@ -124,6 +133,8 @@ export function App() {
         const loadedConfig = await invoke<DesktopConfig>('load_config');
         setConfig(loadedConfig);
         const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
+        computeSessionIdRef.current = nodeStatus.session_id ?? null;
+        computeStatusSequenceRef.current = nodeStatus.status_sequence ?? null;
         setComputeStatus(nodeStatus);
 
         const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
@@ -168,6 +179,27 @@ export function App() {
   useEffect(() => {
     const unlisten = listen<Record<string, unknown>>('compute_node_event', (evt) => {
       const payload = evt.payload;
+      const eventSessionId = typeof payload.session_id === 'number' ? payload.session_id : null;
+      const eventSequence = typeof payload.status_sequence === 'number' ? payload.status_sequence : null;
+
+      if (eventSessionId !== null) {
+        const currentSessionId = computeSessionIdRef.current;
+        if (currentSessionId !== null && eventSessionId < currentSessionId) {
+          return;
+        }
+        if (currentSessionId === null || eventSessionId > currentSessionId) {
+          computeSessionIdRef.current = eventSessionId;
+          computeStatusSequenceRef.current = null;
+        }
+      }
+      if (eventSequence !== null) {
+        const currentSequence = computeStatusSequenceRef.current;
+        if (currentSequence !== null && eventSequence < currentSequence) {
+          return;
+        }
+        computeStatusSequenceRef.current = eventSequence;
+      }
+
       setComputeStatus((prev) => ({
         running:
           typeof payload.running === 'boolean'
@@ -183,17 +215,29 @@ export function App() {
         requested_mode:
           typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
         effective_mode:
-          typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
+          typeof payload.effective_mode === 'string'
+            ? payload.effective_mode
+            : payload.effective_mode === null
+              ? null
+              : prev.effective_mode,
         backend_available:
           typeof payload.backend_available === 'string'
             ? payload.backend_available
-            : prev.backend_available,
+            : payload.backend_available === null
+              ? null
+              : prev.backend_available,
         backend_selected:
           typeof payload.backend_selected === 'string'
             ? payload.backend_selected
-            : prev.backend_selected,
+            : payload.backend_selected === null
+              ? null
+              : prev.backend_selected,
         backend_used:
-          typeof payload.backend_used === 'string' ? payload.backend_used : prev.backend_used,
+          typeof payload.backend_used === 'string'
+            ? payload.backend_used
+            : payload.backend_used === null
+              ? null
+              : prev.backend_used,
         fallback_reason:
           payload.fallback_reason === null
             ? null
@@ -203,6 +247,12 @@ export function App() {
         model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
         warm_load_state:
           typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
+        relay_runtime_state:
+          typeof payload.relay_runtime_state === 'string'
+            ? payload.relay_runtime_state
+            : typeof payload.warm_load_state === 'string'
+              ? payload.warm_load_state
+              : prev.relay_runtime_state,
         warm_load_enabled:
           typeof payload.warm_load_enabled === 'boolean'
             ? payload.warm_load_enabled
@@ -216,6 +266,8 @@ export function App() {
           typeof payload.relay_runtime_path === 'string'
             ? payload.relay_runtime_path
             : prev.relay_runtime_path,
+        session_id: eventSessionId ?? prev.session_id,
+        status_sequence: eventSequence ?? prev.status_sequence,
         last_error:
           payload.last_error === null
             ? null
@@ -225,7 +277,7 @@ export function App() {
                 ? payload.message
                 : prev.last_error,
       }));
-      if (payload.type === 'started' || payload.type === 'error') {
+      if (payload.type === 'started' || payload.type === 'error' || payload.type === 'status') {
         setIsStartingComputeNode(false);
       }
       if (payload.type === 'error') {
@@ -350,7 +402,7 @@ export function App() {
       setError('');
       setComputeStatus((prev) => ({
         ...prev,
-        running: false,
+        running: true,
         registered: false,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,
@@ -361,6 +413,8 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        warm_load_state: 'starting',
+        relay_runtime_state: 'starting',
       }));
       await invoke('start_compute_node', {
         request: {
@@ -473,7 +527,7 @@ export function App() {
         <div style={{ display: 'flex', gap: 8 }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
           <button
-            disabled={!computeStatus.running}
+            disabled={!computeStatus.running || isStartingComputeNode}
             onClick={stopComputeNode}
           >
             Stop operator
@@ -481,7 +535,7 @@ export function App() {
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeNodeRegistered ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{computeStatus.warm_load_state || 'idle'}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState || 'idle'}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{computeStatus.runtime_path || 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{computeStatus.relay_runtime_path || 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -408,8 +408,69 @@ def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, mon
     started = events[0]
     assert started['offloaded_layers'] == 0
     assert started['kv_cache_device'] == 'cpu'
+    required_fields = {
+        'running',
+        'registered',
+        'relay_runtime_state',
+        'runtime_path',
+        'relay_runtime_path',
+        'active_relay_url',
+        'requested_mode',
+        'effective_mode',
+        'backend_available',
+        'backend_selected',
+        'backend_used',
+        'fallback_reason',
+        'model_path',
+        'last_error',
+        'status_sequence',
+        'emitted_at_ms',
+    }
+    for event in events:
+        if event['type'] in {'started', 'status', 'stopped'}:
+            assert required_fields <= set(event), event
     assert any(event.get('registered') is False for event in events if event['type'] == 'status')
     assert any(event.get('registered') is True for event in events if event['type'] == 'status')
+    assert events[-1]['running'] is False
+    assert events[-1]['registered'] is False
+
+
+
+def test_run_keeps_registered_false_until_runtime_ready(capsys, monkeypatch):
+    _reset_cancel_queue()
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
+    _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingThenApiV1Runtime)
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        instance = WarmingThenApiV1Runtime.last_instance
+        if instance is not None and instance.ready_started.is_set() and stop_counter['count'] > 3:
+            instance.ready_release.set()
+        return stop_counter['count'] > 8
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    warming = [event for event in events if event.get('relay_runtime_state') == 'warming']
+    assert warming
+    assert all(event.get('registered') is False for event in warming)
+    assert any(
+        event.get('type') == 'status'
+        and event.get('relay_runtime_state') == 'ready'
+        and event.get('registered') is True
+        for event in events
+    )
 
 
 def test_run_reports_model_initialization_failures(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure the desktop Tauri compute-node operator panel reflects real backend/relay/runtime state instead of stale frontend-only assumptions. 
- Avoid misleading lifecycle displays such as `Registered: yes` while the relay runtime is still warming, and ensure `Running`/`Registered` are lifecycle-accurate across start/stop/restart.

### Description
- Define and emit a structured operator status contract from the Python bridge that includes `relay_runtime_state`, `status_sequence`, `emitted_at_ms`, and preserves `warm_load_*` fields for compatibility. 
- Extend the Rust compute-node state to track `relay_runtime_state`, `session_id`, and `status_sequence`, attach session IDs to bridge events, reject stale events from prior sessions, and mark graceful stops as stopped/unregistered without leaving stale error state. 
- Update the React UI (`desktop-tauri/src/App.tsx`) to consume the canonical status payload, derive `relayRuntimeState` from `relay_runtime_state`/`warm_load_state`, gate `Registered` on runtime readiness, ignore stale session/sequence events, treat explicit `null` backend fields as pending, and disable stop while a startup is pending. 
- Add and update unit tests: Python bridge tests validate emitted payload fields and warm-load registration gating, and React tests validate lifecycle rendering, event sequencing, and stale-event rejection.

### Testing
- Ran Python unit tests: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` which passed (all tests in that file passed). 
- Ran desktop UI tests: `(cd desktop-tauri && npm test)` which passed (Vitest suite; all App tests passed). 
- Ran repository checks: `pre-commit run --all-files` which completed successfully. 
- Rust crate tests attempted locally but a full Cargo/Rust integration run can be blocked by missing system libraries (e.g., `glib-2.0.pc` / `PKG_CONFIG_PATH`) in some environments, so CI should run `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` where system deps are available; this was not run to completion in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a56b6ea34832fa35ccc8eaa464e27)