### PR TITLE
Add API v1 compute-node unregister and immediate cancellation of stopped nodes

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -46,6 +46,7 @@ CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS = frozenset(
 AUTHENTICATED_RELAY_CONTROL_PLANE_RATE_LIMIT_EXEMPT_PATHS = frozenset(
     {
         "/api/v1/relay/servers/register",
+        "/api/v1/relay/servers/unregister",
         "/api/v1/relay/servers/poll",
         "/api/v1/relay/responses",
     }

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -77,7 +77,7 @@ class ComputeProviderError(Exception):
 _RELAY_ERROR_MAP: dict[str, dict[str, Any]] = {
     "no_registered_compute_nodes": {
         "error_type": "service_unavailable_error",
-        "public_message": "No registered compute nodes are available on this relay.",
+        "public_message": "No LLM servers are available right now.",
         "status_code": 503,
     },
     "compute_node_timeout": {

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -186,8 +186,8 @@ E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`). For d
 Symptom:
 - A desktop/Tauri compute node logs `desktop.compute_node_bridge.api_v1_e2ee.register`
   followed by `error=HTTP 403`, while a synthetic register/poll probe succeeds and relay pod logs
-  do not show corresponding `POST /api/v1/relay/servers/register` or
-  `POST /api/v1/relay/servers/poll` requests.
+  do not show corresponding `POST /api/v1/relay/servers/register`,
+  `POST /api/v1/relay/servers/unregister`, or `POST /api/v1/relay/servers/poll` requests.
 
 Why this matters:
 - The relay registration-token guard returns JSON `401` responses for invalid tokens. A non-JSON
@@ -231,7 +231,7 @@ PY
 
 # 5. Compare relay app logs with desktop diagnostics for the same UTC window.
 kubectl -n tokenplace logs deploy/tokenplace --since=30m | \
-  grep -E 'POST /api/v1/relay/servers/(register|poll)|api_v1|relay/servers'
+  grep -E 'POST /api/v1/relay/servers/(register|unregister|poll)|api_v1|relay/servers'
 ```
 
 Decision points:
@@ -243,11 +243,16 @@ Decision points:
   tunnel, and upstream proxy logs before changing relay application code.
 
 Operational note: `/healthz`, `/livez`, `/metrics`, `/relay/diagnostics`, and API v1 compute-node
-heartbeat/control-plane routes are intentionally exempt from the public API rate-limit quota. A
+heartbeat/control-plane routes, including `/api/v1/relay/servers/unregister`, are intentionally
+exempt from the public API rate-limit quota when authenticated. A
 Kubernetes readiness probe that calls `/healthz` every 10 seconds must not exhaust the default
 `API_RATE_LIMIT=60/hour`; before this exemption, staging could return 429 to kube-probe and become
 externally unhealthy even while the relay process was running. User-facing chat/completion routes
 remain rate-limited.
+
+If Cloudflare/WAF skip or allow rules enumerate API v1 compute-node control paths, include
+`POST /api/v1/relay/servers/unregister` alongside register and poll so Stop operator shutdown can
+reach `relay.py` immediately instead of waiting for heartbeat lease expiry.
 
 ## v0.1.0 staging failure modes and operator runbook
 

--- a/docs/security/api_v1_e2ee_relay.md
+++ b/docs/security/api_v1_e2ee_relay.md
@@ -7,6 +7,7 @@ Distributed relay traffic is relay-blind E2EE: relay-owned state and logs contai
 ## Active API v1 routes
 
 - `POST /api/v1/relay/servers/register`
+- `POST /api/v1/relay/servers/unregister`
 - `POST /api/v1/relay/servers/poll`
 - `GET /api/v1/relay/servers/next`
 - `POST /api/v1/relay/requests`

--- a/relay.py
+++ b/relay.py
@@ -663,12 +663,45 @@ def _remove_known_server(server_public_key: str) -> bool:
 def _unregister_server(server_public_key: str) -> bool:
     """Remove a compute node and associated per-server queue/session state."""
 
+    in_flight_requests = {}
+    with server_round_robin_lock:
+        server_payload = known_servers.get(server_public_key)
+        if isinstance(server_payload, dict):
+            with api_v1_in_flight_requests_lock:
+                raw_in_flight = server_payload.get("api_v1_in_flight_requests")
+                if isinstance(raw_in_flight, dict):
+                    in_flight_requests = dict(raw_in_flight)
+
     removed = _remove_known_server(server_public_key)
     dropped_requests = []
     with client_inference_requests_changed:
         dropped_requests = list(client_inference_requests.pop(server_public_key, []) or [])
         client_inference_requests_changed.notify_all()
-    _clear_pending_requests_for_queued_items(dropped_requests)
+
+    cancelled_queue_depth = 0
+    for item in dropped_requests:
+        if not isinstance(item, dict) or not bool(item.get("e2ee_v1")):
+            continue
+        _cancel_api_v1_request(
+            item.get("client_public_key"),
+            item.get("request_id"),
+            status="expired",
+            reason="server_unregistered",
+        )
+        cancelled_queue_depth += 1
+
+    for request_id, entry in in_flight_requests.items():
+        if not isinstance(request_id, str) or not request_id:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        _cancel_api_v1_request(
+            entry.get("client_public_key"),
+            request_id,
+            status="expired",
+            reason="server_unregistered",
+        )
+        cancelled_queue_depth += 1
 
     with stream_lock:
         stale_session_ids = [
@@ -686,6 +719,14 @@ def _unregister_server(server_public_key: str) -> bool:
                 if mapped_session_id == session_id:
                     streaming_sessions_by_client.pop(client_public_key, None)
 
+    LOGGER.info(
+        "server.unregistered",
+        extra={
+            "server_fingerprint": _safe_key_fingerprint(server_public_key),
+            "removed": removed,
+            "cancelled_queue_depth": cancelled_queue_depth,
+        },
+    )
     return removed
 
 
@@ -1139,6 +1180,7 @@ _ALLOWED_API_V1_TERMINAL_REASONS = {
     "requester_gave_up",
     "provider_timeout",
     "pending_request_ttl_exceeded",
+    "server_unregistered",
 }
 
 
@@ -1531,6 +1573,36 @@ def api_v1_relay_servers_register():
         'next_ping_in_x_seconds': lease_seconds,
         'poll_wait_seconds': _api_v1_poll_wait_seconds(),
     }), 200
+
+
+def _handle_server_unregister_request(*, invalid_error_shape: str = "api_v1"):
+    """Handle idempotent compute-node unregister requests for relay routes."""
+
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        if invalid_error_shape == "legacy":
+            return jsonify({'error': 'Invalid request data'}), 400
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+
+    public_key = data.get('server_public_key')
+    if not isinstance(public_key, str) or not public_key.strip():
+        if invalid_error_shape == "legacy":
+            return jsonify({'error': 'Invalid public key'}), 400
+        return jsonify({'error': {'message': 'Invalid public key', 'code': 400}}), 400
+
+    removed = _unregister_server(public_key)
+    return jsonify({'message': 'Server unregistered', 'removed': removed}), 200
+
+
+@app.route('/api/v1/relay/servers/unregister', methods=['POST'])
+def api_v1_relay_servers_unregister():
+    """Explicitly unregister an API v1 compute node and cancel its queued work."""
+
+    return _handle_server_unregister_request()
 
 
 @app.route('/api/v1/relay/servers/poll', methods=['POST'])
@@ -2043,21 +2115,7 @@ def sink():
 @app.route('/unregister', methods=['POST'])
 def unregister():
     """Explicitly unregister a compute node and clear relay queue/session state."""
-
-    auth_error = _validate_server_registration()
-    if auth_error:
-        return auth_error
-
-    data = request.get_json()
-    if not isinstance(data, dict):
-        return jsonify({'error': 'Invalid request data'}), 400
-
-    public_key = data.get('server_public_key')
-    if not isinstance(public_key, str) or not public_key.strip():
-        return jsonify({'error': 'Invalid public key'}), 400
-
-    removed = _unregister_server(public_key)
-    return jsonify({'message': 'Server unregistered', 'removed': removed}), 200
+    return _handle_server_unregister_request(invalid_error_shape="legacy")
 
 @app.route('/source', methods=['POST'])
 def source():

--- a/relay.py
+++ b/relay.py
@@ -1176,25 +1176,28 @@ def _safe_key_fingerprint(value: Any) -> str:
 _ALLOWED_API_V1_TERMINAL_STATUSES = {"cancelled", "expired"}
 _API_V1_UNREGISTER_TOMBSTONE_TTL_SECONDS = 300.0
 api_v1_recently_unregistered_servers: dict[str, float] = {}
+api_v1_recently_unregistered_servers_lock = threading.Lock()
 
 
 def _record_api_v1_server_unregistered(server_public_key: str) -> None:
     if isinstance(server_public_key, str) and server_public_key:
-        api_v1_recently_unregistered_servers[server_public_key] = time.monotonic()
+        with api_v1_recently_unregistered_servers_lock:
+            api_v1_recently_unregistered_servers[server_public_key] = time.monotonic()
 
 
 def _api_v1_server_was_recently_unregistered(server_public_key: str) -> bool:
     if not isinstance(server_public_key, str) or not server_public_key:
         return False
     now = time.monotonic()
-    expired_keys = [
-        key
-        for key, removed_at in api_v1_recently_unregistered_servers.items()
-        if now - removed_at > _API_V1_UNREGISTER_TOMBSTONE_TTL_SECONDS
-    ]
-    for key in expired_keys:
-        api_v1_recently_unregistered_servers.pop(key, None)
-    return server_public_key in api_v1_recently_unregistered_servers
+    with api_v1_recently_unregistered_servers_lock:
+        expired_keys = [
+            key
+            for key, removed_at in api_v1_recently_unregistered_servers.items()
+            if now - removed_at > _API_V1_UNREGISTER_TOMBSTONE_TTL_SECONDS
+        ]
+        for key in expired_keys:
+            api_v1_recently_unregistered_servers.pop(key, None)
+        return server_public_key in api_v1_recently_unregistered_servers
 
 
 _ALLOWED_API_V1_TERMINAL_REASONS = {

--- a/relay.py
+++ b/relay.py
@@ -663,6 +663,7 @@ def _remove_known_server(server_public_key: str) -> bool:
 def _unregister_server(server_public_key: str) -> bool:
     """Remove a compute node and associated per-server queue/session state."""
 
+    _record_api_v1_server_unregistered(server_public_key)
     in_flight_requests = {}
     with server_round_robin_lock:
         server_payload = known_servers.get(server_public_key)
@@ -685,7 +686,7 @@ def _unregister_server(server_public_key: str) -> bool:
         _cancel_api_v1_request(
             item.get("client_public_key"),
             item.get("request_id"),
-            status="expired",
+            status="cancelled",
             reason="server_unregistered",
         )
         cancelled_queue_depth += 1
@@ -698,7 +699,7 @@ def _unregister_server(server_public_key: str) -> bool:
         _cancel_api_v1_request(
             entry.get("client_public_key"),
             request_id,
-            status="expired",
+            status="cancelled",
             reason="server_unregistered",
         )
         cancelled_queue_depth += 1
@@ -1173,6 +1174,29 @@ def _safe_key_fingerprint(value: Any) -> str:
 
 
 _ALLOWED_API_V1_TERMINAL_STATUSES = {"cancelled", "expired"}
+_API_V1_UNREGISTER_TOMBSTONE_TTL_SECONDS = 300.0
+api_v1_recently_unregistered_servers: dict[str, float] = {}
+
+
+def _record_api_v1_server_unregistered(server_public_key: str) -> None:
+    if isinstance(server_public_key, str) and server_public_key:
+        api_v1_recently_unregistered_servers[server_public_key] = time.monotonic()
+
+
+def _api_v1_server_was_recently_unregistered(server_public_key: str) -> bool:
+    if not isinstance(server_public_key, str) or not server_public_key:
+        return False
+    now = time.monotonic()
+    expired_keys = [
+        key
+        for key, removed_at in api_v1_recently_unregistered_servers.items()
+        if now - removed_at > _API_V1_UNREGISTER_TOMBSTONE_TTL_SECONDS
+    ]
+    for key in expired_keys:
+        api_v1_recently_unregistered_servers.pop(key, None)
+    return server_public_key in api_v1_recently_unregistered_servers
+
+
 _ALLOWED_API_V1_TERMINAL_REASONS = {
     "cancelled",
     "expired",
@@ -1636,11 +1660,12 @@ def api_v1_relay_servers_poll():
         if not isinstance(claimed_request, dict):
             return
         if bool(claimed_request.get('e2ee_v1')):
+            was_unregistered = _api_v1_server_was_recently_unregistered(public_key)
             _cancel_api_v1_request(
                 claimed_request.get('client_public_key'),
                 claimed_request.get('request_id'),
-                status='expired',
-                reason='provider_timeout',
+                status='cancelled' if was_unregistered else 'expired',
+                reason='server_unregistered' if was_unregistered else 'provider_timeout',
             )
 
     def _server_not_found_response(claimed_request=None):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -483,7 +483,7 @@ def test_api_v1_chat_completion_staging_no_nodes_returns_clear_503(client, monke
         def json(self):
             return {
                 "error": {
-                    "message": "No registered compute nodes are available on this relay.",
+                    "message": "No LLM servers are available right now.",
                     "code": "no_registered_compute_nodes",
                 }
             }
@@ -513,7 +513,7 @@ def test_api_v1_chat_completion_staging_no_nodes_returns_clear_503(client, monke
     assert data["error"]["code"] == "no_registered_compute_nodes"
     assert (
         data["error"]["message"]
-        == "No registered compute nodes are available on this relay."
+        == "No LLM servers are available right now."
     )
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1575,7 +1575,7 @@ def test_api_v1_response_retrieve_stays_pending_for_long_running_valid_interval(
     assert pending.get_json() == {'status': 'pending'}
 
 
-def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_queue(client):
+def test_api_v1_response_retrieve_returns_terminal_after_unregistered_server_drops_queue(client):
     client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
     queued = client.post(
         '/api/v1/relay/requests',
@@ -1599,14 +1599,15 @@ def test_api_v1_response_retrieve_returns_404_after_unregistered_server_drops_qu
     assert pending.status_code == 202
     assert pending.get_json() == {'status': 'pending'}
 
-    unregistered = client.post('/unregister', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    unregistered = client.post('/api/v1/relay/servers/unregister', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
     assert unregistered.status_code == 200
 
     unknown = client.post(
         '/api/v1/relay/responses/retrieve',
         json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-abandoned'},
     )
-    assert unknown.status_code == 404
+    assert unknown.status_code == 410
+    assert unknown.get_json()['error']['reason'] == 'server_unregistered'
 
 
 def test_api_v1_response_retrieve_request_id_mismatch_keeps_single_response(client):
@@ -2189,7 +2190,7 @@ def test_api_v1_round_robin_preserves_next_node_after_selected_server_unregister
 
     assert _next_api_v1_server_key(client) == server_a
 
-    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    unregistered = client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_a})
     assert unregistered.status_code == 200
     assert unregistered.get_json()['removed'] is True
 
@@ -2405,7 +2406,7 @@ def test_api_v1_request_enqueue_rejects_legacy_only_server_without_queue_entry(c
 def test_api_v1_request_enqueue_rejects_removed_server_without_queue_entry(client):
     server_key = _server_key('enqueue_removed')
     _register_api_v1_server(client, server_key)
-    assert client.post('/unregister', json={'server_public_key': server_key}).status_code == 200
+    assert client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_key}).status_code == 200
 
     response = client.post('/api/v1/relay/requests', json={
         'request_id': 'req-removed-server',
@@ -2466,7 +2467,7 @@ def test_api_v1_round_robin_skips_expired_and_unregistered_nodes(client, monkeyp
     assert [_next_api_v1_server_key(client) for _ in range(4)] == [server_a, server_c, server_a, server_c]
     assert server_b not in known_servers
 
-    unregistered = client.post('/unregister', json={'server_public_key': server_a})
+    unregistered = client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_a})
     assert unregistered.status_code == 200
     assert unregistered.get_json()['removed'] is True
     assert [_next_api_v1_server_key(client) for _ in range(2)] == [server_c, server_c]
@@ -2480,7 +2481,7 @@ def test_api_v1_reregistered_round_robin_node_reenters_at_end(client):
     _register_api_v1_server(client, server_b)
     _register_api_v1_server(client, server_c)
 
-    assert client.post('/unregister', json={'server_public_key': server_b}).status_code == 200
+    assert client.post('/api/v1/relay/servers/unregister', json={'server_public_key': server_b}).status_code == 200
     _register_api_v1_server(client, server_b)
 
     assert [_next_api_v1_server_key(client) for _ in range(6)] == [
@@ -2632,7 +2633,7 @@ def test_api_v1_unregister_removes_known_server_and_next_skips_it(client):
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
     assert client.get('/api/v1/relay/servers/next').status_code == 200
 
-    unregistered = client.post('/unregister', json=server_payload)
+    unregistered = client.post('/api/v1/relay/servers/unregister', json=server_payload)
 
     assert unregistered.status_code == 200
     assert unregistered.get_json()['removed'] is True
@@ -2645,13 +2646,40 @@ def test_api_v1_unregister_removes_known_server_and_next_skips_it(client):
 def test_api_v1_unregister_is_idempotent_when_server_already_gone(client):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
 
-    first = client.post('/unregister', json=server_payload)
-    second = client.post('/unregister', json=server_payload)
+    first = client.post('/api/v1/relay/servers/unregister', json=server_payload)
+    second = client.post('/api/v1/relay/servers/unregister', json=server_payload)
 
     assert first.status_code == 200
     assert second.status_code == 200
     assert first.get_json()['removed'] is False
     assert second.get_json()['removed'] is False
+
+
+def test_api_v1_unregister_cancels_in_flight_request_promptly(client):
+    server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
+    request_id = 'req-inflight-unregister'
+    assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200
+    assert client.post('/api/v1/relay/requests', json={
+        'request_id': request_id,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+    }).status_code == 200
+    poll = client.post('/api/v1/relay/servers/poll', json=server_payload)
+    assert poll.status_code == 200
+    assert poll.get_json()['request_id'] == request_id
+
+    unregistered = client.post('/api/v1/relay/servers/unregister', json=server_payload)
+
+    assert unregistered.status_code == 200
+    retrieved = client.post('/api/v1/relay/responses/retrieve', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': request_id,
+    })
+    assert retrieved.status_code == 410
+    assert retrieved.get_json()['error']['reason'] == 'server_unregistered'
 
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -48,6 +48,7 @@ def client():
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
+    relay_module.api_v1_recently_unregistered_servers.clear()
 
     with app.test_client() as client:
         yield client
@@ -65,6 +66,7 @@ def client():
     client_responses.clear()
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
+    relay_module.api_v1_recently_unregistered_servers.clear()
 
 
 def test_operational_endpoints_are_not_rate_limited_by_public_quota(client):
@@ -1607,6 +1609,7 @@ def test_api_v1_response_retrieve_returns_terminal_after_unregistered_server_dro
         json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-abandoned'},
     )
     assert unknown.status_code == 410
+    assert unknown.get_json()['error']['status'] == 'cancelled'
     assert unknown.get_json()['error']['reason'] == 'server_unregistered'
 
 
@@ -1953,7 +1956,8 @@ def test_api_v1_poll_clears_popped_work_if_server_unregistered_before_dispatch(c
     def _pop_then_unregister(public_key):
         popped = original_pop(public_key)
         if popped is not None:
-            known_servers.pop(public_key, None)
+            relay_module._record_api_v1_server_unregistered(public_key)
+            relay_module._remove_known_server(public_key)
         return popped
 
     monkeypatch.setattr(relay_module, '_pop_next_api_v1_request', _pop_then_unregister)
@@ -1963,6 +1967,18 @@ def test_api_v1_poll_clears_popped_work_if_server_unregistered_before_dispatch(c
 
     assert DUMMY_SERVER_PUB_KEY not in client_inference_requests
     assert DUMMY_CLIENT_PUB_KEY not in client_pending_request_ids
+
+    retrieved = client.post('/api/v1/relay/responses/retrieve', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-requeue-on-unregister-race',
+    })
+    assert retrieved.status_code == 410
+    assert retrieved.get_json()['error'] == {
+        'message': 'Request cancelled',
+        'code': 'cancelled',
+        'status': 'cancelled',
+        'reason': 'server_unregistered',
+    }
 
 
 def test_api_v1_poll_long_wait_dispatches_when_request_arrives(client, monkeypatch):
@@ -2679,6 +2695,7 @@ def test_api_v1_unregister_cancels_in_flight_request_promptly(client):
         'request_id': request_id,
     })
     assert retrieved.status_code == 410
+    assert retrieved.get_json()['error']['status'] == 'cancelled'
     assert retrieved.get_json()['error']['reason'] == 'server_unregistered'
 
 

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -292,8 +292,16 @@ def test_authenticated_api_v1_relay_heartbeat_routes_do_not_inherit_public_quota
     def relay_servers_poll():
         return {"status": "polling"}
 
+    @app.post("/api/v1/relay/servers/unregister")
+    def relay_servers_unregister():
+        return {"status": "unregistered"}
+
     with app.test_client() as client:
-        for path in ("/api/v1/relay/servers/register", "/api/v1/relay/servers/poll"):
+        for path in (
+            "/api/v1/relay/servers/register",
+            "/api/v1/relay/servers/poll",
+            "/api/v1/relay/servers/unregister",
+        ):
             responses = [
                 client.post(
                     path,

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -374,7 +374,7 @@ class TestRelayClient:
 
     @patch('utils.networking.relay_client.requests.post')
     def test_unregister_from_relay_success(self, mock_post, relay_client):
-        """Unregister should post to /unregister and return True on success after registration."""
+        """Unregister should post to /api/v1/relay/servers/unregister and return True on success after registration."""
 
         relay_client._api_v1_registered_relays.add(relay_client.relay_url)
         relay_client._api_v1_last_heartbeat_at[relay_client.relay_url] = 1.0
@@ -386,7 +386,7 @@ class TestRelayClient:
 
         assert result is True
         mock_post.assert_called_once_with(
-            'http://localhost:5000/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
             json={'server_public_key': 'mock_public_key_b64'},
             timeout=relay_client._request_timeout,
         )
@@ -439,8 +439,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://primary-relay:5000/unregister',
-            'http://backup-relay:6000/unregister',
+            'http://primary-relay:5000/api/v1/relay/servers/unregister',
+            'http://backup-relay:6000/api/v1/relay/servers/unregister',
         ]
 
     @patch('utils.networking.relay_client.requests.post')
@@ -460,8 +460,8 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            'http://localhost:5000/unregister',
-            'http://localhost:5000/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
+            'http://localhost:5000/api/v1/relay/servers/unregister',
         ]
 
     @patch('utils.networking.relay_client.requests.post')
@@ -515,9 +515,9 @@ class TestRelayClient:
 
         requested_urls = [call.args[0] for call in mock_post.call_args_list]
         assert requested_urls == [
-            f'{primary}/unregister',
-            f'{backup}/unregister',
-            f'{backup}/unregister',
+            f'{primary}/api/v1/relay/servers/unregister',
+            f'{backup}/api/v1/relay/servers/unregister',
+            f'{backup}/api/v1/relay/servers/unregister',
         ]
         assert client._api_v1_registered_relays == set()
         assert client._api_v1_last_heartbeat_at == {}
@@ -3299,7 +3299,7 @@ def test_unregister_from_relay_is_idempotent_and_clears_api_v1_registration(mock
     assert client.unregister_from_relay() is True
 
     mock_post.assert_called_once_with(
-        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/unregister',
         json={'server_public_key': 'mock_public_key_b64'},
         timeout=15,
     )
@@ -3320,7 +3320,7 @@ def test_unregister_from_relay_rechecks_registration_after_previous_empty_skip(m
     assert client.unregister_from_relay() is True
 
     mock_post.assert_called_once_with(
-        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/unregister',
         json={'server_public_key': 'mock_public_key_b64'},
         timeout=15,
     )
@@ -3390,7 +3390,7 @@ def test_poll_api_v1_encrypted_work_stop_after_register_retries_unregister(mock_
         if url.endswith('/relay/servers/register'):
             client.stop()
             return register_response
-        if url.endswith('/unregister'):
+        if url.endswith('/api/v1/relay/servers/unregister'):
             return unregister_response
         raise AssertionError(f'Unexpected relay request: {url}')
 
@@ -3406,7 +3406,7 @@ def test_poll_api_v1_encrypted_work_stop_after_register_retries_unregister(mock_
     requested_urls = [call.args[0] for call in mock_post.call_args_list]
     assert requested_urls == [
         'http://localhost:5000/api/v1/relay/servers/register',
-        'http://localhost:5000/unregister',
+        'http://localhost:5000/api/v1/relay/servers/unregister',
     ]
     assert client._api_v1_registered_relays == set()
     assert client._api_v1_last_heartbeat_at == {}

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1246,6 +1246,23 @@ class TestRelayClient:
             "https://relay.cloudflare.workers.dev/api/v1", "/relay/servers/register"
         ) == "https://relay.cloudflare.workers.dev/api/v1/relay/servers/register"
 
+    @patch('utils.networking.relay_client.requests.post')
+    def test_unregister_from_relay_uses_api_v1_url_builder_for_prefixed_relay(self, mock_post):
+        client = _standalone_relay_client()
+        prefixed_url = 'http://localhost:5000/api/v1'
+        client._relay_urls = [prefixed_url]
+        client._api_v1_registered_relays.add(prefixed_url)
+        client._api_v1_last_heartbeat_at[prefixed_url] = 1.0
+        mock_post.return_value = MagicMock(status_code=200)
+
+        assert client.unregister_from_relay() is True
+
+        mock_post.assert_called_once_with(
+            'http://localhost:5000/api/v1/relay/servers/unregister',
+            json={'server_public_key': 'mock_public_key_b64'},
+            timeout=15,
+        )
+
     @pytest.mark.parametrize(
         "expected_wait, expected_timeout",
         [
@@ -3285,6 +3302,45 @@ def _standalone_relay_client():
     config.get.side_effect = lambda key, default=None: {'relay.request_timeout': 15}.get(key, default)
     with patch('utils.networking.relay_client.get_config_lazy', return_value=config):
         return RelayClient('http://localhost', 5000, crypto, model)
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_unregister_from_relay_falls_back_to_legacy_unregister_on_404(mock_post):
+    client = _standalone_relay_client()
+    client._api_v1_registered_relays.add('http://localhost:5000')
+    client._api_v1_last_heartbeat_at['http://localhost:5000'] = 123.0
+    api_v1_missing = MagicMock(status_code=404)
+    legacy_success = MagicMock(status_code=200)
+    mock_post.side_effect = [api_v1_missing, legacy_success]
+
+    assert client.unregister_from_relay() is True
+
+    requested_urls = [call.args[0] for call in mock_post.call_args_list]
+    assert requested_urls == [
+        'http://localhost:5000/api/v1/relay/servers/unregister',
+        'http://localhost:5000/unregister',
+    ]
+    assert client._api_v1_registered_relays == set()
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_unregister_from_relay_fallback_strips_api_v1_suffix_for_legacy_unregister(mock_post):
+    client = _standalone_relay_client()
+    prefixed_url = 'http://localhost:5000/api/v1'
+    client._relay_urls = [prefixed_url]
+    client._api_v1_registered_relays.add(prefixed_url)
+    client._api_v1_last_heartbeat_at[prefixed_url] = 123.0
+    api_v1_missing = MagicMock(status_code=404)
+    legacy_success = MagicMock(status_code=200)
+    mock_post.side_effect = [api_v1_missing, legacy_success]
+
+    assert client.unregister_from_relay() is True
+
+    requested_urls = [call.args[0] for call in mock_post.call_args_list]
+    assert requested_urls == [
+        'http://localhost:5000/api/v1/relay/servers/unregister',
+        'http://localhost:5000/unregister',
+    ]
 
 
 @patch('utils.networking.relay_client.requests.post')

--- a/tests/unit/test_relay_registration_token.py
+++ b/tests/unit/test_relay_registration_token.py
@@ -136,6 +136,53 @@ def test_unregister_requires_registration_token(relay_module) -> None:
     assert "client-1" not in relay_module.streaming_sessions_by_client
 
 
+def test_api_v1_unregister_requires_token_and_clears_registry(relay_module) -> None:
+    """API v1 unregister should require auth and remove nodes immediately."""
+
+    relay_module.known_servers.clear()
+    relay_module.client_inference_requests.clear()
+    relay_module.streaming_sessions.clear()
+    relay_module.streaming_sessions_by_client.clear()
+
+    client = relay_module.app.test_client()
+
+    register_response = client.post(
+        "/api/v1/relay/servers/register",
+        json={"server_public_key": "api-v1-node"},
+        headers={"X-Relay-Server-Token": "unit-token"},
+    )
+    assert register_response.status_code == 200
+    assert list(relay_module.known_servers) == ["api-v1-node"]
+
+    unauthorised = client.post(
+        "/api/v1/relay/servers/unregister",
+        json={"server_public_key": "api-v1-node"},
+    )
+    assert unauthorised.status_code == 401
+    assert unauthorised.get_json() == {
+        "error": {
+            "code": 401,
+            "message": "Missing or invalid relay server token",
+        }
+    }
+    assert list(relay_module.known_servers) == ["api-v1-node"]
+
+    authorised = client.post(
+        "/api/v1/relay/servers/unregister",
+        json={"server_public_key": "api-v1-node"},
+        headers={"X-Relay-Server-Token": "unit-token"},
+    )
+    assert authorised.status_code == 200
+    assert authorised.get_json() == {"message": "Server unregistered", "removed": True}
+    assert relay_module.known_servers == {}
+
+    diagnostics = client.get("/relay/diagnostics")
+    assert diagnostics.status_code == 200
+    diagnostics_payload = diagnostics.get_json()
+    assert diagnostics_payload["total_registered_compute_nodes"] == 0
+    assert diagnostics_payload["registered_compute_nodes"] == []
+
+
 def test_unregister_removes_node_from_relay_diagnostics_immediately(relay_module) -> None:
     """Relay diagnostics should stop listing nodes as soon as unregister succeeds."""
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -866,7 +866,7 @@ class RelayClient:
                     request_kwargs['headers'] = headers
 
                 response = requests.post(
-                    f'{candidate_url}/unregister',
+                    f'{candidate_url}/api/v1/relay/servers/unregister',
                     timeout=self._request_timeout,
                     **request_kwargs,
                 )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -865,11 +865,22 @@ class RelayClient:
                 if headers:
                     request_kwargs['headers'] = headers
 
+                unregister_url = self._build_api_v1_url(candidate_url, "/relay/servers/unregister")
                 response = requests.post(
-                    f'{candidate_url}/api/v1/relay/servers/unregister',
+                    unregister_url,
                     timeout=self._request_timeout,
                     **request_kwargs,
                 )
+                if response.status_code == 404:
+                    legacy_base_url = candidate_url.rstrip('/')
+                    if legacy_base_url.endswith('/api/v1'):
+                        legacy_base_url = legacy_base_url[: -len('/api/v1')]
+                    legacy_url = f"{legacy_base_url}/unregister"
+                    response = requests.post(
+                        legacy_url,
+                        timeout=self._request_timeout,
+                        **request_kwargs,
+                    )
                 if response.status_code == 200:
                     if candidate_url in relay_index_by_url:
                         self._active_relay_index = relay_index_by_url[candidate_url]


### PR DESCRIPTION
### Motivation
- The Stop operator must remove a stopped compute node from the relay immediately so the relay stops routing to stale nodes instead of waiting for heartbeat TTL expiry.
- Clients should fail fast with a clear `no_registered_compute_nodes` / terminal `server_unregistered` reason instead of hanging until leases/timeouts expire.
- Preserve API v1 E2EE invariants and keep legacy `/unregister` compatibility while keeping changes minimal and targeted.

### Description
- Added an idempotent API v1 route `POST /api/v1/relay/servers/unregister` and routed the legacy `/unregister` through a shared handler to preserve legacy error shapes for compatibility.
- Implemented immediate removal logic in `_unregister_server`: it now removes the known server, clears per-server queue, cancels queued and in-flight API v1 requests using `_cancel_api_v1_request` with reason `server_unregistered`, clears stream sessions, and logs `server.unregistered` including a safe key fingerprint and `cancelled_queue_depth`.
- Extended `_ALLOWED_API_V1_TERMINAL_REASONS` to include `server_unregistered` so clients receive a specific terminal reason when an in-flight/queued request is cancelled by unregister.
- Updated `RelayClient.unregister_from_relay()` to call the new API v1 unregister path (`/api/v1/relay/servers/unregister`) and preserved idempotent/robust retry semantics.
- Added the unregister path to authenticated rate-limit exemptions and updated onboarding/docs to mention the new route and Cloudflare/WAF allowlist note.
- Updated and added tests to assert immediate diagnostics removal, `servers/next` behavior, queued/in-flight work cancellation, client unregister behavior, and rate-limit exemptions.

### Testing
- Ran targeted unit and integration suites; all executed tests passed: `pytest tests/test_relay.py -k "unregister or next or round_robin or queue or no_servers"` — passed; `pytest tests/unit/test_relay_client.py -k "unregister or stop or register"` — passed; `pytest tests/unit/test_desktop_compute_node_bridge.py -k "stop or unregister or registered"` — passed; `pytest tests/unit/test_rate_limit.py -k "authenticated_api_v1_relay_heartbeat_routes"` — passed; `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` — passed.
- Ran auxiliary validation scripts and checks: `python desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py`, `python desktop-tauri/scripts/test_packaged_operator_e2e.py`, and `pre-commit run --all-files`; these completed without failures in this environment.
- Summary: unit, integration, and relay-client tests covering unregister, queue cancellation, round-robin, diagnostics, and rate-limit exemptions all passed. No failing automated tests observed in the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23c688bf74832f9d2e170c19df43a5)