### PR TITLE
API v1 relay: registration-order round-robin server selection

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -1578,9 +1578,11 @@ def api_v1_relay_servers_poll():
     first_request = None
     deadline = time.monotonic() + poll_wait_seconds
     while True:
+        server_missing = False
         with server_round_robin_lock:
-            if public_key not in known_servers:
-                return _server_not_found_response(first_request)
+            server_missing = public_key not in known_servers
+        if server_missing:
+            return _server_not_found_response(first_request)
         with client_inference_requests_changed:
             first_request = _pop_next_api_v1_request(public_key)
             if first_request is not None:
@@ -1590,19 +1592,23 @@ def api_v1_relay_servers_poll():
                 break
             client_inference_requests_changed.wait(timeout=remaining)
 
+    server_missing = False
     with server_round_robin_lock:
         server_payload = known_servers.get(public_key)
         if server_payload is None:
-            return _server_not_found_response(first_request)
-        server_payload.pop('polling_until_monotonic', None)
+            server_missing = True
+        else:
+            server_payload.pop('polling_until_monotonic', None)
 
-        if first_request is None:
-            server_payload['last_ping'] = datetime.now()
-            return jsonify({
-                'message': 'No requests available',
-                'next_ping_in_x_seconds': 0 if poll_wait_seconds > 0 else max(server_payload['last_ping_duration'], 1),
-                'poll_wait_seconds': poll_wait_seconds,
-            }), 200
+            if first_request is None:
+                server_payload['last_ping'] = datetime.now()
+                return jsonify({
+                    'message': 'No requests available',
+                    'next_ping_in_x_seconds': 0 if poll_wait_seconds > 0 else max(server_payload['last_ping_duration'], 1),
+                    'poll_wait_seconds': poll_wait_seconds,
+                }), 200
+    if server_missing:
+        return _server_not_found_response(first_request)
 
     queue_wait_ms = None
     queued_at = first_request.pop('_queued_at', None)
@@ -1610,18 +1616,22 @@ def api_v1_relay_servers_poll():
         queue_wait_ms = round(max((time.time() - float(queued_at)) * 1000.0, 0.0), 3)
     request_id = first_request.get('request_id')
     if isinstance(request_id, str) and request_id:
+        server_missing = False
         with server_round_robin_lock:
             server_payload = known_servers.get(public_key)
             if server_payload is None:
