### PR TITLE
Define desktop operator parity contract

### DIFF
--- a/docs/architecture/desktop_operator_parity_contract.md
+++ b/docs/architecture/desktop_operator_parity_contract.md
@@ -1,0 +1,34 @@
+# Desktop operator parity contract
+
+This contract defines the platform-neutral behavior that the desktop compute-node operator must preserve across Windows and macOS. The machine-readable test matrix lives in `tests/fixtures/desktop_operator_parity_matrix.json` and should be updated with this document whenever the contract changes.
+
+## Scope
+
+The contract covers the Tauri desktop operator path that starts the Python bridge, prepares the local model runtime, registers with an API v1 relay, processes relay work, and reports lifecycle diagnostics to the UI. API v1 remains non-streaming, and relay-owned state/logs/diagnostics must remain relay-blind: ciphertext payloads plus safe routing metadata only.
+
+## Shared lifecycle requirements
+
+1. **Startup and warm-load**: when warm-load is enabled, the bridge starts model/runtime initialization before relay registration and keeps `registered=false` while the relay runtime state is `starting`, `warming`, or `failed`.
+2. **Runtime detection**: runtime detection must report the interpreter, import prefix, `llama_cpp` module path, detected backend, GPU offload support, detected device, and an actionable error when detection fails.
+3. **GPU backend selection**: `auto`, `gpu`, and `hybrid` select CUDA on CUDA-capable Windows and Metal on Metal-capable macOS. Explicit `cpu` selects CPU everywhere. CPU fallback is allowed only with a clear `fallback_reason`, and explicit GPU modes must fail closed when platform policy requires GPU support.
+4. **Relay registration eligibility**: UI/API status may show `Registered: yes` only after the runtime that will answer relay work is ready and the relay registration is fresh for the active relay URL.
+5. **UI field states**: while runtime readiness is pending, `effective_mode`, `backend_available`, `backend_selected`, and `backend_used` are `pending`. Once ready, these fields reflect the runtime that will process relay work, not merely the platform probe.
+6. **Stop operator**: Stop emits a stopped status with `running=false`, `registered=false`, and `relay_runtime_state=stopped`, and it releases relay/runtime lifecycle resources.
+7. **Start after Stop**: a subsequent Start uses a fresh operator session, drains stale cancel messages, starts a fresh relay session, and can register again after warm-load succeeds.
+8. **Packaged resource resolution**: packaged Windows and macOS builds must resolve the same bridge/runtime modules and packaged requirements/resources before falling back to development paths.
+9. **Dependency isolation**: desktop-only Python dependencies install into an isolated desktop target such as `.token_place_desktop_site` or a user fallback, never by relying on the repository-local `llama_cpp.py` shim.
+10. **Error/fallback behavior**: platform-specific runtime failures must leave `Registered: no` until recovered and must put an actionable, operator-safe message in `last_error` without logging plaintext model payload content.
+
+## Platform matrix
+
+| Matrix entry | Required behavior |
+| --- | --- |
+| Windows CUDA-capable | CUDA-capable `llama-cpp-python` is selected for `auto`/`gpu`/`hybrid`; failed GPU provisioning in GPU modes fails closed with CUDA recovery guidance. |
+| macOS Metal-capable | Metal-capable `llama-cpp-python` is selected for `auto`/`gpu`/`hybrid`; packaged `.app` must use the same bridge/runtime lifecycle as Windows. |
+| CPU fallback | CPU mode and unsupported GPU platforms may run through the same warm-load/register/stop lifecycle, but status must disclose CPU fallback and never claim a GPU backend answered relay work. |
+| Missing runtime/dependency | The operator fails before relay registration with interpreter/import-root/module diagnostics and an actionable `last_error`. |
+
+## Known gaps captured by tests
+
+- **Prompt 2 gap**: macOS runtime bootstrap is currently probe-only when Metal is missing; tests mark the future Metal bootstrap behavior as an expected failure until Prompt 2 implements it.
+- **Prompt 4 gap**: macOS does not yet have the same real packaged operator lifecycle E2E coverage as Windows; tests mark the required E2E parity check as an expected failure until Prompt 4 adds it.

