### PR TITLE
Fix API v1 relay poll cadence and stale queue cleanup

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -90,6 +90,14 @@ _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
         "public_message": "The LLM server took too long to respond. Please try again.",
         "status_code": 504,
     },
+    "compute_node_cancelled": {
+        "error_type": "timeout_error",
+        "public_message": (
+            "The distributed request was cancelled after the browser stopped waiting. "
+            "Please try again."
+        ),
+        "status_code": 504,
+    },
     "compute_node_unreachable": {
         "error_type": "service_unavailable_error",
         "public_message": "The LLM server is unavailable right now. Please try again.",
@@ -158,7 +166,7 @@ class DistributedApiV1ComputeProvider:
     """Provider that dispatches API v1 requests via relay-blind E2EE envelopes."""
 
     base_url: str
-    timeout_seconds: float = 30.0
+    timeout_seconds: float = 60.0
 
     def _relay_url(self, path: str) -> str:
         base_url = self.base_url.rstrip("/")
@@ -173,6 +181,17 @@ class DistributedApiV1ComputeProvider:
         """Create an isolated crypto manager for each relay request."""
         return CryptoManager()
 
+    def _cancel_relay_request(self, *, client_public_key: str, request_id: str) -> None:
+        """Best-effort cleanup for requester-abandoned queued relay work."""
+        try:
+            requests.post(
+                self._relay_url("/api/v1/relay/requests/cancel"),
+                json={"client_public_key": client_public_key, "request_id": request_id},
+                timeout=min(max(self._poll_interval_seconds() + 0.5, 0.5), 2.0),
+            )
+        except requests.RequestException:
+            logger.debug("api_v1.compute_provider.cancel_request_failed request_id=%s", request_id)
+
     def complete_chat(
         self,
         *,
@@ -182,7 +201,7 @@ class DistributedApiV1ComputeProvider:
     ) -> dict[str, Any]:
         _last_backend_path.set("distributed_relay_e2ee_pending")
         crypto_manager = self._build_request_crypto_manager()
-        relay_timeout = max(min(self.timeout_seconds, 30.0), 1.0)
+        relay_timeout = max(float(self.timeout_seconds), 1.0)
         deadline = time.time() + relay_timeout
         relay_request_id = f"api-v1-{uuid.uuid4().hex}"
 
@@ -336,6 +355,19 @@ class DistributedApiV1ComputeProvider:
                     message="relay reported unknown API v1 response request id",
                 )
 
+            if retrieve_response.status_code == 410:
+                error_code = "request_cancelled"
+                try:
+                    error_payload = retrieve_response.json().get("error", {})
+                    if isinstance(error_payload, dict):
+                        error_code = str(error_payload.get("code") or error_code)
+                except ValueError:
+                    pass
+                raise _error_from_code(
+                    "compute_node_timeout" if "expired" in error_code else "compute_node_cancelled",
+                    message=f"relay reported API v1 request terminal state: {error_code}",
+                )
+
             if retrieve_response.status_code != 200:
                 time.sleep(min(poll_interval, max(deadline - time.time(), 0.0)))
                 continue
@@ -406,6 +438,10 @@ class DistributedApiV1ComputeProvider:
             _last_backend_path.set("distributed_relay_e2ee")
             return assistant_message
 
+        self._cancel_relay_request(
+            client_public_key=crypto_manager.public_key_b64,
+            request_id=relay_request_id,
+        )
         raise _error_from_code(
             "compute_node_timeout",
             message="timed out waiting for distributed relay API v1 encrypted response",

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1117,6 +1117,13 @@ def run(args: argparse.Namespace) -> int:
                             f"request_id={request_id}",
                             file=sys.stderr,
                         )
+                    wait_seconds = 0.0
+                    print(
+                        "desktop.compute_node_bridge.api_v1_e2ee.work_processed_next_poll_immediate "
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                        "wait=0.0",
+                        file=sys.stderr,
+                    )
                 else:
                     if has_heartbeat:
                         last_error = None

