### PR TITLE
Add macOS operator debug logs + in-app/terminal affordances for compute-node bridge

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -121,6 +121,33 @@ You can also run the workflow manually with `workflow_dispatch` and provide
 The local prompt panel still uses `src-tauri/python/inference_sidecar.py` as a smoke test for local model setup.
 
 
+
+## macOS packaged operator debug logs
+
+Packaged desktop launches persist operator diagnostics so macOS users do not need a developer terminal to capture the same bridge/runtime detail that Windows console launches expose.
+
+- Compute-node operator sessions write one log per session under the app log directory, in the `operators/` subdirectory. On macOS this is typically `~/Library/Logs/<bundle identifier>/operators/compute-node-<operator_session_id>.log`; use the exact **Debug log** path shown in the desktop UI because the bundle identifier can vary between preview/dev/release builds.
+- Model bridge inspect/download diagnostics are appended to `model-bridge.log` in the same `operators/` log directory.
+- The compute-node log mirrors safe bridge diagnostics: session start, selected bridge path, interpreter, resource root, import root/layout, `desktop_runtime_setup` probe/provision lines, compute-node stdout events, stderr from `compute_node_bridge.py`, runtime warm-load/model-manager lines, registration/poll/request/response metadata, and stop/cancel/unregister/cleanup lines.
+- Logs must remain relay-blind: capture ciphertext/routing metadata and runtime diagnostics only; do not add plaintext prompt/response/tool/model-output logging.
+
+Debug access is opt-in:
+
+1. Start the operator, or reproduce a Start operator failure.
+2. In the desktop **Compute node operator** panel, copy the **Debug log** path or use one of the debug buttons:
+   - **Open debug log** opens the in-app read-only tail that can be refreshed.
+   - **Reveal log file** opens Finder/Explorer/file manager at the current log file.
+   - **Open debug terminal** opens Terminal.app on macOS and tails the current log file; paths with spaces are quoted by the Rust command path and are not executed from user input.
+   - **Copy log tail** copies the in-app tail to the clipboard.
+3. For validation sessions where a terminal should open automatically after the operator process is installed, launch the app with `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1`.
+
+When Start operator fails on macOS, include these lines in the bug report or release-validation note:
+
+- `desktop.compute_node.session.start ... interpreter=... resource_root=... layout=... import_root=... log_file_path=...`
+- `desktop.runtime_setup ... action=... interpreter=... prefix=... llama_module_path=... fallback_reason=...`
+- Any `desktop.compute_node.stderr line=...` traceback/import/provisioning lines around `llama_cpp` or Metal.
+- `desktop.compute_node_bridge.model_init.*`, `desktop.compute_node_bridge.registration.*`, and `desktop.compute_node_bridge.stop_requested` / unregister / cleanup lines if the bridge gets that far.
+
 ## Desktop logging defaults
 
 Desktop subprocess logs now default to high-signal output:

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,7 @@
 use crate::backend::ComputeMode;
+use crate::debug_logs::{
+    app_operator_log_dir, open_terminal_tailing_log, read_log_tail, reveal_log_file, SessionLogFile,
+};
 use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, configure_python_subprocess_env,
     describe_resource_layout, disable_python_user_site, resolve_bridge_script_path,
@@ -10,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -48,6 +51,7 @@ pub struct ComputeNodeStatus {
     pub operator_session_id: Option<String>,
     pub sequence: Option<u64>,
     pub updated_at_ms: Option<u64>,
+    pub log_file_path: Option<String>,
 }
 
 #[derive(Clone, Default)]
