### PR TITLE
Enable macOS Metal runtime bootstrap and unify desktop runtime bootstrap policy

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -42,7 +42,9 @@ class LlamaCppInstallPlan:
         return env
 
 
-def llama_cpp_requirement_spec(requirements_path: str | Path = "requirements.txt") -> str:
+def llama_cpp_requirement_spec(
+    requirements_path: str | Path = "requirements.txt",
+) -> str:
     """Return pinned llama-cpp-python requirement from requirements.txt."""
 
     path = Path(requirements_path)
@@ -83,10 +85,11 @@ def llama_cpp_install_plan(
             platform=detected_platform,
             backend="metal",
             package_spec=package_spec,
-            cmake_args=None,
-            force_cmake=False,
+            cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
+            force_cmake=True,
             index_url="https://pypi.org/simple",
-            only_binary=True,
+            only_binary=False,
+            no_binary=True,
         )
 
     return LlamaCppInstallPlan(
@@ -104,7 +107,9 @@ def llama_cpp_install_plan_fallbacks(
 ) -> list[LlamaCppInstallPlan]:
     """Return ordered install plans with conservative fallbacks per platform."""
 
-    primary = llama_cpp_install_plan(platform=platform, requirements_path=requirements_path)
+    primary = llama_cpp_install_plan(
+        platform=platform, requirements_path=requirements_path
+    )
     plans = [primary]
 
     if primary.platform.startswith("win"):
@@ -127,19 +132,19 @@ def llama_cpp_install_plan_fallbacks(
         )
 
     if primary.platform == "darwin":
-        # The Metal wheel can intermittently fail integrity checks in CI.
-        # Fall back to a deterministic source build with Metal enabled and
-        # GGML native tuning disabled to avoid arm64 i8mm compile issues.
+        # Metal bootstrap uses a source build so the package is explicitly
+        # compiled with GGML Metal support. Fall back to CPU only after the
+        # Metal build plan fails so auto/hybrid modes can remain usable.
         plans.append(
             LlamaCppInstallPlan(
                 platform=primary.platform,
-                backend="metal",
-                package_spec=primary.package_spec,
-                cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
-                force_cmake=True,
+                backend="cpu",
+                package_spec="llama-cpp-python",
+                cmake_args=None,
+                force_cmake=False,
                 index_url="https://pypi.org/simple",
                 only_binary=False,
-                no_binary=True,
+                no_binary=False,
             )
         )
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import platform as platform_module
 import subprocess
 import sys
 import time
@@ -14,6 +15,7 @@ from typing import Dict, Optional
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
+    backend_probe_satisfies_install_plan,
     llama_cpp_install_plan_fallbacks,
     llama_cpp_requirement_spec,
 )
@@ -32,10 +34,18 @@ class RuntimeProbe:
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
 GPU_RUNTIME_FATAL_ACTIONS = frozenset(
-    {"failed", "installed_cpu_fallback", "shadowed_repo_llama_cpp", "unavailable"}
+    {
+        "failed",
+        "installed_cpu_fallback",
+        "metal_install_failed",
+        "metal_cpu_fallback",
+        "shadowed_repo_llama_cpp",
+        "unavailable",
+    }
 )
 PIP_INSTALL_TIMEOUT_SECONDS = 300
 PIP_SOURCE_BUILD_TIMEOUT_SECONDS = 1800
+PIP_SOURCE_BUILD_TIMEOUT_ENV = "TOKEN_PLACE_DESKTOP_PIP_SOURCE_BUILD_TIMEOUT_SECONDS"
 INSTALL_ERROR_SUMMARY_MAX_LEN = 512
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
@@ -206,7 +216,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             interpreter=sys.executable,
             prefix=sys.prefix,
             llama_module_path="missing",
-            error=stderr or f"probe subprocess failed with return code {result.returncode}",
+            error=stderr
+            or f"probe subprocess failed with return code {result.returncode}",
         )
 
     try:
@@ -243,6 +254,17 @@ def _probe_runtime(runtime_root: Path) -> RuntimeProbe:
             # with callables that do not accept keyword arguments.
             return _probe_llama_runtime()
         raise