--- a/relay.py
+++ b/relay.py
@@ -454,7 +454,10 @@ client_responses = {}
 client_responses_lock = threading.Lock()
 client_pending_request_ids = {}
 client_pending_request_ids_lock = threading.Lock()
+client_abandoned_request_ids = {}
+client_abandoned_request_ids_lock = threading.Lock()
 PENDING_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_PENDING_REQUEST_TTL_SECONDS", "300"))
+ABANDONED_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_ABANDONED_REQUEST_TTL_SECONDS", "300"))
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
 api_v1_in_flight_requests_lock = threading.Lock()
@@ -521,6 +524,134 @@ def _api_v1_in_flight_ttl_seconds() -> float:
     except ValueError:
         return max(float(_api_v1_lease_seconds()), 1.0)
     return max(value, 1.0)
+
+
+
+def _safe_public_key_fingerprint(public_key):
+    """Return a short, non-sensitive fingerprint for relay logs."""
+    if not isinstance(public_key, str) or not public_key:
+        return "unknown"
+    if len(public_key) <= 12:
+        return "short-key"
+    return f"{public_key[:8]}...{public_key[-4:]}"
+
+
+def _mark_request_abandoned(client_public_key, request_id, *, status="cancelled"):
+    """Remember terminal requester-side state so retrieve returns deterministic semantics."""
+    if not client_public_key or not request_id:
+        return
+    with client_abandoned_request_ids_lock:
+        abandoned_ids = client_abandoned_request_ids.setdefault(client_public_key, {})
+        abandoned_ids[request_id] = {"status": status, "marked_at": time.time()}
+
+
+def _pop_abandoned_request_status(client_public_key, request_id):
+    if not client_public_key or not request_id:
+        return None
+    with client_abandoned_request_ids_lock:
+        abandoned_ids = client_abandoned_request_ids.get(client_public_key)
+        if not abandoned_ids:
+            return None
+        record = abandoned_ids.get(request_id)
+        if not isinstance(record, dict):
+            abandoned_ids.pop(request_id, None)
+            return None
+        marked_at = record.get("marked_at")
+        if isinstance(marked_at, (int, float)) and ABANDONED_REQUEST_TTL_SECONDS > 0:
+            if (time.time() - float(marked_at)) > ABANDONED_REQUEST_TTL_SECONDS:
+                abandoned_ids.pop(request_id, None)
+                if not abandoned_ids:
+                    client_abandoned_request_ids.pop(client_public_key, None)
+                return None
+        return record.get("status") or "cancelled"
+
+
+def _remove_queued_api_v1_request(client_public_key, request_id, *, status="cancelled"):
+    """Remove an API v1 request from server queues before it can be dispatched."""
+    if not client_public_key or not request_id:
+        return False
+    removed = False
+    with client_inference_requests_changed:
+        for server_public_key, queued_requests in list(client_inference_requests.items()):
+            if not isinstance(queued_requests, list):
+                continue
+            kept = []
+            for item in queued_requests:
+                if (
+                    isinstance(item, dict)
+                    and bool(item.get("e2ee_v1"))
+                    and item.get("client_public_key") == client_public_key
+                    and item.get("request_id") == request_id
+                ):
+                    removed = True
+                    LOGGER.info(
+                        "relay.api_v1.request_removed_from_queue",
+                        extra={
+                            "server_key_fingerprint": _safe_public_key_fingerprint(
+                                server_public_key
+                            ),
+                            "request_id": request_id,
+                            "status": status,
+                        },
+                    )
+                    continue
+                kept.append(item)
+            if kept:
+                client_inference_requests[server_public_key] = kept
+            else:
+                client_inference_requests.pop(server_public_key, None)
+        if removed:
+            client_inference_requests_changed.notify_all()
+    return removed
+
+
+def _cancel_api_v1_request(client_public_key, request_id, *, status="cancelled"):
+    """Cancel/expire a requester-abandoned API v1 request and clean queue state."""
+    if not client_public_key or not request_id:
+        return False
+    removed = _remove_queued_api_v1_request(client_public_key, request_id, status=status)
+    _clear_pending_request(client_public_key, request_id)
+    _mark_request_abandoned(client_public_key, request_id, status=status)
+    log_event = (
+        "relay.api_v1.request_cancelled"
+        if status == "cancelled"
+        else "relay.api_v1.request_expired"
+    )
+    LOGGER.info(
+        log_event,
+        extra={
+            "client_key_fingerprint": _safe_public_key_fingerprint(client_public_key),
+            "request_id": request_id,
+            "removed_from_queue": removed,
+        },
+    )
+    return removed
+
+
+
+def _expire_pending_api_v1_requests():
+    """Expire pending request markers and remove matching queued work."""
+    if PENDING_REQUEST_TTL_SECONDS <= 0:
+        return
+    now = time.time()
+    expired: list[tuple[str, str]] = []
+    with client_pending_request_ids_lock:
+        for client_public_key, pending_ids in list(client_pending_request_ids.items()):
+            if not isinstance(pending_ids, dict):
+                client_pending_request_ids.pop(client_public_key, None)
+                continue
+            for request_id, queued_at in list(pending_ids.items()):
+                try:
+                    age = now - float(queued_at)
+                except (TypeError, ValueError):
+                    age = PENDING_REQUEST_TTL_SECONDS + 1
+                if age > PENDING_REQUEST_TTL_SECONDS:
+                    pending_ids.pop(request_id, None)
+                    expired.append((client_public_key, request_id))
+            if not pending_ids:
+                client_pending_request_ids.pop(client_public_key, None)
+    for client_public_key, request_id in expired:
+        _cancel_api_v1_request(client_public_key, request_id, status="expired")
 
 def _pop_next_api_v1_request(public_key: str):
     queued_requests = client_inference_requests.get(public_key, [])
