### PR TITLE
Bound llama_cpp runtime discovery, reuse desktop probe, and surface warm-load failures

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -643,6 +643,9 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
+    record_probe = getattr(runtime.model_manager, "record_desktop_runtime_probe", None)
+    if callable(record_probe):
+        record_probe(runtime_setup)
     apply_compute_mode(runtime.model_manager, args.mode)
 
     warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)
@@ -786,7 +789,11 @@ def run(args: argparse.Namespace) -> int:
             except Exception as exc:
                 ready = False
                 warm_load_state = "failed"
-                warm_load_failed = "failed to initialize API v1 model runtime"
+                warm_load_failed = str(
+                    getattr(runtime, "last_runtime_error", None)
+                    or getattr(runtime.model_manager, "last_runtime_init_error", None)
+                    or "failed to initialize API v1 model runtime"
+                )
                 warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
                 print(
                     "desktop.compute_node_bridge.api_v1_e2ee.runtime_wait.exception "
@@ -801,7 +808,11 @@ def run(args: argparse.Namespace) -> int:
             except Exception as exc:
                 ready = False
                 warm_load_state = "failed"
-                warm_load_failed = "failed to initialize API v1 model runtime"
+                warm_load_failed = str(
+                    getattr(runtime, "last_runtime_error", None)
+                    or getattr(runtime.model_manager, "last_runtime_init_error", None)
+                    or "failed to initialize API v1 model runtime"
+                )
                 warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
                 print(
                     "desktop.compute_node_bridge.model_init.exception "
@@ -815,7 +826,11 @@ def run(args: argparse.Namespace) -> int:
         warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at) * 1000)
         if not ready:
             warm_load_state = "failed"
-            warm_load_failed = "failed to initialize API v1 model runtime"
+            warm_load_failed = str(
+                getattr(runtime, "last_runtime_error", None)
+                or getattr(runtime.model_manager, "last_runtime_init_error", None)
+                or "failed to initialize API v1 model runtime"
+            )
             print(
                 "desktop.compute_node_bridge.model_init.failed "
                 f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -8,6 +8,30 @@ import sys
 from pathlib import Path
 
 
+def _normalize_path_key(path: str | Path) -> str:
+    raw = str(path).replace("\\", "/")
+    if raw.startswith("//?//UNC//"):
+        raw = "//" + raw[9:]
+    elif raw.startswith("//?/UNC/"):
+        raw = "//" + raw[8:]
+    elif raw.startswith("//?//"):
+        raw = raw[5:]
+    elif raw.startswith("//?/"):
+        raw = raw[4:]
+    while "//" in raw:
+        raw = raw.replace("//", "/")
+    return os.path.normcase(raw).casefold()
+
+
+def _same_path(left: str | Path, right: str | Path) -> bool:
+    try:
+        if Path(left).resolve() == Path(right).resolve():
+            return True
+    except (OSError, RuntimeError, ValueError):
+        pass
+    return _normalize_path_key(left) == _normalize_path_key(right)
+
+
 def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: bool = True) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
@@ -52,7 +76,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
             sys.path[:] = [
                 entry
                 for entry in sys.path
-                if Path(entry or ".").resolve() != user_site_path
+                if not _same_path(entry or ".", user_site_path)
             ]
 
     if not avoid_llama_cpp_shadowing:
@@ -63,7 +87,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
         sys.path[:] = [
             entry
             for entry in sys.path
-            if entry != "" and Path(entry).resolve() != cwd
+            if entry != "" and not _same_path(entry, cwd)
         ]
 
     # Keep repo roots importable for `utils.*` / `config` while avoiding local
@@ -74,7 +98,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
             continue
 
         cwd = str(Path.cwd().resolve())
-        if candidate.resolve() == Path.cwd().resolve():
+        if _same_path(candidate, Path.cwd()):
             while "" in sys.path:
                 sys.path.remove("")
             while cwd in sys.path:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2925,3 +2925,42 @@ def test_platform_neutral_dependency_failure_last_error_is_actionable(
         in payload["last_error"]
     )
     assert "missing=cryptography,requests" in payload["last_error"]
