### PR TITLE
Restore Start→Stop→Start operator lifecycle: reset cancel and relay state so operator re-registers

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -395,6 +395,19 @@ def _start_stdin_reader() -> None:
         _stdin_reader_started = True
 
 
+def _reset_stop_state_for_new_session() -> int:
+    """Clear latched/queued cancel signals before a fresh bridge lifecycle starts."""
+
+    _stop_requested_latched.clear()
+    drained = 0
+    while True:
+        try:
+            _stdin_lines.get_nowait()
+        except queue.Empty:
+            return drained
+        drained += 1
+
+
 def stop_requested() -> bool:
     if _stop_requested_latched.is_set():
         return True
@@ -501,9 +514,15 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
-    _stop_requested_latched.clear()
+    drained_cancel_lines = _reset_stop_state_for_new_session()
     bridge_session_id = _bridge_session_id_from_env()
     status_sequence = 0
+    print(
+        "desktop.compute_node_bridge.session.start "
+        f"session={bridge_session_id} cancel_state_reset=true "
+        f"drained_stale_stdin_lines={drained_cancel_lines}",
+        file=sys.stderr,
+    )
 
     def emit_operator_event(payload: Dict[str, Any]) -> None:
         nonlocal status_sequence
@@ -591,6 +610,15 @@ def run(args: argparse.Namespace) -> int:
             use_configured_relay_fallbacks=False,
         )
     )
+    relay_start = getattr(runtime.relay_client, "start", None)
+    if callable(relay_start):
+        relay_start()
+    print(
+        "desktop.compute_node_bridge.relay_client.started "
+        f"session={bridge_session_id} relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+        f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
+        file=sys.stderr,
+    )
 
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
@@ -606,6 +634,11 @@ def run(args: argparse.Namespace) -> int:
     warm_load_fatal = False
     warm_load_future: Optional[_DaemonWarmLoadFuture] = None
     poll_worker = _CancelablePollWorker()
