### PR TITLE
Add per-session operator logs and macOS debug terminal/ui affordances

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -188,13 +188,13 @@ log file in the app log directory. On macOS this is typically under the user's
 Library logs area in an `operator/` subdirectory, for example:
 
 ```text
-~/Library/Logs/<tauri app identifier>/operator/compute-node-<operator_session_id>.log
+~/Library/Logs/<tauri app identifier>/operator/compute-node-<operator_session_id>-<timestamp>.log
 ```
 
 The Compute node operator panel shows the current `Operator debug log` path after
 Start operator creates a session. Use **Open debug log** for an in-app read-only
-console with copy support, **Reveal log file** to open the containing location,
-or **Open debug terminal** to tail the log. macOS terminal tailing uses
+console with copy support, **Copy log path** to copy the current session path,
+**Reveal log file** to open the containing location, or **Open debug terminal** to tail the log. macOS terminal tailing uses
 Terminal.app and a quoted `tail -n 200 -F` command so paths with spaces work.
 
 For validation runs that should open the terminal automatically when the operator

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -180,3 +180,34 @@ It prints:
   Pass means desktop-side diagnostics and `compute_node_bridge.py` `started` events both report
   CUDA availability/usage with GPU offload and non-CPU KV cache. If the bridge exits before
   startup, errors will use the phrase `compute-node bridge exited before emitting a startup event`.
+
+## Packaged operator debug logs
+
+The packaged desktop app writes compute-node operator diagnostics to a per-session
+log file in the app log directory. On macOS this is typically under the user's
+Library logs area in an `operator/` subdirectory, for example:
+
+```text
+~/Library/Logs/<tauri app identifier>/operator/compute-node-<operator_session_id>.log
+```
+
+The Compute node operator panel shows the current `Operator debug log` path after
+Start operator creates a session. Use **Open debug log** for an in-app read-only
+console with copy support, **Reveal log file** to open the containing location,
+or **Open debug terminal** to tail the log. macOS terminal tailing uses
+Terminal.app and a quoted `tail -n 200 -F` command so paths with spaces work.
+
+For validation runs that should open the terminal automatically when the operator
+starts, launch the app with:
+
+```bash
+TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1
+```
+
+Capture the debug log when Start operator fails. Important startup details include
+`desktop.compute_node.session.start`, `desktop.compute_node.session.layout`, the
+selected interpreter/resource/import roots, `desktop_runtime_setup` probe and
+provision lines, bridge stdout/stderr, model warm-load diagnostics,
+registration/poll/request/response lifecycle lines, and stop/cancel/unregister
+cleanup lines. Logs intentionally avoid plaintext prompts, responses, private
+keys, and decrypted relay payloads.

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -663,6 +663,122 @@ def run_compute_bridge_startup_probe(
             bridge.kill()
 
 
+def enqueue_operator_stderr_log(stderr: object, log_path: Path) -> None:
+    """Mirror bridge stderr using the same source label the desktop app persists."""
+    if not hasattr(stderr, "readline"):
+        return
+
+    with log_path.open("a", encoding="utf-8", errors="replace") as log_file:
+        while True:
+            chunk = stderr.readline()
+            if not chunk:
+                return
+            text = (
+                chunk.decode("utf-8", errors="replace")
+                if isinstance(chunk, bytes)
+                else str(chunk)
+            )
+            log_file.write(f"desktop.compute_node.stderr {text.rstrip()}\n")
+            log_file.flush()
+
+
+def run_operator_log_persistence_probe(
+    tmp_root: Path,
+    bridge_script: Path,
+    *,
+    relay_port: int,
+    resources_root: Path | None = None,
+    layout_label: str = "standard resources",
+) -> None:
+    """Assert packaged bridge diagnostics are persisted through the operator-log mirror."""
+    resources_root = resources_root or (tmp_root / "resources")
+    env = _packaged_env(tmp_root, resources_root, extra_env={"USE_MOCK_LLM": "1"})
+    log_dir = tmp_root / "operator logs with spaces"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    operator_log = log_dir / f"compute-node-{layout_label.replace('/', '_')}.log"
+    bridge = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            str(bridge_script),
+            "--model",
+            "mock.gguf",
+            "--mode",
+            "cpu",
+            "--relay-url",
+            f"http://127.0.0.1:{relay_port}",
+        ],
+        cwd=tmp_root,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=False,
+    )
+    try:
+        assert bridge.stderr is not None
+        assert bridge.stdout is not None
+        assert bridge.stdin is not None
+        threading.Thread(
+            target=enqueue_operator_stderr_log,
+            args=(bridge.stderr, operator_log),
+            daemon=True,
+        ).start()
+        output_queue: queue.Queue[bytes] = queue.Queue()
+        threading.Thread(
+            target=enqueue_bridge_stdout,
+            args=(bridge.stdout, output_queue),
+            daemon=True,
+        ).start()
+
+        deadline = time.time() + 30
+        buffered = ""
+        saw_started = False
+        while time.time() < deadline:
+            if bridge.poll() is not None:
+                break
+            try:
+                chunk = output_queue.get(timeout=0.25)
+            except queue.Empty:
+                continue
+            buffered += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffered:
+                line, buffered = buffered.split("\n", 1)
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "started" and payload.get("running") is True:
+                    saw_started = True
+                    bridge.stdin.write(b'{"type":"cancel"}\n')
+                    bridge.stdin.flush()
+                    break
+            if saw_started:
+                break
+
+        if not saw_started:
+            raise RuntimeError(
+                f"[{layout_label}] bridge did not start while creating operator log; "
+                f"operator_log={_tail_text(operator_log)}"
+            )
+        try:
+            bridge.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            bridge.terminate()
+            bridge.wait(timeout=10)
+    finally:
+        if bridge.poll() is None:
+            bridge.kill()
+
+    assert operator_log.exists(), f"operator log was not created at {operator_log}"
+    log_text = operator_log.read_text(encoding="utf-8", errors="replace")
+    assert "desktop.compute_node.stderr" in log_text, log_text[-4000:]
+    assert (
+        "desktop.runtime_setup" in log_text
+        or "llama_module_path" in log_text
+        or "desktop.compute_node_bridge" in log_text
+    ), log_text[-4000:]
+
+
 def run_polluted_stdlib_packaged_registration_probe(
     tmp_root: Path,
     bridge_script: Path,
@@ -791,6 +907,8 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="token-place-packaged-e2e-") as tmpdir:
         tmp_path = Path(tmpdir)
+        spaced_tmp_path = tmp_path / "Packaged Layout With Spaces"
+        spaced_tmp_path.mkdir(parents=True, exist_ok=True)
         bridge_script = create_packaged_layout(tmp_path)
         run_desktop_dependency_preflight(tmp_path)
         run_unified_root_import_policy_probe(tmp_path)
@@ -798,6 +916,8 @@ def main() -> int:
         run_compute_bridge_import_probe(tmp_path)
         run_llama_cpp_watchdog_regression_probe(tmp_path)
         run_llama_cpp_facade_early_exit_diagnostics_probe(tmp_path)
+        create_packaged_layout(spaced_tmp_path)
+        run_compute_bridge_import_probe(spaced_tmp_path)
 
         mac_bridge_script = create_macos_bundle_layout(tmp_path)
         mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
@@ -852,6 +972,13 @@ def main() -> int:
                     stderr_path=relay_stderr,
                 )
                 run_compute_bridge_startup_probe(
+                    tmp_path,
+                    probe_script,
+                    relay_port=relay_port,
+                    resources_root=probe_resources_root,
+                    layout_label=layout_label,
+                )
+                run_operator_log_persistence_probe(
                     tmp_path,
                     probe_script,
                     relay_port=relay_port,

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::operator_logs::OperatorLogSink;
 use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, configure_python_subprocess_env,
     describe_resource_layout, disable_python_user_site, resolve_bridge_script_path,
@@ -48,6 +49,7 @@ pub struct ComputeNodeStatus {
     pub operator_session_id: Option<String>,
     pub sequence: Option<u64>,
     pub updated_at_ms: Option<u64>,
+    pub log_file_path: Option<String>,
 }
 
 #[derive(Clone, Default)]
@@ -202,7 +204,12 @@ fn event_session_id(payload: &Value) -> Option<&str> {
     payload.get("operator_session_id").and_then(Value::as_str)
 }
 
-fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
+fn startup_failure_status(
+    request: &ComputeNodeRequest,
+    last_error: String,
+    operator_session_id: Option<String>,
+    log_file_path: Option<String>,
+) -> ComputeNodeStatus {
     ComputeNodeStatus {
         running: false,
         registered: false,
@@ -221,9 +228,10 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
-        operator_session_id: None,
+        operator_session_id,
         sequence: None,
         updated_at_ms: Some(current_time_ms()),
+        log_file_path,
     }
 }
 
@@ -324,6 +332,9 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
     } else {
         status.updated_at_ms = Some(current_time_ms());
     }
+    if let Some(log_file_path) = payload.get("log_file_path").and_then(Value::as_str) {
+        status.log_file_path = Some(log_file_path.into());
+    }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
             .get("message")