-                return _server_not_found_response(first_request)
-            with api_v1_in_flight_requests_lock:
-                in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
-                if isinstance(in_flight_requests, dict):
-                    in_flight_requests[request_id] = {
-                        'expires_at': time.monotonic() + _api_v1_in_flight_ttl_seconds(),
-                        'client_public_key': first_request.get('client_public_key'),
-                        'cancel_token': first_request.get('cancel_token'),
-                    }
+                server_missing = True
+            else:
+                with api_v1_in_flight_requests_lock:
+                    in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
+                    if isinstance(in_flight_requests, dict):
+                        in_flight_requests[request_id] = {
+                            'expires_at': time.monotonic() + _api_v1_in_flight_ttl_seconds(),
+                            'client_public_key': first_request.get('client_public_key'),
+                            'cancel_token': first_request.get('cancel_token'),
+                        }
+        if server_missing:
+            return _server_not_found_response(first_request)
 
     LOGGER.info(
         "relay.api_v1.request_dispatched",

--- a/relay.py
+++ b/relay.py
@@ -1560,17 +1560,19 @@ def api_v1_relay_servers_poll():
         server_payload['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
     LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
-    def _clear_claimed_request(claimed_request):
+    def _mark_claimed_request_terminal(claimed_request):
         if not isinstance(claimed_request, dict):
             return
         if bool(claimed_request.get('e2ee_v1')):
-            _clear_pending_request(
+            _cancel_api_v1_request(
                 claimed_request.get('client_public_key'),
                 claimed_request.get('request_id'),
+                status='expired',
+                reason='provider_timeout',
             )
 
     def _server_not_found_response(claimed_request=None):
-        _clear_claimed_request(claimed_request)
+        _mark_claimed_request_terminal(claimed_request)
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
     first_request = None

--- a/relay.py
+++ b/relay.py
@@ -1414,15 +1414,16 @@ def _cancel_token_for_queued_or_in_flight_request(client_public_key, request_id)
                 ):
                     token = item.get("cancel_token")
                     return token if isinstance(token, str) and token else None
-    with api_v1_in_flight_requests_lock:
-        for server_payload in known_servers.values():
-            in_flight_requests = server_payload.get("api_v1_in_flight_requests")
-            if not isinstance(in_flight_requests, dict):
-                continue
-            entry = in_flight_requests.get(request_id)
-            if isinstance(entry, dict) and entry.get("client_public_key") == client_public_key:
-                token = entry.get("cancel_token")
-                return token if isinstance(token, str) and token else None
+    with server_round_robin_lock:
+        with api_v1_in_flight_requests_lock:
+            for server_payload in known_servers.values():
+                in_flight_requests = server_payload.get("api_v1_in_flight_requests")
+                if not isinstance(in_flight_requests, dict):
+                    continue
+                entry = in_flight_requests.get(request_id)
+                if isinstance(entry, dict) and entry.get("client_public_key") == client_public_key:
+                    token = entry.get("cancel_token")
+                    return token if isinstance(token, str) and token else None
     return None
 
 
@@ -1559,16 +1560,17 @@ def api_v1_relay_servers_poll():
         server_payload['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
     LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
-    def _requeue_claimed_request(claimed_request):
-        if claimed_request is None:
+    def _clear_claimed_request(claimed_request):
+        if not isinstance(claimed_request, dict):
             return
-        with client_inference_requests_changed:
-            queued_requests = client_inference_requests.setdefault(public_key, [])
-            queued_requests.insert(0, claimed_request)
-            client_inference_requests_changed.notify_all()
+        if bool(claimed_request.get('e2ee_v1')):
+            _clear_pending_request(
+                claimed_request.get('client_public_key'),
+                claimed_request.get('request_id'),
+            )
 
     def _server_not_found_response(claimed_request=None):
-        _requeue_claimed_request(claimed_request)
+        _clear_claimed_request(claimed_request)
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
     first_request = None

--- a/relay.py
+++ b/relay.py
@@ -1288,15 +1288,16 @@ def _cancel_api_v1_request(client_public_key, request_id, *, status="cancelled",
     _remove_client_responses_for_request(client_public_key, request_id)
     _clear_pending_request(client_public_key, request_id)
     _mark_request_terminal(client_public_key, request_id, status=status, reason=reason)
-    with api_v1_in_flight_requests_lock:
-        for server_payload in known_servers.values():
-            in_flight_requests = server_payload.get("api_v1_in_flight_requests")
-            if not isinstance(in_flight_requests, dict) or request_id not in in_flight_requests:
-                continue
-            if _in_flight_entry_matches_client(in_flight_requests.get(request_id), client_public_key):
-                in_flight_requests.pop(request_id, None)
-                if not in_flight_requests:
-                    server_payload.pop("api_v1_in_flight_requests", None)
+    with server_round_robin_lock:
+        with api_v1_in_flight_requests_lock:
+            for server_payload in known_servers.values():
+                in_flight_requests = server_payload.get("api_v1_in_flight_requests")
+                if not isinstance(in_flight_requests, dict) or request_id not in in_flight_requests:
+                    continue
+                if _in_flight_entry_matches_client(in_flight_requests.get(request_id), client_public_key):
+                    in_flight_requests.pop(request_id, None)
+                    if not in_flight_requests:
+                        server_payload.pop("api_v1_in_flight_requests", None)
     LOGGER.info(
         "relay.api_v1.request_cancelled",
         extra={
@@ -1546,43 +1547,58 @@ def api_v1_relay_servers_poll():
     public_key = data.get('server_public_key')
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
-    if public_key not in known_servers:
-        return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
-    known_servers[public_key]['last_ping'] = datetime.now()
-    known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
-    LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
-    known_servers[public_key]['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
-    with client_inference_requests_changed:
-        first_request = _pop_next_api_v1_request(public_key)
-        if first_request is None and poll_wait_seconds > 0:
-            deadline = time.monotonic() + poll_wait_seconds
-            while first_request is None:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    break
-                client_inference_requests_changed.wait(timeout=remaining)
-                first_request = _pop_next_api_v1_request(public_key)
+    lease_seconds = _api_v1_lease_seconds()
+    with server_round_robin_lock:
+        server_payload = known_servers.get(public_key)
+        if server_payload is None:
+            return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+        server_payload['last_ping'] = datetime.now()
+        server_payload['last_ping_duration'] = lease_seconds
+        server_payload['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
+    LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 
-    server_payload = known_servers.get(public_key)
-    if server_payload is not None:
-        server_payload.pop('polling_until_monotonic', None)
-    else:
-        if first_request is not None:
-            with client_inference_requests_changed:
-                queued_requests = client_inference_requests.setdefault(public_key, [])
-                queued_requests.insert(0, first_request)
-                client_inference_requests_changed.notify_all()
+    def _requeue_claimed_request(claimed_request):
+        if claimed_request is None:
+            return
+        with client_inference_requests_changed:
+            queued_requests = client_inference_requests.setdefault(public_key, [])
+            queued_requests.insert(0, claimed_request)
+            client_inference_requests_changed.notify_all()
+
+    def _server_not_found_response(claimed_request=None):
+        _requeue_claimed_request(claimed_request)
         return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
 
-    if first_request is None:
-        server_payload['last_ping'] = datetime.now()
-        return jsonify({
-            'message': 'No requests available',
-            'next_ping_in_x_seconds': 0 if poll_wait_seconds > 0 else max(server_payload['last_ping_duration'], 1),
-            'poll_wait_seconds': poll_wait_seconds,
-        }), 200
+    first_request = None
+    deadline = time.monotonic() + poll_wait_seconds
+    while True:
+        with server_round_robin_lock:
+            if public_key not in known_servers:
+                return _server_not_found_response(first_request)
+        with client_inference_requests_changed:
+            first_request = _pop_next_api_v1_request(public_key)
+            if first_request is not None:
+                break
+            remaining = deadline - time.monotonic()
+            if poll_wait_seconds <= 0 or remaining <= 0:
+                break
+            client_inference_requests_changed.wait(timeout=remaining)
+
+    with server_round_robin_lock:
+        server_payload = known_servers.get(public_key)
+        if server_payload is None:
+            return _server_not_found_response(first_request)
+        server_payload.pop('polling_until_monotonic', None)
+
+        if first_request is None:
+            server_payload['last_ping'] = datetime.now()
+            return jsonify({
+                'message': 'No requests available',
+                'next_ping_in_x_seconds': 0 if poll_wait_seconds > 0 else max(server_payload['last_ping_duration'], 1),
+                'poll_wait_seconds': poll_wait_seconds,
+            }), 200
 
     queue_wait_ms = None
     queued_at = first_request.pop('_queued_at', None)
@@ -1590,14 +1606,18 @@ def api_v1_relay_servers_poll():
         queue_wait_ms = round(max((time.time() - float(queued_at)) * 1000.0, 0.0), 3)
     request_id = first_request.get('request_id')
     if isinstance(request_id, str) and request_id:
-        with api_v1_in_flight_requests_lock:
-            in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
-            if isinstance(in_flight_requests, dict):
-                in_flight_requests[request_id] = {
-                    'expires_at': time.monotonic() + _api_v1_in_flight_ttl_seconds(),
-                    'client_public_key': first_request.get('client_public_key'),
-                    'cancel_token': first_request.get('cancel_token'),
-                }
+        with server_round_robin_lock:
+            server_payload = known_servers.get(public_key)
+            if server_payload is None:
+                return _server_not_found_response(first_request)
+            with api_v1_in_flight_requests_lock:
+                in_flight_requests = server_payload.setdefault('api_v1_in_flight_requests', {})
+                if isinstance(in_flight_requests, dict):
+                    in_flight_requests[request_id] = {
+                        'expires_at': time.monotonic() + _api_v1_in_flight_ttl_seconds(),
+                        'client_public_key': first_request.get('client_public_key'),
+                        'cancel_token': first_request.get('cancel_token'),
+                    }
 
     LOGGER.info(
         "relay.api_v1.request_dispatched",
@@ -1610,7 +1630,6 @@ def api_v1_relay_servers_poll():
         },
     )
     return jsonify(first_request), 200
-
 
 @app.route('/api/v1/relay/requests', methods=['POST'])
 def api_v1_relay_requests():
@@ -1627,9 +1646,6 @@ def api_v1_relay_requests():
         return jsonify({'error': {'message': msg, 'code': code}}), code
 
     server_public_key = envelope.pop('server_public_key')
-    if server_public_key not in known_servers:
-        return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
-
 
     if not envelope.get('client_public_key'):
         return jsonify({'error': {'message': 'Missing client public key', 'code': 400}}), 400
@@ -1637,15 +1653,19 @@ def api_v1_relay_requests():
     envelope['e2ee_v1'] = True
     queued_at = time.time()
     envelope['_queued_at'] = queued_at
-    _mark_request_pending(
-        envelope.get('client_public_key'),
-        envelope.get('request_id'),
-        cancel_token=envelope.get('cancel_token'),
-    )
-    with client_inference_requests_changed:
-        client_inference_requests.setdefault(server_public_key, []).append(envelope)
-        queue_depth = len(client_inference_requests.get(server_public_key, []))
-        client_inference_requests_changed.notify_all()
+    with server_round_robin_lock:
+        server_payload = known_servers.get(server_public_key)
+        if server_payload is None or not bool(server_payload.get(API_V1_SERVER_MARKER)):
+            return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+        _mark_request_pending(
+            envelope.get('client_public_key'),
+            envelope.get('request_id'),
+            cancel_token=envelope.get('cancel_token'),
+        )
+        with client_inference_requests_changed:
+            client_inference_requests.setdefault(server_public_key, []).append(envelope)
+            queue_depth = len(client_inference_requests.get(server_public_key, []))
+            client_inference_requests_changed.notify_all()
     LOGGER.info(
         "relay.api_v1.request_queued",
         extra={
@@ -1732,16 +1752,17 @@ def api_v1_relay_responses():
         if terminal is not None:
             status = terminal.get('status', 'cancelled')
             return jsonify({'error': {'message': 'Request is no longer waiting for a response', 'code': status, 'status': status}}), 410
-        with api_v1_in_flight_requests_lock:
-            for server_payload in known_servers.values():
-                in_flight_requests = server_payload.get('api_v1_in_flight_requests')
-                if not isinstance(in_flight_requests, dict) or request_id not in in_flight_requests:
-                    continue
-                if _in_flight_entry_matches_client(in_flight_requests.get(request_id), client_public_key):
-                    in_flight_requests.pop(request_id, None)
-                    if not in_flight_requests:
-                        server_payload.pop('api_v1_in_flight_requests', None)
-                    break
+        with server_round_robin_lock:
+            with api_v1_in_flight_requests_lock:
+                for server_payload in known_servers.values():
+                    in_flight_requests = server_payload.get('api_v1_in_flight_requests')
+                    if not isinstance(in_flight_requests, dict) or request_id not in in_flight_requests:
+                        continue
+                    if _in_flight_entry_matches_client(in_flight_requests.get(request_id), client_public_key):
+                        in_flight_requests.pop(request_id, None)
+                        if not in_flight_requests:
+                            server_payload.pop('api_v1_in_flight_requests', None)
+                        break
 
     _queue_client_response(client_public_key, envelope)
     LOGGER.info(

--- a/relay.py
+++ b/relay.py
@@ -451,6 +451,7 @@ def _validate_server_registration():
 known_servers = {}
 server_round_robin_lock = threading.Lock()
 server_round_robin_next_index = 0
+API_V1_SERVER_MARKER = "api_v1_registered"
 client_inference_requests = {}
 client_responses = {}
 client_responses_lock = threading.Lock()
@@ -619,10 +620,48 @@ def _live_server_diagnostics() -> list[dict[str, Any]]:
     return diagnostics
 
 
+def _api_v1_round_robin_keys() -> list[str]:
+    """Return API v1-capable compute node keys in registration order."""
+
+    return [
+        server_public_key
+        for server_public_key, payload in known_servers.items()
+        if bool(payload.get(API_V1_SERVER_MARKER))
+    ]
+
+
+def _remove_known_server(server_public_key: str) -> bool:
+    """Remove a known server while preserving the API v1 round-robin cursor."""
+
+    global server_round_robin_next_index
+    with server_round_robin_lock:
+        api_v1_ordered_keys = _api_v1_round_robin_keys()
+        if server_public_key not in known_servers:
+            return False
+
+        is_api_v1_candidate = server_public_key in api_v1_ordered_keys
+        if is_api_v1_candidate:
+            removed_position = api_v1_ordered_keys.index(server_public_key)
+            current_position = server_round_robin_next_index % len(api_v1_ordered_keys)
+
+        known_servers.pop(server_public_key, None)
+
+        if is_api_v1_candidate:
+            remaining_count = len(api_v1_ordered_keys) - 1
+            if remaining_count <= 0:
+                server_round_robin_next_index = 0
+            elif removed_position < current_position:
+                server_round_robin_next_index = (current_position - 1) % remaining_count
+            else:
+                server_round_robin_next_index = current_position % remaining_count
+
+        return True
+
+
 def _unregister_server(server_public_key: str) -> bool:
     """Remove a compute node and associated per-server queue/session state."""
 
-    removed = known_servers.pop(server_public_key, None) is not None
+    removed = _remove_known_server(server_public_key)
     dropped_requests = []
     with client_inference_requests_changed:
         dropped_requests = list(client_inference_requests.pop(server_public_key, []) or [])
@@ -850,18 +889,19 @@ def _legacy_route_deprecated_response(route_name: str):
 
 
 def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any]]:
-    """Select the next live compute node in registration-order round-robin order."""
+    """Select the next API v1 compute node in registration-order round-robin order."""
 
     global server_round_robin_next_index
-    ordered_keys = list(known_servers.keys())
-    if not ordered_keys:
-        return None, {
-            "eligible_count": 0,
-            "round_robin_index": 0,
-            "round_robin_position": None,
-        }
-
     with server_round_robin_lock:
+        ordered_keys = _api_v1_round_robin_keys()
+        if not ordered_keys:
+            server_round_robin_next_index = 0
+            return None, {
+                "eligible_count": 0,
+                "round_robin_index": 0,
+                "round_robin_position": None,
+            }
+
         eligible_count = len(ordered_keys)
         round_robin_index = server_round_robin_next_index % eligible_count
         server_public_key = ordered_keys[round_robin_index]
@@ -1456,19 +1496,28 @@ def api_v1_relay_servers_register():
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
 
-    if public_key in known_servers:
-        known_servers[public_key]['last_ping'] = datetime.now()
+    existing_payload = known_servers.get(public_key)
+    existing_api_v1_count = len(_api_v1_round_robin_keys())
+    if existing_payload and existing_payload.get(API_V1_SERVER_MARKER):
+        existing_payload['last_ping'] = datetime.now()
         log_event = "server.reregister"
     else:
-        if not known_servers:
+        if existing_api_v1_count == 0:
             server_round_robin_next_index = 0
-        known_servers[public_key] = {
-            'public_key': public_key,
-            'last_ping': datetime.now(),
-            'last_ping_duration': _api_v1_lease_seconds(),
-        }
+        if existing_payload:
+            existing_payload['last_ping'] = datetime.now()
+            known_servers.pop(public_key, None)
+            known_servers[public_key] = existing_payload
+        else:
+            known_servers[public_key] = {
+                'public_key': public_key,
+                'last_ping': datetime.now(),
+                'last_ping_duration': _api_v1_lease_seconds(),
+            }
+        known_servers[public_key][API_V1_SERVER_MARKER] = True
         log_event = "server.registered"
     known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
+    known_servers[public_key][API_V1_SERVER_MARKER] = True
     LOGGER.info(log_event, extra={"server_public_key": public_key})
 
     return jsonify({

--- a/relay.py
+++ b/relay.py
@@ -449,7 +449,7 @@ def _validate_server_registration():
 
 
 known_servers = {}
-server_round_robin_lock = threading.Lock()
+server_round_robin_lock = threading.RLock()
 server_round_robin_next_index = 0
 API_V1_SERVER_MARKER = "api_v1_registered"
 client_inference_requests = {}
@@ -566,44 +566,46 @@ def _evict_stale_servers() -> list[str]:
     default_stale_after = _server_stale_seconds()
     now_monotonic = time.monotonic()
     evicted: list[str] = []
-    for server_public_key, payload in list(known_servers.items()):
-        polling_until = payload.get("polling_until_monotonic")
-        if isinstance(polling_until, (int, float)) and polling_until > now_monotonic:
-            continue
-        with api_v1_in_flight_requests_lock:
-            in_flight_requests = payload.get("api_v1_in_flight_requests")
-            if isinstance(in_flight_requests, dict):
-                for request_id, entry in list(in_flight_requests.items()):
-                    if not isinstance(request_id, str) or not request_id:
-                        continue
-                    expires_at = entry.get("expires_at") if isinstance(entry, dict) else entry
-                    if isinstance(expires_at, (int, float)) and expires_at > now_monotonic:
-                        continue
-                    if in_flight_requests.get(request_id) == entry:
-                        in_flight_requests.pop(request_id, None)
+    with server_round_robin_lock:
+        server_items = list(known_servers.items())
+        for server_public_key, payload in server_items:
+            polling_until = payload.get("polling_until_monotonic")
+            if isinstance(polling_until, (int, float)) and polling_until > now_monotonic:
+                continue
+            with api_v1_in_flight_requests_lock:
+                in_flight_requests = payload.get("api_v1_in_flight_requests")
+                if isinstance(in_flight_requests, dict):
+                    for request_id, entry in list(in_flight_requests.items()):
+                        if not isinstance(request_id, str) or not request_id:
+                            continue
+                        expires_at = entry.get("expires_at") if isinstance(entry, dict) else entry
+                        if isinstance(expires_at, (int, float)) and expires_at > now_monotonic:
+                            continue
+                        if in_flight_requests.get(request_id) == entry:
+                            in_flight_requests.pop(request_id, None)
 
-                has_active_in_flight_requests = any(
-                    isinstance((entry.get("expires_at") if isinstance(entry, dict) else entry), (int, float))
-                    and (entry.get("expires_at") if isinstance(entry, dict) else entry) > now_monotonic
-                    for entry in in_flight_requests.values()
-                )
-                if has_active_in_flight_requests:
-                    continue
-                payload.pop("api_v1_in_flight_requests", None)
+                    has_active_in_flight_requests = any(
+                        isinstance((entry.get("expires_at") if isinstance(entry, dict) else entry), (int, float))
+                        and (entry.get("expires_at") if isinstance(entry, dict) else entry) > now_monotonic
+                        for entry in in_flight_requests.values()
+                    )
+                    if has_active_in_flight_requests:
+                        continue
+                    payload.pop("api_v1_in_flight_requests", None)
 
-        in_flight_until = payload.get("api_v1_in_flight_until_monotonic")
-        if isinstance(in_flight_until, (int, float)) and in_flight_until > now_monotonic:
-            continue
-        payload.pop("api_v1_in_flight_until_monotonic", None)
-        payload.pop("api_v1_in_flight_request_id", None)
-        stale_after = payload.get("last_ping_duration", default_stale_after)
-        if not isinstance(stale_after, (int, float)):
-            stale_after = default_stale_after
-        stale_after = max(float(stale_after), 1.0)
-        if _server_ping_age_seconds(payload.get("last_ping")) <= stale_after:
-            continue
-        if _unregister_server(server_public_key):
-            evicted.append(server_public_key)
+            in_flight_until = payload.get("api_v1_in_flight_until_monotonic")
+            if isinstance(in_flight_until, (int, float)) and in_flight_until > now_monotonic:
+                continue
+            payload.pop("api_v1_in_flight_until_monotonic", None)
+            payload.pop("api_v1_in_flight_request_id", None)
+            stale_after = payload.get("last_ping_duration", default_stale_after)
+            if not isinstance(stale_after, (int, float)):
+                stale_after = default_stale_after
+            stale_after = max(float(stale_after), 1.0)
+            if _server_ping_age_seconds(payload.get("last_ping")) <= stale_after:
+                continue
+            if _unregister_server(server_public_key):
+                evicted.append(server_public_key)
     return evicted
 
 
@@ -888,8 +890,8 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
-def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any]]:
-    """Select the next API v1 compute node in registration-order round-robin order."""
+def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any], dict[str, Any] | None]:
+    """Select and snapshot the next API v1 compute node in registration-order round-robin order."""
 
     global server_round_robin_next_index
     with server_round_robin_lock:
@@ -900,46 +902,47 @@ def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any]]:
                 "eligible_count": 0,
                 "round_robin_index": 0,
                 "round_robin_position": None,
-            }
+            }, None
 
         eligible_count = len(ordered_keys)
         round_robin_index = server_round_robin_next_index % eligible_count
         server_public_key = ordered_keys[round_robin_index]
+        server_payload = dict(known_servers[server_public_key])
         server_round_robin_next_index = (round_robin_index + 1) % eligible_count
         return server_public_key, {
             "eligible_count": eligible_count,
             "round_robin_index": server_round_robin_next_index,
             "round_robin_position": round_robin_index,
-        }
+        }, server_payload
 
 
 def _select_next_server_payload(*, api_v1: bool = False):
     global server_round_robin_next_index
     evicted = _evict_stale_servers()
-    if not known_servers:
-        server_round_robin_next_index = 0
-        if api_v1:
-            return jsonify({
-                'error': {
-                    'message': 'No registered compute nodes are available on this relay.',
-                    'code': 'no_registered_compute_nodes',
-                }
-            }), 503
-        return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
-    if not api_v1:
-        server_public_key = secrets.choice(list(known_servers.keys()))
-        return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
+    with server_round_robin_lock:
+        if not known_servers:
+            server_round_robin_next_index = 0
+            if api_v1:
+                return jsonify({
+                    'error': {
+                        'message': 'No registered compute nodes are available on this relay.',
+                        'code': 'no_registered_compute_nodes',
+                    }
+                }), 503
+            return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
+        if not api_v1:
+            server_public_key = secrets.choice(list(known_servers.keys()))
+            server_payload = dict(known_servers[server_public_key])
+            return jsonify({'server_public_key': server_payload['public_key']})
 
-    server_public_key, selection = _select_round_robin_server_key()
-    if not server_public_key or server_public_key not in known_servers:
-        if api_v1:
-            return jsonify({
-                'error': {
-                    'message': 'No registered compute nodes are available on this relay.',
-                    'code': 'no_registered_compute_nodes',
-                }
-            }), 503
-        return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
+    server_public_key, selection, server_payload = _select_round_robin_server_key()
+    if not server_public_key or server_payload is None:
+        return jsonify({
+            'error': {
+                'message': 'No registered compute nodes are available on this relay.',
+                'code': 'no_registered_compute_nodes',
+            }
+        }), 503
 
     LOGGER.info(
         "relay.server_selected",
@@ -953,7 +956,7 @@ def _select_next_server_payload(*, api_v1: bool = False):
             "api_v1": api_v1,
         },
     )