+
+
+def _source_build_timeout_seconds() -> int:
+    raw = os.getenv(PIP_SOURCE_BUILD_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+    return max(PIP_INSTALL_TIMEOUT_SECONDS, parsed)
 
 
 def _run_pip_install(
@@ -299,7 +321,9 @@ def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
         "--verbose",
         package_spec,
     ]
-    ok, output = _run_pip_install(cmd, env, timeout_seconds=PIP_SOURCE_BUILD_TIMEOUT_SECONDS)
+    ok, output = _run_pip_install(
+        cmd, env, timeout_seconds=_source_build_timeout_seconds()
+    )
     if not metadata_warning:
         return ok, output
 
@@ -374,7 +398,11 @@ def _should_attempt_source_repair() -> tuple[bool, str]:
     if now - last_failed_at >= SOURCE_REPAIR_COOLDOWN_SECONDS:
         return True, ""
     retry_in_seconds = int(SOURCE_REPAIR_COOLDOWN_SECONDS - (now - last_failed_at))
-    return False, entry.get("reason") or f"source repair cooldown active ({retry_in_seconds}s remaining)"
+    return (
+        False,
+        entry.get("reason")
+        or f"source repair cooldown active ({retry_in_seconds}s remaining)",
+    )
 
 
 def _record_source_repair_failure(reason: str) -> None:
@@ -400,7 +428,10 @@ def maybe_reexec_for_runtime_refresh(
 ) -> None:
     if not allow_reexec:
         return
-    if runtime_setup.get("runtime_action") != "installed_cuda_reexec":
+    if runtime_setup.get("runtime_action") not in {
+        "installed_cuda_reexec",
+        "installed_metal_reexec",
+    }:
         return
     if os.environ.get(REEXEC_GUARD_ENV) == "1":
         return
@@ -412,23 +443,140 @@ def maybe_reexec_for_runtime_refresh(
         return
 
 
-def desktop_gpu_runtime_failure_message(mode: str, runtime_setup: Dict[str, str]) -> str | None:
-    """Return fatal runtime bootstrap diagnostics for Windows desktop GPU launch modes."""
+def desktop_gpu_runtime_failure_message(
+    mode: str, runtime_setup: Dict[str, str]
+) -> Optional[str]:
+    """Return fatal runtime bootstrap diagnostics for desktop GPU launch modes."""
 
-    if sys.platform != "win32" or mode not in GPU_MODES:
+    selected_mode = (mode or "auto").strip().lower()
+    if selected_mode not in GPU_MODES:
+        return None
+    if sys.platform != "win32" and not (
+        sys.platform == "darwin" and selected_mode == "gpu"
+    ):
         return None
 
     selected_backend = str(runtime_setup.get("selected_backend", "cpu")).lower()
     runtime_action = str(runtime_setup.get("runtime_action", "none")).lower()
-    if selected_backend != "cpu" or runtime_action not in GPU_RUNTIME_FATAL_ACTIONS:
+    if runtime_action not in GPU_RUNTIME_FATAL_ACTIONS:
+        return None
+    if selected_backend != "cpu" and runtime_action != "metal_install_failed":
         return None
 
     reason = runtime_setup.get("fallback_reason") or "unknown runtime bootstrap failure"
+    if sys.platform == "win32":
+        return (
+            "GPU provisioning failed for desktop Windows launch "
+            f"(mode={selected_mode}, action={runtime_action}): {reason}. "
+            "Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support."
+        )
     return (
-        "GPU provisioning failed for desktop Windows launch "
-        f"(mode={mode}, action={runtime_action}): {reason}. "
-        "Verify CUDA runtime prerequisites and llama-cpp-python CUDA build support."
+        "GPU provisioning failed for desktop macOS launch "
+        f"(mode={selected_mode}, action={runtime_action}): {reason}. "
+        "Verify Metal runtime prerequisites and llama-cpp-python Metal build support."
     )
+
+
+@dataclass(frozen=True)
+class RuntimeBootstrapPolicy:
+    platform: str
+    arch: str
+    backend: str
+    bootstrap_supported: bool
+    reason: str
+
+
+def _normalize_arch(arch: str) -> str:
+    return (arch or "").strip().lower().replace("amd64", "x86_64")
+
+
+def _runtime_bootstrap_policy(
+    *, platform: Optional[str] = None, arch: Optional[str] = None
+) -> RuntimeBootstrapPolicy:
+    detected_platform = (platform or sys.platform).lower()
+    detected_arch = _normalize_arch(arch or platform_module.machine())
+
+    if detected_platform.startswith("win"):
+        supported = detected_arch in {"x86_64", ""}
+        return RuntimeBootstrapPolicy(
+            platform=detected_platform,
+            arch=detected_arch,
+            backend="cuda",
+            bootstrap_supported=supported,
+            reason=(
+                "Windows x86_64 CUDA runtime bootstrap is supported"
+                if supported
+                else f"Windows CUDA runtime bootstrap requires x86_64; detected {detected_arch or 'unknown'}"
+            ),
+        )
+
+    if detected_platform == "darwin":
+        supported = detected_arch in {"arm64", "aarch64", "x86_64", ""}
+        return RuntimeBootstrapPolicy(
+            platform=detected_platform,
+            arch=detected_arch,
+            backend="metal",
+            bootstrap_supported=supported,
+            reason=(
+                "macOS Metal runtime bootstrap is supported"
+                if supported
+                else f"macOS Metal runtime bootstrap requires arm64 or x86_64; detected {detected_arch or 'unknown'}"
+            ),
+        )
+
+    return RuntimeBootstrapPolicy(
+        platform=detected_platform,
+        arch=detected_arch,
+        backend="cpu",
+        bootstrap_supported=False,
+        reason=f"desktop runtime bootstrap is probe-only on {detected_platform or 'unknown platform'}",
+    )
+
+
+def _already_supported_action(backend: str) -> str:
+    if backend == "metal":
+        return "metal_already_supported"
+    return "already_supported"
+
+
+def _probe_only_action(policy: RuntimeBootstrapPolicy) -> str:
+    if policy.backend == "metal":
+        return "metal_probe_only"
+    return "probe_only"
+
+
+def _installed_reexec_action(backend: str) -> str:
+    if backend == "metal":
+        return "installed_metal_reexec"
+    return "installed_cuda_reexec"
+
+
+def _install_failed_action(policy: RuntimeBootstrapPolicy, selected_mode: str) -> str:
+    if policy.backend == "metal":
+        return (
+            "metal_install_failed" if selected_mode == "gpu" else "metal_cpu_fallback"
+        )
+    return "failed"
+
+
+def _install_failure_backend(policy: RuntimeBootstrapPolicy, selected_mode: str) -> str:
+    if policy.backend == "metal" and selected_mode == "gpu":
+        return "metal"
+    return "cpu"
+
+
+def _install_timeout_for_plan(plan: LlamaCppInstallPlan) -> int:
+    if plan.no_binary or plan.force_cmake:
+        return _source_build_timeout_seconds()
+    return PIP_INSTALL_TIMEOUT_SECONDS
+
+
+def _source_repair(
+    requirements_path: Path, policy: RuntimeBootstrapPolicy
+) -> tuple[bool, str]:
+    if policy.backend == "cuda":
+        return _windows_cuda_source_repair(requirements_path)
+    return False, "source repair is handled by shared install plans for this platform"
 
 
 def _resolve_requirements_path(target_root: Path) -> Path:
@@ -442,7 +590,9 @@ def _resolve_requirements_path(target_root: Path) -> Path:
     return candidates[0]
 
 
-def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
+def ensure_desktop_llama_runtime(
+    mode: str, *, repo_root: Optional[Path] = None
+) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
@@ -472,11 +622,25 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         return {
             "selected_backend": before.backend,
             "fallback_reason": "",
-            "runtime_action": "already_supported",
+            "runtime_action": _already_supported_action(before.backend),
             **_probe_result_payload(before),
         }
 
-    if before.backend == "missing" and not sys.platform.startswith("win"):
+    policy = _runtime_bootstrap_policy(platform=sys.platform)
+
+    if os.getenv(DISABLE_BOOTSTRAP_ENV) == "1":
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1; "
+                f"{policy.reason}; interpreter={before.interpreter}; prefix={before.prefix}; "
+                f"llama_module_path={before.llama_module_path}"
+            ),
+            "runtime_action": _probe_only_action(policy),
+            **_probe_result_payload(before),
+        }
+
+    if before.backend == "missing" and not policy.bootstrap_supported:
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
@@ -488,22 +652,13 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             **_probe_result_payload(before),
         }
 
