### PR TITLE
Add per-session operator debug logs and macOS debug-terminal/UI affordances

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -61,6 +61,25 @@ After a successful repair, the sidecar automatically re-execs once so the active
 - CPU fallback mode is available in both cases, with explicit fallback details surfaced in `desktop.runtime_setup ... fallback_reason=...` and `compute_runtime ... fallback_reason=...`. Missing `llama_cpp` is a dependency failure, not silent CPU fallback.
 - `backend_available` reports runtime capability, `backend_selected` reports policy selection, and `backend_used` reports the initialized relay-processing runtime. GPU release claims depend on `backend_used`.
 
+
+## Operator debug logs
+
+Packaged desktop operator sessions persist bridge diagnostics to an app-data log file and expose the current path in the Compute node operator panel. The log mirrors the bridge lifecycle lines that are otherwise easy to miss on macOS packaged launches: model/compute bridge start details, selected interpreter/resource/import roots, `desktop.runtime_setup` probe/provision output, compute-node bridge stdout/stderr, warm-load, registration, polling, request/response metadata, Stop/cancel, unregister, and cleanup lines.
+
+Use the operator panel buttons to:
+
+- **Reveal debug log**: open Finder/Explorer/file-manager at the current log file.
+- **Open debug terminal**: on macOS, open Terminal.app with a read-only `tail -n 200 -f` of the current log file.
+- **Copy log path**: copy the current log path for issue reports.
+
+macOS logs live under the app data directory, for example:
+
+```text
+~/Library/Application Support/<app identifier>/logs/operator-session-<id>-<timestamp>.log
+```
+
+For manual macOS validation, set `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1` before launching the packaged app to auto-open the debug terminal after an operator session starts. Normal packaged launches do not pop up Terminal.app unless this env var or the explicit UI button is used. Logs intentionally avoid private keys and plaintext prompts/responses; keep captures to lifecycle/runtime diagnostics when reporting Start operator failures.
+
 ## Privacy defaults
 
 - Prompt/response plaintext stays in-memory by default.

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -8,9 +8,11 @@ use crate::python_runtime::{
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -48,6 +50,25 @@ pub struct ComputeNodeStatus {
     pub operator_session_id: Option<String>,
     pub sequence: Option<u64>,
     pub updated_at_ms: Option<u64>,
+    pub operator_log_path: Option<String>,
+}
+
+#[derive(Clone)]
+struct OperatorLogHandle {
+    path: PathBuf,
+    file: Arc<Mutex<File>>,
+}
+
+impl OperatorLogHandle {
+    async fn append_line(&self, line: impl AsRef<str>) {
+        let mut file = self.file.lock().await;
+        let _ = writeln!(file, "{}", line.as_ref());
+        let _ = file.flush();
+    }
+
+    fn path_string(&self) -> String {
+        self.path.to_string_lossy().into_owned()
+    }
 }
 
 #[derive(Clone, Default)]
@@ -202,7 +223,12 @@ fn event_session_id(payload: &Value) -> Option<&str> {
     payload.get("operator_session_id").and_then(Value::as_str)
 }
 
-fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
+fn startup_failure_status(
+    request: &ComputeNodeRequest,
+    last_error: String,
+    operator_session_id: Option<String>,
+    operator_log_path: Option<String>,
+) -> ComputeNodeStatus {
     ComputeNodeStatus {
         running: false,
         registered: false,
@@ -221,9 +247,10 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
-        operator_session_id: None,
+        operator_session_id,
         sequence: None,
         updated_at_ms: Some(current_time_ms()),
+        operator_log_path,
     }
 }
 
@@ -334,6 +361,99 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
     true
 }
 