+
+
+def test_pre_registration_runtime_discovery_failure_is_actionable_and_unregistered(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class DiscoveryFailureRuntime(ApiV1Runtime):
+        def __init__(self, config):
+            super().__init__(config)
+            self.last_runtime_error = 'llama_cpp_runtime_discovery_timeout after 0.05s'
+
+        def ensure_api_v1_runtime_ready(self):
+            return False
+
+        def register_and_poll_once(self):  # pragma: no cover - must not register/poll after failed warm-load
+            raise AssertionError('runtime should not register or poll after discovery failure')
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=DiscoveryFailureRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS', '0.5')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 1
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get('type') == 'error')
+    assert error_event['registered'] is False
+    assert error_event['relay_runtime_state'] == 'failed'
+    assert error_event['warm_load_state'] == 'failed'
+    assert error_event['last_error'] == 'llama_cpp_runtime_discovery_timeout after 0.05s'
+    assert error_event['message'] == error_event['last_error']
+    assert 'desktop.compute_node_bridge.model_init.failed' in captured.err
+    assert 'server.registered' not in captured.err

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import json
 import sys
 import tempfile
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -271,7 +272,7 @@ class TestModelManager:
         mock_llama = MagicMock()
         instance = MagicMock()
         mock_llama.return_value = instance
-        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(Llama=mock_llama)
+        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(Llama=mock_llama, GGML_USE_CUDA=True, llama_supports_gpu_offload=lambda: True)
 
         with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
              patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
@@ -300,7 +301,7 @@ class TestModelManager:
         mock_llama = MagicMock()
         instance = MagicMock()
         mock_llama.return_value = instance
-        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(Llama=mock_llama)
+        mock_import_llama_cpp_runtime.return_value = SimpleNamespace(Llama=mock_llama, GGML_USE_CUDA=True, llama_supports_gpu_offload=lambda: True)
 
         with patch.object(model_manager, '_platform_gpu_backend', return_value='cuda'), \
              patch.object(model_manager, '_llama_gpu_offload_available', return_value=True):
@@ -317,7 +318,7 @@ class TestModelManager:
         instance = MagicMock()
 
         mock_llama = MagicMock(return_value=instance)
-        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama)), \
+        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama, GGML_USE_CUDA=True, llama_supports_gpu_offload=lambda: True)), \
              patch('utils.llm.model_manager.resource_monitor.can_allocate_gpu_memory') as mock_can_allocate, \
              patch('utils.llm.model_manager.os.path.exists', return_value=True), \
              patch('utils.llm.model_manager.os.path.getsize', side_effect=OSError('stat failed')), \
@@ -1029,3 +1030,96 @@ class TestModelManager:
         assert 'interpreter=' in summary
         assert 'llama_module_path=' in summary
         assert 'fallback_reason=runtime missing cuda support' in summary
