### PR TITLE
Fix bounded desktop llama runtime discovery

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -643,6 +643,9 @@ def run(args: argparse.Namespace) -> int:
     )
 
     runtime.model_manager.model_path = args.model
+    set_runtime_probe = getattr(runtime.model_manager, "set_llama_runtime_probe", None)
+    if callable(set_runtime_probe):
+        set_runtime_probe(runtime_setup)
     apply_compute_mode(runtime.model_manager, args.mode)
 
     warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -8,6 +8,23 @@ import sys
 from pathlib import Path
 
 
+def _strip_windows_extended_path_prefix(path_value: str) -> str:
+    if path_value.startswith('\\\\?\\UNC\\'):
+        return '\\\\' + path_value[8:]
+    if path_value.startswith('\\\\?\\'):
+        return path_value[4:]
+    return path_value
+
+
+def _normalized_path_key(path_value: object) -> str:
+    stripped = _strip_windows_extended_path_prefix(str(path_value))
+    try:
+        resolved = str(Path(stripped).resolve())
+    except (TypeError, ValueError, OSError):
+        resolved = stripped
+    return resolved.replace('\\', '/').lower()
+
+
 def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: bool = True) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
@@ -36,7 +53,10 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
         has_runtime_modules = (candidate / "utils").is_dir() or (candidate / "config.py").is_file()
         if has_runtime_modules:
             candidate_str = str(candidate)
-            if candidate_str not in valid_candidates:
+            if not any(
+                _normalized_path_key(candidate_str) == _normalized_path_key(existing)
+                for existing in valid_candidates
+            ):
                 valid_candidates.append(candidate_str)
 
     # Preserve candidate priority: first valid candidate should be first on sys.path.
@@ -52,7 +72,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
             sys.path[:] = [
                 entry
                 for entry in sys.path
-                if Path(entry or ".").resolve() != user_site_path
+                if _normalized_path_key(entry or ".") != _normalized_path_key(user_site_path)
             ]
 
     if not avoid_llama_cpp_shadowing:
@@ -63,7 +83,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
         sys.path[:] = [
             entry
             for entry in sys.path
-            if entry != "" and Path(entry).resolve() != cwd
+            if entry != "" and _normalized_path_key(entry) != _normalized_path_key(cwd)
         ]
 
     # Keep repo roots importable for `utils.*` / `config` while avoiding local
@@ -74,7 +94,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
             continue
 
         cwd = str(Path.cwd().resolve())
-        if candidate.resolve() == Path.cwd().resolve():
+        if _normalized_path_key(candidate) == _normalized_path_key(Path.cwd()):
             while "" in sys.path:
                 sys.path.remove("")
             while cwd in sys.path:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -33,6 +33,10 @@ class FakeModelManager:
         self.default_n_gpu_layers = -1
         self.requested_compute_mode = 'auto'
         self.last_compute_diagnostics = None
+        self.llama_runtime_probe = None
+
+    def set_llama_runtime_probe(self, runtime_probe):
+        self.llama_runtime_probe = dict(runtime_probe)
 
 
 class FakeRelayClient:
@@ -2925,3 +2929,51 @@ def test_platform_neutral_dependency_failure_last_error_is_actionable(
         in payload["last_error"]
     )
     assert "missing=cryptography,requests" in payload["last_error"]
+
+
+def test_run_passes_successful_runtime_probe_to_model_manager(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class ProbeRuntime(NullErrorHeartbeatRuntime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            ProbeRuntime.last_instance = self
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ProbeRuntime)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'runtime_action': 'already_supported',
+            'interpreter': r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
+            'llama_module_path': (
+                r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\'
+                r'site-packages\\llama_cpp\\__init__.py'
+            ),
+            'fallback_reason': '',
+        },
+    )
+    call_count = {'n': 0}
+
+    def fake_stop_requested():
+        call_count['n'] += 1
+        return call_count['n'] > 1
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+
+    status = compute_node_bridge.run(SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://token.place',
+        relay_port=None,
+    ))
+
+    assert status == 0
+    assert ProbeRuntime.last_instance is not None
+    assert ProbeRuntime.last_instance.model_manager.llama_runtime_probe['selected_backend'] == 'cuda'
+    output = capsys.readouterr()
+    assert 'desktop.runtime_setup mode=auto selected_backend=cuda' in output.err

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -269,3 +269,10 @@ def test_bootstrap_removes_user_site_and_cwd_shim_while_preserving_packaged_impo
             sys.modules.pop('llama_cpp', None)
         else:
             sys.modules['llama_cpp'] = original_llama_module
