### PR TITLE
Harden packaged desktop Python resource resolution and unify runtime startup

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -107,6 +107,24 @@ def create_macos_bundle_layout(tmp_root: Path) -> Path:
     return create_packaged_layout(resources_tmp_root, resources_dir_name="Resources")
 
 
+def validate_unified_resource_root(resources_root: Path) -> None:
+    required = (
+        "python/compute_node_bridge.py",
+        "python/model_bridge.py",
+        "python/inference_sidecar.py",
+        "python/desktop_runtime_setup.py",
+        "python/path_bootstrap.py",
+        "python/requirements_desktop_runtime.txt",
+        "utils",
+        "config.py",
+        "encrypt.py",
+        "requirements.txt",
+    )
+    missing = [entry for entry in required if not (resources_root / entry).exists()]
+    assert not missing, f"unified resource root {resources_root} missing: {missing}"
+
+
+
 def _packaged_env(
     tmp_root: Path,
     resources_root: Path | None = None,
@@ -114,6 +132,7 @@ def _packaged_env(
     extra_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
     resources_root = resources_root or (tmp_root / "resources")
+    validate_unified_resource_root(resources_root)
     home_dir = tmp_root / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
@@ -415,12 +434,15 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
         tmp_path = Path(tmpdir)
         bridge_script = create_packaged_layout(tmp_path)
+        (tmp_path / "llama_cpp.py").write_text("# repo-local shim must not shadow runtime imports\n", encoding="utf-8")
+        validate_unified_resource_root(tmp_path / "resources")
         run_desktop_dependency_preflight(tmp_path)
         run_model_bridge_inspect_probe(tmp_path)
         run_compute_bridge_import_probe(tmp_path)
 
         mac_bridge_script = create_macos_bundle_layout(tmp_path)
         mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
+        validate_unified_resource_root(mac_resources_root)
         run_desktop_dependency_preflight(tmp_path, resources_root=mac_resources_root)
         run_model_bridge_inspect_probe(tmp_path, resources_root=mac_resources_root)
         run_compute_bridge_import_probe(tmp_path, resources_root=mac_resources_root)

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -167,10 +167,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
     python_root = Path(__file__).resolve().parent
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
     env = os.environ.copy()
-    existing_pythonpath = env.get("PYTHONPATH", "")
     pythonpath_entries = [str(python_root), str(repo_root)]
-    if existing_pythonpath:
-        pythonpath_entries.append(existing_pythonpath)
+    env["PYTHONNOUSERSITE"] = "1"
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     env["TOKEN_PLACE_DESKTOP_PYTHON_ROOT"] = str(python_root)
     env["TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT"] = str(Path(__file__).resolve())
@@ -690,6 +688,7 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
             "interpreter": sys.executable,
             "import_root": str(root),
             "requirements": str(requirements_path),
+            "dependency_target": target_dir_str,
             "detail": _summarize_install_error(output),
         }
 
@@ -702,6 +701,7 @@ def ensure_desktop_python_dependencies(*, repo_root: Optional[Path] = None) -> D
         "interpreter": sys.executable,
         "import_root": str(root),
         "requirements": str(requirements_path),
+        "dependency_target": target_dir_str,
     }
 def _fallback_unpinned_plans(platform: str) -> list[LlamaCppInstallPlan]:
     detected_platform = platform.lower()

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,7 +1,8 @@
 use crate::backend::ComputeMode;
 use crate::python_runtime::{
-    resolve_python_launcher, resolve_runtime_import_root, should_enable_runtime_bootstrap,
-    PythonLauncher, ENABLE_RUNTIME_BOOTSTRAP_ENV,
+    configure_python_subprocess_env_async, python_resource_script_candidates,
+    resolve_python_launcher, resolve_python_resource_script, should_enable_runtime_bootstrap,
+    PythonLauncher, ResolvedPythonResource, ENABLE_RUNTIME_BOOTSTRAP_ENV,
 };
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
@@ -87,64 +88,30 @@ fn bridge_script_candidates(
     manifest_dir: &Path,
     resource_dir: Option<&Path>,
 ) -> Vec<std::path::PathBuf> {
-    let mut candidates = Vec::new();
-
-    if let Some(resource_dir) = resource_dir {
-        candidates.push(resource_dir.join("python").join("compute_node_bridge.py"));
-        candidates.push(resource_dir.join("compute_node_bridge.py"));
-    }
-
-    if let Some(exe_path) = exe_path {
-        if let Some(exe_dir) = exe_path.parent() {
-            candidates.push(
-                exe_dir
-                    .join("resources")
-                    .join("python")
-                    .join("compute_node_bridge.py"),
-            );
-            candidates.push(exe_dir.join("python").join("compute_node_bridge.py"));
-            if let Some(parent_dir) = exe_dir.parent() {
-                candidates.push(
-                    parent_dir
-                        .join("_up_")
-                        .join("resources")
-                        .join("python")
-                        .join("compute_node_bridge.py"),
-                );
-                candidates.push(
-                    parent_dir
-                        .join("Resources")
-                        .join("python")
-                        .join("compute_node_bridge.py"),
-                );
-                candidates.push(
-                    parent_dir
-                        .join("resources")
-                        .join("python")
-                        .join("compute_node_bridge.py"),
-                );
-            }
-        }
-    }
-
-    candidates.push(manifest_dir.join("python").join("compute_node_bridge.py"));
-    candidates
+    python_resource_script_candidates(
+        "compute_node_bridge.py",
+        exe_path,
+        manifest_dir,
+        resource_dir,
+    )
+    .into_iter()
+    .map(|candidate| candidate.script_path)
+    .collect()
 }
 