--- a/tests/fixtures/desktop_operator_parity_matrix.json
+++ b/tests/fixtures/desktop_operator_parity_matrix.json
@@ -1,0 +1,108 @@
+{
+  "contract_version": 1,
+  "platforms": [
+    {
+      "id": "windows_cuda_capable",
+      "os": "windows",
+      "sys_platform": "win32",
+      "accelerator": "cuda",
+      "startup": "warm-load before relay registration",
+      "runtime_detection": "llama-cpp-python reports CUDA and GPU offload support",
+      "gpu_backend_selection": {
+        "auto": "cuda",
+        "gpu": "cuda",
+        "hybrid": "cuda",
+        "cpu": "cpu"
+      },
+      "registration_eligibility": "registered only after API v1 runtime is ready and relay registration is fresh",
+      "ui_status": {
+        "warming_registered": false,
+        "ready_registered_after_relay": true,
+        "backend_used": "cuda"
+      },
+      "stop_start": "Stop emits stopped status; Start after Stop creates a fresh relay session and may register again",
+      "packaged_resource_resolution": "prefer packaged resources/requirements.txt when repo requirements.txt is absent",
+      "dependency_isolation": "desktop bridge dependencies install into .token_place_desktop_site or user fallback target",
+      "error_fallback": "GPU modes fail closed with actionable CUDA provisioning diagnostics when repair cannot provide CUDA"
+    },
+    {
+      "id": "macos_metal_capable",
+      "os": "macos",
+      "sys_platform": "darwin",
+      "accelerator": "metal",
+      "startup": "warm-load before relay registration",
+      "runtime_detection": "llama-cpp-python reports Metal and GPU offload support",
+      "gpu_backend_selection": {
+        "auto": "metal",
+        "gpu": "metal",
+        "hybrid": "metal",
+        "cpu": "cpu"
+      },
+      "registration_eligibility": "registered only after API v1 runtime is ready and relay registration is fresh",
+      "ui_status": {
+        "warming_registered": false,
+        "ready_registered_after_relay": true,
+        "backend_used": "metal"
+      },
+      "stop_start": "same lifecycle contract as Windows",
+      "packaged_resource_resolution": "packaged .app resolves the same bridge/runtime modules and requirements as Windows packages",
+      "dependency_isolation": "desktop bridge dependencies install into app-local/user isolated target, not the repo shim path",
+      "error_fallback": "GPU modes fail closed or surface actionable Metal provisioning diagnostics when Metal runtime support is expected",
+      "known_gap": "runtime bootstrap is probe-only until Prompt 2 adds first-class Metal repair/install"
+    },
+    {
+      "id": "cpu_fallback",
+      "os": "any",
+      "sys_platform": "linux",
+      "accelerator": "cpu",
+      "startup": "warm-load before relay registration unless disabled",
+      "runtime_detection": "no CUDA/Metal backend is available or CPU mode is explicit",
+      "gpu_backend_selection": {
+        "auto": "cpu_fallback",
+        "gpu": "cpu_fallback",
+        "hybrid": "cpu_fallback",
+        "cpu": "cpu"
+      },
+      "registration_eligibility": "registered only after CPU runtime is ready and relay registration is fresh",
+      "ui_status": {
+        "warming_registered": false,
+        "ready_registered_after_relay": true,
+        "backend_used": "cpu"
+      },
+      "error_fallback": "fallback_reason explains unavailable CUDA/Metal support without implying relay registration succeeded"
+    },
+    {
+      "id": "missing_runtime_or_dependency",
+      "os": "any",
+      "sys_platform": "linux",
+      "accelerator": "missing",
+      "startup": "fail before relay registration when required bridge dependencies or runtime imports are unavailable",
+      "runtime_detection": "probe reports missing and includes interpreter/module diagnostics",
+      "gpu_backend_selection": {
+        "auto": "failed",
+        "gpu": "failed",
+        "hybrid": "failed",
+        "cpu": "failed"
+      },
+      "registration_eligibility": "never registered",
+      "ui_status": {
+        "warming_registered": false,
+        "ready_registered_after_relay": false,
+        "backend_used": "pending"
+      },
+      "error_fallback": "last_error names missing modules, interpreter, import root, and next recovery clue"
+    }
+  ],
+  "known_gaps": [
+    {
+      "id": "macos_runtime_bootstrap_probe_only",
+      "owner_prompt": 2,
+      "expectation": "darwin GPU modes should bootstrap/repair Metal runtime instead of returning probe_only"
+    },
+    {
+      "id": "macos_real_operator_lifecycle_e2e",
+      "owner_prompt": 4,
+      "expectation": "macOS packaged operator E2E should cover warm-load, register, multi-turn API v1 relay chat, Stop, Start after Stop, and diagnostics"
+    }
+  ]
+}

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -737,3 +737,48 @@ def test_compute_node_runtime_stop_continues_when_unregister_raises():
         call.stop(),
         call.unregister_from_relay(),
     ]
