### PR TITLE
Make desktop compute-node status lifecycle-aware

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -76,6 +76,22 @@ WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
 API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
+STATUS_CONTRACT_FIELDS = (
+    "running",
+    "registered",
+    "relay_runtime_state",
+    "runtime_path",
+    "relay_runtime_path",
+    "active_relay_url",
+    "requested_mode",
+    "effective_mode",
+    "backend_available",
+    "backend_selected",
+    "backend_used",
+    "fallback_reason",
+    "model_path",
+    "last_error",
+)
 
 
 _POLL_CANCELLED = object()
@@ -523,36 +539,71 @@ def run(args: argparse.Namespace) -> int:
     warm_load_fatal = False
     warm_load_future: Optional[_DaemonWarmLoadFuture] = None
     poll_worker = _CancelablePollWorker()
+    session_id_value = os.getenv("TOKENPLACE_COMPUTE_NODE_SESSION_ID")
+    try:
+        session_id: Optional[int] = int(session_id_value) if session_id_value else None
+    except ValueError:
+        session_id = None
+    event_sequence = 0
+
+    def operator_status_payload(
+        *,
+        event_type: str,
+        running: bool,
+        registered: bool,
+        active_relay_url: str,
+        current_last_error: Optional[str],
+        relay_state_override: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        nonlocal event_sequence
+        event_sequence += 1
+        diagnostics = compute_mode_diagnostics(runtime.model_manager)
+        relay_runtime_state = relay_state_override or warm_load_state
+        payload: Dict[str, Any] = {
+            "type": event_type,
+            "running": running,
+            "registered": registered,
+            "relay_runtime_state": relay_runtime_state,
+            "active_relay_url": active_relay_url,
+            "requested_mode": diagnostics.get("requested_mode"),
+            "effective_mode": diagnostics.get("effective_mode"),
+            "backend_available": diagnostics.get("backend_available"),
+            "backend_selected": diagnostics.get("backend_selected"),
+            "backend_used": diagnostics.get("backend_used"),
+            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
+            "kv_cache_device": diagnostics.get("kv_cache_device"),
+            "fallback_reason": diagnostics.get("fallback_reason"),
+            "interpreter": runtime_setup.get("interpreter", sys.executable),
+            "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
+            "model_path": args.model,
+            "last_error": current_last_error,
+            "warm_load_state": warm_load_state,
+            "warm_load_enabled": warm_load_enabled,
+            "warm_load_duration_ms": warm_load_duration_ms,
+            "runtime_path": runtime_path,
+            "relay_runtime_path": relay_runtime_path,
+            "sequence": event_sequence,
+            "status_contract_fields": STATUS_CONTRACT_FIELDS,
+        }
+        if session_id is not None:
+            payload["session_id"] = session_id
+        return payload
 
     def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
-        fresh_registered = registered and _registration_fresh(runtime.relay_client, active_relay_url)
-        diagnostics = compute_mode_diagnostics(runtime.model_manager)
+        runtime_ready = warm_load_state == "ready" or not warm_load_enabled
+        fresh_registered = (
+            registered
+            and runtime_ready
+            and _registration_fresh(runtime.relay_client, active_relay_url)
+        )
         emit(
-            {
-                "type": "status",
-                "running": True,
-                "registered": fresh_registered,
-                "active_relay_url": active_relay_url,
-                "requested_mode": diagnostics.get("requested_mode"),
-                "effective_mode": diagnostics.get("effective_mode"),
-                "backend_available": diagnostics.get("backend_available"),
-                "backend_selected": diagnostics.get("backend_selected"),
-                "backend_used": diagnostics.get("backend_used"),
-                "offloaded_layers": diagnostics.get(
-                    "offloaded_layers", diagnostics.get("n_gpu_layers")
-                ),
-                "kv_cache_device": diagnostics.get("kv_cache_device"),
-                "fallback_reason": diagnostics.get("fallback_reason"),
-                "interpreter": runtime_setup.get("interpreter", sys.executable),
-                "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-                "model_path": args.model,
-                "last_error": current_last_error,
-                "warm_load_state": warm_load_state,
-                "warm_load_enabled": warm_load_enabled,
-                "warm_load_duration_ms": warm_load_duration_ms,
-                "runtime_path": runtime_path,
-                "relay_runtime_path": relay_runtime_path,
-            }
+            operator_status_payload(
+                event_type="status",
+                running=True,
+                registered=fresh_registered,
+                active_relay_url=active_relay_url,
+                current_last_error=current_last_error,
+            )
         )
 
     def submit_api_v1_error_response(
@@ -698,46 +749,28 @@ def run(args: argparse.Namespace) -> int:
             active_relay_url=active_relay_url,
             current_last_error=last_error,
         )
-        emit(
-            {
-                "type": "error",
-                "message": last_error,
-                "active_relay_url": runtime.relay_client.relay_url,
-                "warm_load_state": warm_load_state,
-                "warm_load_duration_ms": warm_load_duration_ms,
-                "runtime_path": runtime_path,
-                "relay_runtime_path": relay_runtime_path,
-            }
+        error_payload = operator_status_payload(
+            event_type="error",
+            running=False,
+            registered=False,
+            active_relay_url=runtime.relay_client.relay_url,
+            current_last_error=last_error,
+            relay_state_override="failed",
         )
+        error_payload["message"] = last_error
+        emit(error_payload)
         warm_load_fatal = True
 
-    diagnostics = compute_mode_diagnostics(runtime.model_manager)
     last_error: Optional[str] = None
     emit(
-        {
-            "type": "started",
-            "running": True,
-            "registered": False,
-            "active_relay_url": runtime.relay_client.relay_url,
-            "requested_mode": diagnostics.get("requested_mode"),
-            "effective_mode": diagnostics.get("effective_mode"),
-            "backend_available": diagnostics.get("backend_available"),
-            "backend_selected": diagnostics.get("backend_selected"),
-            "backend_used": diagnostics.get("backend_used"),
-            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
-            "kv_cache_device": diagnostics.get("kv_cache_device"),
-            "fallback_reason": diagnostics.get("fallback_reason"),
-            "interpreter": runtime_setup.get("interpreter", sys.executable),
-            "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-            "llama_repo_stub_imported": repo_llama_cpp_shim_imported,
-            "use_mock_llm": bool(getattr(runtime.model_manager, "use_mock_llm", False)),
-            "model_path": args.model,
-            "last_error": None,
-            "warm_load_state": warm_load_state,
-            "warm_load_enabled": warm_load_enabled,
-            "runtime_path": runtime_path,
-            "relay_runtime_path": relay_runtime_path,
-        }
+        operator_status_payload(
+            event_type="started",
+            running=True,
+            registered=False,
+            active_relay_url=runtime.relay_client.relay_url,
+            current_last_error=None,
+            relay_state_override="starting",
+        )
     )
     if runtime_path == "sidecar":
         print(
@@ -1060,31 +1093,16 @@ def run(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
-    diagnostics = compute_mode_diagnostics(runtime.model_manager)
+    warm_load_state = "stopped"
     emit(
-        {
-            "type": "stopped",
-            "running": False,
-            "registered": False,
-            "active_relay_url": runtime.relay_client.relay_url,
-            "requested_mode": diagnostics.get("requested_mode"),
-            "effective_mode": diagnostics.get("effective_mode"),
-            "backend_available": diagnostics.get("backend_available"),
-            "backend_selected": diagnostics.get("backend_selected"),
-            "backend_used": diagnostics.get("backend_used"),
-            "offloaded_layers": diagnostics.get("offloaded_layers", diagnostics.get("n_gpu_layers")),
-            "kv_cache_device": diagnostics.get("kv_cache_device"),
-            "fallback_reason": diagnostics.get("fallback_reason"),
-            "interpreter": runtime_setup.get("interpreter", sys.executable),
-            "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
-            "model_path": args.model,
-            "last_error": last_error,
-            "warm_load_state": warm_load_state,
-            "warm_load_enabled": warm_load_enabled,
-            "warm_load_duration_ms": warm_load_duration_ms,
-            "runtime_path": runtime_path,
-            "relay_runtime_path": relay_runtime_path,
-        }
+        operator_status_payload(
+            event_type="stopped",
+            running=False,
+            registered=False,
+            active_relay_url=runtime.relay_client.relay_url,
+            current_last_error=None if not warm_load_fatal else last_error,
+            relay_state_override="stopped",
+        )
     )
     return 1 if warm_load_fatal else 0
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
@@ -37,11 +38,14 @@ pub struct ComputeNodeStatus {
     pub fallback_reason: Option<String>,
     pub model_path: String,
     pub last_error: Option<String>,
+    pub relay_runtime_state: Option<String>,
     pub warm_load_state: Option<String>,
     pub warm_load_enabled: Option<bool>,
     pub warm_load_duration_ms: Option<u64>,
     pub runtime_path: Option<String>,
     pub relay_runtime_path: Option<String>,
+    pub session_id: Option<u64>,
+    pub sequence: Option<u64>,
 }
 
 #[derive(Clone, Default)]
@@ -50,6 +54,7 @@ pub struct ComputeNodeState {
     pub stdin: Arc<Mutex<Option<ChildStdin>>>,
     pub status: Arc<Mutex<ComputeNodeStatus>>,
     pub lifecycle_lock: Arc<Mutex<()>>,
+    pub active_session_id: Arc<AtomicU64>,
 }
 
 fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error> {
@@ -199,11 +204,14 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         fallback_reason: None,
         model_path: request.model_path.clone(),
         last_error: Some(last_error),
+        relay_runtime_state: Some("failed".into()),
         warm_load_state: Some("failed".into()),
         warm_load_enabled: Some(true),
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
+        session_id: None,
+        sequence: None,
     }
 }
 
@@ -247,11 +255,20 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
     }
+    if payload.get("relay_runtime_state").is_some() {
+        status.relay_runtime_state = payload
+            .get("relay_runtime_state")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
     if payload.get("warm_load_state").is_some() {
         status.warm_load_state = payload
             .get("warm_load_state")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+        if status.relay_runtime_state.is_none() {
+            status.relay_runtime_state = status.warm_load_state.clone();
+        }
     }
     if payload.get("warm_load_enabled").is_some() {
         status.warm_load_enabled = payload.get("warm_load_enabled").and_then(Value::as_bool);
@@ -271,6 +288,12 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
     }
+    if payload.get("session_id").is_some() {
+        status.session_id = payload.get("session_id").and_then(Value::as_u64);
+    }
+    if payload.get("sequence").is_some() {
+        status.sequence = payload.get("sequence").and_then(Value::as_u64);
+    }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
             .get("message")
@@ -278,6 +301,21 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) {
             .map(ToOwned::to_owned)
             .or_else(|| Some("compute-node bridge error".into()));
     }
+}
+
+fn compute_event_session_id(payload: &Value, fallback_session_id: u64) -> u64 {
+    payload
+        .get("session_id")
+        .and_then(Value::as_u64)
+        .unwrap_or(fallback_session_id)
+}
+
+fn should_accept_compute_event(
+    payload: &Value,
+    active_session_id: u64,
+    fallback_session_id: u64,
+) -> bool {
+    compute_event_session_id(payload, fallback_session_id) == active_session_id
 }
 
 fn bridge_exit_status_label(exit_status: std::process::ExitStatus) -> String {
@@ -319,6 +357,7 @@ fn finalize_bridge_exit(
 ) -> Option<Value> {
     status.running = false;
     status.registered = false;
+    status.relay_runtime_state = Some("stopped".into());
 
     let exit_error = bridge_exit_error(exit_status, saw_startup_event);
     if status.last_error.is_none() {
@@ -334,6 +373,7 @@ fn finalize_bridge_exit(
             "type": "error",
             "running": false,
             "registered": false,
+            "relay_runtime_state": "failed",
             "last_error": last_error,
         })
     })
@@ -359,6 +399,7 @@ pub async fn start_compute_node(
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let session_id: u64;
 
     {
         let _lifecycle_lock = state.lifecycle_lock.lock().await;
@@ -371,6 +412,7 @@ pub async fn start_compute_node(
         }
         *child_slot = None;
         *state.stdin.lock().await = None;
+        session_id = state.active_session_id.fetch_add(1, Ordering::SeqCst) + 1;
     }
 
     let bridge_script = resolve_bridge_script(&app);
@@ -421,6 +463,7 @@ pub async fn start_compute_node(
         .arg(format!("{:?}", request.mode).to_lowercase())
         .arg("--relay-url")
         .arg(&request.relay_base_url)
+        .env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", session_id.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -483,15 +526,39 @@ pub async fn start_compute_node(
                 fallback_reason: None,
                 model_path: request.model_path.clone(),
                 last_error: None,
+                relay_runtime_state: Some("starting".into()),
                 warm_load_state: Some("not_started".into()),
                 warm_load_enabled: Some(true),
                 warm_load_duration_ms: None,
                 runtime_path: Some("bridge".into()),
                 relay_runtime_path: Some("bridge".into()),
+                session_id: Some(session_id),
+                sequence: Some(0),
             };
             true
         }
     };