-    if not sys.platform.startswith("win"):
+    if not policy.bootstrap_supported:
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
-                f"GPU runtime unavailable ({before.error or before.backend}); "
-                "desktop auto-repair is currently Windows-focused"
-            ),
-            "runtime_action": "probe_only",
-            **_probe_result_payload(before),
-        }
-
-    if os.getenv(DISABLE_BOOTSTRAP_ENV) == "1":
-        return {
-            "selected_backend": "cpu",
-            "fallback_reason": (
-                f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
+                f"GPU runtime unavailable ({before.error or before.backend}); {policy.reason}; "
+                f"interpreter={before.interpreter}; prefix={before.prefix}; "
+                f"llama_module_path={before.llama_module_path}"
             ),
             "runtime_action": "probe_only",
             **_probe_result_payload(before),
@@ -514,41 +669,44 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             "selected_backend": "cpu",
             "fallback_reason": (
                 "desktop runtime bootstrap skipped during normal startup; set "
-                f"{ENABLE_BOOTSTRAP_ENV}=1 to allow runtime repair/install"
+                f"{ENABLE_BOOTSTRAP_ENV}=1 to allow {policy.backend.upper()} runtime repair/install; "
+                f"interpreter={before.interpreter}; prefix={before.prefix}; "
+                f"llama_module_path={before.llama_module_path}"
             ),
-            "runtime_action": "probe_only",
+            "runtime_action": _probe_only_action(policy),
             **_probe_result_payload(before),
         }
 
     requirements_path = _resolve_requirements_path(target_root)
     last_error = ""
 
-    should_repair, repair_skip_reason = _should_attempt_source_repair()
-    if should_repair:
-        source_ok, source_log = _windows_cuda_source_repair(requirements_path)
-        if source_ok:
-            _clear_source_repair_failure()
-            after = _probe_runtime(target_root)
-            if after.gpu_offload_supported and after.backend == "cuda":
-                return {
-                    "selected_backend": "cuda",
-                    "fallback_reason": "installed CUDA runtime; re-executing sidecar",
-                    "runtime_action": "installed_cuda_reexec",
-                    **_probe_result_payload(after),
-                }
-            source_detail = _summarize_install_error(source_log)
-            last_error = (
-                "CUDA source reinstall completed but runtime still CPU-only; "
-                "check CUDA toolkit/build tools"
-            )
-            if source_detail and source_detail != "install failed":
-                last_error = f"{last_error}; source repair detail: {source_detail}"
-            _record_source_repair_failure(last_error)
+    if policy.backend == "cuda":
+        should_repair, repair_skip_reason = _should_attempt_source_repair()
+        if should_repair:
+            source_ok, source_log = _source_repair(requirements_path, policy)
+            if source_ok:
+                _clear_source_repair_failure()
+                after = _probe_runtime(target_root)
+                if after.gpu_offload_supported and after.backend == policy.backend:
+                    return {
+                        "selected_backend": policy.backend,
+                        "fallback_reason": f"installed {policy.backend.upper()} runtime; re-executing sidecar",
+                        "runtime_action": _installed_reexec_action(policy.backend),
+                        **_probe_result_payload(after),
+                    }
+                source_detail = _summarize_install_error(source_log)
+                last_error = (
+                    f"{policy.backend.upper()} source reinstall completed but runtime still CPU-only; "
+                    "check GPU toolkit/build tools"
+                )
+                if source_detail and source_detail != "install failed":
+                    last_error = f"{last_error}; source repair detail: {source_detail}"
+                _record_source_repair_failure(last_error)
+            else:
+                last_error = _summarize_install_error(source_log)
+                _record_source_repair_failure(last_error)
         else:
-            last_error = _summarize_install_error(source_log)
-            _record_source_repair_failure(last_error)
-    else:
-        last_error = repair_skip_reason
+            last_error = repair_skip_reason
 
     try:
         plans = llama_cpp_install_plan_fallbacks(
@@ -570,7 +728,9 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
             *plan.pip_install_args(),
             plan.package_spec,
         ]
-        ok, log_output = _run_pip_install(cmd, env)
+        ok, log_output = _run_pip_install(
+            cmd, env, timeout_seconds=_install_timeout_for_plan(plan)
+        )
         if not ok:
             last_error = _summarize_install_error(log_output)
             continue
@@ -579,27 +739,48 @@ def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None)
         if after.gpu_offload_supported and after.backend in {"cuda", "metal"}:
             return {
                 "selected_backend": after.backend,
-                "fallback_reason": "installed GPU runtime; re-executing sidecar",
-                "runtime_action": "installed_cuda_reexec",
+                "fallback_reason": f"installed {after.backend.upper()} runtime; re-executing sidecar",
+                "runtime_action": _installed_reexec_action(after.backend),
+                **_probe_result_payload(after),
+            }
+
+        if backend_probe_satisfies_install_plan(plan, after) and plan.backend in {
+            "cuda",
+            "metal",
+        }:
+            return {
+                "selected_backend": plan.backend,
+                "fallback_reason": f"installed {plan.backend.upper()} runtime; re-executing sidecar",
+                "runtime_action": _installed_reexec_action(plan.backend),
                 **_probe_result_payload(after),
             }
 
         if plan.backend == "cpu":
+            action = "installed_cpu_fallback"
+            fallback = "GPU runtime unavailable after repair; using CPU runtime"
+            if policy.backend == "metal":
+                action = "metal_cpu_fallback"
+                fallback = "Metal runtime unavailable after repair; using CPU runtime"
             return {
                 "selected_backend": "cpu",
-                "fallback_reason": "GPU runtime unavailable after repair; using CPU runtime",
-                "runtime_action": "installed_cpu_fallback",
+                "fallback_reason": fallback,
+                "runtime_action": action,
                 **_probe_result_payload(after),
             }
 
+    failure_reason = (
+        last_error or before.error or "unable to install a GPU-capable runtime"
+    )
     return {
-        "selected_backend": "cpu",
-        "fallback_reason": before.error or last_error or "unable to install a GPU-capable runtime",
-        "runtime_action": "failed",
+        "selected_backend": _install_failure_backend(policy, selected_mode),
+        "fallback_reason": (
+            f"{policy.backend.upper()} runtime install failed: {failure_reason}; "
+            f"interpreter={before.interpreter}; prefix={before.prefix}; "
+            f"llama_module_path={before.llama_module_path}"
+        ),
+        "runtime_action": _install_failed_action(policy, selected_mode),
         **_probe_result_payload(before),
     }
-
-
 
 
 def _resolve_desktop_requirements_path(repo_root: Path) -> Path:
@@ -618,7 +799,9 @@ def _desktop_dependency_target(runtime_root: Path) -> Path:
     return runtime_root / ".token_place_desktop_site"
 
 