+
+
+def test_llama_runtime_discovery_timeout_is_bounded(monkeypatch):
+    from utils.llm import model_manager as mm
+
+    monkeypatch.setenv('TOKEN_PLACE_LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS', '0.01')
+
+    def hang_find_spec(_name):
+        time.sleep(0.2)
+        return None
+
+    monkeypatch.setattr(mm.importlib.util, 'find_spec', hang_find_spec)
+
+    started_at = time.perf_counter()
+    with pytest.raises(mm.LlamaRuntimeDiscoveryTimeout) as excinfo:
+        mm._import_llama_cpp_runtime(require_real_runtime=True)
+    elapsed = time.perf_counter() - started_at
+
+    assert elapsed < 0.15
+    assert excinfo.value.stage == 'llama_cpp_runtime_discovery_timeout'
+    assert 'llama_cpp_runtime_discovery_timeout' in str(excinfo.value)
+
+
+def test_desktop_runtime_probe_reused_for_compute_plan(tmp_path):
+    model_path = tmp_path / 'test_model.gguf'
+    model_path.write_bytes(b'fake model data')
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    values = {
+        'model.filename': 'test_model.gguf',
+        'model.url': 'https://example.com/model.gguf',
+        'model.download_chunk_size_mb': 1,
+        'paths.models_dir': str(tmp_path),
+        'model.use_mock': False,
+        'model.context_size': 2048,
+        'model.chat_format': 'llama-3',
+        'model.n_gpu_layers': -1,
+        'model.gpu_memory_headroom_percent': 0.1,
+        'model.enforce_gpu_memory_headroom': True,
+    }
+    mock_config.get.side_effect = lambda key, default=None: values.get(key, default)
+    manager = ModelManager(mock_config)
+    manager.record_desktop_runtime_probe({
+        'selected_backend': 'cuda',
+        'detected_device': 'cuda',
+        'runtime_action': 'already_supported',
+        'interpreter': r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
+        'prefix': r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311',
+        'llama_module_path': r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\site-packages\\llama_cpp\\__init__.py',
+    })
+    manager.requested_compute_mode = 'gpu'
+
+    with patch.object(manager, '_platform_gpu_backend', side_effect=AssertionError('duplicate backend probe')), \
+         patch.object(manager, '_llama_gpu_offload_available', side_effect=AssertionError('duplicate gpu probe')):
+        plan = manager._resolve_compute_plan()
+
+    assert plan['backend_available'] == 'cuda'
+    assert plan['backend_selected'] == 'cuda'
+    assert plan['backend_used'] == 'cuda'
+    assert plan['fallback_reason'] is None
+
+
+def test_windows_extended_path_repo_shim_detection_handles_spaces(monkeypatch, tmp_path):
+    from utils.llm import model_manager as mm
+
+    repo_root = tmp_path / 'token.place desktop'
+    repo_root.mkdir()
+    shim = repo_root / 'llama_cpp.py'
+    shim.write_text('# shim\n', encoding='utf-8')
+    monkeypatch.setattr(mm, 'REPO_LLAMA_CPP_SHIM', shim.resolve())
+
+    extended = r'\\?\\' + str(shim)
+    assert mm._is_repo_llama_cpp_shim(extended)
+
+def test_llama_gpu_probe_timeout_is_actionable(monkeypatch):
+    from utils.llm import model_manager as mm
+
+    monkeypatch.setenv('TOKEN_PLACE_LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS', '0.01')
+
+    def hang_gpu_probe():
+        time.sleep(0.2)
+        return True
+
+    fake_llama = SimpleNamespace(
+        Llama=MagicMock(),
+        GGML_USE_CUDA=True,
+        llama_supports_gpu_offload=hang_gpu_probe,
+    )
+
+    with pytest.raises(mm.LlamaRuntimeDiscoveryTimeout) as excinfo:
+        mm._llama_runtime_capabilities_from_module(fake_llama)
+
+    assert excinfo.value.stage == 'llama_cpp_gpu_probe_timeout'

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -313,12 +313,19 @@ class ComputeNodeRuntime:
         _log_info(f"API v1 runtime warmup about to instantiate model: {model_path}")
         try:
             llm_runtime = get_llm_instance()
-        except Exception:
+        except Exception as exc:
+            self.last_runtime_error = str(exc)
             _log_error("Failed to initialize API v1 runtime for compute node", exc_info=True)
             return False
 
         if llm_runtime is None:
-            _log_error("API v1 runtime warmup failed: get_llm_instance returned None")
+            detail = getattr(self.model_manager, "last_runtime_init_error", None)
+            if detail:
+                self.last_runtime_error = detail
+                _log_error(f"API v1 runtime warmup failed: {detail}")
+            else:
+                self.last_runtime_error = "get_llm_instance returned None"
+                _log_error("API v1 runtime warmup failed: get_llm_instance returned None")
             return False
 
         create_chat_completion = getattr(llm_runtime, "create_chat_completion", None)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -8,6 +8,7 @@ from utils.networking.http_requests_compat import requests
 import json
 import sys
 import importlib
+import concurrent.futures
 from pathlib import Path
 from threading import Lock
 from unittest.mock import MagicMock
