### PR TITLE
Fix API v1 relay queue cleanup cadence

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -158,7 +158,7 @@ class DistributedApiV1ComputeProvider:
     """Provider that dispatches API v1 requests via relay-blind E2EE envelopes."""
 
     base_url: str
-    timeout_seconds: float = 30.0
+    timeout_seconds: float = 120.0
 
     def _relay_url(self, path: str) -> str:
         base_url = self.base_url.rstrip("/")
@@ -182,7 +182,7 @@ class DistributedApiV1ComputeProvider:
     ) -> dict[str, Any]:
         _last_backend_path.set("distributed_relay_e2ee_pending")
         crypto_manager = self._build_request_crypto_manager()
-        relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
+        relay_timeout = max(float(self.timeout_seconds), 1.0)
         deadline = time.time() + relay_timeout
         relay_request_id = f"api-v1-{uuid.uuid4().hex}"
 
@@ -194,6 +194,26 @@ class DistributedApiV1ComputeProvider:
                     message="timed out waiting for distributed relay API v1 encrypted response",
                 )
             return remaining
+
+        def _cancel_relay_request(reason: str) -> None:
+            try:
+                requests.post(
+                    self._relay_url("/api/v1/relay/requests/cancel"),
+                    json={
+                        "client_public_key": crypto_manager.public_key_b64,
+                        "request_id": relay_request_id,
+                        "status": "timeout" if reason == "timeout" else "cancelled",
+                        "reason": reason,
+                    },
+                    timeout=min(1.0, max(deadline - time.time(), 0.1)),
+                )
+            except requests.RequestException:
+                logger.debug(
+                    "api_v1.distributed.cancel_failed request_id=%s reason=%s",
+                    relay_request_id,
+                    reason,
+                    exc_info=True,
+                )
 
         try:
             next_server_response = requests.get(
@@ -336,6 +356,23 @@ class DistributedApiV1ComputeProvider:
                     message="relay reported unknown API v1 response request id",
                 )
 
+            if retrieve_response.status_code in {409, 410}:
+                try:
+                    error_payload = retrieve_response.json()
+                except ValueError:
+                    error_payload = {}
+                error_body = error_payload.get("error") if isinstance(error_payload, dict) else {}
+                error_code = error_body.get("code") if isinstance(error_body, dict) else None
+                if error_code in {"cancelled", "expired", "timeout"}:
+                    raise _error_from_code(
+                        "compute_node_timeout" if error_code in {"expired", "timeout"} else "compute_node_bridge_timeout",
+                        message=f"relay reported API v1 request {error_code}",
+                    )
+                raise _error_from_code(
+                    "compute_node_bridge_error",
+                    message=f"relay response retrieve returned terminal status {retrieve_response.status_code}",
+                )
+
             if retrieve_response.status_code != 200:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
@@ -406,6 +443,7 @@ class DistributedApiV1ComputeProvider:
             _last_backend_path.set("distributed_relay_e2ee")
             return assistant_message
 
+        _cancel_relay_request("timeout")
         raise _error_from_code(
             "compute_node_timeout",
             message="timed out waiting for distributed relay API v1 encrypted response",

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1132,6 +1132,15 @@ def run(args: argparse.Namespace) -> int:
                     current_last_error=last_error,
                 )
 
