### PR TITLE
Define desktop operator parity contract and add platform-matrix parity tests

### DIFF
--- a/tests/fixtures/desktop_operator_parity_contract.json
+++ b/tests/fixtures/desktop_operator_parity_contract.json
@@ -1,0 +1,143 @@
+{
+  "contract_version": 1,
+  "api": "v1_non_streaming_e2ee",
+  "relay_blind_e2ee": true,
+  "platforms": {
+    "windows_cuda": {
+      "os": "win32",
+      "capability": "cuda",
+      "gpu_mode_backend": "cuda",
+      "bootstrap": "gpu_runtime_repair_or_existing_cuda_runtime",
+      "packaged_resource_resolution": "sidecar_resources_or_repo_runtime_root",
+      "known_gap": null
+    },
+    "macos_metal": {
+      "os": "darwin",
+      "capability": "metal",
+      "gpu_mode_backend": "metal",
+      "bootstrap": "gpu_runtime_repair_or_existing_metal_runtime",
+      "packaged_resource_resolution": "app_bundle_resources_or_repo_runtime_root",
+      "known_gap": "Metal runtime bootstrap is currently probe-only; Prompt 2 makes macOS a first-class bootstrap target."
+    },
+    "cpu_fallback": {
+      "os": "any",
+      "capability": "cpu",
+      "gpu_mode_backend": "cpu",
+      "bootstrap": "no_gpu_repair_required_for_cpu_mode",
+      "packaged_resource_resolution": "same_python_bridge_import_root",
+      "known_gap": null
+    },
+    "missing_runtime_dependency": {
+      "os": "any",
+      "capability": "missing",
+      "gpu_mode_backend": "pending",
+      "bootstrap": "fail_closed_with_actionable_last_error",
+      "packaged_resource_resolution": "must_not_import_repo_local_llama_cpp_shim",
+      "known_gap": null
+    }
+  },
+  "lifecycle": [
+    "startup",
+    "warm_load_before_registration",
+    "runtime_detection",
+    "gpu_backend_selection",
+    "relay_registration_after_runtime_ready",
+    "ui_status_fields",
+    "stop_operator",
+    "start_after_stop",
+    "packaged_resource_resolution",
+    "dependency_isolation",
+    "error_fallback_behavior"
+  ],
+  "status_contract": {
+    "registered_true_requires": [
+      "running is true",
+      "relay_runtime_state is ready or processing",
+      "relay registration succeeded and is fresh",
+      "API v1 runtime that will answer relay work is ready"
+    ],
+    "backend_fields": {
+      "backend_available": "detected runtime capability, pending before relay runtime is ready",
+      "backend_selected": "operator-selected backend for the runtime that answers relay work",
+      "backend_used": "actual backend used by that runtime after warm-load"
+    },
+    "error_contract": {
+      "last_error": "null when healthy; otherwise clear, actionable, platform-specific remediation text",
+      "fail_closed": "relay registration remains false when runtime/dependency setup cannot preserve API v1 E2EE operator behavior"
+    },
+    "ui_fields": [
+      "running",
+      "registered",
+      "relay_runtime_state",
+      "runtime_path",
+      "relay_runtime_path",
+      "active_relay_url",
+      "requested_mode",
+      "effective_mode",
+      "backend_available",
+      "backend_selected",
+      "backend_used",
+      "fallback_reason",
+      "model_path",
+      "last_error",
+      "operator_session_id",
+      "sequence",
+      "updated_at_ms"
+    ]
+  },
+  "platform_matrix": [
+    {
+      "name": "windows_cuda_capable_path",
+      "sys_platform": "win32",
+      "mode": "gpu",
+      "probe_backend": "cuda",
+      "probe_gpu_offload_supported": true,
+      "expected_selected_backend": "cuda",
+      "expected_runtime_action": "already_supported",
+      "expected_registration_backend_used": "cuda"
+    },
+    {
+      "name": "macos_metal_capable_path",
+      "sys_platform": "darwin",
+      "mode": "gpu",
+      "probe_backend": "metal",
+      "probe_gpu_offload_supported": true,
+      "expected_selected_backend": "metal",
+      "expected_runtime_action": "already_supported",
+      "expected_registration_backend_used": "metal"
+    },
+    {
+      "name": "cpu_fallback_path",
+      "sys_platform": "linux",
+      "mode": "cpu",
+      "probe_backend": "cpu",
+      "probe_gpu_offload_supported": false,
+      "expected_selected_backend": "cpu",
+      "expected_runtime_action": "skipped",
+      "expected_registration_backend_used": "cpu"
+    },
+    {
+      "name": "missing_runtime_dependency_path",
+      "sys_platform": "win32",
+      "mode": "gpu",
+      "probe_backend": "missing",
+      "probe_gpu_offload_supported": false,
+      "probe_error": "llama-cpp-python is not importable",
+      "expected_selected_backend": "cpu",
+      "expected_runtime_action_when_bootstrap_disabled": "probe_only",
+      "expected_last_error_contains": "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
+    }
+  ],
+  "known_gaps": [
+    {
+      "id": "macos-metal-bootstrap-probe-only",
+      "owner_prompt": 2,
+      "expected_future": "darwin gpu/auto/hybrid bootstrap attempts Metal-capable llama-cpp-python repair before falling back"
+    },
+    {
+      "id": "macos-real-relay-lifecycle-e2e",
+      "owner_prompt": 4,
+      "expected_future": "macOS packaged operator CI covers warm-load, register, multi-turn API v1 relay chat, Stop, Start after Stop, and diagnostics"
+    }
+  ]
+}

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2648,3 +2648,182 @@ def test_run_cancel_during_warm_load_exits_without_registering(capsys, monkeypat
         }
     ]
     assert capsys.readouterr().out.splitlines()[-1]