@@ -20,54 +21,164 @@ logger = logging.getLogger('model_manager')
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 
+LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS = float(
+    os.getenv('TOKEN_PLACE_LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS', '20') or '20'
+)
+
+
+class LlamaRuntimeDiscoveryTimeout(TimeoutError):
+    """Raised when a bounded llama_cpp runtime discovery stage does not finish."""
+
+    def __init__(self, stage: str, timeout_seconds: float):
+        self.stage = stage
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"{stage} after {timeout_seconds:g}s")
+
+
+class LlamaRuntimeDiscoveryError(ImportError):
+    """Raised when llama_cpp runtime discovery fails with stage context."""
+
+    def __init__(self, stage: str, message: str):
+        self.stage = stage
+        super().__init__(f"{stage}: {message}")
+
+
+def _runtime_discovery_timeout_seconds() -> float:
+    raw = os.getenv(
+        'TOKEN_PLACE_LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS',
+        str(LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS),
+    )
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS
+    return value if value > 0 else LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS
+
+
+
+def _path_compare_key(value: Any) -> str:
+    raw = str(value or '').replace('\\', '/')
+    if raw.startswith('//?//UNC//'):
+        raw = '//' + raw[9:]
+    elif raw.startswith('//?/UNC/'):
+        raw = '//' + raw[8:]
+    elif raw.startswith('//?//'):
+        raw = raw[5:]
+    elif raw.startswith('//?/'):
+        raw = raw[4:]
+    while '//' in raw:
+        raw = raw.replace('//', '/')
+    return os.path.normcase(raw).casefold()
+
+
+def _stage_timeout_error_name(stage: str) -> str:
+    return f"llama_cpp_{stage}_timeout" if not stage.startswith('llama_cpp_') else f"{stage}_timeout"
+
+
+def _run_runtime_stage(stage: str, fn):
+    timeout_seconds = _runtime_discovery_timeout_seconds()
+    started_at = time.perf_counter()
+    logger.info(
+        "llama_cpp runtime discovery stage start "
+        "stage=%s interpreter=%s import_root=%s timeout_seconds=%s",
+        stage,
+        sys.executable,
+        os.getenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', 'unset'),
+        f"{timeout_seconds:g}",
+    )
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix=f"tokenplace-llama-{stage}",
+    )
+    future = executor.submit(fn)
+    try:
+        result = future.result(timeout=timeout_seconds)
+    except concurrent.futures.TimeoutError as exc:
+        future.cancel()
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        error_stage = _stage_timeout_error_name(stage)
+        logger.error(
+            "llama_cpp runtime discovery stage timeout "
+            "stage=%s error=%s duration_ms=%s timeout_seconds=%s interpreter=%s import_root=%s",
+            stage,
+            error_stage,
+            duration_ms,
+            f"{timeout_seconds:g}",
+            sys.executable,
+            os.getenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', 'unset'),
+        )
+        raise LlamaRuntimeDiscoveryTimeout(error_stage, timeout_seconds) from exc
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    logger.info(
+        "llama_cpp runtime discovery stage complete stage=%s duration_ms=%s interpreter=%s",
+        stage,
+        duration_ms,
+        sys.executable,
+    )
+    return result
+
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
     """Return True when llama_cpp resolves to the repository-local shim."""
     if not module_path:
         return False
     try:
-        return Path(str(module_path)).resolve() == REPO_LLAMA_CPP_SHIM
+        resolved = Path(str(module_path)).resolve()
+        if resolved == REPO_LLAMA_CPP_SHIM:
+            return True
     except (TypeError, ValueError, OSError):
-        return False
+        pass
+    return _path_compare_key(module_path) == _path_compare_key(REPO_LLAMA_CPP_SHIM)
+
+
+def _reject_repo_llama_cpp_shim(module_path: Any) -> None:
+    if _is_repo_llama_cpp_shim(module_path):
+        sys.modules.pop('llama_cpp', None)
+        raise LlamaRuntimeDiscoveryError(
+            'repo_shim_shadowing',
+            "Refusing to use repository-local llama_cpp.py shim for runtime inference; "
+            "install llama-cpp-python and ensure site-packages wins import priority.",
+        )
 
 
 def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
     """Import llama_cpp while guarding against the repo-local test shim."""
-    llama_spec = importlib.util.find_spec('llama_cpp')
+
+    def _find_spec():
+        return importlib.util.find_spec('llama_cpp')
+
+    llama_spec = _run_runtime_stage('runtime_discovery', _find_spec)
     llama_module_path = getattr(llama_spec, 'origin', None)
