### PR TITLE
Fix packaged llama_cpp startup import path

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -262,6 +262,71 @@ def run_compute_bridge_import_probe(tmp_root: Path, *, resources_root: Path | No
         assert marker not in combined, combined
 
 
+
+def run_llama_cpp_direct_import_regression_probe(
+    tmp_root: Path,
+    *,
+    resources_root: Path | None = None,
+    layout_label: str = "standard resources",
+) -> None:
+    """Ensure packaged warm-load does not block on a child import watchdog."""
+
+    resources_root = resources_root or (tmp_root / "resources")
+    fake_site = tmp_root / f"fake site-packages {layout_label.replace('/', ' ')}"
+    fake_llama = fake_site / "llama_cpp"
+    fake_llama.mkdir(parents=True, exist_ok=True)
+    (fake_llama / "__init__.py").write_text(
+        "import os, time\n"
+        "if os.environ.get('TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH'):\n"
+        "    time.sleep(5)\n"
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.args = args\n"
+        "        self.kwargs = kwargs\n"
+        "GGML_USE_CUDA = True\n"
+        "def llama_supports_gpu_offload():\n"
+        "    return True\n",
+        encoding="utf-8",
+    )
+    env = _packaged_env(
+        tmp_root,
+        resources_root,
+        extra_env={
+            "PYTHONPATH": os.pathsep.join(
+                [str(fake_site), str(resources_root / "python"), str(resources_root)]
+            ),
+            "TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS": "0.2",
+        },
+    )
+    probe = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys; "
+                f"sys.path.insert(0, {str(fake_site)!r}); "
+                f"sys.path.insert(1, {str(resources_root / 'python')!r}); "
+                f"sys.path.insert(2, {str(resources_root)!r}); "
+                "from path_bootstrap import ensure_runtime_import_paths; "
+                f"ensure_runtime_import_paths({str(resources_root / 'python' / 'compute_node_bridge.py')!r}); "
+                "from utils.llm import model_manager; "
+                "runtime = model_manager._import_llama_cpp_runtime(require_real_runtime=True, timeout_seconds=0.2); "
+                "print(json.dumps({'module_path': getattr(runtime, '__file__', None)}))"
+            ),
+        ],
+        cwd=tmp_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=2,
+        check=False,
+    )
+    combined = f"{probe.stdout}\n{probe.stderr}"
+    assert probe.returncode == 0, f"[{layout_label}] llama_cpp direct import probe failed: {combined}"
+    assert "llama_cpp import watchdog start" not in combined, combined
+    payload = json.loads(probe.stdout.strip().splitlines()[-1])
+    assert Path(payload["module_path"]).parent == fake_llama, combined
+
 def run_unified_root_import_policy_probe(
     tmp_root: Path, *, resources_root: Path | None = None
 ) -> None:
@@ -485,6 +550,7 @@ def main() -> int:
         run_unified_root_import_policy_probe(tmp_path)
         run_model_bridge_inspect_probe(tmp_path)
         run_compute_bridge_import_probe(tmp_path)
+        run_llama_cpp_direct_import_regression_probe(tmp_path)
 
         mac_bridge_script = create_macos_bundle_layout(tmp_path)
         mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
@@ -492,6 +558,11 @@ def main() -> int:
         run_unified_root_import_policy_probe(tmp_path, resources_root=mac_resources_root)
         run_model_bridge_inspect_probe(tmp_path, resources_root=mac_resources_root)
         run_compute_bridge_import_probe(tmp_path, resources_root=mac_resources_root)
+        run_llama_cpp_direct_import_regression_probe(
+            tmp_path,
+            resources_root=mac_resources_root,
+            layout_label="macOS Contents/Resources",
+        )
 
         if os.environ.get("TOKEN_PLACE_INSPECT_ONLY") == "1":
             return 0

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1032,6 +1032,15 @@ def run(args: argparse.Namespace) -> int:
                 )
         unregister = getattr(relay_client, "unregister_from_relay", None)
         if callable(unregister):
