### PR TITLE
Improve desktop llama_cpp subprocess facade: env normalization, diagnostics, and e2e guard

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -599,6 +599,25 @@ def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(
         },
     )
     assert str(fake_init) in output, output
+    required_markers = (
+        "API v1 runtime warmup model instantiated",
+        "desktop.compute_node_bridge.model_init.ready",
+        "desktop.compute_node_bridge.registration.succeeded",
+        '"registered": true',
+        '"relay_runtime_state": "ready"',
+    )
+    for marker in required_markers:
+        assert marker in output, output
+    forbidden_markers = (
+        "llama_cpp_import_timeout",
+        "llama_cpp_import subprocess ended",
+        "desktop.compute_node_bridge.model_init.failed",
+        '"registered": true',
+    )
+    failure_prefix = output.split("desktop.compute_node_bridge.model_init.ready", 1)[0]
+    for marker in forbidden_markers[:-1]:
+        assert marker not in output, output
+    assert forbidden_markers[-1] not in failure_prefix, output
 
 
 

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
@@ -1,4 +1,4 @@
-# 2026-06-04 packaged desktop llama_cpp import timeout
+# 2026-06-04 packaged desktop llama_cpp import timeout and facade startup failure
 
 ## Summary
 Packaged desktop compute-node startup could fail before relay registration even when
@@ -6,55 +6,86 @@ Packaged desktop compute-node startup could fail before relay registration even 
 The operator moved from warm-load to failed/stopped and never reached `Registered: yes`.
 
 ## Symptoms
-- Logs stopped after `Locating llama_cpp runtime for model initialization...` in the original
-  regression.
-- A later diagnostic-only fix made the hang bounded, but startup still failed with
-  `llama_cpp_import_timeout after 30s`.
-- Windows packaged logs showed runtime setup selecting CUDA and locating the real
-  `site-packages/llama_cpp/__init__.py`, followed by a child import watchdog timeout before model
-  initialization.
+- Original regression: logs stopped after `Locating llama_cpp runtime for model initialization...`.
+- First attempted fix: discovery finished, but a child import watchdog timed out with
+  `llama_cpp_import_timeout after 30s` before registration.
+- Second attempted fix: warm-load got past runtime discovery by using desktop probe diagnostics and
+  a subprocess runtime facade, but `Llama(...)` failed almost immediately with only the generic
+  parent error `llama_cpp_import subprocess ended`.
+- The unregister side effect was fixed separately: when no API v1 registration succeeded, stop now
+  skips relay unregister instead of mutating relay state for a node that never registered.
 
 ## Timeline
 - Original regression: packaged desktop operator warm-load hung while locating the `llama_cpp`
   runtime, so relay registration and UI `Registered: yes` never happened.
-- Failed fix attempt: bounded subprocess discovery/import watchdogs were added. Discovery via
+- Failed fix attempt 1: bounded subprocess discovery/import watchdogs were added. Discovery via
   `find_spec` completed quickly, but the separate child-process `import llama_cpp` watchdog still
   timed out after 30 seconds.
-- This PR: removed the startup-critical child import watchdog, reused successful desktop runtime
-  probe diagnostics, and kept the real import in the bridge process that initializes the model.
+- Failed fix attempt 2: the warm-load path skipped parent import and returned a subprocess-backed
+  `llama_cpp` facade. That bounded the old hang, but the facade worker could exit before its first
+  protocol message and the parent collapsed the whole failure to `llama_cpp_import subprocess ended`.
+- Current corrective fix: keep the killable facade for no-`SIGALRM` startup paths, but make its
+  environment match the desktop runtime probe, normalize packaged Windows extended paths before they
+  reach child env/import paths, capture stderr/stdout/exit-code diagnostics on early child exit, and
+  catch worker import failures inside the JSON protocol so the parent receives actionable failures.
 