+    logger.info(
+        "llama_cpp find_spec complete module_path=%s interpreter=%s import_root=%s",
+        llama_module_path or 'missing',
+        sys.executable,
+        os.getenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', 'unset'),
+    )
 
-    if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
-        sys.modules.pop('llama_cpp', None)
-        raise ImportError(
-            "Refusing to use repository-local llama_cpp.py shim for runtime inference; "
-            "install llama-cpp-python and ensure site-packages wins import priority."
-        )
+    if require_real_runtime:
+        _reject_repo_llama_cpp_shim(llama_module_path)
 
-    llama_cpp = importlib.import_module('llama_cpp')
+    def _import_module():
+        return importlib.import_module('llama_cpp')
+
+    llama_cpp = _run_runtime_stage('import', _import_module)
     llama_module_path = getattr(llama_cpp, '__file__', None)
+    logger.info(
+        "llama_cpp import complete module_path=%s interpreter=%s",
+        llama_module_path or 'unknown',
+        sys.executable,
+    )
 
-    if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
-        sys.modules.pop('llama_cpp', None)
-        raise ImportError(
-            "Refusing to use repository-local llama_cpp.py shim for runtime inference; "
-            "install llama-cpp-python and ensure site-packages wins import priority."
-        )
+    if require_real_runtime:
+        _reject_repo_llama_cpp_shim(llama_module_path)
 
     return llama_cpp
 
 
-def detect_llama_runtime_capabilities() -> Dict[str, Any]:
-    """Return backend/offload capability details from the installed llama_cpp runtime."""
-    try:
-        llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
-    except Exception as exc:
-        return {
-            'backend': 'missing',
-            'gpu_offload_supported': False,
-            'detected_device': 'none',
-            'error': str(exc),
-        }
-
+def _llama_runtime_capabilities_from_module(llama_cpp: Any) -> Dict[str, Any]:
     backend = 'cpu'
     cuda_markers = (
         'GGML_USE_CUDA',
@@ -90,7 +201,9 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     gpu_offload_supported = False
     if callable(supports_gpu):
         try:
-            gpu_offload_supported = bool(supports_gpu())
+            gpu_offload_supported = bool(_run_runtime_stage('gpu_probe', supports_gpu))
+        except LlamaRuntimeDiscoveryTimeout:
+            raise
         except Exception:
             gpu_offload_supported = False
     else:
@@ -111,6 +224,23 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'llama_module_path': getattr(llama_cpp, '__file__', 'unknown'),
         'error': None,
     }
+
+
+def detect_llama_runtime_capabilities() -> Dict[str, Any]:
+    """Return backend/offload capability details from the installed llama_cpp runtime."""
+    try:
+        llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
+        return _llama_runtime_capabilities_from_module(llama_cpp)
+    except Exception as exc:
+        return {
+            'backend': 'missing',
+            'gpu_offload_supported': False,
+            'detected_device': 'none',
+            'interpreter': sys.executable,
+            'prefix': sys.prefix,
+            'llama_module_path': 'missing',
+            'error': str(exc),
+        }
 
 
 def llama_cpp_verbose_logging_enabled() -> bool:
@@ -167,6 +297,8 @@ class ModelManager:
         self.gpu_headroom_percent = config.get('model.gpu_memory_headroom_percent', 0.1)
         self.enforce_gpu_headroom = config.get('model.enforce_gpu_memory_headroom', True)
         self.requested_compute_mode = 'auto'