+
+
+def _load_desktop_operator_parity_contract():
+    contract_path = Path(__file__).resolve().parents[2] / 'tests' / 'fixtures' / 'desktop_operator_parity_contract.json'
+    return json.loads(contract_path.read_text(encoding='utf-8'))
+
+
+class PlatformReadyRuntime(ApiV1Runtime):
+    last_instance = None
+    backend = 'cpu'
+    requested_mode = 'cpu'
+
+    def __init__(self, _config):
+        super().__init__(_config)
+        PlatformReadyRuntime.last_instance = self
+        self._set_ready_diagnostics()
+
+    def _set_ready_diagnostics(self):
+        gpu_backend = self.backend in {'cuda', 'metal'}
+        self.model_manager.last_compute_diagnostics = {
+            'requested_mode': self.requested_mode,
+            'effective_mode': 'gpu' if gpu_backend else 'cpu',
+            'backend_available': self.backend,
+            'backend_selected': self.backend,
+            'backend_used': self.backend,
+            'n_gpu_layers': -1 if gpu_backend else 0,
+            'offloaded_layers': -1 if gpu_backend else 0,
+            'kv_cache_device': 'gpu' if gpu_backend else 'cpu',
+            'fallback_reason': None,
+        }
+
+    def ensure_api_v1_runtime_ready(self):
+        self._set_ready_diagnostics()
+        self.model_manager.last_compute_diagnostics['api_v1_runtime_ready'] = True
+        return True
+
+
+@pytest.mark.parametrize(
+    'case',
+    [
+        case
+        for case in _load_desktop_operator_parity_contract()['platform_matrix']
+        if case['name'] in {
+            'windows_cuda_capable_path',
+            'macos_metal_capable_path',
+            'cpu_fallback_path',
+        }
+    ],
+    ids=lambda case: case['name'],
+)
+def test_platform_neutral_status_contract_registers_only_after_ready_backend(case, capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    backend = case['expected_registration_backend_used']
+    mode = 'gpu' if backend in {'cuda', 'metal'} else 'cpu'
+
+    class RuntimeForCase(PlatformReadyRuntime):
+        last_instance = None
+        requested_mode = mode
+        backend = case['expected_registration_backend_used']
+
+        def __init__(self, config):
+            super().__init__(config)
+            RuntimeForCase.last_instance = self
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=RuntimeForCase)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': backend,
+            'detected_device': backend,
+            'runtime_action': case['expected_runtime_action'],
+            'fallback_reason': '',
+            'interpreter': sys.executable,
+            'llama_module_path': 'site-packages/llama_cpp/__init__.py',
+        },
+    )
+
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode=mode,
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    status_events = [event for event in events if event['type'] == 'status']
+    assert status_events
+    assert any(
+        event['registered'] is False
+        and event['relay_runtime_state'] in {'starting', 'warming'}
+        and event['backend_used'] == 'pending'
+        for event in status_events
+    )
+    registered_events = [event for event in status_events if event['registered'] is True]
+    assert registered_events
+    for event in registered_events:
+        assert event['running'] is True
+        assert event['relay_runtime_state'] in {'ready', 'processing'}
+        assert event['backend_available'] == backend
+        assert event['backend_selected'] == backend
+        assert event['backend_used'] == backend
+        assert event['last_error'] is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Prompt 2 will make macOS GPU runtime failures fail closed with Metal-specific diagnostics.',
+)
+@pytest.mark.parametrize(
+    'action,fallback_reason,expected_fragment',
+    [
+        ('failed', 'Metal build failed: install xcode command line tools', 'Metal build failed'),
+        ('shadowed_repo_llama_cpp', 'llama_cpp import shadowed by repo-local shim', 'repo-local shim'),
+    ],
+)
+def test_macos_platform_runtime_failures_keep_registration_false_and_actionable(
+    action, fallback_reason, expected_fragment, capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cpu',
+            'detected_device': 'cpu',
+            'runtime_action': action,
+            'fallback_reason': fallback_reason,
+            'interpreter': sys.executable,
+            'llama_module_path': 'missing',
+        },
+    )
+    monkeypatch.setattr(sys.modules['desktop_runtime_setup'].sys, 'platform', 'darwin')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='gpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+    status = compute_node_bridge.run(args)
+
+    assert status == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert len(events) == 1
+    payload = events[0]
+    assert payload['type'] == 'error'
+    assert payload['running'] is False
+    assert payload['registered'] is False
+    assert payload['relay_runtime_state'] == 'failed'
+    assert expected_fragment in payload['last_error']
+    assert 'macOS' in payload['last_error'] or 'Metal' in payload['last_error']
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Prompt 4 will add real macOS relay lifecycle parity coverage beyond inspect/probe smoke tests.',
+)
+def test_macos_packaged_operator_workflow_contract_has_real_relay_lifecycle_coverage():
+    workflow_path = Path(__file__).resolve().parents[2] / '.github' / 'workflows' / 'desktop-operator-e2e.yml'
+    workflow = workflow_path.read_text(encoding='utf-8')
+    macos_section = workflow.split('desktop-operator-packaged-e2e-macos:', 1)[1]
+
+    assert 'TOKENPLACE_REQUIRE_REAL_RELAY_LIFECYCLE_E2E' in macos_section
+    assert 'multi-turn' in macos_section.lower()

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -945,3 +945,95 @@ def test_ensure_desktop_python_dependencies_falls_back_to_home_target_when_runti
     assert '--target' in captured['cmd']
     target_idx = captured['cmd'].index('--target') + 1
     assert captured['cmd'][target_idx] == str(home_dir / '.token_place_desktop_site')
