### PR TITLE
Fix macOS desktop llama runtime provisioning

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -180,3 +180,20 @@ It prints:
   Pass means desktop-side diagnostics and `compute_node_bridge.py` `started` events both report
   CUDA availability/usage with GPU offload and non-CPU KV cache. If the bridge exits before
   startup, errors will use the phrase `compute-node bridge exited before emitting a startup event`.
+
+### macOS packaged Metal runtime provisioning
+
+Packaged macOS operator startup may use Apple Command Line Tools Python (for
+example `/Library/Developer/CommandLineTools/usr/bin/python3`). The desktop
+runtime bootstrap treats that interpreter as an execution host only: it installs
+`llama-cpp-python` into a writable desktop dependency target, adds that target to
+`PYTHONPATH`, and verifies `import llama_cpp` from the same path before relay
+registration.
+
+The `desktop.runtime_setup` log line includes the selected interpreter, Python
+version, prefix/base_prefix, dependency target, pip availability, module path,
+install action, and fallback reason. Metal source builds set
+`CMAKE_ARGS="-DGGML_METAL=on -DGGML_NATIVE=off"` and `FORCE_CMAKE=1`. In `gpu`
+mode, Metal provisioning failure is fatal; in `auto`/`hybrid`, a successful CPU
+runtime install/import is reported as `metal_cpu_fallback` and can still reach
+`Registered: yes`.

--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -192,8 +192,20 @@ registration.
 
 The `desktop.runtime_setup` log line includes the selected interpreter, Python
 version, prefix/base_prefix, dependency target, pip availability, module path,
-install action, and fallback reason. Metal source builds set
+install action, fallback reason, and (when provisioning ran) the bounded pip
+command/stdout/stderr tails plus CMake flags. Status events expose the same
+runtime diagnostics, but `last_error` remains reserved for concise actionable
+startup/relay failures instead of verbose pip logs. Metal source builds set
 `CMAKE_ARGS="-DGGML_METAL=on -DGGML_NATIVE=off"` and `FORCE_CMAKE=1`. In `gpu`
-mode, Metal provisioning failure is fatal; in `auto`/`hybrid`, a successful CPU
-runtime install/import is reported as `metal_cpu_fallback` and can still reach
-`Registered: yes`.
+mode, Metal provisioning failure is fatal before relay registration; in
+`auto`/`hybrid`, a successful CPU runtime install/import is reported as
+`metal_cpu_fallback` and can still reach `Registered: yes`.
+
+To capture debug logs for a packaged app, launch the sidecar/bridge from a
+terminal or collect the packaged app stderr/stdout log and search for
+`desktop.runtime_setup`, `desktop.compute_node_bridge.model_init.*`, and
+`desktop.compute_node_bridge.registration.*`. If CLT Python lacks `pip` or build
+tooling, install/repair pip for that interpreter or install Xcode Command Line
+Tools, then rerun packaged startup; the app-managed dependency target remains
+under `.token_place_desktop_site` and should not require writing into the CLT
+Python prefix.

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -785,6 +785,116 @@ def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(
 
 
 
+def create_fake_metal_llama_cpp_site(tmp_root: Path, layout_label: str) -> Path:
+    fake_site = tmp_root / f"fake metal site-packages {layout_label.replace('/', '_')}"
+    fake_pkg = fake_site / "llama_cpp"
+    fake_pkg.mkdir(parents=True, exist_ok=True)
+    (fake_pkg / "__init__.py").write_text(
+        "GGML_USE_METAL = True\n"
+        "def llama_supports_gpu_offload():\n"
+        "    return True\n"
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.args = args\n"
+        "        self.kwargs = kwargs\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake metal ok'}}]}\n",
+        encoding="utf-8",
+    )
+    return fake_site
+
+
+def patch_packaged_runtime_setup_as_macos(resources_root: Path) -> None:
+    runtime_setup = resources_root / "python" / "desktop_runtime_setup.py"
+    runtime_setup.write_text(
+        runtime_setup.read_text(encoding="utf-8")
+        + "\n# Packaged e2e-only platform shim.\n"
+        + "_desktop_platform = lambda: 'darwin'\n"
+        + "_desktop_arch = lambda: 'arm64'\n",
+        encoding="utf-8",
+    )
+
+
+def run_macos_mock_metal_packaged_registration_probe(
+    tmp_root: Path,
+    bridge_script: Path,
+    *,
+    relay_port: int,
+    resources_root: Path,
+) -> None:
+    fake_metal_site = create_fake_metal_llama_cpp_site(tmp_root, "macOS mock Metal")
+    fake_model = tmp_root / "mock-metal.gguf"
+    fake_model.write_bytes(b"GGUF fake macOS Metal packaged bridge model")
+    output = run_compute_bridge_startup_probe(
+        tmp_root,
+        bridge_script,
+        relay_port=relay_port,
+        resources_root=resources_root,
+        layout_label="macOS Contents/Resources mock Metal registered",
+        use_mock_llm="0",
+        mode="auto",
+        model_path=fake_model,
+        extra_env={
+            "PYTHONPATH": os.pathsep.join(
+                [str(fake_metal_site), str(resources_root / "python"), str(resources_root)]
+            ),
+        },
+    )
+    assert '"registered": true' in output.lower(), output
+    assert "runtime_action=metal_already_supported" in output, output
+
+
+def run_macos_gpu_failure_blocks_registration_probe(
+    tmp_root: Path,
+    bridge_script: Path,
+    *,
+    relay_port: int,
+    resources_root: Path,
+) -> None:
+    patch_packaged_runtime_setup_as_macos(resources_root)
+    broken_site = tmp_root / "fake broken macos llama_cpp"
+    broken_pkg = broken_site / "llama_cpp"
+    broken_pkg.mkdir(parents=True, exist_ok=True)
+    (broken_pkg / "__init__.py").write_text(
+        "raise ImportError('mock Metal runtime unavailable')\n", encoding="utf-8"
+    )
+    env = _packaged_env(
+        tmp_root,
+        resources_root,
+        extra_env={
+            "USE_MOCK_LLM": "1",
+            "PYTHONPATH": os.pathsep.join(
+                [str(broken_site), str(resources_root / "python"), str(resources_root)]
+            ),
+        },
+    )
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            str(bridge_script),
+            "--model",
+            "mock.gguf",
+            "--mode",
+            "gpu",
+            "--relay-url",
+            f"http://127.0.0.1:{relay_port}",
+        ],
+        cwd=tmp_root,
+        env=env,
+        input='{"type":"cancel"}\n',
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0, combined
+    assert "GPU provisioning failed for desktop macOS launch" in combined, combined
+    assert "registered=true" not in combined, combined
+    assert '"registered": true' not in combined.lower(), combined
+    assert "desktop.compute_node_bridge.api_v1_e2ee.register" not in combined, combined
+
+
 def main() -> int:
     env = os.environ.copy()
     env["USE_MOCK_LLM"] = "1"
@@ -872,6 +982,19 @@ def main() -> int:
                     resources_root=probe_resources_root,
                     layout_label=layout_label,
                 )
+                if probe_resources_root == mac_resources_root:
+                    run_macos_mock_metal_packaged_registration_probe(
+                        tmp_path,
+                        probe_script,
+                        relay_port=relay_port,
+                        resources_root=mac_resources_root,
+                    )
+                    run_macos_gpu_failure_blocks_registration_probe(
+                        tmp_path,
+                        probe_script,
+                        relay_port=relay_port,
+                        resources_root=mac_resources_root,
+                    )
             finally:
                 if relay.poll() is None:
                     relay.terminate()

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -568,6 +568,11 @@ def run(args: argparse.Namespace) -> int:
         f"base_prefix={runtime_setup.get('base_prefix', 'unknown')} "
         f"dependency_target={runtime_setup.get('dependency_target', 'unknown')} "
         f"pip={runtime_setup.get('pip_version', 'unknown')} "
+        f"install_command={runtime_setup.get('install_command_summary', 'none')} "
+        f"install_backend={runtime_setup.get('install_backend', 'none')} "
+        f"cmake_args={runtime_setup.get('cmake_args', 'none')} "
+        f"pip_stdout_tail={runtime_setup.get('pip_stdout_tail', 'none')} "
+        f"pip_stderr_tail={runtime_setup.get('pip_stderr_tail', 'none')} "
         f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
@@ -704,6 +709,16 @@ def run(args: argparse.Namespace) -> int:
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
             "dependency_target": runtime_setup.get("dependency_target", "unknown"),
             "python_version": runtime_setup.get("python_version", "unknown"),