+
+
+def test_normalized_path_key_treats_windows_extended_prefix_and_spaces_as_same(path_bootstrap):
+    regular = r"C:\Users\danie\AppData\Local\token.place desktop"
+    extended = r"\\?\C:\Users\danie\AppData\Local\token.place desktop"
+
+    assert path_bootstrap._normalized_path_key(regular) == path_bootstrap._normalized_path_key(extended)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -1029,3 +1029,27 @@ class TestModelManager:
         assert 'interpreter=' in summary
         assert 'llama_module_path=' in summary
         assert 'fallback_reason=runtime missing cuda support' in summary
+
+    def test_successful_desktop_probe_diagnostics_are_reused_for_compute_plan(self, model_manager):
+        """The desktop preflight probe should avoid duplicate fragile discovery during warm-load."""
+        model_manager.set_llama_runtime_probe({
+            'selected_backend': 'cuda',
+            'detected_device': 'cuda',
+            'runtime_action': 'already_supported',
+            'interpreter': r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
+            'llama_module_path': (
+                r'C:\\Users\\danie\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\'
+                r'site-packages\\llama_cpp\\__init__.py'
+            ),
+            'fallback_reason': None,
+        })
+        model_manager.requested_compute_mode = 'gpu'
+
+        with patch('utils.llm.model_manager.detect_llama_runtime_capabilities') as detect:
+            plan = model_manager._resolve_compute_plan()
+
+        detect.assert_not_called()
+        assert plan['backend_available'] == 'cuda'
+        assert plan['backend_selected'] == 'cuda'
+        assert plan['backend_used'] == 'cuda'
+        assert plan['n_gpu_layers'] == -1

