### PR TITLE
relay: deterministic API v1 round‑robin dispatch + tests

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -461,6 +461,8 @@ PENDING_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_PENDING_REQUEST_TTL_SE
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
 api_v1_in_flight_requests_lock = threading.Lock()
+api_v1_round_robin_lock = threading.Lock()
+api_v1_round_robin_cursor = 0
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -620,7 +622,12 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
 def _unregister_server(server_public_key: str) -> bool:
     """Remove a compute node and associated per-server queue/session state."""
 
+    global api_v1_round_robin_cursor
+
     removed = known_servers.pop(server_public_key, None) is not None
+    if removed:
+        with api_v1_round_robin_lock:
+            api_v1_round_robin_cursor = api_v1_round_robin_cursor % max(len(known_servers), 1)
     dropped_requests = []
     with client_inference_requests_changed:
         dropped_requests = list(client_inference_requests.pop(server_public_key, []) or [])
@@ -847,19 +854,56 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
+def _next_server_unavailable_response(*, api_v1: bool):
+    if api_v1:
+        return jsonify({
+            'error': {
+                'message': 'No registered compute nodes are available on this relay.',
+                'code': 'no_registered_compute_nodes',
+            }
+        }), 503
+    return jsonify({'error': {'message': 'No servers available', 'code': 503}}), 503
+
+
 def _select_next_server_payload(*, api_v1: bool = False):
+    """Select the next fresh compute node.
+
+    API v1 uses deterministic in-memory round-robin order over fresh registered
+    compute nodes. New or re-registered-after-unregister nodes enter at the end
+    of the insertion-ordered registry. Legacy /next_server keeps its previous
+    random balancing behavior while it remains enabled.
+    """
+
+    global api_v1_round_robin_cursor
+
     _evict_stale_servers()
     if not known_servers:
-        if api_v1:
-            return jsonify({
-                'error': {
-                    'message': 'No registered compute nodes are available on this relay.',
-                    'code': 'no_registered_compute_nodes',
-                }
-            }), 503
-        return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
-    server_public_key = secrets.choice(list(known_servers.keys()))
-    return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
+        return _next_server_unavailable_response(api_v1=api_v1)
+
+    if not api_v1:
+        server_public_key = secrets.choice(list(known_servers.keys()))
+        return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
+
+    with api_v1_round_robin_lock:
+        eligible_server_keys = list(known_servers.keys())
+        if not eligible_server_keys:
+            return _next_server_unavailable_response(api_v1=api_v1)
+
+        selected_index = api_v1_round_robin_cursor % len(eligible_server_keys)
+        server_public_key = eligible_server_keys[selected_index]
+        selected_public_key = known_servers[server_public_key]['public_key']
+        api_v1_round_robin_cursor = (selected_index + 1) % len(eligible_server_keys)
+
+    LOGGER.info(
+        "relay.api_v1.server_selected",
+        extra={
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
+            "round_robin_index": selected_index,
+            "eligible_server_count": len(eligible_server_keys),
+            "selection_reason": "round_robin_fresh_registered",
+        },
+    )
+    return jsonify({'server_public_key': selected_public_key})
 
 @app.route('/next_server', methods=['GET'])
 def next_server():
@@ -1412,7 +1456,7 @@ def api_v1_relay_servers_register():
         }
         log_event = "server.registered"
     known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
