### PR TITLE
Fix macOS desktop llama runtime provisioning

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -46,13 +46,14 @@ During normal startup, desktop sidecars probe the active sidecar interpreter and
 
 Set `TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP=1` to explicitly disable runtime bootstrap and keep startup in probe-only mode (useful for packaging/troubleshooting while preserving fallback diagnostics).
 
-When GPU runtime repair is needed, desktop uses the same interpreter binary that launches the sidecar process (`sys.executable`) and applies the repo-pinned `llama-cpp-python` source-build recipe with the platform flag:
+When GPU runtime repair is needed, desktop uses the same interpreter binary that launches the sidecar process (`sys.executable`) and applies the repo-pinned `llama-cpp-python` recipe with the platform flag:
 
 - Windows CUDA: `CMAKE_ARGS=-DGGML_CUDA=on`
-- macOS Metal: `CMAKE_ARGS=-DGGML_METAL=on`
-- Both: `FORCE_CMAKE=1` and `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose`
+- macOS Metal source fallback: `CMAKE_ARGS=-DGGML_METAL=on -DGGML_NATIVE=off`
+- Both source-build paths: `FORCE_CMAKE=1` and `pip install llama-cpp-python==<repo-pinned-version> --force-reinstall --no-cache-dir --verbose`
+- macOS packaged apps install `llama-cpp-python` into a writable app-managed target (`.token_place_desktop_site`, or `~/.token_place_desktop_site` if the packaged resources are not writable) with `pip --target` instead of writing into `/Library/Developer/CommandLineTools` or another system prefix.
 
-After a successful repair, the sidecar automatically re-execs once so the active process immediately uses the repaired runtime (no manual restart/environment flag required).
+After a successful repair, the sidecar automatically re-execs once so the active process immediately uses the repaired runtime (no manual restart/environment flag required). In `auto`/`hybrid`, macOS can explicitly fall back to an importable CPU `llama-cpp-python` wheel if Metal provisioning fails; in explicit `gpu`, Metal failure remains fatal and includes the install command, target, pip/CMake details, and stderr tail in debug logs.
 
 ### Platform runtime expectations
 
@@ -153,10 +154,14 @@ example `.../site-packages/llama_cpp/__init__.py`).
 When this shadowing is detected, the stable runtime action is
 `shadowed_repo_llama_cpp` in both verifier and smoke-test diagnostics.
 
+For packaged macOS failures that mention `/Library/Developer/CommandLineTools/usr/bin/python3`, use the debug-log toggles above and look for the `desktop.runtime_setup` line. It should show the interpreter, Python version, `prefix`/`base_prefix`, writable `dependency_target`, `pip_version`, quoted `install_command`, Metal `cmake_args`, `install_log_tail`, and final `llama_module_path`. If CLT Python lacks pip or build tooling, install Xcode Command Line Tools plus pip/build prerequisites, or set `TOKEN_PLACE_SIDECAR_PYTHON=/path/to/python3` to a Python 3 interpreter with working pip; Start operator retries provisioning on the next launch and does not require reinstalling the app.
+
 It prints:
 
 - Shared runtime probe fields (`backend`, `gpu_offload_supported`,
-  `detected_device`, `interpreter`, `prefix`, `llama_module_path`)
+  `detected_device`, `interpreter`, `python_version`, `prefix`, `base_prefix`,
+  `dependency_target`, `pip_version`, `install_command`, `cmake_args`,
+  `install_log_tail`, `llama_module_path`)
 - `compute_runtime_*` summaries using stable fields
   (`requested`, `effective`, `backend_available`, `backend_used`,
   `device_backend`, `device_name`, `offloaded_layers`, `kv_cache`,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -563,8 +563,16 @@ def run(args: argparse.Namespace) -> int:
         f"device={runtime_setup.get('detected_device', 'cpu')} "
         f"action={runtime_setup.get('runtime_action', 'none')} "
         f"interpreter={runtime_setup.get('interpreter', sys.executable)} "
+        f"python_version={runtime_setup.get('python_version', 'unknown')} "
+        f"prefix={runtime_setup.get('prefix', sys.prefix)} "
+        f"base_prefix={runtime_setup.get('base_prefix', runtime_setup.get('prefix', sys.prefix))} "
+        f"dependency_target={runtime_setup.get('dependency_target', '') or 'none'} "
+        f"pip_version={runtime_setup.get('pip_version', '') or 'unknown'} "
+        f"install_command={runtime_setup.get('install_command', '') or 'none'} "
+        f"cmake_args={runtime_setup.get('cmake_args', '') or 'none'} "
         f"llama_module_path={runtime_setup.get('llama_module_path', 'missing')} "
-        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'}",
+        f"fallback_reason={runtime_setup.get('fallback_reason') or 'none'} "
+        f"install_log_tail={runtime_setup.get('install_log_tail', '') or 'none'}",
         file=sys.stderr,
     )
     dependency_setup = ensure_desktop_python_dependencies()

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -6,12 +6,15 @@ import importlib.util
 import json
 import os
 import platform as platform_module
