### PR TITLE
Define desktop operator parity contract

### DIFF
--- a/tests/fixtures/desktop_operator_parity_contract.json
+++ b/tests/fixtures/desktop_operator_parity_contract.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "status_contract": {
+    "startup_warm_load": "Warm-load API v1 relay runtime before registration when warm-load is enabled; emit running status while warming and keep registered=false until ready.",
+    "runtime_detection": "Detect the llama-cpp backend in the same sidecar/import root that will answer relay work.",
+    "gpu_backend_selection": "Windows CUDA and macOS Metal are first-class GPU backends; CPU mode and unsupported hosts fall back to CPU with diagnostics.",
+    "relay_registration_eligibility": "Registered: yes is valid only when the operator is running, relay runtime is ready, runtime registration is fresh, and relay registration/poll succeeds.",
+    "ui_field_states": "UI lifecycle fields use the shared ComputeNodeStatus shape: running, registered, relay_runtime_state, warm_load_state, backend_available, backend_selected, backend_used, fallback_reason, last_error, runtime_path, relay_runtime_path, operator_session_id, sequence, and updated_at_ms.",
+    "stop_operator": "Stop cancels relay polling, unregisters/stops runtime state where available, and emits running=false registered=false relay_runtime_state=stopped.",
+    "start_after_stop": "A new Start after Stop gets a fresh session, ignores stale old-session events, clears stale errors, and must re-establish readiness/registration before showing Registered: yes.",
+    "packaged_resource_resolution": "Packaged Windows and macOS apps resolve the same bridge/runtime resources from Tauri resources, executable-adjacent resources, or manifest fallbacks without using legacy relay endpoints.",
+    "dependency_isolation": "Desktop sidecars run with isolated Python import paths so repo shims/user site packages cannot shadow the packaged runtime that answers relay work.",
+    "error_fallback_behavior": "GPU/runtime/dependency failures fail closed for relay work, do not expose plaintext payloads, and emit actionable last_error diagnostics while keeping registered=false."
+  },
+  "platform_matrix": [
+    {
+      "id": "windows_cuda_capable",
+      "platform": "win32",
+      "requested_mode": "auto",
+      "probe_backend": "cuda",
+      "probe_gpu_offload_supported": true,
+      "probe_device": "cuda",
+      "expected_selected_backend": "cuda",
+      "expected_runtime_action": "already_supported",
+      "expected_registration_backend": "cuda"
+    },
+    {
+      "id": "macos_metal_capable",
+      "platform": "darwin",
+      "requested_mode": "auto",
+      "probe_backend": "metal",
+      "probe_gpu_offload_supported": true,
+      "probe_device": "metal",
+      "expected_selected_backend": "metal",
+      "expected_runtime_action": "already_supported",
+      "expected_registration_backend": "metal"
+    },
+    {
+      "id": "cpu_fallback",
+      "platform": "linux",
+      "requested_mode": "cpu",
+      "probe_backend": "cpu",
+      "probe_gpu_offload_supported": false,
+      "probe_device": "cpu",
+      "expected_selected_backend": "cpu",
+      "expected_runtime_action": "skipped",
+      "expected_registration_backend": "cpu"
+    },
+    {
+      "id": "missing_runtime_dependency",
+      "platform": "linux",
+      "requested_mode": "auto",
+      "probe_backend": "missing",
+      "probe_gpu_offload_supported": false,
+      "probe_device": "none",
+      "probe_error": "No module named llama_cpp",
+      "expected_selected_backend": "cpu",
+      "expected_runtime_action": "probe_only",
+      "expected_registration_backend": "pending",
+      "expected_fallback_contains": "GPU runtime unavailable"
+    }
+  ],
+  "known_gaps": [
+    {
+      "id": "macos_runtime_bootstrap_probe_only",
+      "prompt_owner": "Prompt 2",
+      "current_behavior": "macOS missing/CPU-only Metal runtime returns runtime_action=probe_only instead of attempting Metal bootstrap/repair.",
+      "expected_behavior": "macOS auto/gpu/hybrid launch attempts Metal-capable llama-cpp-python bootstrap and reports a Metal action or actionable failure."
+    },
+    {
+      "id": "macos_real_operator_lifecycle_coverage",
+      "prompt_owner": "Prompt 4",
+      "current_behavior": "macOS coverage is still mostly packaged/inspect/no-relay oriented and does not prove staging-style warm-load, registration, multi-turn relay chat, Stop, Start after Stop, and diagnostics as one real lifecycle.",
+      "expected_behavior": "macOS has the same real packaged operator lifecycle coverage as Windows for warm-load, relay registration, API v1 E2EE chat, multi-turn cleanup, Stop, Start after Stop, and diagnostics."
+    }
+  ]
+}

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from unittest.mock import call, MagicMock
 
 import pytest