+
+
+@pytest.mark.parametrize(
+    'requested_mode,backend_available,gpu_supported,expected_effective,expected_selected,expected_used',
+    [
+        ('auto', 'cuda', True, 'cuda', 'cuda', 'cuda'),
+        ('gpu', 'metal', True, 'metal', 'metal', 'metal'),
+        ('hybrid', 'metal', True, 'hybrid_metal', 'metal', 'metal'),
+        ('auto', 'cpu', False, 'cpu_fallback', 'cpu', 'cpu'),
+        ('cpu', 'metal', True, 'cpu', 'cpu', 'cpu'),
+    ],
+)
+def test_compute_mode_diagnostics_platform_neutral_backend_contract(
+    monkeypatch,
+    requested_mode,
+    backend_available,
+    gpu_supported,
+    expected_effective,
+    expected_selected,
+    expected_used,
+):
+    from utils.llm.model_manager import ModelManager
+
+    manager = object.__new__(ModelManager)
+    manager.default_n_gpu_layers = -1
+    manager.hybrid_n_gpu_layers = 24
+    manager.requested_compute_mode = normalize_compute_mode(requested_mode)
+    monkeypatch.setattr(
+        ModelManager,
+        '_platform_gpu_backend',
+        staticmethod(lambda: None if backend_available == 'cpu' else backend_available),
+    )
+    monkeypatch.setattr(
+        ModelManager,
+        '_llama_gpu_offload_available',
+        staticmethod(lambda: gpu_supported),
+    )
+
+    diagnostics = manager._resolve_compute_plan()
+
+    assert diagnostics['effective_mode'] == expected_effective
+    assert diagnostics['backend_selected'] == expected_selected
+    assert diagnostics['backend_used'] == expected_used
+    if expected_used == 'cpu' and requested_mode != 'cpu' and backend_available == 'cpu':
+        assert diagnostics['fallback_reason'] == 'no CUDA/Metal backend is supported on this platform'

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2648,3 +2648,174 @@ def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypat
         }
     ]
     assert capsys.readouterr().out.splitlines()[-1]
