### PR TITLE
Fix desktop operator restart registration

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -503,6 +503,11 @@ def _sleep_with_cancel(seconds: float) -> bool:
 def run(args: argparse.Namespace) -> int:
     _stop_requested_latched.clear()
     bridge_session_id = _bridge_session_id_from_env()
+    print(
+        "desktop.compute_node_bridge.lifecycle.session_start "
+        f"session_id={bridge_session_id} cancel_latch_reset=true",
+        file=sys.stderr,
+    )
     status_sequence = 0
 
     def emit_operator_event(payload: Dict[str, Any]) -> None:
@@ -591,6 +596,12 @@ def run(args: argparse.Namespace) -> int:
             use_configured_relay_fallbacks=False,
         )
     )
+    print(
+        "desktop.compute_node_bridge.relay_client.created "
+        f"session_id={bridge_session_id} relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+        f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
+        file=sys.stderr,
+    )
 
     runtime.model_manager.model_path = args.model
     apply_compute_mode(runtime.model_manager, args.mode)
@@ -606,6 +617,12 @@ def run(args: argparse.Namespace) -> int:
     warm_load_fatal = False
     warm_load_future: Optional[_DaemonWarmLoadFuture] = None
     poll_worker = _CancelablePollWorker()
+    print(
+        "desktop.compute_node_bridge.poll.worker_created "
+        f"session_id={bridge_session_id} relay={_sanitize_relay_target(runtime.relay_client.relay_url)}",
+        file=sys.stderr,
+    )
+
     def build_status_payload(
         *,
         event_type: str,
@@ -994,7 +1011,8 @@ def run(args: argparse.Namespace) -> int:
                 active_relay_url = runtime.relay_client.relay_url
                 print(
                     "desktop.compute_node_bridge.api_v1_e2ee.register "
-                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
                     file=sys.stderr,
                 )
                 relay_response = poll_worker.call(
@@ -1005,7 +1023,7 @@ def run(args: argparse.Namespace) -> int:
                 if relay_response is _POLL_CANCELLED:
                     print(
                         "desktop.compute_node_bridge.poll.cancelled "
-                        f"relay={_sanitize_relay_target(active_relay_url)}",
+                        f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
                         file=sys.stderr,
                     )
                     break
@@ -1145,14 +1163,14 @@ def run(args: argparse.Namespace) -> int:
         active_relay_url = getattr(getattr(runtime, "relay_client", None), "relay_url", relay_url)
         print(
             "desktop.compute_node_bridge.stop "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
         request_poll_cancel(active_relay_url)
         poll_worker.shutdown()
         print(
             "desktop.compute_node_bridge.poll.worker_stopped "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
         if warm_load_future is not None and not warm_load_future.done():

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -488,6 +488,10 @@ pub async fn start_compute_node(
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
+    eprintln!(
+        "desktop.compute_node.session_start session_id={} bridge_script={} cancellation_token_reset=true",
+        session_id, bridge_script
+    );
 
     let spawn_result = bridge_command
         .arg("--model")
@@ -502,7 +506,10 @@ pub async fn start_compute_node(
         .spawn();
 
     let mut child = match spawn_result {
-        Ok(child) => child,
+        Ok(child) => {
+            eprintln!("desktop.compute_node.bridge_spawned session_id={}", session_id);
+            child
+        },
         Err(err) => {
             {
                 let _lifecycle_lock = state.lifecycle_lock.lock().await;
@@ -672,13 +679,20 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    eprintln!("desktop.compute_node.stop_requested");
+    let stop_session_id = state.status.lock().await.operator_session_id.clone();
+    eprintln!(
+        "desktop.compute_node.stop_requested session_id={}",
+        stop_session_id.as_deref().unwrap_or("none")
+    );
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
     };
     if let Some(stdin) = stdin_handle.as_mut() {
-        eprintln!("desktop.compute_node.cancel_requested");
+        eprintln!(
+            "desktop.compute_node.cancel_requested session_id={}",
+            stop_session_id.as_deref().unwrap_or("none")
+        );
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
     }
@@ -703,12 +717,21 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
 
         if !exited {
-            eprintln!("desktop.compute_node.bridge_kill_requested");
+            eprintln!(
+                "desktop.compute_node.bridge_kill_requested session_id={}",
+                stop_session_id.as_deref().unwrap_or("none")
+            );
             let _ = child.kill().await;
             let _ = child.wait().await;
-            eprintln!("desktop.compute_node.bridge_process_exited killed=true");
+            eprintln!(
+                "desktop.compute_node.bridge_process_exited session_id={} killed=true",
+                stop_session_id.as_deref().unwrap_or("none")
+            );
         } else {
-            eprintln!("desktop.compute_node.bridge_process_exited killed=false");
+            eprintln!(
+                "desktop.compute_node.bridge_process_exited session_id={} killed=false",
+                stop_session_id.as_deref().unwrap_or("none")
+            );
         }
     }
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2491,3 +2491,85 @@ def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypat
         }
     ]
     assert capsys.readouterr().out.splitlines()[-1]
+
+
+def test_run_restart_after_stop_creates_fresh_runtime_and_registers_again(capsys, monkeypatch):
+    _reset_cancel_queue()
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+
+    class RestartRelayClient(FakeRelayClient):
+        def __init__(self):
+            self.relay_url = 'https://staging.token.place'
+            self.stop_calls = 0
+
+        def stop(self):
+            self.stop_calls += 1
+
+        def unregister_from_relay(self):
+            return True
+
+    class RestartRuntime:
+        instances = []
+
+        def __init__(self, _config):
+            self.model_manager = FakeModelManager()
+            self.relay_client = RestartRelayClient()
+            self.register_calls = 0
+            RestartRuntime.instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            return True
+
+        def register_and_poll_once(self):
+            self.register_calls += 1
+            return {'next_ping_in_x_seconds': 0, 'poll_wait_seconds': 0}
+
+        def process_relay_request(self, _payload):
+            return True
+
+        def stop(self):
+            self.relay_client.stop()
+
+    _install_fake_runtime_module(monkeypatch, RestartRuntime)
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', lambda _seconds: True)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://staging.token.place',
+        relay_port=None,
+    )
+
+    compute_node_bridge._stop_requested_latched.set()
+    first_status = compute_node_bridge.run(args)
+    compute_node_bridge._stop_requested_latched.set()
+    second_status = compute_node_bridge.run(args)
+
+    assert first_status == 0
+    assert second_status == 0
+    assert len(RestartRuntime.instances) == 2
+    assert [runtime.register_calls for runtime in RestartRuntime.instances] == [1, 1]
+    assert all(runtime.relay_client.stop_calls >= 1 for runtime in RestartRuntime.instances)
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    started_events = [event for event in events if event['type'] == 'started']
+    registered_events = [
+        event for event in events if event['type'] == 'status' and event.get('registered') is True
+    ]
+    stopped_events = [event for event in events if event['type'] == 'stopped']
+    assert len(started_events) == 2
+    assert len(registered_events) == 2
+    assert len(stopped_events) == 2
+    assert started_events[0]['operator_session_id'] != started_events[1]['operator_session_id']
+    assert all(event['last_error'] is None for event in registered_events)
+
+
+def test_cancelable_poll_worker_shutdown_replaces_stale_poll_loop():
+    first_worker = compute_node_bridge._CancelablePollWorker()
+    first_worker.shutdown()
+    assert first_worker.call(lambda: {'unexpected': True}, lambda: False) is compute_node_bridge._POLL_CANCELLED
+
+    second_worker = compute_node_bridge._CancelablePollWorker()
+    try:
+        assert second_worker.call(lambda: {'ok': True}, lambda: False) == {'ok': True}
+    finally:
+        second_worker.shutdown()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1244,6 +1244,78 @@ class TestRelayClient:
     def test_api_v1_poll_timeout_seconds_defensive(self, relay_client, expected_wait, expected_timeout):
         assert relay_client._api_v1_poll_timeout_seconds(expected_wait) == expected_timeout
 
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_stop_unregister_then_restart_registers_and_polls_again(self, mock_post, relay_client):
+        """A stopped client can be reset and reused without relaunching the desktop app."""
+
+        first_register = MagicMock(status_code=200)
+        first_register.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+        first_poll = MagicMock(status_code=200)
+        first_poll.json.return_value = {'message': 'No requests available'}
+        unregister_ok = MagicMock(status_code=200)
+        second_register = MagicMock(status_code=200)
+        second_register.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+        second_poll = MagicMock(status_code=200)
+        second_poll.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [
+            first_register,
+            first_poll,
+            unregister_ok,
+            second_register,
+            second_poll,
+        ]
+
+        first_result = relay_client.poll_api_v1_encrypted_work()
+        assert first_result['next_ping_in_x_seconds'] == 12
+        assert relay_client.api_v1_registration_fresh() is True
+
+        relay_client.stop()
+        assert relay_client.unregister_from_relay() is True
+        stopped_result = relay_client.poll_api_v1_encrypted_work()
+        assert stopped_result['error'] == 'Relay polling stopped'
+
+        relay_client.reset_for_restart()
+        second_result = relay_client.poll_api_v1_encrypted_work()
+
+        assert second_result['next_ping_in_x_seconds'] == 12
+        register_urls = [
+            call.args[0]
+            for call in mock_post.call_args_list
+            if call.args[0].endswith('/api/v1/relay/servers/register')
+        ]
+        poll_urls = [
+            call.args[0]
+            for call in mock_post.call_args_list
+            if call.args[0].endswith('/api/v1/relay/servers/poll')
+        ]
+        assert register_urls == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/register',
+        ]
+        assert poll_urls == [
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+        assert relay_client.api_v1_registration_fresh() is True
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_reset_for_restart_replaces_stale_poll_stop_with_usable_poll(self, mock_post, relay_client):
+        relay_client.stop()
+        assert relay_client.poll_api_v1_encrypted_work()['error'] == 'Relay polling stopped'
+
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 15, 'poll_wait_seconds': 0}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok]
+
+        relay_client.reset_for_restart()
+        result = relay_client.poll_api_v1_encrypted_work()
+
+        assert result['next_ping_in_x_seconds'] == 15
+        assert mock_post.call_count == 2
+
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_uses_derived_poll_timeout(self, mock_post, relay_client):
         register_ok = MagicMock(status_code=200)

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -367,6 +367,14 @@ class ComputeNodeRuntime:
     def register_and_poll_once(self) -> Dict[str, Any]:
         """Poll relay for one encrypted API v1 work item."""
 
+        if getattr(self.relay_client, "_polling_stopped_by_request", False):
+            reset_for_restart = getattr(self.relay_client, "reset_for_restart", None)
+            if callable(reset_for_restart):
+                reset_for_restart()
+            else:
+                self.relay_client.start()
+        elif getattr(self.relay_client, "stop_polling", False):
+            self.relay_client.start()
         return self.relay_client.poll_api_v1_encrypted_work()
 
     def submit_api_v1_error_response(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -780,12 +780,20 @@ class RelayClient:
             return {}
         return {"X-Relay-Server-Token": self._registration_token}
 
-    def start(self):
-        """Start the polling loop by setting stop_polling to False"""
+    def reset_for_restart(self) -> None:
+        """Reset local lifecycle flags so a stopped client can register again cleanly."""
+
         self.stop_polling = False
         self._polling_stopped_by_request = False
         self._unregister_attempted = False
         self._unregister_complete = False
+        self._api_v1_registered_relays.clear()
+        self._api_v1_last_heartbeat_at.clear()
+        getattr(self, "_api_v1_relay_wait_hints", {}).clear()
+
+    def start(self):
+        """Start the polling loop by setting stop_polling to False"""
+        self.reset_for_restart()
 
     def stop(self):
         """Stop the polling loop by setting stop_polling to True"""


### PR DESCRIPTION
### Motivation
- Starting the operator after a previous Stop could leave relay-client and poll-worker state stale so the restarted session never re-registered with the relay. Restart must create a fresh, usable operator session without requiring an app restart.

### Description
- Add `RelayClient.reset_for_restart()` and make `start()` call it so stopped clients are cleared of stop flags, cached registrations, heartbeats, and wait hints before reuse.
- Have `ComputeNodeRuntime.register_and_poll_once()` detect stopped/stale relay-client state and restart/reset the client before attempting registration/polling.
- Add session-scoped diagnostics and safer event tagging to the Python bridge (`compute_node_bridge.py`) and the Rust Tauri backend (`compute_node.rs`) so Start/Stop/Restart lifecycle events include `session_id` and poll-worker/bridge spawn/stop details without exposing raw keys.
- Add regression tests for relay-client restart (`tests/unit/test_relay_client.py`) and bridge Restart→Stop→Restart behavior plus poll-worker replacement (`tests/unit/test_desktop_compute_node_bridge.py`).

### Testing
- Ran `pytest tests/unit/test_relay_client.py -k "restart or stop or unregister or register"` — all selected tests passed (33 passed).
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py -k "restart or stop or lifecycle or register"` — selected tests passed (12 passed).
- Ran `npm test --prefix desktop-tauri` — desktop UI tests passed (`src/App.test.tsx` suite: 21 tests passed).
- Ran Python compile checks with `python -m py_compile` on modified files — OK.
- Ran `pre-commit run --all-files` — project checks passed.
- Blocked/Not run: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node -- --nocapture` is blocked here due to missing system `glib-2.0.pc` / pkg-config in the container, and `pytest desktop-tauri/scripts/test_desktop_operator_ui_e2e.py` is blocked by missing `selenium` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a826077a8832fa6df9f60e6f180f0)