@@ -57,6 +61,7 @@ pub struct ComputeNodeState {
     pub status: Arc<Mutex<ComputeNodeStatus>>,
     pub lifecycle_lock: Arc<Mutex<()>>,
     pub next_session_id: Arc<Mutex<u64>>,
+    pub current_log_path: Arc<Mutex<Option<PathBuf>>>,
 }
 
 fn parse_compute_node_event_line(line: &str) -> Result<Value, serde_json::Error> {
@@ -202,7 +207,12 @@ fn event_session_id(payload: &Value) -> Option<&str> {
     payload.get("operator_session_id").and_then(Value::as_str)
 }
 
-fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> ComputeNodeStatus {
+fn startup_failure_status(
+    request: &ComputeNodeRequest,
+    last_error: String,
+    operator_session_id: Option<String>,
+    log_file_path: Option<String>,
+) -> ComputeNodeStatus {
     ComputeNodeStatus {
         running: false,
         registered: false,
@@ -221,9 +231,10 @@ fn startup_failure_status(request: &ComputeNodeRequest, last_error: String) -> C
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
-        operator_session_id: None,
+        operator_session_id,
         sequence: None,
         updated_at_ms: Some(current_time_ms()),
+        log_file_path,
     }
 }
 
@@ -324,6 +335,12 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
     } else {
         status.updated_at_ms = Some(current_time_ms());
     }
+    if payload.get("log_file_path").is_some() {
+        status.log_file_path = payload
+            .get("log_file_path")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
             .get("message")
@@ -417,12 +434,17 @@ fn finalize_bridge_exit(
 async fn drain_compute_node_stderr<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     policy: SubprocessLogPolicy,
+    session_log: Option<SessionLogFile>,
 ) -> anyhow::Result<()> {
     let mut lines = BufReader::new(reader).lines();
     let mut filter = SubprocessLogFilter::new("compute_node", policy);
     while let Some(line) = lines.next_line().await? {
+        let log_line = format!("desktop.compute_node.stderr line={line}");
+        if let Some(session_log) = session_log.as_ref() {
+            session_log.write_line(&log_line).await;
+        }
         if filter.should_emit(&line) {
-            eprintln!("desktop.compute_node.stderr line={line}");
+            eprintln!("{log_line}");
         }
     }
     Ok(())
@@ -448,12 +470,55 @@ pub async fn start_compute_node(
         *state.stdin.lock().await = None;
     }
 
+    let session_id = {
+        let mut next_session_id = state.next_session_id.lock().await;
+        *next_session_id += 1;
+        next_session_id.to_string()
+    };
+    let session_log = match app_operator_log_dir(&app) {
+        Ok(log_dir) => match SessionLogFile::create_in_dir(&log_dir, &session_id).await {
+            Ok(log) => Some(log),
+            Err(err) => {
+                eprintln!(
+                    "desktop.compute_node.log_file_create_failed operator_session_id={} error={}",
+                    session_id, err
+                );
+                None
+            }
+        },
+        Err(err) => {
+            eprintln!(
+                "desktop.compute_node.log_dir_resolve_failed operator_session_id={} error={}",
+                session_id, err
+            );
+            None
+        }
+    };
+    let log_file_path = session_log.as_ref().map(SessionLogFile::path_string);
+    if let Some(path) = log_file_path.as_deref() {
+        *state.current_log_path.lock().await = Some(PathBuf::from(path));
+    }
+    if let Some(log) = session_log.as_ref() {
+        log.write_line(format!(
+            "desktop.compute_node.log.start operator_session_id={} relay={} log_file_path={}",
+            session_id,
+            sanitize_relay_target(&request.relay_base_url),
+            log_file_path.as_deref().unwrap_or("unavailable")
+        ))
+        .await;
+    }
+
     let bridge_script = match resolve_bridge_script(&app) {
         Ok(bridge_script) => bridge_script,
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = startup_failure_status(&request, err.clone());
+                *status = startup_failure_status(
+                    &request,
+                    err.clone(),
+                    Some(session_id.clone()),
+                    log_file_path.clone(),
+                );
             }
             return Err(anyhow::anyhow!(err));
         }
@@ -467,7 +532,12 @@ pub async fn start_compute_node(
                 Err(err) => {
                     {
                         let mut status = state.status.lock().await;
-                        *status = startup_failure_status(&request, err.to_string());
+                        *status = startup_failure_status(
+                            &request,
+                            err.to_string(),
+                            Some(session_id.clone()),
+                            log_file_path.clone(),
+                        );
                     }
                     return Err(err);
                 }
@@ -476,7 +546,12 @@ pub async fn start_compute_node(
                 let err = anyhow::anyhow!("python launcher resolver task failed: {err}");
                 {
                     let mut status = state.status.lock().await;
-                    *status = startup_failure_status(&request, err.to_string());
+                    *status = startup_failure_status(
+                        &request,
+                        err.to_string(),
+                        Some(session_id.clone()),
+                        log_file_path.clone(),
+                    );
                 }
                 return Err(err);
             }
@@ -490,15 +565,15 @@ pub async fn start_compute_node(
         Err(err) => {
             {
                 let mut status = state.status.lock().await;
-                *status = startup_failure_status(&request, err.to_string());
+                *status = startup_failure_status(
+                    &request,
+                    err.to_string(),
+                    Some(session_id.clone()),
+                    log_file_path.clone(),
+                );
             }
             return Err(err);
         }
-    };
-    let session_id = {
-        let mut next_session_id = state.next_session_id.lock().await;
-        *next_session_id += 1;
-        next_session_id.to_string()
     };
     let exe_path = std::env::current_exe().ok();
     let resource_dir = app.path().resource_dir().ok();
@@ -515,16 +590,21 @@ pub async fn start_compute_node(
         .get_program()
         .to_string_lossy()
         .into_owned();
-    eprintln!(
-        "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={} cancellation_token_reset=true",
+    let session_start_line = format!(
+        "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={} log_file_path={} cancellation_token_reset=true",
         session_id,
         sanitize_relay_target(&request.relay_base_url),
         bridge_script,
         interpreter,
         selected_resource_root.display(),
         selected_layout,
-        import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into())
+        import_root.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "<unresolved>".into()),
+        log_file_path.as_deref().unwrap_or("unavailable")
     );
+    eprintln!("{session_start_line}");
+    if let Some(log) = session_log.as_ref() {
+        log.write_line(&session_start_line).await;
+    }
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
 
@@ -549,6 +629,8 @@ pub async fn start_compute_node(
                 *status = startup_failure_status(
                     &request,
                     format!("failed to start compute-node bridge: {err}"),
+                    Some(session_id.clone()),
+                    log_file_path.clone(),
                 );
                 *state.child.lock().await = None;
                 *state.stdin.lock().await = None;
@@ -581,11 +663,15 @@ pub async fn start_compute_node(
         {
             false
         } else {
-            eprintln!(
+            let spawned_line = format!(
                 "desktop.compute_node.bridge_process.spawned operator_session_id={} relay={}",
                 session_id,
                 sanitize_relay_target(&request.relay_base_url)
             );
+            eprintln!("{spawned_line}");
+            if let Some(log) = session_log.as_ref() {
+                log.write_line(&spawned_line).await;
+            }
             *child_slot = pending_child.take();
             let mut stdin_slot = state.stdin.lock().await;
             *stdin_slot = pending_stdin.take();
@@ -611,10 +697,27 @@ pub async fn start_compute_node(
                 operator_session_id: Some(session_id.clone()),
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),
+                log_file_path: log_file_path.clone(),
             };
             true
         }
     };
+
+    if installed
+        && matches!(
+            std::env::var("TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL").as_deref(),
+            Ok("1")
+        )
+    {
+        if let Some(path) = log_file_path.as_deref() {
+            let terminal_path = PathBuf::from(path);
+            tokio::task::spawn_blocking(move || {
+                if let Err(err) = open_terminal_tailing_log(&terminal_path) {
+                    eprintln!("desktop.compute_node.debug_terminal_open_failed error={err}");
+                }
+            });
+        }
+    }
 
     if !installed {
         if let Some(mut abandoned_stdin) = pending_stdin.take() {
@@ -629,8 +732,9 @@ pub async fn start_compute_node(
     }
 
     let log_policy = SubprocessLogPolicy::from_env();
+    let stderr_log = session_log.clone();
     let stderr_task = tokio::spawn(async move {
-        if let Err(err) = drain_compute_node_stderr(stderr, log_policy).await {
+        if let Err(err) = drain_compute_node_stderr(stderr, log_policy, stderr_log).await {
             eprintln!("desktop.compute_node.stderr_error error={err}");
         }
     });
@@ -639,6 +743,10 @@ pub async fn start_compute_node(
     let mut saw_error_event = false;
     let mut saw_startup_event = false;
     while let Some(line) = lines.next_line().await? {
+        if let Some(log) = session_log.as_ref() {
+            log.write_line(format!("desktop.compute_node.stdout line={line}"))
+                .await;
+        }
         match parse_compute_node_event_line(&line) {
             Ok(payload) => {
                 if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
@@ -658,16 +766,24 @@ pub async fn start_compute_node(
                 app.emit("compute_node_event", payload)?;
             }
             Err(err) => {
-                eprintln!(
+                let parse_error_line = format!(
                     "desktop.compute_node.stdout_parse_error error={} line={}",
                     err, line
                 );
+                eprintln!("{parse_error_line}");
+                if let Some(log) = session_log.as_ref() {
+                    log.write_line(&parse_error_line).await;
+                }
             }
         }
     }
 
     if let Err(err) = stderr_task.await {
-        eprintln!("desktop.compute_node.stderr_task_join_error error={err}");
+        let join_error_line = format!("desktop.compute_node.stderr_task_join_error error={err}");
+        eprintln!("{join_error_line}");
+        if let Some(log) = session_log.as_ref() {
+            log.write_line(&join_error_line).await;
+        }
     }
 
     let running_child = {
@@ -715,12 +831,50 @@ pub async fn start_compute_node(
     Ok(())
 }
 
+#[allow(dead_code)]
+async fn current_operator_log_path(state: &ComputeNodeState) -> anyhow::Result<PathBuf> {
+    if let Some(path) = state.current_log_path.lock().await.clone() {
+        return Ok(path);
+    }
+    if let Some(path) = state.status.lock().await.log_file_path.clone() {
+        return Ok(PathBuf::from(path));
+    }
+    anyhow::bail!("no operator debug log is available yet")
+}
+
+#[allow(dead_code)]
+pub async fn reveal_current_operator_log(state: ComputeNodeState) -> anyhow::Result<()> {
+    let path = current_operator_log_path(&state).await?;
+    tokio::task::spawn_blocking(move || reveal_log_file(&path)).await??;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn open_current_operator_debug_terminal(state: ComputeNodeState) -> anyhow::Result<()> {
+    let path = current_operator_log_path(&state).await?;
+    tokio::task::spawn_blocking(move || open_terminal_tailing_log(&path)).await??;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn read_current_operator_log_tail(state: ComputeNodeState) -> anyhow::Result<String> {
+    let path = current_operator_log_path(&state).await?;
+    read_log_tail(&path, 256 * 1024).await
+}
+
 pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
     let stop_session_id = state.status.lock().await.operator_session_id.clone();
-    eprintln!(
+    let stop_log_path = state.current_log_path.lock().await.clone();
+    let stop_line = format!(
         "desktop.compute_node.stop_requested operator_session_id={}",
         stop_session_id.as_deref().unwrap_or("unknown")
     );
+    eprintln!("{stop_line}");
+    if let Some(path) = stop_log_path.as_ref() {
+        if let Ok(session_log) = SessionLogFile::append_existing_or_create(path.clone()).await {
+            session_log.write_line(&stop_line).await;
+        }
+    }
     let mut stdin_handle = {
         let mut stdin_lock = state.stdin.lock().await;
         stdin_lock.take()
@@ -924,7 +1078,7 @@ mod tests {
         .expect("spawn stderr script");
 
         let stderr = child.stderr.take().expect("stderr");
-        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true })
+        drain_compute_node_stderr(stderr, SubprocessLogPolicy { verbose_raw: true }, None)
             .await
             .expect("drain stderr");
         let status = child.wait().await.expect("wait child");
@@ -1213,6 +1367,8 @@ mod tests {
         let status = startup_failure_status(
             &request,
             "no usable Python 3 interpreter found for desktop Python subprocess".into(),
+            Some("session-1".into()),
+            Some("/tmp/token.place/operators/compute-node-1.log".into()),
         );
 
         assert!(!status.running);
@@ -1223,6 +1379,11 @@ mod tests {
         );
         assert_eq!(status.active_relay_url, request.relay_base_url);
         assert_eq!(status.model_path, request.model_path);
+        assert_eq!(status.operator_session_id.as_deref(), Some("session-1"));
+        assert_eq!(
+            status.log_file_path.as_deref(),
+            Some("/tmp/token.place/operators/compute-node-1.log")
+        );
     }
 
     #[test]
@@ -1390,11 +1551,17 @@ mod tests {
         let status = startup_failure_status(
             &request,
             "unable to locate desktop Python bridge script 'compute_node_bridge.py'".into(),
+            Some("session-2".into()),
+            Some("/tmp/token.place/operators/compute-node-2.log".into()),
         );
 
         assert!(!status.running);
         assert!(!status.registered);
-        assert_eq!(status.operator_session_id, None);
+        assert_eq!(status.operator_session_id.as_deref(), Some("session-2"));
+        assert_eq!(
+            status.log_file_path.as_deref(),
+            Some("/tmp/token.place/operators/compute-node-2.log")
+        );
         assert_eq!(status.sequence, None);
         assert_eq!(status.relay_runtime_state.as_deref(), Some("failed"));
         assert_eq!(status.warm_load_state.as_deref(), Some("failed"));

--- a/desktop-tauri/src-tauri/src/debug_logs.rs
+++ b/desktop-tauri/src-tauri/src/debug_logs.rs
@@ -1,0 +1,206 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use tauri::Manager;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+#[derive(Clone)]
+pub struct SessionLogFile {
+    path: PathBuf,
+    file: Arc<Mutex<tokio::fs::File>>,
+}
+
+impl SessionLogFile {
+    pub async fn create_in_dir(log_dir: &Path, session_id: &str) -> anyhow::Result<Self> {
+        tokio::fs::create_dir_all(log_dir).await?;
+        let file_name = format!("compute-node-{}.log", sanitize_log_file_token(session_id));
+        let path = log_dir.join(file_name);
+        Self::append_existing_or_create(path).await
+    }
+
+    pub async fn append_existing_or_create(path: PathBuf) -> anyhow::Result<Self> {
+        let file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        Ok(Self {
+            path,
+            file: Arc::new(Mutex::new(file)),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn path_string(&self) -> String {
+        self.path.to_string_lossy().into_owned()
+    }
+
+    pub async fn write_line(&self, line: impl AsRef<str>) {
+        let mut file = self.file.lock().await;
+        let _ = file.write_all(line.as_ref().as_bytes()).await;
+        let _ = file.write_all(b"\n").await;
+        let _ = file.flush().await;
+    }
+}
+
+pub fn app_operator_log_dir(app: &tauri::AppHandle) -> anyhow::Result<PathBuf> {
+    let base = app
+        .path()
+        .app_log_dir()
+        .or_else(|_| app.path().app_data_dir().map(|dir| dir.join("logs")))
+        .map_err(|e| anyhow::anyhow!("log path error: {e}"))?;
+    Ok(base.join("operators"))
+}
+
+pub fn sanitize_log_file_token(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "unknown".into()
+    } else {
+        trimmed.chars().take(80).collect()
+    }
+}
+
+pub fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn macos_terminal_tail_script(log_path: &Path) -> String {
+    let quoted_path = shell_single_quote(&log_path.to_string_lossy());
+    let tail_command = format!(
+        "printf 'Tailing token.place operator log: %s\\n' {quoted_path}; tail -n 200 -F {quoted_path}"
+    );
+    format!(
+        "tell application \"Terminal\" to do script {}",
+        shell_single_quote(&tail_command)
+    )
+}
+
+pub fn open_terminal_tailing_log(log_path: &Path) -> anyhow::Result<()> {
+    if !log_path.is_file() {
+        anyhow::bail!("operator log file does not exist: {}", log_path.display());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let status = Command::new("osascript")
+            .arg("-e")
+            .arg(macos_terminal_tail_script(log_path))
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("osascript failed with status {status}");
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        reveal_log_file(log_path)
+    }
+}
+
+pub fn reveal_log_file(log_path: &Path) -> anyhow::Result<()> {
+    if !log_path.is_file() {
+        anyhow::bail!("operator log file does not exist: {}", log_path.display());
+    }
+
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = Command::new("open");
+        command.arg("-R").arg(log_path);
+        command
+    };
+
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = Command::new("explorer.exe");
+        command.arg(format!("/select,{}", log_path.display()));
+        command
+    };
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    let mut command = {
+        let parent = log_path.parent().unwrap_or_else(|| Path::new("."));
+        let mut command = Command::new("xdg-open");
+        command.arg(parent);
+        command
+    };
+
+    let status = command.status()?;
+    if !status.success() {
+        anyhow::bail!("open log command failed with status {status}");
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn read_log_tail(log_path: &Path, max_bytes: u64) -> anyhow::Result<String> {
+    if !log_path.is_file() {
+        anyhow::bail!("operator log file does not exist: {}", log_path.display());
+    }
+    let metadata = tokio::fs::metadata(log_path).await?;
+    let start = metadata.len().saturating_sub(max_bytes);
+    let mut file = tokio::fs::File::open(log_path).await?;
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    file.seek(std::io::SeekFrom::Start(start)).await?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).await?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn session_log_file_creates_path_under_log_dir() {
+        let temp = TempDir::new().expect("tempdir");
+        let log_dir = temp.path().join("Token Place Logs").join("operators");
+        let log = SessionLogFile::create_in_dir(&log_dir, "session 1/../secret")
+            .await
+            .expect("create log");
+        log.write_line("desktop.compute_node.stderr line=bridge-failure")
+            .await;
+
+        assert!(log.path().is_file());
+        assert!(log.path().starts_with(&log_dir));
+        assert!(log.path_string().contains("session-1"));
+        assert!(log.path_string().contains("secret"));
+        assert!(!log
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains('/'));
+        let contents = tokio::fs::read_to_string(log.path())
+            .await
+            .expect("read log");
+        assert!(contents.contains("bridge-failure"));
+    }
+
+    #[test]
+    fn macos_tail_script_shell_quotes_paths_with_spaces_and_quotes() {
+        let path = Path::new("/Users/example/Library/Logs/Token Place/operators/compute 'one'.log");
+        let script = macos_terminal_tail_script(path);
+
+        assert!(script.contains("Terminal"));
+        assert!(script.contains("Token Place"));
+        assert!(script.contains("'\\''one'\\''"));
+        assert!(!script.contains("; rm -rf"));
+    }
+}

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod compute_node;
 mod config;
+mod debug_logs;
 pub mod forward;
 pub mod keygen;
 mod logging;
@@ -14,6 +15,7 @@ use config::{config_path, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use sidecar::{InferenceRequest, SidecarState};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
@@ -102,7 +104,26 @@ fn configure_runtime_pythonpath(
     )
 }
 
-fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
+fn append_model_bridge_log(app: Option<&tauri::AppHandle>, line: &str) {
+    if let Some(app) = app {
+        if let Ok(log_dir) = debug_logs::app_operator_log_dir(app) {
+            if fs::create_dir_all(&log_dir).is_ok() {
+                if let Ok(mut file) = fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(log_dir.join("model-bridge.log"))
+                {
+                    let _ = writeln!(file, "{line}");
+                }
+            }
+        }
+    }
+}
+
+fn run_model_bridge(
+    action: &str,
+    app: Option<&tauri::AppHandle>,
+) -> Result<ModelArtifactInfo, String> {
     let launcher = python_runtime::resolve_python_launcher("TOKEN_PLACE_PYTHON")
         .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path(Some(&launcher.program))?;
@@ -117,7 +138,7 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
         manifest_dir,
         None,
     );
-    eprintln!(
+    let model_start_line = format!(
         "desktop.model_bridge.start action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
         action,
         bridge_script.display(),
@@ -129,6 +150,8 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
             .map(|path| path.display().to_string())
             .unwrap_or_else(|| "<unresolved>".into())
     );
+    eprintln!("{model_start_line}");
+    append_model_bridge_log(app, &model_start_line);
     let output = bridge_command
         .arg(action)
         .output()
@@ -136,6 +159,12 @@ fn run_model_bridge(action: &str) -> Result<ModelArtifactInfo, String> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        append_model_bridge_log(app, &format!("desktop.model_bridge.stdout line={line}"));
+    }
+    for line in stderr.lines().filter(|line| !line.trim().is_empty()) {
+        append_model_bridge_log(app, &format!("desktop.model_bridge.stderr line={line}"));
+    }
     let json_line = stdout
         .lines()
         .rev()
@@ -286,12 +315,16 @@ async fn start_compute_node(
             compute_node::start_compute_node(app.clone(), compute_state.clone(), request).await
         {
             eprintln!("desktop.compute_node.start_failure error={}", err);
-            {
+            let (operator_session_id, log_file_path) = {
                 let mut status = compute_state.status.lock().await;
                 status.running = false;
                 status.registered = false;
                 status.last_error = Some(err.to_string());
-            }
+                (
+                    status.operator_session_id.clone(),
+                    status.log_file_path.clone(),
+                )
+            };
             let _ = app.emit(
                 "compute_node_event",
                 serde_json::json!({
@@ -300,6 +333,8 @@ async fn start_compute_node(
                     "registered": false,
                     "last_error": err.to_string(),
                     "message": err.to_string(),
+                    "operator_session_id": operator_session_id,
+                    "log_file_path": log_file_path,
                 }),
             );
         }
@@ -321,14 +356,38 @@ async fn get_compute_node_status(
     Ok(state.compute_node.status.lock().await.clone())
 }
 
+#[allow(dead_code)]
 #[tauri::command]
-fn inspect_model_artifact() -> Result<ModelArtifactInfo, String> {
-    run_model_bridge("inspect")
+async fn reveal_operator_debug_log(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    compute_node::reveal_current_operator_log(state.compute_node.clone())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[allow(dead_code)]
+#[tauri::command]
+async fn open_operator_debug_terminal(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    compute_node::open_current_operator_debug_terminal(state.compute_node.clone())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[allow(dead_code)]
+#[tauri::command]
+async fn read_operator_debug_log_tail(state: tauri::State<'_, AppState>) -> Result<String, String> {
+    compute_node::read_current_operator_log_tail(state.compute_node.clone())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-async fn download_model_artifact() -> Result<ModelArtifactInfo, String> {
-    tokio::task::spawn_blocking(|| run_model_bridge("download"))
+fn inspect_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    run_model_bridge("inspect", Some(&app))
+}
+
+#[tauri::command]
+async fn download_model_artifact(app: tauri::AppHandle) -> Result<ModelArtifactInfo, String> {
+    tokio::task::spawn_blocking(move || run_model_bridge("download", Some(&app)))
         .await
         .map_err(|e| format!("download bridge task failed: {e}"))?
 }
@@ -347,6 +406,9 @@ pub fn run() {
             start_compute_node,
             stop_compute_node,
             get_compute_node_status,
+            reveal_operator_debug_log,
+            open_operator_debug_terminal,
+            read_operator_debug_log_tail,
             encrypt_and_forward,
             inspect_model_artifact,
             download_model_artifact

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1118,6 +1118,82 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
   });
 
+  it('shows operator debug log controls and opens the in-app log tail after an error', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      relay_runtime_state: 'failed',
+      active_relay_url: 'https://token.place',
+      last_error: 'metal install failed',
+      log_file_path: '/Users/example/Library/Logs/token.place/operators/compute-node-1.log',
+    });
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'read_operator_debug_log_tail') {
+        return Promise.resolve('desktop.compute_node.stderr line=Metal runtime install failed');
+      }
+      if (command === 'detect_backend') {
+        return Promise.resolve({
+          platform_label: 'macos',
+          preferred_mode: 'auto',
+          available_backend: 'metal',
+          availability_label: 'Metal-capable platform (Apple Silicon)',
+        });
+      }
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          preferred_mode: 'auto',
+        });
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: false,
+          registered: false,
+          active_relay_url: 'https://token.place',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'metal',
+          backend_selected: 'metal',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '/tmp/model.gguf',
+          last_error: 'metal install failed',
+          relay_runtime_state: 'failed',
+          log_file_path: '/Users/example/Library/Logs/token.place/operators/compute-node-1.log',
+        });
+      }
+      if (command === 'inspect_model_artifact') {
+        return Promise.resolve({
+          canonical_family_url: 'https://example.test/models',
+          filename: 'model.gguf',
+          url: 'https://example.test/model.gguf',
+          models_dir: '/tmp',
+          resolved_model_path: '/tmp/model.gguf',
+          exists: true,
+          size_bytes: 1,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(<App />);
+    const openDebugLog = (await screen.findByText('Open debug log')) as HTMLButtonElement;
+    await waitFor(() => expect(openDebugLog.disabled).toBe(false));
+    expect(screen.getByText(/Debug log:/).textContent).toContain('compute-node-1.log');
+    expect(screen.getByText('Reveal log file')).toBeTruthy();
+    expect(screen.getByText('Open debug terminal')).toBeTruthy();
+
+    fireEvent.click(openDebugLog);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Operator debug log').textContent).toContain(
+        'Metal runtime install failed'
+      )
+    );
+    expect(invokeMock.mock.calls.some(([command]) => command === 'read_operator_debug_log_tail')).toBe(true);
+  });
+
   it('surfaces fresh restart errors from a new operator session', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -40,6 +40,7 @@ interface ComputeNodeStatus {
   operator_session_id: string | null;
   sequence: number | null;
   updated_at_ms: number | null;
+  log_file_path: string | null;
 }
 
 interface ModelArtifactInfo {
@@ -81,6 +82,7 @@ const defaultComputeStatus: ComputeNodeStatus = {
   operator_session_id: null,
   sequence: null,
   updated_at_ms: null,
+  log_file_path: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -189,6 +191,8 @@ function mergeComputeStatusEvent(
     sequence: payloadSequence ?? prev.sequence,
     updated_at_ms:
       typeof payload.updated_at_ms === 'number' ? payload.updated_at_ms : prev.updated_at_ms,
+    log_file_path:
+      typeof payload.log_file_path === 'string' ? payload.log_file_path : prev.log_file_path,
     last_error:
       payload.last_error === null
         ? null
@@ -227,6 +231,8 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const [operatorLogTail, setOperatorLogTail] = useState('');
+  const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false);
   const relayRuntimeState = computeStatus.relay_runtime_state || computeStatus.warm_load_state || 'idle';
   const relayRuntimeReady =
     computeStatus.warm_load_enabled === false ||
@@ -437,6 +443,7 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        log_file_path: computeStatusRef.current.log_file_path,
       };
       computeStatusRef.current = optimisticStatus;
       setComputeStatus(optimisticStatus);
@@ -466,6 +473,43 @@ export function App() {
   const stopComputeNode = async () => {
     try {
       await invoke('stop_compute_node');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const revealOperatorDebugLog = async () => {
+    try {
+      await invoke('reveal_operator_debug_log');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const openOperatorDebugTerminal = async () => {
+    try {
+      await invoke('open_operator_debug_terminal');
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const refreshOperatorDebugLog = async () => {
+    try {
+      const tail = await invoke<string>('read_operator_debug_log_tail');
+      setOperatorLogTail(tail);
+      setIsDebugConsoleOpen(true);
+    } catch (e) {
+      setError(formatErrorMessage(e));
+    }
+  };
+
+  const copyOperatorDebugLog = async () => {
+    try {
+      const tail = operatorLogTail || (await invoke<string>('read_operator_debug_log_tail'));
+      setOperatorLogTail(tail);
+      setIsDebugConsoleOpen(true);
+      await navigator.clipboard.writeText(tail);
     } catch (e) {
       setError(formatErrorMessage(e));
     }
@@ -573,6 +617,36 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Backend used: <code>{displayStatusValue(computeStatus.backend_used, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Fallback reason: <code>{computeStatus.fallback_reason || 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Model path: <code>{computeStatus.model_path || config.model_path || 'not set'}</code></p>
+        <p style={{ marginBottom: 0 }}>Debug log: <code>{computeStatus.log_file_path || 'not created yet'}</code></p>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 10 }}>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={refreshOperatorDebugLog}>
+            Open debug log
+          </button>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={revealOperatorDebugLog}>
+            Reveal log file
+          </button>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={openOperatorDebugTerminal}>
+            Open debug terminal
+          </button>
+          <button type="button" disabled={!computeStatus.log_file_path} onClick={copyOperatorDebugLog}>
+            Copy log tail
+          </button>
+        </div>
+        <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
+          macOS packaged builds keep Terminal hidden unless you click Open debug terminal or set
+          <code> TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1</code> before launch.
+        </p>
+        {isDebugConsoleOpen && (
+          <section aria-label="Operator debug log" style={{ marginTop: 10 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+              <strong>Operator debug log tail</strong>
+              <button type="button" onClick={refreshOperatorDebugLog}>Refresh</button>
+            </div>
+            <pre style={{ whiteSpace: 'pre-wrap', maxHeight: 280, overflow: 'auto', padding: 12, border: '1px solid #ddd' }}>
+              {operatorLogTail || 'No log lines loaded yet.'}
+            </pre>
+          </section>
+        )}
         <p style={{ marginBottom: 0 }}>Last error: <code>{computeStatus.last_error || 'none'}</code></p>
       </section>
 

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -28,6 +28,33 @@ The architectural source of truth is [Desktop operator parity contract](architec
 
 Do not make production two-node or round-robin claims until both Windows and macOS release candidates pass this checklist, including GPU-capable runtime evidence for the platform-specific release artifacts.
 
+
+## macOS packaged operator debug logs
+
+Packaged desktop launches persist operator diagnostics so macOS users do not need a developer terminal to capture the same bridge/runtime detail that Windows console launches expose.
+
+- Compute-node operator sessions write one log per session under the app log directory, in the `operators/` subdirectory. On macOS this is typically `~/Library/Logs/<bundle identifier>/operators/compute-node-<operator_session_id>.log`; use the exact **Debug log** path shown in the desktop UI because the bundle identifier can vary between preview/dev/release builds.
+- Model bridge inspect/download diagnostics are appended to `model-bridge.log` in the same `operators/` log directory.
+- The compute-node log mirrors safe bridge diagnostics: session start, selected bridge path, interpreter, resource root, import root/layout, `desktop_runtime_setup` probe/provision lines, compute-node stdout events, stderr from `compute_node_bridge.py`, runtime warm-load/model-manager lines, registration/poll/request/response metadata, and stop/cancel/unregister/cleanup lines.
+- Logs must remain relay-blind: capture ciphertext/routing metadata and runtime diagnostics only; do not add plaintext prompt/response/tool/model-output logging.
+
+Debug access is opt-in:
+
+1. Start the operator, or reproduce a Start operator failure.
+2. In the desktop **Compute node operator** panel, copy the **Debug log** path or use one of the debug buttons:
+   - **Open debug log** opens the in-app read-only tail that can be refreshed.
+   - **Reveal log file** opens Finder/Explorer/file manager at the current log file.
+   - **Open debug terminal** opens Terminal.app on macOS and tails the current log file; paths with spaces are quoted by the Rust command path and are not executed from user input.
+   - **Copy log tail** copies the in-app tail to the clipboard.
+3. For validation sessions where a terminal should open automatically after the operator process is installed, launch the app with `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1`.
+
+When Start operator fails on macOS, include these lines in the bug report or release-validation note:
+
+- `desktop.compute_node.session.start ... interpreter=... resource_root=... layout=... import_root=... log_file_path=...`
+- `desktop.runtime_setup ... action=... interpreter=... prefix=... llama_module_path=... fallback_reason=...`
+- Any `desktop.compute_node.stderr line=...` traceback/import/provisioning lines around `llama_cpp` or Metal.
+- `desktop.compute_node_bridge.model_init.*`, `desktop.compute_node_bridge.registration.*`, and `desktop.compute_node_bridge.stop_requested` / unregister / cleanup lines if the bridge gets that far.
+
 ## Expected desktop UI fields by lifecycle state
 
 | Lifecycle state | Button/operator state | Relay/runtime status fields | Backend fields | Error fields |


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop builds hid compute-node bridge stdout/stderr and runtime-provision diagnostics behind the UI `last_error` field, making bootstrap failures (e.g., Metal/llama_cpp import failures) hard to diagnose. 
- Provide a safe, opt-in, cross-platform debug path that preserves relay-blind invariants while surfacing the same session-level diagnostics Windows’ console builds already expose.

### Description
- Persist per-session operator logs under the app log directory (`operators/compute-node-<session>.log`) and add `log_file_path` to `ComputeNodeStatus` so status/events carry the file path.
- New Rust helper module `debug_logs.rs` to create/append/read session logs, sanitize tokens, and generate a quoted macOS `osascript` Terminal tail command (handles spaces/quotes safely). 
- Compute-node changes mirror key lines into the session file: session start, bridge spawn, stdout/parsed events, stderr lines (filtered for noise), parse/join/stop diagnostics, and optional auto-open of the macOS tail terminal when `TOKEN_PLACE_DESKTOP_OPEN_DEBUG_TERMINAL=1` is set.
- Add Tauri commands to reveal the log file, open a debug terminal tail, and read a tail for the in-app readonly debug console; model-bridge invocations also append stdout/stderr into `model-bridge.log` under the same directory.
- UI additions: show `Debug log` path in the Compute node panel and buttons for `Open debug log` (in-app tail), `Reveal log file`, `Open debug terminal`, and `Copy log tail`; these are disabled until a log exists and are opt-in so Terminal won’t pop on normal users.
- Tests and docs: unit tests for log-path sanitization and macOS quoting, a UI test that the debug controls render and load the tail after an operator error, and docs updated with macOS debug-log location and capture guidance.

### Testing
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` — succeeded (71 passed; 0 failed). 
- `npm --prefix desktop-tauri test` — succeeded (Vitest suite passed); note `--runInBand` is not a Vitest option so the direct `--runInBand` invocation was omitted and the package test ran with `npm --prefix desktop-tauri test`.
- `python desktop-tauri/scripts/test_packaged_operator_e2e.py` — succeeded (packaged resource/isolation probes completed locally).
- `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py` — succeeded (desktop relay parity checks ran locally).
- `python desktop-tauri/scripts/run_desktop_parity_checks.py` — succeeded (full parity checks executed).
- `pre-commit run --all-files` — succeeded (pre-commit hooks passed).

All automated tests listed above completed successfully in the verification runs; added unit and UI tests exercise log file creation, macOS path quoting, and the in-app debug-log affordance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2347e31fd4832f8a916d478b68edda)