+
+
+def _load_desktop_operator_parity_contract():
+    contract_path = REPO_ROOT / 'tests' / 'fixtures' / 'desktop_operator_parity_contract.json'
+    return json.loads(contract_path.read_text(encoding='utf-8'))
+
+
+def test_desktop_operator_parity_contract_defines_required_platform_matrix():
+    contract = _load_desktop_operator_parity_contract()
+
+    assert contract['api'] == 'v1_non_streaming_e2ee'
+    assert contract['relay_blind_e2ee'] is True
+    assert set(contract['platforms']) == {
+        'windows_cuda',
+        'macos_metal',
+        'cpu_fallback',
+        'missing_runtime_dependency',
+    }
+    assert {
+        'startup',
+        'warm_load_before_registration',
+        'runtime_detection',
+        'gpu_backend_selection',
+        'relay_registration_after_runtime_ready',
+        'ui_status_fields',
+        'stop_operator',
+        'start_after_stop',
+        'packaged_resource_resolution',
+        'dependency_isolation',
+        'error_fallback_behavior',
+    } <= set(contract['lifecycle'])
+    assert 'registered_true_requires' in contract['status_contract']
+    assert 'backend_fields' in contract['status_contract']
+    assert 'error_contract' in contract['status_contract']
+    assert len(contract['platform_matrix']) == 4
+
+
+@pytest.mark.parametrize(
+    'case',
+    _load_desktop_operator_parity_contract()['platform_matrix'],
+    ids=lambda case: case['name'],
+)
+def test_desktop_runtime_platform_matrix_fixture_matches_probe_contract(monkeypatch, case):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(desktop_runtime_setup.sys, 'platform', case['sys_platform'])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(
+            backend=case['probe_backend'],
+            gpu=case['probe_gpu_offload_supported'],
+            device=case['probe_backend'],
+            error=case.get('probe_error'),
+        ),
+    )
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(case['mode'])
+
+    assert result['selected_backend'] == case['expected_selected_backend']
+    expected_action = case.get('expected_runtime_action_when_bootstrap_disabled')
+    if expected_action is None:
+        expected_action = case['expected_runtime_action']
+    assert result['runtime_action'] == expected_action
+    if case['name'] == 'missing_runtime_dependency_path':
+        assert case['expected_last_error_contains'] in result['fallback_reason']
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Prompt 2 will replace macOS probe-only GPU setup with Metal runtime bootstrap.',
+)
+def test_macos_gpu_runtime_bootstrap_contract_attempts_metal_repair(monkeypatch):
+    class _DarwinSys:
+        platform = 'darwin'
+        executable = sys.executable
+        prefix = sys.prefix
+        argv = [str(MODULE_PATH)]
+
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _DarwinSys)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([_probe(backend='cpu', gpu=False), _probe(backend='metal', gpu=True)])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=REPO_ROOT)
+
+    assert result['selected_backend'] == 'metal'
+    assert result['runtime_action'] in {'installed_metal_reexec', 'installed_gpu_reexec'}