+import shlex
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
+
+_REAL_SYS = sys
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
@@ -54,6 +57,8 @@ class RuntimeProbe:
     prefix: str
     llama_module_path: str
     error: Optional[str] = None
+    base_prefix: str = ""
+    python_version: str = ""
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
@@ -91,7 +96,40 @@ REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
 ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
 RUNTIME_PROBE_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON"
+DEPENDENCY_TARGET_ENV = "TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET"
 SOURCE_REPAIR_COOLDOWN_SECONDS = 24 * 60 * 60
+INSTALL_LOG_TAIL_MAX_LEN = 2000
+
+
+def _python_version_text() -> str:
+    version_info = getattr(sys, "version_info", None)
+    if version_info is None:
+        return str(getattr(sys, "version", "unknown")).split()[0]
+    try:
+        return ".".join(str(part) for part in version_info[:3])
+    except TypeError:
+        return str(getattr(sys, "version", "unknown")).split()[0]
+
+
+def _text_tail(raw: str, *, limit: int = INSTALL_LOG_TAIL_MAX_LEN) -> str:
+    text = (raw or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def _command_summary(cmd: list[str]) -> str:
+    return " ".join(shlex.quote(str(part)) for part in cmd)
+
+
+def _dependency_target_contains_llama_cpp(path_text: str) -> bool:
+    if not path_text:
+        return False
+    try:
+        target = Path(path_text)
+        return (target / "llama_cpp").exists() or (target / "llama_cpp.py").exists()
+    except OSError:
+        return False
 
 _PROBE_SNIPPET = r"""
 import importlib
@@ -115,6 +153,10 @@ def _safe_resolve_path_text(path_text):
 python_root = os.environ.get("TOKEN_PLACE_DESKTOP_PYTHON_ROOT", "").strip()
 if python_root and python_root not in sys.path:
     sys.path.insert(0, python_root)
+
+dependency_target = os.environ.get("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", "").strip()
+if dependency_target and dependency_target not in sys.path:
+    sys.path.insert(0, dependency_target)
 
 bootstrap_script = os.environ.get("TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT", "").strip()
 if bootstrap_script:
@@ -180,6 +222,8 @@ try:
         "detected_device": backend if gpu_offload_supported else "cpu",
         "interpreter": sys.executable,
         "prefix": sys.prefix,
+        "base_prefix": getattr(sys, "base_prefix", sys.prefix),
+        "python_version": ".".join(str(part) for part in sys.version_info[:3]),
         "llama_module_path": llama_module_path or "unknown",
         "error": None,
     }
@@ -190,6 +234,8 @@ except Exception as exc:
         "detected_device": "none",
         "interpreter": sys.executable,
         "prefix": sys.prefix,
+        "base_prefix": getattr(sys, "base_prefix", sys.prefix),
+        "python_version": ".".join(str(part) for part in sys.version_info[:3]),
         "llama_module_path": "missing",
         "error": str(exc),
     }
@@ -232,13 +278,21 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
     cmd = [sys.executable, "-c", _PROBE_SNIPPET]
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH", "")
-    pythonpath_entries = [str(python_root), str(repo_root)]
+    dependency_target = os.environ.get(DEPENDENCY_TARGET_ENV, "").strip()
+    if not _dependency_target_contains_llama_cpp(dependency_target):
+        dependency_target = ""
+    pythonpath_entries = []
+    if dependency_target:
+        pythonpath_entries.append(dependency_target)
+    pythonpath_entries.extend([str(python_root), str(repo_root)])
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     env["TOKEN_PLACE_DESKTOP_PYTHON_ROOT"] = str(python_root)
     env["TOKEN_PLACE_DESKTOP_BOOTSTRAP_SCRIPT"] = str(_safe_resolve_path(__file__))
     env["TOKEN_PLACE_PROBE_REPO_ROOT"] = str(repo_root)
+    if dependency_target:
+        env[DEPENDENCY_TARGET_ENV] = dependency_target
     try:
         result = subprocess.run(
             cmd,
@@ -258,6 +312,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             prefix=sys.prefix,
             llama_module_path="missing",
             error=str(exc),
+            base_prefix=str(getattr(sys, "base_prefix", sys.prefix)),
+            python_version=_python_version_text(),
         )
 
     stdout = (result.stdout or "").strip()
@@ -271,6 +327,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             prefix=sys.prefix,
             llama_module_path="missing",
             error=stderr or f"probe subprocess failed with return code {result.returncode}",
+            base_prefix=str(getattr(sys, "base_prefix", sys.prefix)),
+            python_version=_python_version_text(),
         )
 
     try:
@@ -282,6 +340,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             "detected_device": "none",
             "interpreter": sys.executable,
             "prefix": sys.prefix,
+            "base_prefix": getattr(sys, "base_prefix", sys.prefix),
+            "python_version": _python_version_text(),
             "llama_module_path": "missing",
             "error": stderr or "probe parse failure",
         }
@@ -294,6 +354,8 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         prefix=str(payload.get("prefix", sys.prefix)),
         llama_module_path=str(payload.get("llama_module_path", "missing")),
         error=payload.get("error"),
+        base_prefix=str(payload.get("base_prefix", getattr(sys, "base_prefix", sys.prefix))),
+        python_version=str(payload.get("python_version", _python_version_text())),
     )
 
 
@@ -399,6 +461,8 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
         "interpreter": probe.interpreter,
         "prefix": probe.prefix,
         "interpreter_prefix": probe.prefix,
+        "base_prefix": probe.base_prefix or probe.prefix,
+        "python_version": probe.python_version or _python_version_text(),
         "llama_module_path": probe.llama_module_path,
     }
 
@@ -618,11 +682,84 @@ def _resolve_requirements_path(target_root: Path) -> Path:
     return candidates[0]
 
 
+
+def _ensure_dependency_target_importable(target_dir: Path) -> None:
+    target_dir_str = str(target_dir)
+    if target_dir_str not in _REAL_SYS.path:
+        _REAL_SYS.path.insert(0, target_dir_str)
+    os.environ[DEPENDENCY_TARGET_ENV] = target_dir_str
+    existing_pythonpath = os.environ.get("PYTHONPATH", "")
+    entries = [target_dir_str]
+    if existing_pythonpath:
+        entries.extend([entry for entry in existing_pythonpath.split(os.pathsep) if entry])
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if entry not in seen:
+            seen.add(entry)
+            deduped.append(entry)
+    os.environ["PYTHONPATH"] = os.pathsep.join(deduped)
+
+
+def _pip_version() -> str:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as exc:
+        return f"unavailable: {exc}"
+    output = (result.stdout or result.stderr or "").strip()
+    if result.returncode != 0:
+        return f"unavailable: {output or f'return code {result.returncode}'}"
+    return output or "available"
+
+
+def _runtime_diagnostics_payload(
+    probe: RuntimeProbe,
+    *,
+    dependency_target: Optional[Path] = None,
+    pip_version: Optional[str] = None,
+    install_command: str = "",
+    cmake_args: str = "",
+    install_log_tail: str = "",
+) -> Dict[str, str]:
+    payload = _probe_result_payload(probe)
+    payload.update(
+        {
+            "dependency_target": str(dependency_target or os.environ.get(DEPENDENCY_TARGET_ENV, "")),
+            "pip_version": pip_version or "",
+            "install_command": install_command,
+            "cmake_args": cmake_args,
+            "install_log_tail": _text_tail(install_log_tail),
+        }
+    )
+    return payload
+
+
+def _macos_runtime_install_target(target_root: Path) -> tuple[Optional[Path], Optional[str]]:
+    target_dir, target_error = _resolve_desktop_dependency_target(target_root)
+    if target_dir is not None:
+        _ensure_dependency_target_importable(target_dir)
+    return target_dir, target_error
+
+
 def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
     target_root = _resolve_runtime_root(repo_root=repo_root)
+    policy = _runtime_bootstrap_policy()
+    expected_backend = policy.expected_backend
+    dependency_target: Optional[Path] = None
+    dependency_target_error: Optional[str] = None
+    pip_version = ""
+    if policy.platform == "darwin" and selected_mode in GPU_MODES:
+        dependency_target, dependency_target_error = _macos_runtime_install_target(target_root)
+        pip_version = _pip_version()
     before = _probe_runtime(target_root)
     if _is_repo_local_llama_module(before.llama_module_path, target_root):
         return {
@@ -651,9 +788,6 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             "runtime_action": _already_supported_action(before.backend),
             **_probe_result_payload(before),
         }
-
-    policy = _runtime_bootstrap_policy()
-    expected_backend = policy.expected_backend
 
     if before.backend == "missing" and not policy.bootstrap_supported:
         return {
@@ -703,8 +837,24 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             **_probe_result_payload(before),
         }
 
+    if policy.platform == "darwin" and dependency_target is None:
+        return {
+            "selected_backend": "cpu",
+            "fallback_reason": (
+                "macOS desktop runtime install target unavailable; "
+                f"interpreter={before.interpreter}; python_version={before.python_version}; "
+                f"prefix={before.prefix}; base_prefix={before.base_prefix}; "
+                f"target_error={dependency_target_error or 'no writable app dependency target'}"
+            ),
+            "runtime_action": _install_failure_action(expected_backend),
+            **_runtime_diagnostics_payload(before, pip_version=pip_version),
+        }
+
     requirements_path = _resolve_requirements_path(target_root)
     last_error = ""
+    last_install_log = ""
+    last_install_command = ""
+    last_cmake_args = ""
 
     if expected_backend == "cuda":
         should_repair, repair_skip_reason = _should_attempt_source_repair()
@@ -754,12 +904,17 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             "install",
             "--force-reinstall",
             *plan.pip_install_args(),
-            plan.package_spec,
         ]
+        if policy.platform == "darwin" and dependency_target is not None:
+            cmd.extend(["--target", str(dependency_target)])
+        cmd.append(plan.package_spec)
+        last_install_command = _command_summary(cmd)
+        last_cmake_args = plan.cmake_args or ""
         timeout_seconds = (
             PIP_SOURCE_BUILD_TIMEOUT_SECONDS if plan.no_binary else PIP_INSTALL_TIMEOUT_SECONDS
         )
         ok, log_output = _run_pip_install(cmd, env, timeout_seconds=timeout_seconds)
+        last_install_log = log_output
         if not ok:
             last_error = _summarize_install_error(log_output)
             continue
@@ -789,21 +944,37 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                         "selected_backend": "cpu",
                         "fallback_reason": reason,
                         "runtime_action": _install_failure_action(expected_backend),
-                        **_probe_result_payload(after),
+                        **_runtime_diagnostics_payload(
+                            after,
+                            dependency_target=dependency_target,
+                            pip_version=pip_version,
+                            install_command=last_install_command,
+                            cmake_args=last_cmake_args,
+                            install_log_tail=last_install_log,
+                        ),
                     }
             return {
                 "selected_backend": selected_backend,
                 "fallback_reason": reason,
                 "runtime_action": _installed_reexec_action(plan.backend),
-                **_probe_result_payload(after),
+                **_runtime_diagnostics_payload(
+                    after,
+                    dependency_target=dependency_target,
+                    pip_version=pip_version,
+                    install_command=last_install_command,
+                    cmake_args=last_cmake_args,
+                    install_log_tail=last_install_log,
+                ),
             }
 
         if plan.backend in {"cuda", "metal"}:
+            backend_label = "Metal" if plan.backend == "metal" else plan.backend.upper()
             last_error = (
-                f"{plan.backend.upper()} install completed but follow-up probe reported "
-                f"backend={after.backend} gpu_offload_supported={after.gpu_offload_supported}"
+                f"{backend_label} install completed but follow-up probe did not report "
+                f"{backend_label} GPU offload; backend={after.backend} "
+                f"gpu_offload_supported={after.gpu_offload_supported}"
             )
-            if plan.backend == "metal":
+            if plan.backend == "metal" and selected_mode == "gpu":
                 return {
                     "selected_backend": "cpu",
                     "fallback_reason": (
@@ -813,7 +984,14 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                         f"llama_module_path={after.llama_module_path}"
                     ),
                     "runtime_action": _install_failure_action(expected_backend),
-                    **_probe_result_payload(after),
+                    **_runtime_diagnostics_payload(
+                        after,
+                        dependency_target=dependency_target,
+                        pip_version=pip_version,
+                        install_command=last_install_command,
+                        cmake_args=last_cmake_args,
+                        install_log_tail=last_install_log,
+                    ),
                 }
 
         if plan.backend == "cpu":
@@ -825,10 +1003,17 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                 "selected_backend": "cpu",
                 "fallback_reason": reason,
                 "runtime_action": _cpu_fallback_action(expected_backend),
-                **_probe_result_payload(after),
+                **_runtime_diagnostics_payload(
+                    after,
+                    dependency_target=dependency_target,
+                    pip_version=pip_version,
+                    install_command=last_install_command,
+                    cmake_args=last_cmake_args,
+                    install_log_tail=last_install_log,
+                ),
             }
 
-    reason = before.error or last_error or "unable to install a GPU-capable runtime"
+    reason = last_error or before.error or "unable to install a GPU-capable runtime"
     if expected_backend == "metal":
         reason = (
             f"Metal runtime install failed ({reason}); interpreter={before.interpreter}; "
@@ -838,7 +1023,14 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         "selected_backend": "cpu",
         "fallback_reason": reason,
         "runtime_action": _install_failure_action(expected_backend),
-        **_probe_result_payload(before),
+        **_runtime_diagnostics_payload(
+            before,
+            dependency_target=dependency_target,
+            pip_version=pip_version,
+            install_command=last_install_command,
+            cmake_args=last_cmake_args,
+            install_log_tail=last_install_log,
+        ),
     }
 
 

--- a/desktop-tauri/src-tauri/python/path_bootstrap.py
+++ b/desktop-tauri/src-tauri/python/path_bootstrap.py
@@ -202,7 +202,9 @@ def ensure_runtime_import_paths(
     script_dir = os.path.dirname(script_path)
     script_root = _parent(script_dir)
     explicit_import_root = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    desktop_dependency_target = os.environ.get("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", "").strip()
     candidates = [
+        _safe_resolve_path_text(desktop_dependency_target) if desktop_dependency_target else None,
         _safe_resolve_path_text(explicit_import_root) if explicit_import_root else None,
         script_root,  # bundled resources root in packaged apps
         _join(
@@ -221,8 +223,11 @@ def ensure_runtime_import_paths(
     for candidate in candidates:
         if candidate is None or not _path_exists(candidate):
             continue
-        has_runtime_modules = _is_dir(_join(candidate, "utils")) or _is_file(
-            _join(candidate, "config.py")
+        has_runtime_modules = (
+            _is_dir(_join(candidate, "utils"))
+            or _is_file(_join(candidate, "config.py"))
+            or _is_dir(_join(candidate, "llama_cpp"))
+            or _is_file(_join(candidate, "llama_cpp.py"))
         )
         if has_runtime_modules:
             candidate_str = _safe_resolve_path_text(candidate)

--- a/docs/desktop_parity_validation.md
+++ b/docs/desktop_parity_validation.md
@@ -102,10 +102,14 @@ python desktop-tauri/scripts/windows_nvidia_gpu_smoke_test.py --mode auto --mode
 
 ```bash
 # macOS shell on Metal-capable hardware.
-CMAKE_ARGS=-DGGML_METAL=on FORCE_CMAKE=1 python -m pip install --force-reinstall --no-cache-dir llama-cpp-python
+CMAKE_ARGS="-DGGML_METAL=on -DGGML_NATIVE=off" FORCE_CMAKE=1 python -m pip install --force-reinstall --no-cache-dir --no-binary llama-cpp-python llama-cpp-python
 python desktop-tauri/scripts/verify_desktop_runtime.py --mode auto --model /path/to/model.gguf
 python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py
 ```
+
+For packaged `.app` validation, open the Prompt-1 debug logs (`TOKEN_PLACE_VERBOSE_SUBPROCESS_LOGS=1` or `TOKEN_PLACE_VERBOSE_LLM_LOGS=1`) before clicking **Start operator**. The macOS `desktop.runtime_setup` line must include `interpreter`, `python_version`, `prefix`, `base_prefix`, `dependency_target`, `pip_version`, `install_command`, `cmake_args`, `install_log_tail`, `llama_module_path`, `selected_backend`, and `fallback_reason`. If the interpreter is `/Library/Developer/CommandLineTools/usr/bin/python3`, confirm the app installs into the writable `dependency_target` with `pip --target` and does not attempt to write into the CLT prefix. If CLT Python reports missing pip/build tooling, install/repair Xcode Command Line Tools and pip or launch with `TOKEN_PLACE_SIDECAR_PYTHON=/path/to/python3`; then click **Start operator** again to retry provisioning.
+
+Acceptance on a real Mac is either Metal (`model_init.ready`, `server.registered`, UI `Registered: yes`, and Metal/GPU offload diagnostics) or an explicit `auto`/`hybrid` CPU fallback with `runtime_action=metal_cpu_fallback`, `selected_backend=cpu`, a Metal `fallback_reason`, and `Registered: yes`. Explicit `gpu` must fail closed if Metal cannot be imported/provisioned.
 
 ```bash
 # Explicit CPU fallback check on either platform.

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -417,6 +417,136 @@ def test_macos_metal_install_failure_is_fatal_for_gpu(monkeypatch):
     assert message and 'Metal' in message
 
 
+
+
+def test_macos_metal_install_uses_writable_target_with_spaces_and_records_diagnostics(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    target = tmp_path / 'Application Support' / 'token.place desktop site'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (target, None),
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_pip_version', lambda: 'pip 24.0 from target')
+    probes = iter([
+        _probe(backend='missing', gpu=False, device='none', error="No module named 'llama_cpp'"),
+        _probe(backend='metal', gpu=True, device='metal'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin',
+        backend='metal',
+        package_spec='llama-cpp-python==0.3.16',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off',
+        force_cmake=True,
+        index_url='https://pypi.org/simple',
+        only_binary=False,
+        no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    captured = {}
+
+    def _install(cmd, env, **kwargs):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        return True, 'build stdout\nclang: metal enabled'
+
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', _install)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(target)
+    assert captured['env']['CMAKE_ARGS'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
+    assert result['dependency_target'] == str(target)
+    assert result['pip_version'] == 'pip 24.0 from target'
+    assert '--target' in result['install_command']
+    assert str(target) in result['install_command']
+    assert result['cmake_args'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
+    assert 'metal enabled' in result['install_log_tail']
+
+
+def test_macos_clt_python_missing_llama_cpp_reports_actionable_install_target(monkeypatch, tmp_path):
+    clt_sys = _PlatformStub('darwin')
+    clt_sys.executable = '/Library/Developer/CommandLineTools/usr/bin/python3'
+    clt_sys.prefix = '/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9'
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', clt_sys)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    target = tmp_path / 'token.place desktop deps'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (target, None),
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_pip_version', lambda: 'pip unavailable: No module named pip')
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: desktop_runtime_setup.RuntimeProbe(
+            backend='missing',
+            gpu_offload_supported=False,
+            detected_device='none',
+            interpreter=clt_sys.executable,
+            prefix=clt_sys.prefix,
+            base_prefix=clt_sys.prefix,
+            python_version='3.9.6',
+            llama_module_path='missing',
+            error="No module named 'llama_cpp'",
+        ),
+    )
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin', backend='metal', package_spec='llama-cpp-python',
+        cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
+        index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (False, 'CMake Error: Metal compiler not found\nNo module named pip'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('gpu', repo_root=REPO_ROOT)
+
+    assert result['runtime_action'] == 'metal_install_failed'
+    assert clt_sys.executable in result['fallback_reason']
+    assert clt_sys.prefix in result['fallback_reason']
+    assert result['dependency_target'] == str(target)
+    assert result['python_version'] == '3.9.6'
+    assert result['pip_version'].startswith('pip unavailable')
+    assert 'No module named pip' in result['install_log_tail']
+    assert '--target' in result['install_command']
+
+
+def test_windows_cuda_already_supported_does_not_use_macos_target_or_metal_install(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cuda', gpu=True, device='cuda'),
+    )
+    invoked = {'pip': False, 'target': False}
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *_args, **_kwargs: (invoked.update(pip=True), '') and (False, 'unexpected'),
+    )
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (invoked.update(target=True), None) and (None, 'unexpected'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT)
+
+    assert result['selected_backend'] == 'cuda'
+    assert result['runtime_action'] == 'already_supported'
+    assert invoked == {'pip': False, 'target': False}
+    assert 'dependency_target' not in result or result['dependency_target'] == ''
+
+
 def test_runtime_root_prefers_token_place_python_import_root(monkeypatch, tmp_path):
     runtime_root = tmp_path / 'resources'
     (runtime_root / 'utils').mkdir(parents=True)


### PR DESCRIPTION
### Motivation
- Packaged macOS Start operator was selecting an unwritable/system interpreter (Command Line Tools Python) and failing with opaque "No module named 'llama_cpp'" errors instead of installing into a writable app-managed target and showing actionable diagnostics.
- The goal is to make macOS `auto`/`gpu`/`hybrid` provisioning robust: install into an app-writable `.token_place_desktop_site` target when available, surface pip/CMake/install stdout tails and environment details, and keep explicit `gpu` mode fatal while allowing safe CPU fallback in `auto`/`hybrid`.

### Description
- Add a macOS app-managed dependency target and ensure it is importable and propagated to the probe subprocess via `TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET`, and use `pip --target` for installs into that writable location. (changes in `desktop_runtime_setup.py` and `path_bootstrap.py`).
- Extend the probe/install diagnostics to include `python_version`, `base_prefix`, `dependency_target`, `pip_version`, `install_command`, `cmake_args`, and a bounded `install_log_tail`, and include these fields in bridge startup logs. (changes in `desktop_runtime_setup.py` and `compute_node_bridge.py`).
- Adjust macOS provisioning logic so `auto`/`hybrid` may fall back to an importable CPU wheel when Metal provisioning fails, while `gpu` remains fatal and returns actionable install/cmake/pip stderr tails; keep Windows CUDA behavior unchanged. (changes in `desktop_runtime_setup.py`).
- Make the packaged dependency target participate in runtime import-path bootstrap so the probe and subsequent imports prefer the app-managed site-packages when it contains `llama_cpp`. (changes in `path_bootstrap.py`).
- Add unit/regression tests for macOS packaged layout, CLT Python diagnostics, install-into-target with spaces, Metal fallback semantics, and keep Windows CUDA parity tests; update README/docs to document macOS packaged validation and troubleshooting. (changes in `tests/unit/test_desktop_runtime_setup.py`, `desktop-tauri/README.md`, `docs/desktop_parity_validation.md`).

### Testing
- Ran `pytest tests/unit/test_desktop_runtime_setup.py` which passed (75 passed). 
- Ran the focused desktop/macOS suites `pytest tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_path_bootstrap.py tests/unit/test_model_manager.py tests/unit/test_desktop_compute_node_bridge.py -k "macos or metal or runtime or warm or register or fallback"` which passed (selected tests passed; suites reported 133 passed, 112 deselected in the focused run). 
- Ran packaged parity and relay parity scripts `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`, and `python desktop-tauri/scripts/run_desktop_parity_checks.py` which completed in CI-like smoke runs in this environment (no hardware Metal required due to test fakes/mocks). 
- Ran `pre-commit run --all-files` which passed project checks. 
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` was attempted but is blocked in this Linux container due to a missing system dependency (`glib-2.0.pc` / libglib development package); this is environment-specific and unrelated to the Python logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a234812d618832f8f3180db894bd7cb)