### PR TITLE
Enable shared desktop runtime bootstrap with first-class macOS Metal support

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Optional, Union
 
 
 @dataclass(frozen=True)
@@ -15,13 +15,13 @@ class LlamaCppInstallPlan:
     platform: str
     backend: str
     package_spec: str
-    cmake_args: str | None
+    cmake_args: Optional[str]
     force_cmake: bool
-    index_url: str | None = None
+    index_url: Optional[str] = None
     only_binary: bool = False
     no_binary: bool = False
 
-    def pip_install_args(self) -> list[str]:
+    def pip_install_args(self) -> List[str]:
         args = ["--upgrade", "--no-cache-dir"]
         if self.index_url:
             args.extend(["--index-url", self.index_url])
@@ -42,7 +42,7 @@ class LlamaCppInstallPlan:
         return env
 
 
-def llama_cpp_requirement_spec(requirements_path: str | Path = "requirements.txt") -> str:
+def llama_cpp_requirement_spec(requirements_path: Union[str, Path] = "requirements.txt") -> str:
     """Return pinned llama-cpp-python requirement from requirements.txt."""
 
     path = Path(requirements_path)
@@ -58,8 +58,8 @@ def llama_cpp_requirement_spec(requirements_path: str | Path = "requirements.txt
 
 
 def llama_cpp_install_plan(
-    platform: str | None = None,
-    requirements_path: str | Path = "requirements.txt",
+    platform: Optional[str] = None,
+    requirements_path: Union[str, Path] = "requirements.txt",
 ) -> LlamaCppInstallPlan:
     """Return explicit, conservative desktop install plan for llama-cpp-python."""
 
@@ -99,9 +99,9 @@ def llama_cpp_install_plan(
 
 
 def llama_cpp_install_plan_fallbacks(
-    platform: str | None = None,
-    requirements_path: str | Path = "requirements.txt",
-) -> list[LlamaCppInstallPlan]:
+    platform: Optional[str] = None,
+    requirements_path: Union[str, Path] = "requirements.txt",
+) -> List[LlamaCppInstallPlan]:
     """Return ordered install plans with conservative fallbacks per platform."""
 
     primary = llama_cpp_install_plan(platform=platform, requirements_path=requirements_path)

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import platform as platform_module
 import subprocess
 import sys
 import time
@@ -14,6 +15,7 @@ from typing import Dict, Optional
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
+    backend_probe_satisfies_install_plan,
     llama_cpp_install_plan_fallbacks,
     llama_cpp_requirement_spec,
 )
@@ -29,6 +31,12 @@ class RuntimeProbe:
     llama_module_path: str
     error: Optional[str] = None
 
