### PR TITLE
Fix desktop operator restart lifecycle

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -79,6 +79,31 @@ API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
 
 
+def _drain_stale_stdin_cancel_messages() -> int:
+    """Discard queued cancel controls before a fresh operator session starts."""
+
+    drained = 0
+    while True:
+        try:
+            line = _stdin_lines.get_nowait()
+        except queue.Empty:
+            return drained
+        if isinstance(line, str) and line.strip():
+            drained += 1
+
+
+def _reset_bridge_lifecycle_state(operator_session_id: str) -> None:
+    """Reset process-local stop/cancel state for a first-class fresh session."""
+
+    _stop_requested_latched.clear()
+    drained = _drain_stale_stdin_cancel_messages()
+    print(
+        "desktop.compute_node_bridge.lifecycle.reset "
+        f"operator_session_id={operator_session_id} "
+        f"stale_cancel_messages_drained={drained}",
+        file=sys.stderr,
+    )
+
 _POLL_CANCELLED = object()
 
 
@@ -116,15 +141,21 @@ class _DaemonWarmLoadFuture:
 class _CancelablePollWorker:
     """Run one relay poll at a time while the bridge keeps checking for cancel."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, operator_session_id: str = "unknown") -> None:
         self._tasks: "queue.Queue[Any]" = queue.Queue()
         self._closed = False
+        self._operator_session_id = operator_session_id
         self._thread = threading.Thread(
             target=self._run,
             name="tokenplace-relay-poll",
             daemon=True,
         )
         self._thread.start()
+        print(
+            "desktop.compute_node_bridge.poll.worker_created "
+            f"operator_session_id={self._operator_session_id}",
+            file=sys.stderr,
+        )
 
     def _run(self) -> None:
         while True:
@@ -166,6 +197,11 @@ class _CancelablePollWorker:
 
     def shutdown(self) -> None:
         self._closed = True
+        print(
+            "desktop.compute_node_bridge.poll.worker_close_requested "
+            f"operator_session_id={self._operator_session_id}",
+            file=sys.stderr,
+        )
         try:
             self._tasks.put_nowait(None)
         except queue.Full:  # pragma: no cover - unbounded queue is not expected to fill
@@ -501,8 +537,8 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
-    _stop_requested_latched.clear()
     bridge_session_id = _bridge_session_id_from_env()
+    _reset_bridge_lifecycle_state(bridge_session_id)
     status_sequence = 0
 
     def emit_operator_event(payload: Dict[str, Any]) -> None:
@@ -573,6 +609,7 @@ def run(args: argparse.Namespace) -> int:
     relay_port = resolve_relay_port(args.relay_port, relay_url)
     print(
         "desktop.compute_node_bridge.start "
+        f"operator_session_id={bridge_session_id} "
         f"model={args.model} mode={args.mode} "
         f"relay_url={_sanitize_relay_target(relay_url)} "
         f"relay_port={relay_port if relay_port is not None else 'none'}",
@@ -591,6 +628,20 @@ def run(args: argparse.Namespace) -> int:
             use_configured_relay_fallbacks=False,
         )
     )
+    start_relay_session = getattr(runtime, "start_relay_session", None)
+    if callable(start_relay_session):
+        start_relay_session()
+    else:
+        relay_start = getattr(getattr(runtime, "relay_client", None), "start", None)
+        if callable(relay_start):
+            relay_start()
+    print(
+        "desktop.compute_node_bridge.relay_client.reset "
+        f"operator_session_id={bridge_session_id} "
+        f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+        f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
+        file=sys.stderr,
+    )
 
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
@@ -605,7 +656,7 @@ def run(args: argparse.Namespace) -> int:
     warm_load_failed: Optional[str] = None
     warm_load_fatal = False
     warm_load_future: Optional[_DaemonWarmLoadFuture] = None
-    poll_worker = _CancelablePollWorker()
+    poll_worker = _CancelablePollWorker(operator_session_id=bridge_session_id)
     def build_status_payload(
         *,
         event_type: str,
@@ -994,7 +1045,9 @@ def run(args: argparse.Namespace) -> int:
                 active_relay_url = runtime.relay_client.relay_url
                 print(
                     "desktop.compute_node_bridge.api_v1_e2ee.register "
-                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    f"operator_session_id={bridge_session_id} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
                     file=sys.stderr,
                 )
                 relay_response = poll_worker.call(
@@ -1032,6 +1085,21 @@ def run(args: argparse.Namespace) -> int:
                 )
                 summary = _relay_response_summary(
                     relay_response, api_v1_payload=api_v1_payload, wait_seconds=wait_seconds
+                )
+
+                registration_event = (
+                    "desktop.compute_node_bridge.registration.succeeded"
+                    if registered
+                    else "desktop.compute_node_bridge.registration.pending"
+                )
+                print(
+                    f"{registration_event} "
+                    f"operator_session_id={bridge_session_id} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)} "
+                    f"request_id={request_id}"
+                    + (f" error={relay_error}" if relay_error else ""),
+                    file=sys.stderr,
                 )
 
                 print(
@@ -1145,6 +1213,7 @@ def run(args: argparse.Namespace) -> int:
         active_relay_url = getattr(getattr(runtime, "relay_client", None), "relay_url", relay_url)
         print(
             "desktop.compute_node_bridge.stop "
+            f"operator_session_id={bridge_session_id} "
             f"relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
@@ -1152,6 +1221,7 @@ def run(args: argparse.Namespace) -> int:
         poll_worker.shutdown()
         print(
             "desktop.compute_node_bridge.poll.worker_stopped "
+            f"operator_session_id={bridge_session_id} "
             f"relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
@@ -1160,6 +1230,7 @@ def run(args: argparse.Namespace) -> int:
         runtime.stop()
         print(
             "desktop.compute_node_bridge.stopped_idle "
+            f"operator_session_id={bridge_session_id} "
             f"relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -191,6 +191,21 @@ fn command_env_value(command: &Command, key: &str) -> Option<String> {
         .map(|value| value.to_string_lossy().into_owned())
 }
 
+fn sanitize_relay_target(relay_url: &str) -> String {
+    let trimmed = relay_url.trim();
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    if let Some((scheme, rest)) = without_query.split_once("://") {
+        let authority = rest.split('/').next().unwrap_or(rest);
+        let safe_authority = authority.rsplit('@').next().unwrap_or(authority);
+        return format!("{scheme}://{safe_authority}");
+    }
+    "unknown".into()
+}
+
 fn current_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -485,6 +500,12 @@ pub async fn start_compute_node(
         *next_session_id += 1;
         next_session_id.to_string()
     };
+    eprintln!(
+        "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} cancellation_token_reset=true",
+        session_id,
+        sanitize_relay_target(&request.relay_base_url),
+        bridge_script
+    );
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
@@ -542,6 +563,11 @@ pub async fn start_compute_node(
         {
             false
         } else {
+            eprintln!(
+                "desktop.compute_node.bridge_process.spawned operator_session_id={} relay={}",
+                session_id,
+                sanitize_relay_target(&request.relay_base_url)
+            );
             *child_slot = pending_child.take();
             let mut stdin_slot = state.stdin.lock().await;
             *stdin_slot = pending_stdin.take();
@@ -672,13 +698,20 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    eprintln!("desktop.compute_node.stop_requested");
+    let stop_session_id = state.status.lock().await.operator_session_id.clone();
+    eprintln!(
+        "desktop.compute_node.stop_requested operator_session_id={}",
+        stop_session_id.as_deref().unwrap_or("unknown")
+    );
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
     };
     if let Some(stdin) = stdin_handle.as_mut() {
-        eprintln!("desktop.compute_node.cancel_requested");
+        eprintln!(
+            "desktop.compute_node.cancel_requested operator_session_id={}",
+            stop_session_id.as_deref().unwrap_or("unknown")
+        );
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
     }
@@ -703,12 +736,21 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
 
         if !exited {
-            eprintln!("desktop.compute_node.bridge_kill_requested");
+            eprintln!(
+                "desktop.compute_node.bridge_kill_requested operator_session_id={}",
+                stop_session_id.as_deref().unwrap_or("unknown")
+            );
             let _ = child.kill().await;
             let _ = child.wait().await;
-            eprintln!("desktop.compute_node.bridge_process_exited killed=true");
+            eprintln!(
+                "desktop.compute_node.bridge_process_exited operator_session_id={} killed=true",
+                stop_session_id.as_deref().unwrap_or("unknown")
+            );
         } else {
-            eprintln!("desktop.compute_node.bridge_process_exited killed=false");
+            eprintln!(
+                "desktop.compute_node.bridge_process_exited operator_session_id={} killed=false",
+                stop_session_id.as_deref().unwrap_or("unknown")
+            );
         }
     }
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -199,9 +199,21 @@ fn sanitize_relay_target(relay_url: &str) -> String {
         .next()
         .unwrap_or(without_fragment);
     if let Some((scheme, rest)) = without_query.split_once("://") {
+        let safe_scheme = scheme
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'));
+        if !safe_scheme || scheme.is_empty() {
+            return "unknown".into();
+        }
         let authority = rest.split('/').next().unwrap_or(rest);
         let safe_authority = authority.rsplit('@').next().unwrap_or(authority);
-        return format!("{scheme}://{safe_authority}");
+        let safe_authority: String = safe_authority
+            .chars()
+            .filter(|ch| !ch.is_control() && !ch.is_whitespace())
+            .collect();
+        if !safe_authority.is_empty() {
+            return format!("{scheme}://{safe_authority}");
+        }
     }
     "unknown".into()
 }
@@ -789,6 +801,21 @@ mod tests {
                 .status()
                 .expect("status")
         }
+    }
+
+    #[test]
+    fn sanitize_relay_target_filters_log_control_characters() {
+        assert_eq!(
+            sanitize_relay_target(
+                "https://user:secret@example.com\nforged=1/path?token=secret#frag"
+            ),
+            "https://example.comforged=1"
+        );
+        assert_eq!(sanitize_relay_target("https://\n\t/path"), "unknown");
+        assert_eq!(
+            sanitize_relay_target("bad\nscheme://example.com"),
+            "unknown"
+        );
     }
 
     #[tokio::test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -205,7 +205,10 @@ fn sanitize_relay_target(relay_url: &str) -> String {
         if !safe_scheme || scheme.is_empty() {
             return "unknown".into();
         }
-        let authority = rest.split('/').next().unwrap_or(rest);
+        let authority = rest
+            .split(|ch: char| ch == '/' || ch.is_control() || ch.is_whitespace())
+            .next()
+            .unwrap_or(rest);
         let safe_authority = authority.rsplit('@').next().unwrap_or(authority);
         let safe_authority: String = safe_authority
             .chars()
@@ -804,12 +807,18 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_relay_target_strips_userinfo_query_and_fragment() {
+        assert_eq!(
+            sanitize_relay_target("https://user:pass@example.com/path?token=secret#frag"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
     fn sanitize_relay_target_filters_log_control_characters() {
         assert_eq!(
-            sanitize_relay_target(
-                "https://user:secret@example.com\nforged=1/path?token=secret#frag"
-            ),
-            "https://example.comforged=1"
+            sanitize_relay_target("https://example.com\nforged=1/path?token=secret#frag"),
+            "https://example.com"
         );
         assert_eq!(sanitize_relay_target("https://\n\t/path"), "unknown");
         assert_eq!(

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -738,6 +738,102 @@ describe('desktop app start failure handling', () => {
     await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
   });
 
+  it('surfaces a fresh restart startup error while ignoring stale old-session events', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'idle',
+      last_error: null,
+      operator_session_id: 'old-session',
+      sequence: 8,
+    });
+
+    render(<App />);
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+
+    const startButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    fireEvent.click(startButton);
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+
+    fireEvent.click((await screen.findByText('Start operator')) as HTMLButtonElement);
+    expect(((await screen.findByText('Start operator')) as HTMLButtonElement).disabled).toBe(true);
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: 'old stale stop after restart',
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        last_error: 'old stale error after restart',
+        operator_session_id: 'session-1',
+        sequence: 4,
+      },
+    });
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('starting');
+    expect(screen.queryByText('old stale error after restart')).toBeNull();
+    expect(((await screen.findByText('Start operator')) as HTMLButtonElement).disabled).toBe(true);
+
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        last_error: 'new session failed before started',
+        operator_session_id: 'session-2',
+        sequence: 1,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Last error:/).textContent).toContain(
+        'new session failed before started'
+      )
+    );
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('failed');
+    expect(((await screen.findByText('Start operator')) as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it('renders the full initial idle compute-node status contract', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -622,6 +622,122 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
   });
 
+
+  it('handles Start Stop Start with fresh registration and cleared errors', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'idle',
+      last_error: 'previous failure',
+      operator_session_id: 'old-session',
+      sequence: 8,
+    });
+
+    render(<App />);
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+
+    const startButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    fireEvent.click(startButton);
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.some(([command]) => command === 'start_compute_node')).toBe(true)
+    );
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.queryByText(/Previous failure/i)).toBeNull();
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: 'old stale stop',
+        operator_session_id: 'old-session',
+        sequence: 9,
+      },
+    });
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('starting');
+
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'warming',
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.some(([command]) => command === 'stop_compute_node')).toBe(true)
+    );
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    fireEvent.click((await screen.findByText('Start operator')) as HTMLButtonElement);
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'warming',
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        active_relay_url: 'https://token.place',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 2,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+  });
+
   it('renders the full initial idle compute-node status contract', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1022,6 +1022,45 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
   });
 
+  it('surfaces fresh restart errors from a new operator session', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      relay_runtime_state: 'stopped',
+      active_relay_url: 'https://token.place',
+      last_error: null,
+      operator_session_id: 'old-session',
+      sequence: 8,
+    });
+
+    render(<App />);
+    const startButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startButton.disabled).toBe(false));
+    fireEvent.click(startButton);
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        last_error: 'fresh preflight failed',
+        operator_session_id: 'new-session',
+        sequence: 1,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Last error:/).textContent).toContain('fresh preflight failed')
+    );
+    await waitFor(() => expect(startButton.disabled).toBe(false));
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('failed');
+  });
+
   it('ignores replayed started events from the stopped prior session', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -416,6 +416,7 @@ export function App() {
         running: false,
         registered: false,
         relay_runtime_state: 'starting',
+        sequence: computeStatusRef.current.operator_session_id ? Number.MAX_SAFE_INTEGER : null,
         active_relay_url: config.relay_base_url,
         requested_mode: config.preferred_mode,
         effective_mode: null,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -97,8 +97,8 @@ function mergeComputeStatusEvent(
 ): ComputeNodeStatus {
   const payloadSession = typeof payload.operator_session_id === 'string' ? payload.operator_session_id : null;
   const payloadSequence = typeof payload.sequence === 'number' ? payload.sequence : null;
-  const isFreshStartEvent =
-    payload.type === 'started' &&
+  const isFreshSessionEvent =
+    (payload.type === 'started' || payload.type === 'error') &&
     payloadSequence === 1 &&
     !prev.running &&
     payloadSession !== null &&
@@ -107,7 +107,7 @@ function mergeComputeStatusEvent(
     prev.operator_session_id &&
     payloadSession &&
     payloadSession !== prev.operator_session_id &&
-    !isFreshStartEvent
+    !isFreshSessionEvent
   ) {
     return prev;
   }
@@ -115,7 +115,7 @@ function mergeComputeStatusEvent(
     payloadSequence !== null &&
     prev.sequence !== null &&
     payloadSequence <= prev.sequence &&
-    !isFreshStartEvent
+    !isFreshSessionEvent
   ) {
     return prev;
   }

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -127,7 +127,12 @@ function mergeComputeStatusEvent(
         : payload.type === 'error'
           ? false
           : prev.running,
-    registered: typeof payload.registered === 'boolean' ? payload.registered : prev.registered,
+    registered:
+      typeof payload.registered === 'boolean'
+        ? payload.registered
+        : payload.type === 'error'
+          ? false
+          : prev.registered,
     active_relay_url:
       typeof payload.active_relay_url === 'string'
         ? payload.active_relay_url
@@ -158,9 +163,15 @@ function mergeComputeStatusEvent(
         ? payload.relay_runtime_state
         : typeof payload.warm_load_state === 'string'
           ? payload.warm_load_state
-          : prev.relay_runtime_state,
+          : payload.type === 'error'
+            ? 'failed'
+            : prev.relay_runtime_state,
     warm_load_state:
-      typeof payload.warm_load_state === 'string' ? payload.warm_load_state : prev.warm_load_state,
+      typeof payload.warm_load_state === 'string'
+        ? payload.warm_load_state
+        : payload.type === 'error'
+          ? 'failed'
+          : prev.warm_load_state,
     warm_load_enabled:
       typeof payload.warm_load_enabled === 'boolean'
         ? payload.warm_load_enabled

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -185,6 +185,23 @@ def test_compute_node_runtime_polling_thread_delegates_to_relay():
     thread.start.assert_called_once_with()
 
 
+def test_compute_node_runtime_start_relay_session_resets_relay_client_start_state():
+    relay_client = MagicMock()
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    crypto_manager = MagicMock()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=crypto_manager,
+    )
+
+    runtime.start_relay_session()
+
+    relay_client.start.assert_called_once_with()
+
+
 def test_compute_node_runtime_polling_thread_supports_api_v1_only_relay_client():
     class ApiV1OnlyRelayClient:
         def __init__(self):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -385,7 +385,11 @@ class RestartTrackingRuntime(FakeRuntime):
         super().__init__(_config)
         self.register_attempts = 0
         self.stopped = False
+        self.relay_session_starts = 0
         RestartTrackingRuntime.instances.append(self)
+
+    def start_relay_session(self):
+        self.relay_session_starts += 1
 
     def register_and_poll_once(self):
         self.register_attempts += 1
@@ -416,6 +420,7 @@ def test_run_start_stop_start_resets_stale_cancel_and_registers_again(capsys, mo
     assert compute_node_bridge.run(args) == 0
     first_events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
     assert first_events[-1]['type'] == 'stopped'
+    assert RestartTrackingRuntime.instances[0].relay_session_starts == 1
     assert RestartTrackingRuntime.instances[0].register_attempts >= 1
     assert RestartTrackingRuntime.instances[0].stopped is True
 
@@ -433,11 +438,47 @@ def test_run_start_stop_start_resets_stale_cancel_and_registers_again(capsys, mo
     second_events = [json.loads(line) for line in second_output.out.splitlines()]
 
     assert len(RestartTrackingRuntime.instances) == 2
+    assert RestartTrackingRuntime.instances[1].relay_session_starts == 1
     assert RestartTrackingRuntime.instances[1].register_attempts >= 1
     assert second_events[0]['type'] == 'started'
     assert any(event['type'] == 'status' and event['registered'] is True for event in second_events)
     assert second_events[-1]['type'] == 'stopped'
     assert 'stale_cancel_messages_drained=1' in second_output.err
+
+
+def test_run_restart_falls_back_to_relay_client_start(capsys, monkeypatch):
+    _reset_cancel_queue()
+    start_calls = []
+
+    class StartableRelayClient(FakeRelayClient):
+        def start(self):
+            start_calls.append('start')
+
+    class RuntimeWithoutSessionHook(FakeRuntime):
+        def __init__(self, _config):
+            super().__init__(_config)
+            self.relay_client = StartableRelayClient()
+
+        def register_and_poll_once(self):
+            return {'next_ping_in_x_seconds': 0, 'error': None}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RuntimeWithoutSessionHook)
+    stop_counter = {'count': 0}
+
+    def stop_after_first_poll():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_first_poll)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    assert compute_node_bridge.run(args) == 0
+
+    assert start_calls == ['start']
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.relay_client.reset' in output.err
 
 
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -378,6 +378,67 @@ def _reset_cancel_queue():
     compute_node_bridge._stdin_reader_started = True
     compute_node_bridge._stop_requested_latched.clear()
 
+class RestartTrackingRuntime(FakeRuntime):
+    instances = []
+
+    def __init__(self, _config):
+        super().__init__(_config)
+        self.register_attempts = 0
+        self.stopped = False
+        RestartTrackingRuntime.instances.append(self)
+
+    def register_and_poll_once(self):
+        self.register_attempts += 1
+        return {'next_ping_in_x_seconds': 0, 'error': None}
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_run_start_stop_start_resets_stale_cancel_and_registers_again(capsys, monkeypatch):
+    _reset_cancel_queue()
+    RestartTrackingRuntime.instances = []
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RestartTrackingRuntime)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    first_stop_counter = {'count': 0}
+
+    def first_stop_requested():
+        first_stop_counter['count'] += 1
+        return first_stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', first_stop_requested)
+    assert compute_node_bridge.run(args) == 0
+    first_events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert first_events[-1]['type'] == 'stopped'
+    assert RestartTrackingRuntime.instances[0].register_attempts >= 1
+    assert RestartTrackingRuntime.instances[0].stopped is True
+
+    compute_node_bridge._stop_requested_latched.set()
+    compute_node_bridge._stdin_lines.put('{"type":"cancel"}')
+    second_stop_counter = {'count': 0}
+
+    def second_stop_requested():
+        second_stop_counter['count'] += 1
+        return second_stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', second_stop_requested)
+    assert compute_node_bridge.run(args) == 0
+    second_output = capsys.readouterr()
+    second_events = [json.loads(line) for line in second_output.out.splitlines()]
+
+    assert len(RestartTrackingRuntime.instances) == 2
+    assert RestartTrackingRuntime.instances[1].register_attempts >= 1
+    assert second_events[0]['type'] == 'started'
+    assert any(event['type'] == 'status' and event['registered'] is True for event in second_events)
+    assert second_events[-1]['type'] == 'stopped'
+    assert 'stale_cancel_messages_drained=1' in second_output.err
+
 
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
     _reset_cancel_queue()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -3289,6 +3289,39 @@ def test_unregister_from_relay_is_idempotent_and_clears_api_v1_registration(mock
 
 
 @patch('utils.networking.relay_client.requests.post')
+def test_start_after_unregister_clears_stale_registration_and_polls_cleanly(mock_post):
+    client = _standalone_relay_client()
+    client._api_v1_registered_relays.add('http://localhost:5000')
+    client._api_v1_last_heartbeat_at['http://localhost:5000'] = 123.0
+    client._api_v1_relay_wait_hints = {
+        'http://localhost:5000': {
+            'next_ping_in_x_seconds': 30,
+            'poll_wait_seconds': 10,
+            'server_public_key': 'mock_public_key_b64',
+        }
+    }
+    client.stop()
+    client._unregister_complete = True
+
+    register_ok = MagicMock(status_code=200)
+    register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+    poll_ok = MagicMock(status_code=200)
+    poll_ok.json.return_value = {'message': 'No requests available'}
+    mock_post.side_effect = [register_ok, poll_ok]
+
+    client.start()
+    result = client.poll_api_v1_encrypted_work()
+
+    requested_urls = [call.args[0] for call in mock_post.call_args_list]
+    assert requested_urls == [
+        'http://localhost:5000/api/v1/relay/servers/register',
+        'http://localhost:5000/api/v1/relay/servers/poll',
+    ]
+    assert result['next_ping_in_x_seconds'] == 12
+    assert client.api_v1_registration_fresh('http://localhost:5000') is True
+
+
+@patch('utils.networking.relay_client.requests.post')
 def test_poll_api_v1_encrypted_work_stop_prevents_register_and_poll(mock_post):
     client = _standalone_relay_client()
     client.stop()

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -364,6 +364,13 @@ class ComputeNodeRuntime:
         )
         return False
 
+    def start_relay_session(self) -> None:
+        """Reset relay-client stop state before a fresh operator session polls."""
+
+        start = getattr(self.relay_client, "start", None)
+        if callable(start):
+            start()
+
     def register_and_poll_once(self) -> Dict[str, Any]:
         """Poll relay for one encrypted API v1 work item."""
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -780,12 +780,37 @@ class RelayClient:
             return {}
         return {"X-Relay-Server-Token": self._registration_token}
 
-    def start(self):
-        """Start the polling loop by setting stop_polling to False"""
+    def reset_api_v1_polling_session(self, *, clear_registration: bool = False) -> None:
+        """Reset stop/unregister state before a fresh API v1 polling session.
+
+        ``clear_registration`` forces the next poll to re-register with the relay, which is
+        required after an explicit Stop because the relay-side lease may have been removed.
+        """
+
         self.stop_polling = False
         self._polling_stopped_by_request = False
         self._unregister_attempted = False
         self._unregister_complete = False
+        if clear_registration:
+            self._api_v1_registered_relays.clear()
+            self._api_v1_last_heartbeat_at.clear()
+            getattr(self, "_api_v1_relay_wait_hints", {}).clear()
+
+    def start(self):
+        """Start the polling loop by setting stop_polling to False."""
+
+        clear_registration = bool(
+            getattr(self, "stop_polling", True)
+            or getattr(self, "_polling_stopped_by_request", False)
+            or getattr(self, "_unregister_complete", False)
+        )
+        self.reset_api_v1_polling_session(clear_registration=clear_registration)
+        log_info(
+            "Starting relay polling relay={} key_fingerprint={} registration_reset={}",
+            _sanitize_relay_target(self.relay_url),
+            self._api_v1_public_key_fingerprint(getattr(self.crypto_manager, "public_key_b64", None)),
+            clear_registration,
+        )
 
     def stop(self):
         """Stop the polling loop by setting stop_polling to True"""


### PR DESCRIPTION
### Motivation

- Make Start → Stop → Start a first-class desktop operator lifecycle so restarting the operator without restarting the app reinitializes bridge/relay state and re-registers with the API v1 relay.
- Prevent stale stop/cancel flags, orphan poll workers, and prior-session events from blocking a fresh session or leaving UI stuck at Running: yes / Registered: no.

### Description

- Reset process-local lifecycle state on bridge start by clearing the latched stop flag and draining queued stdin cancel messages, and emit a session-scoped lifecycle reset diagnostic. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Create session-scoped `_CancelablePollWorker` instances and add lifecycle logs for poll worker creation/closure, registration pending/succeeded, and relay-client reset using sanitized relay targets and key fingerprints. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Add `reset_api_v1_polling_session` / enhanced `start()` in `RelayClient` to reset stop/unregister state and optionally clear stale registration so a stopped client will re-register on next start. (`utils/networking/relay_client.py`)
- Expose `start_relay_session()` on `ComputeNodeRuntime` and call it on bridge start so the runtime can reset the relay-client before polling. (`utils/compute_node_runtime.py`)
- Add Rust/Tauri diagnostics and sanitization around bridge spawn/stop to include operator session id and safe relay targets. (`desktop-tauri/src-tauri/src/compute_node.rs`)
- Harden React optimistic restart handling so a fresh Start does not show Registered: yes until the new session emits readiness, and avoid stale-event overwrites; add a UI test that covers Start → Stop → Start transitions. (`desktop-tauri/src/App.tsx`, `desktop-tauri/src/App.test.tsx`)
- Add/adjust unit tests: Python bridge test for Start → Stop → Start (draining stale cancels and verifying new registration), and relay-client test to verify start-after-stop/unregister re-registration. (`tests/unit/test_desktop_compute_node_bridge.py`, `tests/unit/test_relay_client.py`)

### Testing

- Ran the targeted Python unit suites for the changes and they passed: `pytest tests/unit/test_desktop_compute_node_bridge.py -k "restart or stop or lifecycle or register" -q` — 12 tests selected, all passed.
- Ran relay client unit tests for the registration/stop/start scenarios: `pytest tests/unit/test_relay_client.py -k "restart or stop or unregister or register" -q` — 32 selected, all passed.
- Ran the desktop JS tests: `npm test` (in `desktop-tauri`) — Vitest suite passed (1 file, 22 tests passed). Note: `npm test -- --runInBand` was attempted and failed because Vitest does not accept Jest's `--runInBand` flag.
- Ran `pre-commit run --all-files` — pre-commit hooks and project checks completed (passed in this environment).
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` was attempted but the CI/dev environment lacked the system `glib-2.0` pkg-config dependency required to build Tauri native tests, so Rust/Tauri tests could not be completed here (environment limitation).

All automated tests added/modified for the change passed in the repo test harness aside from the Rust build limitation noted above; follow-up: run the Rust/Tauri test on a machine with `glib-2.0`/`pkg-config` installed to validate the native-side assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a826077a8832fa6df9f60e6f180f0)