-    return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
+    return jsonify({'server_public_key': server_payload['public_key']})
 
 @app.route('/next_server', methods=['GET'])
 def next_server():
@@ -1496,32 +1499,34 @@ def api_v1_relay_servers_register():
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
 
-    existing_payload = known_servers.get(public_key)
-    existing_api_v1_count = len(_api_v1_round_robin_keys())
-    if existing_payload and existing_payload.get(API_V1_SERVER_MARKER):
-        existing_payload['last_ping'] = datetime.now()
-        log_event = "server.reregister"
-    else:
-        if existing_api_v1_count == 0:
-            server_round_robin_next_index = 0
-        if existing_payload:
+    lease_seconds = _api_v1_lease_seconds()
+    with server_round_robin_lock:
+        existing_payload = known_servers.get(public_key)
+        existing_api_v1_count = len(_api_v1_round_robin_keys())
+        if existing_payload and existing_payload.get(API_V1_SERVER_MARKER):
             existing_payload['last_ping'] = datetime.now()
-            known_servers.pop(public_key, None)
-            known_servers[public_key] = existing_payload
+            log_event = "server.reregister"
         else:
-            known_servers[public_key] = {
-                'public_key': public_key,
-                'last_ping': datetime.now(),
-                'last_ping_duration': _api_v1_lease_seconds(),
-            }
+            if existing_api_v1_count == 0:
+                server_round_robin_next_index = 0
+            if existing_payload:
+                existing_payload['last_ping'] = datetime.now()
+                known_servers.pop(public_key, None)
+                known_servers[public_key] = existing_payload
+            else:
+                known_servers[public_key] = {
+                    'public_key': public_key,
+                    'last_ping': datetime.now(),
+                    'last_ping_duration': lease_seconds,
+                }
+            known_servers[public_key][API_V1_SERVER_MARKER] = True
+            log_event = "server.registered"
+        known_servers[public_key]['last_ping_duration'] = lease_seconds
         known_servers[public_key][API_V1_SERVER_MARKER] = True