+
+@dataclass(frozen=True)
+class RuntimeBootstrapPolicy:
+    backend: str
+    bootstrap_allowed: bool
+    unsupported_reason: str = ""
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 GPU_RUNTIME_FATAL_ACTIONS = frozenset(
@@ -400,7 +408,8 @@ def maybe_reexec_for_runtime_refresh(
 ) -> None:
     if not allow_reexec:
         return
-    if runtime_setup.get("runtime_action") != "installed_cuda_reexec":
+    runtime_action = str(runtime_setup.get("runtime_action", ""))
+    if runtime_action not in {"installed_cuda_reexec", "installed_metal_reexec"}:
         return
     if os.environ.get(REEXEC_GUARD_ENV) == "1":
         return
@@ -412,23 +421,91 @@ def maybe_reexec_for_runtime_refresh(
         return
 
 
-def desktop_gpu_runtime_failure_message(mode: str, runtime_setup: Dict[str, str]) -> str | None:
-    """Return fatal runtime bootstrap diagnostics for Windows desktop GPU launch modes."""
+def desktop_gpu_runtime_failure_message(mode: str, runtime_setup: Dict[str, str]) -> Optional[str]:
+    """Return fatal runtime bootstrap diagnostics for desktop GPU launch modes."""
 
-    if sys.platform != "win32" or mode not in GPU_MODES:
+    selected_mode = (mode or "auto").strip().lower()
+    if selected_mode not in GPU_MODES:
         return None
 
     selected_backend = str(runtime_setup.get("selected_backend", "cpu")).lower()
     runtime_action = str(runtime_setup.get("runtime_action", "none")).lower()
-    if selected_backend != "cpu" or runtime_action not in GPU_RUNTIME_FATAL_ACTIONS:
+    if selected_backend != "cpu":
         return None
 
     reason = runtime_setup.get("fallback_reason") or "unknown runtime bootstrap failure"
-    return (
-        "GPU provisioning failed for desktop Windows launch "
-        f"(mode={mode}, action={runtime_action}): {reason}. "
-        "Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support."
+    if sys.platform == "win32" and runtime_action in GPU_RUNTIME_FATAL_ACTIONS:
+        return (
+            "GPU provisioning failed for desktop Windows launch "
+            f"(mode={selected_mode}, action={runtime_action}): {reason}. "
+            "Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support."
+        )
+
+    if sys.platform == "darwin" and selected_mode == "gpu" and runtime_action in {
+        "failed",
+        "metal_install_failed",
+        "metal_cpu_fallback",
+        "metal_probe_only",
+        "shadowed_repo_llama_cpp",
+        "unavailable",
+    }:
+        return (
+            "GPU provisioning failed for desktop macOS launch "
+            f"(mode={selected_mode}, action={runtime_action}): {reason}. "
+            "Verify Xcode Command Line Tools and llama-cpp-python Metal build support."
+        )
+
+    return None
+
+
+def _normalised_machine() -> str:
+    return platform_module.machine().lower().replace("amd64", "x86_64")
+
+
+def _runtime_bootstrap_policy(platform_name: str, mode: str) -> RuntimeBootstrapPolicy:
+    selected_mode = (mode or "auto").strip().lower()
+    detected_platform = (platform_name or sys.platform).lower()
+    if selected_mode not in GPU_MODES:
+        return RuntimeBootstrapPolicy(backend="cpu", bootstrap_allowed=False, unsupported_reason="GPU bootstrap not requested")
+
+    if detected_platform.startswith("win"):
+        machine = _normalised_machine()
+        if machine == "x86_64":
+            return RuntimeBootstrapPolicy(backend="cuda", bootstrap_allowed=True)
+        return RuntimeBootstrapPolicy(
+            backend="cuda",
+            bootstrap_allowed=False,
+            unsupported_reason=f"CUDA bootstrap is supported only on Windows x86_64 (detected {machine or 'unknown'})",
+        )
+
+    if detected_platform == "darwin":
+        return RuntimeBootstrapPolicy(backend="metal", bootstrap_allowed=True)
+
+    return RuntimeBootstrapPolicy(
+        backend="cpu",
+        bootstrap_allowed=False,
+        unsupported_reason=f"desktop runtime bootstrap is not supported on {detected_platform or 'unknown platform'}",
     )
+
+
+def _runtime_action_for_already_supported(backend: str) -> str:
+    if backend == "metal":
+        return "metal_already_supported"
+    return "already_supported"
+
+
+def _runtime_action_for_installed_backend(backend: str) -> str:
+    if backend == "metal":
+        return "installed_metal_reexec"
+    if backend == "cuda":
+        return "installed_cuda_reexec"
+    return "installed_cpu_fallback"
+
+
+def _source_build_timeout_for_plan(plan: LlamaCppInstallPlan) -> int:
+    if plan.force_cmake or plan.no_binary:
+        return int(os.getenv("TOKEN_PLACE_DESKTOP_PIP_SOURCE_BUILD_TIMEOUT_SECONDS", PIP_SOURCE_BUILD_TIMEOUT_SECONDS))
+    return PIP_INSTALL_TIMEOUT_SECONDS
 
 
 def _resolve_requirements_path(target_root: Path) -> Path:
@@ -472,83 +549,88 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         return {
             "selected_backend": before.backend,
             "fallback_reason": "",
-            "runtime_action": "already_supported",
+            "runtime_action": _runtime_action_for_already_supported(before.backend),
             **_probe_result_payload(before),
         }
 
-    if before.backend == "missing" and not sys.platform.startswith("win"):
+    policy = _runtime_bootstrap_policy(sys.platform, selected_mode)
+
+    if os.getenv(DISABLE_BOOTSTRAP_ENV) == "1":
+        action = "metal_probe_only" if policy.backend == "metal" else "probe_only"
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
-                f"desktop model runtime dependency unavailable ({before.error or 'llama_cpp missing'}); "
-                f"interpreter={before.interpreter}; import_root={target_root}; "
-                "install llama-cpp-python for the desktop runtime before registering with the relay"
+                f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1; "
+                f"{policy.backend.upper()} runtime was not installed or repaired"
             ),
-            "runtime_action": "failed",
+            "runtime_action": action,
             **_probe_result_payload(before),
         }
 
-    if not sys.platform.startswith("win"):
+    if not policy.bootstrap_allowed:
+        if before.backend == "missing":
+            return {
+                "selected_backend": "cpu",
+                "fallback_reason": (
+                    f"desktop model runtime dependency unavailable ({before.error or 'llama_cpp missing'}); "
+                    f"interpreter={before.interpreter}; import_root={target_root}; "
+                    "install llama-cpp-python for the desktop runtime before registering with the relay"
+                ),
+                "runtime_action": "failed",
+                **_probe_result_payload(before),
+            }
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
                 f"GPU runtime unavailable ({before.error or before.backend}); "
-                "desktop auto-repair is currently Windows-focused"
-            ),
-            "runtime_action": "probe_only",
-            **_probe_result_payload(before),
-        }
-
-    if os.getenv(DISABLE_BOOTSTRAP_ENV) == "1":
-        return {
-            "selected_backend": "cpu",
-            "fallback_reason": (
-                f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
+                f"{policy.unsupported_reason}"
             ),
             "runtime_action": "probe_only",
             **_probe_result_payload(before),
         }
 
     if os.getenv(ENABLE_BOOTSTRAP_ENV) != "1":
