### PR TITLE
Desktop: make compute-node operator status contract and UI lifecycle accurate

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -77,6 +77,26 @@ RUNTIME_PATH_DEFAULT = "bridge"
 API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
 
+# Structured operator status contract shared by the Python bridge, Rust backend,
+# and React UI. Every lifecycle payload should carry these fields; Rust adds
+# session_id when forwarding an event to the frontend.
+OPERATOR_STATUS_FIELDS = (
+    "running",
+    "registered",
+    "relay_runtime_state",
+    "runtime_path",
+    "relay_runtime_path",
+    "active_relay_url",
+    "requested_mode",
+    "effective_mode",
+    "backend_available",
+    "backend_selected",
+    "backend_used",
+    "fallback_reason",
+    "model_path",
+    "last_error",
+)
+
 
 _POLL_CANCELLED = object()
 
@@ -429,6 +449,27 @@ def _sleep_with_cancel(seconds: float) -> bool:
     return stop_requested()
 
 
+
+def early_status_error_payload(args: argparse.Namespace, message: str) -> Dict[str, Any]:
+    return {
+        "type": "error",
+        "message": message,
+        "running": False,
+        "registered": False,
+        "relay_runtime_state": "failed",
+        "runtime_path": RUNTIME_PATH_DEFAULT,
+        "relay_runtime_path": "bridge",
+        "active_relay_url": getattr(args, "relay_url", ""),
+        "requested_mode": getattr(args, "mode", "auto"),
+        "effective_mode": None,
+        "backend_available": None,
+        "backend_selected": None,
+        "backend_used": None,
+        "fallback_reason": None,
+        "model_path": getattr(args, "model", ""),
+        "last_error": message,
+    }
+
 def run(args: argparse.Namespace) -> int:
     _stop_requested_latched.clear()
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
@@ -448,15 +489,13 @@ def run(args: argparse.Namespace) -> int:
     if dependency_setup.get("ok") != "true":
         missing = dependency_setup.get("missing") or "unknown"
         detail = dependency_setup.get("detail") or dependency_setup.get("action") or "dependency bootstrap failed"
-        emit({
-            "type": "error",
-            "message": (
-                "desktop runtime dependency preflight failed "
-                f"(interpreter={dependency_setup.get('interpreter', sys.executable)} "
-                f"import_root={dependency_setup.get('import_root', 'unknown')} "
-                f"missing={missing}): {detail}"
-            ),
-        })
+        message = (
+            "desktop runtime dependency preflight failed "
+            f"(interpreter={dependency_setup.get('interpreter', sys.executable)} "
+            f"import_root={dependency_setup.get('import_root', 'unknown')} "
+            f"missing={missing}): {detail}"
+        )
+        emit(early_status_error_payload(args, message))
         return 1
     repo_llama_cpp_shim_imported = _is_repo_llama_cpp_shim(
         runtime_setup.get("llama_module_path", "")
@@ -469,7 +508,7 @@ def run(args: argparse.Namespace) -> int:
 
     gpu_runtime_error = desktop_gpu_runtime_failure_message(args.mode, runtime_setup)
     if gpu_runtime_error:
-        emit({"type": "error", "message": gpu_runtime_error})
+        emit(early_status_error_payload(args, gpu_runtime_error))
         return 1
 
     try:
@@ -483,7 +522,8 @@ def run(args: argparse.Namespace) -> int:
             resolve_relay_url,
         )
     except ModuleNotFoundError as exc:
-        emit({"type": "error", "message": f"runtime unavailable: {exc}"})
+        message = f"runtime unavailable: {exc}"
+        emit(early_status_error_payload(args, message))
         return 1
 
     relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
@@ -524,36 +564,63 @@ def run(args: argparse.Namespace) -> int:
     warm_load_future: Optional[_DaemonWarmLoadFuture] = None
     poll_worker = _CancelablePollWorker()
 
-    def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
-        fresh_registered = registered and _registration_fresh(runtime.relay_client, active_relay_url)
+    def relay_runtime_state() -> str:
+        if warm_load_state == "failed":
+            return "failed"
+        if warm_load_state in {"not_started", "warming"}:
+            return "warming"
+        return "ready"
+
+    def operator_status_payload(
+        *,
+        event_type: str,
+        running: bool,
+        registered: bool,
+        active_relay_url: str,
+        current_last_error: Optional[str],
+        current_relay_runtime_state: Optional[str] = None,
+    ) -> Dict[str, Any]:
         diagnostics = compute_mode_diagnostics(runtime.model_manager)
-        emit(
-            {
-                "type": "status",
-                "running": True,
-                "registered": fresh_registered,
-                "active_relay_url": active_relay_url,
-                "requested_mode": diagnostics.get("requested_mode"),
-                "effective_mode": diagnostics.get("effective_mode"),
-                "backend_available": diagnostics.get("backend_available"),
-                "backend_selected": diagnostics.get("backend_selected"),
-                "backend_used": diagnostics.get("backend_used"),
-                "offloaded_layers": diagnostics.get(
-                    "offloaded_layers", diagnostics.get("n_gpu_layers")
-                ),
-                "kv_cache_device": diagnostics.get("kv_cache_device"),
-                "fallback_reason": diagnostics.get("fallback_reason"),
-                "interpreter": runtime_setup.get("interpreter", sys.executable),
-                "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-                "model_path": args.model,
-                "last_error": current_last_error,
-                "warm_load_state": warm_load_state,
-                "warm_load_enabled": warm_load_enabled,
-                "warm_load_duration_ms": warm_load_duration_ms,
-                "runtime_path": runtime_path,
-                "relay_runtime_path": relay_runtime_path,
-            }
+        return {
+            "type": event_type,
+            "running": running,
+            "registered": registered,
+            "active_relay_url": active_relay_url,
+            "requested_mode": diagnostics.get("requested_mode"),
+            "effective_mode": diagnostics.get("effective_mode"),
+            "backend_available": diagnostics.get("backend_available"),
+            "backend_selected": diagnostics.get("backend_selected"),
+            "backend_used": diagnostics.get("backend_used"),
+            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
+            "kv_cache_device": diagnostics.get("kv_cache_device"),
+            "fallback_reason": diagnostics.get("fallback_reason"),
+            "interpreter": runtime_setup.get("interpreter", sys.executable),
+            "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
+            "model_path": args.model,
+            "last_error": current_last_error,
+            "warm_load_state": warm_load_state,
+            "warm_load_enabled": warm_load_enabled,
+            "warm_load_duration_ms": warm_load_duration_ms,
+            "runtime_path": runtime_path,
+            "relay_runtime_path": relay_runtime_path,
+            "relay_runtime_state": current_relay_runtime_state or relay_runtime_state(),
+        }
+
+    def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str], current_relay_runtime_state: Optional[str] = None) -> None:
+        fresh_registered = (
+            registered
+            and relay_runtime_state() == "ready"
+            and _registration_fresh(runtime.relay_client, active_relay_url)
         )