+            "prefix": runtime_setup.get("prefix", runtime_setup.get("interpreter_prefix", "unknown")),
+            "base_prefix": runtime_setup.get("base_prefix", "unknown"),
+            "pip_version": runtime_setup.get("pip_version", "unknown"),
+            "runtime_action": runtime_setup.get("runtime_action", "none"),
+            "runtime_selected_backend": runtime_setup.get("selected_backend", "cpu"),
+            "install_command_summary": runtime_setup.get("install_command_summary"),
+            "install_backend": runtime_setup.get("install_backend"),
+            "cmake_args": runtime_setup.get("cmake_args"),
+            "pip_stdout_tail": runtime_setup.get("pip_stdout_tail"),
+            "pip_stderr_tail": runtime_setup.get("pip_stderr_tail"),
             "model_path": args.model,
             "last_error": current_last_error,
             "warm_load_state": warm_load_state,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -563,6 +563,11 @@ def run(args: argparse.Namespace) -> int:
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
         f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
+        f"python_version={runtime_setup.get('python_version', 'unknown')} "
+        f"prefix={runtime_setup.get('prefix', runtime_setup.get('interpreter_prefix', 'unknown'))} "
+        f"base_prefix={runtime_setup.get('base_prefix', 'unknown')} "
+        f"dependency_target={runtime_setup.get('dependency_target', 'unknown')} "
+        f"pip={runtime_setup.get('pip_version', 'unknown')} "
         f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
         f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
         file=sys.stderr,
@@ -697,6 +702,8 @@ def run(args: argparse.Namespace) -> int:
             "fallback_reason": diagnostics.get("fallback_reason"),
             "interpreter": runtime_setup.get("interpreter", sys.executable),
             "llama_module_path": runtime_setup.get("llama_module_path", "missing"),
+            "dependency_target": runtime_setup.get("dependency_target", "unknown"),
+            "python_version": runtime_setup.get("python_version", "unknown"),
             "model_path": args.model,
             "last_error": current_last_error,
             "warm_load_state": warm_load_state,

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -513,7 +513,7 @@ def _bounded_error_field(value: str) -> str:
     return "..." + text[-(INSTALL_ERROR_SUMMARY_MAX_LEN - 3):]
 
 
-def _extract_install_detail(raw: str, field: str) -> str:
+def _extract_install_detail_value(raw: str, field: str) -> str:
     marker = f"{field}="
     start = raw.find(marker)
     if start < 0:
@@ -524,7 +524,35 @@ def _extract_install_detail(raw: str, field: str) -> str:
     value = value.strip()
     if not value or value == "empty":
         return ""
+    return value
+
+
+def _extract_install_detail(raw: str, field: str) -> str:
+    value = _extract_install_detail_value(raw, field)
+    if not value:
+        return ""
     return f"{field}={_bounded_error_field(value)}"
+
+
+def _install_diagnostics_payload(
+    raw: str, *, backend: str = "", cmake_args: str = ""
+) -> Dict[str, str]:
+    text = (raw or "").strip()
+    payload: Dict[str, str] = {}
+    command = _extract_install_detail_value(text, "command")
+    stdout_tail = _extract_install_detail_value(text, "stdout_tail")
+    stderr_tail = _extract_install_detail_value(text, "stderr_tail")
+    if command:
+        payload["install_command_summary"] = _bounded_error_field(command)
+    if stdout_tail:
+        payload["pip_stdout_tail"] = _bounded_error_field(stdout_tail)
+    if stderr_tail:
+        payload["pip_stderr_tail"] = _bounded_error_field(stderr_tail)
+    if backend:
+        payload["install_backend"] = backend
+    if cmake_args:
+        payload["cmake_args"] = cmake_args
+    return payload
 
 
 def _summarize_install_error(raw: str) -> str:
@@ -873,6 +901,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
 
     requirements_path = _resolve_requirements_path(target_root)
     last_error = ""
+    install_diagnostics: Dict[str, str] = {}
 
     if expected_backend == "cuda":
         should_repair, repair_skip_reason = _should_attempt_source_repair()
@@ -880,6 +909,9 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             source_ok, source_log = _run_windows_cuda_source_repair(requirements_path, dependency_target)
             if source_ok:
                 _clear_source_repair_failure()
+                install_diagnostics = _install_diagnostics_payload(
+                    source_log, backend="cuda", cmake_args="-DGGML_CUDA=on"
+                )
                 after = _probe_runtime(target_root)
                 if after.gpu_offload_supported and after.backend == "cuda":
                     return {
@@ -887,6 +919,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                         "fallback_reason": "installed CUDA runtime; re-executing sidecar",
                         "runtime_action": "installed_cuda_reexec",
                         **_probe_result_payload(after),
+                        **install_diagnostics,
                     }
                 source_detail = _summarize_install_error(source_log)
                 last_error = (
@@ -897,6 +930,9 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                     last_error = f"{last_error}; source repair detail: {source_detail}"
                 _record_source_repair_failure(last_error)
             else:
+                install_diagnostics = _install_diagnostics_payload(
+                    source_log, backend="cuda", cmake_args="-DGGML_CUDA=on"
+                )
                 last_error = _summarize_install_error(source_log)
                 _record_source_repair_failure(last_error)
         else:
@@ -941,6 +977,9 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             PIP_SOURCE_BUILD_TIMEOUT_SECONDS if plan.no_binary else PIP_INSTALL_TIMEOUT_SECONDS
         )
         ok, log_output = _run_pip_install(cmd, env, timeout_seconds=timeout_seconds)
+        install_diagnostics = _install_diagnostics_payload(
+            log_output, backend=plan.backend, cmake_args=plan.cmake_args or ""
+        )
         if not ok:
             last_error = _summarize_install_error(log_output)
             continue
@@ -971,12 +1010,14 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                         "fallback_reason": reason,
                         "runtime_action": _install_failure_action(expected_backend),
                         **_probe_result_payload(after),
+                        **install_diagnostics,
                     }
             return {
                 "selected_backend": selected_backend,
                 "fallback_reason": reason,
                 "runtime_action": _installed_reexec_action(plan.backend),
                 **_probe_result_payload(after),
+                **install_diagnostics,
             }
 
         if plan.backend in {"cuda", "metal"}:
@@ -998,6 +1039,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                     ),
                     "runtime_action": _install_failure_action(expected_backend),
                     **_probe_result_payload(after),
+                    **install_diagnostics,
                 }
             if plan.backend == "metal":
                 continue
@@ -1022,6 +1064,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                 "fallback_reason": reason,
                 "runtime_action": _cpu_fallback_action(expected_backend),
                 **_probe_result_payload(after),
+                **install_diagnostics,
             }
 
     reason = last_error or before.error or "unable to install a GPU-capable runtime"
@@ -1037,6 +1080,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         "fallback_reason": reason,
         "runtime_action": _install_failure_action(expected_backend),
         **_probe_result_payload(before),
+        **install_diagnostics,
     }
 
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -274,7 +274,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
     repo_root = _safe_resolve_path(_resolve_runtime_root(repo_root=runtime_root))
     python_root = _safe_resolve_path(__file__).parent
     dependency_target, _dependency_target_error = _resolve_desktop_dependency_target(repo_root)
-    dependency_target_text = str(dependency_target) if dependency_target is not None else "unknown"
+    dependency_target_env = str(dependency_target) if dependency_target is not None else ""
+    dependency_target_text = dependency_target_env or "unknown"
     pip_version = _pip_version_summary()
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
     env = os.environ.copy()
@@ -288,7 +289,10 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     env["TOKEN_PLACE_DESKTOP_PYTHON_ROOT"] = str(python_root)
     env["TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT"] = str(_safe_resolve_path(__file__))
-    env["TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET"] = dependency_target_text
+    if dependency_target_env:
+        env["TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET"] = dependency_target_env
+    else:
+        env.pop("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", None)
     env["TOKEN_PLACE_DESKTOP_PIP_VERSION"] = pip_version
     env["TOKEN_PLACE_PROBE_REPO_ROOT"] = str(repo_root)
     try:
@@ -420,7 +424,9 @@ def _run_pip_install(
     return False, detail
 
 
-def _source_build_repair(requirements_path: Path, backend: str) -> tuple[bool, str]:
+def _source_build_repair(
+    requirements_path: Path, backend: str, dependency_target: Optional[Path] = None
+) -> tuple[bool, str]:
     env = os.environ.copy()
     backend_label = backend.upper()
     if backend == "cuda":
@@ -449,13 +455,23 @@ def _source_build_repair(requirements_path: Path, backend: str) -> tuple[bool, s
         "-m",
         "pip",
         "install",
+        "--disable-pip-version-check",
         "--force-reinstall",
         "--no-cache-dir",
+    ]
+    if dependency_target is not None:
+        dependency_target_text = str(dependency_target)
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(
+            [dependency_target_text, existing_pythonpath] if existing_pythonpath else [dependency_target_text]
+        )
+        cmd.extend(["--target", dependency_target_text])
+    cmd.extend([
         "--no-binary",
         "llama-cpp-python",
         "--verbose",
         package_spec,
-    ]
+    ])
     ok, output = _run_pip_install(cmd, env, timeout_seconds=PIP_SOURCE_BUILD_TIMEOUT_SECONDS)
     if not metadata_warning:
         return ok, output