+
+
+@pytest.mark.parametrize(
+    'platform_id,backend',
+    [
+        ('windows_cuda_capable', 'cuda'),
+        ('macos_metal_capable', 'metal'),
+        ('cpu_fallback', 'cpu'),
+    ],
+)
+def test_platform_neutral_status_contract_registers_only_after_ready_and_reports_runtime_backend(
+    capsys, monkeypatch, platform_id, backend
+):
+    _reset_cancel_queue()
+    matrix_path = Path(__file__).resolve().parents[2] / 'tests' / 'fixtures' / 'desktop_operator_parity_matrix.json'
+    matrix = json.loads(matrix_path.read_text(encoding='utf-8'))
+    assert any(entry['id'] == platform_id for entry in matrix['platforms'])
+
+    class BackendReadyRuntime(ApiV1Runtime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            BackendReadyRuntime.last_instance = self
+            self.model_manager.last_compute_diagnostics = {
+                'requested_mode': 'auto',
+                'effective_mode': 'pending',
+                'backend_available': 'unknown',
+                'backend_selected': 'unknown',
+                'backend_used': 'unknown',
+                'n_gpu_layers': -1,
+                'offloaded_layers': -1,
+                'kv_cache_device': 'gpu' if backend != 'cpu' else 'cpu',
+                'fallback_reason': None,
+            }
+
+        def ensure_api_v1_runtime_ready(self):
+            self.model_manager.last_compute_diagnostics = {
+                'requested_mode': 'auto',
+                'effective_mode': backend if backend != 'cpu' else 'cpu_fallback',
+                'backend_available': backend,
+                'backend_selected': backend,
+                'backend_used': backend,
+                'n_gpu_layers': -1 if backend != 'cpu' else 0,
+                'offloaded_layers': -1 if backend != 'cpu' else 0,
+                'kv_cache_device': 'gpu' if backend != 'cpu' else 'cpu',
+                'fallback_reason': None if backend != 'cpu' else 'no CUDA/Metal backend is supported on this platform',
+            }
+            return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=BackendReadyRuntime)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': backend,
+            'detected_device': backend,
+            'runtime_action': 'already_supported' if backend != 'cpu' else 'probe_only',
+            'fallback_reason': '',
+            'interpreter': sys.executable,
+            'llama_module_path': 'site-packages/llama_cpp/__init__.py',
+        },
+    )
+    stop_counter = {'count': 0}
+
+    def stop_after_ready_status():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_ready_status)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    lifecycle_events = [event for event in events if event['type'] in {'started', 'status'}]
+
+    assert lifecycle_events[0]['registered'] is False
+    assert lifecycle_events[0]['relay_runtime_state'] in {'starting', 'warming'}
+    assert lifecycle_events[0]['backend_used'] == 'pending'
+    ready_registered = [
+        event for event in lifecycle_events
+        if event.get('relay_runtime_state') == 'ready' and event.get('registered') is True
+    ]
+    assert ready_registered
+    for event in ready_registered:
+        assert event['backend_available'] == backend
+        assert event['backend_selected'] == backend
+        assert event['backend_used'] == backend
+        assert event['last_error'] is None
+
+
+def test_status_contract_keeps_registered_false_when_relay_registration_is_not_fresh(
+    capsys, monkeypatch
+):
+    _reset_cancel_queue()
+
+    class StaleRegistrationRuntime(ApiV1Runtime):
+        def __init__(self, config):
+            super().__init__(config)
+            self.relay_client = StaleRelayClient()
+            self._responses = [{'next_ping_in_x_seconds': 0, 'error': None}]
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StaleRegistrationRuntime)
+    stop_counter = {'count': 0}
+
+    def stop_after_status():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_status)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None
+    )
+
+    assert compute_node_bridge.run(args) == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    status_events = [event for event in events if event['type'] == 'status']
+
+    assert status_events
+    assert all(event['registered'] is False for event in status_events)
+
+
+def test_missing_desktop_dependency_status_error_is_actionable_and_never_registered(
+    capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        lambda: {
+            'ok': 'false',
+            'action': 'requirements_missing',
+            'missing': 'psutil,requests',
+            'interpreter': sys.executable,
+            'import_root': '/Applications/token.place.app/Contents/Resources',
+            'requirements': '/Applications/token.place.app/Contents/Resources/python/requirements_desktop_runtime.txt',
+            'detail': 'requirements file is missing from packaged resources',
+        },
+    )
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='auto', relay_url='https://token.place', relay_port=None
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    error = events[0]
+
+    assert error['type'] == 'error'
+    assert error['registered'] is False
+    assert error['relay_runtime_state'] == 'failed'
+    assert 'desktop runtime dependency preflight failed' in error['last_error']
+    assert 'missing=psutil,requests' in error['last_error']
+    assert 'interpreter=' in error['last_error']
+    assert 'import_root=/Applications/token.place.app/Contents/Resources' in error['last_error']
+
+
+@pytest.mark.xfail(strict=True, reason='Prompt 4 adds real macOS packaged operator lifecycle coverage')
+def test_macos_packaged_operator_e2e_covers_full_lifecycle_parity():
+    workflow = Path(__file__).resolve().parents[2] / '.github' / 'workflows' / 'desktop-operator-e2e.yml'
+    body = workflow.read_text(encoding='utf-8')
+
+    assert 'macos' in body.lower()
+    assert 'test_packaged_operator_e2e.py' in body
+    assert 'multi-turn' in body.lower()
+    assert 'start-after-stop' in body.lower()

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -945,3 +945,122 @@ def test_ensure_desktop_python_dependencies_falls_back_to_home_target_when_runti
     assert '--target' in captured['cmd']
     target_idx = captured['cmd'].index('--target') + 1
     assert captured['cmd'][target_idx] == str(home_dir / '.token_place_desktop_site')
