### PR TITLE
Document desktop parity validation and add shared desktop parity check entry point

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -12,6 +12,7 @@ on:
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py'
+      - 'desktop-tauri/scripts/run_desktop_parity_checks.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -30,6 +31,7 @@ on:
       - 'desktop-tauri/scripts/test_desktop_operator_ui_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py'
       - 'desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py'
+      - 'desktop-tauri/scripts/run_desktop_parity_checks.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -128,11 +130,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r config/requirements_codex_verification.txt
 
-      - name: Run packaged operator bridge e2e (Windows)
-        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
-
-      - name: Run desktop relay operator parity e2e (Windows)
-        run: python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
+      - name: Run shared desktop parity checks (Windows)
+        run: python desktop-tauri/scripts/run_desktop_parity_checks.py --profile ci-windows
 
       - name: Upload desktop relay parity logs on failure (Windows)
         if: failure()
@@ -209,16 +208,8 @@ jobs:
           TOKEN_PLACE_INSPECT_ONLY: "1"
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
 
-      - name: Run packaged operator bridge e2e (macOS)
-        run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
-
-      - name: Run desktop relay operator parity e2e (macOS)
-        run: python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
-
-      - name: Run desktop no-relay lifecycle e2e (macOS, required)
-        env:
-          TOKENPLACE_REQUIRE_NO_RELAY_E2E: "1"
-        run: python desktop-tauri/scripts/test_desktop_no_relay_autostart_e2e.py
+      - name: Run shared desktop parity checks (macOS)
+        run: python desktop-tauri/scripts/run_desktop_parity_checks.py --profile ci-macos
 
       - name: Upload desktop e2e logs on failure (macOS)
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test format docker-build k8s-deploy
+.PHONY: lint test format docker-build k8s-deploy desktop-parity-check
 
 lint:
 	pre-commit run --all-files
@@ -14,3 +14,7 @@ docker-build:
 
 k8s-deploy:
 	kubectl apply -f k8s/
+
+
+desktop-parity-check:
+	python desktop-tauri/scripts/run_desktop_parity_checks.py --profile local-cpu

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ up correctly.
 
 ### hardware acceleration
 
-If you want to also utilize your GPU (instead of just your CPU), follow these platform-specific instructions.
+If you want to also utilize your GPU (instead of just your CPU), follow these platform-specific instructions. Desktop release validation treats Windows CUDA, macOS Metal, CPU fallback, and shared operator lifecycle parity as a single checklist; see [Desktop parity validation checklist](docs/desktop_parity_validation.md) before making desktop runtime or release claims.
 
 #### windows
 
@@ -657,7 +657,7 @@ then reinstall `llama-cpp-python` with Metal support:
 
 ```sh
 brew install cmake
-CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --upgrade
+CMAKE_ARGS="-DGGML_METAL=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --upgrade
 ```
 
 #### unix/linux

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -10,17 +10,16 @@ This folder contains the forward-looking Tauri desktop MVP for token.place.
 - Lets users either browse to an existing GGUF or download the configured GGUF
   artifact into the shared models directory.
 - Runtime backend preference controls expose `auto`, `metal`, `cuda`, and `cpu` modes.
-- Background compute-node mode that registers and polls via `/sink`, decrypts requests, runs local inference, and posts responses to `/source` (or `/stream/source` when streaming is requested by the relay contract).
+- Background compute-node mode that warm-loads locally, registers through API v1 E2EE relay compute-node routes, polls for ciphertext work, runs local inference, and submits encrypted responses.
 - Sidecar-driven local prompt smoke-test output with explicit cancellation.
-- Optional debug-only relay forward action for manual `/next_server` + `/faucet` checks.
+- Optional debug-only relay forward action remains disabled for production; active relay behavior is API v1 E2EE only.
 
 ## Compute-node bridge behavior
 
 Desktop includes a Python compute-node bridge
-(`src-tauri/python/compute_node_bridge.py`) that reuses
-`utils.compute_node_runtime` for the legacy relay `/sink` + `/source` flow used by `server.py`.
-The bridge runs as the primary operator path and emits status events (running/registered, active relay URL, backend mode, model path, and last error).
-Root `server.py` remains the canonical compute-node entrypoint; this desktop path must stay parity-aligned on the same legacy relay contract until post-parity API v1 migration work begins.
+(`src-tauri/python/compute_node_bridge.py`) that reuses shared runtime logic while driving the active API v1 E2EE relay operator lifecycle.
+The bridge runs as the primary operator path and emits the shared status/event contract: running/registered state, active relay URL, runtime path, backend availability/selection/usage, fallback reason, model path, relay runtime state, session sequence, and last error.
+Root `server.py` remains the canonical compute-node entrypoint; desktop behavior should stay parity-aligned with shared Python bridge/runtime code rather than forking Windows and macOS lifecycles.
 
 The fake sidecar remains available at `sidecar/fake_llama_sidecar.py` for CI
 and fast local testing:
