### PR TITLE
Add API v1 unregister, cancel queued/in-flight work on Stop, and make clients fail fast when no servers remain

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -231,7 +231,7 @@ PY
 
 # 5. Compare relay app logs with desktop diagnostics for the same UTC window.
 kubectl -n tokenplace logs deploy/tokenplace --since=30m | \
-  grep -E 'POST /api/v1/relay/servers/(register|poll)|api_v1|relay/servers'
+  grep -E 'POST /api/v1/relay/servers/(register|poll|unregister)|api_v1|relay/servers'
 ```
 
 Decision points:

--- a/docs/security/api_v1_e2ee_relay.md
+++ b/docs/security/api_v1_e2ee_relay.md
@@ -8,6 +8,7 @@ Distributed relay traffic is relay-blind E2EE: relay-owned state and logs contai
 
 - `POST /api/v1/relay/servers/register`
 - `POST /api/v1/relay/servers/poll`
+- `POST /api/v1/relay/servers/unregister`
 - `GET /api/v1/relay/servers/next`
 - `POST /api/v1/relay/requests`
 - `POST /api/v1/relay/responses`

--- a/relay.py
+++ b/relay.py
@@ -660,15 +660,62 @@ def _remove_known_server(server_public_key: str) -> bool:
         return True
 
 
-def _unregister_server(server_public_key: str) -> bool:
+def _terminalize_unregistered_server_items(items, *, reason: str) -> int:
+    """Wake API v1 waiters for queued/in-flight work abandoned by unregister."""
+
+    cancelled = 0
+    for item in items or []:
+        if not isinstance(item, dict) or not bool(item.get("e2ee_v1")):
+            continue
+        client_public_key = item.get("client_public_key")
+        request_id = item.get("request_id")
+        if not client_public_key or not request_id:
+            continue
+        _remove_client_responses_for_request(client_public_key, request_id)
+        _clear_pending_request(client_public_key, request_id)
+        _mark_request_terminal(
+            client_public_key,
+            request_id,
+            status="expired",
+            reason=reason,
+        )
+        cancelled += 1
+    return cancelled
+
+
+def _unregister_server_result(server_public_key: str) -> dict[str, Any]:
     """Remove a compute node and associated per-server queue/session state."""
 
+    in_flight_items = []
+    with server_round_robin_lock:
+        server_payload = known_servers.get(server_public_key)
+        if isinstance(server_payload, dict):
+            with api_v1_in_flight_requests_lock:
+                in_flight_requests = server_payload.get("api_v1_in_flight_requests")
+                if isinstance(in_flight_requests, dict):
+                    for request_id, entry in list(in_flight_requests.items()):
+                        if not isinstance(entry, dict):
+                            continue
+                        in_flight_items.append({
+                            "e2ee_v1": True,
+                            "client_public_key": entry.get("client_public_key"),
+                            "request_id": request_id,
+                        })
+                    in_flight_requests.clear()
+
     removed = _remove_known_server(server_public_key)
-    dropped_requests = []
     with client_inference_requests_changed:
         dropped_requests = list(client_inference_requests.pop(server_public_key, []) or [])
         client_inference_requests_changed.notify_all()
-    _clear_pending_requests_for_queued_items(dropped_requests)
+
+    cancelled_queue_depth = _terminalize_unregistered_server_items(
+        dropped_requests,
+        reason="server_unregistered",
+    )
+    cancelled_in_flight_depth = _terminalize_unregistered_server_items(
+        in_flight_items,
+        reason="server_unregistered",
+    )
 
     with stream_lock:
         stale_session_ids = [
@@ -686,7 +733,25 @@ def _unregister_server(server_public_key: str) -> bool:
                 if mapped_session_id == session_id:
                     streaming_sessions_by_client.pop(client_public_key, None)
 
-    return removed
+    result = {
+        "removed": removed,
+        "cancelled_queue_depth": cancelled_queue_depth,
+        "cancelled_in_flight_depth": cancelled_in_flight_depth,
+    }
+    LOGGER.info(
+        "server.unregistered",
+        extra={
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
+            **result,
+        },
+    )
+    return result
+
+
+def _unregister_server(server_public_key: str) -> bool:
+    """Remove a compute node and associated per-server queue/session state."""
+
+    return bool(_unregister_server_result(server_public_key)["removed"])
 
 
 def _can_resolve_gpu_host(hostname: str) -> bool:
@@ -1139,6 +1204,7 @@ _ALLOWED_API_V1_TERMINAL_REASONS = {
     "requester_gave_up",
     "provider_timeout",
     "pending_request_ttl_exceeded",
+    "server_unregistered",
 }
 
 
@@ -2040,24 +2106,37 @@ def sink():
     return jsonify(response_data)
 
 
-@app.route('/unregister', methods=['POST'])
-def unregister():
+def _handle_server_unregister_request():
     """Explicitly unregister a compute node and clear relay queue/session state."""
 
     auth_error = _validate_server_registration()
     if auth_error:
         return auth_error
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
     if not isinstance(data, dict):
-        return jsonify({'error': 'Invalid request data'}), 400
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
 
     public_key = data.get('server_public_key')
     if not isinstance(public_key, str) or not public_key.strip():
-        return jsonify({'error': 'Invalid public key'}), 400
+        return jsonify({'error': {'message': 'Invalid public key', 'code': 400}}), 400
 
-    removed = _unregister_server(public_key)
-    return jsonify({'message': 'Server unregistered', 'removed': removed}), 200
+    result = _unregister_server_result(public_key)
+    return jsonify({'message': 'Server unregistered', **result}), 200
+
+
+@app.route('/api/v1/relay/servers/unregister', methods=['POST'])
+def api_v1_relay_servers_unregister():
+    """Explicitly unregister an API v1 compute node."""
+
+    return _handle_server_unregister_request()
+
+
+@app.route('/unregister', methods=['POST'])
+def unregister():
+    """Legacy alias for explicit compute node unregister."""
+
+    return _handle_server_unregister_request()
 
 @app.route('/source', methods=['POST'])
 def source():

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1575,7 +1575,7 @@ def test_api_v1_response_retrieve_stays_pending_for_long_running_valid_interval(
     assert pending.get_json() == {'status': 'pending'}
 
 
-def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_queue(client):
+def test_api_v1_response_retrieve_returns_410_after_unregistered_server_cancels_queue(client):
     client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
     queued = client.post(
         '/api/v1/relay/requests',
@@ -1599,14 +1599,19 @@ def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_qu
     assert pending.status_code == 202
     assert pending.get_json() == {'status': 'pending'}
 
-    unregistered = client.post('/unregister', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    unregistered = client.post(
+        '/api/v1/relay/servers/unregister',
+        json={'server_public_key': DUMMY_SERVER_PUB_KEY},
+    )
     assert unregistered.status_code == 200
+    assert unregistered.get_json()['cancelled_queue_depth'] == 1
 
     unknown = client.post(
         '/api/v1/relay/responses/retrieve',
         json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-abandoned'},
     )
-    assert unknown.status_code == 404
+    assert unknown.status_code == 410
+    assert unknown.get_json()["error"]["reason"] == "server_unregistered"
 
 
 def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(client):
@@ -2189,7 +2194,7 @@ def test_api_v1_round_robin_preserves_next_node_after_selected_server_unregister
 
     assert _next_api_v1_server_key(client) == server_a
 
-    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    unregistered = client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_a})
     assert unregistered.status_code == 200
     assert unregistered.get_json()['removed'] is True
 
@@ -2405,7 +2410,7 @@ def test_api_v1_request_enqueue_rejects_legacy_only_server_without_queue_entry(c
 def test_api_v1_request_enqueue_rejects_removed_server_without_queue_entry(client):
     server_key = _server_key('enqueue_removed')
     _register_api_v1_server(client, server_key)
-    assert client.post('/unregister', json={'server_public_key': server_key}).status_code == 200
+    assert client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_key}).status_code == 200
 
     response = client.post('/api/v1/relay/requests', json={
         'request_id': 'req-removed-server',
@@ -2466,7 +2471,7 @@ def test_api_v1_round_robin_skips_expired_and_unregistered_nodes(client, monkeyp
     assert [_next_api_v1_server_key(client) for _ in range(4)] == [server_a, server_c, server_a, server_c]
     assert server_b not in known_servers
 
-    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    unregistered = client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_a})
     assert unregistered.status_code == 200
     assert unregistered.get_json()['removed'] is True
     assert [_next_api_v1_server_key(client) for _ in range(2)] == [server_c, server_c]
@@ -2480,7 +2485,7 @@ def test_api_v1_reregistered_round_robin_node_reenters_at_end(client):
     _register_api_v1_server(client, server_b)
     _register_api_v1_server(client, server_c)
 
-    assert client.post('/unregister', json={'server_public_key': server_b}).status_code == 200
+    assert client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_b}).status_code == 200
     _register_api_v1_server(client, server_b)
 
     assert [_next_api_v1_server_key(client) for _ in range(6)] == [
@@ -2632,7 +2637,7 @@ def test_api_v1_unregister_removes_known_server_and_next_skips_it(client):
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
     assert client.get('/api/v1/relay/servers/next').status_code == 200
 
-    unregistered = client.post('/unregister', json=server_payload)
+    unregistered = client.post('/api/v1/relay/servers/unregister', json=server_payload)
 
     assert unregistered.status_code == 200
     assert unregistered.get_json()['removed'] is True
@@ -2642,11 +2647,34 @@ def test_api_v1_unregister_removes_known_server_and_next_skips_it(client):
     assert next_response.status_code == 503
 
 
+def test_api_v1_unregister_cancels_in_flight_request_promptly(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    request_payload = _api_v1_request_payload('req-in-flight-unregister')
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    assert client.post('/api/v1/relay/requests', json=request_payload).status_code == 200
+
+    poll_response = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll_response.status_code == 200
+    assert poll_response.get_json()['request_id'] == 'req-in-flight-unregister'
+
+    unregistered = client.post('/api/v1/relay/servers/unregister', json=server_payload)
+
+    assert unregistered.status_code == 200
+    assert unregistered.get_json()['removed'] is True
+    assert unregistered.get_json()['cancelled_in_flight_depth'] == 1
+    retrieve = client.post(
+        '/api/v1/relay/responses/retrieve',
+        json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-in-flight-unregister'},
+    )
+    assert retrieve.status_code == 410
+    assert retrieve.get_json()['error']['reason'] == 'server_unregistered'
+
+
 def test_api_v1_unregister_is_idempotent_when_server_already_gone(client):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
 
-    first = client.post('/unregister', json=server_payload)
-    second = client.post('/unregister', json=server_payload)
+    first = client.post('/api/v1/relay/servers/unregister', json=server_payload)
+    second = client.post('/api/v1/relay/servers/unregister', json=server_payload)
 
     assert first.status_code == 200
     assert second.status_code == 200

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -374,7 +374,7 @@ class TestRelayClient:
 
     @patch('utils.networking.relay_client.requests.post')
     def test_unregister_from_relay_success(self, mock_post, relay_client):
-        """Unregister should post to /unregister and return True on success after registration."""
+        """Unregister should post to /api/v1/relay/servers/unregister and return True on success after registration."""
 
         relay_client._api_v1_registered_relays.add(relay_client.relay_url)
         relay_client._api_v1_last_heartbeat_at[relay_client.relay_url] = 1.0
@@ -386,7 +386,7 @@ class TestRelayClient:
 
         assert result is True
         mock_post.assert_called_once_with(
-            'http://localhost:5000/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
             json={'server_public_key': 'mock_public_key_b64'},
             timeout=relay_client._request_timeout,
         )
@@ -439,8 +439,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/unregister',
-            'http://backup-relay:6000/unregister',
+            'http://primary-relay:5000/api/v1/relay/servers/unregister',
+            'http://backup-relay:6000/api/v1/relay/servers/unregister',
         ]
 
     @patch('utils.networking.relay_client.requests.post')
@@ -460,8 +460,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://localhost:5000/unregister',
-            'http://localhost:5000/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
         ]
 
     @patch('utils.networking.relay_client.requests.post')
@@ -515,9 +515,9 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            f'{primary}/unregister',
-            f'{backup}/unregister',
-            f'{backup}/unregister',
+            f'{primary}/api/v1/relay/servers/unregister',
+            f'{backup}/api/v1/relay/servers/unregister',
+            f'{backup}/api/v1/relay/servers/unregister',
         ]
         assert client._api_v1_registered_relays == set()
         assert client._api_v1_last_heartbeat_at == {}
@@ -3299,7 +3299,7 @@ def test_unregister_from_relay_is_idempotent_and_clears_api_v1_registration(mock
     assert client.unregister_from_relay() is True
 
     mock_post.assert_called_once_with(
-        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/unregister',
         json={'server_public_key': 'mock_public_key_b64'},
         timeout=15,
     )
@@ -3320,7 +3320,7 @@ def test_unregister_from_relay_rechecks_registration_after_previous_empty_skip(m
     assert client.unregister_from_relay() is True
 
     mock_post.assert_called_once_with(
-        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/unregister',
         json={'server_public_key': 'mock_public_key_b64'},
         timeout=15,
     )
@@ -3390,7 +3390,7 @@ def test_poll_api_v1_encrypted_work_stop_after_register_retries_unregister(mock_
         if url.endswith('/relay/servers/register'):
             client.stop()
             return register_response
-        if url.endswith('/unregister'):
+        if url.endswith('/api/v1/relay/servers/unregister'):
             return unregister_response
         raise AssertionError(f'Unexpected relay request: {url}')
 
@@ -3406,7 +3406,7 @@ def test_poll_api_v1_encrypted_work_stop_after_register_retries_unregister(mock_
     requested_urls = [call.args[0] for call in mock_post.call_args_list]
     assert requested_urls == [
         'http://localhost:5000/api/v1/relay/servers/register',
-        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/unregister',
     ]
     assert client._api_v1_registered_relays == set()
     assert client._api_v1_last_heartbeat_at == {}

--- a/tests/unit/test_relay_registration_token.py
+++ b/tests/unit/test_relay_registration_token.py
@@ -93,7 +93,7 @@ def test_source_requires_registration_token(relay_module) -> None:
 
 
 def test_unregister_requires_registration_token(relay_module) -> None:
-    """/unregister should require auth parity with /sink and /source."""
+    """API v1 unregister should require auth parity with /sink and /source."""
 
     relay_module.known_servers.clear()
     relay_module.client_inference_requests.clear()
@@ -120,16 +120,19 @@ def test_unregister_requires_registration_token(relay_module) -> None:
     client = relay_module.app.test_client()
     payload = {"server_public_key": "abc"}
 
-    unauthorised = client.post("/unregister", json=payload)
+    unauthorised = client.post("/api/v1/relay/servers/unregister", json=payload)
     assert unauthorised.status_code == 401
 
     authorised = client.post(
-        "/unregister",
+        "/api/v1/relay/servers/unregister",
         json=payload,
         headers={"X-Relay-Server-Token": "unit-token"},
     )
     assert authorised.status_code == 200
-    assert authorised.get_json() == {"message": "Server unregistered", "removed": True}
+    authorised_payload = authorised.get_json()
+    assert authorised_payload["message"] == "Server unregistered"
+    assert authorised_payload["removed"] is True
+    assert authorised_payload["cancelled_queue_depth"] == 0
     assert "abc" not in relay_module.known_servers
     assert "abc" not in relay_module.client_inference_requests
     assert "session-1" not in relay_module.streaming_sessions
@@ -155,7 +158,7 @@ def test_unregister_removes_node_from_relay_diagnostics_immediately(relay_module
     assert before_payload["registered_compute_nodes"][0]["server_public_key"] == "abc"
 
     unregister_response = client.post(
-        "/unregister",
+        "/api/v1/relay/servers/unregister",
         json={"server_public_key": "abc"},
         headers={"X-Relay-Server-Token": "unit-token"},
     )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -866,7 +866,7 @@ class RelayClient:
                     request_kwargs['headers'] = headers
 
                 response = requests.post(
-                    f'{candidate_url}/unregister',
+                    f'{candidate_url}/api/v1/relay/servers/unregister',
                     timeout=self._request_timeout,
                     **request_kwargs,
                 )


### PR DESCRIPTION
### Motivation

- Prevent stale relay selection and long client hangs when a compute node stops by removing stopped nodes immediately and waking any waiters for queued/in-flight work.  

### Description

- Add a new idempotent API v1 route `POST /api/v1/relay/servers/unregister` and keep `/unregister` as a legacy alias, returning a JSON result that includes `removed`, `cancelled_queue_depth`, and `cancelled_in_flight_depth`.  
- Implement `_unregister_server_result` and `_terminalize_unregistered_server_items` to remove the server, clear per-server queues/sessions, and mark API v1 requests terminal with reason `server_unregistered` so client waiters wake promptly.  
- Preserve and adjust round-robin cursor logic via `_remove_known_server` so selection immediately excludes unregistered nodes.  
- Update the compute-node client (`utils/networking/relay_client.py`) to call the new API v1 unregister path when stopping.  
- Add guarded JSON validation and more specific error payload shapes for unregister requests, and emit structured logs (`server.unregistered`, `server_fingerprint`, `cancelled_queue_depth`, `cancelled_in_flight_depth`).  
- Update tests and docs to exercise the new route and behavior and to mention the new public endpoint in relay-related docs; keep E2EE invariants and API v1 semantics intact.  

### Testing

- Ran focused relay tests: `pytest tests/test_relay.py -k "unregister or next or round_robin or queue or no_servers"` and addressed failures until the suite passed (38 passed, 70 deselected).  
- Ran relay client unit tests: `pytest tests/unit/test_relay_client.py -k "unregister or stop or register"` (34 passed).  
- Ran desktop bridge unit tests: `pytest tests/unit/test_desktop_compute_node_bridge.py -k "stop or unregister or registered"` (13 passed).  
- Ran registration-token unit tests: `pytest tests/unit/test_relay_registration_token.py -k unregister` (2 passed).  
- Ran the API/integration suite including `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` (10 passed) and the full test runner triggered by `pre-commit run --all-files` / project test harness (JavaScript + Python suites), which reported the test runner success for the exercised suites.  

All updated tests that exercise unregister semantics (unit + integration) passed locally; docs were updated to include the new `POST /api/v1/relay/servers/unregister` route and to surface the recommended log/grep patterns for operators.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23c688bf74832f9d2e170c19df43a5)