--- a/tests/unit/test_model_manager_llama_import_guard.py
+++ b/tests/unit/test_model_manager_llama_import_guard.py
@@ -46,3 +46,76 @@ def test_import_guard_allows_repo_shim_when_real_runtime_not_required(monkeypatc
 
     loaded = model_manager._import_llama_cpp_runtime(require_real_runtime=False)
     assert loaded is fake_module
+
+
+def test_import_runtime_discovery_hang_times_out(monkeypatch):
+    def _hang(_name):
+        import time
+        time.sleep(1.0)
+
+    monkeypatch.setattr(model_manager.importlib.util, "find_spec", _hang)
+
+    with pytest.raises(model_manager.LlamaCppRuntimeTimeout) as excinfo:
+        model_manager._import_llama_cpp_runtime(
+            require_real_runtime=True,
+            timeout_seconds=0.01,
+        )
+
+    assert excinfo.value.stage == "llama_cpp_runtime_discovery"
+    assert "llama_cpp_runtime_discovery_timeout" in str(excinfo.value)
+
+
+def test_import_hang_times_out_after_successful_discovery(monkeypatch):
+    fake_spec = types.SimpleNamespace(
+        origin=(
+            "C:/Users/danie/AppData/Local/Programs/Python/Python311/Lib/"
+            "site-packages/llama_cpp/__init__.py"
+        )
+    )
+    monkeypatch.setattr(model_manager.importlib.util, "find_spec", lambda _name: fake_spec)
+
+    def _hang(_name):
+        import time
+        time.sleep(1.0)
+
+    monkeypatch.setattr(model_manager.importlib, "import_module", _hang)
+
+    with pytest.raises(model_manager.LlamaCppRuntimeTimeout) as excinfo:
+        model_manager._import_llama_cpp_runtime(
+            require_real_runtime=True,
+            timeout_seconds=0.01,
+        )
+
+    assert excinfo.value.stage == "llama_cpp_import"
+    assert "llama_cpp_import_timeout" in str(excinfo.value)
+
+
+def test_repo_shim_detection_normalizes_windows_extended_paths(monkeypatch):
+    monkeypatch.setattr(
+        model_manager,
+        "REPO_LLAMA_CPP_SHIM",
+        model_manager.Path(r"C:\Users\danie\token.place desktop\llama_cpp.py"),
+    )
+
+    assert model_manager._is_repo_llama_cpp_shim(
+        r"\\?\C:\Users\danie\token.place desktop\llama_cpp.py"
+    )
+
+
+def test_gpu_probe_hang_reports_stage_timeout():
+    def _hang():
+        import time
+        time.sleep(1.0)
+
+    fake_module = types.SimpleNamespace(
+        __file__="C:/Python311/Lib/site-packages/llama_cpp/__init__.py",
+        llama_supports_gpu_offload=_hang,
+    )
+
+    payload = model_manager.detect_llama_runtime_capabilities(
+        fake_module,
+        timeout_seconds=0.01,
+    )
+
+    assert payload['backend'] == 'missing'
+    assert 'llama_cpp_gpu_probe_timeout' in payload['error']

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -9,9 +9,9 @@ import json
 import sys
 import importlib
 from pathlib import Path
-from threading import Lock
+from threading import Lock, Thread
 from unittest.mock import MagicMock
-from typing import Dict, List, Any, Optional, Union, Tuple, Iterable
+from typing import Callable, Dict, List, Any, Optional, Union, Tuple, Iterable, TypeVar
 
 from utils.system import resource_monitor
 
@@ -19,22 +19,123 @@ from utils.system import resource_monitor
 logger = logging.getLogger('model_manager')
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
+DEFAULT_LLAMA_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
+_T = TypeVar('_T')
+
+
+class LlamaCppRuntimeTimeout(TimeoutError):
+    """Raised when a llama_cpp discovery/import/probe stage exceeds its bound."""
+
+    def __init__(self, stage: str, timeout_seconds: float):
+        self.stage = stage
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"{stage}_timeout after {timeout_seconds:g}s")
+
+
+def _parse_positive_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name, '').strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def llama_runtime_stage_timeout_seconds() -> float:
+    return _parse_positive_float_env(
+        'TOKEN_PLACE_LLAMA_RUNTIME_STAGE_TIMEOUT_SECONDS',
+        DEFAULT_LLAMA_RUNTIME_STAGE_TIMEOUT_SECONDS,
+    )
+
+
+def _strip_windows_extended_path_prefix(path_value: str) -> str:
+    if path_value.startswith('\\\\?\\UNC\\'):
+        return '\\\\' + path_value[8:]
+    if path_value.startswith('\\\\?\\'):
+        return path_value[4:]
+    return path_value
+
+
+def _normalize_path_for_comparison(path_value: Any) -> Optional[str]:
+    if not path_value:
+        return None
+    try:
+        stripped = _strip_windows_extended_path_prefix(str(path_value))
+        resolved = str(Path(stripped).resolve())
+    except (TypeError, ValueError, OSError):
+        resolved = _strip_windows_extended_path_prefix(str(path_value))
+    return resolved.replace('\\', '/').lower()
+
+
+def _run_bounded_runtime_stage(
+    stage: str,
+    fn: Callable[[], _T],
+    *,
+    timeout_seconds: Optional[float] = None,
+) -> _T:
+    timeout = llama_runtime_stage_timeout_seconds() if timeout_seconds is None else timeout_seconds
+    result: list[Any] = []
+    error: list[BaseException] = []
+
+    def _target() -> None:
+        try:
+            result.append(fn())
+        except BaseException as exc:  # pragma: no cover - re-raised by caller
+            error.append(exc)
+
+    worker = Thread(target=_target, name=f'tokenplace-{stage}', daemon=True)
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        raise LlamaCppRuntimeTimeout(stage, timeout)
+    if error:
+        raise error[0]
+    return result[0] if result else None  # type: ignore[return-value]
 
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
     """Return True when llama_cpp resolves to the repository-local shim."""
     if not module_path:
         return False
-    try:
-        return Path(str(module_path)).resolve() == REPO_LLAMA_CPP_SHIM
-    except (TypeError, ValueError, OSError):
-        return False
+    module_normalized = _normalize_path_for_comparison(module_path)
+    shim_normalized = _normalize_path_for_comparison(REPO_LLAMA_CPP_SHIM)
+    return bool(module_normalized and shim_normalized and module_normalized == shim_normalized)
 
 
-def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
+def _import_llama_cpp_runtime(
+    *,
+    require_real_runtime: bool = True,
+    timeout_seconds: Optional[float] = None,
+    log_stage: Optional[Callable[[str], None]] = None,
+):
     """Import llama_cpp while guarding against the repo-local test shim."""