@@ -469,15 +485,74 @@ def _source_build_repair(requirements_path: Path, backend: str) -> tuple[bool, s
     return ok, "\n".join(lines)
 
 
-def _windows_cuda_source_repair(requirements_path: Path) -> tuple[bool, str]:
-    return _source_build_repair(requirements_path, "cuda")
+def _windows_cuda_source_repair(
+    requirements_path: Path, dependency_target: Optional[Path] = None
+) -> tuple[bool, str]:
+    return _source_build_repair(requirements_path, "cuda", dependency_target)
+
+
+def _run_windows_cuda_source_repair(
+    requirements_path: Path, dependency_target: Optional[Path]
+) -> tuple[bool, str]:
+    try:
+        return _windows_cuda_source_repair(requirements_path, dependency_target)
+    except TypeError as exc:
+        message = str(exc)
+        if "positional" in message or "argument" in message:
+            # Backward-compatible path for tests that monkeypatch
+            # _windows_cuda_source_repair with callables that only accept the
+            # historical requirements_path argument.
+            return _windows_cuda_source_repair(requirements_path)
+        raise
+
+
+def _bounded_error_field(value: str) -> str:
+    text = (value or "").strip()
+    if len(text) <= INSTALL_ERROR_SUMMARY_MAX_LEN:
+        return text
+    return "..." + text[-(INSTALL_ERROR_SUMMARY_MAX_LEN - 3):]
+
+
+def _extract_install_detail(raw: str, field: str) -> str:
+    marker = f"{field}="
+    start = raw.find(marker)
+    if start < 0:
+        return ""
+    start += len(marker)
+    next_field = raw.find("; ", start)
+    value = raw[start:] if next_field < 0 else raw[start:next_field]
+    value = value.strip()
+    if not value or value == "empty":
+        return ""
+    return f"{field}={_bounded_error_field(value)}"
 
 
 def _summarize_install_error(raw: str) -> str:
     text = (raw or "").strip()
     if not text:
         return "install failed"
-    return text.splitlines()[-1][:INSTALL_ERROR_SUMMARY_MAX_LEN]
+    for field in ("stderr_tail", "stdout_tail"):
+        detail = _extract_install_detail(text, field)
+        if detail:
+            return detail
+    line = text.splitlines()[-1].strip()
+    if len(line) <= INSTALL_ERROR_SUMMARY_MAX_LEN:
+        return line
+    return "..." + line[-(INSTALL_ERROR_SUMMARY_MAX_LEN - 3):]
+
+
+def _runtime_probe_is_importable(probe: RuntimeProbe) -> bool:
+    return probe.backend != "missing" and not probe.error
+
+
+def _prepend_dependency_target_to_sys_path(runtime_root: Path) -> tuple[Optional[Path], Optional[str]]:
+    dependency_target, dependency_target_error = _resolve_desktop_dependency_target(runtime_root)
+    if dependency_target is not None:
+        dependency_target_text = str(dependency_target)
+        active_sys_path = getattr(sys, "path", _PROCESS_SYS_PATH)
+        if dependency_target_text not in active_sys_path:
+            active_sys_path.insert(0, dependency_target_text)
+    return dependency_target, dependency_target_error
 
 
 def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
@@ -715,6 +790,8 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
     selected_mode = (mode or "auto").strip().lower()
     target_root = _resolve_runtime_root(repo_root=repo_root)
     before = _probe_runtime(target_root)
+    dependency_target, dependency_target_error = _prepend_dependency_target_to_sys_path(target_root)
+    dependency_target_text = str(dependency_target) if dependency_target is not None else "unknown"
     if _is_repo_local_llama_module(before.llama_module_path, target_root):
         return {
             "selected_backend": "cpu",
@@ -795,20 +872,12 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         }
 
     requirements_path = _resolve_requirements_path(target_root)
-    dependency_target, dependency_target_error = _resolve_desktop_dependency_target(target_root)
-    if dependency_target is not None:
-        dependency_target_text = str(dependency_target)
-        active_sys_path = getattr(sys, "path", _PROCESS_SYS_PATH)
-        if dependency_target_text not in active_sys_path:
-            active_sys_path.insert(0, dependency_target_text)
-    else:
-        dependency_target_text = "unknown"
     last_error = ""
 
     if expected_backend == "cuda":
         should_repair, repair_skip_reason = _should_attempt_source_repair()
         if should_repair:
-            source_ok, source_log = _windows_cuda_source_repair(requirements_path)
+            source_ok, source_log = _run_windows_cuda_source_repair(requirements_path, dependency_target)
             if source_ok:
                 _clear_source_repair_failure()
                 after = _probe_runtime(target_root)
@@ -934,6 +1003,14 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                 continue
 
         if plan.backend == "cpu":
+            if not _runtime_probe_is_importable(after):
+                last_error = (
+                    "CPU runtime install completed but follow-up probe could not import llama_cpp; "
+                    f"backend={after.backend}; error={after.error or 'unknown'}; "
+                    f"llama_module_path={after.llama_module_path}; "
+                    f"dependency_target={dependency_target_text}; pip={after.pip_version}"
+                )
+                continue
             reason = (
                 f"{(expected_backend or 'GPU').upper()} runtime unavailable after bootstrap"
                 f" ({last_error or before.error or 'probe did not report GPU offload'}); using CPU runtime; "

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -906,35 +906,41 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
     if expected_backend == "cuda":
         should_repair, repair_skip_reason = _should_attempt_source_repair()
         if should_repair:
-            source_ok, source_log = _run_windows_cuda_source_repair(requirements_path, dependency_target)
-            if source_ok:
-                _clear_source_repair_failure()
-                install_diagnostics = _install_diagnostics_payload(
-                    source_log, backend="cuda", cmake_args="-DGGML_CUDA=on"
-                )
-                after = _probe_runtime(target_root)
-                if after.gpu_offload_supported and after.backend == "cuda":
-                    return {
-                        "selected_backend": "cuda",
-                        "fallback_reason": "installed CUDA runtime; re-executing sidecar",
-                        "runtime_action": "installed_cuda_reexec",
-                        **_probe_result_payload(after),
-                        **install_diagnostics,
-                    }
-                source_detail = _summarize_install_error(source_log)
+            if dependency_target is None:
                 last_error = (
-                    "CUDA source reinstall completed but runtime still CPU-only; "
-                    "check CUDA toolkit/build tools"
+                    "desktop dependency target unavailable; cannot install llama-cpp-python "
+                    f"without writing to interpreter prefix; detail={dependency_target_error or 'unknown'}"
                 )
-                if source_detail and source_detail != "install failed":
-                    last_error = f"{last_error}; source repair detail: {source_detail}"
-                _record_source_repair_failure(last_error)
             else:
-                install_diagnostics = _install_diagnostics_payload(
-                    source_log, backend="cuda", cmake_args="-DGGML_CUDA=on"
-                )
-                last_error = _summarize_install_error(source_log)
-                _record_source_repair_failure(last_error)
+                source_ok, source_log = _run_windows_cuda_source_repair(requirements_path, dependency_target)
+                if source_ok:
+                    _clear_source_repair_failure()
+                    install_diagnostics = _install_diagnostics_payload(
+                        source_log, backend="cuda", cmake_args="-DGGML_CUDA=on"
+                    )
+                    after = _probe_runtime(target_root)
+                    if after.gpu_offload_supported and after.backend == "cuda":
+                        return {
+                            "selected_backend": "cuda",
+                            "fallback_reason": "installed CUDA runtime; re-executing sidecar",
+                            "runtime_action": "installed_cuda_reexec",
+                            **_probe_result_payload(after),
+                            **install_diagnostics,
+                        }
+                    source_detail = _summarize_install_error(source_log)
+                    last_error = (
+                        "CUDA source reinstall completed but runtime still CPU-only; "
+                        "check CUDA toolkit/build tools"
+                    )
+                    if source_detail and source_detail != "install failed":
+                        last_error = f"{last_error}; source repair detail: {source_detail}"
+                    _record_source_repair_failure(last_error)
+                else:
+                    install_diagnostics = _install_diagnostics_payload(
+                        source_log, backend="cuda", cmake_args="-DGGML_CUDA=on"
+                    )
+                    last_error = _summarize_install_error(source_log)
+                    _record_source_repair_failure(last_error)
         else:
             last_error = repair_skip_reason
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -54,6 +54,10 @@ class RuntimeProbe:
     prefix: str
     llama_module_path: str
     error: Optional[str] = None
+    python_version: str = "unknown"
+    base_prefix: str = "unknown"
+    dependency_target: str = "unknown"
+    pip_version: str = "unknown"
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
@@ -87,11 +91,14 @@ PIP_SOURCE_BUILD_TIMEOUT_SECONDS = _parse_positive_int_env(
     DEFAULT_PIP_SOURCE_BUILD_TIMEOUT_SECONDS,
 )
 INSTALL_ERROR_SUMMARY_MAX_LEN = 512
+INSTALL_LOG_TAIL_MAX_CHARS = 2000
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
 ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
 RUNTIME_PROBE_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
+_PROCESS_SYS_PATH = sys.path
+_PROCESS_PYTHON_VERSION = sys.version.split()[0]
 
 _PROBE_SNIPPET = r"""
 import importlib
@@ -115,6 +122,10 @@ def _safe_resolve_path_text(path_text):
 python_root = os.environ.get("TOKEN_PLACE_DESKTOP_PYTHON_ROOT", "").strip()
 if python_root and python_root not in sys.path:
     sys.path.insert(0, python_root)
+
+dependency_target = os.environ.get("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", "").strip()
+if dependency_target and dependency_target not in sys.path:
+    sys.path.insert(0, dependency_target)
 
 bootstrap_script = os.environ.get("TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT", "").strip()
 if bootstrap_script:
@@ -180,6 +191,10 @@ try:
         "detected_device": backend if gpu_offload_supported else "cpu",
         "interpreter": sys.executable,
         "prefix": sys.prefix,
+        "base_prefix": getattr(sys, "base_prefix", sys.prefix),
+        "python_version": sys.version.split()[0],
+        "dependency_target": dependency_target or "unknown",
+        "pip_version": os.environ.get("TOKEN_PLACE_DESKTOP_PIP_VERSION", "unknown"),
         "llama_module_path": llama_module_path or "unknown",
         "error": None,
     }
@@ -190,6 +205,10 @@ except Exception as exc:
         "detected_device": "none",
         "interpreter": sys.executable,
         "prefix": sys.prefix,
+        "base_prefix": getattr(sys, "base_prefix", sys.prefix),
+        "python_version": sys.version.split()[0],
+        "dependency_target": dependency_target or "unknown",
+        "pip_version": os.environ.get("TOKEN_PLACE_DESKTOP_PIP_VERSION", "unknown"),
         "llama_module_path": "missing",
         "error": str(exc),
     }
@@ -226,18 +245,51 @@ def _resolve_runtime_root(*, repo_root: Optional[Path] = None) -> Path:
     return script_path.parent
 
 
+def _python_version_text() -> str:
+    version = getattr(sys, "version", "")
+    return version.split()[0] if version else _PROCESS_PYTHON_VERSION
+
+
+def _pip_version_summary() -> str:
+    try:
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=env,
+        )
+    except Exception as exc:
+        return f"unavailable ({exc})"
+    output = (result.stdout or result.stderr or "").strip()
+    if result.returncode != 0:
+        return f"unavailable (returncode={result.returncode}; {output})"
+    return output or "available"
+
+
 def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe:
     repo_root = _safe_resolve_path(_resolve_runtime_root(repo_root=runtime_root))
     python_root = _safe_resolve_path(__file__).parent
+    dependency_target, _dependency_target_error = _resolve_desktop_dependency_target(repo_root)
+    dependency_target_text = str(dependency_target) if dependency_target is not None else "unknown"
+    pip_version = _pip_version_summary()
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH", "")
-    pythonpath_entries = [str(python_root), str(repo_root)]
+    pythonpath_entries = [str(python_root)]
+    if dependency_target is not None:
+        pythonpath_entries.append(str(dependency_target))
+    pythonpath_entries.append(str(repo_root))
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     env["TOKEN_PLACE_DESKTOP_PYTHON_ROOT"] = str(python_root)
     env["TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT"] = str(_safe_resolve_path(__file__))
+    env["TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET"] = dependency_target_text
+    env["TOKEN_PLACE_DESKTOP_PIP_VERSION"] = pip_version
     env["TOKEN_PLACE_PROBE_REPO_ROOT"] = str(repo_root)
     try:
         result = subprocess.run(
@@ -258,6 +310,10 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             prefix=sys.prefix,
             llama_module_path="missing",
             error=str(exc),
+            python_version=_python_version_text(),
+            base_prefix=getattr(sys, "base_prefix", sys.prefix),
+            dependency_target=dependency_target_text,
+            pip_version=pip_version,
         )
 
     stdout = (result.stdout or "").strip()
@@ -271,6 +327,10 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             prefix=sys.prefix,
             llama_module_path="missing",
             error=stderr or f"probe subprocess failed with return code {result.returncode}",
+            python_version=_python_version_text(),
+            base_prefix=getattr(sys, "base_prefix", sys.prefix),
+            dependency_target=dependency_target_text,
+            pip_version=pip_version,
         )
 
     try:
@@ -294,6 +354,10 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         prefix=str(payload.get("prefix", sys.prefix)),
         llama_module_path=str(payload.get("llama_module_path", "missing")),
         error=payload.get("error"),
+        python_version=str(payload.get("python_version", _python_version_text())),
+        base_prefix=str(payload.get("base_prefix", getattr(sys, "base_prefix", sys.prefix))),
+        dependency_target=str(payload.get("dependency_target", dependency_target_text)),
+        pip_version=str(payload.get("pip_version", pip_version)),
     )
 
 
@@ -307,6 +371,17 @@ def _probe_runtime(runtime_root: Path) -> RuntimeProbe:
             # with callables that do not accept keyword arguments.
             return _probe_llama_runtime()
         raise
+
+
+def _tail_text(raw: str, *, limit: int = INSTALL_LOG_TAIL_MAX_CHARS) -> str:
+    text = (raw or "").strip()
+    if len(text) <= limit:
+        return text
+    return "..." + text[-limit:]
+
+
+def _command_summary(cmd: list[str]) -> str:
+    return " ".join(str(part) for part in cmd)
 
 
 def _run_pip_install(
@@ -324,13 +399,25 @@ def _run_pip_install(
             env=env,
             timeout=timeout_seconds,
         )
-    except subprocess.TimeoutExpired:
-        return False, f"pip install timed out after {timeout_seconds}s"
+    except subprocess.TimeoutExpired as exc:
+        stdout = _tail_text(exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or ""))
+        stderr = _tail_text(exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or ""))
+        return (
+            False,
+            f"pip install timed out after {timeout_seconds}s; command={_command_summary(cmd)}; "
+            f"stdout_tail={stdout or 'empty'}; stderr_tail={stderr or 'empty'}",
+        )
 
+    stdout_tail = _tail_text(install.stdout or "")
+    stderr_tail = _tail_text(install.stderr or "")
+    detail = (
+        f"command={_command_summary(cmd)}; returncode={install.returncode}; "
+        f"stdout_tail={stdout_tail or 'empty'}; stderr_tail={stderr_tail or 'empty'}"
+    )
     if install.returncode == 0:
-        return True, (install.stdout or "").strip()
+        return True, detail
 
-    return False, (install.stderr or install.stdout or "").strip()
+    return False, detail
 
 
 def _source_build_repair(requirements_path: Path, backend: str) -> tuple[bool, str]:
@@ -397,8 +484,12 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
     return {
         "detected_device": probe.detected_device or "cpu",
         "interpreter": probe.interpreter,
+        "python_version": probe.python_version,
         "prefix": probe.prefix,
+        "base_prefix": probe.base_prefix,
         "interpreter_prefix": probe.prefix,
+        "dependency_target": probe.dependency_target,
+        "pip_version": probe.pip_version,
         "llama_module_path": probe.llama_module_path,
     }
 
@@ -704,6 +795,14 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         }
 
     requirements_path = _resolve_requirements_path(target_root)
+    dependency_target, dependency_target_error = _resolve_desktop_dependency_target(target_root)
+    if dependency_target is not None:
+        dependency_target_text = str(dependency_target)
+        active_sys_path = getattr(sys, "path", _PROCESS_SYS_PATH)
+        if dependency_target_text not in active_sys_path:
+            active_sys_path.insert(0, dependency_target_text)
+    else:
+        dependency_target_text = "unknown"
     last_error = ""
 
     if expected_backend == "cuda":
@@ -745,14 +844,27 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
     for plan in plans:
         if selected_mode == "gpu" and plan.backend == "cpu":
             continue
+        if dependency_target is None:
+            last_error = (
+                "desktop dependency target unavailable; cannot install llama-cpp-python "
+                f"without writing to interpreter prefix; detail={dependency_target_error or 'unknown'}"
+            )
+            break
         env = os.environ.copy()
         env.update(plan.pip_env())
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(
+            [dependency_target_text, existing_pythonpath] if existing_pythonpath else [dependency_target_text]
+        )
         cmd = [
             sys.executable,
             "-m",
             "pip",
             "install",
+            "--disable-pip-version-check",
             "--force-reinstall",
+            "--target",
+            dependency_target_text,
             *plan.pip_install_args(),
             plan.package_spec,
         ]
@@ -801,25 +913,32 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         if plan.backend in {"cuda", "metal"}:
             last_error = (
                 f"{plan.backend.upper()} install completed but follow-up probe reported "
-                f"backend={after.backend} gpu_offload_supported={after.gpu_offload_supported}"
+                f"backend={after.backend} gpu_offload_supported={after.gpu_offload_supported}; "
+                f"llama_module_path={after.llama_module_path}; dependency_target={dependency_target_text}; "
+                f"pip={after.pip_version}; cmake_args={plan.cmake_args or 'none'}"
             )
-            if plan.backend == "metal":
+            if plan.backend == "metal" and selected_mode == "gpu":
                 return {
                     "selected_backend": "cpu",
                     "fallback_reason": (
                         f"Metal runtime install completed but follow-up probe did not report "
                         f"Metal GPU offload; backend={after.backend} "
                         f"gpu_offload_supported={after.gpu_offload_supported}; "
-                        f"llama_module_path={after.llama_module_path}"
+                        f"llama_module_path={after.llama_module_path}; "
+                        f"dependency_target={dependency_target_text}; pip={after.pip_version}"
                     ),
                     "runtime_action": _install_failure_action(expected_backend),
                     **_probe_result_payload(after),
                 }
+            if plan.backend == "metal":
+                continue
 
         if plan.backend == "cpu":
             reason = (
                 f"{(expected_backend or 'GPU').upper()} runtime unavailable after bootstrap"
-                f" ({last_error or before.error or 'probe did not report GPU offload'}); using CPU runtime"
+                f" ({last_error or before.error or 'probe did not report GPU offload'}); using CPU runtime; "
+                f"dependency_target={dependency_target_text}; llama_module_path={after.llama_module_path}; "
+                f"pip={after.pip_version}"
             )
             return {
                 "selected_backend": "cpu",
@@ -828,11 +947,13 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                 **_probe_result_payload(after),
             }
 
-    reason = before.error or last_error or "unable to install a GPU-capable runtime"
+    reason = last_error or before.error or "unable to install a GPU-capable runtime"
     if expected_backend == "metal":
         reason = (
             f"Metal runtime install failed ({reason}); interpreter={before.interpreter}; "
-            f"prefix={before.prefix}; llama_module_path={before.llama_module_path}"
+            f"python_version={before.python_version}; prefix={before.prefix}; "
+            f"base_prefix={before.base_prefix}; dependency_target={dependency_target_text}; "
+            f"pip={before.pip_version}; llama_module_path={before.llama_module_path}"
         )
     return {
         "selected_backend": "cpu",

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -202,7 +202,9 @@ def ensure_runtime_import_paths(
     script_dir = os.path.dirname(script_path)
     script_root = _parent(script_dir)
     explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    dependency_target = os.environ.get("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", "").strip()
     candidates = [
+        _safe_resolve_path_text(dependency_target) if dependency_target else None,
         _safe_resolve_path_text(explicit_import_root) if explicit_import_root else None,
         script_root,  # bundled resources root in packaged apps
         _join(
@@ -221,8 +223,10 @@ def ensure_runtime_import_paths(
     for candidate in candidates:
         if candidate is None or not _path_exists(candidate):
             continue
-        has_runtime_modules = _is_dir(_join(candidate, "utils")) or _is_file(
-            _join(candidate, "config.py")
+        has_runtime_modules = (
+            _is_dir(_join(candidate, "utils"))
+            or _is_file(_join(candidate, "config.py"))
+            or (dependency_target and _dedupe_key(candidate) == _dedupe_key(dependency_target))
         )
         if has_runtime_modules:
             candidate_str = _safe_resolve_path_text(candidate)

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -174,3 +174,41 @@ Before release sign-off or production round-robin messaging, record:
 6. Two-node staging participation evidence for both Windows and macOS release candidates.
 
 If any item is unavailable because CI, staging, GPU hardware, signing, or network access is missing, mark it as a release blocker or an explicitly accepted preview limitation. Do not silently downgrade platform parity expectations.
+
+## macOS packaged Metal runtime validation
+
+For packaged `.app` builds, the bridge may launch with Apple Command Line Tools
+Python (for example `/Library/Developer/CommandLineTools/usr/bin/python3`) when
+that is the interpreter discovered by the launcher. The runtime setup must not
+install `llama-cpp-python` into that protected prefix. Instead, it installs into a
+writable desktop dependency target and adds that target to the same import path
+used by the follow-up `llama_cpp` probe and the model runtime.
+
+Manual validation on Apple Silicon:
+
+1. Build and install the macOS desktop release from the commit under test.
+2. Enable debug logging from the desktop debug menu/Prompt 1 logging flow, or
+   launch with `TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS=1` for full bridge stderr.
+3. Start the operator with `mode=auto`, staging relay URL, and a local GGUF model.
+4. In bridge logs, find `desktop.runtime_setup` and confirm it includes:
+   - `interpreter`, `python_version`, `prefix`, and `base_prefix`
+   - `dependency_target` pointing to a writable app/user-specific directory
+   - `pip=` availability details
+   - `llama_module_path` under the dependency target or another real
+     `llama-cpp-python` package path, never the repo-local `llama_cpp.py` shim
+   - `selected_backend=metal` with `action=metal_already_supported` or
+     `installed_metal_reexec`, or `selected_backend=cpu` with
+     `action=metal_cpu_fallback` and an explicit Metal failure reason
+5. Confirm `model_init.ready` appears before `server.registered` / API v1
+   registration, then verify the UI shows `Registered: yes`.
+6. Send one encrypted browser chat request, stop the operator, verify relay
+   diagnostics drop to zero or TTL-expire, then start again and confirm
+   registration succeeds a second time.
+
+If Metal provisioning fails, inspect the `desktop.runtime_setup` line and the
+startup error for the pip/cmake tail. Common prerequisite fixes are installing or
+repairing Command Line Tools (`xcode-select --install`), ensuring `python3 -m pip
+--version` works for the selected interpreter, and allowing the app to write its
+desktop dependency target. In `gpu` mode, Metal provisioning failure remains
+fatal. In `auto` and `hybrid`, a successful CPU `llama-cpp-python` install/import
+is an explicit `metal_cpu_fallback`, not a silent GPU success.

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -53,8 +53,10 @@ Do not make production two-node or round-robin claims until both Windows and mac
 
 - Apple Silicon Mac or another Mac that can run a Metal-capable llama.cpp backend.
 - Xcode Command Line Tools available for local source builds when a wheel is not sufficient.
-- Metal-enabled install/repair uses `CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, and the repo-pinned `llama-cpp-python` version.
-- Validate the packaged `.app` path as well as the development path so `.app/Contents/Resources` uses the same bridge/runtime code as Windows packaged builds.
+- Metal-enabled install/repair uses `CMAKE_ARGS=-DGGML_METAL=on -DGGML_NATIVE=off`, `FORCE_CMAKE=1`, and the repo-pinned `llama-cpp-python` version.
+- Validate the packaged `.app` path as well as the development path so `.app/Contents/Resources` uses the same bridge/runtime code as Windows packaged builds. The local packaged e2e covers a fake `.app/Contents/Resources` layout with mock Metal registration and a bounded `gpu` failure path; release sign-off still requires manual Apple Silicon validation with a real Metal-capable runtime.
+- Capture packaged debug logs from app stdout/stderr and preserve `desktop.runtime_setup` plus bridge registration lines. The runtime setup/status payload should show `interpreter`, `python_version`, `prefix`, `base_prefix`, `dependency_target`, `pip_version`, `llama_module_path`, `runtime_action`, and any pip/CMake tails from provisioning.
+- If Apple CLT Python lacks pip or build tooling, install/repair pip for that interpreter or install Xcode Command Line Tools, then rerun the packaged app. The app-managed dependency target is `.token_place_desktop_site`; validation should not require writing packages into the CLT Python prefix.
 
 ### Backend field meanings
 

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3111,3 +3111,67 @@ def test_run_logs_unregister_skip_when_cancelled_before_registration(capsys, mon
     runtime = PreRegistrationCancelRuntime.last_instance
     assert runtime.relay_client.unregister_calls == 0
     assert 'desktop.compute_node_bridge.unregister.skipped' in capsys.readouterr().err
+
+
+def test_runtime_setup_diagnostics_are_logged_and_in_status_without_noisy_last_error(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    runtime_setup = {
+        'selected_backend': 'cpu',
+        'detected_device': 'cpu',
+        'runtime_action': 'metal_cpu_fallback',
+        'interpreter': '/Applications/TokenPlace.app/Contents/Resources/python/bin/python',
+        'python_version': '3.12.4',
+        'prefix': '/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework',
+        'base_prefix': '/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework',
+        'dependency_target': '/Users/alice/Library/Application Support/token.place/.token_place_desktop_site',
+        'pip_version': 'pip 24.0',
+        'install_command_summary': 'python -m pip install --target /deps llama-cpp-python',
+        'install_backend': 'metal',
+        'cmake_args': '-DGGML_METAL=on -DGGML_NATIVE=off',
+        'pip_stdout_tail': 'building wheel',
+        'pip_stderr_tail': 'Metal headers missing',
+        'llama_module_path': '/deps/llama_cpp/__init__.py',
+        'fallback_reason': 'Metal failed; using CPU runtime',
+    }
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_llama_runtime', lambda _mode: runtime_setup)
+    monkeypatch.setattr(compute_node_bridge, 'desktop_gpu_runtime_failure_message', lambda _mode, _setup: None)
+    stop_counter = {'count': 0}
+
+    def fake_stop_requested():
+        stop_counter['count'] += 1
+        return stop_counter['count'] > 2
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='auto', relay_url='https://token.place', relay_port=None)
+
+    assert compute_node_bridge.run(args) == 0
+
+    output = capsys.readouterr()
+    stderr = output.err
+    assert 'desktop.runtime_setup ' in stderr
+    for marker in (
+        'interpreter=/Applications/TokenPlace.app/Contents/Resources/python/bin/python',
+        'python_version=3.12.4',
+        'prefix=/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework',
+        'base_prefix=/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework',
+        'dependency_target=/Users/alice/Library/Application Support/token.place/.token_place_desktop_site',
+        'pip=pip 24.0',
+        'install_command=python -m pip install --target /deps llama-cpp-python',
+        'install_backend=metal',
+        'cmake_args=-DGGML_METAL=on -DGGML_NATIVE=off',
+        'pip_stdout_tail=building wheel',
+        'pip_stderr_tail=Metal headers missing',
+        'llama_module_path=/deps/llama_cpp/__init__.py',
+        'fallback_reason=Metal failed; using CPU runtime',
+    ):
+        assert marker in stderr
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    started = events[0]
+    assert started['last_error'] is None
+    assert started['runtime_action'] == 'metal_cpu_fallback'
+    assert started['base_prefix'].startswith('/Library/Developer')
+    assert started['pip_version'] == 'pip 24.0'
+    assert started['install_command_summary'].startswith('python -m pip install')
+    assert started['cmake_args'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
+    assert started['pip_stderr_tail'] == 'Metal headers missing'

--- a/tests/unit/test_desktop_path_bootstrap.py
+++ b/tests/unit/test_desktop_path_bootstrap.py
@@ -316,3 +316,25 @@ def test_bootstrap_repairs_polluted_site_packages_pathlib_shadow(tmp_path, path_
             sys.modules.pop('pathlib', None)
         else:
             sys.modules['pathlib'] = original_pathlib
+
+
+def test_bootstrap_adds_desktop_dependency_target_before_repo_root(
+    tmp_path, path_bootstrap, monkeypatch
+):
+    repo_root = tmp_path / 'repo'
+    script = repo_root / 'desktop-tauri' / 'src-tauri' / 'python' / 'model_bridge.py'
+    dependency_target = tmp_path / 'Application Support' / 'token.place' / 'python site'
+    (repo_root / 'utils').mkdir(parents=True)
+    dependency_target.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text('# bridge\n', encoding='utf-8')
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET', str(dependency_target))
+
+    original_sys_path = list(sys.path)
+    try:
+        path_bootstrap.ensure_runtime_import_paths(str(script), avoid_llama_cpp_shadowing=True)
+        dependency_index = sys.path.index(str(dependency_target.resolve()))
+        repo_index = sys.path.index(str(repo_root.resolve()))
+        assert dependency_index < repo_index
+    finally:
+        sys.path[:] = original_sys_path

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1740,3 +1740,71 @@ def test_record_desktop_runtime_probe_clears_env_when_payload_is_not_serializabl
 
     assert desktop_runtime_setup._record_desktop_runtime_probe(result) is result
     assert desktop_runtime_setup.RUNTIME_PROBE_ENV not in os.environ
+
+
+def test_windows_cuda_already_supported_preserves_runtime_action(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (tmp_path / 'desktop-site', None),
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cuda', gpu=True, device='cuda'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=tmp_path)
+
+    assert result['runtime_action'] == 'already_supported'
+    assert result['selected_backend'] == 'cuda'
+
+
+def test_windows_cuda_bootstrap_uses_cuda_target_without_macos_metal_branch(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (False, 'cooldown'))
+    dependency_target = tmp_path / 'desktop-site'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (dependency_target, None),
+    )
+    probes = iter([
+        _probe(backend='missing', gpu=False, device='none', error="No module named 'llama_cpp'"),
+        _probe(backend='cuda', gpu=True, device='cuda'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='win32',
+            backend='cuda',
+            package_spec='llama-cpp-python',
+            cmake_args='-DGGML_CUDA=on',
+            force_cmake=True,
+            index_url='https://example.invalid/cuda',
+            only_binary=False,
+            no_binary=True,
+        )
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    captured = {}
+
+    def _run(cmd, env, timeout_seconds):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        captured['timeout_seconds'] = timeout_seconds
+        return True, 'command=python -m pip install --target target; returncode=0; stdout_tail=ok; stderr_tail=empty'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _run)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=tmp_path)
+
+    assert result['runtime_action'] == 'installed_cuda_reexec'
+    assert result['cmake_args'] == '-DGGML_CUDA=on'
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
+    assert '-DGGML_METAL=on' not in ' '.join(captured['cmd'])
+    assert '--target' in captured['cmd']
+    assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(dependency_target)
+    assert result['install_command_summary'].startswith('python -m pip install')

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -130,6 +130,29 @@ def test_macos_metal_already_supported_reports_metal_action(monkeypatch):
     assert result['runtime_action'] == 'metal_already_supported'
 
 
+
+def test_already_supported_runtime_prepends_dependency_target(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    dependency_target = tmp_path / 'desktop-site'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (dependency_target, None),
+    )
+    active_sys_path = []
+    monkeypatch.setattr(desktop_runtime_setup.sys, 'path', active_sys_path, raising=False)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='metal', gpu=True, device='metal'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=tmp_path)
+
+    assert result['runtime_action'] == 'metal_already_supported'
+    assert active_sys_path[0] == str(dependency_target)
+
+
 def test_macos_missing_metal_runtime_bootstrap_attempts_metal_plan(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
     monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
@@ -286,6 +309,40 @@ def test_macos_metal_install_unsatisfied_cpu_probe_falls_back_to_cpu_in_auto(mon
     assert 'follow-up probe reported backend=cpu' in result['fallback_reason']
     assert 'using CPU runtime' in result['fallback_reason']
     assert desktop_runtime_setup.desktop_gpu_runtime_failure_message('auto', result) is None
+
+
+
+def test_macos_cpu_fallback_fails_when_follow_up_probe_is_not_importable(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([
+        _probe(backend='cpu', gpu=False, device='cpu', error='Metal runtime missing'),
+        _probe(backend='cpu', gpu=False, device='cpu', error='Metal still unavailable'),
+        _probe(backend='missing', gpu=False, device='none', error="No module named 'llama_cpp'"),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+            cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+            index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+        ),
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin', backend='cpu', package_spec='llama-cpp-python',
+            cmake_args=None, force_cmake=False, index_url='https://pypi.org/simple',
+            only_binary=False, no_binary=False,
+        ),
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    monkeypatch.setattr(desktop_runtime_setup, 'backend_probe_satisfies_install_plan', lambda *_: False)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['selected_backend'] == 'cpu'
+    assert result['runtime_action'] == 'metal_install_failed'
+    assert 'CPU runtime install completed but follow-up probe could not import llama_cpp' in result['fallback_reason']
+    assert "No module named 'llama_cpp'" in result['fallback_reason']
 
 
 def test_macos_runtime_install_uses_writable_dependency_target(monkeypatch, tmp_path):
@@ -865,6 +922,32 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     assert darwin_plans[2].only_binary is True
 
 
+
+def test_windows_source_repair_uses_dependency_target(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    requirements_path = tmp_path / 'requirements.txt'
+    requirements_path.write_text('llama_cpp_python==0.3.16\n', encoding='utf-8')
+    dependency_target = tmp_path / 'desktop deps'
+    captured = {}
+
+    def fake_run(cmd, env, timeout_seconds):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        captured['timeout_seconds'] = timeout_seconds
+        return True, 'ok'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', fake_run)
+
+    ok, _ = desktop_runtime_setup._windows_cuda_source_repair(requirements_path, dependency_target)
+
+    assert ok is True
+    assert '--target' in captured['cmd']
+    assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(dependency_target)
+    assert captured['env']['PYTHONPATH'].split(os.pathsep)[0] == str(dependency_target)
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
+    assert captured['env']['FORCE_CMAKE'] == '1'
+
+
 def test_windows_source_repair_uses_active_interpreter(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     requirements_path = tmp_path / 'requirements.txt'
@@ -883,14 +966,12 @@ def test_windows_source_repair_uses_active_interpreter(monkeypatch, tmp_path):
     assert ok is True
     assert captured['cmd'][:3] == [sys.executable, '-m', 'pip']
     assert captured['cmd'][3] == 'install'
-    assert captured['cmd'][4:9] == [
-        '--force-reinstall',
-        '--no-cache-dir',
-        '--no-binary',
-        'llama-cpp-python',
-        '--verbose',
-    ]
-    assert captured['cmd'][9].startswith('llama-cpp-python==')
+    assert '--disable-pip-version-check' in captured['cmd']
+    assert '--force-reinstall' in captured['cmd']
+    assert '--no-cache-dir' in captured['cmd']
+    assert '--target' not in captured['cmd']
+    assert captured['cmd'][-4:-1] == ['--no-binary', 'llama-cpp-python', '--verbose']
+    assert captured['cmd'][-1].startswith('llama-cpp-python==')
     assert captured['env']['CMAKE_ARGS'] == '-DGGML_CUDA=on'
     assert captured['env']['FORCE_CMAKE'] == '1'
     assert captured['timeout_seconds'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
@@ -913,7 +994,7 @@ def test_windows_source_repair_returns_actionable_message_when_requirements_miss
     assert 'requirements file not found' in reason
     assert 'falling back to unpinned llama-cpp-python source reinstall' in reason
     assert str(missing_requirements) in reason
-    assert captured['cmd'][9] == 'llama-cpp-python'
+    assert captured['cmd'][-1] == 'llama-cpp-python'
 
 
 def test_windows_source_repair_returns_actionable_message_when_requirement_is_unreadable(monkeypatch, tmp_path):
@@ -965,6 +1046,59 @@ def test_windows_source_repair_returns_actionable_message_when_requirement_is_in
     assert 'falling back to unpinned source reinstall' in reason
     assert str(invalid_requirements) in reason
     assert 'missing pinned llama-cpp-python requirement' in reason
+
+
+
+def test_install_error_summary_prefers_stderr_tail_when_command_is_long():
+    long_command = 'command=' + ('/very/long/path/' * 80)
+    stdout = 'stdout_tail=' + ('download progress ' * 60)
+    stderr = 'stderr_tail=' + ('cmake configure noise ' * 40) + 'fatal cmake error: Metal headers missing'
+
+    summary = desktop_runtime_setup._summarize_install_error(f'{long_command}; returncode=1; {stdout}; {stderr}')
+
+    assert summary.startswith('stderr_tail=')
+    assert 'fatal cmake error: Metal headers missing' in summary
+    assert len(summary) <= desktop_runtime_setup.INSTALL_ERROR_SUMMARY_MAX_LEN + len('stderr_tail=')
+
+
+def test_probe_leaves_dependency_target_env_unset_when_target_is_unresolved(monkeypatch, tmp_path):
+    runtime_root = tmp_path / 'bundle_root'
+    (runtime_root / 'utils').mkdir(parents=True)
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(runtime_root))
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET', 'unknown')
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (None, 'not writable'),
+    )
+    captured = {}
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                'backend': 'missing',
+                'gpu_offload_supported': False,
+                'detected_device': 'none',
+                'interpreter': 'python',
+                'prefix': 'prefix',
+                'llama_module_path': 'missing',
+                'dependency_target': 'unknown',
+            }
+        )
+        stderr = ''
+
+    def fake_run(cmd, **kwargs):
+        captured['env'] = kwargs['env']
+        return _Result()
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', fake_run)
+
+    probe = desktop_runtime_setup._probe_llama_runtime()
+
+    assert 'TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET' not in captured['env']
+    assert './unknown' not in captured['env']['PYTHONPATH']
+    assert probe.dependency_target == 'unknown'
 
 
 def test_probe_marks_error_when_subprocess_has_empty_stdout(monkeypatch):

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -731,6 +731,39 @@ def test_windows_runtime_bootstrap_surfaces_source_repair_detail_when_probe_stay
     assert 'source repair detail: final pip status (metadata warning)' in captured['reason']
 
 
+def test_windows_cuda_source_repair_fails_closed_without_dependency_target(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (None, 'runtime_root not writable; home_fallback not writable'),
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: _probe())
+    invoked = {'source_repair': False, 'pip': False}
+
+    def _source_repair(_requirements_path, _dependency_target=None):
+        invoked['source_repair'] = True
+        return True, 'unexpected source repair call'
+
+    def _pip_install(*_args, **_kwargs):
+        invoked['pip'] = True
+        return True, 'unexpected pip install call'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_windows_cuda_source_repair', _source_repair)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _pip_install)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=tmp_path)
+
+    assert result['runtime_action'] == 'failed'
+    assert 'desktop dependency target unavailable' in result['fallback_reason']
+    assert 'runtime_root not writable; home_fallback not writable' in result['fallback_reason']
+    assert invoked == {'source_repair': False, 'pip': False}
+
+
 def test_runtime_bootstrap_noop_when_gpu_runtime_is_already_present(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     monkeypatch.setattr(

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -163,6 +163,7 @@ def test_macos_missing_metal_runtime_bootstrap_attempts_metal_plan(monkeypatch):
 
     assert result['selected_backend'] == 'metal'
     assert result['runtime_action'] == 'installed_metal_reexec'
+    assert '--target' in captured['cmd']
     assert captured['env']['CMAKE_ARGS'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
     assert captured['env']['FORCE_CMAKE'] == '1'
     assert captured['timeout'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
@@ -253,12 +254,54 @@ def test_macos_metal_source_install_clean_cpu_probe_fails_explicit_gpu_before_re
     assert message and 'metal_install_failed' in message
 
 
-def test_macos_metal_install_unsatisfied_cpu_probe_fails_before_cpu_fallback(monkeypatch):
+def test_macos_metal_install_unsatisfied_cpu_probe_falls_back_to_cpu_in_auto(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
     monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
     probes = iter([
         _probe(backend='cpu', gpu=False, device='cpu', error='Metal runtime missing'),
         _probe(backend='cpu', gpu=False, device='cpu', error='Metal still unavailable'),
+        _probe(backend='cpu', gpu=False, device='cpu', error=None),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+            cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+            index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+        ),
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin', backend='cpu', package_spec='llama-cpp-python',
+            cmake_args=None, force_cmake=False, index_url='https://pypi.org/simple',
+            only_binary=False, no_binary=False,
+        ),
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    monkeypatch.setattr(desktop_runtime_setup, 'backend_probe_satisfies_install_plan', lambda *_: False)
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['selected_backend'] == 'cpu'
+    assert result['runtime_action'] == 'metal_cpu_fallback'
+    assert 'follow-up probe reported backend=cpu' in result['fallback_reason']
+    assert 'using CPU runtime' in result['fallback_reason']
+    assert desktop_runtime_setup.desktop_gpu_runtime_failure_message('auto', result) is None
+
+
+def test_macos_runtime_install_uses_writable_dependency_target(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    runtime_root = tmp_path / 'Token Place.app' / 'Contents' / 'Resources'
+    runtime_root.mkdir(parents=True)
+    dependency_target = tmp_path / 'Application Support' / 'token.place' / 'python site'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (dependency_target, None),
+    )
+    probes = iter([
+        _probe(backend='missing', gpu=False, device='none', error="No module named 'llama_cpp'"),
+        _probe(backend='metal', gpu=True, device='metal'),
     ])
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
     plan = desktop_runtime_setup.LlamaCppInstallPlan(
@@ -267,16 +310,74 @@ def test_macos_metal_install_unsatisfied_cpu_probe_fails_before_cpu_fallback(mon
         index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
     )
     monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
-    monkeypatch.setattr(desktop_runtime_setup, 'backend_probe_satisfies_install_plan', lambda *_: False)
-    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: (True, 'ok'))
+    captured = {}
 
-    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+    def _capture_install(cmd, env, **kwargs):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        return True, 'ok'
 
-    assert result['selected_backend'] == 'cpu'
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _capture_install)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=runtime_root)
+
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert '--target' in captured['cmd']
+    assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(dependency_target)
+    assert str(dependency_target) in captured['env']['PYTHONPATH']
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
+
+
+def test_macos_clt_python_missing_llama_cpp_reports_actionable_diagnostics(monkeypatch, tmp_path):
+    class _CltSysStub(_PlatformStub):
+        executable = '/Library/Developer/CommandLineTools/usr/bin/python3'
+        prefix = '/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9'
+        base_prefix = prefix
+        argv = [str(MODULE_PATH)]
+
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _CltSysStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    dependency_target = tmp_path / 'token place deps'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (dependency_target, None),
+    )
+    before = desktop_runtime_setup.RuntimeProbe(
+        backend='missing',
+        gpu_offload_supported=False,
+        detected_device='none',
+        interpreter=_CltSysStub.executable,
+        prefix=_CltSysStub.prefix,
+        base_prefix=_CltSysStub.base_prefix,
+        python_version='3.9.6',
+        dependency_target=str(dependency_target),
+        pip_version='pip unavailable (ensurepip missing)',
+        llama_module_path='missing',
+        error="No module named 'llama_cpp'",
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: before)
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin', backend='metal', package_spec='llama-cpp-python',
+            cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+            index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+        )
+    ])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (False, 'stderr_tail=cmake: command not found'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=tmp_path)
+
     assert result['runtime_action'] == 'metal_install_failed'
-    assert 'follow-up probe did not report Metal GPU offload' in result['fallback_reason']
-    assert 'backend=cpu' in result['fallback_reason']
-
+    assert '/Library/Developer/CommandLineTools/usr/bin/python3' in result['fallback_reason']
+    assert 'python_version=3.9.6' in result['fallback_reason']
+    assert f'dependency_target={dependency_target}' in result['fallback_reason']
+    assert 'pip unavailable' in result['fallback_reason']
+    assert 'stderr_tail=cmake: command not found' in result['fallback_reason']
 
 def test_macos_bootstrap_disabled_reports_metal_probe_only(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
@@ -990,10 +1091,10 @@ def test_probe_subprocess_sanitizes_repo_root_before_llama_import(monkeypatch):
     assert 'utils.llm.model_manager' not in desktop_runtime_setup._PROBE_SNIPPET
     assert 'importlib.import_module("llama_cpp")' in desktop_runtime_setup._PROBE_SNIPPET
     assert captured['cmd'][:2] == [sys.executable, '-c']
-    assert captured['env']['PYTHONPATH'].split(desktop_runtime_setup.os.pathsep)[:2] == [
-        str(PYTHON_MODULE_DIR),
-        str(Path(__file__).resolve().parents[2]),
-    ]
+    pythonpath_entries = captured['env']['PYTHONPATH'].split(desktop_runtime_setup.os.pathsep)
+    assert pythonpath_entries[0] == str(PYTHON_MODULE_DIR)
+    assert pythonpath_entries[1].endswith('.token_place_desktop_site')
+    assert str(Path(__file__).resolve().parents[2]) in pythonpath_entries
     assert captured['env']['TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT'].endswith(
         'desktop_runtime_setup.py'
     )
@@ -1064,7 +1165,8 @@ def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _OkResult())
     ok, output = desktop_runtime_setup._run_pip_install(['python'], {})
     assert ok is True
-    assert output == 'ok output'
+    assert 'returncode=0' in output
+    assert 'stdout_tail=ok output' in output
 
     class _FailResult:
         returncode = 1
@@ -1074,7 +1176,9 @@ def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *args, **kwargs: _FailResult())
     ok, output = desktop_runtime_setup._run_pip_install(['python'], {})
     assert ok is False
-    assert output == 'real stderr'
+    assert 'returncode=1' in output
+    assert 'stdout_tail=fallback stdout' in output
+    assert 'stderr_tail=real stderr' in output
 
     def _timeout(*_args, **_kwargs):
         raise desktop_runtime_setup.subprocess.TimeoutExpired(cmd='pip', timeout=12)
@@ -1082,7 +1186,9 @@ def test_run_pip_install_success_failure_and_timeout(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', _timeout)
     ok, output = desktop_runtime_setup._run_pip_install(['python'], {}, timeout_seconds=12)
     assert ok is False
-    assert output == 'pip install timed out after 12s'
+    assert 'pip install timed out after 12s' in output
+    assert 'stdout_tail=empty' in output
+    assert 'stderr_tail=empty' in output
 
 
 def test_runtime_state_tracks_and_clears_source_repair_failures(monkeypatch, tmp_path):
@@ -1202,7 +1308,15 @@ def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monke
 
     desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=Path.cwd())
 
-    assert captured['cmd'][:5] == [sys.executable, '-m', 'pip', 'install', '--force-reinstall']
+    assert captured['cmd'][:6] == [
+        sys.executable,
+        '-m',
+        'pip',
+        'install',
+        '--disable-pip-version-check',
+        '--force-reinstall',
+    ]
+    assert '--target' in captured['cmd']
 
 
 def test_is_repo_local_llama_module_uses_case_insensitive_comparison(tmp_path):


### PR DESCRIPTION
### Motivation
- Packaged macOS Start could pick the Apple CLT Python (e.g. `/Library/Developer/CommandLineTools/...`) and fail provisioning with only `No module named 'llama_cpp'` shown, preventing registration.  
- The goal is to provision a usable `llama-cpp-python` runtime without writing into protected system prefixes, verify the runtime from the same interpreter path used by the bridge, and provide clear, actionable diagnostics and safe auto-mode fallback behavior.

### Description
- Add richer probe payload fields (`python_version`, `base_prefix`, `dependency_target`, `pip_version`) and surface them in the bridge `desktop.runtime_setup` log and status payloads.  
- Install `llama-cpp-python` into a writable desktop dependency target (`--target <dir>`), insert that target into `PYTHONPATH` for the follow-up probe, and avoid installing into protected interpreter prefixes (CLT/system).  
- Improve pip/source-install plumbing: use `--target` + `--disable-pip-version-check`, preserve `CMAKE_ARGS`/`FORCE_CMAKE` for Metal/CUDA, and capture command summary plus bounded tails of `stdout`/`stderr` on failures for actionable diagnostics.  
- Add dependency-target awareness to `path_bootstrap.ensure_runtime_import_paths` so dependency target is prioritized before the repo root (prevents repo-local shim shadowing).  
- Keep semantics: `gpu` mode remains fatal on Metal failure; `auto`/`hybrid` may fall back to CPU if CPU `llama-cpp-python` is installable/importable (explicit `metal_cpu_fallback`).  
- Add/adjust unit tests covering CLT Python diagnostics, writable dependency target behavior, CPU-fallback flows, `PYTHONPATH` composition in probe subprocess, and update packaged-e2e/mock tests; update docs with macOS packaged validation steps.

### Testing
- Ran unit tests: `pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_path_bootstrap.py -q` — all listed tests passed.  
- Bridge-focused tests: `pytest tests/unit/test_desktop_compute_node_bridge.py -k "macos or metal or runtime or warm or register or fallback" -q` — selected tests passed.  
- Wider unit suite: `pytest tests/unit/test_compute_node_runtime.py tests/unit/test_model_manager.py -q` — all tests passed.  
- Packaged/layout e2e: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py` — ran in CI-like environment and completed successfully.  
- Desktop parity driver: `python desktop-tauri/scripts/run_desktop_parity_checks.py` — completed successfully.  
- Pre-commit checks: `pre-commit run --all-files` — passed.  
- Note: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` was attempted but failed in this Linux container due to missing system GLib `pkg-config` metadata (`glib-2.0.pc`); this is an environment-specific limitation and not a regression in the Python changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a234812d618832f8f3180db894bd7cb)