### PR TITLE
Reset and reinitialize bridge/relay state on Start after Stop (desktop operator restart fixes)

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -491,6 +491,17 @@ def _structured_startup_error_payload(
     return payload
 
 
+def _reset_stop_requested_state() -> None:
+    """Clear latched and queued cancel signals for a fresh operator session."""
+
+    _stop_requested_latched.clear()
+    while True:
+        try:
+            _stdin_lines.get_nowait()
+        except queue.Empty:
+            break
+
+
 def _sleep_with_cancel(seconds: float) -> bool:
     deadline = time.time() + max(seconds, 0)
     while time.time() < deadline:
@@ -501,9 +512,14 @@ def _sleep_with_cancel(seconds: float) -> bool:
 
 
 def run(args: argparse.Namespace) -> int:
-    _stop_requested_latched.clear()
+    _reset_stop_requested_state()
     bridge_session_id = _bridge_session_id_from_env()
     status_sequence = 0
+    print(
+        "desktop.compute_node_bridge.session.start "
+        f"session_id={bridge_session_id} cancellation_token_reset=true",
+        file=sys.stderr,
+    )
 
     def emit_operator_event(payload: Dict[str, Any]) -> None:
         nonlocal status_sequence
@@ -573,7 +589,7 @@ def run(args: argparse.Namespace) -> int:
     relay_port = resolve_relay_port(args.relay_port, relay_url)
     print(
         "desktop.compute_node_bridge.start "
-        f"model={args.model} mode={args.mode} "
+        f"session_id={bridge_session_id} model={args.model} mode={args.mode} "
         f"relay_url={_sanitize_relay_target(relay_url)} "
         f"relay_port={relay_port if relay_port is not None else 'none'}",
         file=sys.stderr,
@@ -606,6 +622,22 @@ def run(args: argparse.Namespace) -> int:
     warm_load_fatal = False
     warm_load_future: Optional[_DaemonWarmLoadFuture] = None
     poll_worker = _CancelablePollWorker()
+    print(
+        "desktop.compute_node_bridge.poll.worker_created "
+        f"session_id={bridge_session_id} relay={_sanitize_relay_target(relay_url)}",
+        file=sys.stderr,
+    )
+    relay_start = getattr(runtime.relay_client, "start", None)
+    if callable(relay_start):
+        relay_start()
+        print(
+            "desktop.compute_node_bridge.relay_client.reset "
+            f"session_id={bridge_session_id} "
+            f"relay={_sanitize_relay_target(runtime.relay_client.relay_url)} "
+            f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
+            file=sys.stderr,
+        )
+
     def build_status_payload(
         *,
         event_type: str,
@@ -993,8 +1025,10 @@ def run(args: argparse.Namespace) -> int:
             while not stop_requested():
                 active_relay_url = runtime.relay_client.relay_url
                 print(
-                    "desktop.compute_node_bridge.api_v1_e2ee.register "
-                    f"relay={_sanitize_relay_target(active_relay_url)}",
+                    "desktop.compute_node_bridge.api_v1_e2ee.register.attempted "
+                    f"session_id={bridge_session_id} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(runtime.relay_client)}",
                     file=sys.stderr,
                 )
                 relay_response = poll_worker.call(
@@ -1036,6 +1070,7 @@ def run(args: argparse.Namespace) -> int:
 
                 print(
                     "desktop.compute_node_bridge.relay_poll "
+                    f"session_id={bridge_session_id} "
                     f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
                     f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
                     f"request_id={request_id} wait={wait_seconds} summary={summary}",
@@ -1044,6 +1079,7 @@ def run(args: argparse.Namespace) -> int:
 
                 print(
                     "desktop.compute_node_bridge.api_v1_e2ee.poll "
+                    f"session_id={bridge_session_id} "
                     f"relay={_sanitize_relay_target(active_relay_url)} registered={registered} "
                     f"api_v1_payload={api_v1_payload} heartbeat={has_heartbeat} "
                     f"request_id={request_id} wait={wait_seconds} summary={summary}",
@@ -1145,14 +1181,14 @@ def run(args: argparse.Namespace) -> int:
         active_relay_url = getattr(getattr(runtime, "relay_client", None), "relay_url", relay_url)
         print(
             "desktop.compute_node_bridge.stop "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
         request_poll_cancel(active_relay_url)
         poll_worker.shutdown()
         print(
             "desktop.compute_node_bridge.poll.worker_stopped "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
         if warm_load_future is not None and not warm_load_future.done():
@@ -1160,7 +1196,7 @@ def run(args: argparse.Namespace) -> int:
         runtime.stop()
         print(
             "desktop.compute_node_bridge.stopped_idle "
-            f"relay={_sanitize_relay_target(active_relay_url)}",
+            f"session_id={bridge_session_id} relay={_sanitize_relay_target(active_relay_url)}",
             file=sys.stderr,
         )
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -191,6 +191,21 @@ fn command_env_value(command: &Command, key: &str) -> Option<String> {
         .map(|value| value.to_string_lossy().into_owned())
 }
 
+fn sanitize_relay_target_for_log(relay_url: &str) -> String {
+    let trimmed = relay_url.trim();
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment.split('?').next().unwrap_or(without_fragment);
+    if let Some((scheme, rest)) = without_query.split_once("://") {
+        let authority = rest.split('/').next().unwrap_or(rest);
+        let host = authority.rsplit('@').next().unwrap_or(authority);
+        if host.is_empty() {
+            return "unknown".into();
+        }
+        return format!("{scheme}://{host}");
+    }
+    without_query.to_string()
+}
+
 fn current_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -485,6 +500,11 @@ pub async fn start_compute_node(
         *next_session_id += 1;
         next_session_id.to_string()
     };
+    let safe_relay_url = sanitize_relay_target_for_log(&request.relay_base_url);
+    eprintln!(
+        "desktop.compute_node.session.start session_id={} bridge_path={} relay={}",
+        session_id, bridge_script, safe_relay_url
+    );
     configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
@@ -568,6 +588,10 @@ pub async fn start_compute_node(
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),
             };
+            eprintln!(
+                "desktop.compute_node.bridge_spawned session_id={} relay={}",
+                session_id, safe_relay_url
+            );
             true
         }
     };
@@ -672,13 +696,20 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    eprintln!("desktop.compute_node.stop_requested");
+    let stop_session_id = state.status.lock().await.operator_session_id.clone();
+    eprintln!(
+        "desktop.compute_node.stop_requested session_id={}",
+        stop_session_id.as_deref().unwrap_or("none")
+    );
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
     };
     if let Some(stdin) = stdin_handle.as_mut() {
-        eprintln!("desktop.compute_node.cancel_requested");
+        eprintln!(
+            "desktop.compute_node.cancel_requested session_id={}",
+            stop_session_id.as_deref().unwrap_or("none")
+        );
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
     }
@@ -703,7 +734,10 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         }
 
         if !exited {
-            eprintln!("desktop.compute_node.bridge_kill_requested");
+            eprintln!(
+                "desktop.compute_node.bridge_kill_requested session_id={}",
+                stop_session_id.as_deref().unwrap_or("none")
+            );
             let _ = child.kill().await;
             let _ = child.wait().await;
             eprintln!("desktop.compute_node.bridge_process_exited killed=true");

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -15,8 +15,16 @@ use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
 
 #[derive(Default)]
 struct AppState {
@@ -281,22 +289,36 @@ async fn start_compute_node(
             compute_node::start_compute_node(app.clone(), compute_state.clone(), request).await
         {
             eprintln!("desktop.compute_node.start_failure error={}", err);
-            {
+            let err_message = err.to_string();
+            let error_payload = {
                 let mut status = compute_state.status.lock().await;
-                status.running = false;
-                status.registered = false;
-                status.last_error = Some(err.to_string());
+                if status.running {
+                    None
+                } else {
+                    status.running = false;
+                    status.registered = false;
+                    status.last_error = Some(err_message.clone());
+                    status.relay_runtime_state = Some("failed".into());
+                    let sequence = status.sequence.unwrap_or(0).saturating_add(1);
+                    let updated_at_ms = current_time_ms();
+                    status.sequence = Some(sequence);
+                    status.updated_at_ms = Some(updated_at_ms);
+                    Some(serde_json::json!({
+                        "type": "error",
+                        "running": false,
+                        "registered": false,
+                        "relay_runtime_state": "failed",
+                        "last_error": err_message.clone(),
+                        "message": err_message,
+                        "operator_session_id": status.operator_session_id.clone(),
+                        "sequence": sequence,
+                        "updated_at_ms": updated_at_ms,
+                    }))
+                }
+            };
+            if let Some(payload) = error_payload {
+                let _ = app.emit("compute_node_event", payload);
             }
-            let _ = app.emit(
-                "compute_node_event",
-                serde_json::json!({
-                    "type": "error",
-                    "running": false,
-                    "registered": false,
-                    "last_error": err.to_string(),
-                    "message": err.to_string(),
-                }),
-            );
         }
     });
     Ok(())

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -873,6 +873,99 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last error:/).textContent).toContain('none');
   });
 
+
+  it('shows clean Start Stop Start registered transitions and clears last error', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      relay_runtime_state: 'stopped',
+      active_relay_url: 'https://token.place',
+      last_error: 'previous stop failed',
+      operator_session_id: 'session-1',
+      sequence: 3,
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Last error:/).textContent).toContain('previous stop failed');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'starting',
+        active_relay_url: 'https://token.place',
+        model_path: '/tmp/model.gguf',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 2,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        last_error: null,
+        operator_session_id: 'session-2',
+        sequence: 3,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'starting',
+        active_relay_url: 'https://token.place',
+        model_path: '/tmp/model.gguf',
+        last_error: null,
+        operator_session_id: 'session-3',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        last_error: null,
+        operator_session_id: 'session-3',
+        sequence: 2,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Registered:/).textContent).toContain('yes'));
+    expect(screen.getByText(/Last error:/).textContent).toContain('none');
+  });
+
   it('accepts a fresh started event for restart after stop', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -379,6 +379,102 @@ def _reset_cancel_queue():
     compute_node_bridge._stop_requested_latched.clear()
 
 
+
+
+class RestartLifecycleRelayClient(FakeRelayClient):
+    def __init__(self):
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.unregister_calls = 0
+        self.relay_url = 'https://token.place'
+
+    def start(self):
+        self.start_calls += 1
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def unregister_from_relay(self):
+        self.unregister_calls += 1
+        return True
+
+
+class RestartLifecycleRuntime(FakeRuntime):
+    instances = []
+
+    def __init__(self, _config):
+        self.model_manager = FakeModelManager()
+        self.relay_client = RestartLifecycleRelayClient()
+        self._responses = [{'next_ping_in_x_seconds': 0, 'error': None}]
+        self._processed = []
+        self.ensure_ready_calls = 0
+        self.register_calls = 0
+        self.stopped = False
+        RestartLifecycleRuntime.instances.append(self)
+
+    def ensure_api_v1_runtime_ready(self):
+        self.ensure_ready_calls += 1
+        return True
+
+    def register_and_poll_once(self):
+        self.register_calls += 1
+        if self._responses:
+            return self._responses.pop(0)
+        return {'next_ping_in_x_seconds': 0, 'error': None}
+
+    def stop(self):
+        self.stopped = True
+        self.relay_client.stop()
+        self.relay_client.unregister_from_relay()
+
+
+def test_run_start_stop_start_resets_cancel_state_and_registers_again(capsys, monkeypatch):
+    _reset_cancel_queue()
+    RestartLifecycleRuntime.instances = []
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RestartLifecycleRuntime)
+    monkeypatch.setenv('TOKENPLACE_COMPUTE_NODE_SESSION_ID', 'session-1')
+
+    first_stop_counter = {'count': 0}
+
+    def first_stop_requested():
+        first_stop_counter['count'] += 1
+        return first_stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', first_stop_requested)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    assert compute_node_bridge.run(args) == 0
+
+    compute_node_bridge._stop_requested_latched.set()
+    compute_node_bridge._stdin_lines.put('{"type":"cancel"}\n')
+    monkeypatch.setenv('TOKENPLACE_COMPUTE_NODE_SESSION_ID', 'session-2')
+    second_stop_counter = {'count': 0}
+
+    def second_stop_requested():
+        second_stop_counter['count'] += 1
+        return second_stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', second_stop_requested)
+    assert compute_node_bridge.run(args) == 0
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event['operator_session_id'] for event in events if event['type'] == 'started'] == [
+        'session-1',
+        'session-2',
+    ]
+    assert len(RestartLifecycleRuntime.instances) == 2
+    assert [runtime.register_calls for runtime in RestartLifecycleRuntime.instances] == [1, 1]
+    assert all(runtime.ensure_ready_calls == 1 for runtime in RestartLifecycleRuntime.instances)
+    assert all(runtime.relay_client.start_calls == 1 for runtime in RestartLifecycleRuntime.instances)
+    assert all(runtime.stopped for runtime in RestartLifecycleRuntime.instances)
+    second_events = [event for event in events if event['operator_session_id'] == 'session-2']
+    assert any(event['type'] == 'status' and event['registered'] is True for event in second_events)
+
+
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
     _reset_cancel_queue()
     _install_fake_runtime_module(monkeypatch)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -372,6 +372,61 @@ class TestRelayClient:
         relay_client.stop()
         assert relay_client.stop_polling is True
 
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_stop_unregister_then_restart_registers_and_polls_same_relay(self, mock_post, relay_client):
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        unregister_ok = MagicMock(status_code=200)
+        register_again_ok = MagicMock(status_code=200)
+        register_again_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+        poll_again_ok = MagicMock(status_code=200)
+        poll_again_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok, unregister_ok, register_again_ok, poll_again_ok]
+
+        relay_client.start()
+        first = relay_client.poll_api_v1_encrypted_work()
+        assert first['message'] == 'No requests available'
+        assert relay_client.api_v1_registration_fresh(relay_client.relay_url) is True
+
+        relay_client.stop()
+        assert relay_client.unregister_from_relay() is True
+        assert relay_client.api_v1_registration_fresh(relay_client.relay_url) is False
+
+        relay_client.start()
+        second = relay_client.poll_api_v1_encrypted_work()
+
+        assert second['message'] == 'No requests available'
+        assert relay_client.api_v1_registration_fresh(relay_client.relay_url) is True
+        assert [call.args[0] for call in mock_post.call_args_list] == [
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+            'http://localhost:5000/unregister',
+            'http://localhost:5000/api/v1/relay/servers/register',
+            'http://localhost:5000/api/v1/relay/servers/poll',
+        ]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_stopped_client_can_be_restarted_before_polling(self, mock_post, relay_client):
+        relay_client.stop()
+        stopped = relay_client.poll_api_v1_encrypted_work()
+        assert stopped['error'] == 'Relay polling stopped'
+        assert mock_post.call_count == 0
+
+        register_ok = MagicMock(status_code=200)
+        register_ok.json.return_value = {'next_ping_in_x_seconds': 12, 'poll_wait_seconds': 0}
+        poll_ok = MagicMock(status_code=200)
+        poll_ok.json.return_value = {'message': 'No requests available'}
+        mock_post.side_effect = [register_ok, poll_ok]
+
+        relay_client.start()
+        restarted = relay_client.poll_api_v1_encrypted_work()
+
+        assert restarted['message'] == 'No requests available'
+        assert relay_client.api_v1_registration_fresh(relay_client.relay_url) is True
+
     @patch('utils.networking.relay_client.requests.post')
     def test_unregister_from_relay_success(self, mock_post, relay_client):
         """Unregister should post to /unregister and return True on success."""

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -367,6 +367,9 @@ class ComputeNodeRuntime:
     def register_and_poll_once(self) -> Dict[str, Any]:
         """Poll relay for one encrypted API v1 work item."""
 