### PR DESCRIPTION
### Motivation
- Lock down the expected cross-platform desktop compute-node operator behavior for Windows and macOS before making implementation changes to macOS Metal bootstrap and packaged operator lifecycles.
- Capture the current macOS parity gaps explicitly in tests so follow-up work can be targeted and validated against a single source-of-truth contract.

### Description
- Add a machine-readable parity contract at `tests/fixtures/desktop_operator_parity_contract.json` describing lifecycle steps, status fields, platform matrix entries (Windows CUDA, macOS Metal, CPU fallback, missing runtime), and known gaps.
- Add unit tests in `tests/unit/test_desktop_runtime_setup.py` that load the parity fixture and validate probe/bootstrapping expectations per-platform, including a platform-matrix parametrized fixture to exercise probe-only and fallback cases.
- Add unit tests in `tests/unit/test_desktop_compute_node_bridge.py` that assert the status contract (registration only becomes true after runtime warm-load readiness and backend fields reflect the runtime that will answer API v1 relay work) and mark macOS lifecycle/diagnostic checks as expected failures until macOS bootstrap is implemented.
- Keep production behavior unchanged in this PR (tests are primarily fixtures and assertions); known macOS gaps are captured as xfail tests to drive follow-ups.

### Testing
- Ran `pytest tests/unit/test_desktop_runtime_setup.py` which passed with `53 passed, 1 xfailed`.
- Ran `pytest tests/unit/test_compute_node_runtime.py` which passed with `40 passed`.
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py -k "platform or parity or status or lifecycle"` which passed with `6 passed, 3 xfailed` for macOS-specific diagnostics/lifecycle expectations.
- Ran `cd desktop-tauri && npm test` which succeeded for the desktop UI tests (`24 passed`).
- Ran `pre-commit run --all-files` which passed all configured hooks.

Note: the parity fixture and xfail tests intentionally document current macOS gaps (Metal runtime bootstrap and full packaged relay lifecycle); follow-up changes will implement macOS bootstrap and flip xfail tests to passing as work completes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4787e744832faf22011eb010e1e1)