@@ -598,6 +729,7 @@ def _evict_stale_servers() -> list[str]:
 
 
 def _live_server_diagnostics() -> list[dict[str, Any]]:
+    _expire_pending_api_v1_requests()
     diagnostics: list[dict[str, Any]] = []
     for server_public_key, payload in list(known_servers.items()):
         diagnostics.append({
@@ -1045,12 +1177,23 @@ def _clear_pending_requests_for_queued_items(queued_items):
             continue
         if not bool(item.get("e2ee_v1")):
             continue
-        _clear_pending_request(item.get("client_public_key"), item.get("request_id"))
+        client_public_key = item.get("client_public_key")
+        request_id = item.get("request_id")
+        _clear_pending_request(client_public_key, request_id)
+        _mark_request_abandoned(client_public_key, request_id, status="cancelled")
+        LOGGER.info(
+            "relay.api_v1.request_removed_from_queue",
+            extra={
+                "request_id": request_id,
+                "status": "cancelled",
+            },
+        )
 
 
 def _is_request_pending(client_public_key, request_id):
     if not client_public_key or not request_id:
         return False
+    expired = False
     with client_pending_request_ids_lock:
         pending_ids = client_pending_request_ids.get(client_public_key)
         if not pending_ids:
@@ -1058,12 +1201,19 @@ def _is_request_pending(client_public_key, request_id):
         queued_at = pending_ids.get(request_id)
         if queued_at is None:
             return False
-        if PENDING_REQUEST_TTL_SECONDS > 0 and (time.time() - float(queued_at)) > PENDING_REQUEST_TTL_SECONDS:
+        if (
+            PENDING_REQUEST_TTL_SECONDS > 0
+            and (time.time() - float(queued_at)) > PENDING_REQUEST_TTL_SECONDS
+        ):
             pending_ids.pop(request_id, None)
             if not pending_ids:
                 client_pending_request_ids.pop(client_public_key, None)
-            return False
-        return True
+            expired = True
+        else:
+            return True
+    if expired:
+        _cancel_api_v1_request(client_public_key, request_id, status="expired")
+    return False
 
 
 def _pop_client_response(client_public_key, request_id=None):
@@ -1155,6 +1305,7 @@ def api_v1_relay_servers_poll():
     known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
     LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
+    _expire_pending_api_v1_requests()
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     known_servers[public_key]['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
     with client_inference_requests_changed:
@@ -1201,7 +1352,7 @@ def api_v1_relay_servers_poll():
     LOGGER.info(
         "relay.api_v1.request_dispatched",
         extra={
-            "server_public_key": public_key,
+            "server_key_fingerprint": _safe_public_key_fingerprint(public_key),
             "request_id": first_request.get("request_id"),
             "queued_at_unix": queued_at,
             "dispatched_at_unix": time.time(),
@@ -1244,7 +1395,7 @@ def api_v1_relay_requests():
     LOGGER.info(
         "relay.api_v1.request_queued",
         extra={
-            "server_public_key": server_public_key,
+            "server_key_fingerprint": _safe_public_key_fingerprint(server_public_key),
             "request_id": envelope.get("request_id"),
             "queued_at_unix": queued_at,
             "queue_depth": queue_depth,
@@ -1285,8 +1436,45 @@ def api_v1_relay_responses():
                         server_payload.pop('api_v1_in_flight_requests', None)
                     break
 
+    abandoned_status = _pop_abandoned_request_status(client_public_key, request_id)
+    if abandoned_status in {"cancelled", "expired"}:
+        LOGGER.info(
+            "relay.api_v1.late_response_discarded",
+            extra={
+                "client_key_fingerprint": _safe_public_key_fingerprint(client_public_key),
+                "request_id": request_id,
+                "status": abandoned_status,
+            },
+        )
+        return jsonify(
+            {'message': 'Response ignored for abandoned request', 'status': abandoned_status}
+        ), 202
+
     _queue_client_response(client_public_key, envelope)
+    LOGGER.info(
+        "relay.api_v1.response_received",
+        extra={
+            "client_key_fingerprint": _safe_public_key_fingerprint(client_public_key),
+            "request_id": request_id,
+        },
+    )
     return jsonify({'message': 'Response received and queued for client'}), 200
+
+
+@app.route('/api/v1/relay/requests/cancel', methods=['POST'])
+def api_v1_relay_requests_cancel():
+    """Cancel an abandoned API v1 relay request before future dispatch."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+    client_public_key = data.get('client_public_key')
+    request_id = data.get('request_id')
+    if not client_public_key or not request_id:
+        return jsonify(
+            {'error': {'message': 'Missing client_public_key or request_id', 'code': 400}}
+        ), 400
+    removed = _cancel_api_v1_request(client_public_key, request_id, status='cancelled')
+    return jsonify({'status': 'cancelled', 'removed_from_queue': removed}), 200
 
 
 @app.route('/api/v1/relay/responses/retrieve', methods=['POST'])
@@ -1303,13 +1491,32 @@ def api_v1_relay_responses_retrieve():
         if _is_request_pending(client_public_key, request_id):
             LOGGER.debug(
                 "relay.api_v1.response_pending",
-                extra={"client_public_key": client_public_key, "request_id": request_id},
+                extra={
+                    "client_key_fingerprint": _safe_public_key_fingerprint(client_public_key),
+                    "request_id": request_id,
+                },
             )
             return jsonify({"status": "pending"}), 202
+        abandoned_status = _pop_abandoned_request_status(client_public_key, request_id)
+        if abandoned_status in {"cancelled", "expired"}:
+            return jsonify({
+                'error': {
+                    'message': f'API v1 relay request {abandoned_status}',
+                    'code': f'request_{abandoned_status}',
+                    'status': abandoned_status,
+                }
+            }), 410
         if request_id:
             return jsonify({'error': {'message': f'Unknown request_id: {request_id}', 'code': 404}}), 404
         return jsonify({'error': {'message': 'No response available for the given public key', 'code': 404}}), 404
 
+    LOGGER.info(
+        "relay.api_v1.response_retrieved",
+        extra={
+            "client_key_fingerprint": _safe_public_key_fingerprint(client_public_key),
+            "request_id": response.get('request_id') if isinstance(response, dict) else request_id,
+        },
+    )
     return jsonify(response), 200
 
 @app.route('/faucet', methods=['POST'])

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -21,6 +21,7 @@ from relay import (
     known_servers,
     client_inference_requests,
     client_pending_request_ids,
+    client_abandoned_request_ids,
     client_responses,
     streaming_sessions,
     streaming_sessions_by_client,
@@ -42,6 +43,7 @@ def client():
     known_servers.clear()
     client_inference_requests.clear()
     client_pending_request_ids.clear()
+    client_abandoned_request_ids.clear()
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
@@ -57,6 +59,7 @@ def client():
     known_servers.clear()
     client_inference_requests.clear()
     client_pending_request_ids.clear()
+    client_abandoned_request_ids.clear()
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
@@ -1542,7 +1545,7 @@ def test_api_v1_response_retrieve_stays_pending_for_long_running_valid_interval(
     assert pending.get_json() == {'status': 'pending'}
 
 
-def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_queue(client):
+def test_api_v1_response_retrieve_returns_cancelled_after_unregistered_server_drops_queue(client):
     client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
     queued = client.post(
         '/api/v1/relay/requests',
@@ -1573,7 +1576,8 @@ def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_qu
         '/api/v1/relay/responses/retrieve',
         json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-abandoned'},
     )
-    assert unknown.status_code == 404
+    assert unknown.status_code == 410
+    assert unknown.get_json()['error']['code'] == 'request_cancelled'
 
 
 def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(client):
@@ -1898,6 +1902,113 @@ def test_api_v1_provider_envelope_is_queued_polled_responded_and_retrieved_ciphe
     assert retrieved_payload['request_id'] == 'req-provider-style'
     assert retrieved_payload['chat_history'] == 'ciphertext-response-provider-style'
     assert response_plaintext not in json.dumps(retrieved_payload)
+
+
+def test_api_v1_cancel_removes_queued_request_and_returns_terminal_retrieve(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-cancel-before-dispatch',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+    })
+    assert queued.status_code == 200
+    diagnostics = client.get('/relay/diagnostics').get_json()
+    assert diagnostics['registered_compute_nodes'][0]['queue_depth'] == 1
+
+    cancelled = client.post('/api/v1/relay/requests/cancel', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-cancel-before-dispatch',
+    })
+    assert cancelled.status_code == 200
+    assert cancelled.get_json() == {'status': 'cancelled', 'removed_from_queue': True}
+
+    diagnostics = client.get('/relay/diagnostics').get_json()
+    assert diagnostics['registered_compute_nodes'][0]['queue_depth'] == 0
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    assert poll.get_json()['message'] == 'No requests available'
+
+    terminal = client.post('/api/v1/relay/responses/retrieve', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-cancel-before-dispatch',
+    })
+    assert terminal.status_code == 410
+    assert terminal.get_json()['error']['code'] == 'request_cancelled'
+
+
+def test_api_v1_pending_ttl_expiry_removes_stale_queue_depth(client, monkeypatch):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    queued = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-expire-before-dispatch',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+    })
+    assert queued.status_code == 200
+    queued_at = client_pending_request_ids[DUMMY_CLIENT_PUB_KEY]['req-expire-before-dispatch']
+    monkeypatch.setattr(relay_module, 'PENDING_REQUEST_TTL_SECONDS', 1.0)
+    monkeypatch.setattr(relay_module.time, 'time', lambda: queued_at + 2.0)
+
+    expired = client.post('/api/v1/relay/responses/retrieve', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-expire-before-dispatch',
+    })
+    assert expired.status_code == 410
+    assert expired.get_json()['error']['code'] == 'request_expired'
+    assert client_inference_requests.get(DUMMY_SERVER_PUB_KEY, []) == []
+    diagnostics = client.get('/relay/diagnostics').get_json()
+    assert diagnostics['registered_compute_nodes'][0]['queue_depth'] == 0
+
+
+def test_api_v1_three_sequential_requests_leave_queue_depth_zero(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+
+    for idx in range(1, 4):
+        request_id = f'req-sequential-{idx}'
+        queued = client.post('/api/v1/relay/requests', json={
+            'request_id': request_id,
+            'client_public_key': DUMMY_CLIENT_PUB_KEY,
+            'server_public_key': DUMMY_SERVER_PUB_KEY,
+            'chat_history': f'ciphertext-request-{idx}',
+            'cipherkey': 'cipherkey-request',
+            'iv': 'iv-request',
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'version': 1,
+        })
+        assert queued.status_code == 200
+        poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+        assert poll.status_code == 200
+        assert poll.get_json()['request_id'] == request_id
+        response = client.post('/api/v1/relay/responses', json={
+            'request_id': request_id,
+            'client_public_key': DUMMY_CLIENT_PUB_KEY,
+            'chat_history': f'ciphertext-response-{idx}',
+            'cipherkey': 'cipherkey-response',
+            'iv': 'iv-response',
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'version': 1,
+        })
+        assert response.status_code == 200
+        retrieved = client.post('/api/v1/relay/responses/retrieve', json={
+            'client_public_key': DUMMY_CLIENT_PUB_KEY,
+            'request_id': request_id,
+        })
+        assert retrieved.status_code == 200
+        assert retrieved.get_json()['request_id'] == request_id
+        diagnostics = client.get('/relay/diagnostics').get_json()
+        assert diagnostics['registered_compute_nodes'][0]['queue_depth'] == 0
 
 
 def test_api_v1_poll_requeues_popped_work_if_server_unregistered_before_dispatch(client, monkeypatch):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -206,6 +206,47 @@ def test_distributed_compute_provider_treats_retrieve_404_as_unknown_request(mon
         assert "unknown API v1 response request id" in str(exc)
 
 
+def test_distributed_compute_provider_cancels_relay_request_on_timeout(monkeypatch):
+    fake_crypto = _FakeCryptoManager()
+    posted_urls = []
+
+    def fake_get(url, timeout):
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        posted_urls.append((url, copy.deepcopy(json)))
+        if url.endswith("/api/v1/relay/requests"):
+            return _FakeResponse(200, {"message": "Request received"})
+        if url.endswith("/api/v1/relay/responses/retrieve"):
+            return _FakeResponse(202, {"status": "pending"})
+        if url.endswith("/api/v1/relay/requests/cancel"):
+            return _FakeResponse(200, {"status": "cancelled", "removed_from_queue": True})
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=0.01)
+    try:
+        provider.complete_chat(
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        raise AssertionError("expected ComputeProviderError")
+    except ComputeProviderError as exc:
+        assert exc.code == "compute_node_timeout"
+
+    cancel_calls = [item for item in posted_urls if item[0].endswith("/api/v1/relay/requests/cancel")]
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0][1]["client_public_key"] == fake_crypto.public_key_b64
+    assert cancel_calls[0][1]["request_id"].startswith("api-v1-")
+
+
 def test_distributed_compute_provider_rejects_response_client_key_binding_mismatch(monkeypatch):
     """Decrypted API v1 relay responses must be bound to this client key."""
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -160,6 +160,29 @@ class ApiV1Runtime(FakeRuntime):
         return self.relay_client.process_api_v1_chat_request(payload)
 
 
+class SequentialApiV1Runtime(ApiV1Runtime):
+    last_instance = None
+
+    def __init__(self, _config):
+        SequentialApiV1Runtime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = FakeRelayClientRouting()
+        self._responses = [
+            {
+                'protocol': 'tokenplace_api_v1_relay_e2ee',
+                'version': 1,
+                'request_id': request_id,
+                'client_public_key': 'client-key',
+                'chat_history': f'ciphertext-{request_id}',
+                'cipherkey': 'key',
+                'iv': 'iv',
+                'next_ping_in_x_seconds': 30,
+            }
+            for request_id in ('req-turn-1', 'req-turn-2', 'req-turn-3')
+        ]
+        self._processed = []
+
+
 class WarmingThenApiV1Runtime(ApiV1Runtime):
     last_instance = None
 
@@ -888,6 +911,45 @@ def test_run_slow_pre_registration_warm_load_processes_without_runtime_not_ready
     assert len(warming_status_events) >= 2
     assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.submitted' not in output.err
     assert 'compute_node_runtime_not_ready' not in output.err
+
+
+def test_run_polls_immediately_after_each_api_v1_work_payload(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=SequentialApiV1Runtime)
+
+    sleep_values = []
+
+    def fake_sleep_with_cancel(seconds):
+        sleep_values.append(seconds)
+        return False
+
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', fake_sleep_with_cancel)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: len(SequentialApiV1Runtime.last_instance._processed) >= 3,
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    runtime = SequentialApiV1Runtime.last_instance
+    assert [payload['request_id'] for payload in runtime._processed] == [
+        'req-turn-1',
+        'req-turn-2',
+        'req-turn-3',
+    ]
+    assert sleep_values == [0.0, 0.0, 0.0]
+    output = capsys.readouterr()
+    assert output.err.count('api_v1_e2ee.work_processed_next_poll_immediate') == 3
+    assert 'request_id=req-turn-3' in output.err
 
 
 def test_run_malformed_wait_value_does_not_stop_future_api_v1_polling(capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Sequential multi-turn API v1 E2EE requests could be orphaned because the desktop bridge used the relay-provided `next_ping_in_x_seconds` as its post-work sleep, causing long idle windows after processing work and causing browser requests to time out.
- Timed-out browser requests left queued API v1 work in the relay, producing stale `queue_depth` and later delivering orphaned work.

### Description
- Desktop bridge: after successfully processing an API v1 work payload, set the next poll wait to immediate (0.0s) and emit a sanitized lifecycle log `desktop.compute_node_bridge.api_v1_e2ee.work_processed_next_poll_immediate` with `request_id` and redacted relay target. (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Distributed provider: increase default `timeout_seconds` to `60s`, remove previous 30s cap, add `_cancel_relay_request` to POST a best-effort cancel to `/api/v1/relay/requests/cancel` on provider-side timeout, and map relay 410 terminal states to clearer provider errors. (file: `api/v1/compute_provider.py`)
- Relay server: implement abandoned-request tracking and cleanup including
  - in-memory abandoned request registry with TTL and safe fingerprints,
  - `_cancel_api_v1_request` to remove queued work and mark abandoned requests,
  - `_expire_pending_api_v1_requests` to expire pending markers and remove matching queued work,
  - `/api/v1/relay/requests/cancel` endpoint to allow active cancellation,
  - `/api/v1/relay/responses/retrieve` now returns 410 for cancelled/expired requests and 202 for pending, and discards late responses for abandoned requests,
  - diagnostics and lifecycle logs use short, redacted key fingerprints. (file: `relay.py`)
- Tests: add unit/integration tests covering immediate post-work polling, provider cancellation on timeout, pending TTL expiry removes stale queue depth, explicit cancel endpoint behavior, and three sequential API v1 requests leaving queue depth at zero. (files: `tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_api_v1_compute_provider.py`, `tests/test_relay.py`)

### Testing
- Ran unit and integration test suites relevant to the changes and they passed locally: `pytest tests/unit/test_desktop_compute_node_bridge.py -k "api_v1 or poll or stop or queue"` (passed), `pytest tests/unit/test_relay_client.py -k "api_v1 or response or timeout or cancel or queue"` (passed), `pytest tests/test_relay.py -k "api_v1 or responses or queue or cancel or timeout"` (passed after test adjustments), `pytest tests/unit/test_api_v1_compute_provider.py` (passed), and `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` (passed). All selected tests passed and `pre-commit run --all-files` passed project checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a7dee507c832fa5b9281acba23f0c)