### PR TITLE
Add round-robin relay dispatch for registered compute nodes

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -11,7 +11,7 @@ import sys
 import threading
 import time
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
 from urllib.parse import urlparse
 
 from flask import Flask, Response, g, jsonify, request, send_from_directory
@@ -449,6 +449,8 @@ def _validate_server_registration():
 
 
 known_servers = {}
+relay_dispatch_lock = threading.RLock()
+round_robin_next_index = 0
 client_inference_requests = {}
 client_responses = {}
 client_responses_lock = threading.Lock()
@@ -620,7 +622,8 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
 def _unregister_server(server_public_key: str) -> bool:
     """Remove a compute node and associated per-server queue/session state."""
 
-    removed = known_servers.pop(server_public_key, None) is not None
+    with relay_dispatch_lock:
+        removed = known_servers.pop(server_public_key, None) is not None
     dropped_requests = []
     with client_inference_requests_changed:
         dropped_requests = list(client_inference_requests.pop(server_public_key, []) or [])
@@ -847,9 +850,42 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
-def _select_next_server_payload(*, api_v1: bool = False):
+def _fresh_registered_server_keys() -> list[str]:
+    """Return currently eligible compute node keys in deterministic registration order."""
+
     _evict_stale_servers()
-    if not known_servers:
+    return [
+        server_public_key
+        for server_public_key, payload in known_servers.items()
+        if isinstance(payload, dict) and payload.get("public_key") == server_public_key
+    ]
+
+
+def _select_round_robin_server_key() -> tuple[str | None, int, int]:
+    """Select the next fresh compute node using in-memory round-robin order.
+
+    The deterministic order is current registration order. If a node unregisters
+    and later registers again, Python dict insertion order places it at the end
+    of the cycle.
+    """
+
+    global round_robin_next_index
+    with relay_dispatch_lock:
+        server_keys = _fresh_registered_server_keys()
+        total_servers = len(server_keys)
+        if total_servers == 0:
+            round_robin_next_index = 0
+            return None, 0, 0
+
+        selected_position = round_robin_next_index % total_servers
+        selected_key = server_keys[selected_position]
+        round_robin_next_index = (selected_position + 1) % total_servers
+        return selected_key, selected_position, total_servers
+
+
+def _select_next_server_payload(*, api_v1: bool = False):
+    server_public_key, selected_position, total_servers = _select_round_robin_server_key()
+    if server_public_key is None:
         if api_v1:
             return jsonify({
                 'error': {
@@ -858,7 +894,16 @@ def _select_next_server_payload(*, api_v1: bool = False):
                 }
             }), 503
         return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
-    server_public_key = secrets.choice(list(known_servers.keys()))
+
+    LOGGER.info(
+        "relay.server_selected",
+        extra={
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
+            "selection_policy": "round_robin",
+            "round_robin_position": selected_position,
+            "eligible_server_count": total_servers,
+        },
+    )
     return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
 
 @app.route('/next_server', methods=['GET'])
@@ -1401,17 +1446,18 @@ def api_v1_relay_servers_register():
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
 