-    LOGGER.info(log_event, extra={"server_public_key": public_key})
+    LOGGER.info(log_event, extra={"server_fingerprint": _safe_key_fingerprint(public_key)})
 
     return jsonify({
         'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],
@@ -1439,7 +1483,7 @@ def api_v1_relay_servers_poll():
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
     known_servers[public_key]['last_ping'] = datetime.now()
     known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
-    LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
+    LOGGER.info("server.heartbeat", extra={"server_fingerprint": _safe_key_fingerprint(public_key)})
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     known_servers[public_key]['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
@@ -1491,7 +1535,7 @@ def api_v1_relay_servers_poll():
     LOGGER.info(
         "relay.api_v1.request_dispatched",
         extra={
-            "server_public_key": public_key,
+            "server_fingerprint": _safe_key_fingerprint(public_key),
             "request_id": first_request.get("request_id"),
             "queued_at_unix": queued_at,
             "dispatched_at_unix": time.time(),
@@ -1538,7 +1582,7 @@ def api_v1_relay_requests():
     LOGGER.info(
         "relay.api_v1.request_queued",
         extra={
-            "server_public_key": server_public_key,
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
             "request_id": envelope.get("request_id"),
             "queued_at_unix": queued_at,
             "queue_depth": queue_depth,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -47,6 +47,7 @@ def client():
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
+    relay_module.api_v1_round_robin_cursor = 0
 
     with app.test_client() as client:
         yield client
@@ -63,6 +64,7 @@ def client():
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
+    relay_module.api_v1_round_robin_cursor = 0
 
 
 def test_operational_endpoints_are_not_rate_limited_by_public_quota(client):
@@ -128,6 +130,44 @@ def test_inference_endpoint_removed(client):
 
 # --- Test /next_server ---
 
+
+def _register_api_v1_server(client, server_public_key):
+    response = client.post(
+        '/api/v1/relay/servers/register',
+        json={'server_public_key': server_public_key},
+    )
+    assert response.status_code == 200
+    return response
+
+
+def _api_v1_request_payload_for_server(server_public_key, request_id, *, client_public_key=DUMMY_CLIENT_PUB_KEY):
+    return {
+        'server_public_key': server_public_key,
+        'client_public_key': client_public_key,
+        'request_id': request_id,
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'chat_history': f'ciphertext-request-{request_id}',
+        'cipherkey': f'cipherkey-request-{request_id}',
+        'iv': f'iv-request-{request_id}',
+        'cancel_token': f'cancel-token-{request_id}',
+    }
+
+
+def _next_api_v1_server_key(client):
+    response = client.get('/api/v1/relay/servers/next')
+    assert response.status_code == 200
+    return response.get_json()['server_public_key']
+
+
+def _poll_api_v1_request(client, server_public_key):
+    response = client.post(
+        '/api/v1/relay/servers/poll',
+        json={'server_public_key': server_public_key},
+    )
+    assert response.status_code == 200
+    return response.get_json()
+
 def test_next_server_no_servers(client):
     """Test /next_server when no servers are registered."""
     response = client.get("/next_server")
@@ -167,6 +207,132 @@ def test_next_server_one_server(client):
     assert 'server_public_key' in data
     assert data['server_public_key'] == DUMMY_SERVER_PUB_KEY
 
+
+
+def test_api_v1_next_server_round_robins_two_registered_compute_nodes(client):
+    server_a = base64.b64encode(b'api-v1-round-robin-server-a').decode('utf-8')
+    server_b = base64.b64encode(b'api-v1-round-robin-server-b').decode('utf-8')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    selections = [_next_api_v1_server_key(client) for _ in range(4)]
+
+    assert selections == [server_a, server_b, server_a, server_b]
+
+
+def test_api_v1_next_server_round_robins_three_registered_compute_nodes(client):
+    server_a = base64.b64encode(b'api-v1-round-robin-three-a').decode('utf-8')
+    server_b = base64.b64encode(b'api-v1-round-robin-three-b').decode('utf-8')
+    server_c = base64.b64encode(b'api-v1-round-robin-three-c').decode('utf-8')
+    for server in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server)
+
+    selections = [_next_api_v1_server_key(client) for _ in range(6)]
+
+    assert selections == [server_a, server_b, server_c, server_a, server_b, server_c]
+
+
+def test_api_v1_round_robin_skips_expired_and_unregistered_nodes(client):
+    server_a = base64.b64encode(b'api-v1-round-robin-skip-a').decode('utf-8')
+    server_b = base64.b64encode(b'api-v1-round-robin-skip-b').decode('utf-8')
+    server_c = base64.b64encode(b'api-v1-round-robin-skip-c').decode('utf-8')
+    for server in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server)
+
+    assert [_next_api_v1_server_key(client) for _ in range(3)] == [server_a, server_b, server_c]
+    known_servers[server_b]['last_ping'] = datetime.now() - timedelta(seconds=120)
+    known_servers[server_b]['last_ping_duration'] = 1
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [server_a, server_c, server_a, server_c]
+    assert server_b not in known_servers
+
+    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    assert unregistered.status_code == 200
+    assert unregistered.get_json()['removed'] is True
+
+    assert [_next_api_v1_server_key(client) for _ in range(3)] == [server_c, server_c, server_c]
+
+
+def test_api_v1_reregistered_node_reenters_round_robin_at_registry_end(client):
+    server_a = base64.b64encode(b'api-v1-round-robin-reregister-a').decode('utf-8')
+    server_b = base64.b64encode(b'api-v1-round-robin-reregister-b').decode('utf-8')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    assert _next_api_v1_server_key(client) == server_a
+    assert client.post('/unregister', json={'server_public_key': server_a}).status_code == 200
+    assert _next_api_v1_server_key(client) == server_b
+
+    _register_api_v1_server(client, server_a)
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [server_b, server_a, server_b, server_a]
+
+
+def test_api_v1_round_robin_queue_isolation_for_selected_servers(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS', '0')
+    server_a = base64.b64encode(b'api-v1-round-robin-queue-a').decode('utf-8')
+    server_b = base64.b64encode(b'api-v1-round-robin-queue-b').decode('utf-8')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    selected_servers = []
+    for idx in range(4):
+        selected_server = _next_api_v1_server_key(client)
+        selected_servers.append(selected_server)
+        queued = client.post(
+            '/api/v1/relay/requests',
+            json=_api_v1_request_payload_for_server(selected_server, f'req-rr-{idx}'),
+        )
+        assert queued.status_code == 200
+
+    assert selected_servers == [server_a, server_b, server_a, server_b]
+
+    assert _poll_api_v1_request(client, server_b)['request_id'] == 'req-rr-1'
+    assert _poll_api_v1_request(client, server_b)['request_id'] == 'req-rr-3'
+    no_b_work = _poll_api_v1_request(client, server_b)
+    assert no_b_work['message'] == 'No requests available'
+
+    assert _poll_api_v1_request(client, server_a)['request_id'] == 'req-rr-0'
+    assert _poll_api_v1_request(client, server_a)['request_id'] == 'req-rr-2'
+    no_a_work = _poll_api_v1_request(client, server_a)
+    assert no_a_work['message'] == 'No requests available'
+
+
+def test_api_v1_single_node_next_server_remains_stable(client):
+    _register_api_v1_server(client, DUMMY_SERVER_PUB_KEY)
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [DUMMY_SERVER_PUB_KEY] * 4
+
+
+def test_api_v1_round_robin_selection_is_thread_safe(client):
+    server_a = base64.b64encode(b'api-v1-round-robin-thread-a').decode('utf-8')
+    server_b = base64.b64encode(b'api-v1-round-robin-thread-b').decode('utf-8')
+    for server in (server_a, server_b):
+        known_servers[server] = {
+            'public_key': server,
+            'last_ping': datetime.now(),
+            'last_ping_duration': 60,
+        }
+
+    selections = []
+    selection_lock = threading.Lock()
+
+    def select_next():
+        with app.test_request_context('/api/v1/relay/servers/next'):
+            response = relay_module._select_next_server_payload(api_v1=True)
+            payload = response.get_json()
+        with selection_lock:
+            selections.append(payload['server_public_key'])
+
+    threads = [threading.Thread(target=select_next) for _ in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+    assert selections.count(server_a) == 10
+    assert selections.count(server_b) == 10
 
 def test_next_server_evicts_stale_nodes(client):
     """Stale servers should be removed before /next_server selection."""


### PR DESCRIPTION
### Motivation
- Distribute API v1 relay work evenly across multiple fresh registered desktop compute nodes using a simple deterministic round‑robin algorithm while skipping stale/unregistered nodes and preserving per‑server queue semantics.

### Description
- Add in‑memory round‑robin state and synchronization via `api_v1_round_robin_lock` and `api_v1_round_robin_cursor`, and implement deterministic selection in `_select_next_server_payload(api_v1=True)`.
- Ensure unregistration adjusts the round‑robin cursor so the rotation remains valid when nodes are removed, and skip stale/expired nodes via existing eviction logic before selection.
- Improve diagnostics: log a sanitized `server_fingerprint`, `round_robin_index`, and `eligible_server_count` (no raw public keys), and switch registration/heartbeat/request logs to use `_safe_key_fingerprint`.
- Add comprehensive tests in `tests/test_relay.py` (helpers + new tests) that assert A/B and A/B/C cycling, skipping expired/unregistered nodes, reregister behavior, per‑server queue isolation, single‑node stability, and thread safety.

### Testing
- Focused relay tests: `pytest tests/test_relay.py -k "servers or round_robin or api_v1"` — new round‑robin tests passed locally (round‑robin sequences, queue isolation, thread safety all passed).
- Integration: `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` — passed.
- Relay client unit subset: `pytest tests/unit/test_relay_client.py -k "api_v1 or relay"` — passed.
- Full test runner / pre‑commit: `pytest tests/` and `pre-commit run --all-files` were executed; the large majority of tests passed, but one guardrail unit test failed: `tests/unit/test_legacy_route_usage_guardrails.py::test_api_v1_only_active_runtime_paths_do_not_reference_deprecated_legacy_routes` reported an occurrence of a deprecated legacy route (`/next_server`) in `relay.py` that needs to be removed or explicitly allowlisted before merge.

Follow‑up: remove or document the remaining legacy route reference (or add an explicit allowlist entry in the guardrail test if the occurrence is intentional), then re-run `pre-commit run --all-files` and full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8fe90180832fa071607b0a40772a)