+        self.desktop_runtime_probe: Dict[str, Any] = {}
+        self.last_runtime_init_error: Optional[str] = None
         self.last_compute_diagnostics = {
             'requested_mode': 'auto',
             'effective_mode': 'pending',
@@ -190,10 +322,42 @@ class ModelManager:
         runtime = detect_llama_runtime_capabilities()
         return bool(runtime.get('gpu_offload_supported', False))
 
-    def _resolve_compute_plan(self) -> Dict[str, Any]:
+    def record_desktop_runtime_probe(self, runtime_setup: Optional[Dict[str, Any]]) -> None:
+        """Record desktop runtime probe diagnostics to keep warm-load discovery consistent."""
+        self.desktop_runtime_probe = dict(runtime_setup or {})
+
+    def _trusted_runtime_capabilities(self) -> Optional[Dict[str, Any]]:
+        probe = getattr(self, 'desktop_runtime_probe', {}) or {}
+        selected_backend = str(probe.get('selected_backend') or '').lower()
+        if selected_backend not in {'cuda', 'metal'}:
+            return None
+        action = str(probe.get('runtime_action') or '').lower()
+        if action not in {'already_supported', 'metal_already_supported', 'installed_cuda_reexec', 'installed_metal_reexec'}:
+            return None
+        module_path = probe.get('llama_module_path') or ''
+        if _is_repo_llama_cpp_shim(module_path):
+            return None
+        return {
+            'backend': selected_backend,
+            'gpu_offload_supported': True,
+            'detected_device': probe.get('detected_device') or selected_backend,
+            'interpreter': probe.get('interpreter') or sys.executable,
+            'prefix': probe.get('prefix') or probe.get('interpreter_prefix') or sys.prefix,
+            'llama_module_path': module_path or 'unknown',
+            'error': None,
+            'source': 'desktop_runtime_setup',
+        }
+
+    def _resolve_compute_plan(self, runtime_capabilities: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         requested = str(getattr(self, 'requested_compute_mode', 'auto')).lower()
-        backend_available = self._platform_gpu_backend() or 'cpu'
-        gpu_runtime_supported = self._llama_gpu_offload_available()
+        runtime = runtime_capabilities or self._trusted_runtime_capabilities()
+        if runtime is not None:
+            backend = str(runtime.get('backend') or 'cpu')
+            backend_available = backend if backend in {'cuda', 'metal'} else 'cpu'
+            gpu_runtime_supported = bool(runtime.get('gpu_offload_supported', False))
+        else:
+            backend_available = self._platform_gpu_backend() or 'cpu'
+            gpu_runtime_supported = self._llama_gpu_offload_available()
         fallback_reason = None
 
         if requested == 'auto':
@@ -461,19 +625,41 @@ class ModelManager:
                         try:
                             # Dynamically import Llama only when needed
                             self.log_info("Locating llama_cpp runtime for model initialization...")
+                            self.log_info(
+                                "llama_cpp runtime discovery context "
+                                f"interpreter={sys.executable} "
+                                f"import_root={os.getenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', 'unset')} "
+                                f"trusted_probe_backend="
+                                f"{(getattr(self, 'desktop_runtime_probe', {}) or {}).get('selected_backend', 'unknown')} "
+                                f"trusted_probe_module="
+                                f"{(getattr(self, 'desktop_runtime_probe', {}) or {}).get('llama_module_path', 'unknown')}"
+                            )
                             llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
+                            llama_module_path = getattr(llama_cpp, '__file__', 'unknown')
                             self.log_info(
                                 "llama_cpp runtime located "
-                                f"module_path={getattr(llama_cpp, '__file__', 'unknown')}"
+                                f"module_path={llama_module_path} interpreter={sys.executable}"
                             )
                             Llama = llama_cpp.Llama
 
+                            trusted_runtime = self._trusted_runtime_capabilities()
+                            if trusted_runtime is not None:
+                                runtime_capabilities = trusted_runtime
+                                self.log_info(
+                                    "Using desktop runtime probe diagnostics for compute plan "
+                                    f"backend={runtime_capabilities['backend']} "
+                                    f"module_path={runtime_capabilities.get('llama_module_path', 'unknown')}"
+                                )
+                            else:
+                                self.log_info("Probing llama_cpp GPU support for compute plan...")
+                                runtime_capabilities = _llama_runtime_capabilities_from_module(llama_cpp)
                             self.log_info("Selecting compute plan for model initialization...")
-                            compute_plan = self._resolve_compute_plan()
+                            compute_plan = self._resolve_compute_plan(runtime_capabilities)
                             self.log_info(
                                 "Selected compute plan for model initialization "
                                 f"requested={compute_plan['requested_mode']} "
                                 f"backend_selected={compute_plan['backend_selected']} "
+                                f"backend_available={compute_plan['backend_available']} "
                                 f"n_gpu_layers={compute_plan['n_gpu_layers']}"
                             )
                             n_gpu_layers = int(compute_plan['n_gpu_layers'])
@@ -519,7 +705,7 @@ class ModelManager:
                             compute_plan['device_backend'] = compute_plan['backend_used']
                             compute_plan['device_name'] = 'unreported'
                             self.last_compute_diagnostics = compute_plan
-                            runtime_identity = detect_llama_runtime_capabilities()
+                            runtime_identity = runtime_capabilities
                             self.log_info(
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "
@@ -537,6 +723,7 @@ class ModelManager:
                             self.log_info("Llama init completed successfully.")
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
+                            self.last_runtime_init_error = str(e)
                             self.log_error(f"Failed to initialize Llama model: {e}", exc_info=True)
                             return None
 


### PR DESCRIPTION
### Motivation
- Windows packaged desktop compute-node could hang indefinitely during `llama_cpp` discovery/import after the desktop runtime parity changes, leaving the bridge `warming` but unregistered.  
- The runtime probe already finds a usable llama runtime early in startup, but model initialization retried discovery in a fragile, unbounded way causing the hang.  
- Path normalization for packaged Windows layouts (extended `\\?\` prefixes and spaces) and repo-local shim detection needed to be robust and consistent across probe/import paths.  

### Description
- Add bounded, staged runtime discovery helpers (`_run_runtime_stage`) and typed errors (`LlamaRuntimeDiscoveryTimeout`, `LlamaRuntimeDiscoveryError`) with a configurable timeout via `TOKEN_PLACE_LLAMA_RUNTIME_DISCOVERY_TIMEOUT_SECONDS`.  
- Make `_import_llama_cpp_runtime` perform `find_spec` and actual `import` under bounded stages, log discovery context, and reject repository-local `llama_cpp.py` shims using a normalized Windows-friendly path comparison.  
- Add GPU probe under the same bounded stage logic and expose `_llama_runtime_capabilities_from_module`; update `detect_llama_runtime_capabilities` to use the staged import/probe flow.  
- Teach `ModelManager` to record the desktop runtime probe (`record_desktop_runtime_probe`), reuse trusted probe diagnostics for compute-plan selection when applicable, log detailed stage diagnostics, capture `last_runtime_init_error`, and avoid duplicated fragile probes.  
- Propagate actionable runtime-init diagnostics into the bridge warm-load path by recording the probe in `compute_node_bridge` and surfacing `last_runtime_error` / `last_runtime_init_error` as the warm-load failure reason so the node fails closed and remains unregistered.  
- Normalize path comparison/bootstrap logic in `desktop-tauri/src-tauri/python/path_bootstrap.py` to handle extended-length Windows paths and paths with spaces robustly, avoiding false shim/mismatch cases.  
- Update `utils/compute_node_runtime.py` to surface runtime init errors on warmup failures.  
- Add and update unit tests covering discovery timeout, GPU-probe timeout, reuse of desktop probe, Windows extended-path shim detection, and bridge pre-registration failure behavior.  

### Testing
- Ran focused unit suites and bridge tests locally:  
  - `pytest tests/unit/test_desktop_runtime_setup.py` — passed (all cases exercised).  
  - `pytest tests/unit/test_compute_node_runtime.py` — passed.  
  - `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or timeout or runtime or register or restart"` — passed relevant warm/timeout/register tests.  
  - `pytest tests/unit/test_desktop_packaged_layout.py` — ran (platform-specific packaged test skipped in container).  
  - `pytest tests/unit/test_desktop_path_bootstrap.py` — passed.  
  - `pytest tests/unit/test_model_manager.py` — passed (new timeout and path tests included).  
- Ran packaged/operator parity scripts: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python desktop-tauri/scripts/run_desktop_parity_checks.py` locally; they executed without regressions in this environment.  
- `pre-commit run --all-files` — passed.  
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` — not completed in this environment due to a missing system library (`glib-2.0.pc` / `PKG_CONFIG_PATH`), so Rust/Cargo tests were not fully run here.  

If reviewers want a narrower follow-up, I can extract the discovery-stage helpers into a small refactor PR or add more targeted integration tests that simulate the packaged Windows layout with `\\?\` import roots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9191e464832f89c104ed5226e336)