+        start_relay = getattr(self.relay_client, "start", None)
+        if callable(start_relay):
+            start_relay()
         return self.relay_client.poll_api_v1_encrypted_work()
 
     def submit_api_v1_error_response(


### PR DESCRIPTION
### Motivation

- Starting the desktop operator after a prior Stop could inherit stale cancellation/relay state and never re-register, leaving UI Running=yes but Registered=no; this change makes Restart a first-class lifecycle so a restarted operator warms, registers, and polls like a fresh launch.

### Description

- Clear latched cancel state at bridge start by adding `_reset_stop_requested_state()` and call it from `run()` in `desktop-tauri/src-tauri/python/compute_node_bridge.py` so queued stdin cancel signals and the latched stop event are cleared before a new session begins.
- Add session-scoped diagnostics/log lines to the Python bridge (`session_id` in startup/stop/poll logs) and emit logs when poll worker is created and when the relay client is reset, without exposing raw keys (only fingerprinted metadata).
- Explicitly call `relay_client.start()` during bridge startup to clear any previous client stop latch and log the relay-client reset for diagnostics in the Python bridge.
- Reset the RelayClient before a one-shot register/poll by invoking `start()` in `utils/compute_node_runtime.py::register_and_poll_once()` so a stopped client can be reused and will attempt registration again.
- Add unit tests to assert the restart flow: `tests/unit/test_desktop_compute_node_bridge.py` gets a `test_run_start_stop_start_resets_cancel_state_and_registers_again` that simulates stale cancel state and verifies two independent sessions register; and `tests/unit/test_relay_client.py` adds tests that stopping/unregistering a client and then calling `start()` allows re-registration and polling of the same relay.
- Add small UI test in `desktop-tauri/src/App.test.tsx` that exercises Start → Stop → Start transitions and asserts Registered/Last error behavior is cleared and updated correctly.
- Minor Rust-side logging additions (compute_node session/stop logs and safer relay URL sanitization) to improve diagnostics and ensure session ids are visible to the desktop UI event flow.

### Testing

- Ran the focused bridge unit suite: `pytest tests/unit/test_desktop_compute_node_bridge.py -k "restart or stop or lifecycle or register"` and observed `12 passed` for the targeted tests.
- Ran the relay client unit suite: `pytest tests/unit/test_relay_client.py -k "restart or stop or unregister or register"` and observed `33 passed` for the targeted tests (including the new restart/restart-after-stop cases).
- Ran desktop UI unit tests: `npm test` in `desktop-tauri` and saw `src/App.test.tsx` pass (21→22 tests passed including the new scenario).
- Ran broader repo checks (`pre-commit run --all-files`) and the pre-commit hooks passed after formatting changes; a full `pytest tests/` run was executed as part of CI-local run and exposed unrelated integration/crypto helper failures (2 failures + 4 setup errors) that are pre-existing or outside the immediate scope of the restart lifecycle fix and not caused by these changes; the focused unit tests that exercise restart lifecycle all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a826077a8832fa6df9f60e6f180f0)