@@ -417,10 +428,12 @@ fn finalize_bridge_exit(
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     policy: SubprocessLogPolicy,
+    log_sink: OperatorLogSink,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
     let mut filter = SubprocessLogFilter::new("compute_node", policy);
     while let Some(line) = lines.next_line().await? {
+        log_sink.append_line("desktop.compute_node.stderr", &line);
         if filter.should_emit(&line) {
             eprintln!("desktop.compute_node.stderr line={line}");
         }
@@ -448,12 +461,47 @@ pub async fn start_compute_node(
         *state.stdin.lock().await = None;
     }
 
+    let session_id = {
+        let mut next_session_id = state.next_session_id.lock().await;
+        *next_session_id += 1;
+        next_session_id.to_string()
+    };
+    let log_sink = OperatorLogSink::create(&app, &session_id)?;
+    let log_file_path = log_sink.path().to_string_lossy().into_owned();
+    log_sink.append_line(
+        "desktop.compute_node.session.start",
+        &format!(
+            "operator_session_id={} relay={} model_path={} requested_mode={}",
+            session_id,
+            sanitize_relay_target(&request.relay_base_url),
+            request.model_path,
+            format!("{:?}", request.mode).to_lowercase()
+        ),
+    );
+    if std::env::var("TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
+        if let Err(err) = crate::operator_logs::open_debug_terminal(log_sink.path()) {
+            log_sink.append_line(
+                "desktop.compute_node.debug_terminal_error",
+                &format!("open failed: {err}"),
+            );
+        }
+    }
+
     let bridge_script = match resolve_bridge_script(&app) {
         Ok(bridge_script) => bridge_script,
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = startup_failure_status(&request, err.clone());
+                *status = startup_failure_status(
+                    &request,
+                    err.clone(),
+                    Some(session_id.clone()),
+                    Some(log_file_path.clone()),
+                );
             }
             return Err(anyhow::anyhow!(err));
         }
@@ -467,7 +515,12 @@ pub async fn start_compute_node(
                 Err(err) => {
                     {
                         let mut status = state.status.lock().await;
-                        *status = startup_failure_status(&request, err.to_string());
+                        *status = startup_failure_status(
+                            &request,
+                            err.to_string(),
+                            Some(session_id.clone()),
+                            Some(log_file_path.clone()),
+                        );
                     }
                     return Err(err);
                 }
@@ -476,7 +529,12 @@ pub async fn start_compute_node(
                 let err = anyhow::anyhow!("python launcher resolver task failed: {err}");
                 {
                     let mut status = state.status.lock().await;
-                    *status = startup_failure_status(&request, err.to_string());
+                    *status = startup_failure_status(
+                        &request,
+                        err.to_string(),
+                        Some(session_id.clone()),
+                        Some(log_file_path.clone()),
+                    );
                 }
                 return Err(err);
             }
@@ -490,15 +548,15 @@ pub async fn start_compute_node(
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = startup_failure_status(&request, err.to_string());
+                *status = startup_failure_status(
+                    &request,
+                    err.to_string(),
+                    Some(session_id.clone()),
+                    Some(log_file_path.clone()),
+                );
             }
             return Err(err);
         }
-    };
-    let session_id = {
-        let mut next_session_id = state.next_session_id.lock().await;
-        *next_session_id += 1;
-        next_session_id.to_string()
     };
     let exe_path = std::env::current_exe().ok();
     let resource_dir = app.path().resource_dir().ok();
@@ -525,6 +583,19 @@ pub async fn start_compute_node(
         selected_layout,
         import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into())
     );
+    log_sink.append_line(
+        "desktop.compute_node.session.layout",
+        &format!(
+            "operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
+            session_id,
+            sanitize_relay_target(&request.relay_base_url),
+            bridge_script,
+            interpreter,
+            selected_resource_root.display(),
+            selected_layout,
+            import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into())
+        ),
+    );
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
 
@@ -549,6 +620,8 @@ pub async fn start_compute_node(
                 *status = startup_failure_status(
                     &request,
                     format!("failed to start compute-node bridge: {err}"),
+                    Some(session_id.clone()),
+                    Some(log_file_path.clone()),
                 );
                 *state.child.lock().await = None;
                 *state.stdin.lock().await = None;
@@ -611,6 +684,7 @@ pub async fn start_compute_node(
                 operator_session_id: Some(session_id.clone()),
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),
+                log_file_path: Some(log_file_path.clone()),
             };
             true
         }
@@ -629,8 +703,9 @@ pub async fn start_compute_node(
     }
 
     let log_policy = SubprocessLogPolicy::from_env();
+    let stderr_log_sink = log_sink.clone();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_compute_node_stderr(stderr, log_policy).await {
+        if let Err(err) = drain_compute_node_stderr(stderr, log_policy, stderr_log_sink).await {
             eprintln!("desktop.compute_node.stderr_error error={err}");
         }
     });
@@ -639,6 +714,7 @@ pub async fn start_compute_node(
     let mut saw_error_event = false;
     let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
+        log_sink.append_line("desktop.compute_node.stdout", &line);
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
@@ -924,9 +1000,23 @@ mod tests {
         .expect("spawn stderr script");
 
         let stderr = child.stderr.take().expect("stderr");
-        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true })
+        let temp = TempDir::new().expect("tempdir");
+        let log_path = temp.path().join("stderr.log");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .expect("log file");
+        let log_sink = OperatorLogSink {
+            path: log_path.clone(),
+            file: std::sync::Arc::new(std::sync::Mutex::new(file)),
+        };
+        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true }, log_sink)
             .await
             .expect("drain stderr");
+        assert!(std::fs::read_to_string(log_path)
+            .expect("log")
+            .contains("bridge-failure"));
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
     }