@@ -5,6 +7,7 @@ import pytest
 from utils.compute_node_runtime import (
     ApiV1RelayRequestAdapter,
     apply_compute_mode,
+    compute_mode_diagnostics,
     ComputeNodeRuntime,
     ComputeNodeRuntimeConfig,
     LegacyRelayRequestAdapter,
@@ -737,3 +740,48 @@ def test_compute_node_runtime_stop_continues_when_unregister_raises():
         call.stop(),
         call.unregister_from_relay(),
     ]
+
+
+def _desktop_parity_contract():
+    contract_path = (
+        Path(__file__).resolve().parents[2]
+        / 'tests'
+        / 'fixtures'
+        / 'desktop_operator_parity_contract.json'
+    )
+    return json.loads(contract_path.read_text(encoding='utf-8'))
+
+
+@pytest.mark.parametrize(
+    'case',
+    _desktop_parity_contract()['platform_matrix'],
+    ids=lambda case: case['id'],
+)
+def test_compute_mode_status_contract_is_platform_neutral_for_parity_matrix(case):
+    manager = MagicMock()
+    requested_mode = case['requested_mode']
+
+    normalized = apply_compute_mode(manager, requested_mode)
+    initial = compute_mode_diagnostics(manager)
+
+    assert normalized in {'auto', 'cpu', 'gpu', 'hybrid'}
+    assert initial['requested_mode'] == normalized
+    assert {'backend_available', 'backend_selected', 'backend_used', 'fallback_reason'} <= set(
+        initial
+    )
+
+    backend = case['expected_registration_backend']
+    if backend != 'pending':
+        manager.last_compute_diagnostics = {
+            'requested_mode': normalized,
+            'effective_mode': 'cpu' if backend == 'cpu' else 'gpu',
+            'backend_available': backend,
+            'backend_selected': backend,
+            'backend_used': backend,
+            'n_gpu_layers': 0 if backend == 'cpu' else -1,
+            'fallback_reason': None,
+        }
+        ready = compute_mode_diagnostics(manager)
+        assert ready['backend_available'] == backend
+        assert ready['backend_selected'] == backend
+        assert ready['backend_used'] == backend

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2648,3 +2648,149 @@ def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypat
         }
     ]
     assert capsys.readouterr().out.splitlines()[-1]