+    print(
+        "desktop.compute_node_bridge.poll.worker_created "
+        f"session={bridge_session_id} relay={_sanitize_relay_target(runtime.relay_client.relay_url)}",
+        file=sys.stderr,
+    )
     def build_status_payload(
         *,
         event_type: str,
@@ -994,7 +1027,9 @@ def run(args: argparse.Namespace) -> int:
                 active_relay_url = runtime.relay_client.relay_url
                 print(
                     "desktop.compute_node_bridge.api_v1_e2ee.register "
-                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    f"session={bridge_session_id} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
                     file=sys.stderr,
                 )
                 relay_response = poll_worker.call(
@@ -1145,14 +1180,14 @@ def run(args: argparse.Namespace) -> int:
         active_relay_url = getattr(getattr(runtime, "relay_client", None), "relay_url", relay_url)
         print(
             "desktop.compute_node_bridge.stop "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
         request_poll_cancel(active_relay_url)
         poll_worker.shutdown()
         print(
             "desktop.compute_node_bridge.poll.worker_stopped "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
         if warm_load_future is not None and not warm_load_future.done():
@@ -1160,7 +1195,7 @@ def run(args: argparse.Namespace) -> int:
         runtime.stop()
         print(
             "desktop.compute_node_bridge.stopped_idle "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -485,6 +485,12 @@ pub async fn start_compute_node(
         *next_session_id += 1;
         next_session_id.to_string()
     };
+    eprintln!(
+        "desktop.compute_node.session.start session={} relay={} model_path_set={}",
+        session_id,
+        request.relay_base_url,
+        !request.model_path.trim().is_empty()
+    );
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
@@ -546,6 +552,10 @@ pub async fn start_compute_node(
             let mut stdin_slot = state.stdin.lock().await;
             *stdin_slot = pending_stdin.take();
             let mut status = state.status.lock().await;
+            eprintln!(
+                "desktop.compute_node.bridge_spawned session={} script={}",
+                session_id, bridge_script
+            );
             *status = ComputeNodeStatus {
                 running: true,
                 registered: false,
@@ -672,13 +682,20 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    eprintln!("desktop.compute_node.stop_requested");
+    let stop_session = state.status.lock().await.operator_session_id.clone();
+    eprintln!(
+        "desktop.compute_node.stop_requested session={}",
+        stop_session.as_deref().unwrap_or("none")
+    );
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
     };
     if let Some(stdin) = stdin_handle.as_mut() {
-        eprintln!("desktop.compute_node.cancel_requested");
+        eprintln!(
+            "desktop.compute_node.cancel_requested session={}",
+            stop_session.as_deref().unwrap_or("none")
+        );
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
     }
@@ -703,7 +720,10 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
 
         if !exited {
-            eprintln!("desktop.compute_node.bridge_kill_requested");
+            eprintln!(
+                "desktop.compute_node.bridge_kill_requested session={}",
+                stop_session.as_deref().unwrap_or("none")
+            );
             let _ = child.kill().await;
             let _ = child.wait().await;
             eprintln!("desktop.compute_node.bridge_process_exited killed=true");

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -873,6 +873,120 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last error:/).textContent).toContain('none');
   });
 
+  it('supports Start → Stop → Start with a fresh registered session and cleared error', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      relay_runtime_state: 'idle',
+      active_relay_url: 'https://token.place',
+      last_error: 'previous failure',
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Last error:/).textContent).toContain('previous failure');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+
+    fireEvent.click(startOperatorButton);
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.filter(([command]) => command === 'start_compute_node')).toHaveLength(1)
+    );
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'starting',
+        active_relay_url: 'https://token.place',
+        model_path: '/tmp/model.gguf',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        warm_load_state: 'ready',
+        warm_load_enabled: true,
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.some(([command]) => command === 'stop_compute_node')).toBe(true)
+    );
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    fireEvent.click(startOperatorButton);
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.filter(([command]) => command === 'start_compute_node')).toHaveLength(2)
+    );
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'starting',
+        active_relay_url: 'https://token.place',
+        model_path: '/tmp/model.gguf',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 1,
+      },
+    });
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        warm_load_state: 'ready',
+        warm_load_enabled: true,
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 2,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('yes');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
   it('accepts a fresh started event for restart after stop', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -107,6 +107,40 @@ class FakeRuntime:
         return None
 
 
+class RestartRelayClient(FakeRelayClient):
+    def __init__(self):
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.unregister_calls = 0
+        self.relay_url = 'https://token.place'
+
+    def start(self):
+        self.start_calls += 1
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def unregister_from_relay(self):
+        self.unregister_calls += 1
+        return True
+
+
+class RestartLifecycleRuntime(FakeRuntime):
+    instances = []
+
+    def __init__(self, _config):
+        self.model_manager = FakeModelManager()
+        self.relay_client = RestartRelayClient()
+        self._responses = [{'next_ping_in_x_seconds': 0, 'error': None}]
+        self._processed = []
+        self.stop_calls = 0
+        RestartLifecycleRuntime.instances.append(self)
+
+    def stop(self):
+        self.stop_calls += 1
+        return None
+
+
 class StreamingRuntime(FakeRuntime):
     last_instance = None
 
@@ -2491,3 +2525,57 @@ def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypat
         }
     ]
     assert capsys.readouterr().out.splitlines()[-1]