+
+
+def _load_desktop_operator_parity_matrix():
+    matrix_path = REPO_ROOT / 'tests' / 'fixtures' / 'desktop_operator_parity_matrix.json'
+    return json.loads(matrix_path.read_text(encoding='utf-8'))
+
+
+def test_desktop_operator_parity_matrix_defines_required_platform_paths():
+    matrix = _load_desktop_operator_parity_matrix()
+    entries = {entry['id']: entry for entry in matrix['platforms']}
+
+    assert {
+        'windows_cuda_capable',
+        'macos_metal_capable',
+        'cpu_fallback',
+        'missing_runtime_or_dependency',
+    } <= set(entries)
+    assert entries['windows_cuda_capable']['gpu_backend_selection']['auto'] == 'cuda'
+    assert entries['macos_metal_capable']['gpu_backend_selection']['auto'] == 'metal'
+    assert entries['cpu_fallback']['ui_status']['warming_registered'] is False
+    assert entries['missing_runtime_or_dependency']['registration_eligibility'] == 'never registered'
+    assert any(gap['id'] == 'macos_runtime_bootstrap_probe_only' for gap in matrix['known_gaps'])
+
+
+@pytest.mark.parametrize(
+    'matrix_id,sys_platform,mode,initial_probe,expected_action,expected_backend',
+    [
+        (
+            'windows_cuda_capable',
+            'win32',
+            'auto',
+            _probe(backend='cuda', gpu=True, device='cuda'),
+            'already_supported',
+            'cuda',
+        ),
+        (
+            'macos_metal_capable',
+            'darwin',
+            'auto',
+            _probe(backend='metal', gpu=True, device='metal'),
+            'already_supported',
+            'metal',
+        ),
+        (
+            'cpu_fallback',
+            'linux',
+            'cpu',
+            _probe(backend='cpu', gpu=False, device='cpu'),
+            'skipped',
+            'cpu',
+        ),
+        (
+            'missing_runtime_or_dependency',
+            'linux',
+            'auto',
+            _probe(backend='missing', gpu=False, device='none', error='No module named llama_cpp'),
+            'probe_only',
+            'cpu',
+        ),
+    ],
+)
+def test_desktop_runtime_setup_platform_matrix_probe_paths(
+    monkeypatch, matrix_id, sys_platform, mode, initial_probe, expected_action, expected_backend
+):
+    matrix = _load_desktop_operator_parity_matrix()
+    assert any(entry['id'] == matrix_id for entry in matrix['platforms'])
+
+    sys_stub = type(
+        'SysStub',
+        (),
+        {
+            'platform': sys_platform,
+            'executable': sys.executable,
+            'prefix': sys.prefix,
+            'argv': [str(MODULE_PATH)],
+        },
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', sys_stub)
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: initial_probe)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(mode, repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == expected_action
+    assert result['selected_backend'] == expected_backend
+    assert result['detected_device'] == initial_probe.detected_device
+    if matrix_id == 'missing_runtime_or_dependency':
+        assert 'No module named llama_cpp' in result['fallback_reason']
+        assert result['interpreter'] == sys.executable
+
+
+@pytest.mark.xfail(strict=True, reason='Prompt 2 adds first-class macOS Metal runtime bootstrap')
+def test_macos_metal_runtime_bootstrap_repairs_missing_gpu_runtime(monkeypatch, tmp_path):
+    sys_stub = type(
+        'SysStub',
+        (),
+        {
+            'platform': 'darwin',
+            'executable': sys.executable,
+            'prefix': sys.prefix,
+            'argv': [str(MODULE_PATH)],
+        },
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', sys_stub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([
+        _probe(backend='missing', gpu=False, device='none', error='No module named llama_cpp'),
+        _probe(backend='metal', gpu=True, device='metal'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'not windows'))
+
+    requirements = tmp_path / 'resources' / 'requirements.txt'
+    requirements.parent.mkdir(parents=True)
+    requirements.write_text('llama-cpp-python==0.3.16\n', encoding='utf-8')
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=tmp_path)
+
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert result['selected_backend'] == 'metal'


