### PR TITLE
Fix packaged llama_cpp import startup

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -107,6 +107,18 @@ def create_macos_bundle_layout(tmp_root: Path) -> Path:
     return create_packaged_layout(resources_tmp_root, resources_dir_name="Resources")
 
 
+def create_fake_llama_cpp_site_packages(tmp_root: Path) -> Path:
+    site_packages = tmp_root / "fake runtime site-packages"
+    package_dir = site_packages / "llama_cpp"
+    package_dir.mkdir(parents=True, exist_ok=True)
+    (package_dir / "__init__.py").write_text(
+        """\
+import os\nimport time\n\nGGML_USE_CUDA = os.environ.get('TOKEN_PLACE_FAKE_LLAMA_BACKEND') == 'cuda'\nGGML_USE_METAL = os.environ.get('TOKEN_PLACE_FAKE_LLAMA_BACKEND') == 'metal'\n\ndef llama_supports_gpu_offload():\n    return GGML_USE_CUDA or GGML_USE_METAL\n\n# Regression sentinel: the removed model-manager import watchdog used this env\n# contract for child probes. If startup reintroduces that child import, this fake\n# runtime stalls long enough for the packaged e2e registration guard to fail.\nif os.environ.get('TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH'):\n    time.sleep(float(os.environ.get('TOKEN_PLACE_FAKE_LLAMA_CHILD_IMPORT_SLEEP_SECONDS', '120')))\n\nclass Llama:\n    def __init__(self, **kwargs):\n        self.kwargs = kwargs\n\n    def create_chat_completion(self, **_kwargs):\n        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake packaged runtime ok'}}]}\n""",
+        encoding="utf-8",
+    )
+    return site_packages
+
+
 def _packaged_env(
     tmp_root: Path,
     resources_root: Path | None = None,
@@ -346,20 +358,37 @@ def run_compute_bridge_startup_probe(
     relay_port: int,
     resources_root: Path | None = None,
     layout_label: str = "standard resources",
+    use_mock_llm: bool = True,
+    fake_site_packages: Path | None = None,
 ) -> None:
-    env = _packaged_env(tmp_root, resources_root, extra_env={"USE_MOCK_LLM": "1"})
+    extra_env = {"USE_MOCK_LLM": "1" if use_mock_llm else "0"}
+    if fake_site_packages is not None:
+        extra_env.update({
+            "PYTHONPATH": os.pathsep.join([
+                str(fake_site_packages),
+                str((resources_root or (tmp_root / "resources")) / "python"),
+            ]),
+            "TOKEN_PLACE_FAKE_LLAMA_BACKEND": "cuda" if os.name == "nt" else "metal",
+            "TOKEN_PLACE_FAKE_LLAMA_CHILD_IMPORT_SLEEP_SECONDS": "120",
+        })
+    env = _packaged_env(tmp_root, resources_root, extra_env=extra_env)
     log_dir = REPO_ROOT / ".desktop-e2e-logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     safe_layout_label = layout_label.replace(" ", "_").replace("/", "_")
+    model_path = tmp_root / (
+        "mock.gguf" if use_mock_llm else f"fake-{safe_layout_label}.gguf"
+    )
+    if not use_mock_llm:
+        model_path.write_bytes(b"fake gguf")
     log_file = log_dir / f"packaged-bridge-startup-{safe_layout_label}.log"
     bridge = subprocess.Popen(  # noqa: S603
         [
             sys.executable,
             str(bridge_script),
             "--model",
-            "mock.gguf",
+            str(model_path),
             "--mode",
-            "cpu",
+            "cpu" if use_mock_llm else "auto",
             "--relay-url",
             f"http://127.0.0.1:{relay_port}",
         ],
@@ -538,6 +567,18 @@ def main() -> int:
                     relay_port=relay_port,
                     resources_root=probe_resources_root,
                     layout_label=layout_label,
+                )
+                fake_site_packages = create_fake_llama_cpp_site_packages(
+                    tmp_path / f"fake-runtime-{relay_log_label}"
+                )
+                run_compute_bridge_startup_probe(
+                    tmp_path,
+                    probe_script,
+                    relay_port=relay_port,
+                    resources_root=probe_resources_root,
+                    layout_label=f"{layout_label} fake llama_cpp runtime",
+                    use_mock_llm=False,
+                    fake_site_packages=fake_site_packages,
                 )
             finally:
                 if relay.poll() is None:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1005,6 +1005,7 @@ def run(args: argparse.Namespace) -> int:
         return ready
 
     poll_cancel_requested = False
+    relay_registered_once = False
 
     def request_poll_cancel(active_relay_url: str) -> None:
         nonlocal poll_cancel_requested
@@ -1032,6 +1033,15 @@ def run(args: argparse.Namespace) -> int:
                 )
         unregister = getattr(relay_client, "unregister_from_relay", None)
         if callable(unregister):