+
+
+def test_run_restart_lifecycle_resets_cancel_queue_and_registers_second_session(capsys, monkeypatch):
+    _reset_cancel_queue()
+    RestartLifecycleRuntime.instances = []
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RestartLifecycleRuntime)
+    monkeypatch.setenv('TOKENPLACE_COMPUTE_NODE_SESSION_ID', 'session-one')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', lambda _seconds: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    first_status = compute_node_bridge.run(args)
+    assert first_status == 0
+
+    compute_node_bridge._stdin_lines.put('{"type":"cancel"}\n')
+    monkeypatch.setenv('TOKENPLACE_COMPUTE_NODE_SESSION_ID', 'session-two')
+    second_status = compute_node_bridge.run(args)
+    assert second_status == 0
+
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    started_events = [event for event in events if event['type'] == 'started']
+    registered_status_events = [
+        event for event in events if event['type'] == 'status' and event.get('registered') is True
+    ]
+
+    assert [event['operator_session_id'] for event in started_events] == ['session-one', 'session-two']
+    assert {event['operator_session_id'] for event in registered_status_events} == {
+        'session-one',
+        'session-two',
+    }
+    assert len(RestartLifecycleRuntime.instances) == 2
+    assert all(instance.relay_client.start_calls == 1 for instance in RestartLifecycleRuntime.instances)
+    assert all(instance.stop_calls == 1 for instance in RestartLifecycleRuntime.instances)
+    assert 'cancel_state_reset=true drained_stale_stdin_lines=1' in output.err
+    assert output.err.count('desktop.compute_node_bridge.poll.worker_created') == 2
+    assert output.err.count('desktop.compute_node_bridge.poll.worker_stopped') == 2
+    assert output.err.count('desktop.compute_node_bridge.api_v1_e2ee.register session=') == 2
+
+
+def test_reset_stop_state_for_new_session_clears_latched_and_queued_cancel():
+    _reset_cancel_queue()
+    compute_node_bridge._stop_requested_latched.set()
+    compute_node_bridge._stdin_lines.put('{"type":"cancel"}\n')
+
+    drained = compute_node_bridge._reset_stop_state_for_new_session()
+
+    assert drained == 1
+    assert compute_node_bridge.stop_requested() is False

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -7,6 +7,7 @@ import json
 import math
 import pytest
 import sys
+import time
 import requests
 import jsonschema
 from unittest.mock import MagicMock, patch
@@ -3378,3 +3379,62 @@ def test_start_after_stop_allows_api_v1_registration_again(mock_post):
 
     assert result['next_ping_in_x_seconds'] == 12
     assert mock_post.call_count == 2
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_start_after_stop_clears_stale_api_v1_registration_before_poll(mock_post):
+    client = _standalone_relay_client()
+    relay_url = 'http://localhost:5000'
+    client._api_v1_registered_relays.add(relay_url)
+    client._api_v1_last_heartbeat_at[relay_url] = time.monotonic()
+    client._api_v1_relay_wait_hints[relay_url] = {
+        'next_ping_in_x_seconds': 120,
+        'poll_wait_seconds': 120,
+        'server_public_key': client.crypto_manager.public_key_b64,
+    }
+    client.stop()
+    client.start()
+
+    register_ok = MagicMock(status_code=200)
+    register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+    poll_ok = MagicMock(status_code=200)
+    poll_ok.json.return_value = {'message': 'No requests available'}
+    mock_post.side_effect = [register_ok, poll_ok]
+
+    result = client.poll_api_v1_encrypted_work()
+
+    assert result['next_ping_in_x_seconds'] == 12
+    requested_urls = [call.args[0] for call in mock_post.call_args_list]
+    assert requested_urls == [
+        'http://localhost:5000/api/v1/relay/servers/register',
+        'http://localhost:5000/api/v1/relay/servers/poll',
+    ]
+    assert client.api_v1_registration_fresh(relay_url) is True
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_stop_unregister_then_start_recreates_usable_poll_lifecycle(mock_post):
+    client = _standalone_relay_client()
+    relay_url = 'http://localhost:5000'
+    client._api_v1_registered_relays.add(relay_url)
+    client._api_v1_last_heartbeat_at[relay_url] = time.monotonic()
+    client._api_v1_relay_wait_hints[relay_url] = {'next_ping_in_x_seconds': 30}
+    unregister_ok = MagicMock(status_code=200)
+    register_ok = MagicMock(status_code=200)
+    register_ok.json.return_value = {'next_ping_in_x_seconds': 10, 'poll_wait_seconds': 0}
+    poll_ok = MagicMock(status_code=200)
+    poll_ok.json.return_value = {'message': 'No requests available'}
+    mock_post.side_effect = [unregister_ok, register_ok, poll_ok]
+
+    client.stop()
+    assert client.unregister_from_relay() is True
+    client.start()
+    result = client.poll_api_v1_encrypted_work()
+
+    assert result['next_ping_in_x_seconds'] == 10
+    requested_urls = [call.args[0] for call in mock_post.call_args_list]
+    assert requested_urls == [
+        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/register',
+        'http://localhost:5000/api/v1/relay/servers/poll',
+    ]

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -614,6 +614,7 @@ class RelayClient:
         self._last_api_v1_work_relay_url: Optional[str] = None
         self._api_v1_registered_relays: Set[str] = set()
         self._api_v1_last_heartbeat_at: Dict[str, float] = {}