### PR DESCRIPTION
### Motivation
- Lock down a platform-neutral parity contract for the desktop compute-node operator (Windows/macOS) before changing runtime bootstrap behavior. 
- Capture macOS parity gaps (Metal bootstrap and packaged lifecycle E2E) as explicit, actionable test expectations for follow-up prompts. 
- Provide a machine-readable matrix so future implementation changes can be validated against a single source of truth.

### Description
- Add a written parity contract at `docs/architecture/desktop_operator_parity_contract.md` describing warm-load, runtime detection, GPU backend selection, registration eligibility, UI fields, stop/start, packaged resource resolution, dependency isolation, and error/fallback behavior. 
- Add a machine-readable platform matrix fixture at `tests/fixtures/desktop_operator_parity_matrix.json` enumerating Windows CUDA, macOS Metal, CPU fallback, and missing-runtime cases plus known gaps. 
- Add unit tests that consume the matrix and assert platform-neutral probe/selection behavior in `tests/unit/test_desktop_runtime_setup.py`, backend-diagnostics parity in `tests/unit/test_compute_node_runtime.py`, and bridge lifecycle/status parity (register-only-after-ready, backend fields, actionable dependency errors, stale-registration behavior) in `tests/unit/test_desktop_compute_node_bridge.py`. 
- Mark known macOS gaps as expected failures (`xfail`) so Prompts 2–4 can implement fixes without masking regressions.

### Testing
- Ran `pytest tests/unit/test_desktop_runtime_setup.py -q` which passed (53 passed, 1 xfailed). 
- Ran `pytest tests/unit/test_compute_node_runtime.py -q` which passed (45 passed). 
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py -k "platform or parity or status or lifecycle" -q` which passed (8 passed, 1 xfailed; remaining tests were deselected by the filter). 
- Ran `npm test` in `desktop-tauri/` which passed (Vitest: 24 tests passed), while `npm test -- --runInBand` failed because Vitest does not accept the `--runInBand` option. 
- Ran `pre-commit run --all-files` which completed successfully. 

Follow-ups: Prompt 2 should implement first-class macOS Metal runtime bootstrap and convert the macOS xfail to a passing test, and Prompt 4 should add packaged macOS E2E lifecycle validation referenced by the parity matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4787e744832faf22011eb010e1e1)