+                if api_v1_payload:
+                    wait_seconds = 0.0
+                    print(
+                        "desktop.compute_node_bridge.api_v1_e2ee.work_processed_next_poll_immediate "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                        f"wait={wait_seconds}",
+                        file=sys.stderr,
+                    )
+
                 if _sleep_with_cancel(wait_seconds):
                     print(
                         "desktop.compute_node_bridge.stop_requested "

--- a/relay.py
+++ b/relay.py
@@ -454,6 +454,8 @@ client_responses = {}
 client_responses_lock = threading.Lock()
 client_pending_request_ids = {}
 client_pending_request_ids_lock = threading.Lock()
+client_cancelled_request_ids = {}
+client_cancelled_request_ids_lock = threading.Lock()
 PENDING_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_PENDING_REQUEST_TTL_SECONDS", "300"))
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
@@ -522,6 +524,96 @@ def _api_v1_in_flight_ttl_seconds() -> float:
         return max(float(_api_v1_lease_seconds()), 1.0)
     return max(value, 1.0)
 
+
+def _safe_key_fingerprint(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        return "unknown"
+    return f"{value[:8]}...{value[-4:]}" if len(value) > 12 else "short-key"
+
+
+def _queue_depth_for_server(server_public_key: str) -> int:
+    return sum(
+        1
+        for item in client_inference_requests.get(server_public_key, [])
+        if isinstance(item, dict) and not item.get("_cancelled")
+    )
+
+
+def _mark_request_terminal(client_public_key, request_id, status, *, reason=None):
+    if not client_public_key or not request_id:
+        return
+    with client_cancelled_request_ids_lock:
+        client_cancelled_request_ids.setdefault(client_public_key, {})[request_id] = {
+            "status": status,
+            "reason": reason or status,
+            "updated_at": time.time(),
+        }
+
+
+def _pop_request_terminal(client_public_key, request_id):
+    if not client_public_key or not request_id:
+        return None
+    with client_cancelled_request_ids_lock:
+        statuses = client_cancelled_request_ids.get(client_public_key)
+        if not statuses:
+            return None
+        status = statuses.get(request_id)
+        if not status:
+            return None
+        return dict(status) if isinstance(status, dict) else {"status": str(status)}
+
+
+def _remove_queued_api_v1_request(client_public_key, request_id, *, status="cancelled", reason=None):
+    """Remove an abandoned API v1 request from all server queues and mark terminal state."""
+    if not client_public_key or not request_id:
+        return False
+    removed = False
+    removed_server_keys = []
+    with client_inference_requests_changed:
+        for server_public_key, queued_requests in list(client_inference_requests.items()):
+            if not isinstance(queued_requests, list):
+                continue
+            retained = []
+            for item in queued_requests:
+                if (
+                    isinstance(item, dict)
+                    and bool(item.get("e2ee_v1"))
+                    and item.get("client_public_key") == client_public_key
+                    and item.get("request_id") == request_id
+                ):
+                    removed = True
+                    removed_server_keys.append(server_public_key)
+                    continue
+                retained.append(item)
+            if retained:
+                client_inference_requests[server_public_key] = retained
+            else:
+                client_inference_requests.pop(server_public_key, None)
+        if removed:
+            client_inference_requests_changed.notify_all()
+    _clear_pending_request(client_public_key, request_id)
+    _mark_request_terminal(client_public_key, request_id, status, reason=reason)
+    if removed:
+        for server_public_key in removed_server_keys:
+            LOGGER.info(
+                "relay.api_v1.request_removed_from_queue",
+                extra={
+                    "server_fingerprint": _safe_key_fingerprint(server_public_key),
+                    "request_id": request_id,
+                    "status": status,
+                },
+            )
+        LOGGER.info(
+            "relay.api_v1.request_cancelled",
+            extra={
+                "client_fingerprint": _safe_key_fingerprint(client_public_key),
+                "request_id": request_id,
+                "status": status,
+                "reason": reason or status,
+            },
+        )
+    return removed
+
 def _pop_next_api_v1_request(public_key: str):
     queued_requests = client_inference_requests.get(public_key, [])
     if not queued_requests:
@@ -532,10 +624,16 @@ def _pop_next_api_v1_request(public_key: str):
     def _is_legacy_ciphertext_payload(payload):
         return all(key in payload for key in ('client_public_key', 'chat_history', 'cipherkey', 'iv'))
 
-    for idx, candidate in enumerate(queued_requests):
+    idx = 0
+    while idx < len(queued_requests):
+        candidate = queued_requests[idx]
         if bool(candidate.get('e2ee_v1')):
+            if _pop_request_terminal(candidate.get('client_public_key'), candidate.get('request_id')):
+                queued_requests.pop(idx)
+                continue
             first_request = queued_requests.pop(idx)
             break
+        idx += 1
 
     if first_request is None:
         while queued_requests:
@@ -604,7 +702,7 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
             "server_public_key": server_public_key,
             "age_seconds": round(_server_ping_age_seconds(payload.get("last_ping")), 3),
             "next_ping_in_x_seconds": payload.get("last_ping_duration"),
-            "queue_depth": len(client_inference_requests.get(server_public_key, [])),
+            "queue_depth": _queue_depth_for_server(server_public_key),
         })
     diagnostics.sort(key=lambda node: node["server_public_key"])
     return diagnostics