+        self._api_v1_relay_wait_hints: Dict[str, Dict[str, Any]] = {}
         self._unregister_attempted = False
         self._unregister_complete = False
 
@@ -781,11 +782,20 @@ class RelayClient:
         return {"X-Relay-Server-Token": self._registration_token}
 
     def start(self):
-        """Start the polling loop by setting stop_polling to False"""
+        """Start a fresh polling/registration lifecycle."""
+
+        was_stopped = self.stop_polling or getattr(self, "_polling_stopped_by_request", False)
         self.stop_polling = False
         self._polling_stopped_by_request = False
         self._unregister_attempted = False
         self._unregister_complete = False
+        if was_stopped:
+            self._api_v1_registered_relays.clear()
+            self._api_v1_last_heartbeat_at.clear()
+            self._api_v1_relay_wait_hints.clear()
+            log_info(
+                "Relay client lifecycle reset; API v1 registration state cleared for fresh start"
+            )
 
     def stop(self):
         """Stop the polling loop by setting stop_polling to True"""


### PR DESCRIPTION
### Motivation
- Restarting the desktop operator (Start → Stop → Start) could leave stale cancel or relay state behind so the UI flipped Running to yes but Registered never became yes, preventing re-registration and serving work.

### Description
- Clear latched and queued cancel signals at the start of each bridge session with `_reset_stop_state_for_new_session` and emit a sanitized session-start diagnostic. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Ensure the runtime/relay lifecycle is (re)started for a fresh session by calling `runtime.relay_client.start()` before registration polling and create a per-session poll worker with session-scoped logs. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Reset relay-client API v1 registration caches on a fresh `RelayClient.start()` so stale `_api_v1_registered_relays`, heartbeats, and wait-hints cannot block re-registration. (`utils/networking/relay_client.py`)
- Add session-scoped diagnostics in the Rust/Tauri backend for bridge spawn, stop/cancel, and kills so UI/backend events are attributable to the correct operator session. (`desktop-tauri/src-tauri/src/compute_node.rs`)
- Add regression tests and a UI test to cover Start → Stop → Start lifecycle, stale cancel draining, and relay re-registration. (`tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_relay_client.py`, `desktop-tauri/src/App.test.tsx`)

### Testing
- Ran the desktop bridge unit tests: `pytest -q tests/unit/test_desktop_compute_node_bridge.py -k "restart or stop or lifecycle or register"` and all selected tests passed (`13 passed`).
- Ran relay client unit tests: `pytest -q tests/unit/test_relay_client.py -k "restart or stop or unregister or register"` and all selected tests passed (`33 passed`).
- Ran the desktop UI unit suite: `cd desktop-tauri && npm test` and Vitest UI tests passed (`src/App.test.tsx` 22 tests passed).
- Attempted Rust compute_node tests: `cd desktop-tauri/src-tauri && cargo test compute_node` (blocked in this environment due to missing system `glib-2.0` pkg-config dependency and therefore not run to completion).
- Ran project checks: `pre-commit run --all-files` and hooks completed successfully.

All automated tests that exercise the modified lifecycle logic passed in this environment; Rust target compilation for full integration tests is environment-limited and noted as blocked above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a826077a8832fa6df9f60e6f180f0)