+        action = "metal_probe_only" if policy.backend == "metal" else "probe_only"
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
-                "desktop runtime bootstrap skipped during normal startup; set "
+                f"desktop {policy.backend.upper()} runtime bootstrap skipped during normal startup; set "
                 f"{ENABLE_BOOTSTRAP_ENV}=1 to allow runtime repair/install"
             ),
-            "runtime_action": "probe_only",
+            "runtime_action": action,
             **_probe_result_payload(before),
         }
 
     requirements_path = _resolve_requirements_path(target_root)
     last_error = ""
 
-    should_repair, repair_skip_reason = _should_attempt_source_repair()
-    if should_repair:
-        source_ok, source_log = _windows_cuda_source_repair(requirements_path)
-        if source_ok:
-            _clear_source_repair_failure()
-            after = _probe_runtime(target_root)
-            if after.gpu_offload_supported and after.backend == "cuda":
-                return {
-                    "selected_backend": "cuda",
-                    "fallback_reason": "installed CUDA runtime; re-executing sidecar",
-                    "runtime_action": "installed_cuda_reexec",
-                    **_probe_result_payload(after),
-                }
-            source_detail = _summarize_install_error(source_log)
-            last_error = (
-                "CUDA source reinstall completed but runtime still CPU-only; "
-                "check CUDA toolkit/build tools"
-            )
-            if source_detail and source_detail != "install failed":
-                last_error = f"{last_error}; source repair detail: {source_detail}"
-            _record_source_repair_failure(last_error)
+    if policy.backend == "cuda":
+        should_repair, repair_skip_reason = _should_attempt_source_repair()
+        if should_repair:
+            source_ok, source_log = _windows_cuda_source_repair(requirements_path)
+            if source_ok:
+                _clear_source_repair_failure()
+                after = _probe_runtime(target_root)
+                if after.gpu_offload_supported and after.backend == "cuda":
+                    return {
+                        "selected_backend": "cuda",
+                        "fallback_reason": "installed CUDA runtime; re-executing sidecar",
+                        "runtime_action": "installed_cuda_reexec",
+                        **_probe_result_payload(after),
+                    }
+                source_detail = _summarize_install_error(source_log)
+                last_error = (
+                    "CUDA source reinstall completed but runtime still CPU-only; "
+                    "check CUDA toolkit/build tools"
+                )
+                if source_detail and source_detail != "install failed":
+                    last_error = f"{last_error}; source repair detail: {source_detail}"
+                _record_source_repair_failure(last_error)
+            else:
+                last_error = _summarize_install_error(source_log)
+                _record_source_repair_failure(last_error)
         else:
-            last_error = _summarize_install_error(source_log)
-            _record_source_repair_failure(last_error)
-    else:
-        last_error = repair_skip_reason
+            last_error = repair_skip_reason
 
     try:
         plans = llama_cpp_install_plan_fallbacks(
@@ -570,27 +652,47 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             *plan.pip_install_args(),
             plan.package_spec,
         ]
-        ok, log_output = _run_pip_install(cmd, env)
+        ok, log_output = _run_pip_install(
+            cmd,
+            env,
+            timeout_seconds=_source_build_timeout_for_plan(plan),
+        )
         if not ok:
             last_error = _summarize_install_error(log_output)
             continue
 
         after = _probe_runtime(target_root)
-        if after.gpu_offload_supported and after.backend in {"cuda", "metal"}:
+        if backend_probe_satisfies_install_plan(plan, after):
+            if plan.backend in {"cuda", "metal"}:
+                return {
+                    "selected_backend": plan.backend,
+                    "fallback_reason": f"installed {plan.backend.upper()} runtime; re-executing sidecar",
+                    "runtime_action": _runtime_action_for_installed_backend(plan.backend),
+                    **_probe_result_payload(after),
+                }
             return {
-                "selected_backend": after.backend,
-                "fallback_reason": "installed GPU runtime; re-executing sidecar",
-                "runtime_action": "installed_cuda_reexec",
+                "selected_backend": "cpu",
+                "fallback_reason": f"{policy.backend.upper()} runtime unavailable after repair; using CPU runtime",
+                "runtime_action": "metal_cpu_fallback" if policy.backend == "metal" else "installed_cpu_fallback",
                 **_probe_result_payload(after),
             }
 
-        if plan.backend == "cpu":
-            return {
-                "selected_backend": "cpu",
-                "fallback_reason": "GPU runtime unavailable after repair; using CPU runtime",
-                "runtime_action": "installed_cpu_fallback",
-                **_probe_result_payload(after),
-            }
+        last_error = (
+            f"{plan.backend.upper()} install completed but runtime probe still reported "
+            f"backend={after.backend}; error={after.error or 'none'}"
+        )
+
+    if policy.backend == "metal":
+        action = "metal_install_failed" if selected_mode == "gpu" else "metal_cpu_fallback"
+        reason = last_error or before.error or "unable to install a Metal-capable runtime"
+        if action == "metal_cpu_fallback":
+            reason = f"Metal runtime install failed ({reason}); using CPU runtime"
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": reason,
+            "runtime_action": action,
+            **_probe_result_payload(before),
+        }
 
     return {
         "selected_backend": "cpu",

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -187,13 +187,16 @@ pub fn resolve_runtime_import_root(
         }
     }
 
