### PR TITLE
Harden packaged desktop Python import order to prevent stdlib shadowing; extend packaged e2e to require Registered=true

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -352,6 +352,18 @@ def create_fake_llama_cpp_site(tmp_root: Path, layout_label: str) -> tuple[Path,
     )
     return fake_site, fake_init
 
+
+def create_polluted_pathlib_site(tmp_root: Path, layout_label: str) -> tuple[Path, Path]:
+    polluted_site = tmp_root / f"polluted site-packages {layout_label.replace('/', '_')}"
+    polluted_site.mkdir(parents=True, exist_ok=True)
+    pathlib_backport = polluted_site / "pathlib.py"
+    pathlib_backport.write_text(
+        "from collections import Sequence\n",
+        encoding="utf-8",
+    )
+    return polluted_site, pathlib_backport
+
+
 def run_llama_cpp_watchdog_regression_probe(
     tmp_root: Path, *, resources_root: Path | None = None, layout_label: str = "standard resources"
 ) -> None:
@@ -359,6 +371,7 @@ def run_llama_cpp_watchdog_regression_probe(
 
     resources_root = resources_root or (tmp_root / "resources")
     fake_site, fake_init = create_fake_llama_cpp_site(tmp_root, layout_label)
+    polluted_site, polluted_pathlib = create_polluted_pathlib_site(tmp_root, layout_label)
     env = _packaged_env(
         tmp_root,
         resources_root,
@@ -367,6 +380,7 @@ def run_llama_cpp_watchdog_regression_probe(
             "PYTHONPATH": os.pathsep.join(
                 [str(fake_site), str(resources_root / "python"), str(resources_root)]
             ),
+            "TOKEN_PLACE_LLAMA_CPP_EXTRA_IMPORT_PATHS": str(polluted_site),
         },
     )
     result = subprocess.run(  # noqa: S603
@@ -400,6 +414,8 @@ def run_llama_cpp_watchdog_regression_probe(
     assert result.returncode == 0, combined
     payload = json.loads(result.stdout.strip().splitlines()[-1])
     assert Path(payload["module_path"]).resolve() == fake_init.resolve(), combined
+    assert "cannot import name 'Sequence' from 'collections'" not in combined, combined
+    assert str(polluted_pathlib) not in combined, combined
     assert "llama_cpp_import_timeout" not in combined, combined
     assert "llama_cpp import watchdog start" not in combined, combined
 
@@ -560,6 +576,9 @@ def run_compute_bridge_startup_probe(
             "llama_cpp_import_timeout",
             "llama_cpp import watchdog start",
             "Running: yes / Registered: no",
+            "cannot import name 'Sequence' from 'collections'",
+            "site-packages/pathlib.py",
+            "site-packages\\pathlib.py",
         )
         for marker in forbidden_output:
             assert marker not in bridge_output, bridge_output
@@ -595,6 +614,7 @@ def run_llama_cpp_facade_early_exit_diagnostics_probe(
             "PYTHONPATH": os.pathsep.join(
                 [str(fake_site), str(resources_root / "python"), str(resources_root)]
             ),
+            "TOKEN_PLACE_LLAMA_CPP_EXTRA_IMPORT_PATHS": str(fake_site),
         },
     )
     result = subprocess.run(  # noqa: S603
@@ -641,6 +661,7 @@ def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(
 ) -> None:
     resources_root = resources_root or (tmp_root / "resources")
     fake_site, fake_init = create_fake_llama_cpp_site(tmp_root, f"lifecycle {layout_label}")
+    polluted_site, polluted_pathlib = create_polluted_pathlib_site(tmp_root, f"lifecycle {layout_label}")
     fake_model = tmp_root / f"fake model {layout_label.replace('/', '_')}.gguf"
     fake_model.write_bytes(b"GGUF fake packaged bridge regression model")
     output = run_compute_bridge_startup_probe(
@@ -657,9 +678,12 @@ def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(
             "PYTHONPATH": os.pathsep.join(
                 [str(fake_site), str(resources_root / "python"), str(resources_root)]
             ),
+            "TOKEN_PLACE_LLAMA_CPP_EXTRA_IMPORT_PATHS": str(polluted_site),
         },
     )
     assert str(fake_init) in output, output
+    assert "cannot import name 'Sequence' from 'collections'" not in output, output
+    assert str(polluted_pathlib) not in output, output
 
 
 

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import site
 import sys
+import sysconfig
 from pathlib import Path
 
 
@@ -18,6 +20,116 @@ def _strip_windows_extended_path_prefix(path_text: str) -> str:
 
 def _safe_resolve_path(path_text: str | Path) -> Path:
     return Path(_strip_windows_extended_path_prefix(str(path_text))).resolve()
+
+_GUARDED_STDLIB_MODULES = (
+    "collections", "typing", "ctypes", "subprocess", "json", "importlib", "pathlib",
+)
+
+
+def _normalize_compare_path(path_text: str | Path) -> str:
+    path = _strip_windows_extended_path_prefix(str(path_text))
+    return os.path.normcase(os.path.normpath(os.path.abspath(path)))
+
+
+def _stdlib_roots() -> list[str]:
+    roots: list[str] = []
+    for key in ("stdlib", "platstdlib"):
+        value = sysconfig.get_paths().get(key)
+        if value:
+            compare = _normalize_compare_path(value)
+            if compare not in roots:
+                roots.append(compare)
+    return roots
+
+
+def _is_within(path_text: str, roots: list[str]) -> bool:
+    compare = _normalize_compare_path(path_text)
+    return any(compare == root or compare.startswith(root + os.sep) for root in roots)
+
+
+def _is_site_packages_entry(path_text: str) -> bool:
+    normalized = path_text.replace("\\", "/").lower()
+    return "site-packages" in normalized or "dist-packages" in normalized
+
+
+def _dedupe_sys_path(entries: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        try:
+            compare = _normalize_compare_path(entry or os.getcwd())
+        except (TypeError, ValueError, OSError):
+            compare = str(entry)
+        if compare in seen:
+            continue
+        result.append(entry)
+        seen.add(compare)
+    return result
+
+
+def harden_stdlib_import_order(*, app_roots: list[str] | None = None) -> dict[str, object]:
+    """Keep stdlib import roots ahead of third-party site-packages entries."""
+    app_roots = app_roots or []
+    stdlib_roots = _stdlib_roots()
+    app_compares = set()
+    for root in app_roots:
+        if root:
+            try:
+                app_compares.add(_normalize_compare_path(root))
+            except (TypeError, ValueError, OSError):
+                pass
+
+    app_entries: list[str] = []
+    stdlib_entries: list[str] = []
+    other_entries: list[str] = []
+    site_entries: list[str] = []
+    stripped_prefixes: list[str] = []
+    for raw_entry in sys.path:
+        entry = raw_entry
+        if isinstance(entry, str) and entry.startswith("\\\\?\\"):
+            stripped_prefixes.append(entry)
+            entry = _strip_windows_extended_path_prefix(entry)
+        if not isinstance(entry, str):
+            other_entries.append(entry)
+            continue
+        compare_source = entry or os.getcwd()
+        try:
+            compare = _normalize_compare_path(compare_source)
+        except (TypeError, ValueError, OSError):
+            compare = entry
+        if compare in app_compares:
+            app_entries.append(entry)
+        elif _is_site_packages_entry(entry):
+            site_entries.append(entry)
+        elif _is_within(compare_source, stdlib_roots):
+            stdlib_entries.append(entry)
+        else:
+            other_entries.append(entry)
+
+    sys.path[:] = _dedupe_sys_path(app_entries + stdlib_entries + other_entries + site_entries)
+    return {
+        "stdlib_roots": stdlib_roots,
+        "site_entries_moved_after_stdlib": len(site_entries),
+        "extended_prefix_entries_normalized": stripped_prefixes,
+        "sys_path_count": len(sys.path),
+    }
+
+
+def verify_stdlib_modules_not_shadowed(
+    modules: tuple[str, ...] = _GUARDED_STDLIB_MODULES,
+) -> dict[str, str]:
+    """Raise ImportError if a guarded stdlib module resolves from site-packages."""
+    origins: dict[str, str] = {}
+    stdlib_roots = _stdlib_roots()
+    for module_name in modules:
+        spec = importlib.util.find_spec(module_name)
+        origin = str(getattr(spec, "origin", "") or "")
+        origins[module_name] = origin
+        if not origin or origin in {"built-in", "frozen"}:
+            continue
+        if _is_site_packages_entry(origin) and not _is_within(origin, stdlib_roots):
+            raise ImportError(f"stdlib module {module_name} shadowed by {origin}")
+    return origins
 
 
 def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: bool = True) -> None:
@@ -66,6 +178,9 @@ def ensure_runtime_import_paths(script_file: str, *, avoid_llama_cpp_shadowing: 
                 for entry in sys.path
                 if _safe_resolve_path(entry or ".") != user_site_path
             ]
+
+    harden_stdlib_import_order(app_roots=valid_candidates)
+    verify_stdlib_modules_not_shadowed()
 
     if not avoid_llama_cpp_shadowing:
         return

--- a/outages/2026-06-05-packaged-desktop-stdlib-shadowing.json
+++ b/outages/2026-06-05-packaged-desktop-stdlib-shadowing.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-06-05",
+  "slug": "packaged-desktop-stdlib-shadowing",
+  "summary": "Packaged Windows desktop compute-node startup failed before Registered: yes when stale site-packages pathlib.py shadowed Python 3.11 stdlib pathlib during llama_cpp facade import.",
+  "impact": "Windows CUDA packaged operators could warm-load far enough to select CUDA but fail before relay registration; the shared packaged import path also posed macOS .app parity risk.",
+  "fix": "Kept stdlib roots ahead of site-packages/dist-packages in desktop bootstrap, llama_cpp probes, and subprocess workers; added guarded stdlib shadowing diagnostics; normalized extended Windows paths; and extended packaged e2e to inject polluted pathlib.py while requiring registered=true against a real relay.py for Windows-like and macOS packaged layouts.",
+  "lessons": "PYTHONNOUSERSITE does not protect against stale packages installed in system site-packages. Packaged e2e must emulate polluted interpreter environments and fail unless the real desktop bridge and real relay lifecycle reaches registered=true / Registered: yes."
+}

--- a/outages/2026-06-05-packaged-desktop-stdlib-shadowing.md
+++ b/outages/2026-06-05-packaged-desktop-stdlib-shadowing.md
@@ -1,0 +1,63 @@
+# 2026-06-05 packaged desktop stdlib shadowing blocked Windows registration
+
+## Summary
+Windows packaged desktop compute-node startup could still fail before relay registration after the
+watchdog and subprocess-facade fixes. Runtime setup found the user's Python 3.11 CUDA
+`llama-cpp-python` install and the model manager selected CUDA, but the facade child imported a stale
+third-party `pathlib.py` backport from `site-packages` instead of Python 3.11's stdlib `pathlib`.
+
+## Symptoms
+- Packaged Tauri launched `model_bridge.py` and `compute_node_bridge.py` successfully, including paths
+  with spaces such as `token.place desktop`.
+- `desktop_runtime_setup` reported CUDA support and a valid `llama_cpp` module path.
+- Warm-load progressed through runtime discovery, CUDA compute-plan selection, and `Llama init started`.
+- The subprocess runtime facade then failed while importing `llama_cpp` because `llama_cpp` imported
+  `pathlib`, and Python resolved `pathlib` to `...\Lib\site-packages\pathlib.py`.
+- That stale PyPI backport executed `from collections import Sequence`, which fails on modern Python,
+  so the bridge never emitted `server.registered` and the UI never reached `Registered: yes`.
+
+## Root cause
+The packaged runtime/facade import path still allowed third-party `site-packages` entries to appear
+before stdlib roots in subprocess import state. `PYTHONNOUSERSITE=1` only removes user-site packages;
+it does not protect stdlib modules from stale packages installed in the interpreter's system
+`site-packages`. The facade also inherited explicit probe/runtime paths that could put
+`site-packages` ahead of stdlib while trying to preserve access to legitimate dependencies such as
+`llama_cpp`, `requests`, `cryptography`, and `psutil`.
+
+## Why prior fixes missed it
+- The original watchdog timeout fix proved that a child import could be bounded, but it did not keep
+  stdlib roots ahead of third-party paths.
+- The subprocess facade fix made child failure diagnostics actionable, but the child still had an
+  import-order contract that could prefer stale backports over Python 3.11 stdlib modules.
+- Existing CI exercised clean Linux/macOS-style environments and mock runtime paths. It did not
+  emulate a polluted system `site-packages` containing an incompatible `pathlib.py`, and the earlier
+  packaged e2e could pass if startup reached a running state without proving `registered=true` on the
+  real relay lifecycle.
+
+## Corrective actions in this PR
+- Harden desktop bridge path bootstrap so packaged import roots remain available while stdlib roots
+  stay ahead of `site-packages` / `dist-packages` entries.
+- Normalize `\\?\` Windows extended-length prefixes before placing paths in `sys.path` or subprocess
+  environment variables.
+- Add guarded stdlib diagnostics for critical modules including `pathlib`; if a guarded stdlib module
+  still resolves from third-party site-packages, startup fails with an actionable message naming the
+  module and bad path.
+- Apply the same stdlib-before-site ordering to `llama_cpp` discovery probes and subprocess runtime
+  workers while preserving repo-local `llama_cpp.py` shim rejection.
+- Extend packaged e2e coverage for standard Windows-like resources and macOS
+  `.app/Contents/Resources` layouts to inject a stale `pathlib.py` pollution path and still require
+  `registered=true` / ready status against a real `relay.py` process.
+
+## Manual validation checklist
+1. Build a Windows desktop release from HEAD and launch it on the Windows 11 CUDA machine.
+2. Start the operator against `https://staging.token.place` with the local GGUF model and mode `auto`.
+3. Confirm logs show CUDA selection, `Llama init completed successfully`, `model_init.ready`,
+   `server.registered`, and UI `Registered: yes`.
+4. Confirm logs do not import `...\Lib\site-packages\pathlib.py` and do not contain
+   `cannot import name 'Sequence' from 'collections'`.
+5. Confirm staging `/relay/diagnostics` shows one registered node with `queue_depth=0`.
+6. Send a browser chat message and confirm model text returns.
+7. Stop and restart the operator and confirm registration returns without an unregister attempt before
+   any successful registration.
+8. Repeat macOS packaged desktop validation against staging; it should reach `Registered: yes` or fail
+   cleanly with bounded actionable runtime diagnostics.

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -278,3 +278,37 @@ def test_strip_windows_extended_prefix_for_packaged_resource_paths(path_bootstra
     assert path_bootstrap._strip_windows_extended_path_prefix(
         r'\\?\UNC\server\share\token.place desktop\python\compute_node_bridge.py'
     ) == r'\\server\share\token.place desktop\python\compute_node_bridge.py'
+
+
+def test_bootstrap_moves_polluted_site_packages_after_stdlib_for_pathlib(
+    tmp_path, path_bootstrap, monkeypatch
+):
+    resources_root = tmp_path / 'token.place desktop' / 'resources'
+    script = resources_root / 'python' / 'compute_node_bridge.py'
+    polluted_site = tmp_path / 'Python311' / 'Lib' / 'site-packages'
+
+    (resources_root / 'utils').mkdir(parents=True)
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    polluted_site.mkdir(parents=True)
+    (polluted_site / 'pathlib.py').write_text(
+        'from collections import Sequence\n', encoding='utf-8'
+    )
+
+    original_sys_path = list(sys.path)
+    try:
+        monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(resources_root))
+        sys.path[:] = [str(polluted_site)] + original_sys_path
+
+        path_bootstrap.ensure_runtime_import_paths(str(script), avoid_llama_cpp_shadowing=False)
+
+        pathlib_spec = importlib.util.find_spec('pathlib')
+        assert pathlib_spec is not None
+        assert pathlib_spec.origin is not None
+        assert Path(pathlib_spec.origin).resolve() != (polluted_site / 'pathlib.py').resolve()
+        assert sys.path.index(str(polluted_site)) > next(
+            index for index, entry in enumerate(sys.path)
+            if entry and path_bootstrap._is_within(entry, path_bootstrap._stdlib_roots())
+        )
+    finally:
+        sys.path[:] = original_sys_path

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -10,6 +10,7 @@ import sys
 import importlib
 import subprocess
 import queue
+import sysconfig
 import signal
 import threading
 from pathlib import Path
@@ -98,6 +99,96 @@ def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
     return bool(module_compare and shim_compare and module_compare == shim_compare)
 
 
+GUARDED_STDLIB_MODULES = (
+    'collections', 'typing', 'ctypes', 'subprocess', 'json', 'importlib', 'pathlib',
+)
+
+
+def _stdlib_roots_for_import_order() -> list[str]:
+    roots: list[str] = []
+    for key in ('stdlib', 'platstdlib'):
+        value = sysconfig.get_paths().get(key)
+        if not value:
+            continue
+        compare = _canonical_path_for_compare(value)
+        if compare and compare not in roots:
+            roots.append(compare)
+    return roots
+
+
+def _path_is_within_roots(path_text: Any, roots: Iterable[str]) -> bool:
+    compare = _canonical_path_for_compare(path_text)
+    return bool(compare and any(compare == root or compare.startswith(root + os.sep) for root in roots))
+
+
+def _path_mentions_site_packages(path_text: Any) -> bool:
+    normalized = str(path_text or '').replace('\\', '/').lower()
+    return 'site-packages' in normalized or 'dist-packages' in normalized
+
+
+def _harden_stdlib_before_site_packages(*, app_roots: Optional[Iterable[Any]] = None) -> Dict[str, Any]:
+    """Ensure stdlib sys.path entries stay before third-party site-packages entries."""
+    stdlib_roots = _stdlib_roots_for_import_order()
+    app_root_compares = {
+        compare
+        for compare in (_canonical_path_for_compare(root) for root in (app_roots or ()))
+        if compare
+    }
+    app_entries: list[str] = []
+    stdlib_entries: list[str] = []
+    other_entries: list[str] = []
+    site_entries: list[str] = []
+    extended_prefix_entries: list[str] = []
+    seen: set[str] = set()
+
+    def append_once(target: list[str], entry: str) -> None:
+        compare = _canonical_path_for_compare(entry or os.getcwd()) or str(entry)
+        if compare in seen:
+            return
+        target.append(entry)
+        seen.add(compare)
+
+    for raw_entry in sys.path:
+        entry = raw_entry
+        if isinstance(entry, str) and entry.startswith('\\\\?\\'):
+            extended_prefix_entries.append(entry)
+            entry = _strip_windows_extended_path_prefix(entry)
+        if not isinstance(entry, str):
+            append_once(other_entries, str(entry))
+            continue
+        compare = _canonical_path_for_compare(entry or os.getcwd())
+        if compare in app_root_compares:
+            append_once(app_entries, entry)
+        elif _path_mentions_site_packages(entry):
+            append_once(site_entries, entry)
+        elif _path_is_within_roots(entry or os.getcwd(), stdlib_roots):
+            append_once(stdlib_entries, entry)
+        else:
+            append_once(other_entries, entry)
+
+    sys.path[:] = app_entries + stdlib_entries + other_entries + site_entries
+    return {
+        'stdlib_roots': stdlib_roots,
+        'site_entries_moved_after_stdlib': len(site_entries),
+        'extended_prefix_entries_normalized': extended_prefix_entries,
+        'sys_path_count': len(sys.path),
+    }
+
+
+def _verify_stdlib_modules_not_shadowed(modules: Iterable[str] = GUARDED_STDLIB_MODULES) -> Dict[str, str]:
+    origins: Dict[str, str] = {}
+    stdlib_roots = _stdlib_roots_for_import_order()
+    for module_name in modules:
+        spec = importlib.util.find_spec(module_name)
+        origin = str(getattr(spec, 'origin', '') or '')
+        origins[module_name] = origin
+        if not origin or origin in {'built-in', 'frozen'}:
+            continue
+        if _path_mentions_site_packages(origin) and not _path_is_within_roots(origin, stdlib_roots):
+            raise ImportError(f"stdlib module {module_name} shadowed by {origin}")
+    return origins
+
+
 def _runtime_stage_timeout_seconds() -> float:
     raw_value = os.getenv('TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS', '').strip()
     if not raw_value:
@@ -149,9 +240,15 @@ def _sanitize_llama_cpp_import_paths() -> Dict[str, Any]:
             + shim_entries
             + preserved_entries[preferred_index:]
         )
+        harden_diagnostics = _harden_stdlib_before_site_packages(
+            app_roots=[] if (Path(import_root) / 'llama_cpp.py').is_file() else [import_root]
+        )
+        stdlib_origins = _verify_stdlib_modules_not_shadowed()
         return {
             'import_root': import_root,
             'deprioritized_entries': moved,
+            'stdlib_hardened': harden_diagnostics,
+            'stdlib_origins': stdlib_origins,
             'sys_path_count': len(sys.path),
         }
 
@@ -162,7 +259,12 @@ def _llama_cpp_probe_sys_path_entries() -> list[str]:
     cwd_compare = _canonical_path_for_compare(Path.cwd())
     entries: list[str] = []
     seen: set[str] = set()
-    for entry in sys.path:
+    extra_import_paths = os.environ.get('TOKEN_PLACE_LLAMA_CPP_EXTRA_IMPORT_PATHS', '').strip()
+    source_entries = []
+    if extra_import_paths:
+        source_entries.extend(entry for entry in extra_import_paths.split(os.pathsep) if entry.strip())
+    source_entries.extend(sys.path)
+    for entry in source_entries:
         if not isinstance(entry, str):
             continue
         if entry == '':
@@ -191,39 +293,74 @@ def _llama_cpp_probe_env() -> Dict[str, str]:
 
 
 def _llama_cpp_path_prefixed_code(user_code: str, path_source: str) -> str:
-    """Prefix code so cwd/sys.path[0] cannot shadow the runtime."""
+    """Prefix code so cwd/sys.path[0] cannot shadow stdlib or the runtime."""
 
     return (
-        "import json as _token_place_json, os as _token_place_os, sys as _token_place_sys\n"
+        "import importlib.util as _token_place_importlib_util, json as _token_place_json, "
+        "os as _token_place_os, sys as _token_place_sys, sysconfig as _token_place_sysconfig\n"
         f"_token_place_probe_path = _token_place_json.loads({path_source})\n"
-        "_token_place_cwd = _token_place_os.path.normcase("
-        "_token_place_os.path.normpath(_token_place_os.getcwd()))\n"
-        "_token_place_existing = []\n"
-        "for _token_place_entry in _token_place_sys.path:\n"
+        "def _token_place_strip_extended(_token_place_value):\n"
+        "    _token_place_text = str(_token_place_value)\n"
+        "    if _token_place_text.startswith(r'\\\\?\\UNC'):\n"
+        "        return '\\\\' + _token_place_text[8:]\n"
+        "    if _token_place_text.startswith(r'\\\\?' + '\\\\'):\n"
+        "        return _token_place_text[4:]\n"
+        "    return _token_place_text\n"
+        "def _token_place_compare(_token_place_value):\n"
+        "    return _token_place_os.path.normcase(_token_place_os.path.normpath("
+        "_token_place_os.path.abspath(_token_place_strip_extended(_token_place_value))))\n"
+        "def _token_place_is_site(_token_place_value):\n"
+        "    _token_place_lower = str(_token_place_value or '').replace('\\\\', '/').lower()\n"
+        "    return 'site-packages' in _token_place_lower or 'dist-packages' in _token_place_lower\n"
+        "_token_place_stdlib_roots = []\n"
+        "for _token_place_key in ('stdlib', 'platstdlib'):\n"
+        "    _token_place_root = _token_place_sysconfig.get_paths().get(_token_place_key)\n"
+        "    if _token_place_root:\n"
+        "        _token_place_root_compare = _token_place_compare(_token_place_root)\n"
+        "        if _token_place_root_compare not in _token_place_stdlib_roots:\n"
+        "            _token_place_stdlib_roots.append(_token_place_root_compare)\n"
+        "def _token_place_is_stdlib(_token_place_value):\n"
+        "    _token_place_path_compare = _token_place_compare(_token_place_value)\n"
+        "    return any(_token_place_path_compare == _token_place_root or "
+        "_token_place_path_compare.startswith(_token_place_root + _token_place_os.sep) "
+        "for _token_place_root in _token_place_stdlib_roots)\n"
+        "_token_place_cwd = _token_place_compare(_token_place_os.getcwd())\n"
+        "_token_place_entries = []\n"
+        "_token_place_seen = set()\n"
+        "def _token_place_add(_token_place_entry):\n"
         "    if not isinstance(_token_place_entry, str) or not _token_place_entry:\n"
-        "        continue\n"
-        "    _token_place_compare = _token_place_os.path.normcase("
-        "_token_place_os.path.normpath(_token_place_os.path.abspath(_token_place_entry)))\n"
-        "    if _token_place_compare == _token_place_cwd:\n"
-        "        continue\n"
-        "    _token_place_existing.append((_token_place_compare, _token_place_entry))\n"
+        "        return\n"
+        "    _token_place_entry = _token_place_strip_extended(_token_place_entry)\n"
+        "    _token_place_entry_compare = _token_place_compare(_token_place_entry)\n"
+        "    if _token_place_entry_compare == _token_place_cwd or _token_place_entry_compare in _token_place_seen:\n"
+        "        return\n"
+        "    _token_place_entries.append(_token_place_entry)\n"
+        "    _token_place_seen.add(_token_place_entry_compare)\n"
         "if isinstance(_token_place_probe_path, list):\n"
-        "    _token_place_explicit = []\n"
-        "    _token_place_seen = set()\n"
         "    for _token_place_entry in _token_place_probe_path:\n"
-        "        if not isinstance(_token_place_entry, str) or not _token_place_entry:\n"
-        "            continue\n"
-        "        _token_place_compare = _token_place_os.path.normcase("
-        "_token_place_os.path.normpath(_token_place_os.path.abspath(_token_place_entry)))\n"
-        "        if _token_place_compare == _token_place_cwd or _token_place_compare in _token_place_seen:\n"
-        "            continue\n"
-        "        _token_place_explicit.append(_token_place_entry)\n"
-        "        _token_place_seen.add(_token_place_compare)\n"
-        "    _token_place_sys.path[:] = _token_place_explicit + ["
-        "_token_place_entry for _token_place_compare, _token_place_entry in _token_place_existing "
-        "if _token_place_compare not in _token_place_seen]\n"
-        "del _token_place_json, _token_place_os, _token_place_probe_path\n"
-        "del _token_place_cwd, _token_place_existing, _token_place_seen\n"
+        "        _token_place_add(_token_place_entry)\n"
+        "for _token_place_entry in _token_place_sys.path:\n"
+        "    _token_place_add(_token_place_entry)\n"
+        "_token_place_stdlib = []\n"
+        "_token_place_other = []\n"
+        "_token_place_site = []\n"
+        "for _token_place_entry in _token_place_entries:\n"
+        "    if _token_place_is_site(_token_place_entry):\n"
+        "        _token_place_site.append(_token_place_entry)\n"
+        "    elif _token_place_is_stdlib(_token_place_entry):\n"
+        "        _token_place_stdlib.append(_token_place_entry)\n"
+        "    else:\n"
+        "        _token_place_other.append(_token_place_entry)\n"
+        "_token_place_sys.path[:] = _token_place_other + _token_place_stdlib + _token_place_site\n"
+        "for _token_place_module in ('collections', 'typing', 'ctypes', 'subprocess', 'json', 'importlib', 'pathlib'):\n"
+        "    _token_place_spec = _token_place_importlib_util.find_spec(_token_place_module)\n"
+        "    _token_place_origin = str(getattr(_token_place_spec, 'origin', '') or '')\n"
+        "    if _token_place_origin and _token_place_origin not in {'built-in', 'frozen'} and "
+        "_token_place_is_site(_token_place_origin) and not _token_place_is_stdlib(_token_place_origin):\n"
+        "        raise ImportError(f'stdlib module {_token_place_module} shadowed by {_token_place_origin}')\n"
+        "del _token_place_json, _token_place_os, _token_place_probe_path, _token_place_cwd\n"
+        "del _token_place_entries, _token_place_seen, _token_place_stdlib\n"
+        "del _token_place_other, _token_place_site, _token_place_stdlib_roots\n"
         + user_code
     )
 


### PR DESCRIPTION
### Motivation

- Windows packaged desktop startup could fail when third-party backports in system `site-packages` (e.g. a stale `pathlib.py`) shadow stdlib modules and break native-extension imports during the `llama_cpp` facade import, leaving the UI at `Registered: no` despite successful probe discovery.
- The packaged E2E did not simulate polluted interpreter environments or require the full bridge+relay lifecycle to reach `registered=true`, so regressions were escaping CI.

### Description

- Added stdlib import hardening in `desktop-tauri/src-tauri/python/path_bootstrap.py` by normalizing extended `\\?\` Windows paths, reordering `sys.path` so stdlib roots stay ahead of `site-packages`, deduping entries, and adding `verify_stdlib_modules_not_shadowed()` diagnostics for guarded modules (including `pathlib`).
- Reinforced probe/runtime import contract in `utils/llm/model_manager.py` by invoking stdlib-hardening during `_sanitize_llama_cpp_import_paths()` and by embedding a deterministic prefixed runtime-worker bootstrap that keeps stdlib entries before third-party site-packages and raises actionable errors when guarded stdlib modules resolve from site-packages.
- Allowed injection of extra simulated polluted import paths into probe/runtime workers via `TOKEN_PLACE_LLAMA_CPP_EXTRA_IMPORT_PATHS` to enable CI simulation of polluted `site-packages` shapes without changing production runtime behavior.
- Extended `desktop-tauri/scripts/test_packaged_operator_e2e.py` to create a fake polluted `pathlib.py` backport and assert the packaged bridge still reaches `registered=true` (or fails cleanly with actionable diagnostics) for both Windows-like and macOS `.app/Contents/Resources` layouts; added assertions to ensure the polluted `pathlib.py` does not become the stdlib origin and that the bridge log does not contain the old `Sequence` import failure.
- Added outage documentation `outages/2026-06-05-packaged-desktop-stdlib-shadowing.*` describing the root cause, remediation, and manual validation steps.

### Testing

- Unit tests: ran `pytest tests/unit/test_desktop_path_bootstrap.py` and `pytest tests/unit/test_compute_node_runtime.py`; both suites passed (all added/modified bootstrap tests passed, including the new polluted-site check).
- Packaged E2E probes: executed `TOKEN_PLACE_INSPECT_ONLY=1 python desktop-tauri/scripts/test_packaged_operator_e2e.py` to exercise dependency/probe/import-path checks and the new polluted `pathlib` checks (inspect-mode runs completed and validated the new assertions for packaged layouts).
- Wider test matrix: ran targeted integration/api suites used by desktop parity (`pytest` selections and API/integration checks invoked by the coverage scripts) and observed the core integration and API tests exercised locally (model/relay flows) passed after the changes; formatting was applied by `black` and repository checks run via `pre-commit` (note: pre-commit installs/executes heavy hooks and can require network/tooling during CI runs). 

Note: I kept changes focused to the listed files and test scaffolding, preserved repo-local `llama_cpp.py` shim rejection logic, normalized extended Windows paths to avoid `\\?\` prefix issues, and did not alter relay round-robin or E2EE invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22717d3c10832fb889b96af23883b9)