+            if not _registration_fresh(relay_client, active_relay_url):
+                print(
+                    "desktop.compute_node_bridge.unregister.skipped "
+                    f"relay={_sanitize_relay_target(active_relay_url)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                    "reason=not_registered",
+                    file=sys.stderr,
+                )
+                return
             print(
                 "desktop.compute_node_bridge.unregister.attempted "
                 f"relay={_sanitize_relay_target(active_relay_url)} "

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -8,14 +8,34 @@ import sys
 from pathlib import Path
 
 
+def _strip_windows_extended_path_prefix(path_text: str) -> str:
+    """Return a normal path string for import-root comparisons.
+
+    Tauri can log Windows resource paths with the ``\\\\?\\`` extended-length
+    prefix.  Python imports and environment propagation are less surprising with
+    the normal spelling, while subprocess launch sites can still use their
+    original executable/script paths.
+    """
+
+    if path_text.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path_text[8:]
+    if path_text.startswith("\\\\?\\"):
+        return path_text[4:]
+    return path_text
+
+
+def _runtime_path(path_text: str) -> Path:
+    return Path(_strip_windows_extended_path_prefix(path_text)).resolve()
+
+
 def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: bool = True) -> None:
     """Add likely import roots for development and packaged desktop layouts."""
 
-    script_path = Path(script_file).resolve()
+    script_path = _runtime_path(script_file)
     script_root = script_path.parent.parent
     explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
     candidates = [
-        Path(explicit_import_root) if explicit_import_root else None,
+        _runtime_path(explicit_import_root) if explicit_import_root else None,
         script_root,  # bundled resources root in packaged apps
         script_root / "resources",  # no-bundle/debug layout when script is under <exe>/python
         script_root / "Resources",  # macOS-style resources casing

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-06-04",
+  "slug": "packaged-desktop-llama-cpp-import-timeout",
+  "summary": "Packaged desktop compute-node startup could fail before relay registration because a child-process llama_cpp import watchdog timed out despite desktop runtime setup finding a valid CUDA runtime.",
+  "impact": "Windows packaged operators with a known-good CUDA llama-cpp-python runtime could remain Registered: no and never serve relay traffic; macOS packaged runtimes shared the same fragile import seam.",
+  "fix": "Removed the startup-critical child-process llama_cpp pre-import watchdog, kept direct bridge-process import semantics, normalized packaged import roots, and skipped unregister before fresh registration exists.",
+  "lessons": "Packaged runtime probes must not diverge from the actual bridge/model initialization environment, and e2e coverage must require registered=true rather than only process startup or mock/inspect success."
+}

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
@@ -1,0 +1,73 @@
+# 2026-06-04 packaged desktop llama_cpp import timeout
+
+## Summary
+Packaged desktop compute-node startup on Windows 11 could fail before relay registration even when
+`desktop_runtime_setup` had already found a known-good CUDA `llama-cpp-python` runtime. The operator
+stopped after `llama_cpp_import_timeout after 30s` and never reached `Registered: yes`.
+
+## Symptoms
+- Packaged bridge launched from the expected desktop resources path, including paths containing
+  spaces such as `token.place desktop`.
+- Runtime setup reported `selected_backend=cuda`, `device=cuda`, and `runtime_action=already_supported`.
+- Warm-load logged `Locating llama_cpp runtime for model initialization...` and discovered the
+  installed `llama_cpp` module quickly with `find_spec`.
+- A separate `llama_cpp import watchdog` subprocess then timed out after 30 seconds while running
+  `importlib.import_module('llama_cpp')`.
+- The bridge failed closed and surfaced an error, but the operator never became registered with the
+  relay and the UI remained `Registered: no`.
+
+## Timeline
+1. Original regression: packaged desktop operator startup could hang at
+   `Locating llama_cpp runtime for model initialization...` before relay registration.
+2. Failed fix attempt: bounded discovery/import watchdogs improved diagnostics and converted the
+   unbounded hang into `llama_cpp_import_timeout after 30s`, but startup still failed.
+3. This PR: removes the child-process pre-import watchdog from the startup-critical path, keeps
+   direct bridge-process import semantics, and strengthens registration lifecycle tests.
+
+## Why the prior fix was insufficient
+The watchdog imported `llama_cpp` in a child process before the bridge imported it for actual model
+initialization. On packaged Windows/macOS native runtimes, that child can have subtly different cwd,
+`PYTHONPATH`, bootstrap environment, DLL/search-path state, extended-path spelling, stdout/stderr
+behavior, or native CUDA/Metal initialization timing. A timeout in that subprocess therefore became
+an accidental startup blocker even though the runtime setup probe had already validated the installed
+runtime path.
+
+## Why CI/e2e missed it
+Existing packaged checks covered dependency preflight, inspect flows, mock LLM paths, bridge JSON
+startup, and relay polling, but did not sufficiently guard the real packaged lifecycle invariant that
+a warm runtime must either reach `registered=true` / UI `Registered: yes` or fail cleanly with an
+actionable bounded error. In particular, mock and inspect paths could pass without proving the
+startup-critical model-manager import path matched the successful desktop runtime setup probe.
+
+## Cross-platform risk
+Although the reproduced failure was Windows 11 CUDA, the broken seam was shared packaged runtime
+bootstrap/model-manager import logic. macOS Metal and CPU-fallback packaged launches use the same
+bridge/model-manager path, so a child pre-import watchdog could also diverge from the actual
+bridge-process runtime environment there.
+
+## Corrective actions in this PR
+- Removed the startup-critical child-process `llama_cpp` pre-import watchdog from model warm-load.
+- Kept direct import in the actual bridge process so model initialization uses the same interpreter,
+  `sys.path`, cwd, and native-library environment as the running operator.
+- Preserved bounded session behavior through the existing warm-load/pre-registration deadline rather
+  than adding another import subprocess.
+- Normalized Windows `\\?\` resource/import-root strings before adding Python import roots while
+  preserving paths with spaces and macOS `.app/Contents/Resources` layouts.
+- Suppressed relay unregister attempts when no fresh registration was ever confirmed.
+
+## Prevention tests added
+- Unit coverage that model-manager startup no longer calls the import watchdog before direct parent
+  import, including no-SIGALRM platforms.
+- Unit coverage for Windows extended-path import roots with spaces and macOS `.app/Contents/Resources`.
+- Unit coverage that runtime/bridge shutdown skips unregister before a confirmed fresh registration.
+- Existing packaged operator e2e continues to require `registered=true` and fails if the bridge stays
+  `Running: yes / Registered: no`.
+
+## Manual validation checklist
+- Build and install a Windows desktop release from this PR.
+- Start the operator against staging with the known-good CUDA GGUF and `auto` mode.
+- Confirm logs include `llama_cpp runtime located`, `Llama init completed successfully`,
+  `model_init.ready`, and `server.registered`, with no `llama_cpp_import_timeout`.
+- Confirm UI shows `Running: yes`, `Registered: yes`, CUDA backend fields, and no last error.
+- Repeat packaged macOS validation; it should reach `Registered: yes` when runtime support is
+  available or fail cleanly with bounded actionable Metal/runtime diagnostics.

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -799,3 +799,34 @@ def test_compute_node_runtime_replaces_stale_error_on_runtime_shape_failure():
 
     assert runtime.ensure_api_v1_runtime_ready() is False
     assert model_manager.last_runtime_init_error == 'runtime_missing_create_chat_completion'
+
+
+def test_compute_node_runtime_stop_skips_unregister_before_fresh_registration():
+    class RelayClient:
+        def __init__(self):
+            self.stop_calls = 0
+            self.unregister_calls = 0
+            self._api_v1_registered_relays = set()
+
+        def stop(self):
+            self.stop_calls += 1
+
+        def api_v1_registration_fresh(self):
+            return False
+
+        def unregister_from_relay(self):
+            self.unregister_calls += 1
+            return True
+
+    relay_client = RelayClient()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=MagicMock(),
+        relay_client=relay_client,
+        crypto_manager=MagicMock(),
+    )
+
+    runtime.stop()
+
+    assert relay_client.stop_calls == 1
+    assert relay_client.unregister_calls == 0

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3070,3 +3070,66 @@ def test_pre_registration_warmup_timeout_reports_current_runtime_stage(capsys, m
     assert error_event['warm_load_state'] == 'failed'
     assert error_event['last_error'] == 'llama_cpp_gpu_probe_timeout after 0.01s'
     assert error_event['message'] == 'llama_cpp_gpu_probe_timeout after 0.01s'
+
+
+class NeverRegisteredRelayClient(FakeRelayClient):
+    def __init__(self):
+        self.stop_calls = 0
+        self.unregister_calls = 0
+
+    def api_v1_registration_fresh(self, _relay_url=None):
+        return False
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def unregister_from_relay(self):
+        self.unregister_calls += 1
+        return True
+
+
+class NeverRegisteredCancelRuntime(FakeRuntime):
+    last_instance = None
+
+    def __init__(self, _config):
+        NeverRegisteredCancelRuntime.last_instance = self
+        self.model_manager = FakeModelManager()
+        self.relay_client = NeverRegisteredRelayClient()
+        self.stop_calls = 0
+        self._processed = []
+
+    def register_and_poll_once(self):
+        return {'next_ping_in_x_seconds': 60}
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+def test_run_skips_unregister_when_poll_cancel_happens_before_fresh_registration(
+    capsys, monkeypatch
+):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch, runtime_cls=NeverRegisteredCancelRuntime)
+    stop_calls = {'count': 0}
+
+    def fake_stop_requested():
+        stop_calls['count'] += 1
+        return stop_calls['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 0
+
+    runtime = NeverRegisteredCancelRuntime.last_instance
+    assert runtime.relay_client.stop_calls == 1
+    assert runtime.relay_client.unregister_calls == 0
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.unregister.skipped' in output.err
+    assert 'reason=not_registered' in output.err

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -269,3 +269,46 @@ def test_bootstrap_removes_user_site_and_cwd_shim_while_preserving_packaged_impo
             sys.modules.pop('llama_cpp', None)
         else:
             sys.modules['llama_cpp'] = original_llama_module
+
+
+def test_bootstrap_normalizes_windows_extended_import_root_with_spaces(
+    tmp_path, path_bootstrap, monkeypatch
+):
+    script = tmp_path / 'token.place desktop' / 'resources' / 'python' / 'compute_node_bridge.py'
+    explicit_root = tmp_path / 'token.place desktop' / '_up_' / '_up_'
+    (explicit_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    extended_root = '\\\\?\\' + str(explicit_root)
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', extended_root)
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(explicit_root.resolve()) in sys.path
+        assert extended_root not in sys.path
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def test_bootstrap_supports_macos_app_contents_resources_with_spaces(tmp_path, path_bootstrap):
+    script = (
+        tmp_path
+        / 'Token Place.app'
+        / 'Contents'
+        / 'Resources'
+        / 'python'
+        / 'compute_node_bridge.py'
+    )
+    resources_root = script.parents[1]
+    (resources_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script))
+        assert str(resources_root) in sys.path
+        assert sys.path.index(str(resources_root)) == 0
+    finally:
+        sys.path[:] = original_sys_path

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -1465,7 +1465,7 @@ def test_import_llama_cpp_runtime_success_records_sanitized_parent_import(monkey
     monkeypatch.setattr(
         model_manager_module,
         '_run_llama_cpp_import_watchdog',
-        lambda **_kwargs: calls.append('watchdog') or {'module_path': fake_runtime.__file__},
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError('startup must not pre-import in a watchdog subprocess')),
     )
     monkeypatch.setattr(
         model_manager_module.importlib,
@@ -1475,7 +1475,7 @@ def test_import_llama_cpp_runtime_success_records_sanitized_parent_import(monkey
     monkeypatch.setattr(model_manager_module, '_is_repo_llama_cpp_shim', lambda _path: False)
 
     assert model_manager_module._import_llama_cpp_runtime() is fake_runtime
-    assert calls == ['watchdog', 'llama_cpp']
+    assert calls == ['llama_cpp']
 
 
 def test_import_llama_cpp_runtime_rejects_shim_from_discovery_before_parent_import(monkeypatch):
@@ -1515,7 +1515,7 @@ def test_import_llama_cpp_runtime_rejects_shim_from_parent_import(monkeypatch):
         '_find_llama_cpp_spec_in_subprocess',
         lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
     )
-    monkeypatch.setattr(model_manager_module, '_run_llama_cpp_import_watchdog', lambda **_kwargs: {})
+    monkeypatch.setattr(model_manager_module, '_run_llama_cpp_import_watchdog', MagicMock())
     monkeypatch.setattr(model_manager_module.importlib, 'import_module', lambda _name: fake_runtime)
     sys.modules['llama_cpp'] = fake_runtime
 
@@ -1561,7 +1561,7 @@ def test_import_llama_cpp_runtime_reports_parent_import_timeout(monkeypatch):
     )
 
 
-def test_import_llama_cpp_runtime_no_signal_uses_subprocess_facade(monkeypatch):
+def test_import_llama_cpp_runtime_no_signal_uses_direct_parent_import(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
     sys.modules.pop('llama_cpp', None)
@@ -1579,21 +1579,23 @@ def test_import_llama_cpp_runtime_no_signal_uses_subprocess_facade(monkeypatch):
     monkeypatch.setattr(
         model_manager_module,
         '_run_llama_cpp_import_watchdog',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError('startup must not pre-import in a watchdog subprocess')),
     )
+    fake_runtime = SimpleNamespace(__file__='/site-packages/llama_cpp/__init__.py')
+    parent_imports = []
     monkeypatch.setattr(
         model_manager_module.importlib,
         'import_module',
-        lambda _name: (_ for _ in ()).throw(AssertionError('parent import must not run')),
+        lambda name: parent_imports.append(name) or fake_runtime,
     )
 
     runtime = model_manager_module._import_llama_cpp_runtime(timeout_seconds=0.01)
 
-    assert isinstance(runtime, model_manager_module._SubprocessLlamaCppModule)
-    assert runtime.__file__ == '/site-packages/llama_cpp/__init__.py'
+    assert runtime is fake_runtime
+    assert parent_imports == ['llama_cpp']
 
 
-def test_no_signal_warm_load_reports_subprocess_import_timeout(monkeypatch, tmp_path):
+def test_no_signal_warm_load_uses_direct_parent_import_without_watchdog(monkeypatch, tmp_path):
     from utils.llm import model_manager as model_manager_module
 
     model_file = tmp_path / 'test_model.gguf'
@@ -1608,45 +1610,23 @@ def test_no_signal_warm_load_reports_subprocess_import_timeout(monkeypatch, tmp_
         'model.use_mock': False,
         'model.context_size': 2048,
         'model.chat_format': 'llama-3',
-        'model.n_gpu_layers': -1,
+        'model.n_gpu_layers': 0,
         'model.gpu_memory_headroom_percent': 0.1,
         'model.enforce_gpu_memory_headroom': False,
     }.get(key, default)
 
-    class HangingStdout:
-        def __iter__(self):
-            while True:
-                time.sleep(1)
-                yield ''
+    class FakeLlama:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
 
-    class FakeStdin:
-        def write(self, _text):
-            return None
-
-        def flush(self):
-            return None
-
-    class FakeProcess:
-        def __init__(self, *_args, **_kwargs):
-            self.stdin = FakeStdin()
-            self.stdout = HangingStdout()
-            self.stderr = None
-
-        def terminate(self):
-            return None
-
-        def wait(self, timeout=None):
-            raise TimeoutError('still hung')
-
-        def kill(self):
-            return None
-
-        def poll(self):
-            return None
-
+    fake_runtime = SimpleNamespace(
+        __file__='/site-packages/llama_cpp/__init__.py',
+        Llama=FakeLlama,
+    )
+    parent_imports = []
     sys.modules.pop('llama_cpp', None)
     monkeypatch.delattr(model_manager_module.signal, 'SIGALRM', raising=False)
-    monkeypatch.setenv('TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS', '0.01')
     monkeypatch.setattr(
         model_manager_module,
         '_sanitize_llama_cpp_import_paths',
@@ -1655,26 +1635,25 @@ def test_no_signal_warm_load_reports_subprocess_import_timeout(monkeypatch, tmp_
     monkeypatch.setattr(
         model_manager_module,
         '_find_llama_cpp_spec_in_subprocess',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: {'module_path': fake_runtime.__file__},
     )
     monkeypatch.setattr(
         model_manager_module,
         '_run_llama_cpp_import_watchdog',
-        lambda **_kwargs: {'module_path': '/site-packages/llama_cpp/__init__.py'},
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError('startup must not pre-import in a watchdog subprocess')),
     )
-    monkeypatch.setattr(model_manager_module.subprocess, 'Popen', FakeProcess)
     monkeypatch.setattr(
         model_manager_module.importlib,
         'import_module',
-        lambda _name: (_ for _ in ()).throw(AssertionError('parent import must not run')),
+        lambda name: parent_imports.append(name) or fake_runtime,
     )
 
     manager = ModelManager(config)
     manager.requested_compute_mode = 'cpu'
 
-    assert manager.get_llm_instance() is None
-    assert manager.last_runtime_init_error == 'llama_cpp_import_timeout after 0.01s'
-
+    assert isinstance(manager.get_llm_instance(), FakeLlama)
+    assert parent_imports == ['llama_cpp']
+    assert manager.last_runtime_init_error is None
 
 def test_detect_llama_runtime_capabilities_preserves_gpu_probe_timeout(monkeypatch):
     from utils.llm import model_manager as model_manager_module
@@ -2000,22 +1979,21 @@ def test_parent_import_guard_returns_already_imported_module_without_reimport(mo
     assert model_manager_module._import_llama_cpp_in_parent_with_timeout(timeout_seconds=0.01) is fake_runtime
 
 
-def test_parent_import_guard_no_signal_fails_closed_without_parent_import(monkeypatch):
+def test_parent_import_guard_no_signal_imports_directly(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
     sys.modules.pop('llama_cpp', None)
     monkeypatch.delattr(model_manager_module.signal, 'SIGALRM', raising=False)
+    fake_runtime = SimpleNamespace(__file__='/site-packages/llama_cpp/__init__.py')
+    imports = []
     monkeypatch.setattr(
         model_manager_module.importlib,
         'import_module',
-        lambda _name: (_ for _ in ()).throw(AssertionError('parent import must not run')),
+        lambda name: imports.append(name) or fake_runtime,
     )
 
-    with pytest.raises(model_manager_module.LlamaCppRuntimeStageTimeout) as exc_info:
-        model_manager_module._import_llama_cpp_in_parent_with_timeout(timeout_seconds=0.01)
-
-    assert exc_info.value.stage == 'llama_cpp_import'
-    assert exc_info.value.timeout_seconds == 0.01
+    assert model_manager_module._import_llama_cpp_in_parent_with_timeout(timeout_seconds=0.01) is fake_runtime
+    assert imports == ['llama_cpp']
 
 
 def test_subprocess_llama_proxy_timeout_kills_hung_worker(monkeypatch):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -426,7 +426,9 @@ class ComputeNodeRuntime:
         try:
             self.relay_client.stop()
             unregister_fn = getattr(self.relay_client, "unregister_from_relay", None)
-            if callable(unregister_fn):
+            registered_relays = getattr(self.relay_client, "_api_v1_registered_relays", None)
+            should_unregister = not (isinstance(registered_relays, set) and not registered_relays)
+            if callable(unregister_fn) and should_unregister:
                 if not unregister_fn():
                     _log_warning("Relay unregister request failed during shutdown")
         except Exception:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -411,12 +411,16 @@ def _signal_guard_available() -> bool:
 
 
 def _import_llama_cpp_in_parent_with_timeout(*, timeout_seconds: Optional[float] = None):
-    """Import llama_cpp in this process when Python can recoverably time it out.
+    """Import llama_cpp in the bridge process.
 
-    No-SIGALRM platforms (notably Windows) cannot interrupt a first native
-    extension import in the current interpreter.  Those platforms are handled by
-    a subprocess-backed module facade in ``_import_llama_cpp_runtime`` so the
-    real import can either succeed in a child process or be killed cleanly.
+    Packaged desktop startup must exercise the same interpreter, sys.path, cwd,
+    DLL/search-path state, and native-extension environment that model
+    initialization will actually use.  A previous killable child-process
+    pre-import watchdog could diverge from that environment on Windows/macOS and
+    block otherwise valid CUDA/Metal runtimes before the real bridge process had
+    a chance to import them.  Keep a SIGALRM guard where Python supports one,
+    but on no-SIGALRM platforms rely on the outer warm-load/session deadline
+    instead of a second subprocess import.
     """
 
     timeout = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
@@ -425,7 +429,12 @@ def _import_llama_cpp_in_parent_with_timeout(*, timeout_seconds: Optional[float]
         return already_imported
 
     if not _signal_guard_available():
-        raise LlamaCppRuntimeStageTimeout('llama_cpp_import', timeout)
+        logger.info(
+            "llama_cpp direct parent import without SIGALRM guard timeout_seconds=%s interpreter=%s",
+            f"{timeout:g}",
+            sys.executable,
+        )
+        return importlib.import_module('llama_cpp')
 
     if threading.current_thread() is threading.main_thread():
         previous_handler = signal.getsignal(signal.SIGALRM)
@@ -674,17 +683,12 @@ def _import_llama_cpp_runtime(*, require_real_runtime: bool = True, timeout_seco
             "install llama-cpp-python and ensure site-packages wins import priority."
         )
 
-    _run_llama_cpp_import_watchdog(timeout_seconds=timeout_seconds)
-    if not _signal_guard_available() and sys.modules.get('llama_cpp') is None:
-        logger.warning(
-            "llama_cpp parent import delegated to bounded subprocess runtime on no-SIGALRM platform "
-            "module_path=%s interpreter=%s",
-            llama_module_path or 'unknown',
-            sys.executable,
-        )
-        llama_cpp = _SubprocessLlamaCppModule(llama_module_path, timeout_seconds=timeout_seconds)
-    else:
-        llama_cpp = _import_llama_cpp_in_parent_with_timeout(timeout_seconds=timeout_seconds)
+    logger.info(
+        "llama_cpp runtime located module_path=%s interpreter=%s import_strategy=direct_parent",
+        llama_module_path or 'unknown',
+        sys.executable,
+    )
+    llama_cpp = _import_llama_cpp_in_parent_with_timeout(timeout_seconds=timeout_seconds)
     llama_module_path = getattr(llama_cpp, '__file__', None)
     logger.info(
         "llama_cpp import complete module_path=%s interpreter=%s",


### PR DESCRIPTION
### Motivation
- Packaged desktop startup could hang or time out when a child-process watchdog tried to import the native `llama_cpp` extension, causing the bridge to fail before reaching `Registered: yes` on Windows (CUDA) and risking similar divergence on macOS.
- The watchdog subprocess diverged from the actual bridge interpreter/sys.path/CWD/DLL state, producing false timeouts even when `desktop_runtime_setup` had discovered a valid runtime.

### Description
- Remove the startup-critical child-process pre-import watchdog and import `llama_cpp` directly in the bridge/parent process while preserving shim detection and discovery diagnostics, using a SIGALRM guard where supported and direct parent import on no-SIGALRM platforms. (`utils/llm/model_manager.py`) 
- Log the chosen import strategy (`import_strategy=direct_parent`) to aid diagnostics. (`utils/llm/model_manager.py`) 
- Normalize Windows extended-length `\\?\` import-root strings and resolve those paths before adding them to `sys.path`, preserving spaces and macOS `.app/Contents/Resources` layouts. (`desktop-tauri/src-tauri/python/path_bootstrap.py`) 
- Avoid attempting relay `unregister_from_relay` when no fresh API v1 registration exists; skip unregister in bridge cancel and runtime shutdown when registration is not fresh. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`, `utils/compute_node_runtime.py`) 
- Add unit tests and a packaged e2e probe that simulates a `llama_cpp` module which would hang only when imported in the child-probe environment to assert the bridge uses direct parent import and does not log the watchdog start. (`desktop-tauri/scripts/test_packaged_operator_e2e.py`, `tests/unit/*`) 
- Add an outage entry documenting the original regression, the failed watchdog-only attempt, the e2e gap, and the cross-platform corrective actions. (`outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md` and .json)

### Testing
- Ran unit test suites and targeted tests; results: all executed unit tests passed.
  - `pytest tests/unit/test_compute_node_runtime.py` — passed.
  - `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or runtime or import or register or unregister or failed"` — passed.
  - `pytest tests/unit/test_desktop_runtime_setup.py` — passed.
  - `pytest tests/unit/test_desktop_packaged_layout.py` — passed (one skip expected for platform gating).
  - `pytest tests/unit/test_desktop_path_bootstrap.py` — passed.
  - `pytest tests/unit/test_model_manager.py -k "llama_cpp_runtime or no_signal or parent_import_guard or direct_parent"` — passed.
- Packaged e2e / parity checks executed locally: `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`, and `python desktop-tauri/scripts/run_desktop_parity_checks.py` completed successfully in this environment.
- `pre-commit run --all-files` passed.
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not complete in this container due to a missing system dependency (`glib-2.0.pc`), so Rust tests were not run here; this is an environment limitation, not a code failure.

Known residual risks and follow-ups: validate on hardware Windows CUDA and macOS Metal real packaged builds (manual checklist in outage doc), and run full `cargo test` in CI/workstation with `glib-2.0` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212f2ffad4832f8775d53ab3e1776b)