### PR TITLE
Fix packaged-Windows llama_cpp subprocess facade: surface child diagnostics, normalize paths, and add packaged e2e guard

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -227,7 +227,6 @@ def run_model_bridge_inspect_probe(tmp_root: Path, *, resources_root: Path | Non
     assert "desktop-runtime-imports-ok" in check_imports.stdout
 
 
-
 def run_compute_bridge_import_probe(tmp_root: Path, *, resources_root: Path | None = None) -> None:
     resources_root = resources_root or (tmp_root / "resources")
     env = _packaged_env(tmp_root, resources_root)
@@ -328,7 +327,6 @@ def run_unified_root_import_policy_probe(
     assert payload["llama_shim_before_site"] is False, combined
 
 
-
 def create_fake_llama_cpp_site(tmp_root: Path, layout_label: str) -> tuple[Path, Path]:
     fake_site = tmp_root / f"fake site-packages {layout_label.replace('/', '_')}"
     fake_pkg = fake_site / "llama_cpp"
@@ -402,6 +400,76 @@ def run_llama_cpp_watchdog_regression_probe(
     assert Path(payload["module_path"]).resolve() == fake_init.resolve(), combined
     assert "llama_cpp_import_timeout" not in combined, combined
     assert "llama_cpp import watchdog start" not in combined, combined
+
+
+def run_llama_cpp_facade_early_exit_regression_probe(
+    tmp_root: Path, *, resources_root: Path | None = None, layout_label: str = "standard resources"
+) -> None:
+    """Assert facade child early exits surface diagnostics and cannot look registered."""
+
+    resources_root = resources_root or (tmp_root / "resources")
+    fake_site = tmp_root / f"fake exiting site-packages {layout_label.replace('/', '_')}"
+    fake_pkg = fake_site / "llama_cpp"
+    fake_pkg.mkdir(parents=True, exist_ok=True)
+    (fake_pkg / "__init__.py").write_text(
+        "import sys\n"
+        "print('fake facade import stdout before exit')\n"
+        "print('fake facade import stderr before exit', file=sys.stderr)\n"
+        "raise SystemExit(19)\n",
+        encoding="utf-8",
+    )
+    env = _packaged_env(
+        tmp_root,
+        resources_root,
+        extra_env={
+            "TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS": "2",
+            "PYTHONPATH": os.pathsep.join(
+                [str(fake_site), str(resources_root / "python"), str(resources_root)]
+            ),
+        },
+    )
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            (
+                "\n".join(
+                    [
+                        "import pathlib, sys",
+                        f"sys.path.insert(0, {str(fake_site)!r})",
+                        f"sys.path.insert(0, {str(resources_root)!r})",
+                        "from utils.llm import model_manager",
+                        "module_path = pathlib.Path(sys.path[1], 'llama_cpp', '__init__.py')",
+                        "facade = model_manager._SubprocessLlamaCppModule(str(module_path), timeout_seconds=2, desktop_runtime_probe={"
+                        "    'selected_backend': 'cuda', 'gpu_offload_supported': True, "
+                        "    'detected_device': 'cuda', 'interpreter': sys.executable, "
+                        "    'prefix': sys.prefix, 'llama_module_path': str(module_path)})",
+                        "try:",
+                        "    facade.Llama(model_path='fake.gguf')",
+                        "except RuntimeError as exc:",
+                        "    print(str(exc))",
+                        "    raise SystemExit(0)",
+                        "raise SystemExit('facade early-exit probe unexpectedly succeeded')",
+                    ]
+                )
+            ),
+        ],
+        cwd=tmp_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, combined
+    assert "llama_cpp_import subprocess exited before JSON handshake" in combined, combined
+    assert "exit_code=19" in combined, combined
+    assert "fake facade import stdout before exit" in combined, combined
+    assert "fake facade import stderr before exit" in combined, combined
+    assert "registered=true" not in combined.lower(), combined
+    assert "subprocess ended" not in combined, combined
+
 
 def enqueue_bridge_stdout(stdout: object, output_queue: queue.Queue[bytes]) -> None:
     if not hasattr(stdout, "readline"):
@@ -559,6 +627,7 @@ def run_compute_bridge_startup_probe(
             "desktop_runtime_setup module missing",
             "llama_cpp_import_timeout",
             "llama_cpp import watchdog start",
+            "llama_cpp_import subprocess ended",
             "Running: yes / Registered: no",
         )
         for marker in forbidden_output:
@@ -601,7 +670,6 @@ def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(
     assert str(fake_init) in output, output
 
 
-
 def main() -> int:
     env = os.environ.copy()
     env["USE_MOCK_LLM"] = "1"
@@ -614,6 +682,7 @@ def main() -> int:
         run_model_bridge_inspect_probe(tmp_path)
         run_compute_bridge_import_probe(tmp_path)
         run_llama_cpp_watchdog_regression_probe(tmp_path)
+        run_llama_cpp_facade_early_exit_regression_probe(tmp_path)
 
         mac_bridge_script = create_macos_bundle_layout(tmp_path)
         mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
@@ -622,6 +691,9 @@ def main() -> int:
         run_model_bridge_inspect_probe(tmp_path, resources_root=mac_resources_root)
         run_compute_bridge_import_probe(tmp_path, resources_root=mac_resources_root)
         run_llama_cpp_watchdog_regression_probe(
+            tmp_path, resources_root=mac_resources_root, layout_label="macOS Contents/Resources"
+        )
+        run_llama_cpp_facade_early_exit_regression_probe(
             tmp_path, resources_root=mac_resources_root, layout_label="macOS Contents/Resources"
         )
 

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.json
@@ -1,8 +1,8 @@
 {
   "date": "2026-06-04",
   "slug": "packaged-desktop-llama-cpp-import-timeout",
-  "summary": "Packaged desktop compute-node startup timed out in a child llama_cpp import watchdog after runtime setup had already found a supported CUDA runtime, preventing Registered: yes.",
-  "impact": "Windows packaged operators could fail/stopped before relay registration, and the shared packaged import seam also risked macOS Metal parity.",
-  "fix": "Removed the startup-critical child import watchdog, reused desktop runtime setup probe diagnostics, imported llama_cpp in the real bridge process, normalized packaged paths, and skipped unregister before successful registration.",
-  "lessons": "Packaged e2e must prove registered=true for the full desktop + relay lifecycle and must exercise shared runtime/bootstrap code instead of only inspect or mock paths. Native-extension import probes must not run in a divergent child environment unless that environment is proven equivalent."
+  "summary": "Packaged desktop compute-node startup hung or failed in divergent llama_cpp child subprocesses after runtime setup had already found a supported CUDA runtime, preventing Registered: yes.",
+  "impact": "Windows packaged operators could fail/stopped before relay registration with hidden native-runtime diagnostics, and the shared packaged import seam also risked macOS Metal parity.",
+  "fix": "Kept the child import watchdog off the startup-critical path, reused desktop runtime setup probe diagnostics, made the retained subprocess facade use sanitized packaged import/env paths, surfaced child stdout/stderr/exit-code diagnostics, normalized extended Windows paths, and skipped unregister before successful registration.",
+  "lessons": "Packaged e2e must prove registered=true for the full desktop + relay lifecycle and simulate child runtime handshake failures. Native-extension subprocess facades must share the proven runtime bootstrap contract and must never discard early-exit diagnostics."
 }

--- a/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
+++ b/outages/2026-06-04-packaged-desktop-llama-cpp-import-timeout.md
@@ -8,53 +8,76 @@ The operator moved from warm-load to failed/stopped and never reached `Registere
 ## Symptoms
 - Logs stopped after `Locating llama_cpp runtime for model initialization...` in the original
   regression.
-- A later diagnostic-only fix made the hang bounded, but startup still failed with
-  `llama_cpp_import_timeout after 30s`.
+- A first diagnostic-only fix made the hang bounded, but startup still failed with
+  `llama_cpp_import_timeout after 30s` from a child import watchdog.
+- A second fix skipped the parent warm-load import and introduced a subprocess runtime facade. That
+  got as far as compute-plan selection and `Llama init started`, then failed almost immediately with
+  the generic parent error `llama_cpp_import subprocess ended` and no relay registration.
 - Windows packaged logs showed runtime setup selecting CUDA and locating the real
-  `site-packages/llama_cpp/__init__.py`, followed by a child import watchdog timeout before model
-  initialization.
+  `site-packages/llama_cpp/__init__.py`, but the startup-critical worker was still using a second
+  subprocess environment that could exit before the JSON handshake.
 
 ## Timeline
 - Original regression: packaged desktop operator warm-load hung while locating the `llama_cpp`
   runtime, so relay registration and UI `Registered: yes` never happened.
-- Failed fix attempt: bounded subprocess discovery/import watchdogs were added. Discovery via
+- Failed fix attempt 1: bounded subprocess discovery/import watchdogs were added. Discovery via
   `find_spec` completed quickly, but the separate child-process `import llama_cpp` watchdog still
   timed out after 30 seconds.
-- This PR: removed the startup-critical child import watchdog, reused successful desktop runtime
-  probe diagnostics, and kept the real import in the bridge process that initializes the model.
+- Failed fix attempt 2: the import watchdog was avoided by returning a subprocess-backed
+  `llama_cpp` facade on Windows/background warm-load threads. The facade child inherited an
+  inconsistent/opaque startup contract and discarded stderr, so early child exits collapsed to
+  `llama_cpp_import subprocess ended`.
+- This PR: made the retained facade faithful to the runtime/probe import path, normalized packaged
+  `\\?\` paths before child subprocess use, moved child import into the JSON error path, and surfaced
+  exit code/stdout/stderr/cwd/command/import-root/module-path diagnostics when the child exits before
+  handshake.
 
-## Why the prior fix was insufficient
-The watchdog imported `llama_cpp` in a subprocess before the actual bridge process imported it.
-On packaged Windows/macOS native-extension runtimes, that child can have different `sys.path`, cwd,
-`PYTHONPATH`, `PYTHONNOUSERSITE`, import-root, DLL/search-path, and extended-path behavior than the
-runtime setup probe or the real bridge warm-load process. The watchdog therefore became a second
-runtime environment that could fail differently from the environment that needed to start.
+## Root cause
+The startup-critical model initialization path had two subtly different runtime contracts:
+`desktop_runtime_setup` proved that the selected interpreter and native `llama_cpp` package could
+support CUDA/Metal, while the later watchdog/facade child process was launched with its own cwd,
+`PYTHONPATH`, `sys.path`, import-root, and Windows extended-path values. When that second child
+failed before its protocol handshake, stderr was discarded and the parent emitted only a generic
+subprocess-ended error. Paths containing spaces and `\\?\` prefixes made this especially hard to
+reason about on packaged Windows installs.
+
+## Why the prior fixes were insufficient
+The watchdog and then the facade imported `llama_cpp` in a subprocess before or instead of the actual
+bridge process import. On packaged Windows/macOS native-extension runtimes, that child can have
+different `sys.path`, cwd, `PYTHONPATH`, `PYTHONNOUSERSITE`, import-root, DLL/search-path, and
+extended-path behavior than the runtime setup probe or the real bridge warm-load process. The facade
+also read only stdout protocol messages and sent stderr to `DEVNULL`, so a Python traceback, DLL load
+failure, or bootstrap failure was hidden.
 
 ## Why CI/e2e missed it
 Existing packaged coverage validated bridge imports, dependency preflight, mock-LLM bridge events,
-and inspect-style paths, but it did not faithfully simulate the broken child-watchdog import shape.
-Mock runtime mode could still reach bridge registration without exercising real `llama_cpp` import
-sequencing, so CI did not prove that a packaged desktop + relay lifecycle would reject
-`Running: yes / Registered: no` when the model warm-load path stalled before registration.
+and inspect-style paths, but it did not faithfully simulate the broken facade child exiting before
+its JSON handshake. Mock runtime mode could still reach bridge registration without exercising the
+real `llama_cpp` warm-load/facade failure shape, so CI did not prove that a packaged desktop + relay
+lifecycle would reject `Running: yes / Registered: no` when model warm-load failed before
+registration.
 
 ## Cross-platform risk
 The reproduced failure was Windows 11 CUDA, but the seam was shared packaged runtime/path bootstrap
 code. macOS Metal packaged apps use the same bridge/runtime setup/model-manager import handoff and
-could have hit an equivalent child import divergence.
+could have hit an equivalent child import divergence or hidden pre-registration failure.
 
 ## Corrective actions in this PR
 - Reuse the successful `desktop_runtime_setup` probe module path during model warm-load.
-- Remove the startup-critical pre-import child watchdog from the real bridge startup path.
-- Import `llama_cpp` directly in the bridge process and verify that it matches the desktop probe
-  module path when a probe was available.
-- Normalize Windows `\\?\` paths for comparisons/import-root resolution without using extended
-  paths as the preferred packaged import-root representation.
-- Skip relay unregister when no API v1 registration succeeded.
+- Keep the startup-critical pre-import child watchdog out of the real bridge startup path.
+- Make the retained subprocess facade use the same sanitized import path contract as runtime probes,
+  with Windows `\\?\` prefixes stripped from child env/PYTHONPATH values while preserving spaces.
+- Capture facade child stderr/stdout tails and report exit code, command/program, cwd, import root,
+  module-path hint, stage, and traceback/error details on early exit.
+- Catch child import/model-init exceptions inside the worker protocol so failures are returned as
+  JSON instead of disappearing before handshake when possible.
+- Continue to skip relay unregister when no API v1 registration succeeded.
 
 ## Prevention tests added
-- Unit coverage for reusing desktop runtime probe diagnostics and proving the child import watchdog
-  is not called in the startup-critical path.
-- Unit coverage for Windows extended paths with spaces and macOS-style resource paths.
-- Packaged e2e regression coverage with a fake `llama_cpp` that would hang only in the removed child
-  watchdog context, plus existing standard and macOS `Contents/Resources` packaged lifecycle checks
-  that fail unless `registered=true` appears.
+- Unit coverage for facade early exit diagnostics, including stderr tail, stdout tail, exit code,
+  command/cwd/import-root, and module-path hint.
+- Unit coverage for Windows extended paths with spaces in runtime-worker env/PYTHONPATH handling.
+- Packaged e2e coverage that simulates a successful runtime-probe shape followed by a facade child
+  exit before handshake and asserts the lifecycle cannot be considered registered.
+- Existing standard and macOS `Contents/Resources` packaged lifecycle checks continue to fail unless
+  `registered=true` appears.

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2371,6 +2371,87 @@ def test_runtime_worker_env_omits_probe_sys_path_marker(monkeypatch):
     assert env.get('PYTHONPATH')
 
 
+def test_subprocess_llama_proxy_early_exit_surfaces_child_diagnostics(monkeypatch, tmp_path):
+    from utils.llm import model_manager as model_manager_module
+
+    class FakePipe:
+        def __init__(self, lines):
+            self._lines = list(lines)
+
+        def __iter__(self):
+            return iter(self._lines)
+
+    class FakeStdin:
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class FakeProcess:
+        def __init__(self, args, **_kwargs):
+            self.args = args
+            self.stdin = FakeStdin()
+            self.stdout = FakePipe(['child boot log\n'])
+            self.stderr = FakePipe(['Traceback: import failed\n'])
+            self.returncode = 17
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', r'\\?\C:\Users\danie\AppData\Local\token.place desktop\_up_\_up_')
+    monkeypatch.setattr(model_manager_module.subprocess, 'Popen', FakeProcess)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager_module._SubprocessLlamaProxy(
+            model_path='model.gguf',
+            timeout_seconds=1,
+            module_path_hint=r'C:\Python311\Lib\site-packages\llama_cpp\__init__.py',
+            desktop_runtime_probe={
+                'selected_backend': 'cuda',
+                'gpu_offload_supported': True,
+                'llama_module_path': r'C:\Python311\Lib\site-packages\llama_cpp\__init__.py',
+            },
+        )
+
+    message = str(exc_info.value)
+    assert 'llama_cpp_import subprocess exited before JSON handshake' in message
+    assert 'exit_code=17' in message
+    assert 'Traceback: import failed' in message
+    assert 'child boot log' in message
+    assert 'token.place desktop' in message
+    assert "\\\\?\\" not in message
+    assert 'module_path_hint=' in message
+
+
+def test_llama_cpp_runtime_worker_env_strips_extended_windows_paths(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', r'\\?\C:\token.place desktop\_up_\_up_')
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT', r'\\?\C:\token.place desktop\python\desktop_runtime_setup.py')
+    monkeypatch.setattr(
+        model_manager_module,
+        '_llama_cpp_probe_sys_path_entries',
+        lambda: [r'\\?\C:\Python311\Lib\site-packages', r'C:\token.place desktop'],
+    )
+
+    env = model_manager_module._llama_cpp_runtime_worker_env()
+
+    assert env['TOKEN_PLACE_PYTHON_IMPORT_ROOT'] == r'C:\token.place desktop\_up_\_up_'
+    assert env['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'] == r'C:\token.place desktop\python\desktop_runtime_setup.py'
+    assert "\\\\?\\" not in env['PYTHONPATH']
+    assert 'token.place desktop' in env['PYTHONPATH']
+
+
 def test_subprocess_llama_proxy_timeout_kills_hung_worker(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
@@ -2560,7 +2641,7 @@ def test_subprocess_llama_proxy_inference_does_not_use_runtime_stage_timeout(mon
     proxy._send = MagicMock()
     captured_timeouts = []
 
-    def _fake_read(_process, *, timeout_seconds, stage):
+    def _fake_read(_process, *, timeout_seconds, stage, **_kwargs):
         captured_timeouts.append((stage, timeout_seconds))
         return {'status': 'ok', 'result': {'choices': [{'message': {'content': 'ok'}}]}}
 
@@ -2583,7 +2664,7 @@ def test_subprocess_llama_proxy_uses_explicit_inference_timeout(monkeypatch):
     proxy._send = MagicMock()
     captured_timeouts = []
 
-    def _fake_read(_process, *, timeout_seconds, stage):
+    def _fake_read(_process, *, timeout_seconds, stage, **_kwargs):
         captured_timeouts.append((stage, timeout_seconds))
         if len(captured_timeouts) == 1:
             return {'status': 'ok', 'chunk': {'choices': [{'delta': {'content': 'ok'}}]}, 'done': False}

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,6 +51,12 @@ def _strip_windows_extended_path_prefix(path_text: str) -> str:
     return path_text
 
 
+def _subprocess_safe_path_text(path_text: Any) -> str:
+    r"""Return a Python/subprocess-friendly path string without Windows \\?\ prefixes."""
+
+    return _strip_windows_extended_path_prefix(str(path_text))
+
+
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
     if not module_path:
         return None
@@ -88,7 +94,9 @@ def _sanitize_llama_cpp_import_paths() -> Dict[str, Any]:
     """Keep app imports available while preventing repo-local llama_cpp shim precedence."""
 
     with _LLAMA_CPP_IMPORT_PATH_LOCK:
-        import_root = os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+        import_root = _subprocess_safe_path_text(
+            os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+        )
         moved: list[str] = []
         repo_root_compare = _canonical_path_for_compare(REPO_ROOT)
         cwd_compare = _canonical_path_for_compare(Path.cwd())
@@ -151,9 +159,23 @@ def _llama_cpp_probe_sys_path_entries() -> list[str]:
         dedupe_key = compare or entry
         if dedupe_key in seen:
             continue
-        entries.append(entry)
+        entries.append(_subprocess_safe_path_text(entry))
         seen.add(dedupe_key)
     return entries
+
+
+def _normalize_packaged_path_env(env: Dict[str, str]) -> None:
+    """Avoid Windows extended-length prefixes in child env path values."""
+
+    for key in (
+        'TOKEN_PLACE_PYTHON_IMPORT_ROOT',
+        'TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT',
+        'TOKEN_PLACE_DESKTOP_PYTHON_ROOT',
+        'TOKEN_PLACE_PROBE_REPO_ROOT',
+    ):
+        value = env.get(key)
+        if value:
+            env[key] = _subprocess_safe_path_text(value)
 
 
 def _llama_cpp_probe_env() -> Dict[str, str]:
@@ -161,6 +183,8 @@ def _llama_cpp_probe_env() -> Dict[str, str]:
 
     pythonpath_entries = _llama_cpp_probe_sys_path_entries()
     env = os.environ.copy()
+    _normalize_packaged_path_env(env)
+    pythonpath_entries = [_subprocess_safe_path_text(entry) for entry in pythonpath_entries]
     env['PYTHONPATH'] = os.pathsep.join(pythonpath_entries)
     env['TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH'] = json.dumps(pythonpath_entries)
     return env
@@ -225,6 +249,8 @@ def _llama_cpp_runtime_worker_env() -> Dict[str, str]:
 
     pythonpath_entries = _llama_cpp_probe_sys_path_entries()
     env = os.environ.copy()
+    _normalize_packaged_path_env(env)
+    pythonpath_entries = [_subprocess_safe_path_text(entry) for entry in pythonpath_entries]
     env['PYTHONPATH'] = os.pathsep.join(pythonpath_entries)
     env.pop('TOKEN_PLACE_LLAMA_CPP_PROBE_SYS_PATH', None)
     return env
@@ -235,7 +261,7 @@ def _llama_cpp_runtime_worker_code(user_code: str) -> str:
 
     return _llama_cpp_path_prefixed_code(
         user_code,
-        repr(json.dumps(_llama_cpp_probe_sys_path_entries())),
+        repr(json.dumps([_subprocess_safe_path_text(entry) for entry in _llama_cpp_probe_sys_path_entries()])),
     )
 
 
@@ -528,21 +554,118 @@ def _import_llama_cpp_in_parent_with_timeout(
         desktop_runtime_probe=desktop_runtime_probe,
     )
 
+class _ProcessOutputTail:
+    """Thread-safe bounded text tail for subprocess diagnostics."""
+
+    def __init__(self, *, max_chars: int = 4000) -> None:
+        self._max_chars = max_chars
+        self._text = ''
+        self._lock = Lock()
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+        with self._lock:
+            self._text = (self._text + text)[-self._max_chars:]
+
+    def get(self) -> str:
+        with self._lock:
+            return self._text
+
+
+def _format_llama_subprocess_context(
+    process: subprocess.Popen,
+    *,
+    stage: str,
+    stdout_tail: Optional[_ProcessOutputTail] = None,
+    stderr_tail: Optional[_ProcessOutputTail] = None,
+    cwd: Optional[str] = None,
+    module_path_hint: Any = None,
+    desktop_runtime_probe: Any = None,
+) -> str:
+    """Return actionable context for an early llama_cpp subprocess failure."""
+
+    probe = _effective_desktop_runtime_probe(desktop_runtime_probe)
+    import_root = _subprocess_safe_path_text(
+        os.environ.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '').strip() or str(REPO_ROOT)
+    )
+    try:
+        returncode = process.poll()
+        if returncode is None:
+            try:
+                returncode = process.wait(timeout=0.1)
+            except Exception:
+                returncode = process.poll()
+    except Exception:
+        returncode = None
+    command = getattr(process, 'args', None)
+    if isinstance(command, (list, tuple)):
+        command_text = ' '.join(str(part) for part in command[:4])
+        if len(command) > 4:
+            command_text += ' ...'
+    else:
+        command_text = str(command or sys.executable)
+    stdout_text = (stdout_tail.get() if stdout_tail is not None else '').strip()
+    stderr_text = (stderr_tail.get() if stderr_tail is not None else '').strip()
+    probe_module_path = str((probe or {}).get('llama_module_path') or '').strip()
+    selected_module_path = str(module_path_hint or probe_module_path or 'unknown')
+    return (
+        f"{stage} subprocess exited before JSON handshake "
+        f"exit_code={returncode if returncode is not None else 'unknown'} "
+        f"stderr_tail={stderr_text[-1000:]!r} stdout_tail={stdout_text[-1000:]!r} "
+        f"program={sys.executable!r} command={command_text!r} cwd={cwd or 'unknown'!r} "
+        f"import_root={import_root!r} module_path_hint={selected_module_path!r}"
+    )
+
+
+def _start_tail_reader(pipe: Any, tail: _ProcessOutputTail, *, name: str) -> threading.Thread:
+    def _reader() -> None:
+        if pipe is None:
+            return
+        try:
+            for line in pipe:
+                tail.append(line)
+        except Exception as exc:  # pragma: no cover - diagnostic best effort
+            tail.append(f"<tail reader failed: {exc}>\n")
+
+    reader = threading.Thread(target=_reader, name=name, daemon=True)
+    reader.start()
+    return reader
+
+
 def _read_llama_subprocess_message(
     process: subprocess.Popen,
     *,
     timeout_seconds: Optional[float],
     stage: str,
+    stdout_tail: Optional[_ProcessOutputTail] = None,
+    stderr_tail: Optional[_ProcessOutputTail] = None,
+    cwd: Optional[str] = None,
+    module_path_hint: Any = None,
+    desktop_runtime_probe: Any = None,
 ) -> Dict[str, Any]:
     result_queue: queue.Queue[str] = queue.Queue(maxsize=1)
+    stdout_tail = stdout_tail or _ProcessOutputTail()
 
     def _reader() -> None:
         assert process.stdout is not None
         for line in process.stdout:
+            stdout_tail.append(line)
             if line.startswith('TOKEN_PLACE_LLAMA_CPP_JSON:'):
                 result_queue.put(line.split(':', 1)[1].strip())
                 return
-        result_queue.put(json.dumps({'status': 'error', 'error': f'{stage} subprocess ended'}))
+        result_queue.put(json.dumps({
+            'status': 'error',
+            'error': _format_llama_subprocess_context(
+                process,
+                stage=stage,
+                stdout_tail=stdout_tail,
+                stderr_tail=stderr_tail,
+                cwd=cwd,
+                module_path_hint=module_path_hint,
+                desktop_runtime_probe=desktop_runtime_probe,
+            ),
+        }))
 
     reader = threading.Thread(target=_reader, name=f'{stage}_stdout_reader', daemon=True)
     reader.start()
@@ -565,31 +688,63 @@ def _read_llama_subprocess_message(
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'error':
-        raise RuntimeError(str(message.get('error') or f'{stage} failed'))
+        details = str(message.get('error') or f'{stage} failed')
+        traceback_text = str(message.get('traceback') or '').strip()
+        if traceback_text:
+            details = f"{details}; traceback={traceback_text[-2000:]}"
+        raise RuntimeError(details)
     return message
 
 
 class _SubprocessLlamaProxy:
     """Minimal llama_cpp.Llama proxy for no-SIGALRM runtimes."""
 
-    def __init__(self, *args, timeout_seconds: Optional[float] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        timeout_seconds: Optional[float] = None,
+        module_path_hint: Any = None,
+        desktop_runtime_probe: Any = None,
+        **kwargs,
+    ) -> None:
         self._timeout_seconds = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
         self._lock = Lock()
+        self._stdout_tail = _ProcessOutputTail()
+        self._stderr_tail = _ProcessOutputTail()
+        self._cwd = _llama_cpp_probe_subprocess_cwd()
+        self._module_path_hint = module_path_hint
+        self._desktop_runtime_probe = desktop_runtime_probe
+        self._command = [
+            sys.executable,
+            '-u',
+            '-c',
+            _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE),
+        ]
         self._process = subprocess.Popen(
-            [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)],
+            self._command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             env=_llama_cpp_runtime_worker_env(),
-            cwd=_llama_cpp_probe_subprocess_cwd(),
+            cwd=self._cwd,
             bufsize=1,
+        )
+        _start_tail_reader(
+            self._process.stderr,
+            self._stderr_tail,
+            name='llama_cpp_subprocess_stderr_reader',
         )
         self._send({'method': '__init__', 'args': args, 'kwargs': kwargs})
         _read_llama_subprocess_message(
             self._process,
             timeout_seconds=self._timeout_seconds,
             stage='llama_cpp_import',
+            stdout_tail=getattr(self, '_stdout_tail', None),
+            stderr_tail=getattr(self, '_stderr_tail', None),
+            cwd=getattr(self, '_cwd', None),
+            module_path_hint=getattr(self, '_module_path_hint', None),
+            desktop_runtime_probe=getattr(self, '_desktop_runtime_probe', None),
         )
 
     def _send(self, payload: Dict[str, Any]) -> None:
@@ -608,6 +763,11 @@ class _SubprocessLlamaProxy:
                 self._process,
                 timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
                 stage='llama_cpp_inference',
+                stdout_tail=getattr(self, '_stdout_tail', None),
+                stderr_tail=getattr(self, '_stderr_tail', None),
+                cwd=getattr(self, '_cwd', None),
+                module_path_hint=getattr(self, '_module_path_hint', None),
+                desktop_runtime_probe=getattr(self, '_desktop_runtime_probe', None),
             )
         return message.get('result')
 
@@ -619,6 +779,11 @@ class _SubprocessLlamaProxy:
                     self._process,
                     timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
                     stage='llama_cpp_inference',
+                    stdout_tail=getattr(self, '_stdout_tail', None),
+                    stderr_tail=getattr(self, '_stderr_tail', None),
+                    cwd=getattr(self, '_cwd', None),
+                    module_path_hint=getattr(self, '_module_path_hint', None),
+                    desktop_runtime_probe=getattr(self, '_desktop_runtime_probe', None),
                 )
                 if message.get('done'):
                     return
@@ -645,6 +810,7 @@ class _SubprocessLlamaCppModule:
     ) -> None:
         self.__file__ = module_path
         self._timeout_seconds = timeout_seconds
+        self._desktop_runtime_probe = desktop_runtime_probe
         self.__token_place_subprocess_facade__ = True
         probe = _coerce_desktop_runtime_probe(desktop_runtime_probe)
         backend = str((probe or {}).get('backend') or '').lower()
@@ -658,9 +824,18 @@ class _SubprocessLlamaCppModule:
     def Llama(self):
         timeout_seconds = self._timeout_seconds
 
+        module_path_hint = self.__file__
+        desktop_runtime_probe = getattr(self, '_desktop_runtime_probe', None)
+
         class _ConfiguredSubprocessLlama(_SubprocessLlamaProxy):
             def __init__(self, *args, **kwargs):
-                super().__init__(*args, timeout_seconds=timeout_seconds, **kwargs)
+                super().__init__(
+                    *args,
+                    timeout_seconds=timeout_seconds,
+                    module_path_hint=module_path_hint,
+                    desktop_runtime_probe=desktop_runtime_probe,
+                    **kwargs,
+                )
 
         return _ConfiguredSubprocessLlama
 
@@ -682,11 +857,11 @@ def _jsonable(value):
 def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
-init_payload = json.loads(sys.stdin.readline())
-llama_cpp = importlib.import_module('llama_cpp')
 try:
+    init_payload = json.loads(sys.stdin.readline())
+    llama_cpp = importlib.import_module('llama_cpp')
     llama = llama_cpp.Llama(*init_payload.get('args', []), **init_payload.get('kwargs', {}))
-    _emit({'status': 'ok', 'module_path': getattr(llama_cpp, '__file__', None)})
+    _emit({'status': 'ok', 'stage': 'model_initialized', 'module_path': getattr(llama_cpp, '__file__', None)})
     for line in sys.stdin:
         request = json.loads(line)
         if request.get('method') == 'create_chat_completion':


### PR DESCRIPTION
### Motivation
- Packaged Windows desktop warm-load could fail in an opaque subprocess facade (parent logged only `llama_cpp_import subprocess ended`) after `desktop_runtime_setup` had already found a valid CUDA `llama-cpp-python` runtime, preventing the operator from registering (`Registered: yes`).
- Existing watchdog/facade child processes used divergent import/env semantics (including `\\?\` extended Windows paths and discarded stderr), making failures un-actionable and e2e coverage missed the regression. 

### Description
- Improve subprocess diagnostics and path normalization in the model manager by adding a thread-safe bounded output tail and human-friendly failure context so early child exits include `exit_code`, `stdout`/`stderr` tails, `command`, `cwd`, `import_root`, and `module_path_hint` in the propagated error.
- Make the subprocess facade faithful to the proven desktop probe by passing `module_path_hint` and `desktop_runtime_probe` through to the worker, and by normalizing packaged env/path values (strip Windows extended-length `\\?\` prefixes for child `PYTHONPATH` and packaged env keys) before launching subprocesses.
- Modify the subprocess worker bootstrap so model initialization emits an explicit startup stage in its JSON handshake (helpful for distinguishing import vs model-init failures) and ensure the parent reads stderr/stdout tails instead of discarding stderr.
- Reuse successful `desktop_runtime_setup` probe diagnostics as the canonical module-path/import-root when available and avoid a second divergent watchdog import on the startup-critical path.
- Update `path_bootstrap` / runtime import helpers to prefer subprocess-friendly resolved paths and preserve packaged resource order while preventing repo-local `llama_cpp.py` shim precedence.
- Add unit tests that assert child-facade early exit diagnostics are surfaced and that the runtime-worker env strips extended Windows prefixes while preserving spaces; add a packaged e2e regression probe that asserts a facade early exit cannot be mistaken for a successful registration; update outages documentation to record the regression and fixes.

### Testing
- Ran focused unit tests around the modified model manager and subprocess facade: `pytest tests/unit/test_model_manager.py -k "subprocess_llama_proxy_early_exit or runtime_worker_env_strips or runtime_worker_env_omits or subprocess_llama_proxy_timeout"` — passed (selected tests exercised and validated the new tailing/diagnostic behavior).
- Ran broader unit suites exercising compute-node runtime and desktop bridge/bootstrap: `pytest tests/unit/test_compute_node_runtime.py` (48 passed), `pytest tests/unit/test_desktop_compute_node_bridge.py -k "warm or runtime or import or register or unregister or failed or facade"` (35 passed), and `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_packaged_layout.py tests/unit/test_desktop_path_bootstrap.py tests/unit/test_desktop_release_artifacts.py` (101 passed, 1 skipped); these verified macOS/Windows parity, path bootstrap, and probe reuse.
- Executed packaged integration probes and parity scripts: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`; the new facade early-exit regression probe ran and asserted that child early exits surface diagnostic details and do not produce `registered=true` (probe failures were fixed during edits until the probe assertions passed).
- Performed `pre-commit run --all-files` and a full test sweep; most tests passed, and targeted suites covering the change passed; the full-repo sweep exposed environment-dependent failures (rate-limiting in relay tests and transient CI constraints) which are unrelated to the core change and were recorded during verification.

Residual risks / follow-ups: monitor Windows packaged release validation (real CUDA-enabled runtimes) and CI parity (some full-repo tests are sensitive to local rate-limit settings); consider follow-up telemetry to capture any remaining child-startup failure shapes in the wild.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225aacc608832f9bba52affc476b85)