@@ -1213,6 +1303,8 @@ mod tests {
         let status = startup_failure_status(
             &request,
             "no usable Python 3 interpreter found for desktop Python subprocess".into(),
+            Some("session-1".into()),
+            Some("/tmp/operator.log".into()),
         );
 
         assert!(!status.running);
@@ -1390,6 +1482,8 @@ mod tests {
         let status = startup_failure_status(
             &request,
             "unable to locate desktop Python bridge script 'compute_node_bridge.py'".into(),
+            None,
+            None,
         );
 
         assert!(!status.running);

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,8 @@
 use crate::backend::ComputeMode;
-use crate::operator_logs::{append_line_to_path, OperatorLogSink};
+use crate::operator_logs::{
+    append_line_to_path, sanitize_operator_diagnostic_line, sanitize_operator_path_display,
+    OperatorLogSink,
+};
 use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, configure_python_subprocess_env,
     describe_resource_layout, disable_python_user_site, resolve_bridge_script_path,
@@ -436,7 +439,11 @@ async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     let mut lines = BufReader::new(reader).lines();
     let mut filter = SubprocessLogFilter::new("compute_node", policy);
     while let Some(line) = lines.next_line().await? {
-        append_operator_log_line(&log_sink, "desktop.compute_node.stderr", &line);
+        append_operator_log_line(
+            &log_sink,
+            "desktop.compute_node.stderr",
+            &sanitize_operator_diagnostic_line(&line),
+        );
         if filter.should_emit(&line) {
             eprintln!("desktop.compute_node.stderr line={line}");
         }
@@ -541,32 +548,21 @@ fn is_sensitive_bridge_log_key(key: &str) -> bool {
 }
 
 fn sanitize_freeform_bridge_log_line(line: &str) -> String {
-    line.chars()
-        .filter(|ch| !matches!(ch, '\n' | '\r' | '\t'))
-        .take(4096)
-        .collect()
+    sanitize_operator_diagnostic_line(line)
 }
 
 fn sanitize_path_for_operator_log(path: &Path) -> String {
-    let mut value = path.display().to_string();
-    if let Ok(home) = std::env::var("HOME") {
-        if !home.is_empty() && value.starts_with(&home) {
-            value = format!("~{}", &value[home.len()..]);
-        }
-    }
-    sanitize_freeform_bridge_log_line(&value)
+    sanitize_operator_path_display(path)
 }
 
 fn with_log_file_path(mut payload: Value, log_file_path: Option<&str>) -> Value {
     if let Value::Object(map) = &mut payload {
-        if !map.contains_key("log_file_path") {
-            match log_file_path {
-                Some(path) => {
-                    map.insert("log_file_path".into(), Value::String(path.to_string()));
-                }
-                None => {
-                    map.insert("log_file_path".into(), Value::Null);
-                }
+        match log_file_path {
+            Some(path) => {
+                map.insert("log_file_path".into(), Value::String(path.to_string()));
+            }
+            None => {
+                map.insert("log_file_path".into(), Value::Null);
             }
         }
     }
@@ -1175,13 +1171,32 @@ mod tests {
 
     #[test]
     fn compute_node_event_payload_gets_current_log_file_path() {
-        let payload = serde_json::json!({"type": "started", "running": true});
+        let payload = serde_json::json!({
+            "type": "started",
+            "running": true,
+            "log_file_path": "/etc/passwd"
+        });
         let payload = with_log_file_path(payload, Some("/tmp/operator.log"));
 
         assert_eq!(
             payload.get("log_file_path").and_then(Value::as_str),
             Some("/tmp/operator.log")
         );
+    }
+
+    #[test]
+    fn redacts_compute_node_stderr_paths_before_operator_logging() {
+        let line = sanitize_freeform_bridge_log_line(
+            "desktop.runtime_setup llama_module_path=/Users/Example User/project/.venv/lib/llama_cpp/__init__.py interpreter=/Users/Example User/.venv/bin/python3 relay=https://user:pass@relay.example/path?token=secret",
+        );
+
+        assert!(line.contains("llama_module_path=<path>"));
+        assert!(line.contains("interpreter=<path>"));
+        assert!(line.contains("<path:python3>"));
+        assert!(line.contains("relay=https://relay.example"));
+        assert!(!line.contains("/Users/Example User"));
+        assert!(!line.contains("token=secret"));
+        assert!(!line.contains("user:pass"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -457,34 +457,120 @@ fn append_operator_log_path_line(log_file_path: Option<&str>, source: &str, line
 }
 
 fn redact_bridge_stdout_line(line: &str) -> String {
-    let Ok(mut payload) = serde_json::from_str::<Value>(line) else {
-        return line.to_owned();
+    let Ok(payload) = serde_json::from_str::<Value>(line) else {
+        return sanitize_freeform_bridge_log_line(line);
     };
-    redact_sensitive_bridge_fields(&mut payload);
-    serde_json::to_string(&payload).unwrap_or_else(|_| line.to_owned())
+    summarize_bridge_stdout_payload(&payload)
 }
 
-fn redact_sensitive_bridge_fields(value: &mut Value) {
+fn summarize_bridge_stdout_payload(payload: &Value) -> String {
+    let mut summary = serde_json::Map::new();
+    let Some(map) = payload.as_object() else {
+        return "{\"type\":\"non_object_bridge_event\"}".into();
+    };
+
+    for key in [
+        "type",
+        "operator_session_id",
+        "sequence",
+        "updated_at_ms",
+        "running",
+        "registered",
+        "relay_runtime_state",
+        "warm_load_state",
+        "warm_load_enabled",
+        "warm_load_duration_ms",
+        "requested_mode",
+        "effective_mode",
+        "backend_available",
+        "backend_selected",
+        "backend_used",
+        "fallback_reason",
+        "runtime_path",
+        "relay_runtime_path",
+        "interpreter",
+        "llama_module_path",
+        "runtime_action",
+        "runtime_setup_message",
+        "code",
+        "message",
+        "last_error",
+    ] {
+        if let Some(value) = map.get(key) {
+            summary.insert(key.to_string(), sanitize_bridge_log_value(key, value));
+        }
+    }
+
+    for key in ["active_relay_url", "relay_base_url", "relay_url"] {
+        if let Some(value) = map.get(key).and_then(Value::as_str) {
+            summary.insert(key.to_string(), Value::String(sanitize_relay_target(value)));
+        }
+    }
+
+    serde_json::to_string(&Value::Object(summary))
+        .unwrap_or_else(|_| "{\"type\":\"bridge_event_summary_error\"}".into())
+}
+
+fn sanitize_bridge_log_value(key: &str, value: &Value) -> Value {
+    if is_sensitive_bridge_log_key(key) {
+        return Value::String("<redacted>".into());
+    }
     match value {
-        Value::Object(map) => {
-            for (key, value) in map.iter_mut() {
-                if matches!(
-                    key.as_str(),
-                    "model_path" | "active_relay_url" | "relay_base_url" | "relay_url"
-                ) {
-                    *value = Value::String("<redacted>".into());
-                } else {
-                    redact_sensitive_bridge_fields(value);
+        Value::String(text) => Value::String(sanitize_freeform_bridge_log_line(text)),
+        Value::Bool(_) | Value::Number(_) | Value::Null => value.clone(),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .take(8)
+                .map(|item| sanitize_bridge_log_value(key, item))
+                .collect(),
+        ),
+        Value::Object(_) => Value::String("<object omitted>".into()),
+    }
+}
+
+fn is_sensitive_bridge_log_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    normalized.contains("prompt")
+        || normalized.contains("response")
+        || normalized.contains("tool")
+        || normalized.contains("private_key")
+        || normalized.contains("decrypted")
+        || normalized.contains("payload")
+        || normalized == "model_path"
+}
+
+fn sanitize_freeform_bridge_log_line(line: &str) -> String {
+    line.chars()
+        .filter(|ch| !matches!(ch, '\n' | '\r' | '\t'))
+        .take(4096)
+        .collect()
+}
+
+fn sanitize_path_for_operator_log(path: &Path) -> String {
+    let mut value = path.display().to_string();
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() && value.starts_with(&home) {
+            value = format!("~{}", &value[home.len()..]);
+        }
+    }
+    sanitize_freeform_bridge_log_line(&value)
+}
+
+fn with_log_file_path(mut payload: Value, log_file_path: Option<&str>) -> Value {
+    if let Value::Object(map) = &mut payload {
+        if !map.contains_key("log_file_path") {
+            match log_file_path {
+                Some(path) => {
+                    map.insert("log_file_path".into(), Value::String(path.to_string()));
+                }
+                None => {
+                    map.insert("log_file_path".into(), Value::Null);
                 }
             }
         }
-        Value::Array(items) => {
-            for item in items {
-                redact_sensitive_bridge_fields(item);
-            }
-        }
-        _ => {}
     }
+    payload
 }
 
 pub async fn start_compute_node(
@@ -652,10 +738,17 @@ pub async fn start_compute_node(
         &log_sink,
         "desktop.compute_node.session.layout",
         &format!(
-            "operator_session_id={} relay=<redacted> bridge=<redacted> interpreter=<redacted> resource_root=<redacted> layout={:?} import_root={}",
+            "operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
             session_id,
+            sanitize_relay_target(&request.relay_base_url),
+            sanitize_path_for_operator_log(Path::new(&bridge_script)),
+            sanitize_freeform_bridge_log_line(&interpreter),
+            sanitize_path_for_operator_log(&selected_resource_root),
             selected_layout,
-            import_root.as_ref().map(|_| "<redacted>").unwrap_or("<unresolved>")
+            import_root
+                .as_ref()
+                .map(|path| sanitize_path_for_operator_log(path))
+                .unwrap_or_else(|| "<unresolved>".into())
         ),
     );
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
@@ -783,6 +876,7 @@ pub async fn start_compute_node(
         );
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
+                let payload = with_log_file_path(payload, log_file_path.as_deref());
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
                     if event_type == "error" {
                         saw_error_event = true;
@@ -1043,19 +1137,51 @@ mod tests {
     fn redacts_sensitive_bridge_stdout_fields_before_operator_logging() {
         let line = serde_json::json!({
             "type": "status",
+            "operator_session_id": "1",
+            "sequence": 7,
             "model_path": "/Users/Example User/models/model.gguf",
             "active_relay_url": "https://relay.internal.example/path?token=secret",
-            "nested": {"relay_url": "https://nested.example"},
+            "prompt": "plaintext prompt",
+            "tool_args": {"private_key": "secret"},
+            "backend_selected": "cpu",
+            "relay_runtime_state": "ready"
         })
         .to_string();
 
         let redacted = redact_bridge_stdout_line(&line);
+        let payload: Value = serde_json::from_str(&redacted).expect("summary json");
 
-        assert!(redacted.contains("\"model_path\":\"<redacted>\""));
-        assert!(redacted.contains("\"active_relay_url\":\"<redacted>\""));
-        assert!(redacted.contains("\"relay_url\":\"<redacted>\""));
+        assert_eq!(payload.get("type").and_then(Value::as_str), Some("status"));
+        assert_eq!(
+            payload.get("operator_session_id").and_then(Value::as_str),
+            Some("1")
+        );
+        assert_eq!(payload.get("sequence").and_then(Value::as_u64), Some(7));
+        assert_eq!(
+            payload.get("backend_selected").and_then(Value::as_str),
+            Some("cpu")
+        );
+        assert_eq!(
+            payload.get("active_relay_url").and_then(Value::as_str),
+            Some("https://relay.internal.example")
+        );
+        assert!(payload.get("model_path").is_none());
+        assert!(payload.get("prompt").is_none());
+        assert!(payload.get("tool_args").is_none());
         assert!(!redacted.contains("Example User"));
-        assert!(!redacted.contains("relay.internal.example"));
+        assert!(!redacted.contains("plaintext prompt"));
+        assert!(!redacted.contains("token=secret"));
+    }
+
+    #[test]
+    fn compute_node_event_payload_gets_current_log_file_path() {
+        let payload = serde_json::json!({"type": "started", "running": true});
+        let payload = with_log_file_path(payload, Some("/tmp/operator.log"));
+
+        assert_eq!(
+            payload.get("log_file_path").and_then(Value::as_str),
+            Some("/tmp/operator.log")
+        );
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,5 @@
 use crate::backend::ComputeMode;
-use crate::operator_logs::OperatorLogSink;
+use crate::operator_logs::{append_line_to_path, OperatorLogSink};
 use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, configure_python_subprocess_env,
     describe_resource_layout, disable_python_user_site, resolve_bridge_script_path,
@@ -332,8 +332,11 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
     } else {
         status.updated_at_ms = Some(current_time_ms());
     }
-    if let Some(log_file_path) = payload.get("log_file_path").and_then(Value::as_str) {
-        status.log_file_path = Some(log_file_path.into());
+    if payload.get("log_file_path").is_some() {
+        status.log_file_path = payload
+            .get("log_file_path")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
     }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
@@ -428,17 +431,60 @@ fn finalize_bridge_exit(
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     policy: SubprocessLogPolicy,
-    log_sink: OperatorLogSink,
+    log_sink: Option<OperatorLogSink>,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
     let mut filter = SubprocessLogFilter::new("compute_node", policy);
     while let Some(line) = lines.next_line().await? {
-        log_sink.append_line("desktop.compute_node.stderr", &line);
+        append_operator_log_line(&log_sink, "desktop.compute_node.stderr", &line);
         if filter.should_emit(&line) {
             eprintln!("desktop.compute_node.stderr line={line}");
         }
     }
     Ok(())
+}
+
+fn append_operator_log_line(log_sink: &Option<OperatorLogSink>, source: &str, line: &str) {
+    if let Some(log_sink) = log_sink {
+        log_sink.append_line(source, line);
+    }
+}
+
+fn append_operator_log_path_line(log_file_path: Option<&str>, source: &str, line: &str) {
+    if let Some(log_file_path) = log_file_path {
+        let _ = append_line_to_path(Path::new(log_file_path), source, line);
+    }
+}
+
+fn redact_bridge_stdout_line(line: &str) -> String {
+    let Ok(mut payload) = serde_json::from_str::<Value>(line) else {
+        return line.to_owned();
+    };
+    redact_sensitive_bridge_fields(&mut payload);
+    serde_json::to_string(&payload).unwrap_or_else(|_| line.to_owned())
+}
+
+fn redact_sensitive_bridge_fields(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map.iter_mut() {
+                if matches!(
+                    key.as_str(),
+                    "model_path" | "active_relay_url" | "relay_base_url" | "relay_url"
+                ) {
+                    *value = Value::String("<redacted>".into());
+                } else {
+                    redact_sensitive_bridge_fields(value);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_sensitive_bridge_fields(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 pub async fn start_compute_node(
@@ -466,15 +512,32 @@ pub async fn start_compute_node(
         *next_session_id += 1;
         next_session_id.to_string()
     };
-    let log_sink = OperatorLogSink::create(&app, &session_id)?;
-    let log_file_path = log_sink.path().to_string_lossy().into_owned();
-    log_sink.append_line(
+    {
+        let mut status = state.status.lock().await;
+        status.operator_session_id = Some(session_id.clone());
+        status.log_file_path = None;
+        status.last_error = None;
+        status.updated_at_ms = Some(current_time_ms());
+    }
+    let log_sink = match OperatorLogSink::create(&app, &session_id) {
+        Ok(log_sink) => Some(log_sink),
+        Err(err) => {
+            eprintln!(
+                "desktop.compute_node.operator_log_create_error operator_session_id={} error={}",
+                session_id, err
+            );
+            None
+        }
+    };
+    let log_file_path = log_sink
+        .as_ref()
+        .map(|log_sink| log_sink.path().to_string_lossy().into_owned());
+    append_operator_log_line(
+        &log_sink,
         "desktop.compute_node.session.start",
         &format!(
-            "operator_session_id={} relay={} model_path={} requested_mode={}",
+            "operator_session_id={} relay=<redacted> model_path=<redacted> requested_mode={}",
             session_id,
-            sanitize_relay_target(&request.relay_base_url),
-            request.model_path,
             format!("{:?}", request.mode).to_lowercase()
         ),
     );
@@ -483,11 +546,13 @@ pub async fn start_compute_node(
         .as_deref()
         == Some("1")
     {
-        if let Err(err) = crate::operator_logs::open_debug_terminal(log_sink.path()) {
-            log_sink.append_line(
-                "desktop.compute_node.debug_terminal_error",
-                &format!("open failed: {err}"),
-            );
+        if let Some(log_sink) = &log_sink {
+            if let Err(err) = crate::operator_logs::open_debug_terminal(log_sink.path()) {
+                log_sink.append_line(
+                    "desktop.compute_node.debug_terminal_error",
+                    &format!("open failed: {err}"),
+                );
+            }
         }
     }
 
@@ -500,7 +565,7 @@ pub async fn start_compute_node(
                     &request,
                     err.clone(),
                     Some(session_id.clone()),
-                    Some(log_file_path.clone()),
+                    log_file_path.clone(),
                 );
             }
             return Err(anyhow::anyhow!(err));
@@ -519,7 +584,7 @@ pub async fn start_compute_node(
                             &request,
                             err.to_string(),
                             Some(session_id.clone()),
-                            Some(log_file_path.clone()),
+                            log_file_path.clone(),
                         );
                     }
                     return Err(err);
@@ -533,7 +598,7 @@ pub async fn start_compute_node(
                         &request,
                         err.to_string(),
                         Some(session_id.clone()),
-                        Some(log_file_path.clone()),
+                        log_file_path.clone(),
                     );
                 }
                 return Err(err);
@@ -552,7 +617,7 @@ pub async fn start_compute_node(
                     &request,
                     err.to_string(),
                     Some(session_id.clone()),
-                    Some(log_file_path.clone()),
+                    log_file_path.clone(),
                 );
             }
             return Err(err);
@@ -583,17 +648,14 @@ pub async fn start_compute_node(
         selected_layout,
         import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into())
     );
-    log_sink.append_line(
+    append_operator_log_line(
+        &log_sink,
         "desktop.compute_node.session.layout",
         &format!(
-            "operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
+            "operator_session_id={} relay=<redacted> bridge=<redacted> interpreter=<redacted> resource_root=<redacted> layout={:?} import_root={}",
             session_id,
-            sanitize_relay_target(&request.relay_base_url),
-            bridge_script,
-            interpreter,
-            selected_resource_root.display(),
             selected_layout,
-            import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into())
+            import_root.as_ref().map(|_| "<redacted>").unwrap_or("<unresolved>")
         ),
     );
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
@@ -621,7 +683,7 @@ pub async fn start_compute_node(
                     &request,
                     format!("failed to start compute-node bridge: {err}"),
                     Some(session_id.clone()),
-                    Some(log_file_path.clone()),
+                    log_file_path.clone(),
                 );
                 *state.child.lock().await = None;
                 *state.stdin.lock().await = None;
@@ -684,7 +746,7 @@ pub async fn start_compute_node(
                 operator_session_id: Some(session_id.clone()),
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),
-                log_file_path: Some(log_file_path.clone()),
+                log_file_path: log_file_path.clone(),
             };
             true
         }
@@ -714,7 +776,11 @@ pub async fn start_compute_node(
     let mut saw_error_event = false;
     let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
-        log_sink.append_line("desktop.compute_node.stdout", &line);
+        append_operator_log_line(
+            &log_sink,
+            "desktop.compute_node.stdout",
+            &redact_bridge_stdout_line(&line),
+        );
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
@@ -770,6 +836,16 @@ pub async fn start_compute_node(
             )
         };
 
+        append_operator_log_line(
+            &log_sink,
+            "desktop.compute_node.bridge_process_exited",
+            &format!(
+                "operator_session_id={} status={}",
+                session_id,
+                bridge_exit_status_label(exit_status)
+            ),
+        );
+
         if let Some(payload) = exit_payload {
             app.emit("compute_node_event", payload)?;
         }
@@ -792,10 +868,24 @@ pub async fn start_compute_node(
 }
 
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
-    let stop_session_id = state.status.lock().await.operator_session_id.clone();
+    let (stop_session_id, stop_log_file_path) = {
+        let status = state.status.lock().await;
+        (
+            status.operator_session_id.clone(),
+            status.log_file_path.clone(),
+        )
+    };
     eprintln!(
         "desktop.compute_node.stop_requested operator_session_id={}",
         stop_session_id.as_deref().unwrap_or("unknown")
+    );
+    append_operator_log_path_line(
+        stop_log_file_path.as_deref(),
+        "desktop.compute_node.stop_requested",
+        &format!(
+            "operator_session_id={}",
+            stop_session_id.as_deref().unwrap_or("unknown")
+        ),
     );
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
@@ -805,6 +895,14 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
         eprintln!(
             "desktop.compute_node.cancel_requested operator_session_id={}",
             stop_session_id.as_deref().unwrap_or("unknown")
+        );
+        append_operator_log_path_line(
+            stop_log_file_path.as_deref(),
+            "desktop.compute_node.cancel_requested",
+            &format!(
+                "operator_session_id={}",
+                stop_session_id.as_deref().unwrap_or("unknown")
+            ),
         );
         let _ = stdin.write_all(b"{\"type\":\"cancel\"}\n").await;
         let _ = stdin.flush().await;
@@ -834,16 +932,40 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
                 "desktop.compute_node.bridge_kill_requested operator_session_id={}",
                 stop_session_id.as_deref().unwrap_or("unknown")
             );
+            append_operator_log_path_line(
+                stop_log_file_path.as_deref(),
+                "desktop.compute_node.bridge_kill_requested",
+                &format!(
+                    "operator_session_id={}",
+                    stop_session_id.as_deref().unwrap_or("unknown")
+                ),
+            );
             let _ = child.kill().await;
             let _ = child.wait().await;
             eprintln!(
                 "desktop.compute_node.bridge_process_exited operator_session_id={} killed=true",
                 stop_session_id.as_deref().unwrap_or("unknown")
             );
+            append_operator_log_path_line(
+                stop_log_file_path.as_deref(),
+                "desktop.compute_node.bridge_process_exited",
+                &format!(
+                    "operator_session_id={} killed=true",
+                    stop_session_id.as_deref().unwrap_or("unknown")
+                ),
+            );
         } else {
             eprintln!(
                 "desktop.compute_node.bridge_process_exited operator_session_id={} killed=false",
                 stop_session_id.as_deref().unwrap_or("unknown")
+            );
+            append_operator_log_path_line(
+                stop_log_file_path.as_deref(),
+                "desktop.compute_node.bridge_process_exited",
+                &format!(
+                    "operator_session_id={} killed=false",
+                    stop_session_id.as_deref().unwrap_or("unknown")
+                ),
             );
         }
     }
@@ -915,6 +1037,37 @@ mod tests {
             sanitize_relay_target("https://user:pass@example.com/path?token=secret#frag"),
             "https://example.com"
         );
+    }
+
+    #[test]
+    fn redacts_sensitive_bridge_stdout_fields_before_operator_logging() {
+        let line = serde_json::json!({
+            "type": "status",
+            "model_path": "/Users/Example User/models/model.gguf",
+            "active_relay_url": "https://relay.internal.example/path?token=secret",
+            "nested": {"relay_url": "https://nested.example"},
+        })
+        .to_string();
+
+        let redacted = redact_bridge_stdout_line(&line);
+
+        assert!(redacted.contains("\"model_path\":\"<redacted>\""));
+        assert!(redacted.contains("\"active_relay_url\":\"<redacted>\""));
+        assert!(redacted.contains("\"relay_url\":\"<redacted>\""));
+        assert!(!redacted.contains("Example User"));
+        assert!(!redacted.contains("relay.internal.example"));
+    }
+
+    #[test]
+    fn update_status_from_event_clears_log_file_path_on_null() {
+        let mut status = ComputeNodeStatus {
+            log_file_path: Some("/tmp/stale.log".into()),
+            ..ComputeNodeStatus::default()
+        };
+        let payload = serde_json::json!({"type": "status", "log_file_path": null});
+
+        assert!(update_status_from_event(&mut status, &payload));
+        assert_eq!(status.log_file_path, None);
     }
 
     #[test]
@@ -1011,14 +1164,37 @@ mod tests {
             path: log_path.clone(),
             file: std::sync::Arc::new(std::sync::Mutex::new(file)),
         };
-        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true }, log_sink)
-            .await
-            .expect("drain stderr");
+        drain_compute_node_stderr(
+            stderr,
+            SubprocessLogPolicy { verbose_raw: true },
+            Some(log_sink),
+        )
+        .await
+        .expect("drain stderr");
         assert!(std::fs::read_to_string(log_path)
             .expect("log")
             .contains("bridge-failure"));
         let status = child.wait().await.expect("wait child");
         assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn stop_compute_node_appends_lifecycle_line_to_operator_log() {
+        let temp = TempDir::new().expect("tempdir");
+        let log_path = temp.path().join("operator.log");
+        std::fs::write(&log_path, "").expect("create log");
+        let state = ComputeNodeState::default();
+        {
+            let mut status = state.status.lock().await;
+            status.operator_session_id = Some("session-1".into());
+            status.log_file_path = Some(log_path.to_string_lossy().into_owned());
+        }
+
+        stop_compute_node(state).await.expect("stop compute node");
+
+        let log = std::fs::read_to_string(log_path).expect("operator log");
+        assert!(log.contains("desktop.compute_node.stop_requested"));
+        assert!(log.contains("operator_session_id=session-1"));
     }
 
     #[tokio::test]

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 pub mod forward;
 pub mod keygen;
 mod logging;
+mod operator_logs;
 mod python_runtime;
 mod sidecar;
 mod subprocess_logging;
@@ -102,7 +103,7 @@ fn configure_runtime_pythonpath(
     )
 }
 
-fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
+fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path(Some(&launcher.program))?;
@@ -117,8 +118,8 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
         manifest_dir,
         None,
     );
-    eprintln!(
-        "desktop.model_bridge.start action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
+    let start_line = format!(
+        "action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
         action,
         bridge_script.display(),
         bridge_command.get_program().to_string_lossy(),
@@ -129,13 +130,22 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
             .map(|path| path.display().to_string())
             .unwrap_or_else(|| "<unresolved>".into())
     );
-    let output = bridge_command
-        .arg(action)
-        .output()
-        .map_err(|e| format!("unable to run model bridge: {e}"))?;
+    eprintln!("desktop.model_bridge.start {start_line}");
+    let _ = operator_logs::append_model_bridge_log(app, action, &format!("start {start_line}"));
+    let output = bridge_command.arg(action).output().map_err(|e| {
+        let message = format!("unable to run model bridge: {e}");
+        let _ = operator_logs::append_model_bridge_log(app, action, &message);
+        message
+    })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let _ = operator_logs::append_model_bridge_log(app, action, &format!("stdout {line}"));
+    }
+    for line in stderr.lines().filter(|line| !line.trim().is_empty()) {
+        let _ = operator_logs::append_model_bridge_log(app, action, &format!("stderr {line}"));
+    }
     let json_line = stdout
         .lines()
         .rev()
@@ -286,12 +296,13 @@ async fn start_compute_node(
             compute_node::start_compute_node(app.clone(), compute_state.clone(), request).await
         {
             eprintln!("desktop.compute_node.start_failure error={}", err);
-            {
+            let log_file_path = {
                 let mut status = compute_state.status.lock().await;
                 status.running = false;
                 status.registered = false;
                 status.last_error = Some(err.to_string());
-            }
+                status.log_file_path.clone()
+            };
             let _ = app.emit(
                 "compute_node_event",
                 serde_json::json!({
@@ -300,6 +311,7 @@ async fn start_compute_node(
                     "registered": false,
                     "last_error": err.to_string(),
                     "message": err.to_string(),
+                    "log_file_path": log_file_path,
                 }),
             );
         }
@@ -322,15 +334,47 @@ async fn get_compute_node_status(
 }
 
 #[tauri::command]
-fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
-    run_model_bridge("inspect")
+fn inspect_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    run_model_bridge(&app, "inspect")
 }
 
 #[tauri::command]
-async fn download_model_artifact() -> Result<ModelArtifactInfo, String> {
-    tokio::task::spawn_blocking(|| run_model_bridge("download"))
+async fn download_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    tokio::task::spawn_blocking(move || run_model_bridge(&app, "download"))
         .await
         .map_err(|e| format!("download bridge task failed: {e}"))?
+}
+
+fn current_operator_log_path(status: &ComputeNodeStatus) -> Result<PathBuf, String> {
+    status
+        .log_file_path
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            "no operator debug log is available yet; start the operator first".to_string()
+        })
+}
+
+#[tauri::command]
+async fn read_operator_log(state: tauri::State<'_, AppState>) -> Result<String, String> {
+    let status = state.compute_node.status.lock().await.clone();
+    let path = current_operator_log_path(&status)?;
+    operator_logs::read_log_tail(&path, 256 * 1024).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn reveal_operator_log(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let status = state.compute_node.status.lock().await.clone();
+    let path = current_operator_log_path(&status)?;
+    operator_logs::reveal_log_file(&path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn open_operator_debug_terminal(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let status = state.compute_node.status.lock().await.clone();
+    let path = current_operator_log_path(&status)?;
+    operator_logs::open_debug_terminal(&path).map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -349,7 +393,10 @@ pub fn run() {
             get_compute_node_status,
             encrypt_and_forward,
             inspect_model_artifact,
-            download_model_artifact
+            download_model_artifact,
+            read_operator_log,
+            reveal_operator_log,
+            open_operator_debug_terminal
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ use backend::{detect_backend_for, BackendInfo};
 use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
 use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -103,6 +104,63 @@ fn configure_runtime_pythonpath(
     )
 }
 
+fn summarize_model_bridge_output_line(line: &str) -> String {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return operator_logs::sanitize_operator_diagnostic_line(line);
+    };
+    let mut summary = serde_json::Map::new();
+    if let Some(ok) = value.get("ok").and_then(Value::as_bool) {
+        summary.insert("ok".into(), Value::Bool(ok));
+    }
+    if let Some(error) = value.get("error").and_then(Value::as_str) {
+        summary.insert(
+            "error".into(),
+            Value::String(operator_logs::sanitize_operator_diagnostic_line(error)),
+        );
+    }
+    if let Some(payload) = value.get("payload").and_then(Value::as_object) {
+        let mut payload_summary = serde_json::Map::new();
+        for key in [
+            "canonical_family_url",
+            "filename",
+            "url",
+            "exists",
+            "size_bytes",
+        ] {
+            if let Some(payload_value) = payload.get(key) {
+                payload_summary.insert(
+                    key.into(),
+                    sanitize_model_bridge_payload_field(key, payload_value),
+                );
+            }
+        }
+        for key in ["models_dir", "resolved_model_path"] {
+            if payload.get(key).is_some() {
+                payload_summary.insert(key.into(), Value::String("<redacted>".into()));
+            }
+        }
+        summary.insert("payload".into(), Value::Object(payload_summary));
+    }
+    if summary.is_empty() {
+        return "{\"type\":\"model_bridge_event_summary_unavailable\"}".into();
+    }
+    serde_json::to_string(&Value::Object(summary))
+        .unwrap_or_else(|_| "{\"type\":\"model_bridge_event_summary_error\"}".into())
+}
+
+fn sanitize_model_bridge_payload_field(key: &str, value: &Value) -> Value {
+    match value {
+        Value::String(text) if key == "url" || key == "canonical_family_url" => {
+            Value::String(operator_logs::sanitize_operator_diagnostic_line(text))
+        }
+        Value::String(text) => {
+            Value::String(operator_logs::sanitize_operator_diagnostic_line(text))
+        }
+        Value::Bool(_) | Value::Number(_) | Value::Null => value.clone(),
+        Value::Array(_) | Value::Object(_) => Value::String("<omitted>".into()),
+    }
+}
+
 fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
@@ -121,13 +179,15 @@ fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifac
     let start_line = format!(
         "action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
         action,
-        bridge_script.display(),
-        bridge_command.get_program().to_string_lossy(),
-        selected_resource_root.display(),
+        operator_logs::sanitize_operator_path_display(&bridge_script),
+        operator_logs::sanitize_operator_diagnostic_line(
+            &bridge_command.get_program().to_string_lossy(),
+        ),
+        operator_logs::sanitize_operator_path_display(&selected_resource_root),
         selected_layout,
         import_root
             .as_deref()
-            .map(|path| path.display().to_string())
+            .map(operator_logs::sanitize_operator_path_display)
             .unwrap_or_else(|| "<unresolved>".into())
     );
     eprintln!("desktop.model_bridge.start {start_line}");
@@ -141,10 +201,21 @@ fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifac
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
-        let _ = operator_logs::append_model_bridge_log(app, action, &format!("stdout {line}"));
+        let _ = operator_logs::append_model_bridge_log(
+            app,
+            action,
+            &format!("stdout {}", summarize_model_bridge_output_line(line)),
+        );
     }
     for line in stderr.lines().filter(|line| !line.trim().is_empty()) {
-        let _ = operator_logs::append_model_bridge_log(app, action, &format!("stderr {line}"));
+        let _ = operator_logs::append_model_bridge_log(
+            app,
+            action,
+            &format!(
+                "stderr {}",
+                operator_logs::sanitize_operator_diagnostic_line(line)
+            ),
+        );
     }
     let json_line = stdout
         .lines()
@@ -417,6 +488,44 @@ mod tests {
             .find_map(|(env_key, value)| (env_key == key).then_some(value))
             .flatten()
             .map(|value| value.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn model_bridge_log_summary_redacts_local_paths() {
+        let line = serde_json::json!({
+            "ok": true,
+            "payload": {
+                "canonical_family_url": "https://example.com/models?token=secret",
+                "filename": "model.gguf",
+                "url": "https://example.com/model.gguf?token=secret",
+                "models_dir": "/Users/Example User/Library/Application Support/token.place/models",
+                "resolved_model_path": "/Users/Example User/Library/Application Support/token.place/models/model.gguf",
+                "exists": true,
+                "size_bytes": 42
+            }
+        })
+        .to_string();
+
+        let summary = summarize_model_bridge_output_line(&line);
+        let payload: Value = serde_json::from_str(&summary).expect("summary json");
+
+        assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            payload
+                .get("payload")
+                .and_then(|payload| payload.get("models_dir"))
+                .and_then(Value::as_str),
+            Some("<redacted>")
+        );
+        assert_eq!(
+            payload
+                .get("payload")
+                .and_then(|payload| payload.get("resolved_model_path"))
+                .and_then(Value::as_str),
+            Some("<redacted>")
+        );
+        assert!(!summary.contains("Example User"));
+        assert!(!summary.contains("token=secret"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -28,7 +28,7 @@ impl OperatorLogSink {
     }
 
     pub fn append_line(&self, source: &str, line: &str) {
-        let sanitized = sanitize_log_line(line);
+        let sanitized = sanitize_operator_diagnostic_line(line);
         if let Ok(mut file) = self.file.lock() {
             let _ = writeln!(file, "{} {} {}", current_time_ms(), source, sanitized);
             let _ = file.flush();
@@ -84,7 +84,7 @@ pub fn append_line_to_path(log_path: &Path, source: &str, line: &str) -> anyhow:
         "{} {} {}",
         current_time_ms(),
         source,
-        sanitize_log_line(line)
+        sanitize_operator_diagnostic_line(line)
     )?;
     Ok(())
 }
@@ -103,7 +103,7 @@ pub fn append_model_bridge_log(
         "{} desktop.model_bridge.{} {}",
         current_time_ms(),
         sanitize_filename_component(action),
-        sanitize_log_line(line)
+        sanitize_operator_diagnostic_line(line)
     )?;
     Ok(path)
 }
@@ -193,6 +193,89 @@ pub fn read_log_tail(log_path: &Path, max_bytes: usize) -> anyhow::Result<String
     let mut bytes = Vec::with_capacity((len - start) as usize);
     file.read_to_end(&mut bytes)?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
+    let line = sanitize_log_line(line);
+    line.split_whitespace()
+        .map(sanitize_operator_diagnostic_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub fn sanitize_operator_path_display(path: &Path) -> String {
+    sanitize_path_display(&path.display().to_string())
+}
+
+fn sanitize_operator_diagnostic_token(token: &str) -> String {
+    if token.starts_with('{') || token.starts_with('[') {
+        return token.chars().take(4096).collect();
+    }
+    if token.starts_with("http://") || token.starts_with("https://") {
+        return sanitize_url_display(token);
+    }
+
+    for separator in ['=', ':'] {
+        if let Some((key, value)) = token.split_once(separator) {
+            if value.starts_with("http://") || value.starts_with("https://") {
+                return format!("{key}{separator}{}", sanitize_url_display(value));
+            }
+            if is_path_like(value) {
+                return format!("{key}{separator}{}", sanitize_path_display(value));
+            }
+        }
+    }
+
+    if is_path_like(token) {
+        return sanitize_path_display(token);
+    }
+
+    token.chars().take(4096).collect()
+}
+
+fn sanitize_url_display(value: &str) -> String {
+    let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    if let Some((scheme, rest)) = without_query.split_once("://") {
+        let authority = rest.split('/').next().unwrap_or(rest);
+        let safe_authority = authority.rsplit('@').next().unwrap_or(authority);
+        if !scheme.is_empty() && !safe_authority.is_empty() {
+            return format!("{scheme}://{safe_authority}");
+        }
+    }
+    "<url>".into()
+}
+
+fn sanitize_path_display(value: &str) -> String {
+    let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
+    let path = Path::new(trimmed);
+    if trimmed.starts_with('/') && trimmed.split('/').filter(|part| !part.is_empty()).count() <= 2 {
+        return "<path>".into();
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty());
+    match file_name {
+        Some(name) => format!("<path:{name}>"),
+        None => "<path>".into(),
+    }
+}
+
+fn is_path_like(value: &str) -> bool {
+    let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
+    trimmed.starts_with('/')
+        || trimmed.starts_with("~/")
+        || trimmed.starts_with("file://")
+        || trimmed.contains('/')
+        || (trimmed.len() > 2
+            && trimmed.as_bytes()[1] == b':'
+            && (trimmed.as_bytes()[2] == b'/' || trimmed.as_bytes()[2] == b'\\')
+            && trimmed.as_bytes()[0].is_ascii_alphabetic())
 }
 
 fn current_time_ms() -> u64 {

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -16,8 +16,7 @@ impl OperatorLogSink {
     pub fn create(app: &AppHandle, session_id: &str) -> anyhow::Result<Self> {
         let dir = operator_log_dir(app)?;
         fs::create_dir_all(&dir)?;
-        let path = compute_operator_log_path(&dir, session_id);
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let (path, file) = create_unique_operator_log_file(&dir, session_id)?;
         Ok(Self {
             path,
             file: Arc::new(Mutex::new(file)),
@@ -49,6 +48,45 @@ pub fn operator_log_dir(app: &AppHandle) -> anyhow::Result<PathBuf> {
 pub fn compute_operator_log_path(dir: &Path, session_id: &str) -> PathBuf {
     let safe_session_id = sanitize_filename_component(session_id);
     dir.join(format!("compute-node-{safe_session_id}.log"))
+}
+
+fn create_unique_operator_log_file(
+    dir: &Path,
+    session_id: &str,
+) -> anyhow::Result<(PathBuf, File)> {
+    let safe_session_id = sanitize_filename_component(session_id);
+    for attempt in 0..100 {
+        let timestamp = current_time_ms();
+        let suffix = if attempt == 0 {
+            String::new()
+        } else {
+            format!("-{attempt}")
+        };
+        let path = dir.join(format!(
+            "compute-node-{safe_session_id}-{timestamp}{suffix}.log"
+        ));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err.into()),
+        }
+    }
+    anyhow::bail!("failed to create a unique operator log file after 100 attempts")
+}
+
+pub fn append_line_to_path(log_path: &Path, source: &str, line: &str) -> anyhow::Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    writeln!(
+        file,
+        "{} {} {}",
+        current_time_ms(),
+        source,
+        sanitize_log_line(line)
+    )?;
+    Ok(())
 }
 
 pub fn append_model_bridge_log(
@@ -148,9 +186,13 @@ pub fn reveal_log_file(log_path: &Path) -> anyhow::Result<()> {
 }
 
 pub fn read_log_tail(log_path: &Path, max_bytes: usize) -> anyhow::Result<String> {
-    let bytes = fs::read(log_path)?;
-    let start = bytes.len().saturating_sub(max_bytes);
-    Ok(String::from_utf8_lossy(&bytes[start..]).into_owned())
+    let mut file = File::open(log_path)?;
+    let len = file.metadata()?.len();
+    let start = len.saturating_sub(max_bytes as u64);
+    file.seek(SeekFrom::Start(start))?;
+    let mut bytes = Vec::with_capacity((len - start) as usize);
+    file.read_to_end(&mut bytes)?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 fn current_time_ms() -> u64 {
@@ -213,12 +255,43 @@ mod tests {
 
     #[test]
     fn posix_tail_script_quotes_paths_with_spaces_and_quotes() {
-        let path = Path::new("/Users/Daniel Smith/Library/Logs/token.place/compute node's.log");
+        let path = Path::new("/Users/Example User/Library/Logs/token.place/compute node's.log");
         let script = tail_terminal_script(path);
         assert!(script
-            .contains("'/Users/Daniel Smith/Library/Logs/token.place/compute node'\\''s.log'"));
+            .contains("'/Users/Example User/Library/Logs/token.place/compute node'\\''s.log'"));
         assert!(script.contains("tail -n 200 -F"));
         assert!(!script.contains("; rm -rf"));
+    }
+
+    #[test]
+    fn create_uses_unique_non_appended_session_files() {
+        let temp = TempDir::new().expect("tempdir");
+        let (first_path, mut first_file) =
+            create_unique_operator_log_file(temp.path(), "1").expect("first log");
+        writeln!(first_file, "stale").expect("write first");
+        let (second_path, _second_file) =
+            create_unique_operator_log_file(temp.path(), "1").expect("second log");
+
+        assert_ne!(first_path, second_path);
+        assert!(first_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .starts_with("compute-node-1-"));
+        assert_eq!(
+            fs::read_to_string(second_path).expect("second contents"),
+            ""
+        );
+    }
+
+    #[test]
+    fn read_log_tail_reads_only_requested_suffix() {
+        let temp = TempDir::new().expect("tempdir");
+        let path = temp.path().join("operator.log");
+        fs::write(&path, "0123456789abcdef").expect("write log");
+
+        assert_eq!(read_log_tail(&path, 6).expect("tail"), "abcdef");
+        assert_eq!(read_log_tail(&path, 64).expect("tail"), "0123456789abcdef");
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -65,7 +65,7 @@ fn create_unique_operator_log_file(
         let path = dir.join(format!(
             "compute-node-{safe_session_id}-{timestamp}{suffix}.log"
         ));
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
+        match OpenOptions::new().append(true).create_new(true).open(&path) {
             Ok(file) => return Ok((path, file)),
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(err) => return Err(err.into()),
@@ -364,6 +364,41 @@ mod tests {
         assert_eq!(
             fs::read_to_string(second_path).expect("second contents"),
             ""
+        );
+    }
+
+    #[test]
+    fn log_sink_append_mode_preserves_interleaved_lifecycle_appends() {
+        let temp = TempDir::new().expect("tempdir");
+        let (path, file) = create_unique_operator_log_file(temp.path(), "interleave")
+            .expect("create operator log");
+        let sink = OperatorLogSink {
+            path: path.clone(),
+            file: Arc::new(Mutex::new(file)),
+        };
+
+        sink.append_line("desktop.compute_node.stdout", "first bridge line");
+        append_line_to_path(
+            &path,
+            "desktop.compute_node.stop_requested",
+            "operator_session_id=interleave",
+        )
+        .expect("append lifecycle line");
+        sink.append_line("desktop.compute_node.stdout", "second bridge line");
+
+        let raw = fs::read_to_string(path).expect("log contents");
+        assert!(raw.contains("desktop.compute_node.stdout first bridge line"));
+        assert!(raw.contains("desktop.compute_node.stop_requested operator_session_id=interleave"));
+        assert!(raw.contains("desktop.compute_node.stdout second bridge line"));
+        let lifecycle_index = raw
+            .find("desktop.compute_node.stop_requested")
+            .expect("lifecycle line index");
+        let second_sink_index = raw
+            .find("desktop.compute_node.stdout second bridge line")
+            .expect("second sink line index");
+        assert!(
+            lifecycle_index < second_sink_index,
+            "lifecycle append must not be overwritten by subsequent sink writes: {raw}"
         );
     }
 

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -1,0 +1,241 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Manager};
+
+#[derive(Clone)]
+pub struct OperatorLogSink {
+    pub(crate) path: PathBuf,
+    pub(crate) file: Arc<Mutex<File>>,
+}
+
+impl OperatorLogSink {
+    pub fn create(app: &AppHandle, session_id: &str) -> anyhow::Result<Self> {
+        let dir = operator_log_dir(app)?;
+        fs::create_dir_all(&dir)?;
+        let path = compute_operator_log_path(&dir, session_id);
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        Ok(Self {
+            path,
+            file: Arc::new(Mutex::new(file)),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn append_line(&self, source: &str, line: &str) {
+        let sanitized = sanitize_log_line(line);
+        if let Ok(mut file) = self.file.lock() {
+            let _ = writeln!(file, "{} {} {}", current_time_ms(), source, sanitized);
+            let _ = file.flush();
+        }
+    }
+}
+
+pub fn operator_log_dir(app: &AppHandle) -> anyhow::Result<PathBuf> {
+    let base = app
+        .path()
+        .app_log_dir()
+        .or_else(|_| app.path().app_data_dir().map(|dir| dir.join("logs")))
+        .map_err(|err| anyhow::anyhow!("operator log path error: {err}"))?;
+    Ok(base.join("operator"))
+}
+
+pub fn compute_operator_log_path(dir: &Path, session_id: &str) -> PathBuf {
+    let safe_session_id = sanitize_filename_component(session_id);
+    dir.join(format!("compute-node-{safe_session_id}.log"))
+}
+
+pub fn append_model_bridge_log(
+    app: &AppHandle,
+    action: &str,
+    line: &str,
+) -> anyhow::Result<PathBuf> {
+    let dir = operator_log_dir(app)?;
+    fs::create_dir_all(&dir)?;
+    let path = dir.join("model-bridge.log");
+    let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+    writeln!(
+        file,
+        "{} desktop.model_bridge.{} {}",
+        current_time_ms(),
+        sanitize_filename_component(action),
+        sanitize_log_line(line)
+    )?;
+    Ok(path)
+}
+
+pub fn tail_terminal_script(log_path: &Path) -> String {
+    format!(
+        "clear; echo 'Tailing token.place operator log:'; echo {}; tail -n 200 -F {}",
+        quote_posix_arg(&log_path.display().to_string()),
+        quote_posix_arg(&log_path.display().to_string())
+    )
+}
+
+pub fn quote_posix_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn open_debug_terminal(log_path: &Path) -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("osascript")
+            .arg("-e")
+            .arg(format!(
+                "tell application \"Terminal\" to do script {}",
+                quote_applescript_string(&tail_terminal_script(log_path))
+            ))
+            .spawn()?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("cmd")
+            .args([
+                "/C",
+                "start",
+                "token.place operator log",
+                "powershell",
+                "-NoExit",
+                "-Command",
+                &format!(
+                    "Get-Content -LiteralPath {} -Tail 200 -Wait",
+                    quote_powershell_single_string(&log_path.display().to_string())
+                ),
+            ])
+            .spawn()?;
+        return Ok(());
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        Command::new("x-terminal-emulator")
+            .args(["-e", "tail", "-n", "200", "-F"])
+            .arg(log_path)
+            .spawn()?;
+        Ok(())
+    }
+}
+
+pub fn reveal_log_file(log_path: &Path) -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open").arg("-R").arg(log_path).spawn()?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("explorer")
+            .arg(format!("/select,{}", log_path.display()))
+            .spawn()?;
+        return Ok(());
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        let dir = log_path.parent().unwrap_or_else(|| Path::new("."));
+        Command::new("xdg-open").arg(dir).spawn()?;
+        Ok(())
+    }
+}
+
+pub fn read_log_tail(log_path: &Path, max_bytes: usize) -> anyhow::Result<String> {
+    let bytes = fs::read(log_path)?;
+    let start = bytes.len().saturating_sub(max_bytes);
+    Ok(String::from_utf8_lossy(&bytes[start..]).into_owned())
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn sanitize_filename_component(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+        .collect();
+    if sanitized.is_empty() {
+        "unknown".into()
+    } else {
+        sanitized
+    }
+}
+
+fn sanitize_log_line(line: &str) -> String {
+    line.chars()
+        .map(|ch| {
+            if ch.is_control() && ch != '\t' {
+                ' '
+            } else {
+                ch
+            }
+        })
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn quote_applescript_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('\"', "\\\""))
+}
+
+#[cfg(target_os = "windows")]
+fn quote_powershell_single_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn compute_operator_log_path_sanitizes_session_and_preserves_spaces_in_dir() {
+        let temp = TempDir::new().expect("tempdir");
+        let dir = temp.path().join("Token Place Logs");
+        let path = compute_operator_log_path(&dir, "session/../../abc 123!");
+        assert_eq!(path.parent(), Some(dir.as_path()));
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("compute-node-sessionabc123.log")
+        );
+    }
+
+    #[test]
+    fn posix_tail_script_quotes_paths_with_spaces_and_quotes() {
+        let path = Path::new("/Users/Daniel Smith/Library/Logs/token.place/compute node's.log");
+        let script = tail_terminal_script(path);
+        assert!(script
+            .contains("'/Users/Daniel Smith/Library/Logs/token.place/compute node'\\''s.log'"));
+        assert!(script.contains("tail -n 200 -F"));
+        assert!(!script.contains("; rm -rf"));
+    }
+
+    #[test]
+    fn log_sink_writes_lines() {
+        let temp = TempDir::new().expect("tempdir");
+        let path = compute_operator_log_path(temp.path(), "42");
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .expect("file");
+        let sink = OperatorLogSink {
+            path: path.clone(),
+            file: Arc::new(Mutex::new(file)),
+        };
+        sink.append_line("desktop.compute_node.stderr", "bridge stderr line");
+        let raw = fs::read_to_string(path).expect("log");
+        assert!(raw.contains("desktop.compute_node.stderr bridge stderr line"));
+    }
+}

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -633,25 +633,8 @@ describe('desktop app start failure handling', () => {
 
 
 
-  it('renders operator debug log affordances and opens in-app log text', async () => {
+  it('renders operator debug log affordances from live events and opens in-app log text', async () => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === 'get_compute_node_status') {
-        return Promise.resolve({
-          running: true,
-          registered: false,
-          active_relay_url: 'https://token.place',
-          requested_mode: 'auto',
-          effective_mode: 'cpu',
-          backend_available: 'unknown',
-          backend_selected: 'cpu',
-          backend_used: 'cpu',
-          fallback_reason: null,
-          model_path: '/tmp/model.gguf',
-          last_error: null,
-          relay_runtime_state: 'starting',
-          log_file_path: '/Users/Example User/Library/Logs/token.place/operator/compute-node-1.log',
-        });
-      }
       if (command === 'read_operator_log') {
         return Promise.resolve('desktop.compute_node.stderr bridge stderr line');
       }
@@ -664,8 +647,26 @@ describe('desktop app start failure handling', () => {
     render(<App />);
 
     const openLogButton = (await screen.findByText('Open debug log')) as HTMLButtonElement;
-    expect(openLogButton.disabled).toBe(false);
+    expect(openLogButton.disabled).toBe(true);
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        active_relay_url: 'https://token.place',
+        relay_runtime_state: 'starting',
+        log_file_path: '/Users/Example User/Library/Logs/token.place/operator/compute-node-1.log',
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+
+    await waitFor(() => expect(openLogButton.disabled).toBe(false));
     expect(screen.getByText('Reveal log file')).toBeTruthy();
+    expect(screen.getByText('Copy log path')).toBeTruthy();
     expect(screen.getByText('Open debug terminal')).toBeTruthy();
 
     fireEvent.click(openLogButton);
@@ -708,6 +709,37 @@ describe('desktop app start failure handling', () => {
       expect(screen.getByText(/Operator debug log:/).textContent).toContain('not created yet')
     );
     expect((screen.getByText('Open debug log') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+
+  it('copies operator log path and surfaces path copy failures', async () => {
+    const originalClipboard = navigator.clipboard;
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    mockInitialComputeStatus({
+      running: true,
+      registered: false,
+      active_relay_url: 'https://token.place',
+      log_file_path: '/Users/Example User/Library/Logs/token.place/operator/compute-node-1.log',
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByText('Copy log path'));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        '/Users/Example User/Library/Logs/token.place/operator/compute-node-1.log'
+      )
+    );
+
+    writeText.mockRejectedValueOnce(new Error('path clipboard denied'));
+    fireEvent.click(screen.getByText('Copy log path'));
+
+    await waitFor(() => expect(screen.getByText(/path clipboard denied/)).toBeTruthy());
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
   });
 
   it('surfaces clipboard copy failures in the operator debug console', async () => {

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -78,6 +78,51 @@ describe('desktop app start failure handling', () => {
     });
   });
 
+  const mockInitialCommand = (command: string) => {
+    if (command === 'detect_backend') {
+      return Promise.resolve({
+        platform_label: 'macos',
+        preferred_mode: 'auto',
+        available_backend: 'metal',
+        availability_label: 'Metal-capable platform (Apple Silicon)',
+      });
+    }
+    if (command === 'load_config') {
+      return Promise.resolve({
+        model_path: '/tmp/model.gguf',
+        relay_base_url: 'https://token.place',
+        preferred_mode: 'auto',
+      });
+    }
+    if (command === 'get_compute_node_status') {
+      return Promise.resolve({
+        running: false,
+        registered: false,
+        active_relay_url: '',
+        requested_mode: 'auto',
+        effective_mode: 'cpu',
+        backend_available: 'unknown',
+        backend_selected: 'cpu',
+        backend_used: 'cpu',
+        fallback_reason: null,
+        model_path: '',
+        last_error: null,
+        log_file_path: null,
+      });
+    }
+    if (command === 'inspect_model_artifact') {
+      return Promise.resolve({
+        canonical_family_url: 'https://example.test/models',
+        filename: 'model.gguf',
+        url: 'https://example.test/model.gguf',
+        models_dir: '/tmp',
+        resolved_model_path: '/tmp/model.gguf',
+        exists: true,
+        size_bytes: 1,
+      });
+    }
+    return Promise.resolve(undefined);
+  };
 
   const mockInitialComputeStatus = (statusOverrides: Record<string, unknown>) => {
     invokeMock.mockImplementation((command: string) => {
@@ -586,6 +631,48 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
   });
 
+
+
+  it('renders operator debug log affordances and opens in-app log text', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: true,
+          registered: false,
+          active_relay_url: 'https://token.place',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '/tmp/model.gguf',
+          last_error: null,
+          relay_runtime_state: 'starting',
+          log_file_path: '/Users/Daniel Smith/Library/Logs/token.place/operator/compute-node-1.log',
+        });
+      }
+      if (command === 'read_operator_log') {
+        return Promise.resolve('desktop.compute_node.stderr bridge stderr line');
+      }
+      if (command === 'reveal_operator_log' || command === 'open_operator_debug_terminal') {
+        return Promise.resolve(undefined);
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+
+    const openLogButton = (await screen.findByText('Open debug log')) as HTMLButtonElement;
+    expect(openLogButton.disabled).toBe(false);
+    expect(screen.getByText('Reveal log file')).toBeTruthy();
+    expect(screen.getByText('Open debug terminal')).toBeTruthy();
+
+    fireEvent.click(openLogButton);
+
+    await screen.findByLabelText('Operator debug console');
+    expect(screen.getByDisplayValue(/bridge stderr line/)).toBeTruthy();
+  });
 
   it('invokes backend stop and reflects stopped operator event', async () => {
     mockInitialComputeStatus({

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -649,7 +649,7 @@ describe('desktop app start failure handling', () => {
           model_path: '/tmp/model.gguf',
           last_error: null,
           relay_runtime_state: 'starting',
-          log_file_path: '/Users/Daniel Smith/Library/Logs/token.place/operator/compute-node-1.log',
+          log_file_path: '/Users/Example User/Library/Logs/token.place/operator/compute-node-1.log',
         });
       }
       if (command === 'read_operator_log') {
@@ -672,6 +672,81 @@ describe('desktop app start failure handling', () => {
 
     await screen.findByLabelText('Operator debug console');
     expect(screen.getByDisplayValue(/bridge stderr line/)).toBeTruthy();
+  });
+
+
+  it('clears stale operator log path when backend emits null', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: false,
+      active_relay_url: 'https://token.place',
+      log_file_path: '/Users/Example User/Library/Logs/token.place/operator/compute-node-old.log',
+      operator_session_id: 'session-1',
+      sequence: 1,
+    });
+
+    render(<App />);
+    await waitFor(() =>
+      expect(screen.getByText(/Operator debug log:/).textContent).toContain('compute-node-old.log')
+    );
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        log_file_path: null,
+        message: 'operator log unavailable',
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Operator debug log:/).textContent).toContain('not created yet')
+    );
+    expect((screen.getByText('Open debug log') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('surfaces clipboard copy failures in the operator debug console', async () => {
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn(() => Promise.reject(new Error('clipboard denied'))) },
+    });
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: true,
+          registered: false,
+          active_relay_url: 'https://token.place',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '/tmp/model.gguf',
+          last_error: null,
+          relay_runtime_state: 'starting',
+          log_file_path: '/Users/Example User/Library/Logs/token.place/operator/compute-node-1.log',
+        });
+      }
+      if (command === 'read_operator_log') {
+        return Promise.resolve('desktop.compute_node.stderr bridge stderr line');
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByText('Open debug log'));
+    await screen.findByLabelText('Operator debug console');
+    fireEvent.click(screen.getByText('Copy log'));
+
+    await waitFor(() => expect(screen.getByText(/clipboard denied/)).toBeTruthy());
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
   });
 
   it('invokes backend stop and reflects stopped operator event', async () => {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -501,6 +501,21 @@ export function App() {
     }
   };
 
+  const copyOperatorLogPath = async () => {
+    try {
+      const logPath = computeStatus.log_file_path;
+      if (!logPath) return;
+      const writeText = navigator.clipboard?.writeText;
+      if (!writeText) {
+        setError('Clipboard API is unavailable in this webview.');
+        return;
+      }
+      await writeText.call(navigator.clipboard, logPath);
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
   const openOperatorDebugTerminal = async () => {
     try {
       await invoke('open_operator_debug_terminal');
@@ -618,6 +633,9 @@ export function App() {
           </button>
           <button type="button" disabled={!computeStatus.log_file_path} onClick={revealOperatorLog}>
             Reveal log file
+          </button>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={copyOperatorLogPath}>
+            Copy log path
           </button>
           <button type="button" disabled={!computeStatus.log_file_path} onClick={openOperatorDebugTerminal}>
             Open debug terminal

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -40,6 +40,7 @@ interface ComputeNodeStatus {
   operator_session_id: string | null;
   sequence: number | null;
   updated_at_ms: number | null;
+  log_file_path: string | null;
 }
 
 interface ModelArtifactInfo {
@@ -81,6 +82,7 @@ const defaultComputeStatus: ComputeNodeStatus = {
   operator_session_id: null,
   sequence: null,
   updated_at_ms: null,
+  log_file_path: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -189,6 +191,8 @@ function mergeComputeStatusEvent(
     sequence: payloadSequence ?? prev.sequence,
     updated_at_ms:
       typeof payload.updated_at_ms === 'number' ? payload.updated_at_ms : prev.updated_at_ms,
+    log_file_path:
+      typeof payload.log_file_path === 'string' ? payload.log_file_path : prev.log_file_path,
     last_error:
       payload.last_error === null
         ? null
@@ -227,6 +231,8 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const [operatorLogText, setOperatorLogText] = useState('');
+  const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false);
   const relayRuntimeState = computeStatus.relay_runtime_state || computeStatus.warm_load_state || 'idle';
   const relayRuntimeReady =
     computeStatus.warm_load_enabled === false ||
@@ -437,6 +443,7 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        log_file_path: null,
       };
       computeStatusRef.current = optimisticStatus;
       setComputeStatus(optimisticStatus);
@@ -466,6 +473,33 @@ export function App() {
   const stopComputeNode = async () => {
     try {
       await invoke('stop_compute_node');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+
+  const refreshOperatorLog = async () => {
+    try {
+      const logText = await invoke<string>('read_operator_log');
+      setOperatorLogText(logText);
+      setIsDebugConsoleOpen(true);
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const revealOperatorLog = async () => {
+    try {
+      await invoke('reveal_operator_log');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const openOperatorDebugTerminal = async () => {
+    try {
+      await invoke('open_operator_debug_terminal');
     } catch (e) {
       setError(formatErrorMessage(e));
     }
@@ -573,6 +607,36 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Backend used: <code>{displayStatusValue(computeStatus.backend_used, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
+        <p style={{ marginBottom: 0 }}>Operator debug log: <code>{computeStatus.log_file_path || 'not created yet'}</code></p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={refreshOperatorLog}>
+            Open debug log
+          </button>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={revealOperatorLog}>
+            Reveal log file
+          </button>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={openOperatorDebugTerminal}>
+            Open debug terminal
+          </button>
+        </div>
+        {isDebugConsoleOpen && (
+          <section aria-label="Operator debug console" style={{ marginTop: 10 }}>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <strong>Operator debug console</strong>
+              <button type="button" onClick={refreshOperatorLog}>Refresh</button>
+              <button type="button" onClick={() => navigator.clipboard?.writeText(operatorLogText)}>
+                Copy log
+              </button>
+              <button type="button" onClick={() => setIsDebugConsoleOpen(false)}>Close</button>
+            </div>
+            <textarea
+              readOnly
+              rows={12}
+              value={operatorLogText}
+              style={{ width: '100%', marginTop: 8, fontFamily: 'monospace' }}
+            />
+          </section>
+        )}
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>
 

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -192,7 +192,11 @@ function mergeComputeStatusEvent(
     updated_at_ms:
       typeof payload.updated_at_ms === 'number' ? payload.updated_at_ms : prev.updated_at_ms,
     log_file_path:
-      typeof payload.log_file_path === 'string' ? payload.log_file_path : prev.log_file_path,
+      payload.log_file_path === null
+        ? null
+        : typeof payload.log_file_path === 'string'
+          ? payload.log_file_path
+          : prev.log_file_path,
     last_error:
       payload.last_error === null
         ? null
@@ -624,7 +628,19 @@ export function App() {
             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
               <strong>Operator debug console</strong>
               <button type="button" onClick={refreshOperatorLog}>Refresh</button>
-              <button type="button" onClick={() => navigator.clipboard?.writeText(operatorLogText)}>
+              <button
+                type="button"
+                onClick={() => {
+                  const writeText = navigator.clipboard?.writeText;
+                  if (!writeText) {
+                    setError('Clipboard API is unavailable in this webview.');
+                    return;
+                  }
+                  writeText.call(navigator.clipboard, operatorLogText).catch((err) =>
+                    setError(formatErrorMessage(err))
+                  );
+                }}
+              >
                 Copy log
               </button>
               <button type="button" onClick={() => setIsDebugConsoleOpen(false)}>Close</button>

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -184,6 +184,7 @@ for:
 
 - **Open debug log**: opens an in-app read-only console showing the current log
   tail with a copy button.
+- **Copy log path**: copies the current session log path for support notes or shell commands.
 - **Reveal log file**: reveals the log in Finder (or the equivalent file manager
   on other platforms).
 - **Open debug terminal**: opens a terminal tailing the current log. On macOS the

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -174,3 +174,45 @@ Before release sign-off or production round-robin messaging, record:
 6. Two-node staging participation evidence for both Windows and macOS release candidates.
 
 If any item is unavailable because CI, staging, GPU hardware, signing, or network access is missing, mark it as a release blocker or an explicitly accepted preview limitation. Do not silently downgrade platform parity expectations.
+
+## macOS packaged operator debug logs
+
+Packaged macOS launches do not attach to a developer terminal by default, so the
+compute-node operator persists each Start session to an app-local debug log. The
+Tauri status includes `log_file_path`, and the desktop UI exposes opt-in buttons
+for:
+
+- **Open debug log**: opens an in-app read-only console showing the current log
+  tail with a copy button.
+- **Reveal log file**: reveals the log in Finder (or the equivalent file manager
+  on other platforms).
+- **Open debug terminal**: opens a terminal tailing the current log. On macOS the
+  app uses Terminal.app with a read-only `tail -n 200 -F` command and quotes the
+  log path so spaces in `~/Library/Logs/...` work.
+
+The macOS log is created under the app log directory in an `operator/` subfolder,
+with names like `compute-node-<operator_session_id>.log`. The log starts with the
+operator session id, sanitized relay target, requested mode, bridge path,
+interpreter, resource root, packaged layout, and import root. It then mirrors
+bridge stdout/stderr, `desktop_runtime_setup` probe/provision output,
+`model_manager` warm-load output, registration/poll/request/response lifecycle
+lines, and stop/cancel/unregister cleanup lines.
+
+For manual validation, set `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1` before
+launching the packaged app if you want the terminal tail to open automatically
+when Start operator creates a session log. Normal packaged launches keep terminal
+access opt-in through the UI.
+
+When Start operator fails on macOS, capture:
+
+1. The UI **Last error** field.
+2. The **Operator debug log** path shown in the UI.
+3. The first `desktop.compute_node.session.start` and
+   `desktop.compute_node.session.layout` lines.
+4. Any `desktop_runtime_setup`, `llama_module_path`, `interpreter`, `prefix`,
+   `metal`, `llama_cpp`, `model_init`, registration, unregister, cancel, or
+   bridge stderr lines from the log.
+
+Debug logs must remain operator diagnostics only. Do not add plaintext prompts,
+responses, tool arguments, model-output text, private keys, or decrypted relay
+payloads to persisted logs.

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -194,7 +194,7 @@ for:
   log path so spaces in `~/Library/Logs/...` work.
 
 The macOS log is created under the app log directory in an `operator/` subfolder,
-with names like `compute-node-<operator_session_id>.log`. The log starts with the
+with timestamped per-session names like `compute-node-<operator_session_id>-<timestamp>.log`. The log starts with the
 operator session id, sanitized relay target, requested mode, bridge path,
 interpreter, resource root, packaged layout, and import root. It then mirrors
 bridge stdout/stderr, `desktop_runtime_setup` probe/provision output,


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop builds hide compute-node bridge stdout/stderr, making startup provisioning failures (e.g., missing `llama_cpp`) hard to diagnose from the UI-only `Last error` field.  
- Provide parity with Windows console visibility by persisting operator logs, exposing the path in UI/status, and offering safe opt-in terminal tailing or an in-app read-only console.  
- Keep changes scoped to logging/debug diagnostics without changing relay, runtime provisioning, or E2EE behavior.

### Description
- Add a new Rust module `operator_logs.rs` that creates per-session operator log files under the app log directory, sanitizes filenames/lines, quotes POSIX args, and provides helpers to tail/reveal/read logs and to open a terminal tail safely on macOS/Windows/Linux.  
- Extend `ComputeNodeStatus` and `start_compute_node` flow to create a session `OperatorLogSink` before bridge resolution, mirror bridge stdout/stderr and session/layout lines into the session log, store `log_file_path` in status, and include it in error events.  
- Mirror `model_bridge` start/stdout/stderr into a `model-bridge.log` via the new operator log helpers and surface failures into the operator log.  
- Add Tauri commands: `read_operator_log`, `reveal_operator_log`, and `open_operator_debug_terminal` (safe path quoting and platform-specific invocations), and wire them into the invoke handler.  
- UI: add `Operator debug log` display, `Open debug log`, `Reveal log file`, and `Open debug terminal` buttons plus an in-app read-only debug console with copy/refresh/close controls in `App.tsx`.  
- Opt-in auto terminal tailing on session creation via environment variable `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1` (normal packaged behavior remains opt-in).  
- Tests and docs: add unit tests for operator logs (path sanitization, quoting, sink writing), update existing Rust tests to exercise the new log plumbing, add a Vitest UI test that asserts debug affordances render and the in-app console opens, and document macOS debug log location and capture guidance in `docs/desktop_parity_validation.md` and `desktop-tauri/README.md`.

### Testing
- Ran Rust unit tests: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` — all tests passed (72 passed, 0 failed).  
- Ran JS unit tests: `npm test` (Vitest) — test suite passed (App tests passed).  
- Packaged/operator e2e checks executed: `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`, and `python desktop-tauri/scripts/run_desktop_parity_checks.py` — these scripts ran to completion in CI-like environment (no regressions from logging changes observed).  
- Pre-commit and repo checks: `pre-commit run --all-files` — passed.  
- Notes: `npm test -- --runInBand` is a Jest flag and not supported by Vitest; the suite was executed with `npm test` which passed.  

If you want I can split the operator log module and UI wiring into a follow-up PR, or add a small telemetry-safe option to redact additional metadata before writing to disk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2347e31fd4832f8a916d478b68edda)