-def _resolve_desktop_dependency_target(runtime_root: Path) -> tuple[Optional[Path], Optional[str]]:
+def _resolve_desktop_dependency_target(
+    runtime_root: Path,
+) -> tuple[Optional[Path], Optional[str]]:
     preferred_targets = [
         _desktop_dependency_target(runtime_root),
         Path.home() / ".token_place_desktop_site",
@@ -633,14 +816,18 @@ def _resolve_desktop_dependency_target(runtime_root: Path) -> tuple[Optional[Pat
     return None, "; ".join(errors) if errors else "no writable install target"
 
 
-def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> Dict[str, str]:
+def ensure_desktop_python_dependencies(
+    *, repo_root: Optional[Path] = None
+) -> Dict[str, str]:
     """Ensure baseline desktop bridge Python dependencies are importable."""
 
     root = _resolve_runtime_root(repo_root=repo_root)
     requirements_path = _resolve_desktop_requirements_path(root)
 
     required_modules = ("psutil", "requests", "dotenv", "cryptography")
-    missing = [name for name in required_modules if importlib.util.find_spec(name) is None]
+    missing = [
+        name for name in required_modules if importlib.util.find_spec(name) is None
+    ]
     if not missing:
         return {"ok": "true", "action": "already_satisfied", "missing": ""}
 
@@ -664,7 +851,8 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
             "interpreter": sys.executable,
             "import_root": str(root),
             "requirements": str(requirements_path),
-            "detail": target_error or "unable to create desktop dependency install target",
+            "detail": target_error
+            or "unable to create desktop dependency install target",
         }
     target_dir_str = str(target_dir)
     if target_dir_str not in sys.path:
@@ -694,7 +882,9 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
         }
 
     importlib.invalidate_caches()
-    missing_after = [name for name in required_modules if importlib.util.find_spec(name) is None]
+    missing_after = [
+        name for name in required_modules if importlib.util.find_spec(name) is None
+    ]
     return {
         "ok": "true" if not missing_after else "false",
         "action": "installed" if not missing_after else "post_install_missing",
@@ -703,6 +893,8 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
         "import_root": str(root),
         "requirements": str(requirements_path),
     }
+
+
 def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
     detected_platform = platform.lower()
     if detected_platform.startswith("win"):

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -202,10 +202,13 @@ fn should_enable_runtime_bootstrap_for(
     mode: &ComputeMode,
     bootstrap_disabled: bool,
 ) -> bool {
-    target_os == "windows"
-        && target_arch == "x86_64"
-        && mode_requests_gpu(mode)
-        && !bootstrap_disabled
+    let platform_supports_bootstrap = match target_os {
+        "windows" => target_arch == "x86_64",
+        "macos" => matches!(target_arch, "aarch64" | "x86_64"),
+        _ => false,
+    };
+
+    platform_supports_bootstrap && mode_requests_gpu(mode) && !bootstrap_disabled
 }
 
 pub fn should_enable_runtime_bootstrap(mode: &ComputeMode) -> bool {
@@ -401,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_bootstrap_only_enabled_for_windows_x64_gpu_modes() {
+    fn runtime_bootstrap_enabled_for_supported_desktop_gpu_modes() {
         assert!(should_enable_runtime_bootstrap_for(
             "windows",
             "x86_64",
@@ -426,9 +429,27 @@ mod tests {
             &ComputeMode::Cpu,
             false
         ));
+        assert!(should_enable_runtime_bootstrap_for(
+            "macos",
+            "aarch64",
+            &ComputeMode::Auto,
+            false
+        ));
+        assert!(should_enable_runtime_bootstrap_for(
+            "macos",
+            "x86_64",
+            &ComputeMode::Hybrid,
+            false
+        ));
         assert!(!should_enable_runtime_bootstrap_for(
             "linux",
             "x86_64",
+            &ComputeMode::Gpu,
+            false
+        ));
+        assert!(!should_enable_runtime_bootstrap_for(
+            "macos",
+            "arm",
             &ComputeMode::Gpu,
             false
         ));

--- a/tests/fixtures/desktop_operator_parity_matrix.json
+++ b/tests/fixtures/desktop_operator_parity_matrix.json
@@ -44,7 +44,7 @@
             },
             "expect": {
                 "selected_backend": "metal",
-                "runtime_action": "already_supported",
+                "runtime_action": "metal_already_supported",
                 "fallback_reason": "",
                 "registration_eligible_after_warm_load": true
             }
@@ -127,7 +127,7 @@
         },
         {
             "id": "macos_metal_bootstrap_gap",
-            "label": "Known gap: macOS missing Metal runtime bootstrap is probe-only today",
+            "label": "macOS missing Metal runtime bootstrap is probe-only until explicit bootstrap is enabled",
             "platform": "darwin",
             "mode": "auto",
             "probe": {
@@ -136,15 +136,10 @@
                 "device": "cpu",
                 "error": "Metal runtime wheel missing"
             },
-            "expect_future": {
-                "selected_backend": "metal",
-                "runtime_action": "installed_metal_reexec"
-            },
-            "known_gap": "The macOS bootstrap follow-up will replace probe-only behavior with first-class Metal bootstrap support.",
             "expect": {
                 "selected_backend": "cpu",
-                "runtime_action": "probe_only",
-                "fallback_reason_contains": "desktop auto-repair is currently Windows-focused",
+                "runtime_action": "metal_probe_only",
+                "fallback_reason_contains": "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP=1",
                 "registration_eligible_after_warm_load": false,
                 "relay_runtime_state": "pending"
             }

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -19,7 +19,9 @@ from desktop_gpu_packaging import (
 
 
 def test_windows_install_plan_requests_cuda_then_cpu_fallback():
-    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    plans = llama_cpp_install_plan_fallbacks(
+        platform="win32", requirements_path=ROOT / "requirements.txt"
+    )
     assert len(plans) == 2
 
     gpu_plan = plans[0]
@@ -38,29 +40,34 @@ def test_windows_install_plan_requests_cuda_then_cpu_fallback():
     assert cpu_fallback.no_binary is False
 
 
-def test_macos_install_plan_requests_metal_then_source_fallback():
-    plans = llama_cpp_install_plan_fallbacks(platform="darwin", requirements_path=ROOT / "requirements.txt")
+def test_macos_install_plan_requests_metal_then_cpu_fallback():
+    plans = llama_cpp_install_plan_fallbacks(
+        platform="darwin", requirements_path=ROOT / "requirements.txt"
+    )
     assert len(plans) == 2
 
-    wheel_plan = plans[0]
-    assert wheel_plan.backend == "metal"
-    assert wheel_plan.index_url == "https://pypi.org/simple"
-    assert wheel_plan.only_binary is True
-
-    source_fallback = plans[1]
-    assert source_fallback.backend == "metal"
-    assert source_fallback.index_url == "https://pypi.org/simple"
-    assert source_fallback.only_binary is False
-    assert source_fallback.force_cmake is True
-    assert source_fallback.no_binary is True
-    assert source_fallback.pip_env() == {
+    metal_plan = plans[0]
+    assert metal_plan.backend == "metal"
+    assert metal_plan.index_url == "https://pypi.org/simple"
+    assert metal_plan.only_binary is False
+    assert metal_plan.force_cmake is True
+    assert metal_plan.no_binary is True
+    assert metal_plan.pip_env() == {
         "CMAKE_ARGS": "-DGGML_METAL=on -DGGML_NATIVE=off",
         "FORCE_CMAKE": "1",
     }
 
+    cpu_fallback = plans[1]
+    assert cpu_fallback.backend == "cpu"
+    assert cpu_fallback.index_url == "https://pypi.org/simple"
+    assert cpu_fallback.only_binary is False
+    assert cpu_fallback.no_binary is False
+
 
 def test_linux_install_plan_remains_cpu_default():
-    plans = llama_cpp_install_plan_fallbacks(platform="linux", requirements_path=ROOT / "requirements.txt")
+    plans = llama_cpp_install_plan_fallbacks(
+        platform="linux", requirements_path=ROOT / "requirements.txt"
+    )
     assert len(plans) == 1
 
     plan = plans[0]
@@ -72,9 +79,7 @@ def test_linux_install_plan_remains_cpu_default():
 def test_requirement_spec_parses_comments_and_blank_lines(tmp_path):
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(
-        "# comment\n\n"
-        "numpy==2.0.0\n"
-        "llama-cpp-python==0.3.16\n",
+        "# comment\n\n" "numpy==2.0.0\n" "llama-cpp-python==0.3.16\n",
         encoding="utf-8",
     )
 
@@ -133,7 +138,9 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
 
 
 def test_windows_cpu_fallback_install_args_allow_wheel_or_source():
-    plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
+    plans = llama_cpp_install_plan_fallbacks(
+        platform="win32", requirements_path=ROOT / "requirements.txt"
+    )
     cpu_fallback = plans[1]
 
     assert cpu_fallback.pip_install_args() == [
@@ -145,11 +152,16 @@ def test_windows_cpu_fallback_install_args_allow_wheel_or_source():
     ]
 
 
-def test_macos_source_fallback_install_args_force_source_build():
-    plans = llama_cpp_install_plan_fallbacks(platform="darwin", requirements_path=ROOT / "requirements.txt")
-    source_fallback = plans[1]
+def test_macos_primary_install_args_force_metal_source_build():
+    plans = llama_cpp_install_plan_fallbacks(
+        platform="darwin", requirements_path=ROOT / "requirements.txt"
+    )
+    metal_plan = plans[0]
 
-    assert source_fallback.pip_install_args() == [
+    assert metal_plan.backend == "metal"
+    assert metal_plan.cmake_args == "-DGGML_METAL=on -DGGML_NATIVE=off"
+    assert metal_plan.force_cmake is True
+    assert metal_plan.pip_install_args() == [
         "--upgrade",
         "--no-cache-dir",
         "--index-url",
@@ -171,17 +183,23 @@ def test_llama_cpp_install_plan_uses_current_platform_for_windows(monkeypatch):
 
 
 def test_llama_cpp_install_plan_darwin_selects_metal_plan_with_pypi_index():
-    plan = llama_cpp_install_plan(platform="darwin", requirements_path=ROOT / "requirements.txt")
+    plan = llama_cpp_install_plan(
+        platform="darwin", requirements_path=ROOT / "requirements.txt"
+    )
 
     assert plan.backend == "metal"
     assert plan.package_spec.startswith("llama-cpp-python==")
     assert plan.index_url == "https://pypi.org/simple"
-    assert plan.only_binary is True
-    assert plan.no_binary is False
+    assert plan.cmake_args == "-DGGML_METAL=on -DGGML_NATIVE=off"
+    assert plan.force_cmake is True
+    assert plan.only_binary is False
+    assert plan.no_binary is True
 
 
 def test_non_desktop_platform_fallbacks_return_only_primary_plan():
-    plans = llama_cpp_install_plan_fallbacks(platform="freebsd13", requirements_path=ROOT / "requirements.txt")
+    plans = llama_cpp_install_plan_fallbacks(
+        platform="freebsd13", requirements_path=ROOT / "requirements.txt"
+    )
 
     assert len(plans) == 1
     assert plans[0].platform == "freebsd13"
@@ -215,7 +233,11 @@ def test_backend_probe_satisfies_plan_for_matching_backend():
         cmake_args="-DGGML_CUDA=on",
         force_cmake=True,
     )
-    probe = SimpleNamespace(backend="cuda", llama_module_path="site-packages/llama_cpp/__init__.py", error=None)
+    probe = SimpleNamespace(
+        backend="cuda",
+        llama_module_path="site-packages/llama_cpp/__init__.py",
+        error=None,
+    )
 
     assert backend_probe_satisfies_install_plan(plan, probe) is True
 
@@ -228,7 +250,11 @@ def test_backend_probe_rejects_mismatched_cuda_backend():
         cmake_args="-DGGML_CUDA=on",
         force_cmake=True,
     )
-    probe = SimpleNamespace(backend="cpu", llama_module_path="site-packages/llama_cpp/__init__.py", error=None)
+    probe = SimpleNamespace(
+        backend="cpu",
+        llama_module_path="site-packages/llama_cpp/__init__.py",
+        error=None,
+    )
 
     assert backend_probe_satisfies_install_plan(plan, probe) is False
 
@@ -241,7 +267,11 @@ def test_backend_probe_accepts_macos_metal_source_build_with_clean_import_probe(
         cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
         force_cmake=True,
     )
-    probe = SimpleNamespace(backend="cpu", llama_module_path="site-packages/llama_cpp/__init__.py", error=None)
+    probe = SimpleNamespace(
+        backend="cpu",
+        llama_module_path="site-packages/llama_cpp/__init__.py",
+        error=None,
+    )
 
     assert backend_probe_satisfies_install_plan(plan, probe) is True
 
@@ -254,6 +284,8 @@ def test_backend_probe_rejects_macos_metal_source_build_when_probe_errors():
         cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
         force_cmake=True,
     )
-    probe = SimpleNamespace(backend="missing", llama_module_path="missing", error="import failed")
+    probe = SimpleNamespace(
+        backend="missing", llama_module_path="missing", error="import failed"
+    )
 
     assert backend_probe_satisfies_install_plan(plan, probe) is False

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -291,6 +291,119 @@ def test_runtime_bootstrap_falls_back_to_cpu_when_repair_fails(monkeypatch):
     assert result['selected_backend'] == 'cpu'
 
 
+def test_macos_metal_already_supported_uses_backend_specific_action(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='metal', gpu=True, device='metal'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['selected_backend'] == 'metal'
+    assert result['runtime_action'] == 'metal_already_supported'
+    assert result['llama_module_path'].endswith('llama_cpp/__init__.py')
+
+
+def test_macos_missing_metal_bootstrap_enabled_attempts_metal_install_plan(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([
+        _probe(backend='cpu', gpu=False, device='cpu', error='Metal missing'),
+        _probe(backend='metal', gpu=True, device='metal'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin',
+        backend='metal',
+        package_spec='llama-cpp-python==0.3.16',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off',
+        force_cmake=True,
+        index_url='https://pypi.org/simple',
+        only_binary=False,
+        no_binary=True,
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan]
+    )
+    captured = {}
+
+    def _capture_run(cmd, env, timeout_seconds=desktop_runtime_setup.PIP_INSTALL_TIMEOUT_SECONDS):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        captured['timeout_seconds'] = timeout_seconds
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _capture_run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert result['selected_backend'] == 'metal'
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
+    assert captured['env']['FORCE_CMAKE'] == '1'
+    assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
+    assert '--no-binary' in captured['cmd']
+
+
+def test_macos_bootstrap_disabled_is_metal_probe_only_with_actionable_context(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cpu', gpu=False, device='cpu', error='Metal missing'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'metal_probe_only'
+    assert result['selected_backend'] == 'cpu'
+    assert desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV in result['fallback_reason']
+    assert 'interpreter=' in result['fallback_reason']
+    assert 'llama_module_path=' in result['fallback_reason']
+
+
+def test_macos_metal_install_failure_falls_back_for_auto_and_fails_for_gpu(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin',
+        backend='metal',
+        package_spec='llama-cpp-python==0.3.16',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off',
+        force_cmake=True,
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan]
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (False, 'metal compile failed'),
+    )
+
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cpu', gpu=False, device='cpu', error='Metal missing'),
+    )
+    auto_result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+    assert auto_result['runtime_action'] == 'metal_cpu_fallback'
+    assert auto_result['selected_backend'] == 'cpu'
+    assert 'metal compile failed' in auto_result['fallback_reason']
+
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cpu', gpu=False, device='cpu', error='Metal missing'),
+    )
+    gpu_result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=REPO_ROOT)
+    assert gpu_result['runtime_action'] == 'metal_install_failed'
+    assert gpu_result['selected_backend'] == 'metal'
+    assert desktop_runtime_setup.desktop_gpu_runtime_failure_message('gpu', gpu_result) is not None
+
 def test_maybe_reexec_for_runtime_refresh_reexecs_once(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     called = {}
@@ -578,7 +691,8 @@ def test_source_repair_cooldown_skips_immediate_retries(monkeypatch, tmp_path):
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
 
     assert result['runtime_action'] == 'failed'
-    assert result['fallback_reason'] == 'build failed'
+    assert 'build failed' in result['fallback_reason']
+    assert 'interpreter=' in result['fallback_reason']
 
 
 def test_probe_marks_error_when_subprocess_raises(monkeypatch):
@@ -1061,7 +1175,12 @@ def test_desktop_operator_parity_platform_matrix(monkeypatch, case):
     if "last_error_contains" in expected:
         assert expected["last_error_contains"] in result.get("fallback_reason", "")
     if expected.get("registration_eligible_after_warm_load") is False:
-        assert expected["runtime_action"] in {"failed", "probe_only", "pending"}
+        assert expected["runtime_action"] in {
+            "failed",
+            "probe_only",
+            "metal_probe_only",
+            "pending",
+        }
         assert expected.get("relay_runtime_state") in {"failed", "pending"}
     if case["id"] == "missing_runtime_dependency":
         assert expected["backend_available"] == "unavailable"
@@ -1082,31 +1201,3 @@ def test_desktop_operator_parity_platform_matrix(monkeypatch, case):
         assert invoked == {"pip": False, "source_repair": False}
     if case["id"] == "windows_missing_runtime_bootstrap_repair":
         assert invoked == {"pip": False, "source_repair": True}
-
-
-# The non-xfail platform-matrix test above asserts today's macOS probe_only
-# behavior. This strict xfail records only the desired future Metal bootstrap
-# behavior without weakening the current gap lock.
-@pytest.mark.xfail(
-    strict=True,
-    reason="The macOS bootstrap follow-up will replace probe-only runtime behavior with Metal bootstrap support.",
-)
-def test_macos_missing_metal_runtime_bootstrap_gap_future_parity(monkeypatch):
-    case = next(
-        case
-        for case in _load_parity_matrix()["platform_cases"]
-        if case["id"] == "macos_metal_bootstrap_gap"
-    )
-    monkeypatch.setattr(desktop_runtime_setup, "sys", _PlatformStub(case["platform"]))
-    monkeypatch.setattr(
-        desktop_runtime_setup,
-        "_probe_llama_runtime",
-        lambda **_: _probe_from_matrix_case(case),
-    )
-
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime(
-        case["mode"], repo_root=REPO_ROOT
-    )
-
-    assert result["selected_backend"] == case["expect_future"]["selected_backend"]
-    assert result["runtime_action"] == case["expect_future"]["runtime_action"]


### PR DESCRIPTION
### Motivation

- Make macOS a first-class desktop runtime target by enabling Metal-capable `llama-cpp-python` detection and repair through the same shared bootstrap path used for Windows (CUDA), instead of leaving macOS probe-only.
- Replace the previous Windows-only bootstrap gating with a platform-capability policy so platform-specific install plans (CUDA/Metal/CPU) are selected and exercised consistently.

### Description

- Introduce a shared runtime bootstrap policy and helpers (`RuntimeBootstrapPolicy`, `_runtime_bootstrap_policy`, `_already_supported_action`, `_installed_reexec_action`, `_probe_only_action`, `_install_failed_action`, `_install_failure_backend`) to centralize platform/arch/backend decisions and action naming.
- Refactor `ensure_desktop_llama_runtime` to use the policy and to expose Metal flows: probe-only vs install attempt vs source-repair vs CPU fallback, and to include interpreter/prefix/module-path context in diagnostics.
- Make macOS Metal install plans reachable by updating packaging and fallback logic so Darwin selects a Metal source build plan (CMAKE_ARGS includes `-DGGML_METAL=on -DGGML_NATIVE=off`, `FORCE_CMAKE=1`) and by adding a CPU fallback plan after Metal build failure.
- Add environment control and tuning for source-build timeouts (`TOKEN_PLACE_DESKTOP_PIP_SOURCE_BUILD_TIMEOUT_SECONDS`) and make source build timeout selection per-plan (`_install_timeout_for_plan`).
- Add richer runtime_action values and diagnostics: `metal_already_supported`, `installed_metal_reexec`, `metal_probe_only`, `metal_install_failed`, `metal_cpu_fallback`, and include interpreter/prefix/llama_module_path and actionable fallback_reason in responses.
- Update re-exec guard to accept both CUDA and Metal reexec actions and broaden the desktop GPU failure message logic to include macOS GPU-fatal cases when appropriate.
- Update the desktop GPU packaging (`desktop_gpu_packaging.py`) to make the darwin primary plan a deterministic Metal source build and add a CPU fallback plan in fallback lists.
- Adjust Rust-side bootstrap gating (`python_runtime.rs`) to enable runtime bootstrap for supported desktop GPU modes on macOS (arm64/x86_64) in addition to Windows x86_64, while still honoring `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP` and the opt-in `TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP` behavior.
- Add/adjust unit tests and the platform-parity matrix fixtures to cover macOS Metal-capable, macOS missing Metal with bootstrap enabled/disabled, and preserve Windows CUDA behaviors; update tests to expect the new metal-specific runtime_action names.
- Keep existing safety opt-in/opt-out env vars behavior and avoid duplicating platform-specific code paths; reuse `LlamaCppInstallPlan` shape for Metal plans.

### Testing

- Ran `pytest tests/unit/test_desktop_runtime_setup.py` (desktop runtime bootstrap matrix and unit coverage) and `pytest tests/unit/test_desktop_gpu_packaging.py` (packaging contract), and they passed locally after the changes (desktop runtime setup: 78 tests passed; packaging tests passed).
- Ran the targeted suites used by the parity work: `pytest tests/unit/test_compute_node_runtime.py`, `pytest tests/unit/test_desktop_model_bridge.py`, and `pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py`, and they passed locally.
- Executed a broader test pass including integration and API tests used during verification (`pytest tests/unit`, integration and API test sets shown in the transcript); desktop-focused regressions were fixed during the rollout and the updated tests are green locally for the modified areas.
- Ran `pre-commit run --all-files`; formatters (Black) reformatted the changed Python files and lint hooks executed; note that some Rust build hooks (native `pkg-config` / `glib-2.0`) can be environment-dependent and may require platform libraries to run in CI runners.

Notes and follow-ups

- The change intentionally keeps opt-in guard (`TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP`) and the global opt-out (`TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP`) behavior; Windows remains CUDA-first and macOS now prefers Metal in GPU modes.
- Native source builds on macOS still require local toolchains in release CI or developer machines; unit tests mock expensive installs so no network/pip builds run during tests.
- Rust unit tests that call native cargo builds may need platform-specific pkg-config libraries in some CI runners; the Python unit test surface is green for the modified logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceee5cdd4832fbe7a3273be8967df)