### PR TITLE
Improve Windows desktop llama_cpp subprocess facade: normalize paths, surface child diagnostics, and tighten e2e guards

### DIFF
--- a/desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
@@ -240,6 +240,12 @@ def _wait_for_registered(bridge: BridgeProcess, relay_url: str, *, layout_label:
                 f"bridge exited before registration for {layout_label}: "
                 f"code={bridge.process.returncode} log={bridge.log_path}"
             )
+        for line in list(bridge.output_lines):
+            if "llama_cpp_import subprocess ended" in line or "Running: yes / Registered: no" in line:
+                raise RuntimeError(
+                    f"bridge emitted pre-registration regression marker for {layout_label}: "
+                    f"log={bridge.log_path} line={line}"
+                )
         for event in list(bridge.events):
             last_event = event
             if event.get("type") == "error":

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -558,6 +558,7 @@ def run_compute_bridge_startup_probe(
             "compute-node bridge exited before emitting a startup event",
             "desktop_runtime_setup module missing",
             "llama_cpp_import_timeout",
+            "llama_cpp_import subprocess ended",
             "llama_cpp import watchdog start",
             "Running: yes / Registered: no",
         )

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -24,6 +24,7 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
     """Add likely import roots for development and packaged desktop layouts."""
 
     script_path = _safe_resolve_path(script_file)