@@ -61,13 +60,14 @@ source-build recipe:
 After a successful repair, the sidecar automatically re-execs once so the active
 process immediately uses the repaired runtime (no manual restart/environment flag required).
 
-### Platform packaging assumptions (documented, not fully automated in MVP)
+### Platform runtime and parity assumptions
 
-- **macOS Apple Silicon**: run with a Metal-enabled llama.cpp sidecar build.
-- **Windows 11 + NVIDIA GPU**: run with a CUDA-enabled llama.cpp sidecar build.
+- **macOS Apple Silicon/supported Metal Macs**: run with a Metal-enabled llama.cpp sidecar build for GPU release claims.
+- **Windows 10/11 + NVIDIA GPU**: run with a CUDA-enabled llama.cpp sidecar build for GPU release claims.
 - CPU fallback mode is available in both cases, with explicit fallback details
   surfaced in `desktop.runtime_setup ... fallback_reason=...` and
   `compute_runtime ... fallback_reason=...`.
+- Windows/macOS releases use one shared parity checklist for dependency isolation, packaged resource resolution, warm-load before register, relay registration, multi-turn API v1 E2EE chat, Stop, Start after Stop, and two-node round-robin participation: see [Desktop parity validation checklist](../docs/desktop_parity_validation.md).
 
 ## Privacy defaults
 
@@ -169,6 +169,17 @@ It prints:
   (`requested`, `effective`, `backend_available`, `backend_used`,
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,
   `fallback_reason`, `interpreter`, `llama_module_path`)
+
+### Shared desktop parity validation
+
+Use the shared wrapper for packaged bridge and API v1 relay parity checks:
+
+```bash
+python desktop-tauri/scripts/run_desktop_parity_checks.py --profile local-cpu
+make desktop-parity-check
+```
+
+CI uses the same wrapper with `--profile ci-windows` and `--profile ci-macos`. Hardware CUDA/Metal checks and staging two-node round-robin sign-off remain local/staging validation, not generic CI proof; see [Desktop parity validation checklist](../docs/desktop_parity_validation.md).
 
 ### Regression and smoke tests
 