-    if public_key in known_servers:
-        known_servers[public_key]['last_ping'] = datetime.now()
-        log_event = "server.reregister"
-    else:
-        known_servers[public_key] = {
-            'public_key': public_key,
-            'last_ping': datetime.now(),
-            'last_ping_duration': _api_v1_lease_seconds(),
-        }
-        log_event = "server.registered"
-    known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
+    with relay_dispatch_lock:
+        if public_key in known_servers:
+            known_servers[public_key]['last_ping'] = datetime.now()
+            log_event = "server.reregister"
+        else:
+            known_servers[public_key] = {
+                'public_key': public_key,
+                'last_ping': datetime.now(),
+                'last_ping_duration': _api_v1_lease_seconds(),
+            }
+            log_event = "server.registered"
+        known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
     LOGGER.info(log_event, extra={"server_public_key": public_key})
 
     return jsonify({

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -41,6 +41,7 @@ def client():
     os.environ["TOKENPLACE_ENABLE_LEGACY_RELAY_ROUTES"] = "1"
     # Reset state before each test
     known_servers.clear()
+    relay_module.round_robin_next_index = 0
     client_inference_requests.clear()
     client_pending_request_ids.clear()
     client_terminal_request_ids.clear()
@@ -57,6 +58,7 @@ def client():
         os.environ["TOKENPLACE_ENABLE_LEGACY_RELAY_ROUTES"] = previous_legacy_flag
     # Clean up state after test (optional, as fixture resets before)
     known_servers.clear()
+    relay_module.round_robin_next_index = 0
     client_inference_requests.clear()
     client_pending_request_ids.clear()
     client_terminal_request_ids.clear()
@@ -2238,9 +2240,180 @@ def test_api_v1_unregister_is_idempotent_when_server_already_gone(client):
 
 
 
-def _api_v1_request_payload(request_id, *, client_public_key=DUMMY_CLIENT_PUB_KEY, cancel_token="cancel-proof"):
+def _rr_server_key(label: str) -> str:
+    return base64.b64encode(f"round_robin_server_{label}".encode("utf-8")).decode("utf-8")
+
+
+def _register_api_v1_server(client, server_public_key: str):
+    response = client.post(
+        '/api/v1/relay/servers/register',
+        json={'server_public_key': server_public_key},
+    )
+    assert response.status_code == 200
+    return response
+
+
+def _next_api_v1_server(client) -> str:
+    response = client.get('/api/v1/relay/servers/next')
+    assert response.status_code == 200
+    return response.get_json()['server_public_key']
+
+
+def test_api_v1_next_round_robin_two_fresh_registered_nodes(client):
+    server_a = _rr_server_key('a')
+    server_b = _rr_server_key('b')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    assert [_next_api_v1_server(client) for _ in range(4)] == [
+        server_a,
+        server_b,
+        server_a,
+        server_b,
+    ]
+
+
+def test_api_v1_requests_queue_to_round_robin_selected_servers_and_poll_isolated(client):
+    server_a = _rr_server_key('a')
+    server_b = _rr_server_key('b')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    selected_servers = []
+    for idx in range(4):
+        selected = _next_api_v1_server(client)
+        selected_servers.append(selected)
+        queued = client.post(
+            '/api/v1/relay/requests',
+            json=_api_v1_request_payload(
+                f'req-rr-{idx}',
+                server_public_key=selected,
+                client_public_key=f'{DUMMY_CLIENT_PUB_KEY}-{idx}',
+                cancel_token=f'proof-{idx}',
+            ),
+        )
+        assert queued.status_code == 200
+
+    assert selected_servers == [server_a, server_b, server_a, server_b]
+    assert [item['request_id'] for item in client_inference_requests[server_a]] == [
+        'req-rr-0',
+        'req-rr-2',
+    ]
+    assert [item['request_id'] for item in client_inference_requests[server_b]] == [
+        'req-rr-1',
+        'req-rr-3',
+    ]
+
+    first_a = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_a})
+    first_b = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_b})
+    second_a = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_a})
+    second_b = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_b})
+
+    assert first_a.get_json()['request_id'] == 'req-rr-0'
+    assert first_b.get_json()['request_id'] == 'req-rr-1'
+    assert second_a.get_json()['request_id'] == 'req-rr-2'
+    assert second_b.get_json()['request_id'] == 'req-rr-3'
+
+
+def test_api_v1_next_round_robin_three_nodes(client):
+    server_a = _rr_server_key('a')
+    server_b = _rr_server_key('b')
+    server_c = _rr_server_key('c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    assert [_next_api_v1_server(client) for _ in range(6)] == [
+        server_a,
+        server_b,
+        server_c,
+        server_a,
+        server_b,
+        server_c,
+    ]
+
+
+def test_api_v1_next_round_robin_skips_expired_and_unregistered_nodes(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    server_a = _rr_server_key('a')
+    server_b = _rr_server_key('b')
+    server_c = _rr_server_key('c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    known_servers[server_b]['last_ping'] = datetime.now() - timedelta(seconds=5)
+    relay_module.round_robin_next_index = 0
+    assert [_next_api_v1_server(client) for _ in range(4)] == [
+        server_a,
+        server_c,
+        server_a,
+        server_c,
+    ]
+    assert server_b not in known_servers
+
+    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    assert unregistered.status_code == 200
+    assert unregistered.get_json()['removed'] is True
+    assert [_next_api_v1_server(client) for _ in range(3)] == [server_c, server_c, server_c]
+
+
+def test_api_v1_reregistered_node_reenters_round_robin_at_end(client):
+    server_a = _rr_server_key('a')
+    server_b = _rr_server_key('b')
+    server_c = _rr_server_key('c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    assert client.post('/unregister', json={'server_public_key': server_b}).status_code == 200
+    _register_api_v1_server(client, server_b)
+    relay_module.round_robin_next_index = 0
+
+    # Re-registering after unregister inserts the node at the end of registration order.
+    assert [_next_api_v1_server(client) for _ in range(6)] == [
+        server_a,
+        server_c,
+        server_b,
+        server_a,
+        server_c,
+        server_b,
+    ]
+
+
+def test_api_v1_next_round_robin_selection_is_lock_protected(client):
+    server_a = _rr_server_key('a')
+    server_b = _rr_server_key('b')
+    for server_key in (server_a, server_b):
+        _register_api_v1_server(client, server_key)
+
+    selections = []
+    selections_lock = threading.Lock()
+
+    def _select_once():
+        with app.test_client() as thread_client:
+            selected = _next_api_v1_server(thread_client)
+        with selections_lock:
+            selections.append(selected)
+
+    threads = [threading.Thread(target=_select_once) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+    assert selections.count(server_a) == 5
+    assert selections.count(server_b) == 5
+
+
+def _api_v1_request_payload(
+    request_id,
+    *,
+    client_public_key=DUMMY_CLIENT_PUB_KEY,
+    server_public_key=DUMMY_SERVER_PUB_KEY,
+    cancel_token="cancel-proof",
+):
     return {
-        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'server_public_key': server_public_key,
         'client_public_key': client_public_key,
         'request_id': request_id,
         'protocol': 'tokenplace_api_v1_relay_e2ee',


### PR DESCRIPTION
### Motivation
- Provide a simple, deterministic default load‑balancing policy so API v1 requests are distributed evenly across multiple fresh desktop compute nodes. 
- Ensure stale, stopped, or unregistered nodes are not selected and keep per‑server queue isolation and relay‑blind E2EE semantics unchanged. 

### Description
- Implemented an in‑memory round‑robin selector in `relay.py` using a reentrant `relay_dispatch_lock` and `round_robin_next_index`, with deterministic ordering based on current registration order. 
- Added `_fresh_registered_server_keys()` and `_select_round_robin_server_key()` and replaced the previous random selection in `_select_next_server_payload()` with round‑robin selection that skips evicted/stale servers. 
- Guarded API v1 server registration updates with the same dispatch lock so selection sees consistent registration order and re‑registered nodes reenter at the end of the cycle. 
- Emit sanitized diagnostics on selection with `relay.server_selected` logging the server fingerprint (redacted), `selection_policy`, `round_robin_position`, and `eligible_server_count` while avoiding full public key exposure. 
- Added tests and small test harness adjustments in `tests/test_relay.py` to reset round‑robin state and validate: two‑node and three‑node cycling, per‑server queue isolation, skipping expired/unregistered nodes, deterministic re‑entry after unregister/re‑register, and concurrency safety. 

### Testing
- Ran the focused relay tests: `pytest tests/test_relay.py -k "servers or round_robin or api_v1"` and the new/modified round‑robin tests passed. (passed)
- Ran integration suite: `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and all integration tests passed. (passed)
- Ran relay client unit tests: `pytest tests/unit/test_relay_client.py -k "api_v1 or relay"` and the suite passed. (passed)
- Ran pre-commit checks: `pre-commit run --all-files` and hooks passed. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8fe90180832fa071607b0a40772a)