+
+
+def _desktop_parity_contract():
+    contract_path = (
+        Path(__file__).resolve().parents[2]
+        / 'tests'
+        / 'fixtures'
+        / 'desktop_operator_parity_contract.json'
+    )
+    return json.loads(contract_path.read_text(encoding='utf-8'))
+
+
+@pytest.mark.parametrize(
+    'case',
+    [
+        case
+        for case in _desktop_parity_contract()['platform_matrix']
+        if case['id'] in {'windows_cuda_capable', 'macos_metal_capable', 'cpu_fallback'}
+    ],
+    ids=lambda case: case['id'],
+)
+def test_platform_neutral_status_contract_registers_only_ready_runtime_backend(
+    capsys, monkeypatch, case
+):
+    _reset_cancel_queue()
+    backend = case['expected_registration_backend']
+    requested_mode = 'cpu' if backend == 'cpu' else 'auto'
+
+    class ReadyBackendRuntime(ApiV1Runtime):
+        def ensure_api_v1_runtime_ready(self):
+            self.model_manager.last_compute_diagnostics = {
+                'requested_mode': requested_mode,
+                'effective_mode': 'cpu' if backend == 'cpu' else 'gpu',
+                'backend_available': backend,
+                'backend_selected': backend,
+                'backend_used': backend,
+                'n_gpu_layers': 0 if backend == 'cpu' else -1,
+                'offloaded_layers': 0 if backend == 'cpu' else 42,
+                'kv_cache_device': backend,
+                'fallback_reason': None,
+            }
+            return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ReadyBackendRuntime)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': backend,
+            'detected_device': backend,
+            'runtime_action': case['expected_runtime_action'],
+            'interpreter': sys.executable,
+            'llama_module_path': f'/fake/site-packages/llama_cpp_{backend}/__init__.py',
+            'fallback_reason': '',
+        },
+    )
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 3
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode=requested_mode,
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    warming_events = [event for event in events if event.get('relay_runtime_state') == 'warming']
+    assert warming_events
+    assert all(event['registered'] is False for event in warming_events)
+    ready_registered_events = [
+        event
+        for event in events
+        if event.get('type') == 'status'
+        and event.get('registered') is True
+        and event.get('relay_runtime_state') == 'ready'
+    ]
+    assert ready_registered_events
+    for event in ready_registered_events:
+        assert event['backend_available'] == backend
+        assert event['backend_selected'] == backend
+        assert event['backend_used'] == backend
+        assert event['last_error'] is None
+
+
+def test_platform_runtime_failure_status_is_actionable_and_not_registered(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cpu',
+            'runtime_action': 'failed',
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+            'fallback_reason': 'CUDA source build failed: install CUDA toolkit',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'desktop_gpu_runtime_failure_message',
+        lambda mode, setup: (
+            'GPU provisioning failed for desktop Windows launch '
+            f"(mode={mode}, action={setup['runtime_action']}): {setup['fallback_reason']}. "
+            'Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support.'
+        ),
+    )
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='auto', relay_url='https://token.place', relay_port=None
+    )
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get('type') == 'error')
+    assert error_event['registered'] is False
+    assert error_event['relay_runtime_state'] == 'failed'
+    assert 'CUDA source build failed' in error_event['last_error']
+    assert 'Verify CUDA runtime prerequisites' in error_event['last_error']
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Prompt 4 will add macOS real lifecycle parity coverage beyond packaged/inspect/no-relay smoke tests.',
+)
+def test_macos_real_operator_lifecycle_parity_gap_is_captured():
+    workflow = (
+        Path(__file__).resolve().parents[2]
+        / '.github'
+        / 'workflows'
+        / 'desktop-operator-e2e.yml'
+    ).read_text(encoding='utf-8')
+
+    assert 'Run macOS warm-load relay registration multi-turn lifecycle e2e' in workflow
+    assert 'test_desktop_operator_lifecycle_e2e.py' in workflow
+    assert 'TOKENPLACE_REQUIRE_MACOS_RELAY_LIFECYCLE_E2E' in workflow

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -945,3 +945,109 @@ def test_ensure_desktop_python_dependencies_falls_back_to_home_target_when_runti
     assert '--target' in captured['cmd']
     target_idx = captured['cmd'].index('--target') + 1
     assert captured['cmd'][target_idx] == str(home_dir / '.token_place_desktop_site')