-## Why the prior fix was insufficient
-The watchdog imported `llama_cpp` in a subprocess before the actual bridge process imported it.
-On packaged Windows/macOS native-extension runtimes, that child can have different `sys.path`, cwd,
-`PYTHONPATH`, `PYTHONNOUSERSITE`, import-root, DLL/search-path, and extended-path behavior than the
-runtime setup probe or the real bridge warm-load process. The watchdog therefore became a second
-runtime environment that could fail differently from the environment that needed to start.
+## Root cause
+The startup-critical child processes did not faithfully share the same bootstrap contract as the
+successful desktop runtime probe. The Windows packaged bridge can be launched with `\\?\` extended
+paths and an import root containing spaces (for example `token.place desktop`). The runtime probe
+normalizes those paths, sets packaged bootstrap env, and proves that CUDA `llama_cpp` imports from
+site-packages. The subprocess facade worker instead relied on a separate `python -c` bootstrap and
+previously discarded child stderr. If the worker failed while importing `llama_cpp`, resolving the
+packaged import root, or loading native dependencies, it could exit before any JSON handshake and the
+parent would only report a generic subprocess-ended error.
+
+A second diagnostic gap made the failure non-actionable: the worker imported `llama_cpp` before the
+`try` block that emits JSON protocol errors, and the parent launched it with `stderr=DEVNULL`.
+Import-time exceptions therefore disappeared.
+
+## Why the prior fixes were insufficient
+The watchdog and the first facade implementation both introduced another runtime environment in
+front of the real model initialization path. On packaged Windows/macOS native-extension runtimes, a
+child can differ from the bridge and the desktop probe in `sys.path`, cwd, `PYTHONPATH`,
+`TOKEN_PLACE_PYTHON_IMPORT_ROOT`, `TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT`, `PYTHONNOUSERSITE`,
+`PATH`/DLL lookup, and `\\?\` path handling. A startup-critical path must either import in the
+already-proven bridge environment or make the child environment equivalent and observable.
 
 ## Why CI/e2e missed it
 Existing packaged coverage validated bridge imports, dependency preflight, mock-LLM bridge events,
-and inspect-style paths, but it did not faithfully simulate the broken child-watchdog import shape.
-Mock runtime mode could still reach bridge registration without exercising real `llama_cpp` import
-sequencing, so CI did not prove that a packaged desktop + relay lifecycle would reject
-`Running: yes / Registered: no` when the model warm-load path stalled before registration.
+and inspect-style paths. Mock runtime mode could still reach bridge registration without exercising
+real `llama_cpp` import/model initialization sequencing. The fake-runtime packaged lifecycle test
+also did not assert all of the user-visible lifecycle milestones that matter for this outage:
+warm-load success, `model_init.ready`, relay registration, and a status event with
+`registered=true` / `relay_runtime_state=ready`.
 
 ## Cross-platform risk
-The reproduced failure was Windows 11 CUDA, but the seam was shared packaged runtime/path bootstrap
+The reproduced failure was Windows 11 CUDA, but the seam is shared packaged runtime/path bootstrap
 code. macOS Metal packaged apps use the same bridge/runtime setup/model-manager import handoff and
-could have hit an equivalent child import divergence.
+could hit equivalent child import divergence, so macOS `Contents/Resources` packaged parity remains
+part of the regression suite.
 
 ## Corrective actions in this PR
 - Reuse the successful `desktop_runtime_setup` probe module path during model warm-load.
-- Remove the startup-critical pre-import child watchdog from the real bridge startup path.
-- Import `llama_cpp` directly in the bridge process and verify that it matches the desktop probe
-  module path when a probe was available.
-- Normalize Windows `\\?\` paths for comparisons/import-root resolution without using extended
-  paths as the preferred packaged import-root representation.
-- Skip relay unregister when no API v1 registration succeeded.
+- Keep the subprocess runtime facade killable for no-`SIGALRM` warm-load paths, but align its env
+  with the desktop runtime probe: normalized `TOKEN_PLACE_PYTHON_IMPORT_ROOT`, desktop bootstrap
+  env, `PYTHONNOUSERSITE=1`, sanitized `PYTHONPATH`, and normalized `PATH` entries.
+- Avoid passing Windows `\\?\` extended prefixes through the facade worker env/sys.path while still
+  preserving robust path comparisons for repo-local shim rejection.
+- Capture early facade worker failures with exit code, stderr tail, stdout tail, command/program,
+  cwd, import root, module-path hint, and stage name.
+- Catch worker `llama_cpp` import and model-init exceptions inside the JSON protocol and surface the
+  traceback tail to the parent instead of losing it.
+- Keep the no-unregister-before-registration behavior.
 
 ## Prevention tests added
-- Unit coverage for reusing desktop runtime probe diagnostics and proving the child import watchdog
-  is not called in the startup-critical path.
-- Unit coverage for Windows extended paths with spaces and macOS-style resource paths.
-- Packaged e2e regression coverage with a fake `llama_cpp` that would hang only in the removed child
-  watchdog context, plus existing standard and macOS `Contents/Resources` packaged lifecycle checks
-  that fail unless `registered=true` appears.
+- Unit coverage that facade early exit includes child exit code, stderr/stdout tails, import root,
+  command/cwd/module-path context, and normalized paths with spaces.
+- Unit coverage that the facade worker env follows the desktop probe bootstrap contract and strips
+  unsafe `\\?\` prefixes from env/PYTHONPATH/PATH.
+- Unit coverage that JSON protocol worker errors include traceback details.
+- Packaged fake-runtime lifecycle checks now require warm-load success, `model_init.ready`, relay
+  registration, `registered=true`, and `relay_runtime_state=ready`; they reject the old timeout and
+  generic subprocess-ended markers.
+- Existing standard and macOS `Contents/Resources` packaged lifecycle checks continue to fail unless
+  `registered=true` appears.

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2732,3 +2732,104 @@ def test_detect_llama_runtime_capabilities_cpu_facade_reports_probe_exception(mo
     assert diagnostics['detected_device'] == 'none'
     assert diagnostics['llama_module_path'] == '/site/llama_cpp/__init__.py'
     assert diagnostics['error'] == 'probe crashed'
+
+
+def test_subprocess_llama_proxy_early_exit_surfaces_child_diagnostics(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeStdin:
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class FakeStdout:
+        def __iter__(self):
+            return iter(['worker booted before failure\n'])
+
+    class FakeStderr:
+        def read(self):
+            return 'Traceback: No module named llama_cpp\nchild stderr detail'
+
+    class FakeProcess:
+        def __init__(self, *_args, **_kwargs):
+            self.stdin = FakeStdin()
+            self.stdout = FakeStdout()
+            self.stderr = FakeStderr()
+
+        def poll(self):
+            return 7
+
+        def terminate(self):
+            return None
+
+    def _fake_popen(*_args, **_kwargs):
+        return FakeProcess()
+
+    monkeypatch.setattr(model_manager_module.subprocess, 'Popen', _fake_popen)
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=0.01)
+
+    message = str(exc_info.value)
+    assert 'llama_cpp_import subprocess exited before JSON handshake' in message
+    assert 'exit_code=7' in message
+    assert 'stdout_tail=' in message and 'worker booted before failure' in message
+    assert 'stderr_tail=' in message and 'No module named llama_cpp' in message
+    assert '\\\\?\\' not in message
+    assert 'token.place desktop' in message
+
+
+def test_runtime_worker_env_matches_desktop_probe_bootstrap_and_normalizes_extended_paths(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    monkeypatch.setenv('TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH', '["stale"]')
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_')
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\python\compute_node_bridge.py')
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_PYTHON_ROOT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\python')
+    monkeypatch.setenv('TOKEN_PLACE_PROBE_REPO_ROOT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_')
+    monkeypatch.setenv('PATH', os.pathsep.join([r'\\?\C:\CUDA\bin', r'C:\Windows\System32']))
+    monkeypatch.setattr(
+        model_manager_module,
+        '_llama_cpp_probe_sys_path_entries',
+        lambda: [
+            r'\\?\C:\Users\danie\AppData\Local\token.place desktop\python',
+            r'\\?\C:\Users\danie\AppData\Local\Programs\Python\Python311\Lib\site-packages',
+        ],
+    )
+
+    env = model_manager_module._llama_cpp_runtime_worker_env()
+
+    assert 'TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH' not in env
+    assert env['PYTHONNOUSERSITE'] == '1'
+    assert env['TOKEN_PLACE_PYTHON_IMPORT_ROOT'] == r'C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_'
+    assert env['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'] == r'C:\Users\danie\AppData\Local\token.place desktop\python\compute_node_bridge.py'
+    assert env['TOKEN_PLACE_DESKTOP_PYTHON_ROOT'] == r'C:\Users\danie\AppData\Local\token.place desktop\python'
+    assert env['TOKEN_PLACE_PROBE_REPO_ROOT'] == r'C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_'
+    assert '\\\\?\\' not in env['PYTHONPATH']
+    assert 'token.place desktop' in env['PYTHONPATH']
+    assert '\\\\?\\' not in env['PATH']
+
+
+def test_read_llama_subprocess_message_surfaces_worker_error_traceback():
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeStdout:
+        def __iter__(self):
+            return iter([
+                'TOKEN_PLACE_LLAMA_CPP_JSON:{"status":"error","error":"import failed","traceback":"Traceback detail"}\n'
+            ])
+
+    process = SimpleNamespace(stdout=FakeStdout(), stderr=None, poll=lambda: None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager_module._read_llama_subprocess_message(
+            process,
+            timeout_seconds=0.01,
+            stage='llama_cpp_import',
+        )
+
+    assert 'import failed' in str(exc_info.value)
+    assert 'Traceback detail' in str(exc_info.value)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,6 +51,22 @@ def _strip_windows_extended_path_prefix(path_text: str) -> str:
     return path_text
 
 
+def _normalize_runtime_path_text(path_value: Any) -> str:
+    """Return a Python/env friendly path string without Windows extended prefixes."""
+
+    return _strip_windows_extended_path_prefix(str(path_value))
+
+
+def _normalize_runtime_path_list(path_value: str) -> str:
+    if not path_value:
+        return path_value
+    return os.pathsep.join(
+        _normalize_runtime_path_text(entry)
+        for entry in path_value.split(os.pathsep)
+        if entry
+    )
+
+
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
     if not module_path:
         return None
@@ -220,13 +236,50 @@ def _llama_cpp_runtime_worker_env() -> Dict[str, str]:
     that variable belongs to discovery/probe subprocesses and historically
     triggered the removed import-watchdog failure mode in packaged desktop
     builds.  The worker still receives the same sanitized import path via an
-    embedded JSON literal in its bootstrap code.
+    embedded JSON literal in its bootstrap code.  Keep the remaining desktop
+    bootstrap contract aligned with ``desktop_runtime_setup`` and avoid passing
+    Windows extended-length path prefixes through env/PYTHONPATH because the
+    packaged bridge can be launched with extended paths while child Python
+    imports and DLL lookup are more reliable with normal path strings.
     """
 
-    pythonpath_entries = _llama_cpp_probe_sys_path_entries()
+    pythonpath_entries = [
+        _normalize_runtime_path_text(entry)
+        for entry in _llama_cpp_probe_sys_path_entries()
+    ]
     env = os.environ.copy()
     env['PYTHONPATH'] = os.pathsep.join(pythonpath_entries)
     env.pop('TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH', None)
+    for key in (
+        'TOKEN_PLACE_PYTHON_IMPORT_ROOT',
+        'TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT',
+        'TOKEN_PLACE_DESKTOP_PYTHON_ROOT',
+        'TOKEN_PLACE_PROBE_REPO_ROOT',
+    ):
+        if env.get(key):
+            env[key] = _normalize_runtime_path_text(env[key])
+    if env.get('PATH'):
+        env['PATH'] = _normalize_runtime_path_list(env['PATH'])
+    if 'PYTHONNOUSERSITE' not in env:
+        env['PYTHONNOUSERSITE'] = '1'
+    bootstrap_script = env.get('TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT')
+    if not bootstrap_script:
+        try:
+            import path_bootstrap  # type: ignore[import-not-found]
+            bootstrap_script = getattr(path_bootstrap, '__file__', '')
+        except Exception:
+            bootstrap_script = ''
+        if bootstrap_script:
+            env['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'] = _normalize_runtime_path_text(
+                bootstrap_script
+            )
+    if not env.get('TOKEN_PLACE_DESKTOP_PYTHON_ROOT') and bootstrap_script:
+        env['TOKEN_PLACE_DESKTOP_PYTHON_ROOT'] = _normalize_runtime_path_text(
+            Path(bootstrap_script).parent
+        )
+    import_root = env.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT') or str(REPO_ROOT)
+    env['TOKEN_PLACE_PYTHON_IMPORT_ROOT'] = _normalize_runtime_path_text(import_root)
+    env.setdefault('TOKEN_PLACE_PROBE_REPO_ROOT', env['TOKEN_PLACE_PYTHON_IMPORT_ROOT'])
     return env
 
 
@@ -235,7 +288,10 @@ def _llama_cpp_runtime_worker_code(user_code: str) -> str:
 
     return _llama_cpp_path_prefixed_code(
         user_code,
-        repr(json.dumps(_llama_cpp_probe_sys_path_entries())),
+        repr(json.dumps([
+            _normalize_runtime_path_text(entry)
+            for entry in _llama_cpp_probe_sys_path_entries()
+        ])),
     )
 
 
@@ -528,29 +584,85 @@ def _import_llama_cpp_in_parent_with_timeout(
         desktop_runtime_probe=desktop_runtime_probe,
     )
 
+def _tail_for_diagnostics(text: Any, *, max_chars: int = 2000) -> str:
+    value = str(text or '').strip()
+    return value[-max_chars:]
+
+
+def _llama_subprocess_launch_diagnostics(process: subprocess.Popen, *, stage: str) -> Dict[str, Any]:
+    stderr_text = ''
+    if getattr(process, 'stderr', None) is not None:
+        try:
+            stderr_text = process.stderr.read()  # type: ignore[union-attr]
+        except Exception:
+            stderr_text = ''
+    return {
+        'stage': stage,
+        'exit_code': process.poll(),
+        'stderr_tail': _tail_for_diagnostics(stderr_text),
+        'command': getattr(process, '_token_place_command', None),
+        'program': getattr(process, '_token_place_program', sys.executable),
+        'cwd': getattr(process, '_token_place_cwd', None),
+        'import_root': getattr(process, '_token_place_import_root', None),
+        'module_path_hint': getattr(process, '_token_place_module_path_hint', None),
+    }
+
+
+def _format_llama_subprocess_early_exit_error(
+    *,
+    stage: str,
+    stdout_tail: str,
+    diagnostics: Dict[str, Any],
+) -> str:
+    return (
+        f"{stage} subprocess exited before JSON handshake "
+        f"exit_code={diagnostics.get('exit_code')} "
+        f"program={diagnostics.get('program')} "
+        f"cwd={diagnostics.get('cwd')} "
+        f"import_root={diagnostics.get('import_root')} "
+        f"module_path_hint={diagnostics.get('module_path_hint')} "
+        f"stdout_tail={stdout_tail!r} "
+        f"stderr_tail={diagnostics.get('stderr_tail')!r}"
+    )
+
+
 def _read_llama_subprocess_message(
     process: subprocess.Popen,
     *,
     timeout_seconds: Optional[float],
     stage: str,
 ) -> Dict[str, Any]:
-    result_queue: queue.Queue[str] = queue.Queue(maxsize=1)
+    result_queue: queue.Queue[Dict[str, Any]] = queue.Queue(maxsize=1)
 
     def _reader() -> None:
         assert process.stdout is not None
+        stdout_tail = ''
         for line in process.stdout:
+            stdout_tail = _tail_for_diagnostics(stdout_tail + str(line))
             if line.startswith('TOKEN_PLACE_LLAMA_CPP_JSON:'):
-                result_queue.put(line.split(':', 1)[1].strip())
+                result_queue.put({'raw_message': line.split(':', 1)[1].strip()})
                 return
-        result_queue.put(json.dumps({'status': 'error', 'error': f'{stage} subprocess ended'}))
+        diagnostics = _llama_subprocess_launch_diagnostics(process, stage=stage)
+        result_queue.put({
+            'raw_message': json.dumps({
+                'status': 'error',
+                'error': _format_llama_subprocess_early_exit_error(
+                    stage=stage,
+                    stdout_tail=stdout_tail,
+                    diagnostics=diagnostics,
+                ),
+                **diagnostics,
+                'stdout_tail': stdout_tail,
+            })
+        })
 
     reader = threading.Thread(target=_reader, name=f'{stage}_stdout_reader', daemon=True)
     reader.start()
     try:
         if timeout_seconds is None:
-            raw_message = result_queue.get()
+            queued = result_queue.get()
         else:
-            raw_message = result_queue.get(timeout=timeout_seconds)
+            queued = result_queue.get(timeout=timeout_seconds)
     except queue.Empty as exc:
         try:
             process.terminate()
@@ -558,6 +670,7 @@ def _read_llama_subprocess_message(
         except Exception:
             process.kill()
         raise LlamaCppRuntimeStageTimeout(stage, timeout_seconds) from exc
+    raw_message = str(queued.get('raw_message') or '')
     try:
         message = json.loads(raw_message)
     except json.JSONDecodeError as exc:
@@ -565,7 +678,11 @@ def _read_llama_subprocess_message(
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'error':
-        raise RuntimeError(str(message.get('error') or f'{stage} failed'))
+        error = str(message.get('error') or f'{stage} failed')
+        traceback_text = _tail_for_diagnostics(message.get('traceback'))
+        if traceback_text:
+            error = f'{error} traceback_tail={traceback_text!r}'
+        raise RuntimeError(error)
     return message
 
 
@@ -573,17 +690,40 @@ class _SubprocessLlamaProxy:
     """Minimal llama_cpp.Llama proxy for no-SIGALRM runtimes."""
 
     def __init__(self, *args, timeout_seconds: Optional[float] = None, **kwargs) -> None:
-        self._timeout_seconds = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
+        self._timeout_seconds = (
+            timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
+        )
         self._lock = Lock()
+        command = [
+            sys.executable,
+            '-u',
+            '-c',
+            _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE),
+        ]
+        env = _llama_cpp_runtime_worker_env()
+        cwd = _normalize_runtime_path_text(_llama_cpp_probe_subprocess_cwd())
         self._process = subprocess.Popen(
-            [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)],
+            command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
-            env=_llama_cpp_runtime_worker_env(),
-            cwd=_llama_cpp_probe_subprocess_cwd(),
+            env=env,
+            cwd=cwd,
             bufsize=1,
+        )
+        self._process._token_place_command = [
+            command[0],
+            '-u',
+            '-c',
+            '<llama_cpp_runtime_worker>',
+        ]
+        self._process._token_place_program = command[0]
+        self._process._token_place_cwd = cwd
+        self._process._token_place_import_root = env.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT')
+        self._process._token_place_module_path_hint = kwargs.pop(
+            '_token_place_module_path_hint',
+            None,
         )
         self._send({'method': '__init__', 'args': args, 'kwargs': kwargs})
         _read_llama_subprocess_message(
@@ -657,10 +797,16 @@ class _SubprocessLlamaCppModule:
     @property
     def Llama(self):
         timeout_seconds = self._timeout_seconds
+        module_path_hint = self.__file__
 
         class _ConfiguredSubprocessLlama(_SubprocessLlamaProxy):
             def __init__(self, *args, **kwargs):
-                super().__init__(*args, timeout_seconds=timeout_seconds, **kwargs)
+                super().__init__(
+                    *args,
+                    timeout_seconds=timeout_seconds,
+                    _token_place_module_path_hint=module_path_hint,
+                    **kwargs,
+                )
 
         return _ConfiguredSubprocessLlama
 
@@ -682,9 +828,9 @@ def _jsonable(value):
 def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
-init_payload = json.loads(sys.stdin.readline())
-llama_cpp = importlib.import_module('llama_cpp')
 try:
+    init_payload = json.loads(sys.stdin.readline())
+    llama_cpp = importlib.import_module('llama_cpp')
     llama = llama_cpp.Llama(*init_payload.get('args', []), **init_payload.get('kwargs', {}))
     _emit({'status': 'ok', 'module_path': getattr(llama_cpp, '__file__', None)})
     for line in sys.stdin:


### PR DESCRIPTION
### Motivation
- Packaged Windows desktop startup could fail before relay registration when the subprocess facade exited early and the parent only saw the generic `llama_cpp_import subprocess ended` error, hiding useful stderr/stdout/exit diagnostics. 
- The subprocess worker environment could differ from the proven `desktop_runtime_setup` probe (extended `\\?\` paths, `PYTHONPATH`, cwd, `PYTHONNOUSERSITE`, etc.), producing brittle, non-actionable failures. 
- End-to-end checks did not assert the full user-visible lifecycle (`model_init.ready` + `registered=true`), allowing regressions to slip through CI. 

### Description
- Normalize and sanitize packaged runtime paths for subprocess workers by adding `_normalize_runtime_path_text` / `_normalize_runtime_path_list` and applying them to `PYTHONPATH`, `PATH`, and desktop bootstrap env keys so `\\?\` extended prefixes are not passed to child envs. 
- Align the facade worker env with the `desktop_runtime_setup` probe contract by copying/normalizing `TOKEN_PLACE_PYTHON_IMPORT_ROOT`, `TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT`, `TOKEN_PLACE_DESKTOP_PYTHON_ROOT`, and `TOKEN_PLACE_PROBE_REPO_ROOT`, and set `PYTHONNOUSERSITE=1` when absent. 
- Capture and surface actionable child-process diagnostics on early exit by reading `stderr`, capturing `stdout` tail, and reporting `exit_code`, `stderr_tail`, `stdout_tail`, `command/program`, `cwd`, `import_root`, `module_path_hint`, and `stage` instead of a generic message. 
- Move the worker `llama_cpp` import/model-init into the JSON protocol error boundary and change worker `stderr` handling so import exceptions include the `traceback` in the protocol and the parent shows a `traceback_tail`. 
- Start the facade worker with `stderr` captured and attach metadata (`_token_place_*` fields) to the `Popen` instance so diagnostics include command and cwd context, and pass the selected module-path hint into the worker facade so imports are consistent with the desktop probe. 
- Strengthen packaged e2e checks by asserting the lifecycle markers `API v1 runtime warmup model instantiated`, `desktop.compute_node_bridge.model_init.ready`, `desktop.compute_node_bridge.registration.succeeded`, and user-visible `"registered": true` / `"relay_runtime_state": "ready"`. 
- Add unit tests that assert: early facade exit surfaces child diagnostics, worker env normalizes extended Windows paths and matches bootstrap expectations, and worker error protocol surfaces traceback details. 

### Testing
- Ran `python -m py_compile utils/llm/model_manager.py desktop-tauri/scripts/test_packaged_operator_e2e.py tests/unit/test_model_manager.py` and compilation succeeded. 
- Ran `pytest tests/unit/test_model_manager.py` and the suite passed (all added/asserted unit tests passed). 
- Ran `pytest tests/unit/test_compute_node_runtime.py` and `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or runtime or import or register or unregister or failed or facade"` and both suites passed. 
- Ran `pytest` across `tests/unit/test_desktop_runtime_setup.py`, `tests/unit/test_desktop_packaged_layout.py`, `tests/unit/test_desktop_path_bootstrap.py`, and `tests/unit/test_desktop_release_artifacts.py` and all relevant tests passed or were skipped as expected. 
- Executed packaged lifecycle e2e harness `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and the strengthened lifecycle assertions passed for the simulated packaged fake runtime. 
- Ran shared parity checks `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py` and `python desktop-tauri/scripts/run_desktop_parity_checks.py` which completed in this environment. 
- Ran `pre-commit run --all-files` and hooks passed. 
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not complete in this container due to a missing system `glib-2.0.pc` pkg-config dependency (environment limitation), so the Rust tests were not completed here. 

If you want I can split parts of this change into smaller reviewable commits (env normalization, diagnostics, worker protocol, tests) or add any extra logging/detail required for a follow-up Windows release validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225aacc608832f9bba52affc476b85)