### PR TITLE
Fix macOS packaged Start operator runtime provisioning (Metal): install into app-managed target, improved diagnostics, and safe CPU fallback

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -46,13 +46,13 @@ During normal startup, desktop sidecars probe the active sidecar interpreter and
 
 Set `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1` to explicitly disable runtime bootstrap and keep startup in probe-only mode (useful for packaging/troubleshooting while preserving fallback diagnostics).
 
-When GPU runtime repair is needed, desktop uses the same interpreter binary that launches the sidecar process (`sys.executable`) and applies the repo-pinned `llama-cpp-python` source-build recipe with the platform flag:
+When GPU runtime repair is needed, desktop uses the same interpreter binary that launches the sidecar process (`sys.executable`) and applies the repo-pinned `llama-cpp-python` source-build recipe with the platform flag. Packaged macOS builds install into a writable app-managed dependency target (`.app/Contents/Resources/.token_place_desktop_site`, falling back to `~/.token_place_desktop_site`) instead of trying to write into protected CLT/system Python prefixes.
 
 - Windows CUDA: `CMAKE_ARGS=-DGGML_CUDA=on`
 - macOS Metal: `CMAKE_ARGS=-DGGML_METAL=on`
-- Both: `FORCE_CMAKE=1` and `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose`
+- Both: `FORCE_CMAKE=1` and `pip install --target <desktop-dependency-target> llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose` where applicable
 
-After a successful repair, the sidecar automatically re-execs once so the active process immediately uses the repaired runtime (no manual restart/environment flag required).
+After a successful GPU repair, the sidecar automatically re-execs once so the active process immediately uses the repaired runtime (no manual restart/environment flag required). In `auto`/`hybrid`, macOS may explicitly fall back to an importable CPU `llama-cpp-python` runtime if Metal provisioning fails; explicit `gpu` mode keeps Metal failure fatal. Debug logs include interpreter, Python version, prefix/base prefix, dependency target, pip version, install command/CMake flags, output tails, selected backend, fallback reason, and `llama_module_path`.
 
 ### Platform runtime expectations
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -9,6 +9,8 @@ import platform as platform_module
 import subprocess
 import sys
 import time
+
+_REAL_SYS = sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
@@ -233,6 +235,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH", "")
     pythonpath_entries = [str(python_root), str(repo_root)]
+    for dependency_target in _existing_desktop_dependency_targets(repo_root):
+        pythonpath_entries.insert(0, str(dependency_target))
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
@@ -309,6 +313,17 @@ def _probe_runtime(runtime_root: Path) -> RuntimeProbe:
         raise
 
 