+fn should_auto_open_debug_terminal() -> bool {
+    std::env::var("TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn maybe_open_debug_terminal(log_path: Option<&str>) {
+    if !should_auto_open_debug_terminal() {
+        return;
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(log_path) = log_path {
+        let tail_command = format!("tail -n 200 -f {}", shell_single_quote(log_path));
+        if let Err(err) = std::process::Command::new("osascript")
+            .args([
+                "-e",
+                "tell application \"Terminal\" to activate",
+                "-e",
+                &format!(
+                    "tell application \"Terminal\" to do script {:?}",
+                    tail_command
+                ),
+            ])
+            .spawn()
+        {
+            eprintln!("desktop.compute_node.debug_terminal_open_failed error={err}");
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = log_path;
+    }
+}
+
+fn operator_logs_dir(app: &AppHandle) -> anyhow::Result<PathBuf> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| anyhow::anyhow!("app data path error: {e}"))?;
+    let dir = base.join("logs");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn create_operator_log_in_dir(
+    dir: &Path,
+    session_id: &str,
+    relay_url: &str,
+) -> anyhow::Result<OperatorLogHandle> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(format!(
+        "operator-session-{}-{}.log",
+        session_id,
+        current_time_ms()
+    ));
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)?;
+    writeln!(
+        file,
+        "desktop.compute_node.log.start operator_session_id={} relay={} log_path={}",
+        session_id,
+        sanitize_relay_target(relay_url),
+        path.display()
+    )?;
+    Ok(OperatorLogHandle {
+        path,
+        file: Arc::new(Mutex::new(file)),
+    })
+}
+
+fn create_operator_log(
+    app: &AppHandle,
+    session_id: &str,
+    relay_url: &str,
+) -> anyhow::Result<OperatorLogHandle> {
+    create_operator_log_in_dir(&operator_logs_dir(app)?, session_id, relay_url)
+}
+
+async fn log_and_stderr(log: Option<&OperatorLogHandle>, line: String) {
+    eprintln!("{line}");
+    if let Some(log) = log {
+        log.append_line(line).await;
+    }
+}
+
 fn bridge_exit_status_label(exit_status: std::process::ExitStatus) -> String {
     if let Some(code) = exit_status.code() {
         return code.to_string();
@@ -417,12 +537,17 @@ fn finalize_bridge_exit(
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     policy: SubprocessLogPolicy,
+    operator_log: Option<OperatorLogHandle>,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
     let mut filter = SubprocessLogFilter::new("compute_node", policy);
     while let Some(line) = lines.next_line().await? {
         if filter.should_emit(&line) {
-            eprintln!("desktop.compute_node.stderr line={line}");
+            log_and_stderr(
+                operator_log.as_ref(),
+                format!("desktop.compute_node.stderr line={line}"),
+            )
+            .await;
         }
     }
     Ok(())
@@ -434,6 +559,22 @@ pub async fn start_compute_node(
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let session_id = {
+        let mut next_session_id = state.next_session_id.lock().await;
+        *next_session_id += 1;
+        next_session_id.to_string()
+    };
+    let operator_log = match create_operator_log(&app, &session_id, &request.relay_base_url) {
+        Ok(log) => Some(log),
+        Err(err) => {
+            eprintln!(
+                "desktop.compute_node.log_create_failed operator_session_id={} error={}",
+                session_id, err
+            );
+            None
+        }
+    };
+    let operator_log_path = operator_log.as_ref().map(OperatorLogHandle::path_string);
 
     {
         let _lifecycle_lock = state.lifecycle_lock.lock().await;
@@ -453,7 +594,12 @@ pub async fn start_compute_node(
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = startup_failure_status(&request, err.clone());
+                *status = startup_failure_status(
+                    &request,
+                    err.clone(),
+                    Some(session_id.clone()),
+                    operator_log_path.clone(),
+                );
             }
             return Err(anyhow::anyhow!(err));
         }
@@ -467,7 +613,12 @@ pub async fn start_compute_node(
                 Err(err) => {
                     {
                         let mut status = state.status.lock().await;
-                        *status = startup_failure_status(&request, err.to_string());
+                        *status = startup_failure_status(
+                            &request,
+                            err.to_string(),
+                            Some(session_id.clone()),
+                            operator_log_path.clone(),
+                        );
                     }
                     return Err(err);
                 }
@@ -476,7 +627,12 @@ pub async fn start_compute_node(
                 let err = anyhow::anyhow!("python launcher resolver task failed: {err}");
                 {
                     let mut status = state.status.lock().await;
-                    *status = startup_failure_status(&request, err.to_string());
+                    *status = startup_failure_status(
+                        &request,
+                        err.to_string(),
+                        Some(session_id.clone()),
+                        operator_log_path.clone(),
+                    );
                 }
                 return Err(err);
             }
@@ -490,15 +646,15 @@ pub async fn start_compute_node(
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = startup_failure_status(&request, err.to_string());
+                *status = startup_failure_status(
+                    &request,
+                    err.to_string(),
+                    Some(session_id.clone()),
+                    operator_log_path.clone(),
+                );
             }
             return Err(err);
         }
-    };
-    let session_id = {
-        let mut next_session_id = state.next_session_id.lock().await;
-        *next_session_id += 1;
-        next_session_id.to_string()
     };
     let exe_path = std::env::current_exe().ok();
     let resource_dir = app.path().resource_dir().ok();
@@ -515,16 +671,18 @@ pub async fn start_compute_node(
         .get_program()
         .to_string_lossy()
         .into_owned();
-    eprintln!(
-        "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={} cancellation_token_reset=true",
+    let session_start_line = format!(
+        "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={} cancellation_token_reset=true log_path={}",
         session_id,
         sanitize_relay_target(&request.relay_base_url),
         bridge_script,
         interpreter,
         selected_resource_root.display(),
         selected_layout,
-        import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into())
+        import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into()),
+        operator_log_path.as_deref().unwrap_or("<unavailable>")
     );
+    log_and_stderr(operator_log.as_ref(), session_start_line).await;
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
 
@@ -549,6 +707,8 @@ pub async fn start_compute_node(
                 *status = startup_failure_status(
                     &request,
                     format!("failed to start compute-node bridge: {err}"),
+                    Some(session_id.clone()),
+                    operator_log_path.clone(),
                 );
                 *state.child.lock().await = None;
                 *state.stdin.lock().await = None;
@@ -581,11 +741,15 @@ pub async fn start_compute_node(
         {
             false
         } else {
-            eprintln!(
-                "desktop.compute_node.bridge_process.spawned operator_session_id={} relay={}",
-                session_id,
-                sanitize_relay_target(&request.relay_base_url)
-            );
+            log_and_stderr(
+                operator_log.as_ref(),
+                format!(
+                    "desktop.compute_node.bridge_process.spawned operator_session_id={} relay={}",
+                    session_id,
+                    sanitize_relay_target(&request.relay_base_url)
+                ),
+            )
+            .await;
             *child_slot = pending_child.take();
             let mut stdin_slot = state.stdin.lock().await;
             *stdin_slot = pending_stdin.take();
@@ -611,7 +775,9 @@ pub async fn start_compute_node(
                 operator_session_id: Some(session_id.clone()),
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),
+                operator_log_path: operator_log_path.clone(),
             };
+            maybe_open_debug_terminal(operator_log_path.as_deref());
             true
         }
     };
@@ -629,9 +795,14 @@ pub async fn start_compute_node(
     }
 
     let log_policy = SubprocessLogPolicy::from_env();
+    let stderr_log = operator_log.clone();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_compute_node_stderr(stderr, log_policy).await {
-            eprintln!("desktop.compute_node.stderr_error error={err}");
+        if let Err(err) = drain_compute_node_stderr(stderr, log_policy, stderr_log.clone()).await {
+            log_and_stderr(
+                stderr_log.as_ref(),
+                format!("desktop.compute_node.stderr_error error={err}"),
+            )
+            .await;
         }
     });
 
@@ -639,6 +810,10 @@ pub async fn start_compute_node(
     let mut saw_error_event = false;
     let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
+        if let Some(log) = operator_log.as_ref() {
+            log.append_line(format!("desktop.compute_node.stdout line={line}"))
+                .await;
+        }
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
@@ -658,16 +833,24 @@ pub async fn start_compute_node(
                 app.emit("compute_node_event", payload)?;
             }
             Err(err) => {
-                eprintln!(
-                    "desktop.compute_node.stdout_parse_error error={} line={}",
-                    err, line
-                );
+                log_and_stderr(
+                    operator_log.as_ref(),
+                    format!(
+                        "desktop.compute_node.stdout_parse_error error={} line={}",
+                        err, line
+                    ),
+                )
+                .await;
             }
         }
     }
 
     if let Err(err) = stderr_task.await {
-        eprintln!("desktop.compute_node.stderr_task_join_error error={err}");
+        log_and_stderr(
+            operator_log.as_ref(),
+            format!("desktop.compute_node.stderr_task_join_error error={err}"),
+        )
+        .await;
     }
 
     let running_child = {
@@ -710,6 +893,15 @@ pub async fn start_compute_node(
         if current_session.as_deref() == Some(session_id.as_str()) {
             *state.stdin.lock().await = None;
         }
+    }
+
+    if let Some(log) = operator_log.as_ref() {
+        log.append_line(format!(
+            "desktop.compute_node.session.end operator_session_id={} relay={}",
+            session_id,
+            sanitize_relay_target(&request.relay_base_url)
+        ))
+        .await;
     }
 
     Ok(())
@@ -904,6 +1096,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn operator_log_file_records_start_and_stderr_lines_with_spaces_in_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let log_dir = temp
+            .path()
+            .join("Application Support")
+            .join("token.place logs");
+        let log = create_operator_log_in_dir(
+            &log_dir,
+            "session 1",
+            "https://user:secret@relay.example/path?token=secret",
+        )
+        .expect("create operator log");
+
+        log.append_line("desktop.compute_node.stderr line=bridge diagnostic")
+            .await;
+        let raw = std::fs::read_to_string(log.path).expect("read operator log");
+
+        assert!(raw.contains("desktop.compute_node.log.start operator_session_id=session 1"));
+        assert!(raw.contains("relay=https://relay.example"));
+        assert!(!raw.contains("user:secret"));
+        assert!(!raw.contains("token=secret"));
+        assert!(raw.contains("desktop.compute_node.stderr line=bridge diagnostic"));
+    }
+
+    #[tokio::test]
     async fn drain_compute_node_stderr_reads_all_lines() {
         let mut child = {
             #[cfg(windows)]
@@ -924,7 +1141,7 @@ mod tests {
         .expect("spawn stderr script");
 
         let stderr = child.stderr.take().expect("stderr");
-        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true })
+        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true }, None)
             .await
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
@@ -1213,6 +1430,8 @@ mod tests {
         let status = startup_failure_status(
             &request,
             "no usable Python 3 interpreter found for desktop Python subprocess".into(),
+            Some("session-1".into()),
+            Some("/tmp/operator.log".into()),
         );
 
         assert!(!status.running);
@@ -1390,6 +1609,8 @@ mod tests {
         let status = startup_failure_status(
             &request,
             "unable to locate desktop Python bridge script 'compute_node_bridge.py'".into(),
+            None,
+            None,
         );
 
         assert!(!status.running);

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -13,7 +13,10 @@ use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
 use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
+#[cfg(target_os = "windows")]
+use std::ffi::OsString;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
@@ -102,7 +105,7 @@ fn configure_runtime_pythonpath(
     )
 }
 
-fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
+fn run_model_bridge(action: &str, log_path: Option<PathBuf>) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path(Some(&launcher.program))?;
@@ -117,8 +120,8 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
         manifest_dir,
         None,
     );