-    llama_spec = importlib.util.find_spec('llama_cpp')
+
+    def _log(message: str) -> None:
+        if callable(log_stage):
+            log_stage(message)
+
+    import_root = os.getenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+    _log(
+        "llama_cpp runtime discovery stage=resolve_import_root "
+        f"interpreter={sys.executable} import_root={import_root} "
+        f"prefix={sys.prefix}"
+    )
+
+    started_at = time.perf_counter()
+    _log("llama_cpp runtime discovery stage=find_spec start")
+    llama_spec = _run_bounded_runtime_stage(
+        'llama_cpp_runtime_discovery',
+        lambda: importlib.util.find_spec('llama_cpp'),
+        timeout_seconds=timeout_seconds,
+    )
     llama_module_path = getattr(llama_spec, 'origin', None)
+    _log(
+        "llama_cpp runtime discovery stage=find_spec done "
+        f"duration_ms={int((time.perf_counter() - started_at) * 1000)} "
+        f"module_path={llama_module_path or 'missing'}"
+    )
 
     if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
         sys.modules.pop('llama_cpp', None)
@@ -43,8 +144,19 @@ def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
             "install llama-cpp-python and ensure site-packages wins import priority."
         )
 
-    llama_cpp = importlib.import_module('llama_cpp')
+    started_at = time.perf_counter()
+    _log("llama_cpp runtime discovery stage=import start")
+    llama_cpp = _run_bounded_runtime_stage(
+        'llama_cpp_import',
+        lambda: importlib.import_module('llama_cpp'),
+        timeout_seconds=timeout_seconds,
+    )
     llama_module_path = getattr(llama_cpp, '__file__', None)
+    _log(
+        "llama_cpp runtime discovery stage=import done "
+        f"duration_ms={int((time.perf_counter() - started_at) * 1000)} "
+        f"module_path={llama_module_path or 'unknown'}"
+    )
 
     if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
         sys.modules.pop('llama_cpp', None)
@@ -55,19 +167,8 @@ def _import_llama_cpp_runtime(*, require_real_runtime: bool = True):
 
     return llama_cpp
 
-
-def detect_llama_runtime_capabilities() -> Dict[str, Any]:
-    """Return backend/offload capability details from the installed llama_cpp runtime."""
-    try:
-        llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
-    except Exception as exc:
-        return {
-            'backend': 'missing',
-            'gpu_offload_supported': False,
-            'detected_device': 'none',
-            'error': str(exc),
-        }
-
+def _capabilities_from_llama_cpp(llama_cpp: Any, *, timeout_seconds: Optional[float] = None) -> Dict[str, Any]:
+    """Return backend/offload capability details from an imported llama_cpp module."""
     backend = 'cpu'
     cuda_markers = (
         'GGML_USE_CUDA',
@@ -90,7 +191,15 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
     gpu_offload_supported = False
     if callable(supports_gpu):
         try:
-            gpu_offload_supported = bool(supports_gpu())
+            gpu_offload_supported = bool(
+                _run_bounded_runtime_stage(
+                    'llama_cpp_gpu_probe',
+                    supports_gpu,
+                    timeout_seconds=timeout_seconds,
+                )
+            )
+        except LlamaCppRuntimeTimeout:
+            raise
         except Exception:
             gpu_offload_supported = False
     else:
@@ -112,6 +221,27 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'error': None,
     }
 
+
+def detect_llama_runtime_capabilities(
+    llama_cpp: Any = None, *, timeout_seconds: Optional[float] = None
+) -> Dict[str, Any]:
+    """Return backend/offload capability details from the installed llama_cpp runtime."""
+    try:
+        runtime = llama_cpp or _import_llama_cpp_runtime(
+            require_real_runtime=True,
+            timeout_seconds=timeout_seconds,
+        )
+        return _capabilities_from_llama_cpp(runtime, timeout_seconds=timeout_seconds)
+    except Exception as exc:
+        return {
+            'backend': 'missing',
+            'gpu_offload_supported': False,
+            'detected_device': 'none',
+            'interpreter': sys.executable,
+            'prefix': sys.prefix,
+            'llama_module_path': 'missing',
+            'error': str(exc),
+        }
 
 def llama_cpp_verbose_logging_enabled() -> bool:
     """Return whether raw llama.cpp verbose logging should be enabled."""