-        log_event = "server.registered"
-    known_servers[public_key]['last_ping_duration'] = _api_v1_lease_seconds()
-    known_servers[public_key][API_V1_SERVER_MARKER] = True
     LOGGER.info(log_event, extra={"server_public_key": public_key})
 
     return jsonify({
-        'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration'],
+        'next_ping_in_x_seconds': lease_seconds,
         'poll_wait_seconds': _api_v1_poll_wait_seconds(),
     }), 200
 
@@ -1939,17 +1944,19 @@ def sink():
         return jsonify({'error': 'Invalid public key'}), 400
 
     # Update or add the server to known_servers
-    if public_key in known_servers:
-        known_servers[public_key]['last_ping'] = datetime.now()
-    else:
-        known_servers[public_key] = {
-            'public_key': public_key,
-            'last_ping': datetime.now(),
-            'last_ping_duration': 10
-        }
+    with server_round_robin_lock:
+        if public_key in known_servers:
+            known_servers[public_key]['last_ping'] = datetime.now()
+        else:
+            known_servers[public_key] = {
+                'public_key': public_key,
+                'last_ping': datetime.now(),
+                'last_ping_duration': 10
+            }
+        next_ping_duration = known_servers[public_key]['last_ping_duration']
 
     response_data = {
-        'next_ping_in_x_seconds': known_servers[public_key]['last_ping_duration']
+        'next_ping_in_x_seconds': next_ping_duration
     }
 
     # Check if there are any client requests for this server