-    eprintln!(
-        "desktop.model_bridge.start action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
+    let start_line = format!(
+        "desktop.model_bridge.start action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={} log_path={}",
         action,
         bridge_script.display(),
         bridge_command.get_program().to_string_lossy(),
@@ -127,8 +130,14 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
         import_root
             .as_deref()
             .map(|path| path.display().to_string())
-            .unwrap_or_else(|| "<unresolved>".into())
+            .unwrap_or_else(|| "<unresolved>".into()),
+        log_path
+            .as_deref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<unavailable>".into())
     );
+    eprintln!("{start_line}");
+    append_desktop_log_line(log_path.as_deref(), &start_line);
     let output = bridge_command
         .arg(action)
         .output()
@@ -136,6 +145,18 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        append_desktop_log_line(
+            log_path.as_deref(),
+            &format!("desktop.model_bridge.stdout line={line}"),
+        );
+    }
+    for line in stderr.lines().filter(|line| !line.trim().is_empty()) {
+        append_desktop_log_line(
+            log_path.as_deref(),
+            &format!("desktop.model_bridge.stderr line={line}"),
+        );
+    }
     let json_line = stdout
         .lines()
         .rev()
@@ -178,6 +199,111 @@ fn resolve_config_dir(app: &tauri::AppHandle, state: &AppState) -> anyhow::Resul
     fs::create_dir_all(&dir)?;
     *state.config_dir.blocking_lock() = Some(dir.clone());
     Ok(dir)