--- a/desktop-tauri/scripts/run_desktop_parity_checks.py
+++ b/desktop-tauri/scripts/run_desktop_parity_checks.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run the shared desktop operator parity validation suite.
+
+This wrapper is intentionally thin: it groups the existing focused validation
+scripts behind one evergreen entry point so CI and release docs do not grow
+separate Windows/macOS checklists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _run(script_name: str, *, env: dict[str, str] | None = None) -> None:
+    command = [sys.executable, str(SCRIPT_DIR / script_name)]
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    print(f"desktop parity check: running {' '.join(command)}", flush=True)
+    subprocess.run(command, cwd=REPO_ROOT, env=merged_env, check=True)
+
+
+def _scripts_for_profile(profile: str) -> Iterable[tuple[str, dict[str, str] | None]]:
+    if profile == "inspect-only":
+        yield "test_packaged_operator_e2e.py", {"TOKEN_PLACE_INSPECT_ONLY": "1"}
+        return
+
+    yield "test_packaged_operator_e2e.py", None
+    yield "test_desktop_relay_operator_parity_e2e.py", None
+
+    if profile in {"ci-macos", "local-macos"}:
+        yield "test_desktop_no_relay_autostart_e2e.py", {
+            "TOKENPLACE_REQUIRE_NO_RELAY_E2E": "1"
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=(
+            "ci-windows",
+            "ci-macos",
+            "local-windows",
+            "local-macos",
+            "local-cpu",
+            "inspect-only",
+        ),
+        default="local-cpu",
+        help=(
+            "Validation profile. Windows/macOS profiles share packaged-resource and API v1 relay parity checks; "
+            "macOS profiles also require the no-relay lifecycle e2e. Hardware CUDA/Metal smoke checks remain manual "
+            "because CI runners do not provide release-class GPUs."
+        ),
+    )
+    args = parser.parse_args()
+
+    for script_name, env in _scripts_for_profile(args.profile):
+        _run(script_name, env=env)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -56,6 +56,17 @@ E2E tests validate complete user workflows:
 python -m pytest tests/test_e2e_*.py
 ```
 
+### Desktop Operator Parity Tests
+
+Desktop operator parity tests validate the shared Windows/macOS lifecycle contract: dependency isolation, packaged resource resolution, warm-load before register, API v1 E2EE relay registration, multi-turn relay chat, Stop, Start after Stop, and CPU fallback diagnostics. The shared entry point keeps local and CI commands aligned:
+
+```sh
+python desktop-tauri/scripts/run_desktop_parity_checks.py --profile local-cpu
+make desktop-parity-check
+```
+
+CI uses `--profile ci-windows` and `--profile ci-macos` in `.github/workflows/desktop-operator-e2e.yml`. Hardware CUDA/Metal validation and staging two-node round-robin sign-off are local/staging-only checks because generic CI runners do not provide release-class GPUs or a real external relay fleet. See [Desktop parity validation checklist](desktop_parity_validation.md) for the full checklist, lifecycle UI field table, and copy-paste staging/status commands.
+
 ### Visual Verification Tests
 
 **Pytest marker**: `visual`

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -1,0 +1,219 @@
+# Desktop parity validation checklist
+
+Desktop operator parity is an evergreen release requirement for token.place. A
+Windows desktop operator and a macOS desktop operator must expose the same user
+lifecycle, relay lifecycle, status fields, and relay-blind API v1 E2EE behavior.
+Platform-specific code is allowed only where the runtime must be installed or
+probed differently.
+
+## Parity contract
+
+For every desktop release candidate and every desktop runtime/bridge change,
+validate the same checklist on Windows and macOS before claiming two-node or
+round-robin production readiness.
+
+| Area | Windows expectation | macOS expectation | Required evidence |
+| --- | --- | --- | --- |
+| GPU runtime | CUDA-capable `llama-cpp-python` build on NVIDIA machines. | Metal-capable `llama-cpp-python` build on Apple Silicon and supported Intel Macs. | Runtime diagnostics show GPU backend availability and usage for GPU/hybrid modes. |
+| CPU fallback | CPU mode works without CUDA and reports why GPU was not used. | CPU mode works without Metal and reports why GPU was not used. | `fallback_reason` is explicit when requested GPU/hybrid mode cannot use GPU. |
+| Dependency isolation | Packaged bridge imports from packaged resources/site packages, not repo-local shims. | Packaged `.app` imports from packaged resources/site packages, not repo-local shims. | Packaged inspect smoke passes and `llama_module_path` is not `./llama_cpp.py`. |
+| Packaged resource resolution | The packaged layout resolves the same Python bridge/runtime files as development. | The `.app` resource layout resolves the same Python bridge/runtime files as development. | Packaged operator bridge e2e passes. |
+| Warm-load before register | Model/runtime warm-load completes before relay registration. | Model/runtime warm-load completes before relay registration. | Logs include `desktop.compute_node_bridge.model_init.ready reason=pre_registration` before register. |
+| Relay registration | Operator registers through API v1 E2EE compute-node routes. | Operator registers through API v1 E2EE compute-node routes. | `/relay/diagnostics` lists the node using safe routing metadata only. |
+| Multi-turn relay chat | Multiple API v1 E2EE chat turns complete without plaintext relay state/logs. | Multiple API v1 E2EE chat turns complete without plaintext relay state/logs. | Local or staging API v1 relay parity e2e completes two or more turns. |
+| Stop | Stop terminates polling/processing and clears registered UI state. | Stop terminates polling/processing and clears registered UI state. | UI shows `Running: no`, `Registered: no`, and stopped state. |
+| Start after Stop | A fresh Start creates a new session and can register again. | A fresh Start creates a new session and can register again. | Start/Stop/Start e2e or manual UI validation passes. |
+| Two-node round-robin | A Windows node can participate with a second node without starving it. | A macOS node can participate with a second node without starving it. | Staging diagnostics/metrics show both nodes receive work over repeated encrypted requests. |
+
+## Do not fork platform behavior
+
+- Put shared operator behavior in the Python bridge/runtime path first. Windows
+  and macOS should not have separate relay lifecycles, prompt handling,
+  registration timing, Stop behavior, or Start-after-Stop behavior.
+- Keep the Rust status/event contract shared. UI fields should be populated from
+  the same status event keys on every platform.
+- Use platform adapters only for runtime install/probe differences, such as
+  CUDA repair/build steps on Windows or Metal build/probe steps on macOS.
+- API v1 relay traffic remains non-streaming and relay-blind E2EE. Relay-owned
+  state, logs, diagnostics, and metrics may contain ciphertext plus safe routing
+  metadata only; plaintext prompts, responses, tool arguments, or model output
+  must fail closed instead of being queued or logged.
+
+## Validation tiers
+
+| Tier | Scope | Commands | Notes |
+| --- | --- | --- | --- |
+| CI-only | Linux UI smoke, Windows packaged/API v1 parity, macOS packaged/API v1 parity, macOS no-relay lifecycle. | GitHub Actions workflow `Desktop operator app e2e`. | CI runners do not prove release-class CUDA or Metal acceleration. |
+| Local-only | Hardware runtime checks, app UI lifecycle, CPU fallback on developer machines. | `verify_desktop_runtime.py`, GPU smoke scripts, `npm run tauri dev`. | Run on the actual release hardware class whenever GPU claims change. |
+| Staging-only | External relay registration, queue depth, multi-turn encrypted chat, and two-node round-robin. | `curl`/Python probes against `https://staging.token.place`. | Requires staging relay access and at least one real external desktop compute node. |
+
+## Shared script entry point
+
+Use one entry point for packaged bridge and API v1 relay parity checks so the
+Windows/macOS checklist stays aligned:
+
+```sh
+# Cross-platform CPU/local relay parity smoke.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --profile local-cpu
+
+# Same command via Makefile.
+make desktop-parity-check
+
+# CI-equivalent Windows packaged/API v1 relay parity.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --profile ci-windows
+
+# CI-equivalent macOS packaged/API v1 relay parity plus no-relay lifecycle.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --profile ci-macos
+```
+
+The wrapper intentionally delegates to existing focused scripts; it does not
+replace hardware validation or staging validation.
+
+## Copy-paste manual validation commands
+
+### Local relay e2e
+
+```sh
+# Install focused verification dependencies when needed.
+python -m pip install -r config/requirements_codex_verification.txt
+
+# Run the shared packaged-resource + local API v1 relay parity checks.
+python desktop-tauri/scripts/run_desktop_parity_checks.py --profile local-cpu
+```
+
+### Desktop runtime status checks
+
+```sh
+# CPU fallback/status check; should be valid on Windows and macOS.
+python desktop-tauri/scripts/verify_desktop_runtime.py --mode cpu --model /path/to/model.gguf
+
+# Windows CUDA status check on a Windows NVIDIA release-validation host.
+python desktop-tauri/scripts/verify_desktop_runtime.py --mode gpu --model C:\path\to\model.gguf
+python desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py --mode auto --model C:\path\to\model.gguf
+
+# macOS Metal status check on a macOS release-validation host.
+python desktop-tauri/scripts/verify_desktop_runtime.py --mode gpu --model /path/to/model.gguf
+```
+
+### Desktop UI Stop/Start checks
+
+```sh
+cd desktop-tauri
+npm ci
+npm run tauri dev
+```
+
+Then use the UI to select a GGUF, set the relay URL, click **Start operator**,
+wait for warm-load/registration, click **Stop operator**, and click **Start
+operator** again. The expected fields by lifecycle state are in the table below.
+
+### Staging relay validation
+
+```sh
+export TOKENPLACE_STAGING_RELAY=https://staging.token.place
+
+curl -fsS "$TOKENPLACE_STAGING_RELAY/healthz"
+curl -fsS "$TOKENPLACE_STAGING_RELAY/livez"
+curl -fsS "$TOKENPLACE_STAGING_RELAY/relay/diagnostics"
+curl -fsS "$TOKENPLACE_STAGING_RELAY/metrics" | head -n 80
+```
+
+After starting the desktop operator against the staging relay, repeat the
+safe-metadata checks:
+
+```sh
+curl -fsS "$TOKENPLACE_STAGING_RELAY/relay/diagnostics" | python -m json.tool
+curl -fsS "$TOKENPLACE_STAGING_RELAY/metrics" | grep -E 'queue|registered|poll|request|response|round|server' | head -n 80
+```
+
+### Queue-depth checks
+
+```sh
+# Local relay queue/registration safe-metadata check.
+curl -fsS http://127.0.0.1:5010/relay/diagnostics | python -m json.tool
+curl -fsS http://127.0.0.1:5010/metrics | grep -E 'queue|registered|poll|request|response|round|server' | head -n 80
+
+# Staging relay queue/registration safe-metadata check.
+curl -fsS "$TOKENPLACE_STAGING_RELAY/relay/diagnostics" | python -m json.tool
+curl -fsS "$TOKENPLACE_STAGING_RELAY/metrics" | grep -E 'queue|registered|poll|request|response|round|server' | head -n 80
+```
+
+### Stop/Start relay checks
+
+```sh
+# 1. With the desktop operator running, confirm the node appears in diagnostics.
+curl -fsS "$TOKENPLACE_STAGING_RELAY/relay/diagnostics" | python -m json.tool
+
+# 2. Click Stop operator in the desktop UI, then confirm the node no longer polls/accepts work.
+curl -fsS "$TOKENPLACE_STAGING_RELAY/relay/diagnostics" | python -m json.tool
+
+# 3. Click Start operator again, then confirm a fresh registration/session appears.
+curl -fsS "$TOKENPLACE_STAGING_RELAY/relay/diagnostics" | python -m json.tool
+```
+
+## Expected desktop UI fields by lifecycle state
+
+| Lifecycle state | Running | Registered | Relay runtime state | Runtime/relay runtime path | Backend fields | Fallback reason | Last error | Primary operator action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| idle | `no` | `no` | `idle` | `pending` until loaded | Requested mode may show config; selected/used pending | `none` | `none` | **Start operator** enabled when model path is set. |
+| warming | `yes` or starting transition | `no` | `starting` or `warming` | Runtime path should become `bridge`; relay runtime path should become `bridge` when API v1 warm-load is active. | `backend_available`/`backend_selected` may still be pending until probe/init completes. | `none` unless a GPU request already fell back. | `none` | **Stop operator** enabled once process is running. |
+| ready/registering | `yes` | `no` until relay accepts registration | `ready` or `registering` | Both paths should be populated. | Available and selected backend should be populated; used backend may still be pending until model init reports. | Explicit when selected backend differs from requested mode. | `none` | Wait for registration; do not show registered `yes` during warm-load. |
+| registered/polling | `yes` | `yes` | `registered` or `polling` | Populated. | `backend_available`, `backend_selected`, and `backend_used` populated. | `none` for expected GPU/CPU usage; explicit for fallback. | `none` | **Stop operator** available. |
+| processing | `yes` | `yes` | `processing` | Populated. | Backend fields remain stable for the active session. | Unchanged unless runtime reports a fallback. | `none` unless the request fails. | Stop should cancel/terminate cleanly without exposing plaintext relay state. |
+| stopped | `no` | `no` | `stopped` | Last known paths may remain visible for diagnostics. | Last known backend fields may remain visible. | Last known fallback may remain visible. | `none` for normal Stop. | **Start operator** enabled and must create a fresh session. |
+| failed | `no` | `no` | `failed` | Last known or `pending`. | Last known or `pending`. | Include fallback only if relevant to failure. | Error message populated, redacted, and metadata-only. | **Start operator** re-enabled after failure cleanup. |
+
+## Runtime backend guidance
+
+### Windows CUDA prerequisites
+
+- Windows 10/11 with an NVIDIA GPU and current NVIDIA drivers.
+- Visual Studio C++ build tools, CMake tools for Windows, C++ core features, and
+  a Windows SDK.
+- CUDA Toolkit installed and visible to the build environment.
+- Rebuild the active desktop sidecar interpreter with CUDA support:
+
+```powershell
+$env:CMAKE_ARGS = "-DGGML_CUDA=on"
+$env:FORCE_CMAKE = "1"
+python -m pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose
+```
+
+### macOS Metal prerequisites
+
+- macOS host with Apple Silicon or a supported Metal-capable Mac.
+- Xcode Command Line Tools and CMake available.
+- Rebuild the active desktop sidecar interpreter with Metal support:
+
+```sh
+xcode-select --install  # if command line tools are not already installed
+brew install cmake
+CMAKE_ARGS="-DGGML_METAL=on" FORCE_CMAKE=1 python -m pip install llama-cpp-python --force-reinstall --upgrade --no-cache-dir --verbose
+```
+
+### Interpreting backend fields
+
+- `backend_available` is what the platform/runtime probe believes is available
+  before or during model initialization (`cuda`, `metal`, or `cpu`).
+- `backend_selected` is what desktop chose after applying the requested mode
+  (`auto`, `gpu`, `hybrid`, or `cpu`) and any platform/runtime constraints.
+- `backend_used` is what the model runtime actually used after initialization;
+  this is the authoritative field for release hardware claims.
+- `fallback_reason` explains why the selected or used backend is less capable
+  than requested. Empty/`none` means no fallback was needed; a populated value is
+  expected for CPU fallback tests and a release blocker for GPU-required claims
+  unless the reason is intentionally documented.
+
+## Two-node round-robin sign-off
+
+Before publishing production claims that two desktop operators can participate
+in round-robin work distribution:
+
+1. Register one Windows CUDA-capable operator and one macOS Metal-capable
+   operator, or explicitly document any CPU fallback node used for the test.
+2. Confirm both nodes appear in `/relay/diagnostics` with safe routing metadata.
+3. Send repeated API v1 E2EE chat requests against the relay.
+4. Confirm diagnostics/metrics show both registered nodes polling and receiving
+   work over the sample window.
+5. Confirm relay logs and diagnostics never contain plaintext prompts or model
+   outputs.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -375,7 +375,7 @@ Warning:
 
 ### Required external compute node validation checklist (sign-off gate)
 
