### PR TITLE
Fix desktop warm-load timeout handling

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -253,6 +253,19 @@ def _api_v1_warm_load_wait_seconds(default: float = API_V1_WARM_LOAD_WAIT_DEFAUL
     return value
 
 
+def _format_seconds_for_message(seconds: float) -> str:
+    if math.isfinite(seconds) and seconds.is_integer():
+        return str(int(seconds))
+    return f"{seconds:g}"
+
+
+def _warm_load_timeout_message(timeout_seconds: float) -> str:
+    return (
+        "API v1 relay runtime warm-load timed out after "
+        f"{_format_seconds_for_message(timeout_seconds)}s"
+    )
+
+
 def _relay_error_message(relay_response: Dict[str, Any]) -> Optional[str]:
     """Return a normalized relay error message if the response includes one."""
 
@@ -924,8 +937,10 @@ def run(args: argparse.Namespace) -> int:
             remaining_seconds = warm_load_deadline_seconds - elapsed_seconds
             if remaining_seconds <= 0:
                 warm_load_state = "failed"
-                warm_load_failed = "timed out initializing API v1 model runtime before relay registration"
+                warm_load_failed = _warm_load_timeout_message(warm_load_deadline_seconds)
                 warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
+                if warm_load_future is not None and not warm_load_future.done():
+                    warm_load_future.cancel()
                 last_error = warm_load_failed
                 print(
                     "desktop.compute_node_bridge.registration.gate_wait_timeout "

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -506,6 +506,49 @@ describe('desktop app start failure handling', () => {
   });
 
 
+  it('shows warm-load timeout as not running and keeps registration gated', async () => {
+    render(<App />);
+    await screen.findByText('Start operator');
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'warming',
+        warm_load_state: 'warming',
+        last_error: null,
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        warm_load_state: 'failed',
+        last_error: 'API v1 relay runtime warm-load timed out after 120s',
+        message: 'API v1 relay runtime warm-load timed out after 120s',
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Running:/).textContent).toContain('no'));
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('failed');
+    expect(screen.getByText(/Last error:/).textContent).toContain(
+      'API v1 relay runtime warm-load timed out after 120s'
+    );
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+  });
+
+
   it('replays cached warming readiness and relay runtime path without showing registered yes', async () => {
     mockInitialComputeStatus({
       running: true,

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1870,8 +1870,76 @@ def test_run_pre_registration_warmup_times_out_without_registering(capsys, monke
     ]
     assert len(warming_status_events) == 1
     assert "registration.gate_wait_timeout" in captured.err
+    assert "API v1 relay runtime warm-load timed out after 0.05s" in captured.out
     assert "api_v1_e2ee.runtime_wait.start" not in captured.err
     assert "api_v1_e2ee.runtime_wait.timeout" not in captured.err
+
+
+def test_run_start_after_pre_registration_warmup_timeout_gets_fresh_session(capsys, monkeypatch):
+    _reset_cancel_queue()
+    events = []
+    release_first_warmup = threading.Event()
+    instances = []
+
+    class RetryWarmupRuntime(FakeRuntime):
+        def __init__(self, config):
+            super().__init__(config)
+            self.index = len(instances)
+            instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            events.append(f"warm-{self.index}")
+            if self.index == 0:
+                release_first_warmup.wait()
+                events.append("late-first-warm-done")
+                return True
+            return True
+
+        def register_and_poll_once(self):
+            events.append(f"poll-{self.index}")
+            return {"next_ping_in_x_seconds": 0}
+
+        def stop(self):
+            events.append(f"stop-{self.index}")
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RetryWarmupRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "1")
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS", "0.02")
+    monkeypatch.setattr(compute_node_bridge, "stop_requested", lambda: False)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    try:
+        first_status = compute_node_bridge.run(args)
+        assert first_status == 1
+        assert events == ["warm-0", "stop-0"]
+
+        stop_calls = {"count": 0}
+
+        def stop_after_second_poll():
+            stop_calls["count"] += 1
+            return stop_calls["count"] > 2
+
+        monkeypatch.setattr(compute_node_bridge, "stop_requested", stop_after_second_poll)
+        monkeypatch.setenv("TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS", "0.5")
+        second_status = compute_node_bridge.run(args)
+        assert second_status == 0
+    finally:
+        release_first_warmup.set()
+
+    captured = capsys.readouterr()
+    output_events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+    error_events = [event for event in output_events if event.get("type") == "error"]
+    assert error_events
+    assert "timed out" in error_events[0]["message"]
+    assert any(
+        event.get("registered") is True
+        for event in output_events
+        if event.get("type") == "status"
+    )
+    assert "poll-0" not in events
+    assert "poll-1" in events
 
 
 def test_run_cancel_stays_responsive_during_active_relay_poll(capsys, monkeypatch):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -290,7 +290,7 @@ class ComputeNodeRuntime:
             return True
 
         if self.model_manager.download_model_if_needed():
-            _log_info("Model ready for inference")
+            _log_info("Model file ready; API v1 runtime still requires Llama initialization")
             return True
 
         _log_error("Failed to download or verify model")
@@ -307,6 +307,18 @@ class ComputeNodeRuntime:
             _log_error("Model manager missing get_llm_instance required for API v1 warmup")
             return False
 
+        model_path = getattr(self.model_manager, "model_path", "unknown")
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        requested_mode = (
+            diagnostics.get("requested_mode")
+            if isinstance(diagnostics, dict)
+            else getattr(self.model_manager, "requested_compute_mode", "unknown")
+        )
+        _log_info(
+            "API v1 runtime warmup stage=model_file_located "
+            f"model_path={model_path} requested_mode={requested_mode}"
+        )
+        _log_info("API v1 runtime warmup stage=llama_init_start")
         try:
             llm_runtime = get_llm_instance()
         except Exception:
@@ -317,6 +329,7 @@ class ComputeNodeRuntime:
             _log_error("API v1 runtime warmup failed: get_llm_instance returned None")
             return False
 
+        _log_info("API v1 runtime warmup stage=llama_init_completed")
         create_chat_completion = getattr(llm_runtime, "create_chat_completion", None)
         if not callable(create_chat_completion):
             _log_error(
@@ -329,6 +342,7 @@ class ComputeNodeRuntime:
             diagnostics["api_v1_runtime_ready"] = True
             self.model_manager.last_compute_diagnostics = diagnostics
 
+        _log_info("API v1 runtime warmup stage=runtime_ready")
         return True
 
     def start_relay_polling(self) -> threading.Thread:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -459,11 +459,28 @@ class ModelManager:
                         return None
                     else:
                         try:
+                            self.log_info(
+                                f"model_init.stage=model_file_located path={self.model_path}"
+                            )
+                            self.log_info("model_init.stage=runtime_import_start")
                             # Dynamically import Llama only when needed
                             llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
+                            self.log_info(
+                                "model_init.stage=runtime_import_completed "
+                                f"llama_module_path={getattr(llama_cpp, '__file__', 'unknown')}"
+                            )
                             Llama = llama_cpp.Llama
 
                             compute_plan = self._resolve_compute_plan()
+                            self.log_info(
+                                "model_init.stage=compute_plan_selected "
+                                f"requested={compute_plan['requested_mode']} "
+                                f"effective={compute_plan['effective_mode']} "
+                                f"backend_selected={compute_plan['backend_selected']} "
+                                f"backend_used={compute_plan['backend_used']} "
+                                f"n_gpu_layers={compute_plan['n_gpu_layers']} "
+                                f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
+                            )
                             n_gpu_layers = int(compute_plan['n_gpu_layers'])
                             if self.enforce_gpu_headroom and n_gpu_layers != 0:
                                 try:
@@ -486,7 +503,12 @@ class ModelManager:
                                             'insufficient GPU memory headroom for safe offload'
                                         )
 
+                            self.log_info(
+                                "model_init.stage=llama_instantiate_about_to_start "
+                                f"model_path={self.model_path} n_gpu_layers={n_gpu_layers}"
+                            )
                             self.log_info(f"Initializing Llama model from {self.model_path}...")
+                            self.log_info("model_init.stage=llama_init_started")
                             self.llm = Llama(
                                 model_path=self.model_path,
                                 n_gpu_layers=n_gpu_layers,
@@ -521,8 +543,14 @@ class ModelManager:
                                 f"llama_module_path={runtime_identity.get('llama_module_path', 'unknown')} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
+                            self.log_info("model_init.stage=llama_init_completed")
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
+                            self.log_error(
+                                "model_init.stage=llama_init_failed "
+                                f"error_type={type(e).__name__}: {e}",
+                                exc_info=True,
+                            )
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)
                             return None
 


### PR DESCRIPTION
### Motivation
- Prevent the desktop operator from getting stuck indefinitely in a pre-registration warm-load (Running: yes / Registered: no) when the API v1 runtime never becomes ready. 
- Make warm-load failures observable, cancel the stuck warm-load work, and allow a clean Stop/Start retry without advertising a relay compute node.

### Description
- Mark timed-out pre-registration warm-loads as failed, cancel the pending warm-load future, emit a clear timeout message, and avoid registering with the relay after timeout (changes in `desktop-tauri/src-tauri/python/compute_node_bridge.py`).
- Clarify `ensure_model_ready` logging so "model file ready" does not imply a loaded Llama runtime and add API v1 warmup stage diagnostics (`ensure_api_v1_runtime_ready`) to make Llama init stages explicit (`utils/compute_node_runtime.py`).
- Add fine-grained model-init instrumentation inside the model manager around file location, runtime import, compute-plan selection, Llama instantiation start/completion, and failure (`utils/llm/model_manager.py`).
- Add unit tests for warm-load timeout behavior and Start-after-timeout retry, and a React UI test that surfaces warm-load timeout and keeps Registered gated (`tests/unit/test_desktop_compute_node_bridge.py`, `desktop-tauri/src/App.test.tsx`).

### Testing
- Ran targeted Python unit tests: `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or registration or timeout or restart or stop"` and `pytest tests/unit/test_compute_node_runtime.py`, both passed (all selected tests passed).
- Ran broader unit/integration suites: `pytest tests/unit/test_desktop_runtime_setup.py`, `pytest tests/unit/test_relay_client.py -k "register or stop or warm or api_v1"`, and `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py`, all passed (selected tests and integration e2e passed in this environment).
- Ran desktop React tests: `npm --prefix desktop-tauri test -- App.test.tsx` which passed (25 tests).
- Ran `pre-commit run --all-files`, which completed successfully.
- E2E / platform-blocking checks: `python desktop-tauri/scripts/test_desktop_operator_ui_e2e.py` could not run here due to missing Python `selenium` in this environment, and `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` is blocked by missing system `glib-2.0` pkg-config dependency in this CI environment; these are noted as environment limitations and not regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b70a34f5c832f892213dff9911452)