### PR TITLE
Document desktop parity validation and add shared parity check script

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -12,6 +12,8 @@ on:
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py'
+      - 'desktop-tauri/scripts/run_desktop_parity_checks.py'
+      - 'docs/desktop_parity_validation.md'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -30,6 +32,8 @@ on:
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py'
+      - 'desktop-tauri/scripts/run_desktop_parity_checks.py'
+      - 'docs/desktop_parity_validation.md'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -128,11 +132,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r config/requirements_codex_verification.txt
 
-      - name: Run packaged operator bridge e2e (Windows)
-        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
-
-      - name: Run desktop relay operator parity e2e (Windows)
-        run: python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
+      - name: Run desktop parity checks (Windows)
+        run: python desktop-tauri/scripts/run_desktop_parity_checks.py
 
       - name: Upload desktop relay parity logs on failure (Windows)
         if: failure()
@@ -209,11 +210,8 @@ jobs:
           TOKEN_PLACE_INSPECT_ONLY: "1"
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
 
-      - name: Run packaged operator bridge e2e (macOS)
-        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
-
-      - name: Run desktop relay operator parity e2e (macOS)
-        run: python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
+      - name: Run desktop parity checks (macOS)
+        run: python desktop-tauri/scripts/run_desktop_parity_checks.py
 
       - name: Run desktop no-relay lifecycle e2e (macOS, required)
         env:

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The `desktop-tauri/` app is the forward-looking desktop path, but it is currentl
 
 See also:
 
+- [`docs/desktop_parity_validation.md`](docs/desktop_parity_validation.md) for the shared Windows/macOS operator parity and release-validation checklist.
 - [`docs/design/tauri_desktop_client.md`](docs/design/tauri_desktop_client.md)
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
@@ -248,6 +249,10 @@ See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay
   contracts after parity and operational readiness gates are complete.
 - **Operator platform targets:** Windows 11 + NVIDIA/CUDA and macOS Apple Silicon + Metal first,
   CPU fallback always supported, Raspberry Pi as a later low-power compute-node target.
+
+For desktop release validation, use the shared Windows/macOS parity checklist in
+[docs/desktop_parity_validation.md](docs/desktop_parity_validation.md) before making production
+claims about desktop relay participation or two-node round-robin behavior.
 
 ## sugarkube deployment
 
@@ -657,7 +662,7 @@ then reinstall `llama-cpp-python` with Metal support:
 
 ```sh
 brew install cmake
-CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --upgrade
+CMAKE_ARGS="-DGGML_METAL=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --upgrade
 ```
 
 #### unix/linux

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -10,17 +10,24 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
 - Lets users either browse to an existing GGUF or download the configured GGUF
   artifact into the shared models directory.
 - Runtime backend preference controls expose `auto`, `metal`, `cuda`, and `cpu` modes.
-- Background compute-node mode that registers and polls via `/sink`, decrypts requests, runs local inference, and posts responses to `/source` (or `/stream/source` when streaming is requested by the relay contract).
+- Background compute-node mode that warm-loads the model runtime, registers to the relay only after readiness, polls for API v1 E2EE work, decrypts locally, runs inference, and submits encrypted responses.
 - Sidecar-driven local prompt smoke-test output with explicit cancellation.
-- Optional debug-only relay forward action for manual `/next_server` + `/faucet` checks.
+- Optional debug-only relay forward action remains disabled for active runtime paths; relay validation must use API v1 E2EE.
 
 ## Compute-node bridge behavior
 
 Desktop includes a Python compute-node bridge
 (`src-tauri/python/compute_node_bridge.py`) that reuses