@@ -1046,6 +1144,12 @@ def _clear_pending_requests_for_queued_items(queued_items):
         if not bool(item.get("e2ee_v1")):
             continue
         _clear_pending_request(item.get("client_public_key"), item.get("request_id"))
+        _mark_request_terminal(
+            item.get("client_public_key"),
+            item.get("request_id"),
+            "cancelled",
+            reason="server_unregistered",
+        )
 
 
 def _is_request_pending(client_public_key, request_id):
@@ -1062,8 +1166,18 @@ def _is_request_pending(client_public_key, request_id):
             pending_ids.pop(request_id, None)
             if not pending_ids:
                 client_pending_request_ids.pop(client_public_key, None)
-            return False
-        return True
+            expired = True
+        else:
+            expired = False
+    if expired:
+        _remove_queued_api_v1_request(
+            client_public_key,
+            request_id,
+            status="expired",
+            reason="pending_request_ttl_exceeded",
+        )
+        return False
+    return True
 
 
 def _pop_client_response(client_public_key, request_id=None):
@@ -1201,7 +1315,7 @@ def api_v1_relay_servers_poll():
     LOGGER.info(
         "relay.api_v1.request_dispatched",
         extra={
-            "server_public_key": public_key,
+            "server_fingerprint": _safe_key_fingerprint(public_key),
             "request_id": first_request.get("request_id"),
             "queued_at_unix": queued_at,
             "dispatched_at_unix": time.time(),
@@ -1239,12 +1353,12 @@ def api_v1_relay_requests():
     _mark_request_pending(envelope.get('client_public_key'), envelope.get('request_id'))
     with client_inference_requests_changed:
         client_inference_requests.setdefault(server_public_key, []).append(envelope)
-        queue_depth = len(client_inference_requests.get(server_public_key, []))
+        queue_depth = _queue_depth_for_server(server_public_key)
         client_inference_requests_changed.notify_all()
     LOGGER.info(
         "relay.api_v1.request_queued",
         extra={
-            "server_public_key": server_public_key,
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
             "request_id": envelope.get("request_id"),
             "queued_at_unix": queued_at,
             "queue_depth": queue_depth,
@@ -1286,6 +1400,13 @@ def api_v1_relay_responses():
                     break
 
     _queue_client_response(client_public_key, envelope)
+    LOGGER.info(
+        "relay.api_v1.response_received",
+        extra={
+            "client_fingerprint": _safe_key_fingerprint(client_public_key),
+            "request_id": request_id,
+        },
+    )
     return jsonify({'message': 'Response received and queued for client'}), 200
 
 
@@ -1303,14 +1424,57 @@ def api_v1_relay_responses_retrieve():
         if _is_request_pending(client_public_key, request_id):
             LOGGER.debug(
                 "relay.api_v1.response_pending",
-                extra={"client_public_key": client_public_key, "request_id": request_id},
+                extra={"client_fingerprint": _safe_key_fingerprint(client_public_key), "request_id": request_id},
             )
             return jsonify({"status": "pending"}), 202
+        terminal = _pop_request_terminal(client_public_key, request_id)
+        if terminal is not None:
+            status = terminal.get("status", "cancelled")
+            status_code = 410 if status in {"cancelled", "expired", "timeout"} else 409
+            return jsonify({
+                "error": {
+                    "message": f"Request {request_id} is {status}",
+                    "code": status,
+                    "status": status,
+                    "reason": terminal.get("reason", status),
+                }
+            }), status_code
         if request_id:
             return jsonify({'error': {'message': f'Unknown request_id: {request_id}', 'code': 404}}), 404
         return jsonify({'error': {'message': 'No response available for the given public key', 'code': 404}}), 404
 
+    LOGGER.info(
+        "relay.api_v1.response_retrieved",
+        extra={
+            "client_fingerprint": _safe_key_fingerprint(client_public_key),
+            "request_id": response.get('request_id') if isinstance(response, dict) else request_id,
+        },
+    )
     return jsonify(response), 200
+
+
+@app.route('/api/v1/relay/requests/cancel', methods=['POST'])
+def api_v1_relay_requests_cancel():
+    """Cancel an abandoned encrypted API v1 relay request before dispatch."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+    client_public_key = data.get('client_public_key')
+    request_id = data.get('request_id')
+    if not client_public_key or not request_id:
+        return jsonify({'error': {'message': 'Missing client_public_key or request_id', 'code': 400}}), 400
+    status = data.get('status') or 'cancelled'
+    reason = data.get('reason') or status
+    removed = _remove_queued_api_v1_request(
+        client_public_key,
+        request_id,
+        status=str(status),
+        reason=str(reason),
+    )
+    if not removed and _pop_request_terminal(client_public_key, request_id) is None:
+        _clear_pending_request(client_public_key, request_id)
+        _mark_request_terminal(client_public_key, request_id, str(status), reason=str(reason))
+    return jsonify({'status': str(status), 'request_id': request_id, 'removed': bool(removed)}), 200
 
 @app.route('/faucet', methods=['POST'])
 def faucet():

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -100,6 +100,8 @@ def reset_relay_state(monkeypatch):
     relay.known_servers.clear()
     relay.client_inference_requests.clear()
     relay.client_responses.clear()
+    relay.client_pending_request_ids.clear()
+    relay.client_cancelled_request_ids.clear()
     relay.streaming_sessions.clear()
     relay.streaming_sessions_by_client.clear()
     compute_provider._build_api_v1_compute_provider.cache_clear()
@@ -111,6 +113,8 @@ def reset_relay_state(monkeypatch):
     relay.known_servers.clear()
     relay.client_inference_requests.clear()
     relay.client_responses.clear()
+    relay.client_pending_request_ids.clear()
+    relay.client_cancelled_request_ids.clear()
     relay.streaming_sessions.clear()
     relay.streaming_sessions_by_client.clear()
     compute_provider._build_api_v1_compute_provider.cache_clear()
@@ -379,7 +383,6 @@ def test_api_v1_desktop_bridge_registration_poll_no_work_heartbeat():
         assert poll_payload["next_ping_in_x_seconds"] == 0
 
 
-
 def test_api_v1_desktop_bridge_reregisters_after_idle_no_work_before_browser_request(monkeypatch):
     """A desktop node that idled after no-work polling should renew before browser work."""
 
@@ -457,6 +460,83 @@ def test_api_v1_desktop_bridge_reregisters_after_idle_no_work_before_browser_req
     assert response.status_code == 200, response.text
     completion = _decrypt_browser_response(browser_crypto, response.json())
     assert completion["choices"][0]["message"]["content"] == "pong from desktop"
+
+
+def test_api_v1_desktop_bridge_three_sequential_turns_single_node(monkeypatch):
+    """One desktop node drains immediate sequential API v1 work without stale queue depth."""
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0.01")
+
+    with live_relay_server() as base_url:
+        desktop_client = RelayClient(
+            base_url=base_url,
+            port=None,
+            crypto_manager=CryptoManager(),
+            model_manager=FakeDesktopModelManager(),
+            include_configured_servers=False,
+        )
+        desktop_client._request_timeout = 1
+        assert desktop_client.register_api_v1_compute_node(base_url)["next_ping_in_x_seconds"] > 0
+
+        monkeypatch.setattr(
+            routes,
+            "get_api_v1_compute_provider_for_mode",
+            lambda **_kwargs: compute_provider.DistributedApiV1ComputeProvider(
+                base_url=base_url,
+                timeout_seconds=5,
+            ),
+        )
+
+        for turn in range(3):
+            browser_crypto = EncryptionManager()
+            response_holder = {}
+            payload = {
+                "model": "llama-3-8b-instruct",
+                "encrypted": True,
+                "client_public_key": browser_crypto.public_key_b64,
+                "messages": _encrypt_browser_messages(
+                    [{"role": "user", "content": f"sequential turn {turn + 1}"}]
+                ),
+                "metadata": {
+                    "inference_target": "desktop_bridge_api_v1_e2ee",
+                    "relay_path": "api_v1_e2ee",
+                },
+            }
+
+            browser_thread = threading.Thread(
+                target=lambda: response_holder.setdefault(
+                    "response",
+                    requests.post(
+                        f"{base_url}/api/v1/chat/completions",
+                        json=payload,
+                        timeout=10,
+                    ),
+                ),
+                daemon=True,
+            )
+            browser_thread.start()
+
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                relay_payload = desktop_client.poll_api_v1_encrypted_work()
+                if relay_payload.get("protocol") == "tokenplace_api_v1_relay_e2ee":
+                    assert desktop_client.process_client_request(relay_payload) is True
+                    break
+                time.sleep(0.01)
+            else:  # pragma: no cover - diagnostic failure path
+                pytest.fail(f"desktop did not receive turn {turn + 1}")
+
+            browser_thread.join(timeout=5)
+            response = response_holder.get("response")
+            assert response is not None
+            assert response.status_code == 200, response.text
+            completion = _decrypt_browser_response(browser_crypto, response.json())
+            assert completion["choices"][0]["message"]["content"] == "pong from desktop"
+            diagnostics = requests.get(f"{base_url}/relay/diagnostics", timeout=2).json()
+            assert diagnostics["registered_compute_nodes"][0]["queue_depth"] == 0
+            assert relay.client_inference_requests == {}
+
+        assert len(desktop_client.model_manager.runtime.calls) == 3
 
 
 @pytest.mark.parametrize("encrypted", [False, True])

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -21,6 +21,7 @@ from relay import (
     known_servers,
     client_inference_requests,
     client_pending_request_ids,
+    client_cancelled_request_ids,
     client_responses,
     streaming_sessions,
     streaming_sessions_by_client,
@@ -42,6 +43,7 @@ def client():
     known_servers.clear()
     client_inference_requests.clear()
     client_pending_request_ids.clear()
+    client_cancelled_request_ids.clear()
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
@@ -57,6 +59,7 @@ def client():
     known_servers.clear()
     client_inference_requests.clear()
     client_pending_request_ids.clear()
+    client_cancelled_request_ids.clear()
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
@@ -1573,7 +1576,8 @@ def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_qu
         '/api/v1/relay/responses/retrieve',
         json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-abandoned'},
     )
-    assert unknown.status_code == 404
+    assert unknown.status_code == 410
+    assert unknown.get_json()['error']['code'] == 'cancelled'
 
 
 def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(client):
@@ -2232,3 +2236,66 @@ def test_api_v1_unregister_is_idempotent_when_server_already_gone(client):
     assert second.status_code == 200
     assert first.get_json()['removed'] is False
     assert second.get_json()['removed'] is False
+
+
+def _api_v1_ciphertext_request(request_id):
+    return {
+        'request_id': request_id,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': f'ciphertext-request-{request_id}',
+        'cipherkey': f'cipherkey-request-{request_id}',
+        'iv': f'iv-request-{request_id}',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+    }
+
+
+def test_api_v1_cancel_removes_queued_request_and_reports_terminal_retrieve(client):
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    queued = client.post('/api/v1/relay/requests', json=_api_v1_ciphertext_request('req-cancel'))
+    assert queued.status_code == 200
+    assert client.get('/relay/diagnostics').get_json()['registered_compute_nodes'][0]['queue_depth'] == 1
+
+    cancelled = client.post(
+        '/api/v1/relay/requests/cancel',
+        json={
+            'client_public_key': DUMMY_CLIENT_PUB_KEY,
+            'request_id': 'req-cancel',
+            'status': 'timeout',
+            'reason': 'api_requester_timeout',
+        },
+    )
+    assert cancelled.status_code == 200
+    assert cancelled.get_json()['removed'] is True
+    assert client.get('/relay/diagnostics').get_json()['registered_compute_nodes'][0]['queue_depth'] == 0
+
+    poll = client.post('/api/v1/relay/servers/poll', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    assert poll.status_code == 200
+    assert poll.get_json()['message'] == 'No requests available'
+
+    retrieved = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-cancel'},
+    )
+    assert retrieved.status_code == 410
+    assert retrieved.get_json()['error']['code'] == 'timeout'
+
+
+def test_api_v1_pending_ttl_expiry_removes_queued_request(client, monkeypatch):
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    queued = client.post('/api/v1/relay/requests', json=_api_v1_ciphertext_request('req-expire'))
+    assert queued.status_code == 200
+
+    queued_at = client_pending_request_ids[DUMMY_CLIENT_PUB_KEY]['req-expire']
+    monkeypatch.setattr(relay_module, 'PENDING_REQUEST_TTL_SECONDS', 1.0)
+    monkeypatch.setattr(relay_module.time, 'time', lambda: queued_at + 2.0)
+
+    expired = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-expire'},
+    )
+    assert expired.status_code == 410
+    assert expired.get_json()['error']['code'] == 'expired'
+    assert DUMMY_SERVER_PUB_KEY not in client_inference_requests
+    assert client.get('/relay/diagnostics').get_json()['registered_compute_nodes'][0]['queue_depth'] == 0

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -769,3 +769,55 @@ def test_get_api_v1_compute_provider_for_mode_reads_fallback_from_env(monkeypatc
 
     provider = get_api_v1_compute_provider_for_mode(mode="distributed", distributed_fallback_enabled=None)
     assert isinstance(provider, LocalApiV1ComputeProvider)
+
+
+def test_distributed_compute_provider_cancels_queued_request_on_timeout(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+    posted = []
+    now = {"value": 1000.0}
+
+    def fake_time():
+        return now["value"]
+
+    def fake_sleep(seconds):
+        now["value"] += max(float(seconds), 0.0)
+
+    def fake_get(url, timeout):
+        assert url == "https://node-a.example/api/v1/relay/servers/next"
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        posted.append((url, copy.deepcopy(json), timeout))
+        if url.endswith("/api/v1/relay/requests"):
+            return _FakeResponse(200, {"message": "Request received"})
+        if url.endswith("/api/v1/relay/responses/retrieve"):
+            return _FakeResponse(202, {"status": "pending"})
+        if url.endswith("/api/v1/relay/requests/cancel"):
+            return _FakeResponse(200, {"status": "timeout", "removed": True})
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+    monkeypatch.setattr(compute_provider.time, "time", fake_time)
+    monkeypatch.setattr(compute_provider.time, "sleep", fake_sleep)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=1)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_timeout"
+
+    cancel_payloads = [payload for url, payload, _timeout in posted if url.endswith('/api/v1/relay/requests/cancel')]
+    assert len(cancel_payloads) == 1
+    assert cancel_payloads[0]["client_public_key"] == fake_crypto.public_key_b64
+    assert cancel_payloads[0]["request_id"].startswith("api-v1-")
+    assert cancel_payloads[0]["status"] == "timeout"

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -803,6 +803,73 @@ def test_run_api_v1_payload_uses_relay_api_v1_response_endpoint(capsys, monkeypa
     assert "ModuleNotFoundError: No module named 'api'" not in output.err
 
 
+def test_run_api_v1_payload_polls_immediately_after_work(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class TwoTurnRuntime(ApiV1Runtime):
+        last_instance = None
+
+        def __init__(self, _config):
+            TwoTurnRuntime.last_instance = self
+            self.model_manager = FakeModelManager()
+            self.relay_client = FakeRelayClientRouting()
+            self._responses = [
+                {
+                    'protocol': 'tokenplace_api_v1_relay_e2ee',
+                    'version': 1,
+                    'request_id': 'req-1',
+                    'client_public_key': 'client-key',
+                    'chat_history': 'ciphertext-1',
+                    'cipherkey': 'key-1',
+                    'iv': 'iv-1',
+                    'next_ping_in_x_seconds': 30,
+                },
+                {
+                    'protocol': 'tokenplace_api_v1_relay_e2ee',
+                    'version': 1,
+                    'request_id': 'req-2',
+                    'client_public_key': 'client-key',
+                    'chat_history': 'ciphertext-2',
+                    'cipherkey': 'key-2',
+                    'iv': 'iv-2',
+                    'next_ping_in_x_seconds': 30,
+                },
+            ]
+            self._processed = []
+
+        def process_relay_request(self, payload):
+            self._processed.append(payload)
+            return self.relay_client.process_api_v1_chat_request(payload)
+
+    sleep_values = []
+
+    def fake_sleep_with_cancel(seconds):
+        sleep_values.append(seconds)
+        return False
+
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 5
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=TwoTurnRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', fake_sleep_with_cancel)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    status = compute_node_bridge.run(
+        SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+    )
+
+    assert status == 0
+    runtime = TwoTurnRuntime.last_instance
+    assert [payload['request_id'] for payload in runtime._processed] == ['req-1', 'req-2']
+    assert sleep_values[:2] == [0.0, 0.0]
+    output = capsys.readouterr()
+    assert 'api_v1_e2ee.work_processed_next_poll_immediate relay=https://token.place request_id=req-1' in output.err
+    assert 'api_v1_e2ee.work_processed_next_poll_immediate relay=https://token.place request_id=req-2' in output.err
+
 def test_run_api_v1_payload_waits_boundedly_then_processes(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch, runtime_cls=WarmingThenApiV1Runtime)
@@ -1373,7 +1440,6 @@ def resolve_relay_url(relay_url, **_kwargs):
 
 def resolve_relay_port(relay_port, _relay_url):
     return relay_port
-
 
 
 def is_api_v1_relay_payload(_payload):

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2254,8 +2254,21 @@ class RelayClient:
                     continue
 
                 consecutive_failures = 0
+                api_v1_work_payload = (
+                    relay_response.get('protocol') == 'tokenplace_api_v1_relay_e2ee'
+                    and isinstance(relay_response.get('request_id'), str)
+                    and {'chat_history', 'cipherkey', 'iv'}.issubset(relay_response.keys())
+                )
                 if relay_response.get('protocol') == 'tokenplace_api_v1_relay_e2ee':
+                    request_id = relay_response.get('request_id')
                     self.process_client_request(relay_response)
+                    if api_v1_work_payload:
+                        wait_seconds = 0.0
+                        log_info(
+                            "api_v1_e2ee.work_processed_next_poll_immediate request_id={} relay={}",
+                            request_id or "none",
+                            _sanitize_relay_target(self.relay_url),
+                        )
                 time.sleep(wait_seconds)
             except Exception as e:
                 consecutive_failures += 1


### PR DESCRIPTION
### Motivation
- Sequential API v1 desktop-relay flows could leave browser requests orphaned when the desktop slept for the normal heartbeat interval after processing work, producing repeated 202s then 404/502 and stale `queue_depth` diagnostics.
- The distributed provider should cancel/mark queued requests when the API-side requester times out, and `/responses/retrieve` must expose terminal semantics instead of hiding them behind generic errors.

### Description
- Desktop bridge: when an API v1 E2EE work payload is processed, override the post-work sleep to `0.0` and emit `desktop.compute_node_bridge.api_v1_e2ee.work_processed_next_poll_immediate` so the node polls again immediately. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- RelayClient poll loop: detect real API v1 work payloads and set `wait_seconds = 0.0` after processing a work payload, logging `api_v1_e2ee.work_processed_next_poll_immediate`. (`utils/networking/relay_client.py`)
- Distributed compute provider: raise default `timeout_seconds` to 120s, use the full deadline for the relay timeout, add `_cancel_relay_request` to POST `/api/v1/relay/requests/cancel` when local retrieve loop times out, and map terminal retrieve responses (409/410 with codes `cancelled`, `expired`, `timeout`) to structured `ComputeProviderError` values. (`api/v1/compute_provider.py`)
- Relay: add terminal request tracking and cancellation helpers (`client_cancelled_request_ids`, `_mark_request_terminal`, `_pop_request_terminal`, `_remove_queued_api_v1_request`), skip cancelled items when popping the next request, compute sanitized `queue_depth`, emit lifecycle logs (`request_queued`, `request_removed_from_queue`, `request_cancelled`, `response_received`, `response_retrieved`), and add `/api/v1/relay/requests/cancel` endpoint; make `/responses/retrieve` return `202` for pending, `410` for terminal cancelled/expired/timeout with structured error bodies. (`relay.py`)
- Tests: add/extend unit and integration tests covering immediate post-work polling, provider timeout cancellation and cancel payload POST, stale queue TTL expiry cleanup, cancel endpoint behavior, and a three-turn integration regression for single-node sequential API v1 E2EE processing. (tests updated under `tests/` and `tests/integration/`)

### Testing
- Ran unit tests and focused suites; all tests passed locally:
  - `pytest tests/unit/test_desktop_compute_node_bridge.py -k "api_v1 or poll or stop or queue"` — passed (21 passed)
  - `pytest tests/unit/test_relay_client.py -k "api_v1 or response or timeout or cancel or queue"` — passed (78 passed)
  - `pytest tests/test_relay.py -k "api_v1 or responses or queue or cancel or timeout"` — passed (49 passed)
  - `pytest tests/unit/test_api_v1_compute_provider.py` — passed (23 passed)
  - `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` — passed (10 passed)
  - `pre-commit run --all-files` — passed

All changes were committed with message: `Fix API v1 relay queue cleanup cadence`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a7dee507c832fa5b9281acba23f0c)