+            if not relay_registered_once:
+                print(
+                    "desktop.compute_node_bridge.unregister.skipped "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                    "reason=never_registered",
+                    file=sys.stderr,
+                )
+                return
             print(
                 "desktop.compute_node_bridge.unregister.attempted "
                 f"relay={_sanitize_relay_target(active_relay_url)} "
@@ -1140,6 +1150,9 @@ def run(args: argparse.Namespace) -> int:
                     f"request_id={request_id} wait={wait_seconds} summary={summary}",
                     file=sys.stderr,
                 )
+
+                if registered:
+                    relay_registered_once = True
 
                 if not registered:
                     if relay_error is not None:

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -8,14 +8,26 @@ import sys
 from pathlib import Path
 
 
+def _strip_windows_extended_path_prefix(path_text: str) -> str:
+    if path_text.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path_text[8:]
+    if path_text.startswith("\\\\?\\"):
+        return path_text[4:]
+    return path_text
+
+
+def _normal_import_path(path: Path | str) -> Path:
+    return Path(_strip_windows_extended_path_prefix(str(path)))
+
+
 def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: bool = True) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
-    script_path = Path(script_file).resolve()
+    script_path = _normal_import_path(script_file).resolve()
     script_root = script_path.parent.parent
     explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
     candidates = [
-        Path(explicit_import_root) if explicit_import_root else None,
+        _normal_import_path(explicit_import_root) if explicit_import_root else None,
         script_root,  # bundled resources root in packaged apps
         script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
         script_root / "Resources",  # macOS-style resources casing

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-06-04",
+  "slug": "packaged-desktop-llama-cpp-import-timeout",
+  "summary": "Packaged desktop compute-node warm-load could fail before relay registration because model initialization ran a duplicate llama_cpp child-process import watchdog that diverged from the successful desktop runtime setup probe.",
+  "impact": "Windows CUDA packaged operators could remain Running: yes / Registered: no and never serve relay API v1 work; macOS packaged operators shared the same bootstrap seam and needed parity protection.",
+  "fix": "Removed the startup-critical child import watchdog, kept direct llama_cpp import in the bridge process under the existing warm-load deadline, normalized packaged import roots, reused desktop runtime setup diagnostics, suppressed unregister before successful registration, and added registered=true packaged e2e guards including a fake non-mock llama_cpp regression path.",
+  "lessons": "Mock/import-only packaged checks are not sufficient for desktop operator readiness; CI must require the packaged bridge plus relay lifecycle to reach registered=true and must exercise shared runtime import/bootstrap code without divergent child import environments."
+}

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
@@ -1,0 +1,47 @@
+# Packaged desktop llama_cpp import timeout blocked compute-node registration
+
+- **Date:** 2026-06-04
+- **Status:** Corrective action added
+- **Area:** Packaged desktop operator runtime bootstrap (Windows CUDA, macOS Metal/CPU parity)
+
+## Symptoms
+
+Packaged desktop compute-node startup could hang or fail before relay registration. The UI remained effectively `Running: yes / Registered: no`, and logs stopped near `Locating llama_cpp runtime for model initialization...` or later failed with `llama_cpp_import_timeout after 30s`.
+
+## Timeline
+
+1. A packaged desktop regression left the operator stuck while locating or importing the `llama_cpp` runtime during API v1 pre-registration warm-load.
+2. A follow-up added subprocess discovery/import watchdog diagnostics. Discovery (`find_spec`) completed quickly and reported the installed `llama-cpp-python` module, but the new child-process import watchdog still timed out after 30 seconds on a known-good Windows 11 CUDA runtime.
+3. The bridge transitioned to failed/stopped instead of hanging forever, but it still never reached `model_init.ready`, `server.registered`, or UI `Registered: yes`.
+4. This PR removes the startup-critical child import watchdog path, reuses the packaged runtime setup probe for compute planning, and keeps pre-registration warm-load bounded by the bridge session deadline.
+
+## Root cause
+
+The model warm-load path imported `llama_cpp` in a separate watchdog subprocess after desktop runtime setup had already proven the runtime import/probe path. That second process used a different import environment (`PYTHONPATH`, cwd, probe env vars, and packaged path normalization) from the actual bridge runtime. On native CUDA/Metal builds, that duplicate child import could hang or diverge even when the real runtime was usable.
+
+Windows `\\?\` extended paths and spaces in packaged resource paths increased the risk that import-root comparison and child process path contracts differed from the runtime setup probe. macOS `.app/Contents/Resources` uses the same shared bootstrap seam, so the prevention must be platform-neutral.
+
+## Why prior coverage missed it
+
+Existing packaged desktop e2e coverage primarily exercised mock LLM and import-inspection paths. Those tests proved that the bridge launched and dependencies were importable, but they did not require a non-mock packaged runtime warm-load to complete and report `registered=true`/`Registered: yes`. As a result, a real packaged desktop + relay lifecycle could remain in `Running: yes / Registered: no` without failing CI.
+
+## Corrective actions in this PR
+
+- Removed the startup-critical `llama_cpp` pre-import watchdog from model initialization.
+- Kept direct import in the actual bridge process, using the same sanitized runtime path rules as desktop runtime setup.
+- Preserved the broader pre-registration warm-load deadline so genuine runtime stalls fail closed with an actionable `Last error` instead of leaving the operator half-registered.
+- Reused desktop runtime setup diagnostics for compute planning to avoid repeated fragile CUDA/Metal probing.
+- Normalized Windows extended path prefixes before adding packaged import roots while preserving spaces in resource paths and macOS `.app/Contents/Resources` resolution.
+- Suppressed relay unregister attempts when no relay registration has succeeded.
+
+## Prevention tests added
+
+- Unit coverage for no-SIGALRM direct import without invoking the child import watchdog.
+- Unit coverage for Windows extended-path packaged import roots with spaces.
+- Relay unregister coverage that no-ops before successful API v1 registration.
+- Packaged operator e2e coverage that requires `registered=true` for both standard resources and macOS `Contents/Resources` layouts.
+- A fake non-mock `llama_cpp` packaged runtime guard that would stall if the removed child-watchdog import environment is reintroduced, ensuring CI catches the previous failure shape without requiring CUDA hardware.
+
+## Manual validation checklist
+
+After merge, build Windows and macOS packaged releases from HEAD. On Windows 11 with the known-good CUDA `llama-cpp-python` runtime, verify logs progress through `llama_cpp runtime located`, `Selected compute plan`, `Llama init completed successfully`, `model_init.ready`, and `server.registered`; verify UI `Registered: yes`, no `llama_cpp_import_timeout`, staging diagnostics show one node with `queue_depth=0`, chat returns model text, Stop unregisters/TTL-expires the node, and Start reaches `Registered: yes` again. Repeat macOS packaged validation and require either `Registered: yes` with an available runtime or a bounded actionable Metal/runtime error.

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1939,6 +1939,7 @@ def test_run_pre_registration_warmup_times_out_without_registering(capsys, monke
     ]
     assert len(warming_status_events) == 1
     assert "registration.gate_wait_timeout" in captured.err
+    assert "desktop.compute_node_bridge.unregister.attempted" not in captured.err
     assert "api_v1_e2ee.runtime_wait.start" not in captured.err
     assert "api_v1_e2ee.runtime_wait.timeout" not in captured.err
 

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -269,3 +269,25 @@ def test_bootstrap_removes_user_site_and_cwd_shim_while_preserving_packaged_impo
             sys.modules.pop('llama_cpp', None)
         else:
             sys.modules['llama_cpp'] = original_llama_module
+
+
+def test_bootstrap_normalizes_windows_extended_import_root_with_spaces(
+    tmp_path, path_bootstrap, monkeypatch
+):
+    resources_root = tmp_path / 'token.place desktop' / 'resources'
+    script = resources_root / 'python' / 'compute_node_bridge.py'
+    (resources_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    extended_root = '\\\\?\\' + str(resources_root)
+    extended_script = '\\\\?\\' + str(script)
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', extended_root)
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(extended_script)
+        assert str(resources_root) in sys.path
+        assert extended_root not in sys.path
+        assert sys.path.index(str(resources_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -1475,7 +1475,7 @@ def test_import_llama_cpp_runtime_success_records_sanitized_parent_import(monkey
     monkeypatch.setattr(model_manager_module, '_is_repo_llama_cpp_shim', lambda _path: False)
 
     assert model_manager_module._import_llama_cpp_runtime() is fake_runtime
-    assert calls == ['watchdog', 'llama_cpp']
+    assert calls == ['llama_cpp']
 
 
 def test_import_llama_cpp_runtime_rejects_shim_from_discovery_before_parent_import(monkeypatch):
@@ -1515,7 +1515,6 @@ def test_import_llama_cpp_runtime_rejects_shim_from_parent_import(monkeypatch):
         '_find_llama_cpp_spec_in_subprocess',
         lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
     )
-    monkeypatch.setattr(model_manager_module, '_run_llama_cpp_import_watchdog', lambda **_kwargs: {})
     monkeypatch.setattr(model_manager_module.importlib, 'import_module', lambda _name: fake_runtime)
     sys.modules['llama_cpp'] = fake_runtime
 
@@ -1540,12 +1539,6 @@ def test_import_llama_cpp_runtime_reports_parent_import_timeout(monkeypatch):
         '_find_llama_cpp_spec_in_subprocess',
         lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
     )
-    monkeypatch.setattr(
-        model_manager_module,
-        '_run_llama_cpp_import_watchdog',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
-    )
-
     def _slow_parent_import(_name):
         time.sleep(0.2)
         return SimpleNamespace(__file__='/site-packages/llama_cpp/__init__.py')
@@ -1561,10 +1554,12 @@ def test_import_llama_cpp_runtime_reports_parent_import_timeout(monkeypatch):
     )
 
 
-def test_import_llama_cpp_runtime_no_signal_uses_subprocess_facade(monkeypatch):
+def test_import_llama_cpp_runtime_no_signal_uses_direct_parent_import(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
+    fake_runtime = SimpleNamespace(__file__='/site-packages/llama_cpp/__init__.py')
     sys.modules.pop('llama_cpp', None)
+    calls = []
     monkeypatch.delattr(model_manager_module.signal, 'SIGALRM', raising=False)
     monkeypatch.setattr(
         model_manager_module,
@@ -1574,26 +1569,27 @@ def test_import_llama_cpp_runtime_no_signal_uses_subprocess_facade(monkeypatch):
     monkeypatch.setattr(
         model_manager_module,
         '_find_llama_cpp_spec_in_subprocess',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: {'module_path': fake_runtime.__file__},
     )
     monkeypatch.setattr(
         model_manager_module,
         '_run_llama_cpp_import_watchdog',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: calls.append('watchdog'),
     )
     monkeypatch.setattr(
         model_manager_module.importlib,
         'import_module',
-        lambda _name: (_ for _ in ()).throw(AssertionError('parent import must not run')),
+        lambda name: calls.append(name) or fake_runtime,
     )
+    monkeypatch.setattr(model_manager_module, '_is_repo_llama_cpp_shim', lambda _path: False)
 
     runtime = model_manager_module._import_llama_cpp_runtime(timeout_seconds=0.01)
 
-    assert isinstance(runtime, model_manager_module._SubprocessLlamaCppModule)
-    assert runtime.__file__ == '/site-packages/llama_cpp/__init__.py'
+    assert runtime is fake_runtime
+    assert calls == ['llama_cpp']
 
 
-def test_no_signal_warm_load_reports_subprocess_import_timeout(monkeypatch, tmp_path):
+def test_no_signal_warm_load_uses_direct_import_without_subprocess_watchdog(monkeypatch, tmp_path):
     from utils.llm import model_manager as model_manager_module
 
     model_file = tmp_path / 'test_model.gguf'
@@ -1613,37 +1609,18 @@ def test_no_signal_warm_load_reports_subprocess_import_timeout(monkeypatch, tmp_
         'model.enforce_gpu_memory_headroom': False,
     }.get(key, default)
 
-    class HangingStdout:
-        def __iter__(self):
-            while True:
-                time.sleep(1)
-                yield ''
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
 
-    class FakeStdin:
-        def write(self, _text):
-            return None
+        def create_chat_completion(self, **_kwargs):
+            return {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
 
-        def flush(self):
-            return None
-
-    class FakeProcess:
-        def __init__(self, *_args, **_kwargs):
-            self.stdin = FakeStdin()
-            self.stdout = HangingStdout()
-            self.stderr = None
-
-        def terminate(self):
-            return None
-
-        def wait(self, timeout=None):
-            raise TimeoutError('still hung')
-
-        def kill(self):
-            return None
-
-        def poll(self):
-            return None
-
+    fake_runtime = SimpleNamespace(
+        __file__='/site-packages/llama_cpp/__init__.py',
+        Llama=FakeLlama,
+    )
+    calls = []
     sys.modules.pop('llama_cpp', None)
     monkeypatch.delattr(model_manager_module.signal, 'SIGALRM', raising=False)
     monkeypatch.setenv('TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS', '0.01')
@@ -1655,25 +1632,28 @@ def test_no_signal_warm_load_reports_subprocess_import_timeout(monkeypatch, tmp_
     monkeypatch.setattr(
         model_manager_module,
         '_find_llama_cpp_spec_in_subprocess',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: {'module_path': fake_runtime.__file__},
     )
     monkeypatch.setattr(
         model_manager_module,
         '_run_llama_cpp_import_watchdog',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: calls.append('watchdog'),
     )
-    monkeypatch.setattr(model_manager_module.subprocess, 'Popen', FakeProcess)
     monkeypatch.setattr(
         model_manager_module.importlib,
         'import_module',
-        lambda _name: (_ for _ in ()).throw(AssertionError('parent import must not run')),
+        lambda name: calls.append(name) or fake_runtime,
     )
+    monkeypatch.setattr(model_manager_module, '_is_repo_llama_cpp_shim', lambda _path: False)
 
     manager = ModelManager(config)
     manager.requested_compute_mode = 'cpu'
 
-    assert manager.get_llm_instance() is None
-    assert manager.last_runtime_init_error == 'llama_cpp_import_timeout after 0.01s'
+    llm = manager.get_llm_instance()
+
+    assert isinstance(llm, FakeLlama)
+    assert calls == ['llama_cpp']
+    assert manager.last_runtime_init_error is None
 
 
 def test_detect_llama_runtime_capabilities_preserves_gpu_probe_timeout(monkeypatch):
@@ -2000,22 +1980,22 @@ def test_parent_import_guard_returns_already_imported_module_without_reimport(mo
     assert model_manager_module._import_llama_cpp_in_parent_with_timeout(timeout_seconds=0.01) is fake_runtime
 
 
-def test_parent_import_guard_no_signal_fails_closed_without_parent_import(monkeypatch):
+def test_parent_import_guard_no_signal_uses_direct_import(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
+    fake_runtime = SimpleNamespace(__file__='/site-packages/llama_cpp/__init__.py')
     sys.modules.pop('llama_cpp', None)
     monkeypatch.delattr(model_manager_module.signal, 'SIGALRM', raising=False)
     monkeypatch.setattr(
         model_manager_module.importlib,
         'import_module',
-        lambda _name: (_ for _ in ()).throw(AssertionError('parent import must not run')),
+        lambda _name: fake_runtime,
     )
 
-    with pytest.raises(model_manager_module.LlamaCppRuntimeStageTimeout) as exc_info:
+    assert (
         model_manager_module._import_llama_cpp_in_parent_with_timeout(timeout_seconds=0.01)
-
-    assert exc_info.value.stage == 'llama_cpp_import'
-    assert exc_info.value.timeout_seconds == 0.01
+        is fake_runtime
+    )
 
 
 def test_subprocess_llama_proxy_timeout_kills_hung_worker(monkeypatch):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -376,6 +376,8 @@ class TestRelayClient:
     def test_unregister_from_relay_success(self, mock_post, relay_client):
         """Unregister should post to /unregister and return True on success."""
 
+        relay_client._api_v1_registered_relays.add('http://localhost:5000')
+        relay_client._api_v1_last_heartbeat_at['http://localhost:5000'] = 1.0
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_post.return_value = mock_response
@@ -414,6 +416,10 @@ class TestRelayClient:
                 model_manager=mock_model_manager,
             )
 
+        client._api_v1_registered_relays.update({
+            'http://primary-relay:5000',
+            'http://backup-relay:6000',
+        })
         success_response = MagicMock()
         success_response.status_code = 200
         failure_response = MagicMock()
@@ -434,6 +440,7 @@ class TestRelayClient:
     def test_unregister_from_relay_retries_after_transient_failure(self, mock_post, relay_client):
         """A failed unregister attempt should not make later attempts no-ops."""
 
+        relay_client._api_v1_registered_relays.add('http://localhost:5000')
         failure_response = MagicMock()
         failure_response.status_code = 503
         success_response = MagicMock()
@@ -535,6 +542,7 @@ class TestRelayClient:
                 model_manager=mock_model_manager,
             )
 
+        client._api_v1_registered_relays.add('http://localhost:5000')
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_post.return_value = mock_response
@@ -3286,6 +3294,16 @@ def test_unregister_from_relay_is_idempotent_and_clears_api_v1_registration(mock
     assert client._api_v1_registered_relays == set()
     assert client._api_v1_last_heartbeat_at == {}
     assert client._api_v1_relay_wait_hints == {}
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_unregister_from_relay_skips_network_when_never_registered(mock_post):
+    client = _standalone_relay_client()
+
+    assert client.unregister_from_relay() is True
+
+    mock_post.assert_not_called()
+    assert client._unregister_complete is True
 
 
 @patch('utils.networking.relay_client.requests.post')

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -87,7 +87,9 @@ def _sanitize_llama_cpp_import_paths() -> Dict[str, Any]:
     """Keep app imports available while preventing repo-local llama_cpp shim precedence."""
 
     with _LLAMA_CPP_IMPORT_PATH_LOCK:
-        import_root = os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+        import_root = _strip_windows_extended_path_prefix(
+            os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+        )
         moved: list[str] = []
         repo_root_compare = _canonical_path_for_compare(REPO_ROOT)
         cwd_compare = _canonical_path_for_compare(Path.cwd())
@@ -323,7 +325,12 @@ def _probe_llama_cpp_capabilities_in_subprocess(*, timeout_seconds: Optional[flo
     )
 
 def _run_llama_cpp_import_watchdog(*, timeout_seconds: Optional[float] = None) -> Dict[str, Any]:
-    """Validate llama_cpp import in a killable subprocess before parent import."""
+    """Legacy diagnostic helper for isolated llama_cpp import probes.
+
+    Packaged desktop startup intentionally does not call this helper anymore: the
+    runtime setup probe already imports llama_cpp, and a second pre-import child
+    process can diverge from the real bridge process on native CUDA/Metal builds.
+    """
 
     timeout = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
     env = _llama_cpp_probe_env()
@@ -414,9 +421,10 @@ def _import_llama_cpp_in_parent_with_timeout(*, timeout_seconds: Optional[float]
     """Import llama_cpp in this process when Python can recoverably time it out.
 
     No-SIGALRM platforms (notably Windows) cannot interrupt a first native
-    extension import in the current interpreter.  Those platforms are handled by
-    a subprocess-backed module facade in ``_import_llama_cpp_runtime`` so the
-    real import can either succeed in a child process or be killed cleanly.
+    extension import in the current interpreter.  Packaged desktop warm-load runs
+    on a daemon thread with an outer registration deadline, so those platforms
+    use the same direct parent import path as runtime setup instead of a divergent
+    pre-import child process.
     """
 
     timeout = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
@@ -425,7 +433,13 @@ def _import_llama_cpp_in_parent_with_timeout(*, timeout_seconds: Optional[float]
         return already_imported
 
     if not _signal_guard_available():
-        raise LlamaCppRuntimeStageTimeout('llama_cpp_import', timeout)
+        logger.info(
+            "llama_cpp parent import using uninterruptible platform path bounded by caller warm-load deadline "
+            "timeout_seconds=%s interpreter=%s",
+            f"{timeout:g}",
+            sys.executable,
+        )
+        return importlib.import_module('llama_cpp')
 
     if threading.current_thread() is threading.main_thread():
         previous_handler = signal.getsignal(signal.SIGALRM)
@@ -674,17 +688,12 @@ def _import_llama_cpp_runtime(*, require_real_runtime: bool = True, timeout_seco
             "install llama-cpp-python and ensure site-packages wins import priority."
         )
 
-    _run_llama_cpp_import_watchdog(timeout_seconds=timeout_seconds)
-    if not _signal_guard_available() and sys.modules.get('llama_cpp') is None:
-        logger.warning(
-            "llama_cpp parent import delegated to bounded subprocess runtime on no-SIGALRM platform "
-            "module_path=%s interpreter=%s",
-            llama_module_path or 'unknown',
-            sys.executable,
-        )
-        llama_cpp = _SubprocessLlamaCppModule(llama_module_path, timeout_seconds=timeout_seconds)
-    else:
-        llama_cpp = _import_llama_cpp_in_parent_with_timeout(timeout_seconds=timeout_seconds)
+    logger.info(
+        "llama_cpp direct import start module_path=%s interpreter=%s",
+        llama_module_path or 'unknown',
+        sys.executable,
+    )
+    llama_cpp = _import_llama_cpp_in_parent_with_timeout(timeout_seconds=timeout_seconds)
     llama_module_path = getattr(llama_cpp, '__file__', None)
     logger.info(
         "llama_cpp import complete module_path=%s interpreter=%s",

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -838,6 +838,11 @@ class RelayClient:
         self._api_v1_relay_wait_hints = relay_wait_hints
         registered_relays = getattr(self, "_api_v1_registered_relays", set())
 
+        if not registered_relays:
+            log_info("Compute node was never registered; skipping unregister request")
+            self._unregister_complete = True
+            return True
+
         ordered_relay_urls = [
             self._relay_urls[(self._active_relay_index + offset) % len(self._relay_urls)]
             for offset in range(len(self._relay_urls))


### PR DESCRIPTION
### Motivation
- Packaged desktop operators could hang or fail to reach relay registration because model warm-load used a duplicate child-process `llama_cpp` import watchdog that diverged from the runtime setup probe, causing timeouts (observed on Windows CUDA) and leaving the UI `Running: yes / Registered: no`.
- The fix aims to implement a shared, cross-platform solution in shared runtime/bootstrap code rather than a narrow Windows-only workaround and to add tests and e2e guards so the lifecycle must reach `registered=true`.

### Description
- Remove the startup-critical child import watchdog path and import `llama_cpp` directly in the bridge process using the same sanitized import rules as desktop runtime setup, while keeping warm-load bounded by the existing registration deadline. (`utils/llm/model_manager.py`)
- Normalize Windows extended-length `\\?\` path prefixes before using them as import roots to avoid mismatches with packaged/runtime probes and preserve spaces in resource paths. (`desktop-tauri/src-tauri/python/path_bootstrap.py`, `utils/llm/model_manager.py`)
- Suppress relay unregister calls when no API v1 registration was ever observed, and also make `RelayClient.unregister_from_relay` a no-op when there are no registered relays. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`, `utils/networking/relay_client.py`)
- Add a fake non-mock `llama_cpp` site-packages stub for packaged e2e that can simulate the previous watchdog hang shape so CI catches regressions without requiring CUDA hardware. (`desktop-tauri/scripts/test_packaged_operator_e2e.py`)
- Add and update unit tests for: direct no-SIGALRM import behavior, Windows extended-path normalization, unregister-before-registration no-op behavior, and adjustments for the removed watchdog behavior. (`tests/unit/*`) 
- Add an outage entry and JSON metadata documenting the original regression, the failed watchdog-only fix, the e2e gap, and the preventive coverage added. (`outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.*`)