+    os.environ.setdefault("TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT", str(script_path))
     script_root = script_path.parent.parent
     explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
     candidates = [

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
@@ -3,6 +3,6 @@
   "slug": "packaged-desktop-llama-cpp-import-timeout",
   "summary": "Packaged desktop compute-node startup timed out in a child llama_cpp import watchdog after runtime setup had already found a supported CUDA runtime, preventing Registered: yes.",
   "impact": "Windows packaged operators could fail/stopped before relay registration, and the shared packaged import seam also risked macOS Metal parity.",
-  "fix": "Removed the startup-critical child import watchdog, reused desktop runtime setup probe diagnostics, imported llama_cpp in the real bridge process, normalized packaged paths, and skipped unregister before successful registration.",
-  "lessons": "Packaged e2e must prove registered=true for the full desktop + relay lifecycle and must exercise shared runtime/bootstrap code instead of only inspect or mock paths. Native-extension import probes must not run in a divergent child environment unless that environment is proven equivalent."
+  "fix": "Kept the startup-critical child import watchdog removed, made the retained subprocess runtime facade replay the desktop bootstrap/path contract, normalized packaged Windows paths, surfaced child exit stdout/stderr/exit-code diagnostics, and skipped unregister before successful registration.",
+  "lessons": "Packaged e2e must prove registered=true for the full desktop + relay lifecycle and must exercise shared runtime/bootstrap code instead of only inspect or mock paths. Native-extension subprocesses must either be environment-equivalent to the successful desktop probe or fail with actionable stderr/stdout/exit-code diagnostics."
 }

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
@@ -20,15 +20,25 @@ The operator moved from warm-load to failed/stopped and never reached `Registere
 - Failed fix attempt: bounded subprocess discovery/import watchdogs were added. Discovery via
   `find_spec` completed quickly, but the separate child-process `import llama_cpp` watchdog still
   timed out after 30 seconds.
-- This PR: removed the startup-critical child import watchdog, reused successful desktop runtime
-  probe diagnostics, and kept the real import in the bridge process that initializes the model.
+- Second failed fix attempt: the direct parent import was skipped on no-`SIGALRM` desktop warm-load
+  paths and replaced with a subprocess runtime facade. The facade progressed past discovery, but its
+  worker could exit before the first protocol message while stderr/stdout were discarded, collapsing
+  the root cause to the generic `llama_cpp_import subprocess ended`.
+- This PR: made the retained facade use the same bootstrap contract as the desktop runtime probe,
+  normalized extended Windows paths before child launch, moved worker imports inside the JSON error
+  envelope, and surfaced child exit code/stdout/stderr/cwd/import-root/module-path diagnostics.
 
-## Why the prior fix was insufficient
+## Why the prior fixes were insufficient
 The watchdog imported `llama_cpp` in a subprocess before the actual bridge process imported it.
 On packaged Windows/macOS native-extension runtimes, that child can have different `sys.path`, cwd,
 `PYTHONPATH`, `PYTHONNOUSERSITE`, import-root, DLL/search-path, and extended-path behavior than the
 runtime setup probe or the real bridge warm-load process. The watchdog therefore became a second
 runtime environment that could fail differently from the environment that needed to start.
+
+The subprocess facade then repeated part of the same mistake: it inherited a sanitized `PYTHONPATH`,
+but it did not faithfully replay the desktop bootstrap path contract and discarded child stderr.
+Import failures before the facade handshake therefore looked like `llama_cpp_import subprocess ended`
+instead of the real import/DLL/bootstrap failure.
 
 ## Why CI/e2e missed it
 Existing packaged coverage validated bridge imports, dependency preflight, mock-LLM bridge events,
@@ -44,17 +54,22 @@ could have hit an equivalent child import divergence.
 
 ## Corrective actions in this PR
 - Reuse the successful `desktop_runtime_setup` probe module path during model warm-load.
-- Remove the startup-critical pre-import child watchdog from the real bridge startup path.
-- Import `llama_cpp` directly in the bridge process and verify that it matches the desktop probe
-  module path when a probe was available.
+- Keep the removed pre-import watchdog off the startup-critical path.
+- Retain the subprocess runtime facade only with the same packaged bootstrap path semantics as the
+  probe, including `TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT` and normalized desktop path env vars.
+- Capture facade worker stdout/stderr tails, exit code, cwd, command, import root, and module path
+  hint on early exit so any remaining failure is actionable.
 - Normalize Windows `\\?\` paths for comparisons/import-root resolution without using extended
-  paths as the preferred packaged import-root representation.
+  paths as the preferred packaged bootstrap-script representation.
 - Skip relay unregister when no API v1 registration succeeded.
 
 ## Prevention tests added
 - Unit coverage for reusing desktop runtime probe diagnostics and proving the child import watchdog
   is not called in the startup-critical path.
 - Unit coverage for Windows extended paths with spaces and macOS-style resource paths.
-- Packaged e2e regression coverage with a fake `llama_cpp` that would hang only in the removed child
-  watchdog context, plus existing standard and macOS `Contents/Resources` packaged lifecycle checks
-  that fail unless `registered=true` appears.
+- Unit coverage that facade early exit includes exit code, stdout/stderr tails, cwd, import root,
+  command, and module path hints.
+- Unit coverage that packaged bootstrap records a normalized bootstrap script path for facade
+  children and that Windows extended paths with spaces are normalized before child launch.
+- Packaged and relay parity e2e guards now fail on `llama_cpp_import subprocess ended`,
+  `Running: yes / Registered: no`, or any lifecycle that does not emit `registered=true`.

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -92,6 +92,23 @@ def test_bootstrap_prefers_explicit_env_import_root(tmp_path, path_bootstrap, mo
         sys.path[:] = original_sys_path
 
 
+def test_bootstrap_records_normalized_env_for_facade_children(tmp_path, path_bootstrap, monkeypatch):
+    script = tmp_path / 'token.place desktop' / 'python' / 'compute_node_bridge.py'
+    import_root = tmp_path / 'token.place desktop' / '_up_' / '_up_'
+    (import_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    monkeypatch.delenv('TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', raising=False)
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths('\\\\?\\' + str(script))
+        assert os.environ['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'] == str(script.resolve())
+        assert str(import_root.resolve()) in sys.path
+    finally:
+        sys.path[:] = original_sys_path
+
 def test_bootstrap_keeps_repo_root_importable_without_shadowing_llama_cpp(
     tmp_path, path_bootstrap, monkeypatch
 ):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2371,6 +2371,70 @@ def test_runtime_worker_env_omits_probe_sys_path_marker(monkeypatch):
     assert env.get('PYTHONPATH')
 
 
+
+def test_runtime_worker_env_normalizes_windows_extended_desktop_paths(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_')
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\python\compute_node_bridge.py')
+    monkeypatch.setattr(
+        model_manager_module,
+        '_llama_cpp_probe_sys_path_entries',
+        lambda: [r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_'],
+    )
+
+    env = model_manager_module._llama_cpp_runtime_worker_env()
+
+    assert env['TOKEN_PLACE_PYTHON_IMPORT_ROOT'] == r'C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_'
+    assert env['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'] == r'C:\Users\danie\AppData\Local\token.place desktop\python\compute_node_bridge.py'
+    assert env['PYTHONPATH'] == r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_'
+
+
+def test_read_llama_subprocess_message_early_exit_includes_actionable_diagnostics():
+    from utils.llm import model_manager as model_manager_module
+
+    class EmptyStdout:
+        def __iter__(self):
+            return iter(())
+
+    class FakeProcess:
+        args = ['python', '-u', '-c', '<worker>']
+        stdout = EmptyStdout()
+
+        def wait(self, timeout=None):
+            return 2
+
+        def poll(self):
+            return 2
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager_module._read_llama_subprocess_message(
+            FakeProcess(),
+            timeout_seconds=1,
+            stage='llama_cpp_import',
+            stdout_tail=['worker booted'],
+            stderr_tail=['Traceback line', 'ImportError: DLL load failed'],
+            command=['python', '-u', '-c'],
+            cwd=r'C:\Users\danie\AppData\Local\Programs\Python\Python311',
+            module_path_hint=r'C:\Users\danie\AppData\Local\Programs\Python\Python311\Lib\site-packages\llama_cpp\__init__.py',
+        )
+
+    message = str(exc_info.value)
+    assert 'llama_cpp_import subprocess ended' in message
+    assert 'exit_code=2' in message
+    assert 'stderr_tail=' in message
+    assert 'ImportError: DLL load failed' in message
+    assert 'stdout_tail=' in message
+    assert 'worker booted' in message
+    assert 'module_path_hint=' in message
+    assert 'Python311' in message
+
 def test_subprocess_llama_proxy_timeout_kills_hung_worker(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,6 +51,29 @@ def _strip_windows_extended_path_prefix(path_text: str) -> str:
     return path_text
 
 
+def _runtime_env_path_value(value: Any) -> str:
+    """Return an env-safe path string without Windows extended-length prefixes."""
+
+    if value is None:
+        return ''
+    return _strip_windows_extended_path_prefix(str(value))
+
+
+def _normalize_runtime_env_paths(env: Dict[str, str]) -> Dict[str, str]:
+    """Normalize desktop runtime path env vars before spawning Python children."""
+
+    for name in (
+        'TOKEN_PLACE_PYTHON_IMPORT_ROOT',
+        'TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT',
+        'TOKEN_PLACE_DESKTOP_PYTHON_ROOT',
+        'TOKEN_PLACE_PROBE_REPO_ROOT',
+    ):
+        value = env.get(name)
+        if value:
+            env[name] = _runtime_env_path_value(value)
+    return env
+
+
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
     if not module_path:
         return None
@@ -163,7 +186,7 @@ def _llama_cpp_probe_env() -> Dict[str, str]:
     env = os.environ.copy()
     env['PYTHONPATH'] = os.pathsep.join(pythonpath_entries)
     env['TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH'] = json.dumps(pythonpath_entries)
-    return env
+    return _normalize_runtime_env_paths(env)
 
 
 def _llama_cpp_path_prefixed_code(user_code: str, path_source: str) -> str:
@@ -227,7 +250,7 @@ def _llama_cpp_runtime_worker_env() -> Dict[str, str]:
     env = os.environ.copy()
     env['PYTHONPATH'] = os.pathsep.join(pythonpath_entries)
     env.pop('TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH', None)
-    return env
+    return _normalize_runtime_env_paths(env)
 
 
 def _llama_cpp_runtime_worker_code(user_code: str) -> str:
@@ -528,21 +551,77 @@ def _import_llama_cpp_in_parent_with_timeout(
         desktop_runtime_probe=desktop_runtime_probe,
     )
 
+def _append_tail_line(tail: List[str], line: str, *, max_lines: int = 40) -> None:
+    tail.append(line.rstrip('\r\n'))
+    if len(tail) > max_lines:
+        del tail[: len(tail) - max_lines]
+
+
+def _format_llama_subprocess_failure(
+    *,
+    stage: str,
+    process: subprocess.Popen,
+    stdout_tail: Iterable[str] = (),
+    stderr_tail: Iterable[str] = (),
+    command: Any = None,
+    cwd: Any = None,
+    module_path_hint: Any = None,
+) -> str:
+    try:
+        exit_code = process.poll()
+    except Exception:
+        exit_code = 'unknown'
+    command_value = command if command is not None else getattr(process, 'args', 'unknown')
+    import_root = os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+    stdout_text = '\n'.join(str(line) for line in stdout_tail if str(line))[-2000:]
+    stderr_text = '\n'.join(str(line) for line in stderr_tail if str(line))[-4000:]
+    return (
+        f"{stage} subprocess ended exit_code={exit_code} "
+        f"command={command_value!r} cwd={cwd or 'unknown'} "
+        f"import_root={_runtime_env_path_value(import_root) or 'unknown'} "
+        f"module_path_hint={module_path_hint or 'unknown'} "
+        f"stdout_tail={stdout_text!r} stderr_tail={stderr_text!r}"
+    )
+
+
 def _read_llama_subprocess_message(
     process: subprocess.Popen,
     *,
     timeout_seconds: Optional[float],
     stage: str,
+    stdout_tail: Optional[List[str]] = None,
+    stderr_tail: Optional[List[str]] = None,
+    command: Any = None,
+    cwd: Any = None,
+    module_path_hint: Any = None,
 ) -> Dict[str, Any]:
     result_queue: queue.Queue[str] = queue.Queue(maxsize=1)
+    stdout_lines = stdout_tail if stdout_tail is not None else []
+    stderr_lines = stderr_tail if stderr_tail is not None else []
 
     def _reader() -> None:
         assert process.stdout is not None
         for line in process.stdout:
+            _append_tail_line(stdout_lines, line)
             if line.startswith('TOKEN_PLACE_LLAMA_CPP_JSON:'):
                 result_queue.put(line.split(':', 1)[1].strip())
                 return
-        result_queue.put(json.dumps({'status': 'error', 'error': f'{stage} subprocess ended'}))
+        try:
+            process.wait(timeout=0.2)
+        except Exception:
+            pass
+        result_queue.put(json.dumps({
+            'status': 'error',
+            'error': _format_llama_subprocess_failure(
+                stage=stage,
+                process=process,
+                stdout_tail=stdout_lines,
+                stderr_tail=stderr_lines,
+                command=command,
+                cwd=cwd,
+                module_path_hint=module_path_hint,
+            ),
+        }))
 
     reader = threading.Thread(target=_reader, name=f'{stage}_stdout_reader', daemon=True)
     reader.start()
@@ -565,7 +644,11 @@ def _read_llama_subprocess_message(
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'error':
-        raise RuntimeError(str(message.get('error') or f'{stage} failed'))
+        error_text = str(message.get('error') or f'{stage} failed')
+        traceback_text = str(message.get('traceback') or '').strip()
+        if traceback_text and 'traceback=' not in error_text:
+            error_text = f"{error_text} traceback={traceback_text[-4000:]}"
+        raise RuntimeError(error_text)
     return message
 
 
@@ -575,22 +658,57 @@ class _SubprocessLlamaProxy:
     def __init__(self, *args, timeout_seconds: Optional[float] = None, **kwargs) -> None:
         self._timeout_seconds = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
         self._lock = Lock()
+        self._stdout_tail: List[str] = []
+        self._stderr_tail: List[str] = []
+        self._command = [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)]
+        self._cwd = _llama_cpp_probe_subprocess_cwd()
         self._process = subprocess.Popen(
-            [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)],
+            self._command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             env=_llama_cpp_runtime_worker_env(),
-            cwd=_llama_cpp_probe_subprocess_cwd(),
+            cwd=self._cwd,
             bufsize=1,
         )
+        self._start_stderr_tail_reader()
         self._send({'method': '__init__', 'args': args, 'kwargs': kwargs})
         _read_llama_subprocess_message(
             self._process,
             timeout_seconds=self._timeout_seconds,
             stage='llama_cpp_import',
+            stdout_tail=self._stdout_tail,
+            stderr_tail=self._stderr_tail,
+            command=self._command[:3],
+            cwd=self._cwd,
+            module_path_hint=getattr(self, '_module_path_hint', None),
         )
+
+    def _start_stderr_tail_reader(self) -> None:
+        if self._process.stderr is None:
+            return
+
+        def _reader() -> None:
+            assert self._process.stderr is not None
+            for line in self._process.stderr:
+                _append_tail_line(self._stderr_tail, line)
+
+        threading.Thread(
+            target=_reader,
+            name='llama_cpp_subprocess_stderr_reader',
+            daemon=True,
+        ).start()
+
+    def _read_context(self) -> Dict[str, Any]:
+        if not hasattr(self, '_stdout_tail'):
+            return {}
+        return {
+            'stdout_tail': self._stdout_tail,
+            'stderr_tail': self._stderr_tail,
+            'command': self._command[:3],
+            'cwd': self._cwd,
+        }
 
     def _send(self, payload: Dict[str, Any]) -> None:
         if self._process.stdin is None:
@@ -608,6 +726,7 @@ class _SubprocessLlamaProxy:
                 self._process,
                 timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
                 stage='llama_cpp_inference',
+                **self._read_context(),
             )
         return message.get('result')
 
@@ -619,6 +738,7 @@ class _SubprocessLlamaProxy:
                     self._process,
                     timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
                     stage='llama_cpp_inference',
+                    **self._read_context(),
                 )
                 if message.get('done'):
                     return
@@ -658,7 +778,11 @@ class _SubprocessLlamaCppModule:
     def Llama(self):
         timeout_seconds = self._timeout_seconds
 
+        module_path_hint = self.__file__
+
         class _ConfiguredSubprocessLlama(_SubprocessLlamaProxy):
+            _module_path_hint = module_path_hint
+
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, timeout_seconds=timeout_seconds, **kwargs)
 
@@ -666,7 +790,28 @@ class _SubprocessLlamaCppModule:
 
 
 _LLAMA_CPP_RUNTIME_WORKER_CODE = """
-import importlib, json, sys, traceback
+import importlib, json, os, sys, traceback
+
+def _strip_windows_extended_path_prefix(path_text):
+    if path_text.startswith("\\\\\\\\?\\\\UNC\\\\"):
+        return "\\\\\\\\" + path_text[8:]
+    if path_text.startswith("\\\\\\\\?\\\\"):
+        return path_text[4:]
+    return path_text
+
+def _bootstrap_desktop_paths():
+    bootstrap_script = os.environ.get('TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT', '').strip()
+    if not bootstrap_script:
+        return
+    bootstrap_script = _strip_windows_extended_path_prefix(bootstrap_script)
+    bootstrap_dir = os.path.dirname(bootstrap_script)
+    if bootstrap_dir and bootstrap_dir not in sys.path:
+        sys.path.insert(0, bootstrap_dir)
+    try:
+        from path_bootstrap import ensure_runtime_import_paths
+        ensure_runtime_import_paths(bootstrap_script, avoid_llama_cpp_shadowing=True)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
 
 def _jsonable(value):
     if hasattr(value, 'model_dump'):
@@ -683,8 +828,9 @@ def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
 init_payload = json.loads(sys.stdin.readline())
-llama_cpp = importlib.import_module('llama_cpp')
 try:
+    _bootstrap_desktop_paths()
+    llama_cpp = importlib.import_module('llama_cpp')
     llama = llama_cpp.Llama(*init_payload.get('args', []), **init_payload.get('kwargs', {}))
     _emit({'status': 'ok', 'module_path': getattr(llama_cpp, '__file__', None)})
     for line in sys.stdin:


### PR DESCRIPTION
### Motivation
- Packaged Windows desktop startup could progress past runtime discovery but fail before registration when the subprocess llama_cpp facade exited early and the parent collapsed that into a generic `llama_cpp_import subprocess ended` error, hiding actionable stderr/exit details.  
- The facade child environment could differ from the proven `desktop_runtime_setup` probe (extended `\\?\` paths, PYTHONPATH, cwd, bootstrap script), producing flaky Windows-only import/DLL failures.  
- E2E coverage did not fail when the operator reached `Running: yes` but never reached `Registered: yes`, leaving a regression gap for packaged desktop parity.

### Description
- Normalize and strip Windows extended-length prefixes from desktop runtime path env vars before launching child probes/workers by adding `_normalize_runtime_env_paths` and `_runtime_env_path_value`, and apply it to probe/worker envs so children do not inherit unsafe `\\?\` values.  
- Record a normalized `TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT` inside `ensure_runtime_import_paths` and replay that bootstrap inside the subprocess facade worker so the child replays the same packaged import/bootstrap contract used by the successful desktop probe.  
- Harden the subprocess facade in `utils/llm/model_manager.py` by capturing `stderr` (previously DEVNULL), tracking stdout/stderr tails, reading worker stderr in a side thread, and including exit code, command, cwd, import-root, module-path hint, stdout tail, and stderr tail in early-exit diagnostics.  
- Move the child `import llama_cpp` into the worker's JSON envelope and include traceback text in the JSON error payload so import/DLL/bootstrap exceptions surface to the parent as actionable errors rather than a generic ended message.  
- Expose the facade module-path hint to the proxy instances so parent can include it in failure diagnostics, and add small plumbing (`_read_context`, `_append_tail_line`, `_format_llama_subprocess_failure`) to compose the actionable message.  
- Strengthen packaged/relay e2e guard checks so the packaged probe and relay-parity scripts fail if the bridge emits `llama_cpp_import subprocess ended`, `Running: yes / Registered: no`, or otherwise never reports `registered=true` before timing out.  
- Add unit tests for normalized Windows extended path env behavior and for actionable early-exit diagnostics, and update the outage entry describing the original hang and the two prior failed fixes plus the new prevention tests.

### Testing
- Ran the focused unit/test sweep and integration scripts; `pytest` suites used and results: `pytest tests/unit/test_compute_node_runtime.py` (passed), `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or runtime or import or register or unregister or failed or facade"` (passed), `pytest tests/unit/test_desktop_runtime_setup.py` (passed), `pytest tests/unit/test_desktop_packaged_layout.py` (passed with the platform-specific packaged layout test skipped on Linux), `pytest tests/unit/test_desktop_path_bootstrap.py` (passed), `pytest tests/unit/test_desktop_release_artifacts.py` (passed), and targeted `pytest tests/unit/test_model_manager.py -k "facade or subprocess or probe_windows_extended or runtime_worker_env_normalizes"` (passed).  
- Packaged e2e and parity checks executed: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` (passed in this environment), `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py` (passed), and `python desktop-tauri/scripts/run_desktop_parity_checks.py` (packaged + relay checks passed in this environment).  
- Pre-commit hooks ran: `pre-commit run --all-files` (passed).  
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` was attempted but is blocked in this Linux CI environment by a missing system `glib-2.0` pkg-config dependency (`glib-2.0.pc`); Rust tests were not completed here due to that system dependency.  

Residual risk / follow-ups: manual Windows packaged validation (build & install on Windows 11 with the real CUDA `llama-cpp-python`) is required to fully confirm that the packaged runtime warm-load reaches `Registered: yes` in real-world Windows CUDA environments; CI Rust tests are blocked by system `glib` provisioning and should be re-run in the appropriate environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225aacc608832f9bba52affc476b85)