+
+    if installed {
+        app.emit(
+            "compute_node_event",
+            serde_json::json!({
+                "type": "starting",
+                "running": true,
+                "registered": false,
+                "active_relay_url": request.relay_base_url.clone(),
+                "requested_mode": format!("{:?}", request.mode).to_lowercase(),
+                "model_path": request.model_path.clone(),
+                "relay_runtime_state": "starting",
+                "warm_load_state": "not_started",
+                "runtime_path": "bridge",
+                "relay_runtime_path": "bridge",
+                "last_error": null,
+                "session_id": session_id,
+                "sequence": 0,
+            }),
+        )?;
+    }
 
     if !installed {
         if let Some(mut abandoned_stdin) = pending_stdin.take() {
@@ -517,7 +584,7 @@ pub async fn start_compute_node(
     let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
         match parse_compute_node_event_line(&line) {
-            Ok(payload) => {
+            Ok(mut payload) => {
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
                     if event_type == "error" {
                         saw_error_event = true;
@@ -525,6 +592,19 @@ pub async fn start_compute_node(
                     if event_type == "started" || event_type == "status" {
                         saw_startup_event = true;
                     }
+                }
+                if !payload.is_object() {
+                    continue;
+                }
+                if payload.get("session_id").and_then(Value::as_u64).is_none() {
+                    payload["session_id"] = Value::from(session_id);
+                }
+                if !should_accept_compute_event(
+                    &payload,
+                    state.active_session_id.load(Ordering::SeqCst),
+                    session_id,
+                ) {
+                    continue;
                 }
                 {
                     let mut status = state.status.lock().await;
@@ -558,8 +638,11 @@ pub async fn start_compute_node(
             finalize_bridge_exit(&mut status, exit_status, saw_startup_event, saw_error_event)
         };
 
-        if let Some(payload) = exit_payload {
-            app.emit("compute_node_event", payload)?;
+        if let Some(mut payload) = exit_payload {
+            if state.active_session_id.load(Ordering::SeqCst) == session_id {
+                payload["session_id"] = Value::from(session_id);
+                app.emit("compute_node_event", payload)?;
+            }
         }
     } else {
         let mut status = state.status.lock().await;
@@ -574,8 +657,12 @@ pub async fn start_compute_node(
     Ok(())
 }
 
-pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
+pub async fn stop_compute_node(
+    app: Option<AppHandle>,
+    state: ComputeNodeState,
+) -> anyhow::Result<()> {
     eprintln!("desktop.compute_node.stop_requested");
+    let stopped_session_id = state.active_session_id.fetch_add(1, Ordering::SeqCst) + 1;
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
@@ -619,6 +706,36 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         let mut status = state.status.lock().await;
         status.running = false;
         status.registered = false;
+        status.relay_runtime_state = Some("stopped".into());
+        status.warm_load_state = Some("stopped".into());
+        status.last_error = None;
+        status.session_id = Some(stopped_session_id);
+        status.sequence = Some(0);
+        if let Some(app) = app {
+            app.emit(
+                "compute_node_event",
+                serde_json::json!({
+                    "type": "stopped",
+                    "running": false,
+                    "registered": false,
+                    "relay_runtime_state": "stopped",
+                    "warm_load_state": "stopped",
+                    "active_relay_url": status.active_relay_url.clone(),
+                    "requested_mode": status.requested_mode.clone(),
+                    "effective_mode": status.effective_mode.clone(),
+                    "backend_available": status.backend_available.clone(),
+                    "backend_selected": status.backend_selected.clone(),
+                    "backend_used": status.backend_used.clone(),
+                    "fallback_reason": status.fallback_reason.clone(),
+                    "model_path": status.model_path.clone(),
+                    "last_error": null,
+                    "runtime_path": status.runtime_path.clone(),
+                    "relay_runtime_path": status.relay_runtime_path.clone(),
+                    "session_id": stopped_session_id,
+                    "sequence": 0,
+                }),
+            )?;
+        }
     }
     Ok(())
 }
@@ -704,9 +821,11 @@ mod tests {
         let state = ComputeNodeState::default();
         let lifecycle_guard = state.lifecycle_lock.lock().await;
 
-        let result =
-            tokio::time::timeout(Duration::from_millis(200), stop_compute_node(state.clone()))
-                .await;
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            stop_compute_node(None, state.clone()),
+        )
+        .await;
 
         assert!(result.is_ok(), "stop should not block on lifecycle lock");
         drop(lifecycle_guard);
@@ -743,8 +862,11 @@ mod tests {
             status.registered = true;
         }
 
-        let stop_result =
-            tokio::time::timeout(Duration::from_secs(2), stop_compute_node(state.clone())).await;
+        let stop_result = tokio::time::timeout(
+            Duration::from_secs(2),
+            stop_compute_node(None, state.clone()),
+        )
+        .await;
         assert!(stop_result.is_ok(), "stop should complete without hanging");
         stop_result
             .expect("timeout result")
@@ -782,7 +904,9 @@ mod tests {
         *state.child.lock().await = Some(first_child);
         *state.stdin.lock().await = Some(first_stdin);
 
-        stop_compute_node(state.clone()).await.expect("first stop");
+        stop_compute_node(None, state.clone())
+            .await
+            .expect("first stop");
         assert!(state.child.lock().await.is_none());
         assert!(state.stdin.lock().await.is_none());
 
@@ -797,9 +921,46 @@ mod tests {
         *state.child.lock().await = Some(second_child);
         *state.stdin.lock().await = Some(second_stdin);
 
-        stop_compute_node(state.clone()).await.expect("second stop");
+        stop_compute_node(None, state.clone())
+            .await
+            .expect("second stop");
         assert!(state.child.lock().await.is_none());
         assert!(state.stdin.lock().await.is_none());
+    }
+
+    #[test]
+    fn should_accept_compute_event_rejects_stale_prior_session_events() {
+        let active_session_id = 2;
+        let current_payload = serde_json::json!({
+            "type": "status",
+            "session_id": 2,
+            "sequence": 1,
+        });
+        let stale_payload = serde_json::json!({
+            "type": "status",
+            "session_id": 1,
+            "sequence": 99,
+        });
+        let legacy_payload = serde_json::json!({
+            "type": "status",
+            "sequence": 1,
+        });
+
+        assert!(should_accept_compute_event(
+            &current_payload,
+            active_session_id,
+            active_session_id
+        ));
+        assert!(!should_accept_compute_event(
+            &stale_payload,
+            active_session_id,
+            active_session_id
+        ));
+        assert!(should_accept_compute_event(
+            &legacy_payload,
+            active_session_id,
+            active_session_id
+        ));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -303,8 +303,11 @@ async fn start_compute_node(
 }
 
 #[tauri::command]
-async fn stop_compute_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    compute_node::stop_compute_node(state.compute_node.clone())
+async fn stop_compute_node(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    compute_node::stop_compute_node(Some(app), state.compute_node.clone())
         .await
         .map_err(|e| e.to_string())
 }

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -667,4 +667,183 @@ describe('desktop app start failure handling', () => {
     );
     expect(screen.getByText(/Error:/).textContent).toContain('event failure path');
   });
+  it('renders accurate compute-node lifecycle fields from structured status events', async () => {
+    mockInitialComputeStatus({
+      relay_runtime_state: 'idle',
+      warm_load_state: 'idle',
+      warm_load_enabled: true,
+      runtime_path: null,
+      relay_runtime_path: null,
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('idle');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        sequence: 1,
+        running: true,
+        registered: false,
+        relay_runtime_state: 'warming',
+        active_relay_url: 'https://relay.example',
+        requested_mode: 'gpu',
+        effective_mode: 'pending',
+        backend_available: 'unknown',
+        backend_selected: 'unknown',
+        backend_used: 'unknown',
+        fallback_reason: null,
+        model_path: '/models/relay.gguf',
+        runtime_path: 'sidecar',
+        relay_runtime_path: 'bridge',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming');
+    expect(screen.getByText(/Runtime path:/).textContent).toContain('sidecar');
+    expect(screen.getByText(/Relay runtime path:/).textContent).toContain('bridge');
+    expect(screen.getByText(/Active relay URL:/).textContent).toContain('https://relay.example');
+    expect(screen.getByText(/Requested mode:/).textContent).toContain('gpu');
+    expect(screen.getByText(/Effective mode:/).textContent).toContain('pending');
+    expect(screen.getByText(/Backend available:/).textContent).toContain('unknown');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        sequence: 2,
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        active_relay_url: 'https://relay.example',
+        requested_mode: 'gpu',
+        effective_mode: 'gpu',
+        backend_available: 'cuda',
+        backend_selected: 'cuda',
+        backend_used: 'cuda',
+        fallback_reason: null,
+        model_path: '/models/relay.gguf',
+        runtime_path: 'bridge',
+        relay_runtime_path: 'bridge',
+        last_error: null,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('ready');
+    expect(screen.getByText(/Backend available:/).textContent).toContain('cuda');
+    expect(screen.getByText(/Backend selected:/).textContent).toContain('cuda');
+    expect(screen.getByText(/Backend used:/).textContent).toContain('cuda');
+    expect(screen.getByText(/Fallback reason:/).textContent).toContain('none');
+    expect(screen.getByText(/Model path:/).textContent).toContain('/models/relay.gguf');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        sequence: 3,
+        running: true,
+        registered: true,
+        relay_runtime_state: 'processing',
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Relay runtime state:/).textContent).toContain('processing'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        session_id: 2,
+        sequence: 0,
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: null,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
+  it('ignores stale compute-node events from an older backend session after restart', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 2,
+        sequence: 1,
+        running: true,
+        registered: false,
+        relay_runtime_state: 'warming',
+        last_error: null,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming'));
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        session_id: 1,
+        sequence: 99,
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        last_error: 'old bridge failed late',
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Relay runtime state:/).textContent).toContain('warming'));
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
+  it('renders failed compute-node status without implying registration', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        session_id: 1,
+        sequence: 1,
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        active_relay_url: 'https://relay.example',
+        requested_mode: 'auto',
+        effective_mode: 'cpu',
+        backend_available: 'cuda',
+        backend_selected: 'cuda',
+        backend_used: 'cpu',
+        fallback_reason: 'cuda init failed',
+        model_path: '/models/relay.gguf',
+        runtime_path: 'bridge',
+        relay_runtime_path: 'bridge',
+        last_error: 'failed to initialize API v1 model runtime',
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('failed');
+    expect(screen.getByText(/Fallback reason:/).textContent).toContain('cuda init failed');
+    expect(screen.getByText(/Last error:/).textContent).toContain('failed to initialize API v1 model runtime');
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -31,11 +31,14 @@ interface ComputeNodeStatus {
   fallback_reason: string | null;
   model_path: string;
   last_error: string | null;
+  relay_runtime_state: string | null;
   warm_load_state: string | null;
   warm_load_enabled: boolean | null;
   warm_load_duration_ms: number | null;
   runtime_path: string | null;
   relay_runtime_path: string | null;
+  session_id: number | null;
+  sequence: number | null;
 }
 
 interface ModelArtifactInfo {
@@ -68,15 +71,131 @@ const defaultComputeStatus: ComputeNodeStatus = {
   fallback_reason: null,
   model_path: '',
   last_error: null,
+  relay_runtime_state: 'idle',
   warm_load_state: null,
   warm_load_enabled: null,
   warm_load_duration_ms: null,
   runtime_path: null,
   relay_runtime_path: null,
+  session_id: null,
+  sequence: null,
 };
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+
+function normalizeRelayRuntimeState(status: ComputeNodeStatus): string {
+  return status.relay_runtime_state || status.warm_load_state || 'idle';
+}
+
+function isRelayRuntimeReady(status: ComputeNodeStatus): boolean {
+  const relayState = normalizeRelayRuntimeState(status);
+  return status.warm_load_enabled === false || relayState === 'ready' || relayState === 'processing';
+}
+
+function mergeComputeNodeStatus(
+  prev: ComputeNodeStatus,
+  payload: Record<string, unknown>
+): ComputeNodeStatus {
+  const payloadSessionId = typeof payload.session_id === 'number' ? payload.session_id : null;
+  const payloadSequence = typeof payload.sequence === 'number' ? payload.sequence : null;
+  if (
+    payloadSessionId !== null &&
+    prev.session_id !== null &&
+    payloadSessionId < prev.session_id
+  ) {
+    return prev;
+  }
+  if (
+    payloadSessionId !== null &&
+    prev.session_id !== null &&
+    payloadSessionId === prev.session_id &&
+    payloadSequence !== null &&
+    prev.sequence !== null &&
+    payloadSequence < prev.sequence
+  ) {
+    return prev;
+  }
+
+  const nextRelayRuntimeState =
+    typeof payload.relay_runtime_state === 'string'
+      ? payload.relay_runtime_state
+      : typeof payload.warm_load_state === 'string'
+        ? payload.warm_load_state
+        : payload.type === 'stopped'
+          ? 'stopped'
+          : payload.type === 'error'
+            ? 'failed'
+            : prev.relay_runtime_state;
+
+  return {
+    running:
+      typeof payload.running === 'boolean'
+        ? payload.running
+        : payload.type === 'error'
+          ? false
+          : prev.running,
+    registered: typeof payload.registered === 'boolean' ? payload.registered : prev.registered,
+    active_relay_url:
+      typeof payload.active_relay_url === 'string'
+        ? payload.active_relay_url
+        : prev.active_relay_url,
+    requested_mode:
+      typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
+    effective_mode:
+      typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
+    backend_available:
+      typeof payload.backend_available === 'string'
+        ? payload.backend_available
+        : prev.backend_available,
+    backend_selected:
+      typeof payload.backend_selected === 'string'
+        ? payload.backend_selected
+        : prev.backend_selected,
+    backend_used:
+      typeof payload.backend_used === 'string' ? payload.backend_used : prev.backend_used,
+    fallback_reason:
+      payload.fallback_reason === null
+        ? null
+        : typeof payload.fallback_reason === 'string'
+          ? payload.fallback_reason
+          : prev.fallback_reason,
+    model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
+    relay_runtime_state: nextRelayRuntimeState,
+    warm_load_state:
+      payload.warm_load_state === null
+        ? null
+        : typeof payload.warm_load_state === 'string'
+          ? payload.warm_load_state
+          : nextRelayRuntimeState !== prev.relay_runtime_state
+            ? nextRelayRuntimeState
+            : prev.warm_load_state,
+    warm_load_enabled:
+      typeof payload.warm_load_enabled === 'boolean'
+        ? payload.warm_load_enabled
+        : prev.warm_load_enabled,
+    warm_load_duration_ms:
+      typeof payload.warm_load_duration_ms === 'number'
+        ? payload.warm_load_duration_ms
+        : prev.warm_load_duration_ms,
+    runtime_path: typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
+    relay_runtime_path:
+      typeof payload.relay_runtime_path === 'string'
+        ? payload.relay_runtime_path
+        : prev.relay_runtime_path,
+    session_id: payloadSessionId ?? prev.session_id,
+    sequence: payloadSequence ?? prev.sequence,
+    last_error:
+      payload.last_error === null
+        ? null
+        : typeof payload.last_error === 'string'
+          ? payload.last_error
+          : typeof payload.message === 'string'
+            ? payload.message
+            : prev.last_error,
+  };
 }
 
 export function selectedModelPath(selection: string | string[] | null): string {
@@ -106,10 +225,7 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
-  const relayRuntimeReady =
-    computeStatus.warm_load_enabled === false ||
-    computeStatus.warm_load_state === null ||
-    computeStatus.warm_load_state === 'ready';
+  const relayRuntimeReady = isRelayRuntimeReady(computeStatus);
   const computeNodeRegistered = computeStatus.running && computeStatus.registered && relayRuntimeReady;
   const saveTimerRef = useRef<number | null>(null);
   const requestIdRef = useRef('');
@@ -168,63 +284,7 @@ export function App() {
   useEffect(() => {
     const unlisten = listen<Record<string, unknown>>('compute_node_event', (evt) => {
       const payload = evt.payload;
-      setComputeStatus((prev) => ({
-        running:
-          typeof payload.running === 'boolean'
-            ? payload.running
-            : payload.type === 'error'
-              ? false
-              : prev.running,
-        registered: typeof payload.registered === 'boolean' ? payload.registered : prev.registered,
-        active_relay_url:
-          typeof payload.active_relay_url === 'string'
-            ? payload.active_relay_url
-            : prev.active_relay_url,
-        requested_mode:
-          typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
-        effective_mode:
-          typeof payload.effective_mode === 'string' ? payload.effective_mode : prev.effective_mode,
-        backend_available:
-          typeof payload.backend_available === 'string'
-            ? payload.backend_available
-            : prev.backend_available,
-        backend_selected:
-          typeof payload.backend_selected === 'string'
-            ? payload.backend_selected
-            : prev.backend_selected,
-        backend_used:
-          typeof payload.backend_used === 'string' ? payload.backend_used : prev.backend_used,
-        fallback_reason:
-          payload.fallback_reason === null
-            ? null
-            : typeof payload.fallback_reason === 'string'
-              ? payload.fallback_reason
-              : prev.fallback_reason,
-        model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
-        warm_load_state:
-          typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
-        warm_load_enabled:
-          typeof payload.warm_load_enabled === 'boolean'
-            ? payload.warm_load_enabled
-            : prev.warm_load_enabled,
-        warm_load_duration_ms:
-          typeof payload.warm_load_duration_ms === 'number'
-            ? payload.warm_load_duration_ms
-            : prev.warm_load_duration_ms,
-        runtime_path: typeof payload.runtime_path === 'string' ? payload.runtime_path : prev.runtime_path,
-        relay_runtime_path:
-          typeof payload.relay_runtime_path === 'string'
-            ? payload.relay_runtime_path
-            : prev.relay_runtime_path,
-        last_error:
-          payload.last_error === null
-            ? null
-            : typeof payload.last_error === 'string'
-              ? payload.last_error
-              : typeof payload.message === 'string'
-                ? payload.message
-                : prev.last_error,
-      }));
+      setComputeStatus((prev) => mergeComputeNodeStatus(prev, payload));
       if (payload.type === 'started' || payload.type === 'error') {
         setIsStartingComputeNode(false);
       }
@@ -361,6 +421,8 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        relay_runtime_state: 'starting',
+        warm_load_state: 'starting',
       }));
       await invoke('start_compute_node', {
         request: {
@@ -481,7 +543,7 @@ export function App() {
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{computeNodeRegistered ? 'yes' : 'no'}</strong></p>
-        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{computeStatus.warm_load_state || 'idle'}</code></p>
+        <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{normalizeRelayRuntimeState(computeStatus)}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{computeStatus.runtime_path || 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{computeStatus.relay_runtime_path || 'bridge'}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{computeStatus.active_relay_url || config.relay_base_url}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2386,3 +2386,98 @@ def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypat
         }
     ]
     assert capsys.readouterr().out.splitlines()[-1]
+
+
+def test_status_events_include_full_operator_status_contract(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setenv('TOKENPLACE_COMPUTE_NODE_SESSION_ID', '7')
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    status_payloads = [event for event in events if event['type'] in {'started', 'status', 'stopped'}]
+    assert status_payloads
+    required_fields = set(compute_node_bridge.STATUS_CONTRACT_FIELDS)
+    for payload in status_payloads:
+        assert required_fields.issubset(payload), payload
+        assert payload['session_id'] == 7
+        assert isinstance(payload['sequence'], int)
+        assert payload['relay_runtime_state'] in {'starting', 'warming', 'ready', 'stopped'}
+        assert payload['runtime_path'] in {'bridge', 'sidecar'}
+        assert payload['relay_runtime_path'] == 'bridge'
+
+
+def test_registered_remains_false_until_runtime_ready_and_relay_registration(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingTimeoutApiV1Runtime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
+    monkeypatch.setattr(compute_node_bridge, 'PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS', 0.01)
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    status_events = [event for event in events if event['type'] == 'status']
+    warming_events = [event for event in status_events if event['relay_runtime_state'] == 'warming']
+    ready_registered_events = [
+        event
+        for event in status_events
+        if event['relay_runtime_state'] == 'ready' and event['registered'] is True
+    ]
+    assert warming_events
+    assert all(event['registered'] is False for event in warming_events)
+    assert ready_registered_events
+
+
+def test_graceful_stop_status_clears_registration_and_last_error(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=IncompatibleRelayRuntime)
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    stopped = events[-1]
+    assert stopped['type'] == 'stopped'
+    assert stopped['running'] is False
+    assert stopped['registered'] is False
+    assert stopped['relay_runtime_state'] == 'stopped'
+    assert stopped['last_error'] is None


### PR DESCRIPTION
### Motivation
- Prevent the desktop compute-node panel from showing misleading lifecycle states (e.g. `Registered: yes` while runtime is warming) by introducing a single structured operator status contract shared across the Python bridge, Rust backend, and React UI.
- Ensure lifecycle transitions (starting → warming → ready/registered → processing → stopped/failed) are deterministic and that stale events from old bridge sessions cannot overwrite current UI state.

### Description
- Add a structured status payload and contract in the Python bridge with `STATUS_CONTRACT_FIELDS`, `session_id`, `sequence`, `relay_runtime_state`, and sequence numbers, and make `started/status/error/stopped` events emit the full operator fields. (desktop-tauri/src-tauri/python/compute_node_bridge.py)
- Make the Rust backend stamp each bridge session, pass a session id to the bridge, emit a `starting` event, ignore stale events from prior sessions, and emit a deterministic `stopped` event on stop/finalize. Also update `stop_compute_node` to surface the AppHandle for immediate UI emission. (desktop-tauri/src-tauri/src/compute_node.rs, desktop-tauri/src-tauri/src/main.rs)
- Update React state merging so the frontend consumes structured status events (added `mergeComputeNodeStatus`, `normalizeRelayRuntimeState`, and `isRelayRuntimeReady`) and rejects stale session/sequence events, and render all compute-node UI fields from the backend status payloads. (desktop-tauri/src/App.tsx)
- Add/adjust tests and UI coverage to assert lifecycle fidelity: UI tests to validate idle/warming/ready/processing/stopped/error states and stale-event rejection, and bridge tests to assert the status contract and registration semantics. (desktop-tauri/src/App.test.tsx, tests/unit/test_desktop_compute_node_bridge.py)

### Testing
- Ran unit bridge tests: `pytest tests/unit/test_desktop_compute_node_bridge.py -q` — 64 passed.
- Ran UI tests: `npm --prefix desktop-tauri test` (Vitest) — test suite passed (desktop UI tests passed).
- Type check: `npx --prefix desktop-tauri tsc --noEmit` — succeeded (no TypeScript errors).
- Project hooks: `pre-commit run --all-files` — passed (repo checks passed).
- Notes about platform-limited checks: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node -- --nocapture` could not complete in this container due to missing system `glib-2.0.pc` required by `glib-sys`/Tauri (environment/system dependency), and Playwright browser screenshot attempts failed because Playwright browsers are not installed here; these are environment constraints and not regressions in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a56b6ea34832fa35ccc8eaa464e27)