-fn resolve_bridge_script(app: &AppHandle) -> String {
+fn resolve_bridge_resource(app: &AppHandle) -> anyhow::Result<ResolvedPythonResource> {
     let exe_path = std::env::current_exe().ok();
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let resource_dir = app.path().resource_dir().ok();
-    let candidates =
-        bridge_script_candidates(exe_path.as_deref(), manifest_dir, resource_dir.as_deref());
-
-    if let Some(path) = first_existing_script(candidates) {
-        return path;
-    }
-
-    "python/compute_node_bridge.py".into()
+    resolve_python_resource_script(
+        "compute_node_bridge.py",
+        exe_path.as_deref(),
+        manifest_dir,
+        resource_dir.as_deref(),
+    )
 }
 
+#[cfg(test)]
 fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> {
     candidates
         .into_iter()
@@ -152,27 +119,12 @@ fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> 
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn configure_runtime_pythonpath(command: &mut Command, manifest_dir: &Path, bridge_script: &str) {
-    command.env("PYTHONNOUSERSITE", "1");
-    if let Some(import_root) =
-        resolve_runtime_import_root(Some(Path::new(bridge_script)), manifest_dir)
-    {
-        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
-        match std::env::var("PYTHONPATH") {
-            Ok(existing) if !existing.trim().is_empty() => {
-                let mut components = vec![import_root.clone()];
-                components.extend(std::env::split_paths(&existing));
-                if let Ok(joined) = std::env::join_paths(components) {
-                    command.env("PYTHONPATH", joined);
-                } else {
-                    command.env("PYTHONPATH", import_root);
-                }
-            }
-            _ => {
-                command.env("PYTHONPATH", import_root);
-            }
-        }
-    }
+fn configure_runtime_pythonpath(
+    command: &mut Command,
+    manifest_dir: &Path,
+    bridge_script: &str,
+) -> Option<std::path::PathBuf> {
+    configure_python_subprocess_env_async(command, Path::new(bridge_script), manifest_dir)
 }
 
 fn configure_runtime_bootstrap_env(command: &mut Command, mode: &ComputeMode) {
@@ -478,7 +430,8 @@ pub async fn start_compute_node(
         *state.stdin.lock().await = None;
     }
 
-    let bridge_script = resolve_bridge_script(&app);
+    let bridge_resource = resolve_bridge_resource(&app)?;
+    let bridge_script = bridge_resource.script_path.to_string_lossy().into_owned();
     let launcher = if is_python_script(&bridge_script) {
         match tokio::task::spawn_blocking(|| resolve_python_launcher("TOKEN_PLACE_SIDECAR_PYTHON"))
             .await
@@ -506,7 +459,7 @@ pub async fn start_compute_node(
         None
     };
 
-    let mut bridge_command = match build_bridge_command(&bridge_script, launcher) {
+    let mut bridge_command = match build_bridge_command(&bridge_script, launcher.clone()) {
         Ok(command) => command,
         Err(err) => {
             {
@@ -521,13 +474,24 @@ pub async fn start_compute_node(
         *next_session_id += 1;
         next_session_id.to_string()
     };
+    let import_root =
+        configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
     eprintln!(
-        "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} cancellation_token_reset=true",
+        "desktop.compute_node.session.start operator_session_id={} relay={} resource_root={} layout={} bridge={} interpreter={} import_root={} cancellation_token_reset=true",
         session_id,
         sanitize_relay_target(&request.relay_base_url),
-        bridge_script
+        bridge_resource.resource_root.to_string_lossy(),
+        bridge_resource.resource_layout,
+        bridge_script,
+        launcher
+            .as_ref()
+            .map(PythonLauncher::display)
+            .unwrap_or_else(|| "native-executable".into()),
+        import_root
+            .as_deref()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "unresolved".into())
     );
-    configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
 
@@ -868,13 +832,8 @@ mod tests {
             ..ComputeNodeStatus::default()
         };
 
-        let payload = finalize_bridge_exit(
-            &mut status,
-            success_exit_status(),
-            true,
-            true,
-            "session-1",
-        );
+        let payload =
+            finalize_bridge_exit(&mut status, success_exit_status(), true, true, "session-1");
 
         assert!(payload.is_none());
         assert!(!status.running);

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -14,7 +14,7 @@ use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
@@ -43,87 +43,62 @@ struct BridgeResponse {
     error: Option<String>,
 }
 
-fn find_existing_bridge_script_path() -> Option<PathBuf> {
+fn resolve_model_bridge_resource() -> Result<python_runtime::ResolvedPythonResource, String> {
     let current_exe = std::env::current_exe().ok();
-    let candidates = model_bridge_script_candidates(
+    python_runtime::resolve_python_resource_script(
+        "model_bridge.py",
         current_exe.as_deref(),
-        Path::new(env!("CARGO_MANIFEST_DIR")),
-    );
-    candidates.into_iter().find(|path| path.is_file())
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")),
+        None,
+    )
+    .map_err(|e| e.to_string())
 }
 
-fn model_bridge_script_candidates(exe_path: Option<&Path>, manifest_dir: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-
-    if let Some(current_exe) = exe_path {
-        if let Some(exe_dir) = current_exe.parent() {
-            candidates.push(
-                exe_dir
-                    .join("resources")
-                    .join("python")
-                    .join("model_bridge.py"),
-            );
-            candidates.push(exe_dir.join("python").join("model_bridge.py"));
-            candidates.push(
-                exe_dir
-                    .join("..")
-                    .join("resources")
-                    .join("python")
-                    .join("model_bridge.py"),
-            );
-            candidates.push(
-                exe_dir
-                    .join("..")
-                    .join("Resources")
-                    .join("python")
-                    .join("model_bridge.py"),
-            );
-        }
-    }
-
-    candidates.push(manifest_dir.join("python").join("model_bridge.py"));
-    candidates
+fn model_bridge_script_candidates(
+    exe_path: Option<&std::path::Path>,
+    manifest_dir: &std::path::Path,
+) -> Vec<PathBuf> {
+    python_runtime::python_resource_script_candidates(
+        "model_bridge.py",
+        exe_path,
+        manifest_dir,
+        None,
+    )
+    .into_iter()
+    .map(|candidate| candidate.script_path)
+    .collect()
 }
 
-fn resolve_model_bridge_script_path() -> Result<PathBuf, String> {
-    find_existing_bridge_script_path().ok_or_else(|| {
-        "unable to locate model bridge script relative to executable/resources or development source tree".into()
-    })
-}
-
-fn configure_runtime_pythonpath(command: &mut std::process::Command, bridge_script: &Path) {
-    command.env("PYTHONNOUSERSITE", "1");
-    // NOTE: CARGO_MANIFEST_DIR is compile-time and primarily helps local/dev launches.
-    // Packaged end-user launches rely on python/path_bootstrap.py for runtime import roots.
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    if let Some(import_root) =
-        python_runtime::resolve_runtime_import_root(Some(bridge_script), manifest_dir)
-    {
-        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", &import_root);
-        match std::env::var("PYTHONPATH") {
-            Ok(existing) if !existing.trim().is_empty() => {
-                let mut components = vec![import_root.clone()];
-                components.extend(std::env::split_paths(&existing));
-                if let Ok(joined) = std::env::join_paths(components) {
-                    command.env("PYTHONPATH", joined);
-                } else {
-                    command.env("PYTHONPATH", import_root);
-                }
-            }
-            _ => {
-                command.env("PYTHONPATH", import_root);
-            }
-        }
-    }
+fn configure_runtime_pythonpath(
+    command: &mut std::process::Command,
+    bridge_script: &std::path::Path,
+) -> Option<PathBuf> {
+    python_runtime::configure_python_subprocess_env_blocking(
+        command,
+        bridge_script,
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")),
+    )
 }
 
 fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
-    let bridge_script = resolve_model_bridge_script_path()?;
+    let bridge_resource = resolve_model_bridge_resource()?;
+    let bridge_script = bridge_resource.script_path;
     let mut bridge_command =
         launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
-    configure_runtime_pythonpath(&mut bridge_command, &bridge_script);
+    let import_root = configure_runtime_pythonpath(&mut bridge_command, &bridge_script);
+    eprintln!(
+        "desktop.model_bridge.launch resource_root={} layout={} bridge={} interpreter={} import_root={}",
+        bridge_resource.resource_root.to_string_lossy(),
+        bridge_resource.resource_layout,
+        bridge_script.to_string_lossy(),
+        launcher.display(),
+        import_root
+            .as_deref()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "unresolved".into())
+    );
     let output = bridge_command
         .arg(action)
         .output()
@@ -458,10 +433,10 @@ mod tests {
             "bundle.resources should only include required Python bridge/runtime resources"
         );
 
-
-
         assert!(
-            resources.iter().all(|entry| !entry.as_str().unwrap_or_default().contains("relay.py")),
+            resources
+                .iter()
+                .all(|entry| !entry.as_str().unwrap_or_default().contains("relay.py")),
             "bundle.resources must never include relay.py"
         );
 

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -6,6 +6,173 @@ use crate::backend::ComputeMode;
 pub const ENABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP";
 pub const DISABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonResourceRoot {
+    pub root: PathBuf,
+    pub layout: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPythonResource {
+    pub resource_root: PathBuf,
+    pub resource_layout: &'static str,
+    pub script_path: PathBuf,
+}
+
+fn push_resource_root(
+    candidates: &mut Vec<PythonResourceRoot>,
+    root: PathBuf,
+    layout: &'static str,
+) {
+    if candidates.iter().any(|candidate| candidate.root == root) {
+        return;
+    }
+    candidates.push(PythonResourceRoot { root, layout });
+}
+
+pub fn python_resource_root_candidates(
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+    resource_dir: Option<&Path>,
+) -> Vec<PythonResourceRoot> {
+    let mut candidates = Vec::new();
+
+    if let Some(resource_dir) = resource_dir {
+        push_resource_root(
+            &mut candidates,
+            resource_dir.to_path_buf(),
+            "tauri-resource-dir",
+        );
+    }
+
+    if let Some(exe_path) = exe_path {
+        if let Some(exe_dir) = exe_path.parent() {
+            push_resource_root(
+                &mut candidates,
+                exe_dir.join("resources"),
+                "executable-resources",
+            );
+            push_resource_root(
+                &mut candidates,
+                exe_dir.to_path_buf(),
+                "executable-python-dir",
+            );
+            if let Some(parent_dir) = exe_dir.parent() {
+                push_resource_root(
+                    &mut candidates,
+                    parent_dir.join("_up_").join("resources"),
+                    "windows-updater-resources",
+                );
+                push_resource_root(
+                    &mut candidates,
+                    parent_dir.join("Resources"),
+                    "macos-app-resources",
+                );
+                push_resource_root(
+                    &mut candidates,
+                    parent_dir.join("resources"),
+                    "linux-app-resources",
+                );
+            }
+        }
+    }
+
+    push_resource_root(&mut candidates, manifest_dir.to_path_buf(), "dev-src-tauri");
+    candidates
+}
+
+pub fn python_resource_script_candidates(
+    script_name: &str,
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+    resource_dir: Option<&Path>,
+) -> Vec<ResolvedPythonResource> {
+    python_resource_root_candidates(exe_path, manifest_dir, resource_dir)
+        .into_iter()
+        .map(|candidate| ResolvedPythonResource {
+            script_path: candidate.root.join("python").join(script_name),
+            resource_root: candidate.root,
+            resource_layout: candidate.layout,
+        })
+        .collect()
+}
+
+pub fn resolve_python_resource_script(
+    script_name: &str,
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+    resource_dir: Option<&Path>,
+) -> anyhow::Result<ResolvedPythonResource> {
+    let candidates =
+        python_resource_script_candidates(script_name, exe_path, manifest_dir, resource_dir);
+    candidates
+        .iter()
+        .find(|candidate| candidate.script_path.is_file())
+        .cloned()
+        .ok_or_else(|| {
+            let attempted = candidates
+                .iter()
+                .map(|candidate| {
+                    format!(
+                        "{}:{}",
+                        candidate.resource_layout,
+                        candidate.script_path.to_string_lossy()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            anyhow::anyhow!(
+                "unable to locate bundled Python resource script '{script_name}'; attempted resource roots/scripts: {attempted}"
+            )
+        })
+}
+
+pub fn configure_python_subprocess_env_blocking(
+    command: &mut Command,
+    script_path: &Path,
+    manifest_dir: &Path,
+) -> Option<PathBuf> {
+    command.env("PYTHONNOUSERSITE", "1");
+    let import_root = resolve_runtime_import_root(Some(script_path), manifest_dir);
+    if let Some(import_root) = &import_root {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root);
+        let mut components = Vec::new();
+        if let Some(script_dir) = script_path.parent() {
+            components.push(script_dir.to_path_buf());
+        }
+        components.push(import_root.clone());
+        if let Ok(joined) = std::env::join_paths(components) {
+            command.env("PYTHONPATH", joined);
+        } else {
+            command.env("PYTHONPATH", import_root);
+        }
+    }
+    import_root
+}
+
+pub fn configure_python_subprocess_env_async(
+    command: &mut tokio::process::Command,
+    script_path: &Path,
+    manifest_dir: &Path,
+) -> Option<PathBuf> {
+    command.env("PYTHONNOUSERSITE", "1");
+    let import_root = resolve_runtime_import_root(Some(script_path), manifest_dir);
+    if let Some(import_root) = &import_root {
+        command.env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root);
+        let mut components = Vec::new();
+        if let Some(script_dir) = script_path.parent() {
+            components.push(script_dir.to_path_buf());
+        }
+        components.push(import_root.clone());
+        if let Ok(joined) = std::env::join_paths(components) {
+            command.env("PYTHONPATH", joined);
+        } else {
+            command.env("PYTHONPATH", import_root);
+        }
+    }
+    import_root
+}
+
 #[derive(Debug, Clone)]
 pub struct PythonLauncher {
     pub program: String,
@@ -32,6 +199,12 @@ impl PythonLauncher {
         cmd.args(&self.args);
         cmd.arg(script_path);
         cmd
+    }
+
+    pub fn display(&self) -> String {
+        format!("{} {}", self.program, self.args.join(" "))
+            .trim()
+            .to_string()
     }
 }
 
@@ -187,13 +360,16 @@ pub fn resolve_runtime_import_root(
         }
     }
 
-    candidates.into_iter().find(|candidate| {
-        candidate.join("utils").is_dir() || candidate.join("config.py").is_file()
-    })
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
 }
 
 fn mode_requests_gpu(mode: &ComputeMode) -> bool {
-    matches!(mode, ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid)
+    matches!(
+        mode,
+        ComputeMode::Auto | ComputeMode::Gpu | ComputeMode::Hybrid
+    )
 }
 
 fn should_enable_runtime_bootstrap_for(
@@ -224,12 +400,12 @@ pub fn should_enable_runtime_bootstrap(mode: &ComputeMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
+    use tempfile::TempDir;
 
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
@@ -390,14 +566,84 @@ mod tests {
     #[test]
     fn resolve_runtime_import_root_detects_nested_up_layout() {
         let temp = TempDir::new().expect("tempdir");
-        let script = temp.path().join("resources").join("python").join("model_bridge.py");
-        std::fs::create_dir_all(script.parent().expect("script parent")).expect("create script dir");
+        let script = temp
+            .path()
+            .join("resources")
+            .join("python")
+            .join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create script dir");
         std::fs::write(&script, "#!/usr/bin/env python3\n").expect("write script");
         let import_root = temp.path().join("resources").join("_up_").join("_up_");
         std::fs::create_dir_all(import_root.join("utils")).expect("create utils dir");
 
         let resolved = resolve_runtime_import_root(Some(&script), Path::new("/missing"));
         assert_eq!(resolved.as_deref(), Some(import_root.as_path()));
+    }
+
+    #[test]
+    fn shared_resource_helper_resolves_macos_app_resources() {
+        let temp = TempDir::new().expect("tempdir");
+        let resources = temp
+            .path()
+            .join("Token Place.app")
+            .join("Contents")
+            .join("Resources");
+        let python_dir = resources.join("python");
+        std::fs::create_dir_all(&python_dir).expect("create python dir");
+        std::fs::write(python_dir.join("compute_node_bridge.py"), "print('ok')\n")
+            .expect("write bridge");
+        std::fs::create_dir_all(resources.join("utils")).expect("create utils");
+        let exe_path = temp
+            .path()
+            .join("Token Place.app")
+            .join("Contents")
+            .join("MacOS")
+            .join("token.place");
+
+        let resolved = resolve_python_resource_script(
+            "compute_node_bridge.py",
+            Some(&exe_path),
+            Path::new("/missing/src-tauri"),
+            None,
+        )
+        .expect("resolve macOS resource bridge");
+
+        assert_eq!(resolved.resource_root, resources);
+        assert_eq!(resolved.resource_layout, "macos-app-resources");
+    }
+
+    #[test]
+    fn subprocess_env_ignores_existing_pythonpath_and_disables_user_site() {
+        let temp = TempDir::new().expect("tempdir");
+        let root = temp.path().join("resources");
+        let script = root.join("python").join("model_bridge.py");
+        std::fs::create_dir_all(script.parent().expect("script parent"))
+            .expect("create python dir");
+        std::fs::create_dir_all(root.join("utils")).expect("create utils");
+        let mut command = Command::new("python3");
+
+        let import_root =
+            configure_python_subprocess_env_blocking(&mut command, &script, Path::new("/missing"));
+        assert_eq!(import_root.as_deref(), Some(root.as_path()));
+        let env_value = |key: &str| {
+            command
+                .get_envs()
+                .find_map(|(env_key, value)| (env_key == key).then_some(value))
+                .flatten()
+                .map(|value| value.to_string_lossy().into_owned())
+        };
+        assert_eq!(env_value("PYTHONNOUSERSITE").as_deref(), Some("1"));
+        let pythonpath = env_value("PYTHONPATH").expect("PYTHONPATH set");
+        assert!(pythonpath.contains(
+            &script
+                .parent()
+                .expect("script parent")
+                .to_string_lossy()
+                .to_string()
+        ));
+        assert!(pythonpath.contains(&root.to_string_lossy().to_string()));
+        assert!(!pythonpath.contains("should/not/leak"));
     }
 
     #[test]

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1110,3 +1110,69 @@ def test_macos_missing_metal_runtime_bootstrap_gap_future_parity(monkeypatch):
 
     assert result["selected_backend"] == case["expect_future"]["selected_backend"]
     assert result["runtime_action"] == case["expect_future"]["runtime_action"]
+
+
+def _load_path_bootstrap_module():
+    spec = importlib.util.spec_from_file_location(
+        'path_bootstrap_under_test', PYTHON_MODULE_DIR / 'path_bootstrap.py'
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_path_bootstrap_prefers_site_packages_over_repo_local_llama_shim(monkeypatch, tmp_path):
+    path_bootstrap = _load_path_bootstrap_module()
+    runtime_root = tmp_path / 'runtime'
+    python_dir = runtime_root / 'python'
+    python_dir.mkdir(parents=True)
+    (runtime_root / 'utils').mkdir()
+    (runtime_root / 'llama_cpp.py').write_text('# packaged repo shim\n', encoding='utf-8')
+    fake_site = tmp_path / 'venv' / 'lib' / 'site-packages'
+    fake_site.mkdir(parents=True)
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(runtime_root))
+    original_sys_path = list(sys.path)
+    try:
+        sys.path[:] = [str(fake_site)]
+        path_bootstrap.ensure_runtime_import_paths(str(python_dir / 'model_bridge.py'))
+        assert str(fake_site) in sys.path
+        assert str(runtime_root) in sys.path
+        assert sys.path.index(str(runtime_root)) > sys.path.index(str(fake_site))
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def test_probe_subprocess_env_disables_user_site_and_uses_deterministic_pythonpath(
+    monkeypatch, tmp_path
+):
+    runtime_root = tmp_path / 'runtime'
+    (runtime_root / 'utils').mkdir(parents=True)
+    captured = {}
+
+    def _capture_run(_cmd, **kwargs):
+        captured['env'] = kwargs['env']
+        class Result:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    'backend': 'cpu',
+                    'gpu_offload_supported': False,
+                    'detected_device': 'cpu',
+                    'interpreter': sys.executable,
+                    'prefix': sys.prefix,
+                    'llama_module_path': 'missing',
+                }
+            )
+            stderr = ''
+        return Result()
+
+    monkeypatch.setenv('PYTHONPATH', '/user/site/should/not/leak')
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _capture_run)
+
+    desktop_runtime_setup._probe_llama_runtime(runtime_root=runtime_root)
+
+    env = captured['env']
+    assert env['PYTHONNOUSERSITE'] == '1'
+    assert '/user/site/should/not/leak' not in env['PYTHONPATH']
+    assert str(runtime_root) in env['PYTHONPATH']


### PR DESCRIPTION
### Motivation
- Packaged macOS `.app` launches must resolve the same Python bridge/runtime resources as Windows so bridges (`compute_node_bridge.py`, `model_bridge.py`, `inference_sidecar.py`, `desktop_runtime_setup.py`, `path_bootstrap.py`, etc.), `utils`, and config files come from one coherent resource root and not the dev tree or user-site.
- Python subprocess launches need deterministic import roots (no user-site leakage or repo-local shim shadowing) and clearer diagnostics about which resource root and interpreter were chosen.
- Reduce duplicated path-resolution logic across model-bridge, compute-node bridge, and runtime bootstrap code by centralizing helpers.

### Description
- Added a shared Rust helper API in `desktop-tauri/src-tauri/src/python_runtime.rs` to enumerate resource roots and resolve Python bridge script candidates (supports Tauri resource dir, executable-adjacent python, `_up_` updater layout, macOS `Contents/Resources`, Linux-style resources, and dev `CARGO_MANIFEST_DIR` fallback) and return a `ResolvedPythonResource` with layout metadata.
- Centralized Python subprocess env configuration with `configure_python_subprocess_env_blocking` / `configure_python_subprocess_env_async` to set `PYTHONNOUSERSITE=1`, `TOKEN_PLACE_PYTHON_IMPORT_ROOT`, and a deterministic `PYTHONPATH` so site-packages wins over repo shims.
- Rewired model bridge and compute-node bridge startup to use the shared resolver and environment helpers and emit diagnostic logs including `resource_root`, `resource_layout`, `bridge` path, `interpreter`, and `import_root` when launching bridges (`desktop-tauri/src-tauri/src/main.rs` and `desktop-tauri/src-tauri/src/compute_node.rs`).
- Hardened Python runtime probe/install behavior in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` by disabling user-site imports for probes, making probe `PYTHONPATH` deterministic, and returning the selected `dependency_target` in dependency-install diagnostic responses.
- Tests and e2e scaffolding updated: `desktop-tauri/scripts/test_packaged_operator_e2e.py` validates a unified resource root (including macOS `Contents/Resources`) and that a repo-local `llama_cpp.py` shim does not shadow packaged/site imports; unit tests added/extended for macOS resource resolution and subprocess env behavior.

### Testing
- Ran unit test suite: `pytest tests/unit/test_desktop_runtime_setup.py -q` — result: `57 passed, 1 xfailed`.
- Packaged operator e2e: `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` — exit 0 (inspect-only checks passed), and `python desktop-tauri/scripts/test_packaged_operator_e2e.py` — exit 0 (full packaged e2e probes passed in this environment).
- Pre-commit checks: `pre-commit run --all-files` — all configured checks passed.
- Rust crate tests: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not be completed in this environment due to a missing system dependency (`glib-2.0.pc` / `glib-2.0 >= 2.70` required by a native crate via `pkg-config`); Rust unit tests that do not require system libs were exercised where possible during the change and new Rust unit tests were added for the shared resolver.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cef7581d8832f941527c299fb205b)