--- a/relay.py
+++ b/relay.py
@@ -449,6 +449,8 @@ def _validate_server_registration():
 
 
 known_servers = {}
+server_round_robin_lock = threading.Lock()
+server_round_robin_next_index = 0
 client_inference_requests = {}
 client_responses = {}
 client_responses_lock = threading.Lock()
@@ -847,9 +849,35 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
+def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any]]:
+    """Select the next live compute node in registration-order round-robin order."""
+
+    global server_round_robin_next_index
+    ordered_keys = list(known_servers.keys())
+    if not ordered_keys:
+        return None, {
+            "eligible_count": 0,
+            "round_robin_index": 0,
+            "round_robin_position": None,
+        }
+
+    with server_round_robin_lock:
+        eligible_count = len(ordered_keys)
+        round_robin_index = server_round_robin_next_index % eligible_count
+        server_public_key = ordered_keys[round_robin_index]
+        server_round_robin_next_index = (round_robin_index + 1) % eligible_count
+        return server_public_key, {
+            "eligible_count": eligible_count,
+            "round_robin_index": server_round_robin_next_index,
+            "round_robin_position": round_robin_index,
+        }
+
+
 def _select_next_server_payload(*, api_v1: bool = False):
-    _evict_stale_servers()
+    global server_round_robin_next_index
+    evicted = _evict_stale_servers()
     if not known_servers:
+        server_round_robin_next_index = 0
         if api_v1:
             return jsonify({
                 'error': {
@@ -858,7 +886,33 @@ def _select_next_server_payload(*, api_v1: bool = False):
                 }
             }), 503
         return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
-    server_public_key = secrets.choice(list(known_servers.keys()))
+    if not api_v1:
+        server_public_key = secrets.choice(list(known_servers.keys()))
+        return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
+
+    server_public_key, selection = _select_round_robin_server_key()
+    if not server_public_key or server_public_key not in known_servers:
+        if api_v1:
+            return jsonify({
+                'error': {
+                    'message': 'No registered compute nodes are available on this relay.',
+                    'code': 'no_registered_compute_nodes',
+                }
+            }), 503
+        return jsonify({'error': {'message': 'No servers available','code': 503}}), 503
+
+    LOGGER.info(
+        "relay.server_selected",
+        extra={
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
+            "selection_policy": "registration_order_round_robin",
+            "round_robin_index": selection.get("round_robin_index"),
+            "round_robin_position": selection.get("round_robin_position"),
+            "eligible_count": selection.get("eligible_count"),
+            "evicted_stale_count": len(evicted),
+            "api_v1": api_v1,
+        },
+    )
     return jsonify({'server_public_key': known_servers[server_public_key]['public_key']})
 
 @app.route('/next_server', methods=['GET'])
@@ -1389,6 +1443,7 @@ def _pop_client_response(client_public_key, request_id=None):
 @app.route('/api/v1/relay/servers/register', methods=['POST'])
 def api_v1_relay_servers_register():
     """Register or heartbeat a compute node for API v1 encrypted relay workloads."""
+    global server_round_robin_next_index
     auth_error = _validate_server_registration()
     if auth_error:
         return auth_error
@@ -1405,6 +1460,8 @@ def api_v1_relay_servers_register():
         known_servers[public_key]['last_ping'] = datetime.now()
         log_event = "server.reregister"
     else:
+        if not known_servers:
+            server_round_robin_next_index = 0
         known_servers[public_key] = {
             'public_key': public_key,
             'last_ping': datetime.now(),

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2133,6 +2133,15 @@ def test_api_v1_poll_long_wait_wakes_on_shared_queue_legacy_compat_enqueue(clien
     assert result['json']['chat_history'] == 'legacy-ciphertext-request'
 
 
+def test_api_v1_next_selects_single_fresh_api_v1_node(client):
+    server_key = _server_key('single_fresh_api_v1')
+    _register_api_v1_server(client, server_key)
+
+    selections = [_next_api_v1_server_key(client) for _ in range(3)]
+
+    assert selections == [server_key, server_key, server_key]
+
+
 def test_api_v1_next_round_robins_two_registered_compute_nodes(client):
     server_a = _server_key('round_robin_a')
     server_b = _server_key('round_robin_b')
@@ -2156,7 +2165,7 @@ def test_api_v1_next_round_robins_three_registered_compute_nodes(client):
     assert selections == [server_a, server_b, server_c, server_a, server_b, server_c]
 
 
-def test_api_v1_next_filters_out_legacy_only_servers(client):
+def test_api_v1_next_ignores_legacy_sink_registered_nodes(client):
     legacy_server = _server_key('legacy_only')
     api_server_a = _server_key('api_filter_a')
     api_server_b = _server_key('api_filter_b')
@@ -2212,6 +2221,28 @@ def test_api_v1_round_robin_preserves_next_node_after_earlier_server_eviction(cl
         server_c,
     ]
     assert server_a not in known_servers
+
+
+def test_api_v1_round_robin_does_not_skip_after_next_cursor_target_expires(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
+    server_a = _server_key('cursor_target_expired_a')
+    server_b = _server_key('cursor_target_expired_b')
+    server_c = _server_key('cursor_target_expired_c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    assert _next_api_v1_server_key(client) == server_a
+    known_servers[server_b]['last_ping'] = datetime.now() - timedelta(seconds=5)
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [
+        server_c,
+        server_a,
+        server_c,
+        server_a,
+    ]
+    assert server_b not in known_servers
+
 
 def test_api_v1_round_robin_request_queueing_preserves_per_server_isolation(client):
     server_a = _server_key('queue_a')
@@ -2310,6 +2341,7 @@ def test_api_v1_round_robin_selection_is_concurrency_safe(client):
     assert len(selections) == 20
     assert selections.count(server_a) == 10
     assert selections.count(server_b) == 10
+
 
 def test_api_v1_next_keeps_in_flight_server_alive_then_expires(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1933,7 +1933,7 @@ def test_api_v1_provider_envelope_is_queued_polled_responded_and_retrieved_ciphe
     assert response_plaintext not in json.dumps(retrieved_payload)
 
 
-def test_api_v1_poll_requeues_popped_work_if_server_unregistered_before_dispatch(client, monkeypatch):
+def test_api_v1_poll_clears_popped_work_if_server_unregistered_before_dispatch(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
 
@@ -1960,9 +1960,8 @@ def test_api_v1_poll_requeues_popped_work_if_server_unregistered_before_dispatch
     poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
     assert poll.status_code == 404
 
-    queued_after = client_inference_requests.get(DUMMY_SERVER_PUB_KEY, [])
-    assert len(queued_after) == 1
-    assert queued_after[0]['request_id'] == 'req-requeue-on-unregister-race'
+    assert DUMMY_SERVER_PUB_KEY not in client_inference_requests
+    assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids
 
 
 def test_api_v1_poll_long_wait_dispatches_when_request_arrives(client, monkeypatch):
@@ -2245,10 +2244,11 @@ def test_api_v1_round_robin_does_not_skip_after_next_cursor_target_expires(clien
 
 
 
-def test_api_v1_poll_requeues_claimed_request_if_server_removed(client, monkeypatch):
+def test_api_v1_poll_clears_claimed_request_if_server_removed(client, monkeypatch):
     server_key = _server_key('poll_removed')
     request_id = 'req-poll-removed'
     _register_api_v1_server(client, server_key)
+    relay_module._mark_request_pending(DUMMY_CLIENT_PUB_KEY, request_id, cancel_token='proof')
     client_inference_requests[server_key] = [{
         'request_id': request_id,
         'client_public_key': DUMMY_CLIENT_PUB_KEY,
@@ -2273,7 +2273,8 @@ def test_api_v1_poll_requeues_claimed_request_if_server_removed(client, monkeypa
     assert response.status_code == 404
     assert response.get_json()['error']['code'] == 404
     assert server_key not in known_servers
-    assert client_inference_requests[server_key][0]['request_id'] == request_id
+    assert server_key not in client_inference_requests
+    assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids
 
 
 class _LockCheckingKnownServers(dict):
@@ -2285,6 +2286,34 @@ class _LockCheckingKnownServers(dict):
         if relay_module.server_round_robin_lock._is_owned():
             self.values_checked_under_server_lock = True
         return super().values()
+
+
+def test_api_v1_cancel_token_lookup_scans_known_servers_under_registry_lock(client, monkeypatch):
+    request_id = 'req-cancel-token-lock-scan'
+    checking_servers = _LockCheckingKnownServers({
+        DUMMY_SERVER_PUB_KEY: {
+            'public_key': DUMMY_SERVER_PUB_KEY,
+            'last_ping': datetime.now(),
+            'last_ping_duration': 60,
+            relay_module.API_V1_SERVER_MARKER: True,
+            'api_v1_in_flight_requests': {
+                request_id: {
+                    'expires_at': time.monotonic() + 60,
+                    'client_public_key': DUMMY_CLIENT_PUB_KEY,
+                    'cancel_token': 'proof',
+                },
+            },
+        },
+    })
+    monkeypatch.setattr(relay_module, 'known_servers', checking_servers)
+
+    token = relay_module._cancel_token_for_queued_or_in_flight_request(
+        DUMMY_CLIENT_PUB_KEY,
+        request_id,
+    )
+
+    assert token == 'proof'
+    assert checking_servers.values_checked_under_server_lock is True
 
 
 def test_api_v1_cancel_scans_known_servers_under_registry_lock(client, monkeypatch):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2244,6 +2244,120 @@ def test_api_v1_round_robin_does_not_skip_after_next_cursor_target_expires(clien
     assert server_b not in known_servers
 
 
+
+def test_api_v1_poll_requeues_claimed_request_if_server_removed(client, monkeypatch):
+    server_key = _server_key('poll_removed')
+    request_id = 'req-poll-removed'
+    _register_api_v1_server(client, server_key)
+    client_inference_requests[server_key] = [{
+        'request_id': request_id,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+        'e2ee_v1': True,
+    }]
+
+    def pop_and_remove(public_key):
+        queued_requests = client_inference_requests.get(public_key, [])
+        claimed = queued_requests.pop(0) if queued_requests else None
+        if not queued_requests:
+            client_inference_requests.pop(public_key, None)
+        relay_module._remove_known_server(public_key)
+        return claimed
+
+    monkeypatch.setattr(relay_module, '_pop_next_api_v1_request', pop_and_remove)
+
+    response = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_key})
+
+    assert response.status_code == 404
+    assert response.get_json()['error']['code'] == 404
+    assert server_key not in known_servers
+    assert client_inference_requests[server_key][0]['request_id'] == request_id
+
+
+class _LockCheckingKnownServers(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.values_checked_under_server_lock = False
+
+    def values(self):
+        if relay_module.server_round_robin_lock._is_owned():
+            self.values_checked_under_server_lock = True
+        return super().values()
+
+
+def test_api_v1_cancel_scans_known_servers_under_registry_lock(client, monkeypatch):
+    request_id = 'req-cancel-lock-scan'
+    checking_servers = _LockCheckingKnownServers({
+        DUMMY_SERVER_PUB_KEY: {
+            'public_key': DUMMY_SERVER_PUB_KEY,
+            'last_ping': datetime.now(),
+            'last_ping_duration': 60,
+            relay_module.API_V1_SERVER_MARKER: True,
+            'api_v1_in_flight_requests': {
+                request_id: {
+                    'expires_at': time.monotonic() + 60,
+                    'client_public_key': DUMMY_CLIENT_PUB_KEY,
+                    'cancel_token': 'proof',
+                },
+            },
+        },
+    })
+    monkeypatch.setattr(relay_module, 'known_servers', checking_servers)
+    relay_module._mark_request_pending(DUMMY_CLIENT_PUB_KEY, request_id, cancel_token='proof')
+
+    cancelled = client.post('/api/v1/relay/requests/cancel', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': request_id,
+        'status': 'cancelled',
+        'reason': 'requester_cancelled',
+        'cancel_token': 'proof',
+    })
+
+    assert cancelled.status_code == 200
+    assert checking_servers.values_checked_under_server_lock is True
+    assert 'api_v1_in_flight_requests' not in checking_servers[DUMMY_SERVER_PUB_KEY]
+
+
+def test_api_v1_request_enqueue_rejects_legacy_only_server_without_queue_entry(client):
+    legacy_server = _server_key('enqueue_legacy_only')
+    legacy_registration = client.post('/sink', json={'server_public_key': legacy_server})
+    assert legacy_registration.status_code == 200
+
+    response = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-legacy-only',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': legacy_server,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+
+    assert response.status_code == 404
+    assert legacy_server not in client_inference_requests
+    assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids
+
+
+def test_api_v1_request_enqueue_rejects_removed_server_without_queue_entry(client):
+    server_key = _server_key('enqueue_removed')
+    _register_api_v1_server(client, server_key)
+    assert client.post('/unregister', json={'server_public_key': server_key}).status_code == 200
+
+    response = client.post('/api/v1/relay/requests', json={
+        'request_id': 'req-removed-server',
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': server_key,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    })
+
+    assert response.status_code == 404
+    assert server_key not in client_inference_requests
+    assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids
+
+
 def test_api_v1_round_robin_request_queueing_preserves_per_server_isolation(client):
     server_a = _server_key('queue_a')
     server_b = _server_key('queue_b')
@@ -2508,6 +2622,7 @@ def test_api_v1_expired_pending_response_submission_returns_gone(client, monkeyp
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     queued = client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-expired-late-response'))
     assert queued.status_code == 200
@@ -2534,6 +2649,7 @@ def test_api_v1_queued_response_before_ttl_survives_delayed_retrieve(client, mon
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     request_id = 'req-response-before-ttl'
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload(request_id)).status_code == 200
@@ -2559,6 +2675,7 @@ def test_api_v1_queued_response_before_ttl_survives_diagnostics_cleanup(client, 
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     request_id = 'req-response-diagnostics-cleanup'
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload(request_id)).status_code == 200
@@ -2584,6 +2701,7 @@ def test_api_v1_late_duplicate_response_preserves_accepted_response(client, monk
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     request_id = 'req-late-duplicate-response'
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload(request_id)).status_code == 200
@@ -2609,6 +2727,7 @@ def test_api_v1_cancel_requires_matching_cancel_token(client):
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-cancel-auth', cancel_token='proof')).status_code == 200
 
@@ -2629,6 +2748,7 @@ def test_api_v1_cancel_sanitizes_status_and_reason(client):
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-sanitize-cancel', cancel_token='proof')).status_code == 200
 
@@ -2657,6 +2777,7 @@ def test_api_v1_cancelled_queued_response_retrieve_returns_gone(client):
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     request_id = 'req-response-then-cancel'
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload(request_id, cancel_token='proof')).status_code == 200
@@ -2685,6 +2806,7 @@ def test_api_v1_response_after_in_flight_cancel_is_rejected_and_queue_depth_zero
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     request_id = 'req-dispatched-cancelled'
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload(request_id, cancel_token='proof')).status_code == 200
@@ -2714,6 +2836,7 @@ def test_api_v1_cancel_only_clears_matching_client_in_flight_entry(client):
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
         'api_v1_in_flight_requests': {
             'shared-req': {'expires_at': time.monotonic() + 60, 'client_public_key': DUMMY_CLIENT_PUB_KEY, 'cancel_token': 'matching-proof'}
         },
@@ -2722,6 +2845,7 @@ def test_api_v1_cancel_only_clears_matching_client_in_flight_entry(client):
         'public_key': other_server_key,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
         'api_v1_in_flight_requests': {
             'shared-req': {'expires_at': time.monotonic() + 60, 'client_public_key': 'other-client', 'cancel_token': 'other-proof'}
         },
@@ -2748,6 +2872,7 @@ def test_api_v1_pending_ttl_cleanup_runs_without_retrieve(client, monkeypatch):
         'public_key': DUMMY_SERVER_PUB_KEY,
         'last_ping': datetime.now(),
         'last_ping_duration': 60,
+        relay_module.API_V1_SERVER_MARKER: True,
     }
     request_id = 'req-cleanup-without-retrieve'
     assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload(request_id, cancel_token='proof')).status_code == 200

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2266,12 +2266,23 @@ def test_api_v1_poll_marks_claimed_request_terminal_if_server_removed(client, mo
         relay_module._remove_known_server(public_key)
         return claimed
 
+    terminalized_without_server_lock = []
+    original_cancel = relay_module._cancel_api_v1_request
+
+    def cancel_without_server_lock(*args, **kwargs):
+        terminalized_without_server_lock.append(
+            not relay_module.server_round_robin_lock._is_owned()
+        )
+        return original_cancel(*args, **kwargs)
+
     monkeypatch.setattr(relay_module, '_pop_next_api_v1_request', pop_and_remove)
+    monkeypatch.setattr(relay_module, '_cancel_api_v1_request', cancel_without_server_lock)
 
     response = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_key})
 
     assert response.status_code == 404
     assert response.get_json()['error']['code'] == 404
+    assert terminalized_without_server_lock == [True]
     assert server_key not in known_servers
     assert server_key not in client_inference_requests
     assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -103,11 +103,7 @@ def test_api_v1_register_and_poll_are_not_rate_limited_by_public_quota(client, m
 def test_api_v1_client_relay_read_paths_are_not_rate_limited_by_public_quota(client):
     """Client discovery and response polling stay outside the public API quota."""
 
-    known_servers[DUMMY_SERVER_PUB_KEY] = {
-        "public_key": DUMMY_SERVER_PUB_KEY,
-        "last_ping": datetime.now(),
-        "last_ping_duration": 60,
-    }
+    _register_api_v1_server(client, DUMMY_SERVER_PUB_KEY)
     client_pending_request_ids[DUMMY_CLIENT_PUB_KEY] = {"request-1": time.time()}
 
     next_responses = [client.get("/api/v1/relay/servers/next") for _ in range(65)]
@@ -2159,6 +2155,63 @@ def test_api_v1_next_round_robins_three_registered_compute_nodes(client):
 
     assert selections == [server_a, server_b, server_c, server_a, server_b, server_c]
 
+
+def test_api_v1_next_filters_out_legacy_only_servers(client):
+    legacy_server = _server_key('legacy_only')
+    api_server_a = _server_key('api_filter_a')
+    api_server_b = _server_key('api_filter_b')
+
+    legacy_registration = client.post('/sink', json={'server_public_key': legacy_server})
+    assert legacy_registration.status_code == 200
+    _register_api_v1_server(client, api_server_a)
+    _register_api_v1_server(client, api_server_b)
+
+    selections = [_next_api_v1_server_key(client) for _ in range(4)]
+
+    assert selections == [api_server_a, api_server_b, api_server_a, api_server_b]
+    assert legacy_server not in selections
+
+
+def test_api_v1_round_robin_preserves_next_node_after_selected_server_unregisters(client):
+    server_a = _server_key('cursor_selected_removed_a')
+    server_b = _server_key('cursor_selected_removed_b')
+    server_c = _server_key('cursor_selected_removed_c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    assert _next_api_v1_server_key(client) == server_a
+
+    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    assert unregistered.status_code == 200
+    assert unregistered.get_json()['removed'] is True
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [
+        server_b,
+        server_c,
+        server_b,
+        server_c,
+    ]
+
+
+def test_api_v1_round_robin_preserves_next_node_after_earlier_server_eviction(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
+    server_a = _server_key('cursor_evicted_a')
+    server_b = _server_key('cursor_evicted_b')
+    server_c = _server_key('cursor_evicted_c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    assert _next_api_v1_server_key(client) == server_a
+    known_servers[server_a]['last_ping'] = datetime.now() - timedelta(seconds=5)
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [
+        server_b,
+        server_c,
+        server_b,
+        server_c,
+    ]
+    assert server_a not in known_servers
 
 def test_api_v1_round_robin_request_queueing_preserves_per_server_isolation(client):
     server_a = _server_key('queue_a')

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -41,6 +41,7 @@ def client():
     os.environ["TOKENPLACE_ENABLE_LEGACY_RELAY_ROUTES"] = "1"
     # Reset state before each test
     known_servers.clear()
+    relay_module.server_round_robin_next_index = 0
     client_inference_requests.clear()
     client_pending_request_ids.clear()
     client_terminal_request_ids.clear()
@@ -57,6 +58,7 @@ def client():
         os.environ["TOKENPLACE_ENABLE_LEGACY_RELAY_ROUTES"] = previous_legacy_flag
     # Clean up state after test (optional, as fixture resets before)
     known_servers.clear()
+    relay_module.server_round_robin_next_index = 0
     client_inference_requests.clear()
     client_pending_request_ids.clear()
     client_terminal_request_ids.clear()
@@ -183,6 +185,38 @@ def test_next_server_evicts_stale_nodes(client):
     assert response.status_code == 503
     assert payload["error"]["message"] == "No servers available"
     assert DUMMY_SERVER_PUB_KEY not in known_servers
+
+
+def _server_key(label):
+    return base64.b64encode(f"server_public_key_{label}".encode()).decode("utf-8")
+
+
+def _register_api_v1_server(client, server_public_key):
+    response = client.post(
+        '/api/v1/relay/servers/register',
+        json={'server_public_key': server_public_key},
+    )
+    assert response.status_code == 200
+    return response
+
+
+def _next_api_v1_server_key(client):
+    response = client.get('/api/v1/relay/servers/next')
+    assert response.status_code == 200
+    return response.get_json()['server_public_key']
+
+
+def _queue_api_v1_request(client, *, server_public_key, request_id, client_public_key=None):
+    response = client.post('/api/v1/relay/requests', json={
+        'request_id': request_id,
+        'client_public_key': client_public_key or f'{DUMMY_CLIENT_PUB_KEY}-{request_id}',
+        'server_public_key': server_public_key,
+        'chat_history': f'ciphertext-{request_id}',
+        'cipherkey': f'cipherkey-{request_id}',
+        'iv': f'iv-{request_id}',
+    })
+    assert response.status_code == 200
+    return response
 
 # --- Test /sink ---
 
@@ -2102,6 +2136,127 @@ def test_api_v1_poll_long_wait_wakes_on_shared_queue_legacy_compat_enqueue(clien
     assert result['status'] == 200
     assert result['json']['chat_history'] == 'legacy-ciphertext-request'
 
+
+def test_api_v1_next_round_robins_two_registered_compute_nodes(client):
+    server_a = _server_key('round_robin_a')
+    server_b = _server_key('round_robin_b')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    selections = [_next_api_v1_server_key(client) for _ in range(4)]
+
+    assert selections == [server_a, server_b, server_a, server_b]
+
+
+def test_api_v1_next_round_robins_three_registered_compute_nodes(client):
+    server_a = _server_key('round_robin_three_a')
+    server_b = _server_key('round_robin_three_b')
+    server_c = _server_key('round_robin_three_c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    selections = [_next_api_v1_server_key(client) for _ in range(6)]
+
+    assert selections == [server_a, server_b, server_c, server_a, server_b, server_c]
+
+
+def test_api_v1_round_robin_request_queueing_preserves_per_server_isolation(client):
+    server_a = _server_key('queue_a')
+    server_b = _server_key('queue_b')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    selected_servers = []
+    for idx in range(4):
+        selected_server = _next_api_v1_server_key(client)
+        selected_servers.append(selected_server)
+        _queue_api_v1_request(
+            client,
+            server_public_key=selected_server,
+            request_id=f'req-round-robin-{idx}',
+        )
+
+    assert selected_servers == [server_a, server_b, server_a, server_b]
+
+    first_a = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_a})
+    second_a = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_a})
+    first_b = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_b})
+    second_b = client.post('/api/v1/relay/servers/poll', json={'server_public_key': server_b})
+
+    assert [first_a.status_code, second_a.status_code, first_b.status_code, second_b.status_code] == [200] * 4
+    assert first_a.get_json()['request_id'] == 'req-round-robin-0'
+    assert second_a.get_json()['request_id'] == 'req-round-robin-2'
+    assert first_b.get_json()['request_id'] == 'req-round-robin-1'
+    assert second_b.get_json()['request_id'] == 'req-round-robin-3'
+
+
+def test_api_v1_round_robin_skips_expired_and_unregistered_nodes(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS', '1')
+    monkeypatch.setenv('TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS', '1')
+    server_a = _server_key('skip_a')
+    server_b = _server_key('skip_b')
+    server_c = _server_key('skip_c')
+    for server_key in (server_a, server_b, server_c):
+        _register_api_v1_server(client, server_key)
+
+    assert [_next_api_v1_server_key(client) for _ in range(3)] == [server_a, server_b, server_c]
+
+    known_servers[server_b]['last_ping'] = datetime.now() - timedelta(seconds=5)
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [server_a, server_c, server_a, server_c]
+    assert server_b not in known_servers
+
+    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    assert unregistered.status_code == 200
+    assert unregistered.get_json()['removed'] is True
+    assert [_next_api_v1_server_key(client) for _ in range(2)] == [server_c, server_c]
+
+
+def test_api_v1_reregistered_round_robin_node_reenters_at_end(client):
+    server_a = _server_key('reregister_a')
+    server_b = _server_key('reregister_b')
+    server_c = _server_key('reregister_c')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+    _register_api_v1_server(client, server_c)
+
+    assert client.post('/unregister', json={'server_public_key': server_b}).status_code == 200
+    _register_api_v1_server(client, server_b)
+
+    assert [_next_api_v1_server_key(client) for _ in range(6)] == [
+        server_a,
+        server_c,
+        server_b,
+        server_a,
+        server_c,
+        server_b,
+    ]
+
+
+def test_api_v1_round_robin_selection_is_concurrency_safe(client):
+    server_a = _server_key('concurrent_a')
+    server_b = _server_key('concurrent_b')
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    selections = []
+    lock = threading.Lock()
+
+    def select_next():
+        with app.test_client() as thread_client:
+            selected = _next_api_v1_server_key(thread_client)
+        with lock:
+            selections.append(selected)
+
+    threads = [threading.Thread(target=select_next) for _ in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+    assert len(selections) == 20
+    assert selections.count(server_a) == 10
+    assert selections.count(server_b) == 10
 
 def test_api_v1_next_keeps_in_flight_server_alive_then_expires(client, monkeypatch):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2244,7 +2244,7 @@ def test_api_v1_round_robin_does_not_skip_after_next_cursor_target_expires(clien
 
 
 
-def test_api_v1_poll_clears_claimed_request_if_server_removed(client, monkeypatch):
+def test_api_v1_poll_marks_claimed_request_terminal_if_server_removed(client, monkeypatch):
     server_key = _server_key('poll_removed')
     request_id = 'req-poll-removed'
     _register_api_v1_server(client, server_key)
@@ -2275,6 +2275,29 @@ def test_api_v1_poll_clears_claimed_request_if_server_removed(client, monkeypatc
     assert server_key not in known_servers
     assert server_key not in client_inference_requests
     assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids
+
+    retrieved = client.post('/api/v1/relay/responses/retrieve', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': request_id,
+    })
+    assert retrieved.status_code == 410
+    assert retrieved.get_json()['error'] == {
+        'message': 'Request expired',
+        'code': 'expired',
+        'status': 'expired',
+        'reason': 'provider_timeout',
+    }
+
+    late_response = client.post('/api/v1/relay/responses', json={
+        'request_id': request_id,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'ciphertext-response',
+        'cipherkey': 'cipherkey-response',
+        'iv': 'iv-response',
+    })
+    assert late_response.status_code == 410
+    assert late_response.get_json()['error']['status'] == 'expired'
+    assert DUMMY_CLIENT_PUB_KEY not in client_responses
 
 
 class _LockCheckingKnownServers(dict):


### PR DESCRIPTION
### Motivation
- Support distributing API v1 E2EE requests across multiple fresh registered desktop compute nodes using a simple deterministic round-robin policy.
- Ensure stale, stopped, or unregistered nodes are never selected and preserve per-server queue isolation and single-node behavior.
- Add lightweight diagnostics describing which fingerprint was chosen and the round-robin position without exposing full keys.

### Description
- Add in-memory round-robin state (`server_round_robin_lock`, `server_round_robin_next_index`) and a registrar-aware selector ` _select_round_robin_server_key()` to pick the next server in registration-order round-robin.
- Switch API v1 `/api/v1/relay/servers/next` to use the round-robin selector while keeping legacy `/next_server` random selection intact for non-API-v1 paths.
- Reset the round-robin cursor when the relay becomes empty and when the first API v1 server registers, and skip evicted/stale/unregistered servers during selection.
- Emit sanitized diagnostics via `LOGGER.info` including `_safe_key_fingerprint`, `selection_policy`, `round_robin_index/position`, and eligible counts (no raw public keys logged), and add test helpers plus multiple new tests validating cycle order, skipping, re-registration, per-server queue isolation, and concurrency safety in `tests/test_relay.py`.

### Testing
- Ran the targeted relay tests with `pytest tests/test_relay.py -k "servers or round_robin or api_v1" -q` and observed the new round-robin test suite pass.
- Ran integration and client-unit suites with `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and `pytest tests/unit/test_relay_client.py -k "api_v1 or relay" -q` and observed all targeted tests pass.
- Ran repository checks with `pre-commit run --all-files` and the hooks and project checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8fe90180832fa071607b0a40772a)