-Run this in staging before production promotion:
+Run this in staging before production promotion. When the external node is the desktop operator, also run the shared [desktop parity validation checklist](desktop_parity_validation.md) so Windows/macOS behavior, hardware fallback, Stop/Start lifecycle, and two-node round-robin evidence do not drift.
 
 1. External compute node registers successfully to relay.
 2. Relay `/healthz` `knownServers` increments from `0` to `>=1`.
@@ -391,6 +391,8 @@ curl -fsS https://staging.token.place/healthz
 curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/metrics | head -n 40
 ```
+
+Desktop-specific staging checks should include safe queue-depth and Stop/Start checks from [desktop_parity_validation.md](desktop_parity_validation.md). Treat health probes as necessary but insufficient: production round-robin claims require evidence that two registered nodes both poll and receive encrypted work over the validation window.
 
 ### Image tag, chart version, and Git tag must be validated independently
 


### PR DESCRIPTION
### Motivation
- Make Windows/macOS desktop operator parity an evergreen release requirement so future desktop/runtime work cannot drift into separate platform-specific checklists. 
- Provide a single, copy-paste validation checklist and a lightweight wrapper that groups existing focused packaged/operator parity tests so CI, local, and staging flows stay aligned. 

### Description
- Add `docs/desktop_parity_validation.md` with the parity contract, lifecycle UI field table, manual copy-paste validation commands (local, staging), platform runtime guidance, validation tiers, and two-node round-robin sign-off expectations. 
- Add `desktop-tauri/scripts/run_desktop_parity_checks.py` as a thin wrapper entry point that delegates to existing focused scripts (`test_packaged_operator_e2e.py`, `test_desktop_relay_operator_parity_e2e.py`, and macOS no-relay check) via `--profile` to keep Windows/macOS checks shared. 
- Wire the wrapper into `Makefile` as `make desktop-parity-check` and update `.github/workflows/desktop-operator-e2e.yml` to run the shared wrapper in the Windows/macOS packaged jobs (profiles `ci-windows`/`ci-macos`), and add the script to the workflow path filters. 
- Update `README.md`, `desktop-tauri/README.md`, `docs/TESTING.md`, and `docs/relay_sugarkube_onboarding.md` to reference the shared checklist and clarify shared operator/runtime expectations; also fix Metal CMAKE flag guidance for consistent instructions. 

### Testing
- Compiled the wrapper with `python -m py_compile desktop-tauri/scripts/run_desktop_parity_checks.py` and it succeeded. 
- Ran code-formatting and lint plumbing (`python -m black desktop-tauri/scripts/run_desktop_parity_checks.py`) which reformatted the new wrapper as expected. 
- Verified the wrapper help with `python desktop-tauri/scripts/run_desktop_parity_checks.py --help` and it returned the usage help as expected. 
- Exercised the shared wrapper locally with `python desktop-tauri/scripts/run_desktop_parity_checks.py --profile local-cpu`, which invoked the existing packaged/operator parity tests and completed in this environment. 
- Ran repository checks with `pre-commit run --all-files` and targeted pre-commit checks against the new files, and all configured hooks passed; note that hardware CUDA/Metal smoke tests and two-node staging round-robin sign-off are intentionally local/staging-only and were not run here because CI runners do not provide release-class GPUs or a staging relay fleet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e65aae934832f9e8cf1cca1be63b3)