@@ -167,6 +297,7 @@ class ModelManager:
         self.gpu_headroom_percent = config.get('model.gpu_memory_headroom_percent', 0.1)
         self.enforce_gpu_headroom = config.get('model.enforce_gpu_memory_headroom', True)
         self.requested_compute_mode = 'auto'
+        self.llama_runtime_probe: Optional[Dict[str, Any]] = None
         self.last_compute_diagnostics = {
             'requested_mode': 'auto',
             'effective_mode': 'pending',
@@ -177,17 +308,49 @@ class ModelManager:
             'fallback_reason': None,
         }
 
-    @staticmethod
-    def _platform_gpu_backend() -> Optional[str]:
-        runtime = detect_llama_runtime_capabilities()
+    def set_llama_runtime_probe(self, runtime_probe: Dict[str, Any]) -> None:
+        """Record successful desktop runtime probe diagnostics for model init."""
+        if not isinstance(runtime_probe, dict):
+            return
+        if runtime_probe.get('runtime_action') == 'shadowed_repo_llama_cpp':
+            return
+        backend = str(runtime_probe.get('selected_backend') or runtime_probe.get('backend') or 'cpu')
+        gpu_supported = (
+            backend in {'cuda', 'metal'}
+            or str(runtime_probe.get('detected_device', '')).lower() in {'cuda', 'metal'}
+        )
+        self.llama_runtime_probe = {
+            'backend': backend,
+            'gpu_offload_supported': gpu_supported,
+            'detected_device': runtime_probe.get('detected_device') or backend,
+            'interpreter': runtime_probe.get('interpreter') or sys.executable,
+            'prefix': runtime_probe.get('prefix') or sys.prefix,
+            'llama_module_path': runtime_probe.get('llama_module_path') or 'unknown',
+            'error': runtime_probe.get('fallback_reason'),
+        }
+
+    def _runtime_capabilities(self) -> Dict[str, Any]:
+        if self.llama_runtime_probe is not None:
+            return dict(self.llama_runtime_probe)
+        return detect_llama_runtime_capabilities()
+
+    def _platform_gpu_backend(self=None) -> Optional[str]:
+        runtime = (
+            self._runtime_capabilities()
+            if isinstance(self, ModelManager)
+            else detect_llama_runtime_capabilities()
+        )
         backend = str(runtime.get('backend') or 'cpu')
         if backend in {'cuda', 'metal'}:
             return backend
         return None
 
-    @staticmethod
-    def _llama_gpu_offload_available() -> bool:
-        runtime = detect_llama_runtime_capabilities()
+    def _llama_gpu_offload_available(self=None) -> bool:
+        runtime = (
+            self._runtime_capabilities()
+            if isinstance(self, ModelManager)
+            else detect_llama_runtime_capabilities()
+        )
         return bool(runtime.get('gpu_offload_supported', False))
 
     def _resolve_compute_plan(self) -> Dict[str, Any]:
@@ -461,12 +624,24 @@ class ModelManager:
                         try:
                             # Dynamically import Llama only when needed
                             self.log_info("Locating llama_cpp runtime for model initialization...")
-                            llama_cpp = _import_llama_cpp_runtime(require_real_runtime=True)
+                            llama_cpp = _import_llama_cpp_runtime(
+                                require_real_runtime=True,
+                                timeout_seconds=llama_runtime_stage_timeout_seconds(),
+                                log_stage=self.log_info,
+                            )
                             self.log_info(
                                 "llama_cpp runtime located "
                                 f"module_path={getattr(llama_cpp, '__file__', 'unknown')}"
                             )
                             Llama = llama_cpp.Llama
+                            imported_runtime_identity = detect_llama_runtime_capabilities(
+                                llama_cpp,
+                                timeout_seconds=llama_runtime_stage_timeout_seconds(),
+                            )
+                            if imported_runtime_identity.get('error'):
+                                raise RuntimeError(imported_runtime_identity['error'])
+                            if not self.llama_runtime_probe:
+                                self.llama_runtime_probe = imported_runtime_identity
 
                             self.log_info("Selecting compute plan for model initialization...")
                             compute_plan = self._resolve_compute_plan()