+def _command_summary(cmd: list[str]) -> str:
+    return " ".join(str(part) for part in cmd)
+
+
+def _tail_lines(text: str, *, max_lines: int = 40) -> str:
+    lines = (text or "").strip().splitlines()
+    if not lines:
+        return ""
+    return "\n".join(lines[-max_lines:])
+
+
 def _run_pip_install(
     cmd: list[str],
     env: dict[str, str],
@@ -325,12 +340,23 @@ def _run_pip_install(
             timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
-        return False, f"pip install timed out after {timeout_seconds}s"
+        return False, (
+            f"command={_command_summary(cmd)} timed out after {timeout_seconds}s; "
+            f"CMAKE_ARGS={env.get('CMAKE_ARGS', '')}; FORCE_CMAKE={env.get('FORCE_CMAKE', '')}"
+        )
 
+    combined = "\n".join(
+        part for part in [(install.stdout or "").strip(), (install.stderr or "").strip()] if part
+    )
+    detail = (
+        f"command={_command_summary(cmd)}; returncode={install.returncode}; "
+        f"CMAKE_ARGS={env.get('CMAKE_ARGS', '')}; FORCE_CMAKE={env.get('FORCE_CMAKE', '')}; "
+        f"output_tail={_tail_lines(combined)}"
+    )
     if install.returncode == 0:
-        return True, (install.stdout or "").strip()
+        return True, detail
 
-    return False, (install.stderr or install.stdout or "").strip()
+    return False, detail
 
 
 def _source_build_repair(requirements_path: Path, backend: str) -> tuple[bool, str]:
@@ -618,6 +644,57 @@ def _resolve_requirements_path(target_root: Path) -> Path:
     return candidates[0]
 
 
+def _existing_desktop_dependency_targets(runtime_root: Path) -> list[Path]:
+    candidates = [
+        _desktop_dependency_target(runtime_root),
+        Path.home() / ".token_place_desktop_site",
+    ]
+    existing: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        key = os.path.normcase(str(resolved)).casefold()
+        if key in seen or not resolved.is_dir():
+            continue
+        seen.add(key)
+        existing.append(resolved)
+    return existing
+
+
+def _python_runtime_diagnostics(dependency_target: Optional[Path] = None) -> Dict[str, str]:
+    diagnostics = {
+        "interpreter": sys.executable,
+        "python_version": _REAL_SYS.version.replace("\n", " "),
+        "prefix": sys.prefix,
+        "base_prefix": getattr(sys, "base_prefix", sys.prefix),
+        "dependency_target": str(dependency_target) if dependency_target else "",
+    }
+    try:
+        pip = subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        diagnostics["pip_version"] = (pip.stdout or pip.stderr or "").strip()
+        diagnostics["pip_returncode"] = str(pip.returncode)
+    except Exception as exc:
+        diagnostics["pip_version"] = "unavailable"
+        diagnostics["pip_returncode"] = "error"
+        diagnostics["pip_error"] = str(exc)
+    return diagnostics
+
+
+def _install_target_args(target_dir: Optional[Path]) -> list[str]:
+    if target_dir is None:
+        return []
+    return ["--target", str(target_dir)]
+
+
 def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
@@ -704,7 +781,25 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         }
 
     requirements_path = _resolve_requirements_path(target_root)
+    dependency_target, dependency_target_error = _resolve_desktop_dependency_target(target_root)
+    runtime_diagnostics = _python_runtime_diagnostics(dependency_target)
+    if dependency_target is not None:
+        dependency_target_str = str(dependency_target)
+        if dependency_target_str not in _REAL_SYS.path:
+            _REAL_SYS.path.insert(0, dependency_target_str)
+        os.environ["TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET"] = dependency_target_str
     last_error = ""
+
+    if dependency_target is None:
+        last_error = (
+            "desktop runtime dependency target unavailable; "
+            f"detail={dependency_target_error or 'no writable target'}; "
+            f"interpreter={runtime_diagnostics['interpreter']}; "
+            f"python_version={runtime_diagnostics['python_version']}; "
+            f"prefix={runtime_diagnostics['prefix']}; "
+            f"base_prefix={runtime_diagnostics['base_prefix']}; "
+            f"pip={runtime_diagnostics.get('pip_version', 'unavailable')}"
+        )
 
     if expected_backend == "cuda":
         should_repair, repair_skip_reason = _should_attempt_source_repair()
@@ -747,12 +842,18 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             continue
         env = os.environ.copy()
         env.update(plan.pip_env())
+        if dependency_target is not None:
+            existing_pythonpath = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = os.pathsep.join(
+                part for part in [str(dependency_target), existing_pythonpath] if part
+            )
         cmd = [
             sys.executable,
             "-m",
             "pip",
             "install",
             "--force-reinstall",
+            *_install_target_args(dependency_target),
             *plan.pip_install_args(),
             plan.package_spec,
         ]
@@ -804,17 +905,22 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                 f"backend={after.backend} gpu_offload_supported={after.gpu_offload_supported}"
             )
             if plan.backend == "metal":
-                return {
-                    "selected_backend": "cpu",
-                    "fallback_reason": (
-                        f"Metal runtime install completed but follow-up probe did not report "
-                        f"Metal GPU offload; backend={after.backend} "
-                        f"gpu_offload_supported={after.gpu_offload_supported}; "
-                        f"llama_module_path={after.llama_module_path}"
-                    ),
-                    "runtime_action": _install_failure_action(expected_backend),
-                    **_probe_result_payload(after),
-                }
+                last_error = (
+                    f"Metal runtime install completed but follow-up probe did not report "
+                    f"Metal GPU offload; backend={after.backend} "
+                    f"gpu_offload_supported={after.gpu_offload_supported}; "
+                    f"llama_module_path={after.llama_module_path}; "
+                    f"dependency_target={dependency_target or 'unavailable'}; "
+                    f"pip={runtime_diagnostics.get('pip_version', 'unavailable')}"
+                )
+                if selected_mode == "gpu":
+                    return {
+                        "selected_backend": "cpu",
+                        "fallback_reason": last_error,
+                        "runtime_action": _install_failure_action(expected_backend),
+                        **_probe_result_payload(after),
+                    }
+                continue
 
         if plan.backend == "cpu":
             reason = (
@@ -828,11 +934,15 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                 **_probe_result_payload(after),
             }
 