-    candidates.into_iter().find(|candidate| {
-        candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-    })
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
 }
 
 fn mode_requests_gpu(mode: &ComputeMode) -> bool {
-    matches!(mode, ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid)
+    matches!(
+        mode,
+        ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid
+    )
 }
 
 fn should_enable_runtime_bootstrap_for(
@@ -202,10 +205,14 @@ fn should_enable_runtime_bootstrap_for(
     mode: &ComputeMode,
     bootstrap_disabled: bool,
 ) -> bool {
-    target_os == "windows"
-        && target_arch == "x86_64"
-        && mode_requests_gpu(mode)
-        && !bootstrap_disabled
+    if bootstrap_disabled || !mode_requests_gpu(mode) {
+        return false;
+    }
+
+    matches!(
+        (target_os, target_arch),
+        ("windows", "x86_64") | ("macos", "aarch64") | ("macos", "x86_64")
+    )
 }
 
 pub fn should_enable_runtime_bootstrap(mode: &ComputeMode) -> bool {
@@ -224,12 +231,12 @@ pub fn should_enable_runtime_bootstrap(mode: &ComputeMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -390,8 +397,13 @@ mod tests {
     #[test]
     fn resolve_runtime_import_root_detects_nested_up_layout() {
         let temp = TempDir::new().expect("tempdir");
-        let script = temp.path().join("resources").join("python").join("model_bridge.py");
-        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script dir");
+        let script = temp
+            .path()
+            .join("resources")
+            .join("python")
+            .join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create script dir");
         std::fs::write(&script, "#!/usr/bin/env python3\n").expect("write script");
         let import_root = temp.path().join("resources").join("_up_").join("_up_");
         std::fs::create_dir_all(import_root.join("utils")).expect("create utils dir");
@@ -401,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_bootstrap_only_enabled_for_windows_x64_gpu_modes() {
+    fn runtime_bootstrap_enabled_for_supported_desktop_gpu_modes() {
         assert!(should_enable_runtime_bootstrap_for(
             "windows",
             "x86_64",
@@ -426,9 +438,27 @@ mod tests {
             &ComputeMode::Cpu,
             false
         ));
+        assert!(should_enable_runtime_bootstrap_for(
+            "macos",
+            "aarch64",
+            &ComputeMode::Auto,
+            false
+        ));
+        assert!(should_enable_runtime_bootstrap_for(
+            "macos",
+            "x86_64",
+            &ComputeMode::Hybrid,
+            false
+        ));
         assert!(!should_enable_runtime_bootstrap_for(
             "linux",
             "x86_64",
+            &ComputeMode::Gpu,
+            false
+        ));
+        assert!(!should_enable_runtime_bootstrap_for(
+            "windows",
+            "aarch64",
             &ComputeMode::Gpu,
             false
         ));

--- a/tests/fixtures/desktop_operator_parity_matrix.json
+++ b/tests/fixtures/desktop_operator_parity_matrix.json
@@ -44,7 +44,7 @@
             },
             "expect": {
                 "selected_backend": "metal",
-                "runtime_action": "already_supported",
+                "runtime_action": "metal_already_supported",
                 "fallback_reason": "",
                 "registration_eligible_after_warm_load": true
             }
@@ -127,7 +127,7 @@
         },
         {
             "id": "macos_metal_bootstrap_gap",
-            "label": "Known gap: macOS missing Metal runtime bootstrap is probe-only today",
+            "label": "macOS missing Metal runtime explicit bootstrap repair path",
             "platform": "darwin",
             "mode": "auto",
             "probe": {
@@ -136,17 +136,24 @@
                 "device": "cpu",
                 "error": "Metal runtime wheel missing"
             },
-            "expect_future": {
-                "selected_backend": "metal",
-                "runtime_action": "installed_metal_reexec"
-            },
-            "known_gap": "The macOS bootstrap follow-up will replace probe-only behavior with first-class Metal bootstrap support.",
             "expect": {
-                "selected_backend": "cpu",
-                "runtime_action": "probe_only",
-                "fallback_reason_contains": "desktop auto-repair is currently Windows-focused",
-                "registration_eligible_after_warm_load": false,
-                "relay_runtime_state": "pending"
+                "selected_backend": "metal",
+                "runtime_action": "installed_metal_reexec",
+                "fallback_reason": "installed METAL runtime; re-executing sidecar",
+                "registration_eligible_after_warm_load": true
+            },
+            "env": {
+                "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP": "1"
+            },
+            "after_probe": {
+                "backend": "metal",
+                "gpu": true,
+                "device": "metal",
+                "error": null
+            },
+            "pip_install_result": {
+                "ok": true,
+                "log": "ok"
             }
         }
     ],

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -856,6 +856,94 @@ def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monke
     assert captured['cmd'][:5] == [sys.executable, '-m', 'pip', 'install', '--force-reinstall']
 
 
+def test_macos_metal_bootstrap_disabled_is_probe_only_with_clear_reason(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe(error='Metal missing'))
+    invoked = {'pip': False}
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (invoked.update(pip=True), '') and (False, 'unexpected'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'metal_probe_only'
+    assert result['selected_backend'] == 'cpu'
+    assert desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert invoked['pip'] is False
+
+
+def test_macos_metal_install_failure_falls_back_for_auto_but_is_fatal_for_gpu(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe(error='Metal missing'))
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (False, 'clang: error: metal build failed'),
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        'llama_cpp_install_plan_fallbacks',
+        lambda **_kwargs: [
+            desktop_runtime_setup.LlamaCppInstallPlan(
+                platform='darwin',
+                backend='metal',
+                package_spec='llama-cpp-python==0.3.16',
+                cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off',
+                force_cmake=True,
+                index_url='https://pypi.org/simple',
+                no_binary=True,
+            )
+        ],
+    )
+
+    auto_result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+    gpu_result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=REPO_ROOT)
+
+    assert auto_result['runtime_action'] == 'metal_cpu_fallback'
+    assert 'using CPU runtime' in auto_result['fallback_reason']
+    assert desktop_runtime_setup.desktop_gpu_runtime_failure_message('auto', auto_result) is None
+    assert gpu_result['runtime_action'] == 'metal_install_failed'
+    assert desktop_runtime_setup.desktop_gpu_runtime_failure_message('gpu', gpu_result)
+
+
+def test_macos_metal_install_plan_uses_source_build_timeout_and_env(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([_probe(error='Metal missing'), _probe(backend='metal', gpu=True, device='metal')])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin',
+        backend='metal',
+        package_spec='llama-cpp-python==0.3.16',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off',
+        force_cmake=True,
+        index_url='https://pypi.org/simple',
+        no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    captured = {}
+
+    def _capture_run(cmd, env, timeout_seconds=desktop_runtime_setup.PIP_INSTALL_TIMEOUT_SECONDS):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        captured['timeout_seconds'] = timeout_seconds
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _capture_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('hybrid', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
+    assert captured['env']['FORCE_CMAKE'] == '1'
+    assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+
+
 def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):
     repo_root = tmp_path / 'RepoRoot'
     repo_root.mkdir(parents=True)
@@ -1040,12 +1128,12 @@ def test_desktop_operator_parity_platform_matrix(monkeypatch, case):
         "_windows_cuda_source_repair",
         _matrix_source_repair,
     )
-    monkeypatch.setattr(
-        desktop_runtime_setup,
-        "_run_pip_install",
-        lambda *_args, **_kwargs: (invoked.update(pip=True), "")
-        and (False, "unexpected"),
-    )
+    def _matrix_pip_install(*_args, **_kwargs):
+        invoked.update(pip=True)
+        result = case.get("pip_install_result", {"ok": False, "log": "unexpected"})
+        return result["ok"], result["log"]
+
+    monkeypatch.setattr(desktop_runtime_setup, "_run_pip_install", _matrix_pip_install)
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime(
         case["mode"], repo_root=REPO_ROOT
@@ -1077,36 +1165,9 @@ def test_desktop_operator_parity_platform_matrix(monkeypatch, case):
         "macos_metal_capable",
         "cpu_fallback",
         "missing_runtime_dependency",
-        "macos_metal_bootstrap_gap",
     }:
         assert invoked == {"pip": False, "source_repair": False}
     if case["id"] == "windows_missing_runtime_bootstrap_repair":
         assert invoked == {"pip": False, "source_repair": True}
-
-
-# The non-xfail platform-matrix test above asserts today's macOS probe_only
-# behavior. This strict xfail records only the desired future Metal bootstrap
-# behavior without weakening the current gap lock.
-@pytest.mark.xfail(
-    strict=True,
-    reason="The macOS bootstrap follow-up will replace probe-only runtime behavior with Metal bootstrap support.",
-)
-def test_macos_missing_metal_runtime_bootstrap_gap_future_parity(monkeypatch):
-    case = next(
-        case
-        for case in _load_parity_matrix()["platform_cases"]
-        if case["id"] == "macos_metal_bootstrap_gap"
-    )
-    monkeypatch.setattr(desktop_runtime_setup, "sys", _PlatformStub(case["platform"]))
-    monkeypatch.setattr(
-        desktop_runtime_setup,
-        "_probe_llama_runtime",
-        lambda **_: _probe_from_matrix_case(case),
-    )
-
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime(
-        case["mode"], repo_root=REPO_ROOT
-    )
-
-    assert result["selected_backend"] == case["expect_future"]["selected_backend"]
-    assert result["runtime_action"] == case["expect_future"]["runtime_action"]
+    if case["id"] == "macos_metal_bootstrap_gap":
+        assert invoked == {"pip": True, "source_repair": False}


### PR DESCRIPTION
### Motivation

- Bring macOS runtime bootstrap to parity with Windows by making Metal installs reachable, diagnosable, and recoverable through the shared desktop bootstrap path.
- Replace the previous Windows-only bootstrap gating with a platform capability policy that expresses per-platform supported backend and bootstrap allowance.

### Description

- Add a `RuntimeBootstrapPolicy` and `_runtime_bootstrap_policy` in `desktop_runtime_setup.py` and use it to drive bootstrap decisions for Windows (CUDA) and macOS (Metal), while keeping non-supported platforms probe-only.
- Make Metal plans reachable: reuse the existing `LlamaCppInstallPlan` flow and `backend_probe_satisfies_install_plan` to accept macOS wheel or deterministic source builds, set appropriate `CMAKE_ARGS` and `FORCE_CMAKE`, and use a source-build timeout configurable via `TOKEN_PLACE_DESKTOP_PIP_SOURCE_BUILD_TIMEOUT_SECONDS`.
- Improve diagnostics and runtime action names to distinguish `metal_already_supported`, `installed_metal_reexec`, `metal_probe_only`, `metal_install_failed`, and `metal_cpu_fallback`, and include interpreter, prefix, and module path in payloads.
- Extend re-exec guard and failure messaging to treat macOS Metal-install failures correctly (fatal for explicit `gpu` mode, CPU fallback visible for `auto`/`hybrid`).
- Small typing/annotation cleanups in `desktop_gpu_packaging.py` for clearer `LlamaCppInstallPlan` types and pip arg typing.
- Enable desktop runtime bootstrap gating for macOS in the Rust launcher (`python_runtime.rs`) so Tauri/sidecar env handling sets `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` for supported macOS GPU modes.
- Update parity matrix fixture and unit tests in `tests/unit/test_desktop_runtime_setup.py` to cover macOS Metal-capable, bootstrap-repair and opt-out behaviors and add focused macOS bootstrap unit tests; keep heavy operations mocked so tests do not perform real installs.

### Testing

- Ran targeted verification commands locally: `pytest tests/unit/test_desktop_runtime_setup.py`, `pytest tests/unit/test_desktop_gpu_packaging.py`, `pytest tests/unit/test_compute_node_runtime.py`, `pytest tests/unit/test_desktop_model_bridge.py`, `pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py`, and full unit/integration/API suites via `pytest tests/unit`, `pytest tests/integration`, and `pytest tests` as part of CI smoke; the updated unit, integration, and API test suites passed in the local run after iterating on tests and mocks (no real `pip` installs were executed because install paths were mocked).
- Ran the repository standard checks with `pre-commit run --all-files` during development and iterated until test hooks and linters completed with the verification test sweep.

Residual risks and follow-ups: macOS packaged `.app` launcher/resource resolution changes are covered in subsequent prompts; further E2E packaged-operator lifecycle tests on macOS (warm-load/register/multi-turn/stop/start) are planned in later work to validate packaged runtime paths end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceee5cdd4832fbe7a3273be8967df)