@@ -519,7 +694,7 @@ class ModelManager:
                             compute_plan['device_backend'] = compute_plan['backend_used']
                             compute_plan['device_name'] = 'unreported'
                             self.last_compute_diagnostics = compute_plan
-                            runtime_identity = detect_llama_runtime_capabilities()
+                            runtime_identity = imported_runtime_identity
                             self.log_info(
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "


### PR DESCRIPTION
### Motivation
- Windows desktop compute nodes could hang indefinitely during model warm-load while re-running fragile `llama_cpp` discovery/import after a successful desktop probe, blocking registration. 
- Runtime discovery and GPU-probe steps are potentially blocking (import/find_spec/gpu probe) and must be bounded and observable so the bridge can fail closed instead of remaining "warming" forever. 
- The desktop preflight probe already obtains a trustworthy runtime identity; model initialization should reuse that probe to avoid repeating fragile discovery on packaged Windows paths (including `\\?\` extended-length paths and paths containing spaces). 

### Description
- Implemented bounded runtime discovery/probe stages in `utils/llm/model_manager.py` by adding `_run_bounded_runtime_stage`, `LlamaCppRuntimeTimeout`, and `TOKEN_PLACE_LLAMA_RUNTIME_STAGE_TIMEOUT_SECONDS` support, and wiring timeouts around `importlib.util.find_spec`, `importlib.import_module`, and the `llama_supports_gpu_offload` probe. 
- Added Windows extended-path normalization and repo-shim comparison helpers to avoid mismatches between `\?\` and regular paths and to reject repo-local `llama_cpp.py` shims reliably. 
- Reused the successful desktop probe diagnostics during warm-load: `compute_node_bridge` now calls `set_llama_runtime_probe(runtime_setup)` on the runtime `ModelManager` before applying compute mode so the model init path can trust the earlier probe instead of duplicating discovery. 
- Hardened logging/diagnostics around each stage (import root, stage start/done, duration_ms, module path, interpreter/prefix) and convert discovery/probe timeouts into actionable errors to keep the bridge unregistered on failure rather than stuck in warming. 
- Path bootstrap improvements: `desktop-tauri/src-tauri/python/path_bootstrap.py` adds normalized path keys and extended-prefix stripping so packaged import-root logic handles `\\?\` and space-containing paths consistently. 
- Tests: added/updated unit tests to cover bounded discovery/import/probe timeouts, normalized Windows extended paths, reuse of successful desktop probe diagnostics, and bridge behavior when runtime probe is passed into the model manager. Key tests added/modified include `tests/unit/test_model_manager_llama_import_guard.py`, `tests/unit/test_model_manager.py`, `tests/unit/test_desktop_compute_node_bridge.py`, and `tests/unit/test_desktop_path_bootstrap.py`. 

### Testing
- Ran the targeted Python unit suites: `pytest tests/unit/test_desktop_runtime_setup.py`, `pytest tests/unit/test_compute_node_runtime.py`, `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or timeout or runtime or register or restart"`, `pytest tests/unit/test_desktop_packaged_layout.py`, `pytest tests/unit/test_desktop_path_bootstrap.py`, and `pytest tests/unit/test_model_manager.py tests/unit/test_model_manager_llama_import_guard.py`; these completed successfully (unit tests passed and the packaged-layout check was skipped where platform-guarded). 
- Executed packaged/operator parity scripts: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python desktop-tauri/scripts/run_desktop_parity_checks.py`; they ran in this environment without failing. 
- Ran `pre-commit run --all-files` and formatting (`black`) during the workflow; hooks and checks passed. 
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` but the environment lacked the system `glib-2.0` pkg-config dependency (build failed because `glib-2.0.pc` was not found); this is an environment/system dependency issue and not code-related. 

Notes: the change intentionally avoids altering relay behavior, E2EE invariants, or macOS parity semantics; the new timeouts are configurable via `TOKEN_PLACE_LLAMA_RUNTIME_STAGE_TIMEOUT_SECONDS` and tests assert the expected timeout/error diagnostics and path-normalization behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9191e464832f89c104ed5226e336)