-    reason = before.error or last_error or "unable to install a GPU-capable runtime"
+    reason = last_error or before.error or "unable to install a GPU-capable runtime"
     if expected_backend == "metal":
         reason = (
             f"Metal runtime install failed ({reason}); interpreter={before.interpreter}; "
-            f"prefix={before.prefix}; llama_module_path={before.llama_module_path}"
+            f"python_version={runtime_diagnostics.get('python_version', _REAL_SYS.version).replace(chr(10), ' ')}; "
+            f"prefix={before.prefix}; base_prefix={runtime_diagnostics.get('base_prefix', '')}; "
+            f"dependency_target={runtime_diagnostics.get('dependency_target', '') or 'unavailable'}; "
+            f"pip={runtime_diagnostics.get('pip_version', 'unavailable')}; "
+            f"llama_module_path={before.llama_module_path}"
         )
     return {
         "selected_backend": "cpu",

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -202,6 +202,12 @@ def ensure_runtime_import_paths(
     script_dir = os.path.dirname(script_path)
     script_root = _parent(script_dir)
     explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    explicit_dependency_target = os.environ.get("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", "").strip()
+    dependency_candidates = [
+        _safe_resolve_path_text(explicit_dependency_target) if explicit_dependency_target else None,
+        _join(script_root, ".token_place_desktop_site"),
+        _join(os.path.expanduser("~"), ".token_place_desktop_site"),
+    ]
     candidates = [
         _safe_resolve_path_text(explicit_import_root) if explicit_import_root else None,
         script_root,  # bundled resources root in packaged apps
@@ -217,6 +223,14 @@ def ensure_runtime_import_paths(
         _parent(script_dir, 3),  # repo root in development tree
     ]
 
+    valid_dependency_targets: list[str] = []
+    for candidate in dependency_candidates:
+        if candidate is None or not _is_dir(candidate):
+            continue
+        candidate_str = _safe_resolve_path_text(candidate)
+        if candidate_str not in valid_dependency_targets:
+            valid_dependency_targets.append(candidate_str)
+
     valid_candidates: list[str] = []
     for candidate in candidates:
         if candidate is None or not _path_exists(candidate):
@@ -229,7 +243,7 @@ def ensure_runtime_import_paths(
             if candidate_str not in valid_candidates:
                 valid_candidates.append(candidate_str)
 
-    sys.path[:] = _ordered_sys_path_with_stdlib_first(valid_candidates)
+    sys.path[:] = _ordered_sys_path_with_stdlib_first(valid_dependency_targets + valid_candidates)
 
     if os.environ.get("PYTHONNOUSERSITE") == "1":
         user_site = getattr(site, "USER_SITE", None)

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -53,7 +53,9 @@ Do not make production two-node or round-robin claims until both Windows and mac
 
 - Apple Silicon Mac or another Mac that can run a Metal-capable llama.cpp backend.
 - Xcode Command Line Tools available for local source builds when a wheel is not sufficient.
-- Metal-enabled install/repair uses `CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, and the repo-pinned `llama-cpp-python` version.
+- Packaged `.app` launches may use the interpreter selected by macOS/Tauri (for example `/Library/Developer/CommandLineTools/usr/bin/python3`). The runtime bootstrap must never install into that protected prefix directly; it installs `llama-cpp-python` into a writable desktop dependency target such as `.app/Contents/Resources/.token_place_desktop_site`, or `~/.token_place_desktop_site` when the packaged resources directory is not writable.
+- Metal-enabled install/repair uses `CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, and the repo-pinned `llama-cpp-python` version. The debug log should include the interpreter, Python version, prefix/base prefix, dependency target, pip version, install command summary, CMake flags, pip/CMake output tail, and resulting `llama_module_path`.
+- In `auto` and `hybrid`, failed Metal provisioning may fall back to an importable CPU `llama-cpp-python` runtime and still register; `backend_selected=cpu`/`fallback_reason` must make the fallback explicit. In explicit `gpu` mode, Metal provisioning failure remains fatal and the operator must stay unregistered/idle so Start can be retried after prerequisites are fixed.
 - Validate the packaged `.app` path as well as the development path so `.app/Contents/Resources` uses the same bridge/runtime code as Windows packaged builds.
 
 ### Backend field meanings
@@ -102,10 +104,16 @@ python desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py --mode auto --mode
 
 ```bash
 # macOS shell on Metal-capable hardware.
+# First validate the same interpreter that packaged desktop will use. If it is
+# CLT Python and pip/build tooling is missing, install Xcode Command Line Tools
+# (`xcode-select --install`) or use the app-managed dependency target fallback.
+/Library/Developer/CommandLineTools/usr/bin/python3 -m pip --version || true
 CMAKE_ARGS=-DGGML_METAL=on FORCE_CMAKE=1 python -m pip install --force-reinstall --no-cache-dir llama-cpp-python
 python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto --model /path/to/model.gguf
 python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
 ```
+
+For packaged-app hardware validation, open the debug log/console added for packaged desktop launches, start the operator in `auto`, and confirm either `desktop.runtime_setup ... runtime_action=installed_metal_reexec` followed by `model_init.ready`/`server.registered`, or an explicit CPU fallback (`runtime_action=metal_cpu_fallback`, `backend_selected=cpu`) followed by registration. If the log mentions CLT Python without pip/build tooling, fix Xcode Command Line Tools or pip availability and press Start again; no reinstall should be required.
 
 ```bash
 # Explicit CPU fallback check on either platform.

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -417,6 +417,98 @@ def test_macos_metal_install_failure_is_fatal_for_gpu(monkeypatch):
     assert message and 'Metal' in message
 
 
+
+def test_macos_packaged_runtime_installs_llama_cpp_into_writable_target_with_spaces(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    runtime_root = tmp_path / 'Token Place.app' / 'Contents' / 'Resources'
+    runtime_root.mkdir(parents=True)
+    probes = iter([
+        _probe(backend='missing', gpu=False, device='none', error="No module named 'llama_cpp'"),
+        _probe(backend='metal', gpu=True, device='metal'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+        index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    captured = {}
+
+    def _install(cmd, env, **kwargs):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _install)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=runtime_root)
+
+    target = runtime_root / '.token_place_desktop_site'
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert '--target' in captured['cmd']
+    assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(target)
+    assert 'Token Place.app' in captured['cmd'][captured['cmd'].index('--target') + 1]
+    assert captured['env']['PYTHONPATH'].split(os.pathsep)[0] == str(target)
+
+
+def test_macos_clt_python_missing_llama_cpp_reports_actionable_diagnostics(monkeypatch, tmp_path):
+    class _CltPythonStub(_PlatformStub):
+        executable = '/Library/Developer/CommandLineTools/usr/bin/python3'
+        prefix = '/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9'
+        base_prefix = prefix
+
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _CltPythonStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    runtime_root = tmp_path / 'Token Place.app' / 'Contents' / 'Resources'
+    runtime_root.mkdir(parents=True)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: desktop_runtime_setup.RuntimeProbe(
+            backend='missing',
+            gpu_offload_supported=False,
+            detected_device='none',
+            interpreter=_CltPythonStub.executable,
+            prefix=_CltPythonStub.prefix,
+            llama_module_path='missing',
+            error="No module named 'llama_cpp'",
+        ),
+    )
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin', backend='metal', package_spec='llama-cpp-python',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+        index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_python_runtime_diagnostics',
+        lambda dependency_target=None: {
+            'interpreter': _CltPythonStub.executable,
+            'python_version': '3.9.6 (CLT)',
+            'prefix': _CltPythonStub.prefix,
+            'base_prefix': _CltPythonStub.base_prefix,
+            'dependency_target': str(dependency_target or ''),
+            'pip_version': 'pip unavailable: No module named pip',
+        },
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (False, 'clang: error: Metal toolchain missing'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=runtime_root)
+
+    assert result['runtime_action'] == 'metal_install_failed'
+    assert '/Library/Developer/CommandLineTools/usr/bin/python3' in result['fallback_reason']
+    assert 'python_version=3.9.6 (CLT)' in result['fallback_reason']
+    assert 'dependency_target=' in result['fallback_reason']
+    assert 'pip=pip unavailable' in result['fallback_reason']
+    assert 'llama_module_path=missing' in result['fallback_reason']
+
 def test_runtime_root_prefers_token_place_python_import_root(monkeypatch, tmp_path):
     runtime_root = tmp_path / 'resources'
     (runtime_root / 'utils').mkdir(parents=True)
@@ -426,6 +518,98 @@ def test_runtime_root_prefers_token_place_python_import_root(monkeypatch, tmp_pa
 
     assert resolved == runtime_root.resolve()
 
+
+
+def test_macos_packaged_runtime_installs_llama_cpp_into_writable_target_with_spaces(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    runtime_root = tmp_path / 'Token Place.app' / 'Contents' / 'Resources'
+    runtime_root.mkdir(parents=True)
+    probes = iter([
+        _probe(backend='missing', gpu=False, device='none', error="No module named 'llama_cpp'"),
+        _probe(backend='metal', gpu=True, device='metal'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+        index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    captured = {}
+
+    def _install(cmd, env, **kwargs):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _install)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=runtime_root)
+
+    target = runtime_root / '.token_place_desktop_site'
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert '--target' in captured['cmd']
+    assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(target)
+    assert 'Token Place.app' in captured['cmd'][captured['cmd'].index('--target') + 1]
+    assert captured['env']['PYTHONPATH'].split(os.pathsep)[0] == str(target)
+
+
+def test_macos_clt_python_missing_llama_cpp_reports_actionable_diagnostics(monkeypatch, tmp_path):
+    class _CltPythonStub(_PlatformStub):
+        executable = '/Library/Developer/CommandLineTools/usr/bin/python3'
+        prefix = '/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9'
+        base_prefix = prefix
+
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _CltPythonStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    runtime_root = tmp_path / 'Token Place.app' / 'Contents' / 'Resources'
+    runtime_root.mkdir(parents=True)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: desktop_runtime_setup.RuntimeProbe(
+            backend='missing',
+            gpu_offload_supported=False,
+            detected_device='none',
+            interpreter=_CltPythonStub.executable,
+            prefix=_CltPythonStub.prefix,
+            llama_module_path='missing',
+            error="No module named 'llama_cpp'",
+        ),
+    )
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin', backend='metal', package_spec='llama-cpp-python',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+        index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_python_runtime_diagnostics',
+        lambda dependency_target=None: {
+            'interpreter': _CltPythonStub.executable,
+            'python_version': '3.9.6 (CLT)',
+            'prefix': _CltPythonStub.prefix,
+            'base_prefix': _CltPythonStub.base_prefix,
+            'dependency_target': str(dependency_target or ''),
+            'pip_version': 'pip unavailable: No module named pip',
+        },
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (False, 'clang: error: Metal toolchain missing'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=runtime_root)
+
+    assert result['runtime_action'] == 'metal_install_failed'
+    assert '/Library/Developer/CommandLineTools/usr/bin/python3' in result['fallback_reason']
+    assert 'python_version=3.9.6 (CLT)' in result['fallback_reason']
+    assert 'dependency_target=' in result['fallback_reason']
+    assert 'pip=pip unavailable' in result['fallback_reason']
+    assert 'llama_module_path=missing' in result['fallback_reason']
 
 def test_runtime_root_prefers_token_place_python_import_root_with_config_py(monkeypatch, tmp_path):
     runtime_root = tmp_path / 'token-place-root'
@@ -990,10 +1174,9 @@ def test_probe_subprocess_sanitizes_repo_root_before_llama_import(monkeypatch):
     assert 'utils.llm.model_manager' not in desktop_runtime_setup._PROBE_SNIPPET
     assert 'importlib.import_module("llama_cpp")' in desktop_runtime_setup._PROBE_SNIPPET
     assert captured['cmd'][:2] == [sys.executable, '-c']
-    assert captured['env']['PYTHONPATH'].split(desktop_runtime_setup.os.pathsep)[:2] == [
-        str(PYTHON_MODULE_DIR),
-        str(Path(__file__).resolve().parents[2]),
-    ]
+    pythonpath_entries = captured['env']['PYTHONPATH'].split(desktop_runtime_setup.os.pathsep)
+    assert str(PYTHON_MODULE_DIR) in pythonpath_entries[:3]
+    assert str(Path(__file__).resolve().parents[2]) in pythonpath_entries[:3]
     assert captured['env']['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'].endswith(
         'desktop_runtime_setup.py'
     )
@@ -1064,7 +1247,8 @@ def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _OkResult())
     ok, output = desktop_runtime_setup._run_pip_install(['python'], {})
     assert ok is True
-    assert output == 'ok output'
+    assert 'command=python' in output
+    assert 'output_tail=ok output' in output
 
     class _FailResult:
         returncode = 1
@@ -1074,7 +1258,8 @@ def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _FailResult())
     ok, output = desktop_runtime_setup._run_pip_install(['python'], {})
     assert ok is False
-    assert output == 'real stderr'
+    assert 'returncode=1' in output
+    assert 'real stderr' in output
 
     def _timeout(*_args, **_kwargs):
         raise desktop_runtime_setup.subprocess.TimeoutExpired(cmd='pip', timeout=12)
@@ -1082,7 +1267,8 @@ def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _timeout)
     ok, output = desktop_runtime_setup._run_pip_install(['python'], {}, timeout_seconds=12)
     assert ok is False
-    assert output == 'pip install timed out after 12s'
+    assert 'timed out after 12s' in output
+    assert 'command=python' in output
 
 
 def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Packaged macOS Start operator could pick a protected CLT/system Python (e.g. `/Library/Developer/CommandLineTools/usr/bin/python3`), fail to import `llama_cpp`, and abort registration with an unhelpful UI error.  
- Make provisioning robust for packaged `.app` layouts by using a writable app-managed dependency target, surface actionable diagnostics, and choose safe fallback semantics for `auto`/`hybrid` versus `gpu` modes.

### Description
- Prefer and expose writable desktop dependency targets and propagate them into probe/install flows so packaged apps install into `.app/Contents/Resources/.token_place_desktop_site` or `~/.token_place_desktop_site` rather than protected interpreter prefixes.  
- Install `llama-cpp-python` using `pip --target <desktop-dependency-target>` when a writable target exists and ensure the target is on `PYTHONPATH` for follow-up probes.  
- Improve `pip`/CMake diagnostics by capturing a command summary, CMake flags, return code, and the tail of `stdout`/`stderr` to make install failures actionable.  
- Add runtime diagnostics helper that reports `interpreter`, `python_version`, `prefix`/`base_prefix`, `dependency_target`, and `pip` info and include these details in `fallback_reason`/error messages for Metal failures.  
- Adjust `auto`/`hybrid` semantics so macOS `auto` can fall back to a CPU `llama-cpp-python` if Metal provisioning fails but CPU install/import succeeds, while `gpu` remains fatal when Metal cannot be provisioned.  
- Propagate app-managed dependency targets into the probe subprocess `PYTHONPATH` so child probes see installed packages.  
- Update `path_bootstrap` to consider dependency targets first while preserving stdlib-first and repo-shim protections.  
- Add unit tests covering packaged `.app` layout with spaces, CLT Python diagnostic messaging, Metal install -> CPU fallback flows, and other runtime bootstrap cases; and update README/docs with macOS packaged guidance and validation steps.

### Testing
- Ran unit tests: `pytest tests/unit/test_desktop_runtime_setup.py` (passed), `pytest tests/unit/test_desktop_path_bootstrap.py` (passed), `pytest tests/unit/test_compute_node_runtime.py` and `pytest tests/unit/test_model_manager.py` (both passed), and `pytest tests/unit/test_desktop_compute_node_bridge.py -k "macos or metal or runtime or warm or register or fallback"` (selected tests passed).  
- Ran higher-level parity/e2e helpers: `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`, and `python desktop-tauri/scripts/run_desktop_parity_checks.py` (executed in this environment; checks exercised the packaged-layout and parity flows and returned normally).  
- Pre-commit checks: `pre-commit run --all-files` (passed).  
- Environment-limited build: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` could not complete in this container because the system `glib-2.0` pkg-config dependency (`glib-2.0.pc`) is missing (CI/packaging runners with native toolchain will be required to run the full Rust/Tauri suite).  

If you want any small follow-ups (change wording, split tests/docs into a separate PR, or tweak the failure message formatting), I can prepare them quickly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a234812d618832f8f3180db894bd7cb)