+}
+
+fn desktop_logs_dir(app: &tauri::AppHandle) -> anyhow::Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| anyhow::anyhow!("app data path error: {e}"))?
+        .join("logs");
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn append_desktop_log_line(path: Option<&Path>, line: &str) {
+    if let Some(path) = path {
+        if let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(path) {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_tail_script(log_path: &Path) -> String {
+    format!(
+        "tail -n 200 -f {}",
+        shell_single_quote(&log_path.to_string_lossy())
+    )
+}
+
+#[cfg(test)]
+fn macos_tail_script_for_test(log_path: &Path) -> String {
+    format!(
+        "tail -n 200 -f {}",
+        shell_single_quote(&log_path.to_string_lossy())
+    )
+}
+
+fn require_current_operator_log_path(status: &ComputeNodeStatus) -> Result<PathBuf, String> {
+    let raw = status
+        .operator_log_path
+        .as_deref()
+        .ok_or_else(|| "operator debug log is not available yet".to_string())?;
+    let path = PathBuf::from(raw);
+    if !path.is_file() {
+        return Err(format!(
+            "operator debug log does not exist: {}",
+            path.display()
+        ));
+    }
+    Ok(path)
+}
+
+fn reveal_log_file(path: &Path) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("-R")
+            .arg(path)
+            .spawn()
+            .map_err(|e| format!("unable to reveal operator debug log: {e}"))?;
+        return Ok(());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let select_arg = format!("/select,{}", path.display());
+        std::process::Command::new("explorer")
+            .arg(OsString::from(select_arg))
+            .spawn()
+            .map_err(|e| format!("unable to reveal operator debug log: {e}"))?;
+        return Ok(());
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        let parent = path.parent().unwrap_or(path);
+        std::process::Command::new("xdg-open")
+            .arg(parent)
+            .spawn()
+            .map_err(|e| format!("unable to reveal operator debug log directory: {e}"))?;
+        Ok(())
+    }
+}
+
+fn open_log_terminal(path: &Path) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let script = macos_tail_script(path);
+        std::process::Command::new("osascript")
+            .args([
+                "-e",
+                "tell application \"Terminal\" to activate",
+                "-e",
+                &format!("tell application \"Terminal\" to do script {:?}", script),
+            ])
+            .spawn()
+            .map_err(|e| format!("unable to open macOS debug terminal: {e}"))?;
+        return Ok(());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = path;
+        Err("debug terminal tailing is currently implemented for macOS packaged validation; use Reveal log file on this platform".into())
+    }
 }
 
 #[tauri::command]