### Testing
- Ran unit and component test suites and e2e probes locally; selected results below: 
  - `pytest tests/unit/test_compute_node_runtime.py` — passed (43 passed).
  - `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or runtime or import or register or unregister or failed"` — passed (34 passed).
  - `pytest tests/unit/test_desktop_runtime_setup.py` — passed (70 passed).
  - `pytest tests/unit/test_desktop_packaged_layout.py` — skipped (environment-specific).
  - `pytest tests/unit/test_desktop_path_bootstrap.py` — passed (10 passed), including new Windows extended-path test.
  - `pytest tests/unit/test_model_manager.py -k "import_llama_cpp_runtime or no_signal or llama_cpp_probe_subprocess_cwd or windows_unc or parent_import_guard_no_signal"` — passed after adapting tests to direct-parent import behavior (9 passed in selection).
  - Packaged e2e: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` — ran probes for packaged standard and macOS Resources layouts and new fake-runtime variant; the bridge emitted `registered=true` as required by the test harness for both standard and fake runtime runs.
  - Parity e2e: `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py` and `python desktop-tauri/scripts/run_desktop_parity_checks.py` — exercised packaged parity checks and completed under this environment.
  - `pre-commit run --all-files` — passed.
- Not-run / environment-limited: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` failed in this container due to missing system `glib-2.0` pkg-config dependency (`glib-2.0.pc`), which is external to the code change and unrelated to Python runtime fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212f2ffad4832f8775d53ab3e1776b)