+        emit(operator_status_payload(
+            event_type="status",
+            running=True,
+            registered=fresh_registered,
+            active_relay_url=active_relay_url,
+            current_last_error=current_last_error,
+            current_relay_runtime_state=current_relay_runtime_state,
+        ))
+
 
     def submit_api_v1_error_response(
         relay_response: Dict[str, Any],
@@ -618,9 +685,8 @@ def run(args: argparse.Namespace) -> int:
         if warm_load_future is None:
             return False
         if block and not warm_load_future.done():
-            timeout = block_timeout_seconds
             try:
-                ready = bool(warm_load_future.result(timeout=timeout))
+                ready = bool(warm_load_future.result(timeout=block_timeout_seconds))
             except concurrent.futures.TimeoutError:
                 warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
                 return False
@@ -656,7 +722,7 @@ def run(args: argparse.Namespace) -> int:
         warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
         if not ready:
             warm_load_state = "failed"
-            warm_load_failed = "failed to initialize API v1 model runtime"
+            warm_load_failed = warm_load_failed or "failed to initialize API v1 model runtime"
             print(
                 "desktop.compute_node_bridge.model_init.failed "
                 f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
@@ -698,47 +764,32 @@ def run(args: argparse.Namespace) -> int:
             active_relay_url=active_relay_url,
             current_last_error=last_error,
         )
-        emit(
-            {
-                "type": "error",
-                "message": last_error,
-                "active_relay_url": runtime.relay_client.relay_url,
-                "warm_load_state": warm_load_state,
-                "warm_load_duration_ms": warm_load_duration_ms,
-                "runtime_path": runtime_path,
-                "relay_runtime_path": relay_runtime_path,
-            }
+        error_payload = operator_status_payload(
+            event_type="error",
+            running=False,
+            registered=False,
+            active_relay_url=runtime.relay_client.relay_url,
+            current_last_error=last_error,
+            current_relay_runtime_state="failed",
         )
+        error_payload["message"] = last_error
+        emit(error_payload)
         warm_load_fatal = True
 
-    diagnostics = compute_mode_diagnostics(runtime.model_manager)
     last_error: Optional[str] = None
-    emit(
-        {
-            "type": "started",
-            "running": True,
-            "registered": False,
-            "active_relay_url": runtime.relay_client.relay_url,
-            "requested_mode": diagnostics.get("requested_mode"),
-            "effective_mode": diagnostics.get("effective_mode"),
-            "backend_available": diagnostics.get("backend_available"),
-            "backend_selected": diagnostics.get("backend_selected"),
-            "backend_used": diagnostics.get("backend_used"),
-            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
-            "kv_cache_device": diagnostics.get("kv_cache_device"),
-            "fallback_reason": diagnostics.get("fallback_reason"),
-            "interpreter": runtime_setup.get("interpreter", sys.executable),
-            "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-            "llama_repo_stub_imported": repo_llama_cpp_shim_imported,
-            "use_mock_llm": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
-            "model_path": args.model,
-            "last_error": None,
-            "warm_load_state": warm_load_state,
-            "warm_load_enabled": warm_load_enabled,
-            "runtime_path": runtime_path,
-            "relay_runtime_path": relay_runtime_path,
-        }
+    started_payload = operator_status_payload(
+        event_type="started",
+        running=True,
+        registered=False,
+        active_relay_url=runtime.relay_client.relay_url,
+        current_last_error=None,
+        current_relay_runtime_state="warming" if warm_load_enabled else "ready",
     )
+    started_payload.update({
+        "llama_repo_stub_imported": repo_llama_cpp_shim_imported,
+        "use_mock_llm": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
+    })
+    emit(started_payload)
     if runtime_path == "sidecar":
         print(
             "desktop.compute_node_bridge.runtime_path.relay_uses_bridge "
@@ -898,6 +949,12 @@ def run(args: argparse.Namespace) -> int:
         if warm_runtime_before_registration():
             while not stop_requested():
                 active_relay_url = runtime.relay_client.relay_url
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                    current_relay_runtime_state="registering",
+                )
                 print(
                     "desktop.compute_node_bridge.api_v1_e2ee.register "
                     f"relay={_sanitize_relay_target(active_relay_url)}",
@@ -965,6 +1022,12 @@ def run(args: argparse.Namespace) -> int:
                             "operator; update relay.py to repo HEAD"
                         )
                 elif api_v1_payload:
+                    emit_status_event(
+                        registered=True,
+                        active_relay_url=active_relay_url,
+                        current_last_error=last_error,
+                        current_relay_runtime_state="processing",
+                    )
                     print(
                         f"desktop.compute_node_bridge.request_route runtime_path={runtime_path} "
                         f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
@@ -1060,32 +1123,15 @@ def run(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
-    diagnostics = compute_mode_diagnostics(runtime.model_manager)
-    emit(
-        {
-            "type": "stopped",
-            "running": False,
-            "registered": False,
-            "active_relay_url": runtime.relay_client.relay_url,
-            "requested_mode": diagnostics.get("requested_mode"),
-            "effective_mode": diagnostics.get("effective_mode"),
-            "backend_available": diagnostics.get("backend_available"),
-            "backend_selected": diagnostics.get("backend_selected"),
-            "backend_used": diagnostics.get("backend_used"),
-            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
-            "kv_cache_device": diagnostics.get("kv_cache_device"),
-            "fallback_reason": diagnostics.get("fallback_reason"),
-            "interpreter": runtime_setup.get("interpreter", sys.executable),
-            "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-            "model_path": args.model,
-            "last_error": last_error,
-            "warm_load_state": warm_load_state,
-            "warm_load_enabled": warm_load_enabled,
-            "warm_load_duration_ms": warm_load_duration_ms,
-            "runtime_path": runtime_path,
-            "relay_runtime_path": relay_runtime_path,
-        }
-    )
+    stopped_error = last_error if warm_load_fatal else None
+    emit(operator_status_payload(
+        event_type="stopped",
+        running=False,
+        registered=False,
+        active_relay_url=runtime.relay_client.relay_url,
+        current_last_error=stopped_error,
+        current_relay_runtime_state="failed" if warm_load_fatal else "stopped",
+    ))
     return 1 if warm_load_fatal else 0
 
 
@@ -1101,7 +1147,8 @@ def main() -> int:
         args.mode = _normalize_compute_mode_local(args.mode)
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
-        emit({"type": "error", "message": f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"})
+        message = f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"
+        emit(early_status_error_payload(args, message))
         return 1
 
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -42,6 +42,8 @@ pub struct ComputeNodeStatus {
     pub warm_load_duration_ms: Option<u64>,
     pub runtime_path: Option<String>,
     pub relay_runtime_path: Option<String>,
+    pub relay_runtime_state: String,
+    pub session_id: u64,
 }
 
 #[derive(Clone, Default)]
@@ -50,6 +52,7 @@ pub struct ComputeNodeState {
     pub stdin: Arc<Mutex<Option<ChildStdin>>>,
     pub status: Arc<Mutex<ComputeNodeStatus>>,
     pub lifecycle_lock: Arc<Mutex<()>>,
+    pub session_id: Arc<Mutex<u64>>,
 }
 
 fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error> {
@@ -204,6 +207,8 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
+        relay_runtime_state: "failed".into(),
+        session_id: 0,
     }
 }
 
@@ -271,6 +276,12 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
     }
+    if let Some(relay_runtime_state) = payload.get("relay_runtime_state").and_then(Value::as_str) {
+        status.relay_runtime_state = relay_runtime_state.into();
+    }
+    if let Some(session_id) = payload.get("session_id").and_then(Value::as_u64) {
+        status.session_id = session_id;
+    }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
             .get("message")
@@ -319,6 +330,7 @@ fn finalize_bridge_exit(
 ) -> Option<Value> {
     status.running = false;
     status.registered = false;
+    status.relay_runtime_state = "stopped".into();
 
     let exit_error = bridge_exit_error(exit_status, saw_startup_event);
     if status.last_error.is_none() {
@@ -334,6 +346,7 @@ fn finalize_bridge_exit(
             "type": "error",
             "running": false,
             "registered": false,
+            "relay_runtime_state": "failed",
             "last_error": last_error,
         })
     })
@@ -372,6 +385,12 @@ pub async fn start_compute_node(
         *child_slot = None;
         *state.stdin.lock().await = None;
     }
+
+    let session_id = {
+        let mut session_id = state.session_id.lock().await;
+        *session_id += 1;
+        *session_id
+    };
 
     let bridge_script = resolve_bridge_script(&app);
     let launcher = if is_python_script(&bridge_script) {
@@ -488,6 +507,8 @@ pub async fn start_compute_node(
                 warm_load_duration_ms: None,
                 runtime_path: Some("bridge".into()),
                 relay_runtime_path: Some("bridge".into()),
+                relay_runtime_state: "starting".into(),
+                session_id,
             };
             true
         }
@@ -503,6 +524,34 @@ pub async fn start_compute_node(
             let _ = abandoned_child.wait().await;
         }
         anyhow::bail!("compute node already running; stop it before starting a new session");
+    }
+
+    {
+        let status = state.status.lock().await.clone();
+        app.emit(
+            "compute_node_event",
+            serde_json::json!({
+                "type": "status",
+                "running": status.running,
+                "registered": status.registered,
+                "active_relay_url": status.active_relay_url,
+                "requested_mode": status.requested_mode,
+                "effective_mode": status.effective_mode,
+                "backend_available": status.backend_available,
+                "backend_selected": status.backend_selected,
+                "backend_used": status.backend_used,
+                "fallback_reason": status.fallback_reason,
+                "model_path": status.model_path,
+                "last_error": status.last_error,
+                "warm_load_state": status.warm_load_state,
+                "warm_load_enabled": status.warm_load_enabled,
+                "warm_load_duration_ms": status.warm_load_duration_ms,
+                "runtime_path": status.runtime_path,
+                "relay_runtime_path": status.relay_runtime_path,
+                "relay_runtime_state": status.relay_runtime_state,
+                "session_id": status.session_id,
+            }),
+        )?;
     }
 
     let log_policy = SubprocessLogPolicy::from_env();
@@ -525,6 +574,14 @@ pub async fn start_compute_node(
                     if event_type == "started" || event_type == "status" {
                         saw_startup_event = true;
                     }
+                }
+                let mut payload = payload;
+                if let Some(object) = payload.as_object_mut() {
+                    object.insert("session_id".into(), Value::from(session_id));
+                }
+                let current_session_id = *state.session_id.lock().await;
+                if current_session_id != session_id {
+                    continue;
                 }
                 {
                     let mut status = state.status.lock().await;
@@ -558,13 +615,20 @@ pub async fn start_compute_node(
             finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
-        if let Some(payload) = exit_payload {
-            app.emit("compute_node_event", payload)?;
+        if let Some(mut payload) = exit_payload {
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("session_id".into(), Value::from(session_id));
+            }
+            if *state.session_id.lock().await == session_id {
+                app.emit("compute_node_event", payload)?;
+            }
         }
     } else {
         let mut status = state.status.lock().await;
         status.running = false;
         status.registered = false;
+        status.relay_runtime_state = "stopped".into();
+        status.last_error = None;
     }
     {
         let _lifecycle_lock = state.lifecycle_lock.lock().await;
@@ -615,10 +679,19 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
     }
 
+    let next_session_id = {
+        let mut session_id = state.session_id.lock().await;
+        *session_id += 1;
+        *session_id
+    };
+
     {
         let mut status = state.status.lock().await;
         status.running = false;
         status.registered = false;
+        status.relay_runtime_state = "stopped".into();
+        status.last_error = None;
+        status.session_id = next_session_id;
     }
     Ok(())
 }
@@ -933,6 +1006,55 @@ mod tests {
             payload.get("last_error").and_then(Value::as_str),
             Some(last_error)
         );
+    }
+
+    #[test]
+    fn update_status_from_event_records_runtime_state_and_session_id() {
+        let mut status = ComputeNodeStatus::default();
+        let payload = serde_json::json!({
+            "type": "status",
+            "running": true,
+            "registered": false,
+            "relay_runtime_state": "warming",
+            "session_id": 3,
+        });
+
+        update_status_from_event(&mut status, &payload);
+
+        assert!(status.running);
+        assert!(!status.registered);
+        assert_eq!(status.relay_runtime_state, "warming");
+        assert_eq!(status.session_id, 3);
+    }
+
+    #[test]
+    fn stale_session_payload_would_not_overwrite_newer_status() {
+        let mut status = ComputeNodeStatus {
+            running: true,
+            registered: false,
+            relay_runtime_state: "starting".into(),
+            session_id: 2,
+            ..ComputeNodeStatus::default()
+        };
+        let stale_payload = serde_json::json!({
+            "type": "status",
+            "running": false,
+            "registered": false,
+            "relay_runtime_state": "stopped",
+            "session_id": 1,
+        });
+
+        if stale_payload
+            .get("session_id")
+            .and_then(Value::as_u64)
+            .is_none_or(|incoming| incoming >= status.session_id)
+        {
+            update_status_from_event(&mut status, &stale_payload);
+        }
+
+        assert!(status.running);
+        assert_eq!(status.relay_runtime_state, "starting");
+        assert_eq!(status.session_id, 2);
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -281,10 +281,17 @@ async fn start_compute_node(
             compute_node::start_compute_node(app.clone(), compute_state.clone(), request).await
         {
             eprintln!("desktop.compute_node.start_failure error={}", err);
+            let session_id = {
+                let status_session = compute_state.status.lock().await.session_id;
+                let current_session = *compute_state.session_id.lock().await;
+                status_session.max(current_session)
+            };
             {
                 let mut status = compute_state.status.lock().await;
                 status.running = false;
                 status.registered = false;
+                status.relay_runtime_state = "failed".into();
+                status.session_id = session_id;
                 status.last_error = Some(err.to_string());
             }
             let _ = app.emit(
@@ -293,6 +300,8 @@ async fn start_compute_node(
                     "type": "error",
                     "running": false,
                     "registered": false,
+                    "relay_runtime_state": "failed",
+                    "session_id": session_id,
                     "last_error": err.to_string(),
                     "message": err.to_string(),
                 }),

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1,24 +1,33 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App";
 
 const invokeMock = vi.fn();
 const listenMock = vi.fn();
-const eventHandlers = new Map<string, (evt: { payload: Record<string, unknown> }) => void>();
+const eventHandlers = new Map<
+  string,
+  (evt: { payload: Record<string, unknown> }) => void
+>();
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
 }));
 
-vi.mock('@tauri-apps/api/event', () => ({
+vi.mock("@tauri-apps/api/event", () => ({
   listen: (...args: unknown[]) => listenMock(...args),
 }));
 
-vi.mock('@tauri-apps/plugin-dialog', () => ({
+vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
 }));
 
-describe('desktop app start failure handling', () => {
+describe("desktop app start failure handling", () => {
   afterEach(() => {
     cleanup();
   });
@@ -28,48 +37,55 @@ describe('desktop app start failure handling', () => {
     listenMock.mockReset();
     eventHandlers.clear();
     listenMock.mockImplementation((event: string, handler: unknown) => {
-      eventHandlers.set(event, handler as (evt: { payload: Record<string, unknown> }) => void);
+      eventHandlers.set(
+        event,
+        handler as (evt: { payload: Record<string, unknown> }) => void,
+      );
       return Promise.resolve(() => {});
     });
 
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'detect_backend') {
+      if (command === "detect_backend") {
         return Promise.resolve({
-          platform_label: 'macos',
-          preferred_mode: 'auto',
-          available_backend: 'metal',
-          availability_label: 'Metal-capable platform (Apple Silicon)',
+          platform_label: "macos",
+          preferred_mode: "auto",
+          available_backend: "metal",
+          availability_label: "Metal-capable platform (Apple Silicon)",
         });
       }
-      if (command === 'load_config') {
+      if (command === "load_config") {
         return Promise.resolve({
-          model_path: '/tmp/model.gguf',
-          relay_base_url: 'https://token.place',
-          preferred_mode: 'auto',
+          model_path: "/tmp/model.gguf",
+          relay_base_url: "https://token.place",
+          preferred_mode: "auto",
         });
       }
-      if (command === 'get_compute_node_status') {
+      if (command === "get_compute_node_status") {
         return Promise.resolve({
           running: false,
           registered: false,
-          active_relay_url: '',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
+          active_relay_url: "",
+          requested_mode: "auto",
+          effective_mode: "cpu",
+          backend_available: "unknown",
+          backend_selected: "cpu",
+          backend_used: "cpu",
           fallback_reason: null,
-          model_path: '',
+          model_path: "",
           last_error: null,
+          relay_runtime_state: "idle",
+          runtime_path: null,
+          relay_runtime_path: null,
+          session_id: 0,
         });
       }
-      if (command === 'inspect_model_artifact') {
+      if (command === "inspect_model_artifact") {
         return Promise.resolve({
-          canonical_family_url: 'https://example.test/models',
-          filename: 'model.gguf',
-          url: 'https://example.test/model.gguf',
-          models_dir: '/tmp',
-          resolved_model_path: '/tmp/model.gguf',
+          canonical_family_url: "https://example.test/models",
+          filename: "model.gguf",
+          url: "https://example.test/model.gguf",
+          models_dir: "/tmp",
+          resolved_model_path: "/tmp/model.gguf",
           exists: true,
           size_bytes: 1,
         });
@@ -78,47 +94,52 @@ describe('desktop app start failure handling', () => {
     });
   });
 
-
-  const mockInitialComputeStatus = (statusOverrides: Record<string, unknown>) => {
+  const mockInitialComputeStatus = (
+    statusOverrides: Record<string, unknown>,
+  ) => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'detect_backend') {
+      if (command === "detect_backend") {
         return Promise.resolve({
-          platform_label: 'macos',
-          preferred_mode: 'auto',
-          available_backend: 'metal',
-          availability_label: 'Metal-capable platform (Apple Silicon)',
+          platform_label: "macos",
+          preferred_mode: "auto",
+          available_backend: "metal",
+          availability_label: "Metal-capable platform (Apple Silicon)",
         });
       }
-      if (command === 'load_config') {
+      if (command === "load_config") {
         return Promise.resolve({
-          model_path: '/tmp/model.gguf',
-          relay_base_url: 'https://token.place',
-          preferred_mode: 'auto',
+          model_path: "/tmp/model.gguf",
+          relay_base_url: "https://token.place",
+          preferred_mode: "auto",
         });
       }
-      if (command === 'get_compute_node_status') {
+      if (command === "get_compute_node_status") {
         return Promise.resolve({
           running: false,
           registered: false,
-          active_relay_url: '',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
+          active_relay_url: "",
+          requested_mode: "auto",
+          effective_mode: "cpu",
+          backend_available: "unknown",
+          backend_selected: "cpu",
+          backend_used: "cpu",
           fallback_reason: null,
-          model_path: '',
+          model_path: "",
           last_error: null,
+          relay_runtime_state: "idle",
+          runtime_path: null,
+          relay_runtime_path: null,
+          session_id: 0,
           ...statusOverrides,
         });
       }
-      if (command === 'inspect_model_artifact') {
+      if (command === "inspect_model_artifact") {
         return Promise.resolve({
-          canonical_family_url: 'https://example.test/models',
-          filename: 'model.gguf',
-          url: 'https://example.test/model.gguf',
-          models_dir: '/tmp',
-          resolved_model_path: '/tmp/model.gguf',
+          canonical_family_url: "https://example.test/models",
+          filename: "model.gguf",
+          url: "https://example.test/model.gguf",
+          models_dir: "/tmp",
+          resolved_model_path: "/tmp/model.gguf",
           exists: true,
           size_bytes: 1,
         });
@@ -127,232 +148,255 @@ describe('desktop app start failure handling', () => {
     });
   };
 
-  it('moves local inference from starting to failed when invoke rejects', async () => {
+  it("moves local inference from starting to failed when invoke rejects", async () => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'start_inference') {
-        return Promise.reject(new Error('python runtime unavailable'));
+      if (command === "start_inference") {
+        return Promise.reject(new Error("python runtime unavailable"));
       }
       return Promise.resolve(
-        command === 'load_config'
+        command === "load_config"
           ? {
-              model_path: '/tmp/model.gguf',
-              relay_base_url: 'https://token.place',
-              preferred_mode: 'auto',
+              model_path: "/tmp/model.gguf",
+              relay_base_url: "https://token.place",
+              preferred_mode: "auto",
             }
-          : command === 'detect_backend'
+          : command === "detect_backend"
             ? {
-                platform_label: 'macos',
-                preferred_mode: 'auto',
-                available_backend: 'metal',
-                availability_label: 'Metal-capable platform (Apple Silicon)',
+                platform_label: "macos",
+                preferred_mode: "auto",
+                available_backend: "metal",
+                availability_label: "Metal-capable platform (Apple Silicon)",
               }
-            : command === 'get_compute_node_status'
+            : command === "get_compute_node_status"
               ? {
                   running: false,
                   registered: false,
-                  active_relay_url: '',
-                  requested_mode: 'auto',
-                  effective_mode: 'cpu',
-                  backend_available: 'unknown',
-                  backend_selected: 'cpu',
-                  backend_used: 'cpu',
+                  active_relay_url: "",
+                  requested_mode: "auto",
+                  effective_mode: "cpu",
+                  backend_available: "unknown",
+                  backend_selected: "cpu",
+                  backend_used: "cpu",
                   fallback_reason: null,
-                  model_path: '',
+                  model_path: "",
                   last_error: null,
                 }
               : {
-                  canonical_family_url: 'https://example.test/models',
-                  filename: 'model.gguf',
-                  url: 'https://example.test/model.gguf',
-                  models_dir: '/tmp',
-                  resolved_model_path: '/tmp/model.gguf',
+                  canonical_family_url: "https://example.test/models",
+                  filename: "model.gguf",
+                  url: "https://example.test/model.gguf",
+                  models_dir: "/tmp",
+                  resolved_model_path: "/tmp/model.gguf",
                   exists: true,
                   size_bytes: 1,
-                }
+                },
       );
     });
 
     render(<App />);
-    const promptArea = (await screen.findByText('Prompt'))
-      .parentElement?.querySelector('textarea');
+    const promptArea = (
+      await screen.findByText("Prompt")
+    ).parentElement?.querySelector("textarea");
     expect(promptArea).toBeTruthy();
-    fireEvent.change(promptArea as HTMLTextAreaElement, { target: { value: 'hello' } });
+    fireEvent.change(promptArea as HTMLTextAreaElement, {
+      target: { value: "hello" },
+    });
     const startInferenceButton = (await screen.findByText(
-      'Start local inference'
+      "Start local inference",
     )) as HTMLButtonElement;
     await waitFor(() => expect(startInferenceButton.disabled).toBe(false));
     fireEvent.click(startInferenceButton);
 
     await waitFor(() =>
-      expect(screen.getByText('Status:').textContent).toContain('failed')
+      expect(screen.getByText("Status:").textContent).toContain("failed"),
     );
     expect(screen.getByText(/Error:/).textContent).toContain(
-      'python runtime unavailable'
+      "python runtime unavailable",
     );
   });
 
-  it('surfaces compute-node start failures in last error', async () => {
+  it("surfaces compute-node start failures in last error", async () => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'start_compute_node') {
-        return Promise.reject(new Error('relay unreachable'));
+      if (command === "start_compute_node") {
+        return Promise.reject(new Error("relay unreachable"));
       }
-      if (command === 'detect_backend') {
+      if (command === "detect_backend") {
         return Promise.resolve({
-          platform_label: 'macos',
-          preferred_mode: 'auto',
-          available_backend: 'metal',
-          availability_label: 'Metal-capable platform (Apple Silicon)',
+          platform_label: "macos",
+          preferred_mode: "auto",
+          available_backend: "metal",
+          availability_label: "Metal-capable platform (Apple Silicon)",
         });
       }
-      if (command === 'load_config') {
+      if (command === "load_config") {
         return Promise.resolve({
-          model_path: '/tmp/model.gguf',
-          relay_base_url: 'https://token.place',
-          preferred_mode: 'auto',
+          model_path: "/tmp/model.gguf",
+          relay_base_url: "https://token.place",
+          preferred_mode: "auto",
         });
       }
-      if (command === 'get_compute_node_status') {
+      if (command === "get_compute_node_status") {
         return Promise.resolve({
           running: false,
           registered: false,
-          active_relay_url: '',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
+          active_relay_url: "",
+          requested_mode: "auto",
+          effective_mode: "cpu",
+          backend_available: "unknown",
+          backend_selected: "cpu",
+          backend_used: "cpu",
           fallback_reason: null,
-          model_path: '',
+          model_path: "",
           last_error: null,
+          relay_runtime_state: "idle",
+          runtime_path: null,
+          relay_runtime_path: null,
+          session_id: 0,
         });
       }
       return Promise.resolve({
-        canonical_family_url: 'https://example.test/models',
-        filename: 'model.gguf',
-        url: 'https://example.test/model.gguf',
-        models_dir: '/tmp',
-        resolved_model_path: '/tmp/model.gguf',
+        canonical_family_url: "https://example.test/models",
+        filename: "model.gguf",
+        url: "https://example.test/model.gguf",
+        models_dir: "/tmp",
+        resolved_model_path: "/tmp/model.gguf",
         exists: true,
         size_bytes: 1,
       });
     });
 
     render(<App />);
-    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    const startOperatorButton = (await screen.findByText(
+      "Start operator",
+    )) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
     fireEvent.click(startOperatorButton);
     await waitFor(() =>
       expect(screen.getByText(/Last error:/).textContent).toContain(
-        'relay unreachable'
-      )
+        "relay unreachable",
+      ),
     );
   });
 
-  it('blocks duplicate start clicks while compute-node startup is pending', async () => {
+  it("blocks duplicate start clicks while compute-node startup is pending", async () => {
     let resolveStart: (() => void) | undefined;
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'start_compute_node') {
+      if (command === "start_compute_node") {
         return new Promise<void>((resolve) => {
           resolveStart = resolve;
         });
       }
-      if (command === 'detect_backend') {
+      if (command === "detect_backend") {
         return Promise.resolve({
-          platform_label: 'macos',
-          preferred_mode: 'auto',
-          available_backend: 'metal',
-          availability_label: 'Metal-capable platform (Apple Silicon)',
+          platform_label: "macos",
+          preferred_mode: "auto",
+          available_backend: "metal",
+          availability_label: "Metal-capable platform (Apple Silicon)",
         });
       }
-      if (command === 'load_config') {
+      if (command === "load_config") {
         return Promise.resolve({
-          model_path: '/tmp/model.gguf',
-          relay_base_url: 'https://token.place',
-          preferred_mode: 'auto',
+          model_path: "/tmp/model.gguf",
+          relay_base_url: "https://token.place",
+          preferred_mode: "auto",
         });
       }
-      if (command === 'get_compute_node_status') {
+      if (command === "get_compute_node_status") {
         return Promise.resolve({
           running: false,
           registered: false,
-          active_relay_url: '',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
+          active_relay_url: "",
+          requested_mode: "auto",
+          effective_mode: "cpu",
+          backend_available: "unknown",
+          backend_selected: "cpu",
+          backend_used: "cpu",
           fallback_reason: null,
-          model_path: '',
+          model_path: "",
           last_error: null,
+          relay_runtime_state: "idle",
+          runtime_path: null,
+          relay_runtime_path: null,
+          session_id: 0,
         });
       }
       return Promise.resolve({
-        canonical_family_url: 'https://example.test/models',
-        filename: 'model.gguf',
-        url: 'https://example.test/model.gguf',
-        models_dir: '/tmp',
-        resolved_model_path: '/tmp/model.gguf',
+        canonical_family_url: "https://example.test/models",
+        filename: "model.gguf",
+        url: "https://example.test/model.gguf",
+        models_dir: "/tmp",
+        resolved_model_path: "/tmp/model.gguf",
         exists: true,
         size_bytes: 1,
       });
     });
 
     render(<App />);
-    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
-    const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+    const startOperatorButton = (await screen.findByText(
+      "Start operator",
+    )) as HTMLButtonElement;
+    const stopOperatorButton = (await screen.findByText(
+      "Stop operator",
+    )) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
 
     fireEvent.click(startOperatorButton);
     fireEvent.click(startOperatorButton);
 
     expect(
-      invokeMock.mock.calls.filter(([command]) => command === 'start_compute_node')
+      invokeMock.mock.calls.filter(
+        ([command]) => command === "start_compute_node",
+      ),
     ).toHaveLength(1);
     expect(startOperatorButton.disabled).toBe(true);
-    expect(stopOperatorButton.disabled).toBe(true);
+    expect(stopOperatorButton.disabled).toBe(false);
 
     resolveStart?.();
   });
 
-  it('keeps model path blank on first launch when config has no persisted model path', async () => {
+  it("keeps model path blank on first launch when config has no persisted model path", async () => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'detect_backend') {
+      if (command === "detect_backend") {
         return Promise.resolve({
-          platform_label: 'macos',
-          preferred_mode: 'auto',
-          available_backend: 'metal',
-          availability_label: 'Metal-capable platform (Apple Silicon)',
+          platform_label: "macos",
+          preferred_mode: "auto",
+          available_backend: "metal",
+          availability_label: "Metal-capable platform (Apple Silicon)",
         });
       }
-      if (command === 'load_config') {
+      if (command === "load_config") {
         return Promise.resolve({
-          model_path: '',
-          relay_base_url: 'https://token.place',
-          preferred_mode: 'auto',
+          model_path: "",
+          relay_base_url: "https://token.place",
+          preferred_mode: "auto",
         });
       }
-      if (command === 'get_compute_node_status') {
+      if (command === "get_compute_node_status") {
         return Promise.resolve({
           running: false,
           registered: false,
-          active_relay_url: '',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
+          active_relay_url: "",
+          requested_mode: "auto",
+          effective_mode: "cpu",
+          backend_available: "unknown",
+          backend_selected: "cpu",
+          backend_used: "cpu",
           fallback_reason: null,
-          model_path: '',
+          model_path: "",
           last_error: null,
+          relay_runtime_state: "idle",
+          runtime_path: null,
+          relay_runtime_path: null,
+          session_id: 0,
         });
       }
-      if (command === 'inspect_model_artifact') {
+      if (command === "inspect_model_artifact") {
         return Promise.resolve({
-          canonical_family_url: 'https://example.test/models',
-          filename: 'model.gguf',
-          url: 'https://example.test/model.gguf',
-          models_dir: '/tmp',
-          resolved_model_path: 'C:\\Users\\dev\\Downloads\\model.gguf',
+          canonical_family_url: "https://example.test/models",
+          filename: "model.gguf",
+          url: "https://example.test/model.gguf",
+          models_dir: "/tmp",
+          resolved_model_path: "C:\\Users\\dev\\Downloads\\model.gguf",
           exists: false,
           size_bytes: null,
         });
@@ -361,310 +405,524 @@ describe('desktop app start failure handling', () => {
     });
 
     render(<App />);
-    const modelInput = (await screen.findByLabelText('Model GGUF path')) as HTMLInputElement;
-    await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe(''));
+    const modelInput = (await screen.findByLabelText(
+      "Model GGUF path",
+    )) as HTMLInputElement;
+    await waitFor(() =>
+      expect((modelInput as HTMLInputElement).value).toBe(""),
+    );
     expect(
       invokeMock.mock.calls.some(
         (call) =>
-          call[0] === 'save_config' &&
-          typeof call[1]?.config?.model_path === 'string' &&
-          call[1].config.model_path.includes('C:\\Users\\dev')
-      )
+          call[0] === "save_config" &&
+          typeof call[1]?.config?.model_path === "string" &&
+          call[1].config.model_path.includes("C:\\Users\\dev"),
+      ),
     ).toBe(false);
   });
 
-  it('restores persisted user-selected model path from saved config', async () => {
+  it("restores persisted user-selected model path from saved config", async () => {
     render(<App />);
-    const modelInput = (await screen.findByLabelText('Model GGUF path')) as HTMLInputElement;
-    await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe('/tmp/model.gguf'));
+    const modelInput = (await screen.findByLabelText(
+      "Model GGUF path",
+    )) as HTMLInputElement;
+    await waitFor(() =>
+      expect((modelInput as HTMLInputElement).value).toBe("/tmp/model.gguf"),
+    );
   });
 
-  it('surfaces bridge startup exits through compute_node_event errors', async () => {
+  it("surfaces bridge startup exits through compute_node_event errors", async () => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'start_compute_node') {
+      if (command === "start_compute_node") {
         return Promise.resolve(undefined);
       }
-      if (command === 'detect_backend') {
+      if (command === "detect_backend") {
         return Promise.resolve({
-          platform_label: 'macos',
-          preferred_mode: 'auto',
-          available_backend: 'metal',
-          availability_label: 'Metal-capable platform (Apple Silicon)',
+          platform_label: "macos",
+          preferred_mode: "auto",
+          available_backend: "metal",
+          availability_label: "Metal-capable platform (Apple Silicon)",
         });
       }
-      if (command === 'load_config') {
+      if (command === "load_config") {
         return Promise.resolve({
-          model_path: '/tmp/model.gguf',
-          relay_base_url: 'https://token.place',
-          preferred_mode: 'auto',
+          model_path: "/tmp/model.gguf",
+          relay_base_url: "https://token.place",
+          preferred_mode: "auto",
         });
       }
-      if (command === 'get_compute_node_status') {
+      if (command === "get_compute_node_status") {
         return Promise.resolve({
           running: false,
           registered: false,
-          active_relay_url: '',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
+          active_relay_url: "",
+          requested_mode: "auto",
+          effective_mode: "cpu",
+          backend_available: "unknown",
+          backend_selected: "cpu",
+          backend_used: "cpu",
           fallback_reason: null,
-          model_path: '',
+          model_path: "",
           last_error: null,
+          relay_runtime_state: "idle",
+          runtime_path: null,
+          relay_runtime_path: null,
+          session_id: 0,
         });
       }
       return Promise.resolve({
-        canonical_family_url: 'https://example.test/models',
-        filename: 'model.gguf',
-        url: 'https://example.test/model.gguf',
-        models_dir: '/tmp',
-        resolved_model_path: '/tmp/model.gguf',
+        canonical_family_url: "https://example.test/models",
+        filename: "model.gguf",
+        url: "https://example.test/model.gguf",
+        models_dir: "/tmp",
+        resolved_model_path: "/tmp/model.gguf",
         exists: true,
         size_bytes: 1,
       });
     });
 
     render(<App />);
-    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    const startOperatorButton = (await screen.findByText(
+      "Start operator",
+    )) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
     fireEvent.click(startOperatorButton);
 
-    const computeHandler = eventHandlers.get('compute_node_event');
+    const computeHandler = eventHandlers.get("compute_node_event");
     expect(computeHandler).toBeTruthy();
     computeHandler?.({
       payload: {
-        type: 'error',
+        type: "error",
         running: false,
         registered: false,
         last_error:
-          'compute-node bridge exited with status 0 before emitting a startup event',
+          "compute-node bridge exited with status 0 before emitting a startup event",
       },
     });
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("no"),
+    );
     expect(screen.getByText(/Last error:/).textContent).toContain(
-      'before emitting a startup event'
+      "before emitting a startup event",
     );
   });
 
-  it('keeps running state healthy when started and status events are healthy', async () => {
+  it("keeps running state healthy when started and status events are healthy", async () => {
     render(<App />);
-    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    const startOperatorButton = (await screen.findByText(
+      "Start operator",
+    )) as HTMLButtonElement;
     await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
     fireEvent.click(startOperatorButton);
 
-    const computeHandler = eventHandlers.get('compute_node_event');
+    const computeHandler = eventHandlers.get("compute_node_event");
     expect(computeHandler).toBeTruthy();
     computeHandler?.({
       payload: {
-        type: 'started',
+        type: "started",
         running: true,
         registered: false,
+        relay_runtime_state: "warming",
         last_error: null,
       },
     });
     computeHandler?.({
       payload: {
-        type: 'status',
+        type: "status",
         running: true,
         registered: true,
-        warm_load_state: 'ready',
+        warm_load_state: "ready",
+        relay_runtime_state: "ready",
         last_error: null,
       },
     });
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
-    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/Registered:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Last error:/).textContent).toContain("none");
   });
 
-
-  it('does not display registered yes while relay runtime is warming', async () => {
+  it("does not display registered yes while relay runtime is warming", async () => {
     render(<App />);
-    await screen.findByText('Start operator');
+    await screen.findByText("Start operator");
 
-    const computeHandler = eventHandlers.get('compute_node_event');
+    const computeHandler = eventHandlers.get("compute_node_event");
     expect(computeHandler).toBeTruthy();
     computeHandler?.({
       payload: {
-        type: 'status',
+        type: "status",
         running: true,
         registered: true,
-        warm_load_state: 'warming',
-        effective_mode: 'pending',
-        backend_available: 'unknown',
-        backend_selected: 'unknown',
-        backend_used: 'unknown',
+        warm_load_state: "warming",
+        relay_runtime_state: "warming",
+        effective_mode: "pending",
+        backend_available: "unknown",
+        backend_selected: "unknown",
+        backend_used: "unknown",
         last_error: null,
       },
     });
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('no');
-    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("no");
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+      "warming",
+    );
   });
 
-
-  it('replays cached warming readiness and relay runtime path without showing registered yes', async () => {
+  it("replays cached warming readiness and relay runtime path without showing registered yes", async () => {
     mockInitialComputeStatus({
       running: true,
       registered: true,
-      active_relay_url: 'https://token.place',
-      model_path: '/tmp/model.gguf',
-      warm_load_state: 'warming',
+      active_relay_url: "https://token.place",
+      model_path: "/tmp/model.gguf",
+      warm_load_state: "warming",
+      relay_runtime_state: "warming",
       warm_load_enabled: true,
       warm_load_duration_ms: 25,
-      runtime_path: 'sidecar',
-      relay_runtime_path: 'bridge',
+      runtime_path: "sidecar",
+      relay_runtime_path: "bridge",
     });
 
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('no');
-    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
-    expect(screen.getByText(/Relay runtime path:/).textContent).toContain('bridge');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("no");
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+      "warming",
+    );
+    expect(screen.getByText(/Relay runtime path:/).textContent).toContain(
+      "bridge",
+    );
   });
 
-  it('allows cached ready relay runtime status to display registered yes', async () => {
+  it("allows cached ready relay runtime status to display registered yes", async () => {
     mockInitialComputeStatus({
       running: true,
       registered: true,
-      active_relay_url: 'https://token.place',
-      model_path: '/tmp/model.gguf',
-      warm_load_state: 'ready',
+      active_relay_url: "https://token.place",
+      model_path: "/tmp/model.gguf",
+      warm_load_state: "ready",
+      relay_runtime_state: "ready",
       warm_load_enabled: true,
       warm_load_duration_ms: 25,
-      runtime_path: 'bridge',
-      relay_runtime_path: 'bridge',
+      runtime_path: "bridge",
+      relay_runtime_path: "bridge",
     });
 
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
-    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('ready');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("yes");
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+      "ready",
+    );
   });
 
-  it('allows cached registered status when warm-load is disabled', async () => {
+  it("allows cached registered status when warm-load is disabled", async () => {
     mockInitialComputeStatus({
       running: true,
       registered: true,
-      active_relay_url: 'https://token.place',
-      model_path: '/tmp/model.gguf',
-      warm_load_state: 'not_started',
+      active_relay_url: "https://token.place",
+      model_path: "/tmp/model.gguf",
+      warm_load_state: "ready",
+      relay_runtime_state: "ready",
       warm_load_enabled: false,
       warm_load_duration_ms: null,
-      runtime_path: 'bridge',
-      relay_runtime_path: 'bridge',
+      runtime_path: "bridge",
+      relay_runtime_path: "bridge",
     });
 
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
-    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('not_started');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("yes");
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+      "ready",
+    );
   });
 
-  it('does not display registered yes for stopped cached compute node status', async () => {
+  it("does not display registered yes for stopped cached compute node status", async () => {
     mockInitialComputeStatus({
       running: false,
       registered: true,
-      active_relay_url: 'https://token.place',
-      model_path: '/tmp/model.gguf',
-      warm_load_state: 'ready',
+      active_relay_url: "https://token.place",
+      model_path: "/tmp/model.gguf",
+      warm_load_state: "ready",
+      relay_runtime_state: "ready",
       warm_load_enabled: true,
       warm_load_duration_ms: 25,
-      runtime_path: 'bridge',
-      relay_runtime_path: 'bridge',
+      runtime_path: "bridge",
+      relay_runtime_path: "bridge",
     });
 
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("no"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("no");
   });
 
-
-  it('invokes backend stop and reflects stopped operator event', async () => {
+  it("invokes backend stop and reflects stopped operator event", async () => {
     mockInitialComputeStatus({
       running: true,
       registered: true,
-      active_relay_url: 'https://token.place',
-      warm_load_state: 'ready',
+      active_relay_url: "https://token.place",
+      warm_load_state: "ready",
+      relay_runtime_state: "ready",
       warm_load_enabled: true,
     });
 
     render(<App />);
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("yes");
 
-    const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+    const stopOperatorButton = (await screen.findByText(
+      "Stop operator",
+    )) as HTMLButtonElement;
     fireEvent.click(stopOperatorButton);
 
     await waitFor(() =>
-      expect(invokeMock.mock.calls.some(([command]) => command === 'stop_compute_node')).toBe(true)
+      expect(
+        invokeMock.mock.calls.some(
+          ([command]) => command === "stop_compute_node",
+        ),
+      ).toBe(true),
     );
 
-    const computeHandler = eventHandlers.get('compute_node_event');
+    const computeHandler = eventHandlers.get("compute_node_event");
     expect(computeHandler).toBeTruthy();
     computeHandler?.({
       payload: {
-        type: 'stopped',
+        type: "stopped",
         running: false,
         registered: false,
-        active_relay_url: 'https://token.place',
+        active_relay_url: "https://token.place",
+        relay_runtime_state: "stopped",
       },
     });
 
-    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
-    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("no"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("no");
   });
 
-  it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
+  it("renders every compute operator field from ready status payload", async () => {
     render(<App />);
-    const promptArea = (await screen.findByText('Prompt'))
-      .parentElement?.querySelector('textarea');
+    await screen.findByText("Start operator");
+
+    const computeHandler = eventHandlers.get("compute_node_event");
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: "status",
+        running: true,
+        registered: true,
+        relay_runtime_state: "ready",
+        runtime_path: "sidecar",
+        relay_runtime_path: "bridge",
+        active_relay_url: "https://relay.example",
+        requested_mode: "gpu",
+        effective_mode: "gpu",
+        backend_available: "cuda",
+        backend_selected: "cuda",
+        backend_used: "cuda",
+        fallback_reason: null,
+        model_path: "/models/cuda.gguf",
+        last_error: null,
+        session_id: 1,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("yes");
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+      "ready",
+    );
+    expect(screen.getByText(/Runtime path:/).textContent).toContain("sidecar");
+    expect(screen.getByText(/Relay runtime path:/).textContent).toContain(
+      "bridge",
+    );
+    expect(screen.getByText(/Active relay URL:/).textContent).toContain(
+      "https://relay.example",
+    );
+    expect(screen.getByText(/Requested mode:/).textContent).toContain("gpu");
+    expect(screen.getByText(/Effective mode:/).textContent).toContain("gpu");
+    expect(screen.getByText(/Backend available:/).textContent).toContain(
+      "cuda",
+    );
+    expect(screen.getByText(/Backend selected:/).textContent).toContain("cuda");
+    expect(screen.getByText(/Backend used:/).textContent).toContain("cuda");
+    expect(screen.getByText(/Fallback reason:/).textContent).toContain("none");
+    expect(screen.getByText(/Model path:/).textContent).toContain(
+      "/models/cuda.gguf",
+    );
+    expect(screen.getByText(/Last error:/).textContent).toContain("none");
+  });
+
+  it("renders registering processing stopped and error lifecycle fields accurately", async () => {
+    render(<App />);
+    await screen.findByText("Start operator");
+    const computeHandler = eventHandlers.get("compute_node_event");
+    expect(computeHandler).toBeTruthy();
+
+    computeHandler?.({
+      payload: {
+        type: "status",
+        running: true,
+        registered: false,
+        relay_runtime_state: "registering",
+        session_id: 1,
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+        "registering",
+      ),
+    );
+    expect(screen.getByText(/Registered:/).textContent).toContain("no");
+
+    computeHandler?.({
+      payload: {
+        type: "status",
+        running: true,
+        registered: true,
+        relay_runtime_state: "processing",
+        session_id: 1,
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+        "processing",
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/Registered:/).textContent).toContain("yes"),
+    );
+
+    computeHandler?.({
+      payload: {
+        type: "error",
+        running: false,
+        registered: false,
+        relay_runtime_state: "failed",
+        message: "relay auth failed",
+        session_id: 1,
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+        "failed",
+      ),
+    );
+    expect(screen.getByText(/Last error:/).textContent).toContain(
+      "relay auth failed",
+    );
+  });
+
+  it("ignores stale compute events from an older backend session", async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      relay_runtime_state: "ready",
+      active_relay_url: "https://relay.example",
+      session_id: 2,
+    });
+
+    render(<App />);
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+
+    const computeHandler = eventHandlers.get("compute_node_event");
+    computeHandler?.({
+      payload: {
+        type: "stopped",
+        running: false,
+        registered: false,
+        relay_runtime_state: "stopped",
+        session_id: 1,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Running:/).textContent).toContain("yes"),
+    );
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain(
+      "ready",
+    );
+  });
+
+  it("marks local inference as failed on emitted error events after start invoke resolves", async () => {
+    render(<App />);
+    const promptArea = (
+      await screen.findByText("Prompt")
+    ).parentElement?.querySelector("textarea");
     expect(promptArea).toBeTruthy();
-    fireEvent.change(promptArea as HTMLTextAreaElement, { target: { value: 'hello' } });
+    fireEvent.change(promptArea as HTMLTextAreaElement, {
+      target: { value: "hello" },
+    });
     const startInferenceButton = (await screen.findByText(
-      'Start local inference'
+      "Start local inference",
     )) as HTMLButtonElement;
     await waitFor(() => expect(startInferenceButton.disabled).toBe(false));
     fireEvent.click(startInferenceButton);
 
-    const inferenceHandler = eventHandlers.get('inference_event');
+    const inferenceHandler = eventHandlers.get("inference_event");
     expect(inferenceHandler).toBeTruthy();
     inferenceHandler?.({
       payload: {
-        request_id: '00000000-0000-4000-8000-000000000000',
-        type: 'error',
-        message: 'ignore stale request',
+        request_id: "00000000-0000-4000-8000-000000000000",
+        type: "error",
+        message: "ignore stale request",
       },
     });
     inferenceHandler?.({
       payload: {
-        request_id: 'not-the-current-request',
-        type: 'error',
-        message: 'ignore stale request',
+        request_id: "not-the-current-request",
+        type: "error",
+        message: "ignore stale request",
       },
     });
 
-    const startInvocation = invokeMock.mock.calls.find((args) => args[0] === 'start_inference');
+    const startInvocation = invokeMock.mock.calls.find(
+      (args) => args[0] === "start_inference",
+    );
     expect(startInvocation).toBeTruthy();
-    const currentRequestId = startInvocation?.[1]?.request?.request_id as string;
+    const currentRequestId = startInvocation?.[1]?.request
+      ?.request_id as string;
     inferenceHandler?.({
       payload: {
         request_id: currentRequestId,
-        type: 'error',
-        message: 'event failure path',
+        type: "error",
+        message: "event failure path",
       },
     });
 
     await waitFor(() =>
-      expect(screen.getByText('Status:').textContent).toContain('failed')
+      expect(screen.getByText("Status:").textContent).toContain("failed"),
     );
-    expect(screen.getByText(/Error:/).textContent).toContain('event failure path');
+    expect(screen.getByText(/Error:/).textContent).toContain(
+      "event failure path",
+    );
   });
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -1,15 +1,21 @@
-import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
-import { open } from '@tauri-apps/plugin-dialog';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-type UiState = 'idle' | 'starting' | 'streaming' | 'canceled' | 'completed' | 'failed';
-type BackendMode = 'auto' | 'cpu' | 'gpu' | 'hybrid';
+type UiState =
+  | "idle"
+  | "starting"
+  | "streaming"
+  | "canceled"
+  | "completed"
+  | "failed";
+type BackendMode = "auto" | "cpu" | "gpu" | "hybrid";
 
 interface BackendInfo {
   platform_label: string;
   preferred_mode: BackendMode;
-  available_backend: 'cpu' | 'cuda' | 'metal';
+  available_backend: "cpu" | "cuda" | "metal";
   availability_label: string;
 }
 
@@ -36,6 +42,8 @@ interface ComputeNodeStatus {
   warm_load_duration_ms: number | null;
   runtime_path: string | null;
   relay_runtime_path: string | null;
+  relay_runtime_state: string;
+  session_id: number;
 }
 
 interface ModelArtifactInfo {
@@ -59,20 +67,22 @@ interface SidecarEvent {
 const defaultComputeStatus: ComputeNodeStatus = {
   running: false,
   registered: false,
-  active_relay_url: '',
-  requested_mode: 'auto',
+  active_relay_url: "",
+  requested_mode: "auto",
   effective_mode: null,
   backend_available: null,
   backend_selected: null,
   backend_used: null,
   fallback_reason: null,
-  model_path: '',
+  model_path: "",
   last_error: null,
   warm_load_state: null,
   warm_load_enabled: null,
   warm_load_duration_ms: null,
   runtime_path: null,
   relay_runtime_path: null,
+  relay_runtime_state: "idle",
+  session_id: 0,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -80,55 +90,61 @@ function formatErrorMessage(error: unknown): string {
 }
 
 export function selectedModelPath(selection: string | string[] | null): string {
-  if (typeof selection === 'string') {
+  if (typeof selection === "string") {
     return selection;
   }
-  if (Array.isArray(selection) && selection.length > 0 && typeof selection[0] === 'string') {
+  if (
+    Array.isArray(selection) &&
+    selection.length > 0 &&
+    typeof selection[0] === "string"
+  ) {
     return selection[0];
   }
-  return '';
+  return "";
 }
 
 export function App() {
   const [backend, setBackend] = useState<BackendInfo | null>(null);
   const [config, setConfig] = useState<DesktopConfig>({
-    model_path: '',
-    relay_base_url: 'https://token.place',
-    preferred_mode: 'auto',
+    model_path: "",
+    relay_base_url: "https://token.place",
+    preferred_mode: "auto",
   });
-  const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
-  const [prompt, setPrompt] = useState('');
-  const [output, setOutput] = useState('');
-  const [requestId, setRequestId] = useState<string>('');
-  const [status, setStatus] = useState<UiState>('idle');
+  const [computeStatus, setComputeStatus] =
+    useState<ComputeNodeStatus>(defaultComputeStatus);
+  const [prompt, setPrompt] = useState("");
+  const [output, setOutput] = useState("");
+  const [requestId, setRequestId] = useState<string>("");
+  const [status, setStatus] = useState<UiState>("idle");
   const [artifact, setArtifact] = useState<ModelArtifactInfo | null>(null);
   const [isDownloadingModel, setIsDownloadingModel] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
-  const relayRuntimeReady =
-    computeStatus.warm_load_enabled === false ||
-    computeStatus.warm_load_state === null ||
-    computeStatus.warm_load_state === 'ready';
-  const computeNodeRegistered = computeStatus.running && computeStatus.registered && relayRuntimeReady;
+  const relayRuntimeReady = ["ready", "processing"].includes(
+    computeStatus.relay_runtime_state,
+  );
+  const computeNodeRegistered =
+    computeStatus.running && computeStatus.registered && relayRuntimeReady;
   const saveTimerRef = useRef<number | null>(null);
-  const requestIdRef = useRef('');
+  const requestIdRef = useRef("");
 
   useEffect(() => {
-    invoke<BackendInfo>('detect_backend')
+    invoke<BackendInfo>("detect_backend")
       .then(setBackend)
       .catch((e) => setError(formatErrorMessage(e)));
 
     const initializeConfigAndArtifact = async () => {
       try {
-        const loadedConfig = await invoke<DesktopConfig>('load_config');
+        const loadedConfig = await invoke<DesktopConfig>("load_config");
         setConfig(loadedConfig);
-        const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
-        setComputeStatus(nodeStatus);
+        const nodeStatus = await invoke<ComputeNodeStatus>(
+          "get_compute_node_status",
+        );
+        setComputeStatus({ ...defaultComputeStatus, ...nodeStatus });
 
-        const info = await invoke<ModelArtifactInfo>('inspect_model_artifact');
+        const info = await invoke<ModelArtifactInfo>("inspect_model_artifact");
         setArtifact(info);
-
       } catch (e) {
         setError(formatErrorMessage(e));
       }
@@ -142,22 +158,22 @@ export function App() {
   }, [requestId]);
 
   useEffect(() => {
-    const unlisten = listen<SidecarEvent>('inference_event', (evt) => {
+    const unlisten = listen<SidecarEvent>("inference_event", (evt) => {
       const payload = evt.payload;
       if (payload.request_id !== requestIdRef.current) {
         return;
       }
-      if (payload.type === 'started') {
-        setStatus('streaming');
-      } else if (payload.type === 'token' && payload.text) {
+      if (payload.type === "started") {
+        setStatus("streaming");
+      } else if (payload.type === "token" && payload.text) {
         setOutput((prev) => prev + payload.text);
-      } else if (payload.type === 'done') {
-        setStatus('completed');
-      } else if (payload.type === 'canceled') {
-        setStatus('canceled');
-      } else if (payload.type === 'error') {
-        setStatus('failed');
-        setError(payload.message ?? payload.code ?? 'unknown error');
+      } else if (payload.type === "done") {
+        setStatus("completed");
+      } else if (payload.type === "canceled") {
+        setStatus("canceled");
+      } else if (payload.type === "error") {
+        setStatus("failed");
+        setError(payload.message ?? payload.code ?? "unknown error");
       }
     });
     return () => {
@@ -166,78 +182,119 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    const unlisten = listen<Record<string, unknown>>('compute_node_event', (evt) => {
-      const payload = evt.payload;
-      setComputeStatus((prev) => ({
-        running:
-          typeof payload.running === 'boolean'
-            ? payload.running
-            : payload.type === 'error'
-              ? false
-              : prev.running,
-        registered: typeof payload.registered === 'boolean' ? payload.registered : prev.registered,
-        active_relay_url:
-          typeof payload.active_relay_url === 'string'
-            ? payload.active_relay_url
-            : prev.active_relay_url,
-        requested_mode:
-          typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
-        effective_mode:
-          typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
-        backend_available:
-          typeof payload.backend_available === 'string'
-            ? payload.backend_available
-            : prev.backend_available,
-        backend_selected:
-          typeof payload.backend_selected === 'string'
-            ? payload.backend_selected
-            : prev.backend_selected,
-        backend_used:
-          typeof payload.backend_used === 'string' ? payload.backend_used : prev.backend_used,
-        fallback_reason:
-          payload.fallback_reason === null
-            ? null
-            : typeof payload.fallback_reason === 'string'
-              ? payload.fallback_reason
-              : prev.fallback_reason,
-        model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
-        warm_load_state:
-          typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
-        warm_load_enabled:
-          typeof payload.warm_load_enabled === 'boolean'
-            ? payload.warm_load_enabled
-            : prev.warm_load_enabled,
-        warm_load_duration_ms:
-          typeof payload.warm_load_duration_ms === 'number'
-            ? payload.warm_load_duration_ms
-            : prev.warm_load_duration_ms,
-        runtime_path: typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
-        relay_runtime_path:
-          typeof payload.relay_runtime_path === 'string'
-            ? payload.relay_runtime_path
-            : prev.relay_runtime_path,
-        last_error:
-          payload.last_error === null
-            ? null
-            : typeof payload.last_error === 'string'
+    const unlisten = listen<Record<string, unknown>>(
+      "compute_node_event",
+      (evt) => {
+        const payload = evt.payload;
+        setComputeStatus((prev) => {
+          const payloadSessionId =
+            typeof payload.session_id === "number"
+              ? payload.session_id
+              : undefined;
+          if (
+            payloadSessionId !== undefined &&
+            payloadSessionId < prev.session_id
+          ) {
+            return prev;
+          }
+          return {
+            running:
+              typeof payload.running === "boolean"
+                ? payload.running
+                : payload.type === "error"
+                  ? false
+                  : prev.running,
+            registered:
+              typeof payload.registered === "boolean"
+                ? payload.registered
+                : prev.registered,
+            active_relay_url:
+              typeof payload.active_relay_url === "string"
+                ? payload.active_relay_url
+                : prev.active_relay_url,
+            requested_mode:
+              typeof payload.requested_mode === "string"
+                ? payload.requested_mode
+                : prev.requested_mode,
+            effective_mode:
+              typeof payload.effective_mode === "string"
+                ? payload.effective_mode
+                : prev.effective_mode,
+            backend_available:
+              typeof payload.backend_available === "string"
+                ? payload.backend_available
+                : prev.backend_available,
+            backend_selected:
+              typeof payload.backend_selected === "string"
+                ? payload.backend_selected
+                : prev.backend_selected,
+            backend_used:
+              typeof payload.backend_used === "string"
+                ? payload.backend_used
+                : prev.backend_used,
+            fallback_reason:
+              payload.fallback_reason === null
+                ? null
+                : typeof payload.fallback_reason === "string"
+                  ? payload.fallback_reason
+                  : prev.fallback_reason,
+            model_path:
+              typeof payload.model_path === "string"
+                ? payload.model_path
+                : prev.model_path,
+            warm_load_state:
+              typeof payload.warm_load_state === "string"
+                ? payload.warm_load_state
+                : prev.warm_load_state,
+            warm_load_enabled:
+              typeof payload.warm_load_enabled === "boolean"
+                ? payload.warm_load_enabled
+                : prev.warm_load_enabled,
+            warm_load_duration_ms:
+              typeof payload.warm_load_duration_ms === "number"
+                ? payload.warm_load_duration_ms
+                : prev.warm_load_duration_ms,
+            runtime_path:
+              typeof payload.runtime_path === "string"
+                ? payload.runtime_path
+                : prev.runtime_path,
+            relay_runtime_path:
+              typeof payload.relay_runtime_path === "string"
+                ? payload.relay_runtime_path
+                : prev.relay_runtime_path,
+            relay_runtime_state:
+              typeof payload.relay_runtime_state === "string"
+                ? payload.relay_runtime_state
+                : prev.relay_runtime_state,
+            session_id: payloadSessionId ?? prev.session_id,
+            last_error:
+              payload.last_error === null
+                ? null
+                : typeof payload.last_error === "string"
+                  ? payload.last_error
+                  : typeof payload.message === "string"
+                    ? payload.message
+                    : prev.last_error,
+          };
+        });
+        if (
+          payload.type === "started" ||
+          payload.type === "stopped" ||
+          payload.type === "error"
+        ) {
+          setIsStartingComputeNode(false);
+        }
+        if (payload.type === "error") {
+          const computeMessage =
+            typeof payload.last_error === "string"
               ? payload.last_error
-              : typeof payload.message === 'string'
+              : typeof payload.message === "string"
                 ? payload.message
-                : prev.last_error,
-      }));
-      if (payload.type === 'started' || payload.type === 'error') {
-        setIsStartingComputeNode(false);
-      }
-      if (payload.type === 'error') {
-        const computeMessage =
-          typeof payload.last_error === 'string'
-            ? payload.last_error
-            : typeof payload.message === 'string'
-              ? payload.message
-              : 'compute-node operator failed';
-        setError(computeMessage);
-      }
-    });
+                : "compute-node operator failed";
+          setError(computeMessage);
+        }
+      },
+    );
 
     return () => {
       unlisten.then((f) => f());
@@ -256,24 +313,30 @@ export function App() {
     () =>
       Boolean(config.model_path.trim()) &&
       Boolean(prompt.trim()) &&
-      status !== 'starting' &&
-      status !== 'streaming',
-    [config.model_path, prompt, status]
+      status !== "starting" &&
+      status !== "streaming",
+    [config.model_path, prompt, status],
   );
 
   const canStartComputeNode = useMemo(
-    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
-    [config.model_path, computeStatus.running, isStartingComputeNode]
+    () =>
+      Boolean(config.model_path.trim()) &&
+      !computeStatus.running &&
+      !isStartingComputeNode,
+    [config.model_path, computeStatus.running, isStartingComputeNode],
   );
-  const availableBackend = backend?.available_backend ?? 'cpu';
-  const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
+  const availableBackend = backend?.available_backend ?? "cpu";
+  const gpuCapable =
+    availableBackend === "metal" || availableBackend === "cuda";
 
   const scheduleConfigSave = (next: DesktopConfig) => {
     if (saveTimerRef.current !== null) {
       window.clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = window.setTimeout(() => {
-      invoke('save_config', { config: next }).catch((e) => setError(formatErrorMessage(e)));
+      invoke("save_config", { config: next }).catch((e) =>
+        setError(formatErrorMessage(e)),
+      );
       saveTimerRef.current = null;
     }, 300);
   };
@@ -288,7 +351,7 @@ export function App() {
       const selection = await open({
         multiple: false,
         directory: false,
-        filters: [{ name: 'GGUF models', extensions: ['gguf'] }],
+        filters: [{ name: "GGUF models", extensions: ["gguf"] }],
       });
       const path = selectedModelPath(selection);
       if (path) {
@@ -302,8 +365,8 @@ export function App() {
   const downloadModel = async () => {
     try {
       setIsDownloadingModel(true);
-      setError('');
-      const info = await invoke<ModelArtifactInfo>('download_model_artifact');
+      setError("");
+      const info = await invoke<ModelArtifactInfo>("download_model_artifact");
       setArtifact(info);
       setConfig((prev) => {
         const next = { ...prev, model_path: info.resolved_model_path };
@@ -318,14 +381,14 @@ export function App() {
   };
 
   const startInference = async () => {
-    setOutput('');
-    setError('');
-    setStatus('starting');
+    setOutput("");
+    setError("");
+    setStatus("starting");
     const nextRequestId = crypto.randomUUID();
     requestIdRef.current = nextRequestId;
     setRequestId(nextRequestId);
     try {
-      await invoke('start_inference', {
+      await invoke("start_inference", {
         request: {
           request_id: nextRequestId,
           model_path: config.model_path,
@@ -334,23 +397,23 @@ export function App() {
         },
       });
     } catch (e) {
-      setStatus('failed');
+      setStatus("failed");
       setError(formatErrorMessage(e));
     }
   };
 
   const cancelInference = async () => {
     if (!requestIdRef.current) return;
-    await invoke('cancel_inference', { request_id: requestIdRef.current });
+    await invoke("cancel_inference", { request_id: requestIdRef.current });
   };
 
   const startComputeNode = async () => {
     try {
       setIsStartingComputeNode(true);
-      setError('');
+      setError("");
       setComputeStatus((prev) => ({
         ...prev,
-        running: false,
+        running: true,
         registered: false,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,
@@ -361,8 +424,10 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        relay_runtime_state: "starting",
+        session_id: prev.session_id + 1,
       }));
-      await invoke('start_compute_node', {
+      await invoke("start_compute_node", {
         request: {
           model_path: config.model_path,
           relay_base_url: config.relay_base_url,
@@ -384,7 +449,14 @@ export function App() {
 
   const stopComputeNode = async () => {
     try {
-      await invoke('stop_compute_node');
+      setComputeStatus((prev) => ({
+        ...prev,
+        running: false,
+        registered: false,
+        relay_runtime_state: "stopped",
+        last_error: null,
+      }));
+      await invoke("stop_compute_node");
     } catch (e) {
       setError(formatErrorMessage(e));
     }
@@ -393,8 +465,8 @@ export function App() {
   const forwardEncrypted = async () => {
     try {
       setIsForwarding(true);
-      setError('');
-      await invoke('encrypt_and_forward', {
+      setError("");
+      await invoke("encrypt_and_forward", {
         relay_base_url: config.relay_base_url,
         final_output: output,
       });
@@ -406,113 +478,212 @@ export function App() {
   };
 
   return (
-    <main style={{ maxWidth: 820, margin: '20px auto', fontFamily: 'sans-serif' }}>
+    <main
+      style={{ maxWidth: 820, margin: "20px auto", fontFamily: "sans-serif" }}
+    >
       <h1>token.place desktop compute node</h1>
-      <p>Platform GPU availability: <strong>{backend?.availability_label ?? 'loading...'}</strong></p>
+      <p>
+        Platform GPU availability:{" "}
+        <strong>{backend?.availability_label ?? "loading..."}</strong>
+      </p>
       <label htmlFor="model-path-input">Model GGUF path</label>
-      <div style={{ display: 'flex', gap: 8 }}>
+      <div style={{ display: "flex", gap: 8 }}>
         <input
           id="model-path-input"
           value={config.model_path}
-          style={{ width: '100%' }}
-          onChange={(e) => updateConfig({ ...config, model_path: e.target.value })}
+          style={{ width: "100%" }}
+          onChange={(e) =>
+            updateConfig({ ...config, model_path: e.target.value })
+          }
         />
-        <button type="button" onClick={chooseModelPath}>Browse</button>
-        <button type="button" onClick={downloadModel} disabled={isDownloadingModel}>
-          {isDownloadingModel ? 'Downloading…' : 'Download'}
+        <button type="button" onClick={chooseModelPath}>
+          Browse
+        </button>
+        <button
+          type="button"
+          onClick={downloadModel}
+          disabled={isDownloadingModel}
+        >
+          {isDownloadingModel ? "Downloading…" : "Download"}
         </button>
       </div>
       {artifact && (
         <section style={{ marginTop: 8, fontSize: 14 }}>
           <div>
-            Canonical model family:{' '}
-            <a href={artifact.canonical_family_url} target="_blank" rel="noreferrer">
+            Canonical model family:{" "}
+            <a
+              href={artifact.canonical_family_url}
+              target="_blank"
+              rel="noreferrer"
+            >
               {artifact.canonical_family_url}
             </a>
           </div>
-          <div>Runtime GGUF filename: <code>{artifact.filename}</code></div>
           <div>
-            Runtime GGUF source:{' '}
+            Runtime GGUF filename: <code>{artifact.filename}</code>
+          </div>
+          <div>
+            Runtime GGUF source:{" "}
             <a href={artifact.url} target="_blank" rel="noreferrer">
               {artifact.url}
             </a>
           </div>
-          <div>Runtime models directory: <code>{artifact.models_dir}</code></div>
-          <div>Runtime resolved path: <code>{artifact.resolved_model_path}</code></div>
           <div>
-            Downloaded: <strong>{artifact.exists ? 'yes' : 'no'}</strong>
-            {artifact.size_bytes != null ? ` (${artifact.size_bytes.toLocaleString()} bytes)` : ''}
+            Runtime models directory: <code>{artifact.models_dir}</code>
+          </div>
+          <div>
+            Runtime resolved path: <code>{artifact.resolved_model_path}</code>
+          </div>
+          <div>
+            Downloaded: <strong>{artifact.exists ? "yes" : "no"}</strong>
+            {artifact.size_bytes != null
+              ? ` (${artifact.size_bytes.toLocaleString()} bytes)`
+              : ""}
           </div>
         </section>
       )}
 
-      <label style={{ display: 'block', marginTop: 12 }}>Compute mode</label>
+      <label style={{ display: "block", marginTop: 12 }}>Compute mode</label>
       <select
         value={config.preferred_mode}
-        onChange={(e) => updateConfig({ ...config, preferred_mode: e.target.value as BackendMode })}
+        onChange={(e) =>
+          updateConfig({
+            ...config,
+            preferred_mode: e.target.value as BackendMode,
+          })
+        }
       >
         <option value="auto">Auto</option>
         <option value="cpu">CPU only</option>
-        <option value="gpu" disabled={!gpuCapable}>GPU only</option>
-        <option value="hybrid" disabled={!gpuCapable}>Hybrid (partial GPU offload)</option>
+        <option value="gpu" disabled={!gpuCapable}>
+          GPU only
+        </option>
+        <option value="hybrid" disabled={!gpuCapable}>
+          Hybrid (partial GPU offload)
+        </option>
       </select>
-      <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
-        Operator note: GPU mode requests full offload when CUDA/Metal is available; Hybrid requests
-        partial offload. Unsupported platforms fall back to CPU with diagnostics.
+      <p style={{ marginTop: 8, fontSize: 12, color: "#555" }}>
+        Operator note: GPU mode requests full offload when CUDA/Metal is
+        available; Hybrid requests partial offload. Unsupported platforms fall
+        back to CPU with diagnostics.
       </p>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
+      <label style={{ display: "block", marginTop: 12 }}>Relay URL</label>
       <input
         value={config.relay_base_url}
-        style={{ width: '100%' }}
-        onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })}
+        style={{ width: "100%" }}
+        onChange={(e) =>
+          updateConfig({ ...config, relay_base_url: e.target.value })
+        }
       />
 
-      <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
+      <section style={{ marginTop: 14, border: "1px solid #ddd", padding: 12 }}>
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
-          <button
-            disabled={!computeStatus.running}
-            onClick={stopComputeNode}
-          >
+        <div style={{ display: "flex", gap: 8 }}>
+          <button disabled={!canStartComputeNode} onClick={startComputeNode}>
+            Start operator
+          </button>
+          <button disabled={!computeStatus.running} onClick={stopComputeNode}>
             Stop operator
           </button>
         </div>
-        <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Registered: <strong>{computeNodeRegistered ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{computeStatus.warm_load_state || 'idle'}</code></p>
-        <p style={{ marginBottom: 0 }}>Runtime path: <code>{computeStatus.runtime_path || 'bridge'}</code></p>
-        <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{computeStatus.relay_runtime_path || 'bridge'}</code></p>
-        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>
-        <p style={{ marginBottom: 0 }}>Requested mode: <code>{computeStatus.requested_mode || config.preferred_mode}</code></p>
-        <p style={{ marginBottom: 0 }}>Effective mode: <code>{computeStatus.effective_mode ?? 'pending'}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend available: <code>{computeStatus.backend_available ?? 'pending'}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend selected: <code>{computeStatus.backend_selected ?? 'pending'}</code></p>
-        <p style={{ marginBottom: 0 }}>Backend used: <code>{computeStatus.backend_used ?? 'pending'}</code></p>
-        <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
-        <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
-        <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
+        <p style={{ marginBottom: 0 }}>
+          Running: <strong>{computeStatus.running ? "yes" : "no"}</strong>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Registered: <strong>{computeNodeRegistered ? "yes" : "no"}</strong>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Relay runtime state:{" "}
+          <code>{computeStatus.relay_runtime_state || "idle"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Runtime path: <code>{computeStatus.runtime_path || "bridge"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Relay runtime path:{" "}
+          <code>{computeStatus.relay_runtime_path || "bridge"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Active relay URL:{" "}
+          <code>{computeStatus.active_relay_url || config.relay_base_url}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Requested mode:{" "}
+          <code>{computeStatus.requested_mode || config.preferred_mode}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Effective mode:{" "}
+          <code>{computeStatus.effective_mode ?? "pending"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Backend available:{" "}
+          <code>{computeStatus.backend_available ?? "pending"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Backend selected:{" "}
+          <code>{computeStatus.backend_selected ?? "pending"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Backend used: <code>{computeStatus.backend_used ?? "pending"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Fallback reason:{" "}
+          <code>{computeStatus.fallback_reason || "none"}</code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Model path:{" "}
+          <code>
+            {computeStatus.model_path || config.model_path || "not set"}
+          </code>
+        </p>
+        <p style={{ marginBottom: 0 }}>
+          Last error: <code>{computeStatus.last_error || "none"}</code>
+        </p>
       </section>
 
-      <section style={{ marginTop: 14, borderTop: '1px solid #ddd', paddingTop: 12 }}>
+      <section
+        style={{ marginTop: 14, borderTop: "1px solid #ddd", paddingTop: 12 }}
+      >
         <h2 style={{ marginTop: 0 }}>Local prompt smoke test</h2>
-        <label style={{ display: 'block', marginTop: 12 }}>Prompt</label>
-        <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={6} style={{ width: '100%' }} />
+        <label style={{ display: "block", marginTop: 12 }}>Prompt</label>
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={6}
+          style={{ width: "100%" }}
+        />
 
-        <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
-          <button disabled={!canStart} onClick={startInference}>Start local inference</button>
-          <button disabled={status !== 'starting' && status !== 'streaming'} onClick={cancelInference}>Cancel</button>
+        <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
+          <button disabled={!canStart} onClick={startInference}>
+            Start local inference
+          </button>
+          <button
+            disabled={status !== "starting" && status !== "streaming"}
+            onClick={cancelInference}
+          >
+            Cancel
+          </button>
           <button disabled={!output || isForwarding} onClick={forwardEncrypted}>
             Debug relay forward (disabled; API v1 E2EE only)
           </button>
         </div>
 
-        <p>Status: <strong>{status}</strong></p>
+        <p>
+          Status: <strong>{status}</strong>
+        </p>
       </section>
 
-      {error && <p style={{ color: 'crimson' }}>Error: {error}</p>}
-      <pre style={{ whiteSpace: 'pre-wrap', padding: 12, border: '1px solid #ddd' }}>{output}</pre>
+      {error && <p style={{ color: "crimson" }}>Error: {error}</p>}
+      <pre
+        style={{
+          whiteSpace: "pre-wrap",
+          padding: 12,
+          border: "1px solid #ddd",
+        }}
+      >
+        {output}
+      </pre>
     </main>
   );
 }

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -379,6 +379,86 @@ def _reset_cancel_queue():
     compute_node_bridge._stop_requested_latched.clear()
 
 
+
+
+def test_run_status_payloads_include_full_operator_contract(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1Runtime)
+
+    call_count = {'count': 0}
+
+    def fake_stop_requested():
+        call_count['count'] += 1
+        return call_count['count'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://relay.example', relay_port=None)
+
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    required = set(compute_node_bridge.OPERATOR_STATUS_FIELDS)
+    lifecycle_events = [event for event in events if event.get('type') in {'started', 'status', 'stopped'}]
+    assert lifecycle_events
+    for event in lifecycle_events:
+        assert required.issubset(event.keys())
+    assert events[0]['registered'] is False
+    assert events[0]['relay_runtime_state'] == 'warming'
+    assert any(event.get('relay_runtime_state') == 'registering' and event.get('registered') is False for event in events)
+    assert any(event.get('relay_runtime_state') == 'processing' for event in events)
+    assert events[-1]['running'] is False
+    assert events[-1]['registered'] is False
+    assert events[-1]['relay_runtime_state'] == 'stopped'
+    assert events[-1]['last_error'] is None
+
+
+def test_run_registered_false_until_runtime_ready_and_registration_fresh(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingThenApiV1Runtime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
+    monkeypatch.setattr(compute_node_bridge, 'PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS', 0.01)
+
+    stop_calls = {'count': 0}
+
+    def fake_stop_requested():
+        stop_calls['count'] += 1
+        runtime = WarmingThenApiV1Runtime.last_instance
+        if runtime is not None and runtime.ready_started.is_set():
+            runtime.ready_release.set()
+        return stop_calls['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    pre_ready_events = [
+        event for event in events
+        if event.get('type') in {'started', 'status'} and event.get('relay_runtime_state') != 'ready' and event.get('relay_runtime_state') != 'processing'
+    ]
+    assert pre_ready_events
+    assert all(event['registered'] is False for event in pre_ready_events)
+    assert any(event.get('registered') is True and event.get('relay_runtime_state') in {'ready', 'processing'} for event in events)
+
+
+def test_run_graceful_stop_clears_registration_and_last_error(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=NullErrorHeartbeatRuntime)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    stopped = events[-1]
+    assert stopped['type'] == 'stopped'
+    assert stopped['running'] is False
+    assert stopped['registered'] is False
+    assert stopped['relay_runtime_state'] == 'stopped'
+    assert stopped['last_error'] is None
+
+
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)
@@ -571,16 +651,16 @@ def test_run_windows_gpu_mode_emits_error_when_runtime_bootstrap_fails(capsys, m
 
     assert status == 1
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
-    assert events == [
-        {
-            'type': 'error',
-            'message': (
-                'GPU provisioning failed for desktop Windows launch '
-                '(mode=auto, action=failed): cuda wheel install failed. '
-                'Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support.'
-            ),
-        }
-    ]
+    assert events[0]['type'] == 'error'
+    assert events[0]['running'] is False
+    assert events[0]['registered'] is False
+    assert events[0]['relay_runtime_state'] == 'failed'
+    assert events[0]['last_error'] == events[0]['message']
+    assert events[0]['message'] == (
+        'GPU provisioning failed for desktop Windows launch '
+        '(mode=auto, action=failed): cuda wheel install failed. '
+        'Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support.'
+    )
 
 
 def test_run_windows_gpu_mode_emits_error_when_runtime_is_shadowed(capsys, monkeypatch):
@@ -610,17 +690,17 @@ def test_run_windows_gpu_mode_emits_error_when_runtime_is_shadowed(capsys, monke
 
     assert status == 1
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
-    assert events == [
-        {
-            'type': 'error',
-            'message': (
-                'GPU provisioning failed for desktop Windows launch '
-                '(mode=auto, action=shadowed_repo_llama_cpp): '
-                'llama_cpp import shadowed by repo-local shim. '
-                'Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support.'
-            ),
-        }
-    ]
+    assert events[0]['type'] == 'error'
+    assert events[0]['running'] is False
+    assert events[0]['registered'] is False
+    assert events[0]['relay_runtime_state'] == 'failed'
+    assert events[0]['last_error'] == events[0]['message']
+    assert events[0]['message'] == (
+        'GPU provisioning failed for desktop Windows launch '
+        '(mode=auto, action=shadowed_repo_llama_cpp): '
+        'llama_cpp import shadowed by repo-local shim. '
+        'Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support.'
+    )
 
 
 def test_run_windows_gpu_mode_accepts_bootstrap_enabled_cuda_runtime(capsys, monkeypatch):
@@ -2112,7 +2192,12 @@ def test_run_reports_unreachable_for_non_heartbeat_response(capsys, monkeypatch)
 
     assert status == 0
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
-    status_event = next(event for event in events if event.get("type") == "status")
+    status_event = next(
+        event
+        for event in events
+        if event.get("type") == "status"
+        and isinstance(event.get("last_error"), str)
+    )
     assert status_event["registered"] is False
     assert "relay appears unreachable" in status_event["last_error"]
 


### PR DESCRIPTION
### Motivation
- Eliminate split-brain and stale-event UI states by defining a single structured operator status payload shared between the Python bridge, Rust backend, and React UI. 
- Ensure `Registered`/`Running` and all backend/runtime fields reflect actual relay/runtime readiness (warm-load, registration freshness, relay payloads) instead of frontend-only heuristics. 
- Prevent old bridge sessions from overwriting newer UI state after stop/restart and provide lifecycle-aware diagnostics for warm-load/registration/processing/stop/error states.

### Description
- Add a documented operator status contract and payload fields in the Python bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) and use it for all lifecycle emits; introduced `OPERATOR_STATUS_FIELDS`, `operator_status_payload`, and `emit_status_event`. 
- Implement runtime readiness helpers and error-response helpers in the bridge: `ensure_runtime_ready`, `submit_api_v1_error_response`, and improved `fail_on_warm_load_error`/`early_status_error_payload` to emit full operator status fields for early failures. 
- Update bridge polling/registration logic to include `relay_runtime_state` transitions (warming/registering/processing/ready/failed/stopped), and to mark `registered` only when both relay heartbeats/API payloads and registration freshness indicate eligibility. 
- Rust backend (`desktop-tauri/src-tauri/src/compute_node.rs`) now tracks `relay_runtime_state` and `session_id`, attaches `session_id` to events forwarded to the frontend, emits an initial status after starting the child bridge, and ignores/filters stale events from previous sessions so the UI can't be overwritten by old bridge processes. 
- Frontend React changes (`desktop-tauri/src/App.tsx` and tests) extend the `ComputeNodeStatus` shape with `relay_runtime_state` and `session_id`, use `relay_runtime_state` to compute `Registered` semantics, increment a session id on Start, ignore older session events, and make start/stop optimistic updates lifecycle-aware. 
- Add and update unit tests: Python bridge unit tests (`tests/unit/test_desktop_compute_node_bridge.py`) augmented to assert the operator status contract, warm-load/registration semantics, and shutdown/unregister behavior; frontend tests (`desktop-tauri/src/App.test.tsx`) updated to validate all displayed fields and ignore stale events. 

### Testing
- Ran the bridge unit suite with `pytest tests/unit/test_desktop_compute_node_bridge.py`, which was used to drive and validate the bridge changes and lifecycle semantics; tests passed after implementing the bridge helpers and session-guard logic. 
- Ran TypeScript compile checks with `npx tsc --noEmit -p desktop-tauri/tsconfig.json`, which completed (typecheck warnings present but no blocking errors). 
- Updated and ran the React unit tests under `desktop-tauri/src/App.test.tsx` (via local test harness in the rollout) to verify rendering and lifecycle transitions; tests assert expected field values for started/warming/registered/processing/stopped/error and for stale-event ignoring. 

Residual risks and follow-ups: runtime/relay behavior is still constrained to API v1 non-streaming assumptions; Prompt 3 (multi-desktop relay dispatch/round-robin) remains out of scope and must integrate with the same status/session contract in a follow-up PR. Please run the full repo-standard checks (`pre-commit run --all-files` / `./run_all_tests.sh`) in CI for final verification on the target environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a56b6ea34832fa35ccc8eaa464e27)