+
+
+def _desktop_parity_contract():
+    contract_path = (
+        REPO_ROOT / 'tests' / 'fixtures' / 'desktop_operator_parity_contract.json'
+    )
+    return json.loads(contract_path.read_text(encoding='utf-8'))
+
+
+def test_desktop_operator_parity_contract_defines_required_lifecycle_surfaces():
+    contract = _desktop_parity_contract()
+
+    assert contract['schema_version'] == 1
+    assert set(contract['status_contract']) == {
+        'startup_warm_load',
+        'runtime_detection',
+        'gpu_backend_selection',
+        'relay_registration_eligibility',
+        'ui_field_states',
+        'stop_operator',
+        'start_after_stop',
+        'packaged_resource_resolution',
+        'dependency_isolation',
+        'error_fallback_behavior',
+    }
+    assert [case['id'] for case in contract['platform_matrix']] == [
+        'windows_cuda_capable',
+        'macos_metal_capable',
+        'cpu_fallback',
+        'missing_runtime_dependency',
+    ]
+    assert {gap['id'] for gap in contract['known_gaps']} == {
+        'macos_runtime_bootstrap_probe_only',
+        'macos_real_operator_lifecycle_coverage',
+    }
+
+
+@pytest.mark.parametrize(
+    'case', _desktop_parity_contract()['platform_matrix'], ids=lambda case: case['id']
+)
+def test_desktop_runtime_platform_matrix_matches_parity_contract(monkeypatch, case):
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        'sys',
+        type(
+            'SysStub',
+            (),
+            {
+                'platform': case['platform'],
+                'executable': sys.executable,
+                'prefix': sys.prefix,
+                'argv': [str(MODULE_PATH)],
+            },
+        ),
+    )
+    monkeypatch.delenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(
+            backend=case['probe_backend'],
+            gpu=case['probe_gpu_offload_supported'],
+            device=case['probe_device'],
+            error=case.get('probe_error'),
+        ),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(case['requested_mode'])
+
+    assert result['selected_backend'] == case['expected_selected_backend']
+    assert result['runtime_action'] == case['expected_runtime_action']
+    if expected_reason := case.get('expected_fallback_contains'):
+        assert expected_reason in result['fallback_reason']
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Prompt 2 will replace macOS probe-only Metal runtime bootstrap with first-class Metal repair/install.',
+)
+def test_macos_missing_metal_runtime_bootstrap_gap_is_captured(monkeypatch):
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        'sys',
+        type(
+            'DarwinSysStub',
+            (),
+            {
+                'platform': 'darwin',
+                'executable': sys.executable,
+                'prefix': sys.prefix,
+                'argv': [str(MODULE_PATH)],
+            },
+        ),
+    )
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cpu', gpu=False, device='cpu'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto')
+
+    assert result['selected_backend'] == 'metal'
+    assert result['runtime_action'] in {'installed_metal_reexec', 'already_supported'}


### PR DESCRIPTION
### Motivation
- Lock down a source-of-truth parity contract describing the expected cross-platform desktop operator lifecycle and status shape before implementing macOS bootstrap/lifecycle changes.
- Capture platform matrix cases (Windows CUDA, macOS Metal, CPU fallback, missing runtime) as test fixtures so behavior is explicit and verifiable.
- Mark existing macOS gaps (probe-only Metal bootstrap and missing real lifecycle e2e coverage) as expected failures to make follow-up prompts actionable.

### Description
- Added a JSON parity contract at `tests/fixtures/desktop_operator_parity_contract.json` that documents lifecycle invariants, a 4-case platform matrix, and known macOS gaps.
- Added unit tests that consume the contract: `tests/unit/test_desktop_runtime_setup.py` (runtime bootstrap matrix & contract validation), `tests/unit/test_compute_node_runtime.py` (compute-mode diagnostics platform-neutral checks), and `tests/unit/test_desktop_compute_node_bridge.py` (bridge status/registration parity checks and actionable failure reporting).
- Tests include platform-matrix parametrization and explicit `pytest.mark.xfail` tests to record the two known macOS gaps without changing production behavior.

### Testing
- Ran `pytest tests/unit/test_desktop_runtime_setup.py` and it passed (53 passed, 1 xfailed as expected).
- Ran `pytest tests/unit/test_compute_node_runtime.py` and it passed (44 passed).
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py -k "platform or parity or status or lifecycle"` and it passed for the selected parity/lifecycle tests (7 passed, 1 xfailed expected).
- Ran the combined parity-focused selection: `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py -k "platform or parity or status or lifecycle"` and it passed (17 passed, 1 xfailed where expected).
- Ran desktop UI unit tests via `npm test` in `desktop-tauri/` and they passed (`vitest`: 24 tests passed).
- Ran `pre-commit run --all-files` and code checks passed (formatters/lint/hooks/project checks completed without failures).

Commands to reproduce the verification:
- `pytest tests/unit/test_desktop_runtime_setup.py`
- `pytest tests/unit/test_compute_node_runtime.py`
- `pytest tests/unit/test_desktop_compute_node_bridge.py -k "platform or parity or status or lifecycle"`
- `cd desktop-tauri && npm test`
- `pre-commit run --all-files`

All automated checks listed above completed successfully for the changes in this PR; the macOS gaps are intentionally captured as XFAIL to drive the next implementation prompts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4787e744832faf22011eb010e1e1)