@@ -275,6 +401,20 @@ async fn encrypt_and_forward(relay_base_url: String, final_output: String) -> Re
 }
 
 #[tauri::command]
+async fn reveal_operator_debug_log(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let status = state.compute_node.status.lock().await.clone();
+    let path = require_current_operator_log_path(&status)?;
+    reveal_log_file(&path)
+}
+
+#[tauri::command]
+async fn open_operator_debug_terminal(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let status = state.compute_node.status.lock().await.clone();
+    let path = require_current_operator_log_path(&status)?;
+    open_log_terminal(&path)
+}
+
+#[tauri::command]
 async fn start_compute_node(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
@@ -286,12 +426,16 @@ async fn start_compute_node(
             compute_node::start_compute_node(app.clone(), compute_state.clone(), request).await
         {
             eprintln!("desktop.compute_node.start_failure error={}", err);
-            {
+            let (operator_log_path, operator_session_id) = {
                 let mut status = compute_state.status.lock().await;
                 status.running = false;
                 status.registered = false;
                 status.last_error = Some(err.to_string());
-            }
+                (
+                    status.operator_log_path.clone(),
+                    status.operator_session_id.clone(),
+                )
+            };
             let _ = app.emit(
                 "compute_node_event",
                 serde_json::json!({
@@ -300,6 +444,8 @@ async fn start_compute_node(
                     "registered": false,
                     "last_error": err.to_string(),
                     "message": err.to_string(),
+                    "operator_session_id": operator_session_id,
+                    "operator_log_path": operator_log_path,
                 }),
             );
         }
@@ -322,13 +468,19 @@ async fn get_compute_node_status(
 }
 
 #[tauri::command]
-fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
-    run_model_bridge("inspect")
+fn inspect_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    let log_path = desktop_logs_dir(&app)
+        .ok()
+        .map(|dir| dir.join("model-bridge.log"));
+    run_model_bridge("inspect", log_path)
 }
 
 #[tauri::command]
-async fn download_model_artifact() -> Result<ModelArtifactInfo, String> {
-    tokio::task::spawn_blocking(|| run_model_bridge("download"))
+async fn download_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    let log_path = desktop_logs_dir(&app)
+        .ok()
+        .map(|dir| dir.join("model-bridge.log"));
+    tokio::task::spawn_blocking(move || run_model_bridge("download", log_path))
         .await
         .map_err(|e| format!("download bridge task failed: {e}"))?
 }
@@ -347,6 +499,8 @@ pub fn run() {
             start_compute_node,
             stop_compute_node,
             get_compute_node_status,
+            reveal_operator_debug_log,
+            open_operator_debug_terminal,
             encrypt_and_forward,
             inspect_model_artifact,
             download_model_artifact
@@ -370,6 +524,48 @@ mod tests {
             .find_map(|(env_key, value)| (env_key == key).then_some(value))
             .flatten()
             .map(|value| value.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn macos_tail_script_quotes_paths_with_spaces_and_single_quotes() {
+        let path = PathBuf::from("/Users/example/Token Place/operator's log.log");
+        let script = macos_tail_script_for_test(&path);
+
+        assert_eq!(
+            script,
+            "tail -n 200 -f '/Users/example/Token Place/operator'\\''s log.log'"
+        );
+        assert!(!script.contains('\n'));
+    }
+
+    #[test]
+    fn require_current_operator_log_path_requires_existing_file() {
+        let temp = TempDir::new().expect("tempdir");
+        let log_path = temp.path().join("operator session.log");
+        std::fs::write(&log_path, "desktop.compute_node.stderr line=diagnostic\n")
+            .expect("write log");
+        let status = ComputeNodeStatus {
+            operator_log_path: Some(log_path.to_string_lossy().into_owned()),
+            ..ComputeNodeStatus::default()
+        };
+
+        assert_eq!(
+            require_current_operator_log_path(&status).expect("log path"),
+            log_path
+        );
+
+        let missing_status = ComputeNodeStatus {
+            operator_log_path: Some(
+                temp.path()
+                    .join("missing.log")
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            ..ComputeNodeStatus::default()
+        };
+        assert!(require_current_operator_log_path(&missing_status)
+            .expect_err("missing log should fail")
+            .contains("does not exist"));
     }
 
     #[test]

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1234,4 +1234,31 @@ describe('desktop app start failure handling', () => {
     );
     expect(screen.getByText(/Error:/).textContent).toContain('event failure path');
   });
+
+  it('renders debug log affordances when an operator log path is available', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: false,
+      active_relay_url: 'https://token.place',
+      model_path: '/tmp/model.gguf',
+      warm_load_state: 'warming',
+      operator_log_path: '/Users/example/Library/Application Support/place.token.desktop/logs/operator session.log',
+    });
+
+    render(<App />);
+
+    const revealButton = (await screen.findByText('Reveal debug log')) as HTMLButtonElement;
+    const terminalButton = screen.getByText('Open debug terminal') as HTMLButtonElement;
+    const copyButton = screen.getByText('Copy log path') as HTMLButtonElement;
+    await waitFor(() => expect(revealButton.disabled).toBe(false));
+    expect(terminalButton.disabled).toBe(false);
+    expect(copyButton.disabled).toBe(false);
+    expect(screen.getByText(/Debug log:/).textContent).toContain('operator session.log');
+
+    fireEvent.click(revealButton);
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.some(([command]) => command === 'reveal_operator_debug_log')).toBe(true)
+    );
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -40,6 +40,7 @@ interface ComputeNodeStatus {
   operator_session_id: string | null;
   sequence: number | null;
   updated_at_ms: number | null;
+  operator_log_path: string | null;
 }
 
 interface ModelArtifactInfo {
@@ -81,6 +82,7 @@ const defaultComputeStatus: ComputeNodeStatus = {
   operator_session_id: null,
   sequence: null,
   updated_at_ms: null,
+  operator_log_path: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -189,6 +191,8 @@ function mergeComputeStatusEvent(
     sequence: payloadSequence ?? prev.sequence,
     updated_at_ms:
       typeof payload.updated_at_ms === 'number' ? payload.updated_at_ms : prev.updated_at_ms,
+    operator_log_path:
+      typeof payload.operator_log_path === 'string' ? payload.operator_log_path : prev.operator_log_path,
     last_error:
       payload.last_error === null
         ? null
@@ -471,6 +475,31 @@ export function App() {
     }
   };
 
+  const revealOperatorDebugLog = async () => {
+    try {
+      await invoke('reveal_operator_debug_log');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const openOperatorDebugTerminal = async () => {
+    try {
+      await invoke('open_operator_debug_terminal');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const copyOperatorLogPath = async () => {
+    if (!computeStatus.operator_log_path) return;
+    try {
+      await navigator.clipboard.writeText(computeStatus.operator_log_path);
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
   const forwardEncrypted = async () => {
     try {
       setIsForwarding(true);
@@ -551,13 +580,34 @@ export function App() {
 
       <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
           <button
             disabled={!computeStatus.running}
             onClick={stopComputeNode}
           >
             Stop operator
+          </button>
+          <button
+            type="button"
+            disabled={!computeStatus.operator_log_path}
+            onClick={revealOperatorDebugLog}
+          >
+            Reveal debug log
+          </button>
+          <button
+            type="button"
+            disabled={!computeStatus.operator_log_path}
+            onClick={openOperatorDebugTerminal}
+          >
+            Open debug terminal
+          </button>
+          <button
+            type="button"
+            disabled={!computeStatus.operator_log_path}
+            onClick={copyOperatorLogPath}
+          >
+            Copy log path
           </button>
         </div>
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
@@ -573,6 +623,7 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Backend used: <code>{displayStatusValue(computeStatus.backend_used, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
+        <p style={{ marginBottom: 0 }}>Debug log: <code>{computeStatus.operator_log_path || 'not available yet'}</code></p>
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>
 

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -12,6 +12,31 @@ The architectural source of truth is [Desktop operator parity contract](architec
 - Keep relay-blind API v1 E2EE invariant: relay-owned state, logs, diagnostics, and payloads may contain ciphertext and safe routing metadata only. Do not add plaintext prompt, response, tool argument, or model-output logging while debugging desktop parity.
 - API v1 relay inference is non-streaming. Do not add streaming or legacy `/sink`, `/faucet`, `/source`, `/retrieve`, or `/next_server` fallbacks to make desktop parity pass.
 
+
+## macOS packaged debug log capture
+
+Packaged Tauri operator sessions persist a per-session log under the app data log directory. On macOS this is typically:
+
+```text
+~/Library/Application Support/<app identifier>/logs/operator-session-<operator_session_id>-<timestamp>.log
+```
+
+The Compute node operator panel shows the active **Debug log** path and provides opt-in buttons to reveal the file, copy its path, or open Terminal.app tailing the current log. For scripted/manual validation, launch the packaged app with:
+
+```bash
+TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1 open /Applications/TokenPlace.app
+```
+
+When **Start operator** fails on macOS, capture the Debug log path and include the following safe diagnostics from the log:
+
+- `desktop.compute_node.log.start` and `desktop.compute_node.session.start` lines, including `operator_session_id`, sanitized relay URL, bridge path, interpreter, resource root, layout, import root, and log path.
+- `desktop.runtime_setup ...` probe/provision lines, including selected action and interpreter/prefix/module path diagnostics.
+- `desktop.compute_node.stderr line=...` lines from `compute_node_bridge.py`.
+- Warm-load and model-manager lines such as `desktop.compute_node_bridge.model_init.ready` or setup failures before registration.
+- API v1 registration/poll/request/response metadata and Stop/cancel/unregister/cleanup lines when the session gets that far.
+
+Do not include private keys, plaintext prompts/responses, tool arguments, or decrypted payloads in captured logs. The relay-blind E2EE invariant still applies: relay-owned logs/diagnostics must remain ciphertext-only plus safe routing metadata.
+
 ## Required parity checklist
 
 | Area | Windows CUDA expectation | macOS Metal expectation | CPU fallback expectation | Evidence to capture |


### PR DESCRIPTION
### Motivation
- macOS packaged desktop builds hid compute-node bridge stdout/stderr and runtime provisioning diagnostics behind the UI `Last error` field, making startup failures hard to diagnose.
- Provide a safe, opt-in, cross-platform way to persist and expose the same bridge/runtime lines that Windows users already see in a console. 

### Description
- Persist per-session operator logs under the app data `logs` directory and surface the path on the status as `operator_log_path` (Rust: `compute_node.rs` `ComputeNodeStatus` and `OperatorLogHandle`).
- Mirror important lifecycle lines into the per-session log: `desktop.compute_node.log.start`, `desktop.compute_node.session.start`, compute-node stdout/stderr lines, bridge diagnostics, warm-load/registration lines, session end lines, and sanitized relay metadata (no plaintext secrets).
- Add opt-in macOS debug terminal tailing via `osascript` with robust single-quoting and a controlling env var `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL`; open/Reveal log operations are implemented as Tauri commands `reveal_operator_debug_log` and `open_operator_debug_terminal` (Rust: `main.rs`).
- Add in-app UI affordances (`Reveal debug log`, `Open debug terminal`, `Copy log path`) and expose the active log path in the Compute node operator panel (TSX: `App.tsx`), plus unit/UI coverage for the new affordances (`App.test.tsx`).
- Record model-bridge diagnostics into an app-data `model-bridge.log` for `inspect`/`download` flows and wire those calls through `run_model_bridge` (Rust: `main.rs`).
- Document the macOS packaged log location, how to tail it, and what safe diagnostics to capture (updates to `desktop-tauri/README.md` and `docs/desktop_parity_validation.md`).

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` and all unit tests passed (72 tests passed).
- Ran frontend tests with `npm --prefix desktop-tauri test` (Vitest) and UI tests passed (25 tests passed); an initial attempt with a Jest-only flag (`--runInBand`) was rejected by Vitest and was rerun without that flag.
- Executed packaged/packaging parity and e2e scripts: `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`, and `python desktop-tauri/scripts/run_desktop_parity_checks.py`, and the scripted checks completed successfully in this environment.
- Ran repository checks via `pre-commit run --all-files` which completed successfully.

Note: the macOS debug terminal tail is opt-in (env var or explicit UI button) and is implemented only for macOS packaged validation to avoid surprising users; relay-blind E2EE invariants and secret-redaction rules were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2347e31fd4832f8a916d478b68edda)