-`utils.compute_node_runtime` for the legacy relay `/sink` + `/source` flow used by `server.py`.
-The bridge runs as the primary operator path and emits status events (running/registered, active relay URL, backend mode, model path, and last error).
-Root `server.py` remains the canonical compute-node entrypoint; this desktop path must stay parity-aligned on the same legacy relay contract until post-parity API v1 migration work begins.
+`utils.compute_node_runtime` for the active API v1 E2EE relay lifecycle.
+The bridge runs as the primary operator path and emits shared status events
+(running/registered, relay runtime state, active relay URL, backend mode, model
+path, fallback reason, and last error). Root `server.py` remains the canonical
+compute-node entrypoint; desktop behavior must stay parity-aligned with the
+shared API v1 E2EE relay contract.
+
+See [`../docs/desktop_parity_validation.md`](../docs/desktop_parity_validation.md)
+for the evergreen Windows/macOS parity checklist, manual release-validation
+commands, expected UI fields by lifecycle state, and platform runtime guidance.
 
 The fake sidecar remains available at `sidecar/fake_llama_sidecar.py` for CI
 and fast local testing:
@@ -63,11 +70,13 @@ process immediately uses the repaired runtime (no manual restart/environment fla
 
 ### Platform packaging assumptions (documented, not fully automated in MVP)
 
-- **macOS Apple Silicon**: run with a Metal-enabled llama.cpp sidecar build.
-- **Windows 11 + NVIDIA GPU**: run with a CUDA-enabled llama.cpp sidecar build.
+- **macOS Apple Silicon**: run with a Metal-enabled `llama-cpp-python` sidecar build.
+- **Windows 11 + NVIDIA GPU**: run with a CUDA-enabled `llama-cpp-python` sidecar build.
 - CPU fallback mode is available in both cases, with explicit fallback details
   surfaced in `desktop.runtime_setup ... fallback_reason=...` and
   `compute_runtime ... fallback_reason=...`.
+- Windows and macOS share the same operator lifecycle contract; platform-specific
+  code should only adapt runtime install/probe and launcher/resource discovery.
 
 ## Privacy defaults
 
@@ -146,6 +155,12 @@ Both flags are equivalent opt-in toggles and intended for troubleshooting.
 
 
 ### Manual runtime verification
+
+Use the shared parity entry point for local/CI bridge validation:
+
+```bash
+python desktop-tauri/scripts/run_desktop_parity_checks.py
+```
 
 Use the helper below to print authoritative runtime wiring details from the same
 Python environment used by desktop sidecars:

--- a/desktop-tauri/scripts/run_desktop_parity_checks.py
+++ b/desktop-tauri/scripts/run_desktop_parity_checks.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Single entry point for desktop Windows/macOS parity validation.
+
+The default profile runs the dependency-isolated packaged bridge smoke and the
+local API v1 E2EE relay parity harness. Optional flags add platform/hardware
+runtime probes without making CI depend on CUDA/Metal or a real GGUF.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _script(name: str) -> Path:
+    return SCRIPT_DIR / name
+
+
+def _run(label: str, command: list[str], *, env: dict[str, str] | None = None, dry_run: bool = False) -> int:
+    printable = " ".join(command)
+    print(f"\n==> {label}\n{printable}", flush=True)
+    if dry_run:
+        return 0
+    completed = subprocess.run(command, cwd=REPO_ROOT, env=env, check=False)  # noqa: S603
+    return int(completed.returncode)
+
+
+def _append_runtime_checks(args: argparse.Namespace, commands: list[tuple[str, list[str], dict[str, str] | None]]) -> None:
+    if not args.model:
+        return
+    commands.append(
+        (
+            "desktop runtime resolver/probe",
+            [
+                sys.executable,
+                str(_script("verify_desktop_runtime.py")),
+                "--mode",
+                args.mode,
+                "--model",
+                args.model,
+            ],
+            None,
+        )
+    )
+    if args.gpu_smoke and platform.system() == "Windows":
+        commands.append(
+            (
+                "Windows NVIDIA CUDA desktop smoke",
+                [
+                    sys.executable,
+                    str(_script("windows_nvidia_gpu_smoke_test.py")),
+                    "--mode",
+                    args.mode,
+                    "--model",
+                    args.model,
+                ],
+                None,
+            )
+        )
+    elif args.gpu_smoke:
+        print("Skipping Windows NVIDIA GPU smoke because this host is not Windows.", flush=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skip-packaged",
+        action="store_true",
+        help="Skip dependency-isolated packaged bridge smoke.",
+    )
+    parser.add_argument(
+        "--skip-relay-parity",
+        action="store_true",
+        help="Skip local API v1 E2EE relay parity e2e.",
+    )
+    parser.add_argument(
+        "--include-macos-no-relay",
+        action="store_true",
+        help="On macOS, also require the built-app no-relay lifecycle e2e.",
+    )
+    parser.add_argument(
+        "--model",
+        help="Optional GGUF path for runtime probe or hardware smoke checks.",
+    )
+    parser.add_argument(
+        "--mode",
+        default="auto",
+        choices=("auto", "cpu", "gpu", "hybrid", "metal", "cuda"),
+        help="Compute mode for optional runtime checks.",
+    )
+    parser.add_argument(
+        "--gpu-smoke",
+        action="store_true",
+        help="Add platform GPU smoke checks when supported by the local host.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing them.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    commands: list[tuple[str, list[str], dict[str, str] | None]] = []
+    if not args.skip_packaged:
+        commands.append(
+            (
+                "packaged operator bridge e2e",
+                [sys.executable, str(_script("test_packaged_operator_e2e.py"))],
+                None,
+            )
+        )
+    if not args.skip_relay_parity:
+        commands.append(
+            (
+                "local API v1 E2EE relay parity e2e",
+                [sys.executable, str(_script("test_desktop_relay_operator_parity_e2e.py"))],
+                None,
+            )
+        )
+    if args.include_macos_no_relay:
+        if platform.system() == "Darwin":
+            env = os.environ.copy()
+            env["TOKENPLACE_REQUIRE_NO_RELAY_E2E"] = "1"
+            commands.append(
+                (
+                    "macOS no-relay lifecycle e2e",
+                    [sys.executable, str(_script("test_desktop_no_relay_autostart_e2e.py"))],
+                    env,
+                )
+            )
+        else:
+            print("Skipping macOS no-relay lifecycle e2e because this host is not macOS.", flush=True)
+    _append_runtime_checks(args, commands)
+
+    if not commands:
+        print("No desktop parity checks selected.", flush=True)
+        return 0
+
+    failures: list[tuple[str, int]] = []
+    for label, command, env in commands:
+        code = _run(label, command, env=env, dry_run=args.dry_run)
+        if code != 0:
+            failures.append((label, code))
+            break
+    if failures:
+        label, code = failures[0]
+        print(f"\nFAILED: {label} exited with {code}", flush=True)
+        return code
+    print("\nDesktop parity checks completed successfully.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -236,6 +236,8 @@ during tests or `https://token.place/api/v1` in production.
 - `tests/unit/test_path_handling.py` - Quick checks for path utilities on each OS
 - `tests/platform_tests/test_path_handling.py` - Tests path handling across platforms
 - `tests/platform_tests/test_config.py` - Tests configuration loading on different platforms
+- `desktop-tauri/scripts/run_desktop_parity_checks.py` - Shared Windows/macOS desktop operator parity entry point
+- `desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py` - Local mocked API v1 E2EE relay lifecycle parity
 
 **Key Scenarios Tested**:
 - Correct path resolution across Windows, macOS, and Linux
@@ -244,6 +246,11 @@ during tests or `https://token.place/api/v1` in production.
   isolated when they patch runtime settings
 - Platform-specific behavior adaptations
 - Support for XDG environment variables like `XDG_CONFIG_HOME` and `XDG_STATE_HOME`
+- Desktop operator parity across Windows CUDA, macOS Metal, CPU fallback, packaged resource
+  resolution, warm-load before registration, relay registration, multi-turn API v1 E2EE chat,
+  Stop, Start after Stop, and two-node round-robin staging participation. See
+  [Desktop Windows/macOS parity validation](desktop_parity_validation.md) for CI-only,
+  local-only, and staging-only release gates.
 
 ### 5. Security and Failure Recovery
 

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -1,0 +1,261 @@
+# Desktop Windows/macOS parity validation
+
+Desktop operator behavior is a shared contract across Windows and macOS. Treat this page as the
+evergreen development and release checklist for desktop compute-node changes; do not fork it into
+separate platform-specific checklists that drift over time.
+
+## Validation scope labels
+
+| Label | Where it runs | What it proves | Typical command |
+| --- | --- | --- | --- |
+| CI-only | GitHub-hosted runners without CUDA/Metal hardware or real GGUF models | Packaged import/resource resolution, dependency isolation, mocked API v1 E2EE relay lifecycle, Stop, and Start after Stop | `python desktop-tauri/scripts/run_desktop_parity_checks.py` |
+| Local-only | Developer or release hardware with real Windows CUDA or macOS Metal runtime | GPU-capable `llama-cpp-python` install, runtime diagnostics, and CPU fallback interpretation | `python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto --model /path/to/model.gguf` |
+| Staging-only | External relay such as `https://staging.token.place` plus real desktop nodes | Registration visibility, queue depth, multi-node participation, and production-like relay health | `curl -fsS "$STAGING_RELAY/relay/diagnostics"` |
+
+## Shared desktop parity checklist
+
+Every desktop release candidate and any change that touches Python bridge logic, Tauri status/event
+contracts, packaged resources, or relay participation must validate this checklist against both
+Windows and macOS before making two-node or round-robin production claims:
+
+- [ ] **Windows CUDA:** on Windows 11 with an NVIDIA GPU, `auto`, `gpu`, or `hybrid` mode detects a
+  CUDA-capable runtime and reports GPU usage instead of silently falling back to CPU.
+- [ ] **macOS Metal:** on Apple Silicon, `auto`, `gpu`, or `hybrid` mode detects a Metal-capable
+  runtime and reports GPU usage instead of silently falling back to CPU.
+- [ ] **CPU fallback:** explicit `cpu` mode works on both platforms, and any automatic fallback has a
+  clear `fallback_reason` rather than ambiguous `unknown` or `pending` fields after readiness.
+- [ ] **Dependency isolation:** packaged bridge imports resolve from bundled resources or the active
+  sidecar interpreter, never from repo-local shadows such as `llama_cpp.py`.
+- [ ] **Packaged resource resolution:** Windows-style resources and macOS `.app/Contents/Resources`
+  layouts resolve the same bridge/runtime files.
+- [ ] **Warm-load before register:** the model runtime reaches ready state before the operator reports
+  relay registration.
+- [ ] **Relay registration:** `/relay/diagnostics` shows the external compute node and the desktop UI
+  reports `Registered: yes` only when the relay-processing runtime is ready.
+- [ ] **Multi-turn API v1 E2EE chat:** at least three encrypted API v1 turns complete through the
+  relay without plaintext relay-owned state, logs, or diagnostics.
+- [ ] **Stop:** Stop unregisters the compute node and drains the relay diagnostics count back to zero.
+- [ ] **Start after Stop:** starting again after Stop creates a fresh session and can process another
+  encrypted API v1 turn.
+- [ ] **Two-node round-robin participation:** with one Windows node and one macOS node registered to
+  the same staging relay, repeated API v1 encrypted requests select both nodes in registration-order
+  round-robin. Do not change relay round-robin behavior as part of desktop parity work.
+
+## Single script entry point
+
+Use the shared entry point for local and CI desktop parity checks:
+
+```bash
+python desktop-tauri/scripts/run_desktop_parity_checks.py
+```
+
+The default profile runs:
+
+1. `test_packaged_operator_e2e.py` for dependency-isolated packaged bridge resolution.
+2. `test_desktop_relay_operator_parity_e2e.py` for local mocked relay registration, warm-load,
+   multi-turn API v1 E2EE chat, Stop, Start after Stop, and queue-depth drain checks.
+
+Optional local hardware probes:
+
+```bash
+# macOS Apple Silicon or Windows CUDA: inspect the active desktop runtime and diagnostics.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --model /path/to/model.gguf --mode auto
+
+# Windows NVIDIA release hardware: add the CUDA smoke assertion.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --model C:\path\to\model.gguf --mode auto --gpu-smoke
+
+# macOS built-app lifecycle check after building the Tauri binary/app bundle.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --include-macos-no-relay
+```
+
+CI still invokes individual scripts where a workflow needs a narrower matrix leg, but those commands
+must stay equivalent to the shared entry point rather than defining a different platform contract.
+
+## Manual validation commands
+
+### Local relay e2e
+
+Run the self-contained mocked local relay parity harness:
+
+```bash
+python desktop-tauri/scripts/run_desktop_parity_checks.py
+```
+
+For focused debugging, run the underlying relay parity script directly:
+
+```bash
+python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
+```
+
+Expected result: the script exits `0`, log files under `.desktop-e2e-logs/` show API v1 encrypted
+request queue/response events, and `/relay/diagnostics` returns zero registered nodes after Stop.
+
+### Staging relay validation
+
+Use an environment variable so the same commands can target staging, production preview, or a local
+relay without rewriting examples:
+
+```bash
+export STAGING_RELAY=https://staging.token.place
+curl -fsS "$STAGING_RELAY/healthz"
+curl -fsS "$STAGING_RELAY/relay/diagnostics"
+curl -fsS "$STAGING_RELAY/metrics" | head -n 40
+```
+
+With one Windows node and one macOS node registered, confirm both nodes are visible:
+
+```bash
+curl -fsS "$STAGING_RELAY/relay/diagnostics" | python -m json.tool
+```
+
+Expected result: `total_registered_compute_nodes` is `2`, each entry in `registered_compute_nodes`
+has a `queue_depth`, and no diagnostics value contains plaintext prompts, messages, responses, tool
+arguments, or model output.
+
+Confirm API v1 selection reaches both registered nodes without changing relay round-robin behavior:
+
+```bash
+export STAGING_RELAY=https://staging.token.place
+for i in 1 2 3 4; do
+  curl -fsS "$STAGING_RELAY/api/v1/relay/servers/next" | python -c 'import json,sys,hashlib; d=json.load(sys.stdin); k=d.get("server_public_key", ""); print(hashlib.sha256(k.encode()).hexdigest()[:12])'
+done
+```
+
+Expected result: with exactly two API v1-capable desktop nodes registered, the printed fingerprints
+alternate between two values in registration-order round-robin.
+
+### Desktop status checks
+
+From the desktop UI, verify these fields after pressing **Start operator**:
+
+```text
+Running
+Registered
+Relay runtime state
+Runtime path
+Relay runtime path
+Active relay URL
+Requested mode
+Effective mode
+Backend available
+Backend selected
+Backend used
+Fallback reason
+Model path
+Last error
+```
+
+For runtime details from the same Python environment used by sidecars:
+
+```bash
+python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto --model /path/to/model.gguf
+```
+
+### Queue-depth checks
+
+Check staging queue depth without exposing payload content:
+
+```bash
+export STAGING_RELAY=https://staging.token.place
+curl -fsS "$STAGING_RELAY/relay/diagnostics" \
+  | python -c 'import json,sys; d=json.load(sys.stdin); print([(i, n.get("queue_depth")) for i,n in enumerate(d.get("registered_compute_nodes", []), 1)])'
+```
+
+During idle/after Stop, expected queue depths are `0`. During processing, a node may briefly show a
+positive queue depth, but it must return to `0` after the client retrieves the encrypted response.
+
+### Stop/Start checks
+
+Use the desktop UI for manual release validation:
+
+1. Start the operator on Windows and macOS.
+2. Confirm both nodes appear in relay diagnostics.
+3. Send at least three encrypted API v1 chat turns through the staging relay.
+4. Press **Stop operator** on one node.
+5. Confirm diagnostics decrement and that node's UI reports stopped state.
+6. Press **Start operator** on the same node.
+7. Confirm diagnostics increment again and another encrypted API v1 turn completes.
+
+Copy-paste diagnostics around each step:
+
+```bash
+export STAGING_RELAY=https://staging.token.place
+watch -n 2 'curl -fsS "$STAGING_RELAY/relay/diagnostics" | python -m json.tool'
+```
+
+If `watch` is unavailable, rerun this portable command manually:
+
+```bash
+curl -fsS "$STAGING_RELAY/relay/diagnostics" | python -m json.tool
+```
+
+## Expected UI fields by lifecycle state
+
+| Lifecycle state | Running | Registered | Relay runtime state | Backend fields | Fallback reason | Last error | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| idle | `no` | `no` | `idle` or blank before first status load | `pending`, blank, or saved defaults | `none` | `none` | No bridge process is running. |
+| warming | `yes` | `no` | `starting` then `warming` | `pending` until runtime readiness | `none` | `none` unless warm-load fails | Registration must not be reported yet. |
+| ready/registering | `yes` | `no` until relay accepts registration | `ready` | concrete values such as `cuda`, `metal`, or `cpu` | `none` or explicit fallback detail | `none` | Runtime is warm and relay registration may start. |
+| registered/polling | `yes` | `yes` | `ready` | concrete values | `none` or explicit fallback detail | `none` | Node is eligible for API v1 E2EE relay work. |
+| processing | `yes` | `yes` | `processing` or `ready` between polls | concrete values | unchanged from ready state | `none` unless request handling fails | Queue depth may be briefly positive. |
+| stopped | `no` | `no` | `stopped` | last concrete values may remain visible | unchanged from last run | `none` for graceful Stop | Relay diagnostics should no longer list the node. |
+| failed | `no` | `no` | `failed` | `pending` or last known values | required when fallback caused failure | error message required | GPU-only failure should fail closed rather than silently use CPU. |
+
+## Runtime guidance
+
+### Windows CUDA prerequisites
+
+- Windows 11 or compatible Windows host with an NVIDIA GPU and current NVIDIA driver.
+- Visual Studio Build Tools with C++ core features, C++ CMake tools, and a Windows SDK.
+- CUDA Toolkit installed and visible to the build environment.
+- A CUDA-enabled `llama-cpp-python` build for the interpreter that launches the desktop sidecar:
+
+```powershell
+$env:CMAKE_ARGS = "-DGGML_CUDA=on"
+$env:FORCE_CMAKE = "1"
+python -m pip install llama-cpp-python --force-reinstall --no-cache-dir --verbose
+```
+
+### macOS Metal prerequisites
+
+- Apple Silicon macOS host.
+- Xcode Command Line Tools and CMake.
+- A Metal-enabled `llama-cpp-python` build for the interpreter that launches the desktop sidecar:
+
+```bash
+xcode-select --install  # if command line tools are not installed yet
+brew install cmake
+CMAKE_ARGS="-DGGML_METAL=on" FORCE_CMAKE=1 python -m pip install llama-cpp-python --force-reinstall --no-cache-dir --verbose
+```
+
+### Diagnostic field meanings
+
+- `backend_available`: what the runtime probe found on this host before model initialization, such
+  as `cuda`, `metal`, or `cpu`.
+- `backend_selected`: what desktop chose from the requested mode and available backend. For example,
+  `auto` on Apple Silicon should select `metal` when Metal is available.
+- `backend_used`: what `llama-cpp-python` actually used after `Llama(...)` initialization. This is
+  the authoritative release-readiness field for GPU usage.
+- `fallback_reason`: why selected/used backend fell back or failed. `none` is expected only when the
+  requested backend is available and used, or when explicit CPU mode was requested.
+
+Interpretation rules:
+
+- `backend_selected=metal` or `cuda` with `backend_used=cpu` is a fallback. It is acceptable only in
+  CPU fallback validation and must include a useful `fallback_reason`.
+- `gpu` mode on Windows/macOS should fail closed if the GPU runtime is unavailable; do not report
+  production GPU readiness from CPU fallback results.
+- `pending` values are valid only before relay runtime readiness. They are not acceptable for a
+  registered/polling release sign-off state.
+
+## Do not fork platform behavior
+
+- Implement shared Python bridge behavior first. Windows and macOS should call the same bridge
+  lifecycle, warm-load, registration, API v1 E2EE, Stop, and Start-after-Stop code paths.
+- Keep the Rust/Tauri status and event contract shared. UI fields should mean the same thing on both
+  platforms.
+- Limit platform adapters to runtime installation/probe differences, packaged path discovery, and
+  OS-specific launcher mechanics.
+- Do not add Windows-only or macOS-only relay lifecycle semantics. If a platform needs special
+  handling, express it as a small adapter feeding the shared contract.
+- Do not route around API v1 E2EE or revive deprecated legacy relay endpoints for parity shortcuts.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -375,7 +375,9 @@ Warning:
 
 ### Required external compute node validation checklist (sign-off gate)
 
-Run this in staging before production promotion:
+Run this in staging before production promotion. For desktop-backed claims, use the shared
+Windows/macOS checklist in [desktop_parity_validation.md](desktop_parity_validation.md) rather than
+separate platform notes that can drift.
 
 1. External compute node registers successfully to relay.
 2. Relay `/healthz` `knownServers` increments from `0` to `>=1`.
@@ -383,13 +385,19 @@ Run this in staging before production promotion:
 4. Client encrypted request is accepted/queued by relay.
 5. Compute node receives and processes the queued request.
 6. Client retrieves encrypted response successfully.
+7. Before making two-node/round-robin production claims, register one Windows CUDA desktop node and
+   one macOS Metal desktop node to staging and verify both participate in API v1 E2EE request
+   selection without changing relay round-robin behavior.
 
 Example checks:
 
 ```bash
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/relay/diagnostics
-curl -fsS https://staging.token.place/metrics | head -n 40
+STAGING_RELAY=https://staging.token.place
+curl -fsS "$STAGING_RELAY/healthz"
+curl -fsS "$STAGING_RELAY/relay/diagnostics"
+curl -fsS "$STAGING_RELAY/metrics" | head -n 40
+curl -fsS "$STAGING_RELAY/relay/diagnostics" \
+  | python -c 'import json,sys; d=json.load(sys.stdin); print([(i, n.get("queue_depth")) for i,n in enumerate(d.get("registered_compute_nodes", []), 1)])'
 ```
 
 ### Image tag, chart version, and Git tag must be validated independently


### PR DESCRIPTION
### Motivation
- Make Windows/macOS desktop operator parity an evergreen development and release requirement so platform behavior does not drift. 
- Provide one shared checklist and a single entrypoint so CI, local, and staging validation commands remain consistent across platforms. 
- Surface platform runtime guidance (Windows CUDA / macOS Metal), status-field meanings, and a do-not-fork platform-behavior guardrail for future changes.

### Description
- Add `docs/desktop_parity_validation.md` containing the shared parity checklist, manual validation commands (local, staging), expected UI fields by lifecycle state, runtime guidance, and “do not fork platform behavior” rules. 
- Add `desktop-tauri/scripts/run_desktop_parity_checks.py` as a single entry point that runs the packaged bridge smoke and the local API v1 E2EE relay parity e2e, with optional runtime/GPU and macOS no-relay probes. 
- Update desktop docs and onboarding: link the parity guide from `README.md`, update `desktop-tauri/README.md`, add parity references to `docs/TESTING.md`, and add staging guidance to `docs/relay_sugarkube_onboarding.md`. 
- Wire CI to the new entrypoint by calling the parity script in `.github/workflows/desktop-operator-e2e.yml` for Windows and macOS legs, and fix the macOS Metal build flag to use current `GGML_METAL` convention.

### Testing
- `python -m py_compile desktop-tauri/scripts/run_desktop_parity_checks.py` — succeeded. 
- `python desktop-tauri/scripts/run_desktop_parity_checks.py --dry-run` — succeeded (prints planned commands without executing). 
- `python desktop-tauri/scripts/run_desktop_parity_checks.py` — executed the packaged import smoke and local API v1 E2EE parity harness and exited `0` in this environment (CI-friendly mocked/local flow); logs written under `.desktop-e2e-logs/`. 
- `pre-commit run --all-files` — completed and passed in this branch. 
- `git diff --check` — no whitespace or formatting errors found. 

Notes: GPU hardware-accelerated checks (Windows CUDA / macOS Metal) and two-node staging validations are marked as local-only or staging-only in the docs and were not executed here due to environment hardware/placement limits; those are expected to be run on release hardware or against staging relays as described in `docs/desktop_parity_validation.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e65aae934832f9e8cf1cca1be63b3)