### PR TITLE
Separate relay control-plane rate limits from user/chat API budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Install Playwright browsers
+      - name: Install Playwright browsers and system dependencies
         if: steps.prep.outputs.rc != '2'
-        run: playwright install
+        run: playwright install --with-deps chromium
       - name: Install Node.js dependencies
         if: steps.prep.outputs.rc != '2'
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 
 | Variable        | Default      | Description                                                        |
 |-----------------|--------------|--------------------------------------------------------------------|
-| API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for API requests                                |
+| API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for user-facing API requests; API v1 compute-node control-plane routes use separate budgets |
+| API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT | 240/hour | Per-server-public-key budget for compute-node register/lease refresh traffic |
+| API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT | 1200/hour | Per-server-public-key budget for compute-node poll/heartbeat traffic |
+| API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT | 1200/hour | Per-client-public-key budget for encrypted compute-node response submissions |
+| API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT | 10000/hour | Aggregate per-IP abuse budget shared by compute-node control-plane routes |
 | API_STREAM_RATE_LIMIT | 30/minute   | Per-IP rate limit applied only to streaming chat completions          |
 | SERVICE_NAME    | token.place  | Service identifier returned by health endpoints (whitespace-only overrides
 |                 |              | fall back to `token.place`)                                             |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 | API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for user-facing API requests; API v1 compute-node control-plane routes use separate budgets |
 | API_RELAY_CONTROL_PLANE_RATE_LIMIT | route default | Shared fallback for compute-node control-plane route budgets when a route-specific override is unset |
 | API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT | 240/hour | Per-server-public-key budget for authenticated compute-node register/lease refresh traffic |
+| API_RELAY_CONTROL_PLANE_UNREGISTER_RATE_LIMIT | 240/hour | Per-server-public-key budget for authenticated compute-node unregister/shutdown traffic |
 | API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT | 1200/hour | Per-server-public-key budget for authenticated compute-node poll/heartbeat traffic |
 | API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT | 1200/hour | Per-client-public-key budget for authenticated encrypted compute-node response submissions |
 | API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT | 10000/hour | Aggregate per-IP abuse budget shared by compute-node control-plane routes |

--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ Environment variables can be stored in a `.env` file and overridden in a `.env.l
 | Variable        | Default      | Description                                                        |
 |-----------------|--------------|--------------------------------------------------------------------|
 | API_RATE_LIMIT  | 60/hour      | Per-IP rate limit for user-facing API requests; API v1 compute-node control-plane routes use separate budgets |
-| API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT | 240/hour | Per-server-public-key budget for compute-node register/lease refresh traffic |
-| API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT | 1200/hour | Per-server-public-key budget for compute-node poll/heartbeat traffic |
-| API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT | 1200/hour | Per-client-public-key budget for encrypted compute-node response submissions |
+| API_RELAY_CONTROL_PLANE_RATE_LIMIT | route default | Shared fallback for compute-node control-plane route budgets when a route-specific override is unset |
+| API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT | 240/hour | Per-server-public-key budget for authenticated compute-node register/lease refresh traffic |
+| API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT | 1200/hour | Per-server-public-key budget for authenticated compute-node poll/heartbeat traffic |
+| API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT | 1200/hour | Per-client-public-key budget for authenticated encrypted compute-node response submissions |
 | API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT | 10000/hour | Aggregate per-IP abuse budget shared by compute-node control-plane routes |
+| TOKENPLACE_RATE_LIMIT_STORAGE_URI | (in-memory) | Optional shared Flask-Limiter/limits backend URI (for example Redis or Memcached) used by public and control-plane budgets |
 | API_STREAM_RATE_LIMIT | 30/minute   | Per-IP rate limit applied only to streaming chat completions          |
 | SERVICE_NAME    | token.place  | Service identifier returned by health endpoints (whitespace-only overrides
 |                 |              | fall back to `token.place`)                                             |

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -132,6 +132,12 @@ def _relay_server_token_is_valid() -> bool:
     return any(secrets.compare_digest(candidate, token) for token in tokens)
 
 
+def _relay_server_token_boundary_has_configured_token() -> bool:
+    """Return True only when this request matched an explicit relay token."""
+
+    return bool(_load_relay_server_registration_tokens()) and _relay_server_token_is_valid()
+
+
 def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     """Return True when a route should not consume the public API quota."""
 
@@ -190,22 +196,20 @@ def _control_plane_limits_from_env() -> dict[str, dict[str, Any]]:
 
 
 def _control_plane_identity_for_request(path: str, data: Any) -> tuple[str, str]:
-    if isinstance(data, dict):
-        if path in {
-            "/api/v1/relay/servers/register",
-            "/api/v1/relay/servers/unregister",
-            "/api/v1/relay/servers/poll",
-        }:
-            server_public_key = data.get("server_public_key")
-            if isinstance(server_public_key, str) and server_public_key.strip():
-                return "server_public_key", server_public_key.strip()
-        if path == "/api/v1/relay/responses":
-            client_public_key = data.get("client_public_key")
-            request_id = data.get("request_id")
-            if isinstance(client_public_key, str) and client_public_key.strip():
-                return "client_public_key", client_public_key.strip()
-            if isinstance(request_id, str) and request_id.strip():
-                return "request_id", request_id.strip()
+    if path == "/api/v1/relay/responses":
+        # Response envelopes are validated by relay.py after this before_request hook.
+        # Keep response budgeting IP-only here so malformed JSON cannot spoof-limit
+        # a victim client_public_key/request_id before envelope validation runs.
+        return "client_ip", get_remote_address()
+
+    if isinstance(data, dict) and path in {
+        "/api/v1/relay/servers/register",
+        "/api/v1/relay/servers/unregister",
+        "/api/v1/relay/servers/poll",
+    }:
+        server_public_key = data.get("server_public_key")
+        if isinstance(server_public_key, str) and server_public_key.strip():
+            return "server_public_key", server_public_key.strip()
     return "client_ip", get_remote_address()
 
 
@@ -344,9 +348,10 @@ def _install_control_plane_rate_limiter(app, storage_uri: str | None) -> None:
         ]
 
         # Only charge high-cardinality identity buckets after passing the same
-        # token boundary as relay.py. Invalid token attempts stay keyed to client
-        # IP so callers cannot spoof a victim server/client bucket.
-        if _relay_server_token_is_valid():
+        # configured-token boundary as relay.py. Invalid-token and tokenless
+        # anonymous requests stay keyed to client IP so callers cannot spoof a
+        # victim server/client bucket before relay.py validates the request.
+        if _relay_server_token_boundary_has_configured_token():
             data = request.get_json(silent=True)
             identity_kind, identity_value = _control_plane_identity_for_request(
                 route, data

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import secrets
 import sys
-import threading
 import time
 from typing import Any
 
@@ -14,6 +14,8 @@ from flask import jsonify, request
 from flask_limiter import Limiter
 from flask_limiter.errors import RateLimitExceeded
 from flask_limiter.util import get_remote_address
+from limits.storage import storage_from_string
+from limits.strategies import FixedWindowRateLimiter
 from limits.util import parse
 from prometheus_flask_exporter import PrometheusMetrics
 
@@ -37,7 +39,6 @@ CONTROL_PLANE_ROUTE_DEFAULT_LIMITS = {
     "/api/v1/relay/servers/poll": "1200/hour",
     "/api/v1/relay/responses": "1200/hour",
 }
-CONTROL_PLANE_DEFAULT_LIMIT = "1200/hour"
 CONTROL_PLANE_IP_DEFAULT_LIMIT = "10000/hour"
 
 # Paths that support operations, health checking, metrics scraping, and
@@ -62,9 +63,10 @@ CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS = frozenset(
     }
 )
 
-# API v1 compute-node control-plane routes bypass the low public user quota and
-# are protected by a separate, higher budget below. This keeps healthy desktop
-# nodes from being treated like user chat traffic while preserving abuse limits.
+# Authenticated API v1 compute-node control-plane POST routes bypass the low
+# public user quota and are protected by a separate, higher budget below. This
+# keeps healthy desktop nodes from being treated like user chat traffic while
+# preserving abuse limits.
 RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS = frozenset(CONTROL_PLANE_ROUTE_LIMIT_ENVS)
 
 
@@ -114,14 +116,31 @@ def _load_relay_server_registration_tokens() -> list[str]:
     return [token for token in normalized if token]
 
 
+def _relay_server_token_is_valid() -> bool:
+    """Return True when configured relay tokens are absent or matched."""
+
+    tokens = _load_relay_server_registration_tokens()
+    if not tokens:
+        return True
+
+    candidate = request.headers.get("X-Relay-Server-Token", "").strip()
+    if not candidate:
+        return False
+    return any(secrets.compare_digest(candidate, token) for token in tokens)
+
+
 def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     """Return True when a route should not consume the public API quota."""
 
     normalized_path = _normalized_path(path)
+    if normalized_path in RATE_LIMIT_EXEMPT_PATHS:
+        return True
+    if normalized_path in CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS:
+        return True
     return (
-        normalized_path in RATE_LIMIT_EXEMPT_PATHS
-        or normalized_path in CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS
-        or normalized_path in RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS
+        request.method == "POST"
+        and normalized_path in RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS
+        and _relay_server_token_is_valid()
     )
 
 
@@ -132,7 +151,7 @@ def _resolve_rate_limit_storage_uri() -> str | None:
 
 
 def _fingerprint(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def _parse_rate_limit_item(raw_limit: str, fallback: str):
@@ -183,32 +202,59 @@ def _control_plane_identity_for_request(path: str, data: Any) -> tuple[str, str]
     return "client_ip", get_remote_address()
 
 
-def _control_plane_window_seconds(limit_item: Any) -> int:
-    return int(limit_item.multiples * limit_item.GRANULARITY.seconds)
-
-
-def _check_control_plane_bucket(
-    buckets: dict[tuple[str, str, str], tuple[int, float]],
-    lock: threading.Lock,
+def _control_plane_bucket_identifier(
     *,
     route: str,
     bucket_kind: str,
     bucket_value: str,
-    limit_item: Any,
-    now: float,
-) -> tuple[bool, int, str]:
-    window_seconds = _control_plane_window_seconds(limit_item)
-    bucket_key = (route, bucket_kind, bucket_value)
-    with lock:
-        count, reset_at = buckets.get(bucket_key, (0, now + window_seconds))
-        if now >= reset_at:
-            count = 0
-            reset_at = now + window_seconds
-        if count >= int(limit_item.amount):
-            retry_after = max(int(reset_at - now), 1)
-            return False, retry_after, ":".join(bucket_key)
-        buckets[bucket_key] = (count + 1, reset_at)
-    return True, 0, ":".join(bucket_key)
+) -> tuple[str, str, str]:
+    """Return bounded, non-raw storage identifiers for a control-plane bucket."""
+
+    return (route, bucket_kind, _fingerprint(bucket_value))
+
+
+def _control_plane_retry_after(
+    rate_limiter: Any, limit_item: Any, identifiers: tuple[str, str, str]
+) -> int:
+    window = rate_limiter.get_window_stats(limit_item, *identifiers)
+    return max(int(window.reset_time - time.time()), 1)
+
+
+def _check_control_plane_limits(
+    rate_limiter: Any,
+    checks: list[tuple[str, str, Any]],
+    *,
+    route: str,
+) -> tuple[bool, int, str, str, Any]:
+    """Atomically enough test all buckets before charging any bucket.
+
+    The limits backend gives shared storage and TTL for individual buckets. Testing
+    every bucket before recording hits avoids burning an identity quota for a
+    request that is already rejected by the aggregate IP budget.
+    """
+
+    planned_hits: list[tuple[str, tuple[str, str, str], Any]] = []
+    for bucket_kind, bucket_value, limit_item in checks:
+        identifiers = _control_plane_bucket_identifier(
+            route=route,
+            bucket_kind=bucket_kind,
+            bucket_value=bucket_value,
+        )
+        if not rate_limiter.test(limit_item, *identifiers):
+            retry_after = _control_plane_retry_after(
+                rate_limiter, limit_item, identifiers
+            )
+            return False, retry_after, bucket_kind, ":".join(identifiers), limit_item
+        planned_hits.append((bucket_kind, identifiers, limit_item))
+
+    for bucket_kind, identifiers, limit_item in planned_hits:
+        if not rate_limiter.hit(limit_item, *identifiers):
+            retry_after = _control_plane_retry_after(
+                rate_limiter, limit_item, identifiers
+            )
+            return False, retry_after, bucket_kind, ":".join(identifiers), limit_item
+
+    return True, 0, "", "", None
 
 
 def _build_control_plane_rate_limit_response(limit_item: Any, retry_after: int):
@@ -230,52 +276,59 @@ def _build_control_plane_rate_limit_response(limit_item: Any, retry_after: int):
     return response
 
 
-def _install_control_plane_rate_limiter(app) -> None:
+def _install_control_plane_rate_limiter(app, storage_uri: str | None) -> None:
     route_limits = _control_plane_limits_from_env()
-    buckets: dict[tuple[str, str, str], tuple[int, float]] = {}
-    lock = threading.Lock()
-    app.config["relay_control_plane_rate_limit_buckets"] = buckets
-    app.config["relay_control_plane_rate_limit_lock"] = lock
+    control_plane_storage_uri = storage_uri or "memory://"
+    control_plane_storage = storage_from_string(control_plane_storage_uri)
+    control_plane_rate_limiter = FixedWindowRateLimiter(control_plane_storage)
+    app.config["relay_control_plane_rate_limit_storage_uri"] = control_plane_storage_uri
+    app.config["relay_control_plane_rate_limiter"] = control_plane_rate_limiter
 
     @app.before_request
     def _enforce_control_plane_rate_limit():
         route = _normalized_path(request.path)
         route_limit = route_limits.get(route)
-        if route_limit is None:
+        if route_limit is None or request.method != "POST":
             return None
 
-        data = request.get_json(silent=True)
-        identity_kind, identity_value = _control_plane_identity_for_request(route, data)
         remote_address = get_remote_address()
-        now = time.time()
-        checks = [(identity_kind, identity_value, route_limit["identity"])]
-        if identity_kind != "client_ip" or identity_value != remote_address:
-            checks.append(("client_ip", remote_address, route_limit["ip"]))
-        for bucket_kind, bucket_value, limit_item in checks:
-            allowed, retry_after, raw_bucket_key = _check_control_plane_bucket(
-                buckets,
-                lock,
+        checks: list[tuple[str, str, Any]] = [
+            ("client_ip", remote_address, route_limit["ip"])
+        ]
+
+        # Only charge high-cardinality identity buckets after passing the same
+        # token boundary as relay.py. Invalid token attempts stay keyed to client
+        # IP so callers cannot spoof a victim server/client bucket.
+        if _relay_server_token_is_valid():
+            data = request.get_json(silent=True)
+            identity_kind, identity_value = _control_plane_identity_for_request(
+                route, data
+            )
+            if identity_kind != "client_ip" or identity_value != remote_address:
+                checks.append((identity_kind, identity_value, route_limit["identity"]))
+
+        allowed, retry_after, bucket_kind, bucket_key, limit_item = (
+            _check_control_plane_limits(
+                control_plane_rate_limiter,
+                checks,
                 route=route,
-                bucket_kind=bucket_kind,
-                bucket_value=bucket_value,
-                limit_item=limit_item,
-                now=now,
             )
-            if allowed:
-                continue
-            bucket_fingerprint = _fingerprint(raw_bucket_key)
-            LOGGER.warning(
-                "relay_control_plane_rate_limited",
-                extra={
-                    "route": route,
-                    "route_class": CONTROL_PLANE_ROUTE_CLASS,
-                    "limiter_bucket_kind": bucket_kind,
-                    "limiter_bucket_fingerprint": bucket_fingerprint,
-                    "retry_after": retry_after,
-                },
-            )
-            return _build_control_plane_rate_limit_response(limit_item, retry_after)
-        return None
+        )
+        if allowed:
+            return None
+
+        bucket_fingerprint = _fingerprint(bucket_key)
+        LOGGER.warning(
+            "relay_control_plane_rate_limited",
+            extra={
+                "route": route,
+                "route_class": CONTROL_PLANE_ROUTE_CLASS,
+                "limiter_bucket_kind": bucket_kind,
+                "limiter_bucket_fingerprint": bucket_fingerprint,
+                "retry_after": retry_after,
+            },
+        )
+        return _build_control_plane_rate_limit_response(limit_item, retry_after)
 
 
 def _build_rate_limit_response(exc: RateLimitExceeded):
@@ -330,7 +383,7 @@ def init_app(app):
     def _handle_rate_limit(exc: RateLimitExceeded):
         return _build_rate_limit_response(exc)
 
-    _install_control_plane_rate_limiter(app)
+    _install_control_plane_rate_limiter(app, limiter_storage_uri)
 
     PrometheusMetrics(app)
     app.register_blueprint(v1_routes.v1_bp)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -195,11 +195,59 @@ def _control_plane_limits_from_env() -> dict[str, dict[str, Any]]:
     return route_limits
 
 
+def _response_envelope_identity_for_rate_limit(data: Any) -> tuple[str, str] | None:
+    """Return a response identity only after minimal ciphertext-envelope checks.
+
+    relay.py performs the authoritative response validation after this
+    before_request hook. Keep this preflight intentionally narrow: it only allows
+    the response route-specific budget to use client metadata once the payload has
+    the expected ciphertext-envelope shape, so malformed requests cannot burn a
+    spoofed victim client bucket before relay.py rejects them.
+    """
+
+    if not isinstance(data, dict):
+        return None
+
+    forbidden_plaintext_fields = {
+        "messages",
+        "prompt",
+        "input",
+        "content",
+        "response",
+        "text",
+    }
+    if any(field in data for field in forbidden_plaintext_fields):
+        return None
+
+    allowed_fields = {
+        "client_public_key",
+        "ciphertext",
+        "chat_history",
+        "cipherkey",
+        "iv",
+        "request_id",
+        "protocol",
+        "version",
+        "cancel_token",
+    }
+    if any(field not in allowed_fields for field in data):
+        return None
+    if not ("ciphertext" in data or "chat_history" in data):
+        return None
+    if "cipherkey" not in data or "iv" not in data:
+        return None
+
+    client_public_key = data.get("client_public_key")
+    if isinstance(client_public_key, str) and client_public_key.strip():
+        return "client_public_key", client_public_key.strip()
+    return None
+
+
 def _control_plane_identity_for_request(path: str, data: Any) -> tuple[str, str]:
     if path == "/api/v1/relay/responses":
-        # Response envelopes are validated by relay.py after this before_request hook.
-        # Keep response budgeting IP-only here so malformed JSON cannot spoof-limit
-        # a victim client_public_key/request_id before envelope validation runs.
+        identity = _response_envelope_identity_for_rate_limit(data)
+        if identity is not None:
+            return identity
         return "client_ip", get_remote_address()
 
     if isinstance(data, dict) and path in {

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -281,8 +281,17 @@ def _check_control_plane_limits(
             return False, retry_after, bucket_kind, ":".join(identifiers), limit_item
         planned_hits.append((bucket_kind, identifiers, limit_item))
 
+    # Record identity buckets before the aggregate client-IP bucket. The limits
+    # backend records each hit separately, so a concurrent over-limit identity
+    # race must fail before it can consume the NAT-wide IP budget shared by
+    # other valid compute nodes. If a later bucket still rejects, the
+    # compensating rollback below removes the earlier per-request hit.
+    ordered_hits = sorted(
+        planned_hits, key=lambda planned_hit: planned_hit[0] == "client_ip"
+    )
+
     recorded_hits: list[tuple[tuple[str, str, str], Any]] = []
-    for bucket_kind, identifiers, limit_item in planned_hits:
+    for bucket_kind, identifiers, limit_item in ordered_hits:
         if rate_limiter.hit(limit_item, *identifiers):
             recorded_hits.append((identifiers, limit_item))
             continue

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -31,11 +31,13 @@ CONTROL_PLANE_DEFAULT_LIMIT_ENV = "API_RELAY_CONTROL_PLANE_RATE_LIMIT"
 CONTROL_PLANE_IP_LIMIT_ENV = "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT"
 CONTROL_PLANE_ROUTE_LIMIT_ENVS = {
     "/api/v1/relay/servers/register": "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT",
+    "/api/v1/relay/servers/unregister": "API_RELAY_CONTROL_PLANE_UNREGISTER_RATE_LIMIT",
     "/api/v1/relay/servers/poll": "API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT",
     "/api/v1/relay/responses": "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT",
 }
 CONTROL_PLANE_ROUTE_DEFAULT_LIMITS = {
     "/api/v1/relay/servers/register": "240/hour",
+    "/api/v1/relay/servers/unregister": "240/hour",
     "/api/v1/relay/servers/poll": "1200/hour",
     "/api/v1/relay/responses": "1200/hour",
 }
@@ -189,7 +191,11 @@ def _control_plane_limits_from_env() -> dict[str, dict[str, Any]]:
 
 def _control_plane_identity_for_request(path: str, data: Any) -> tuple[str, str]:
     if isinstance(data, dict):
-        if path in {"/api/v1/relay/servers/register", "/api/v1/relay/servers/poll"}:
+        if path in {
+            "/api/v1/relay/servers/register",
+            "/api/v1/relay/servers/unregister",
+            "/api/v1/relay/servers/poll",
+        }:
             server_public_key = data.get("server_public_key")
             if isinstance(server_public_key, str) and server_public_key.strip():
                 return "server_public_key", server_public_key.strip()
@@ -221,17 +227,44 @@ def _control_plane_retry_after(
     return max(int(window.reset_time - time.time()), 1)
 
 
+def _control_plane_storage_decr(
+    rate_limiter: Any, limit_item: Any, identifiers: tuple[str, str, str]
+) -> None:
+    """Best-effort rollback for a control-plane bucket hit."""
+
+    storage = getattr(rate_limiter, "storage", None)
+    decr = getattr(storage, "decr", None)
+    if decr is None:
+        LOGGER.warning(
+            "rate_limit.control_plane_rollback_unavailable",
+            extra={"limiter_bucket_fingerprint": _fingerprint(":".join(identifiers))},
+        )
+        return
+    decr(limit_item.key_for(*identifiers))
+
+
+def _rollback_control_plane_hits(
+    rate_limiter: Any,
+    recorded_hits: list[tuple[tuple[str, str, str], Any]],
+) -> None:
+    """Remove hits recorded for a request that ultimately did not pass all buckets."""
+
+    for identifiers, limit_item in reversed(recorded_hits):
+        _control_plane_storage_decr(rate_limiter, limit_item, identifiers)
+
+
 def _check_control_plane_limits(
     rate_limiter: Any,
     checks: list[tuple[str, str, Any]],
     *,
     route: str,
 ) -> tuple[bool, int, str, str, Any]:
-    """Atomically enough test all buckets before charging any bucket.
+    """Test all buckets and roll back partial accounting on later rejection.
 
     The limits backend gives shared storage and TTL for individual buckets. Testing
-    every bucket before recording hits avoids burning an identity quota for a
-    request that is already rejected by the aggregate IP budget.
+    every bucket before recording hits avoids charging obviously rejected requests,
+    and compensating rollback prevents a later failed bucket from leaving earlier
+    buckets charged for a request that returned 429.
     """
 
     planned_hits: list[tuple[str, tuple[str, str, str], Any]] = []
@@ -248,12 +281,16 @@ def _check_control_plane_limits(
             return False, retry_after, bucket_kind, ":".join(identifiers), limit_item
         planned_hits.append((bucket_kind, identifiers, limit_item))
 
+    recorded_hits: list[tuple[tuple[str, str, str], Any]] = []
     for bucket_kind, identifiers, limit_item in planned_hits:
-        if not rate_limiter.hit(limit_item, *identifiers):
-            retry_after = _control_plane_retry_after(
-                rate_limiter, limit_item, identifiers
-            )
-            return False, retry_after, bucket_kind, ":".join(identifiers), limit_item
+        if rate_limiter.hit(limit_item, *identifiers):
+            recorded_hits.append((identifiers, limit_item))
+            continue
+
+        recorded_hits.append((identifiers, limit_item))
+        retry_after = _control_plane_retry_after(rate_limiter, limit_item, identifiers)
+        _rollback_control_plane_hits(rate_limiter, recorded_hits)
+        return False, retry_after, bucket_kind, ":".join(identifiers), limit_item
 
     return True, 0, "", "", None
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -2,20 +2,43 @@
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import os
-import secrets
 import sys
+import threading
+import time
+from typing import Any
+
 from flask import jsonify, request
 from flask_limiter import Limiter
 from flask_limiter.errors import RateLimitExceeded
 from flask_limiter.util import get_remote_address
+from limits.util import parse
 from prometheus_flask_exporter import PrometheusMetrics
 
-from config import get_config
 from api.v1 import routes as v1_routes
 from api.v2 import routes as v2_routes
+from config import get_config
 
 RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
+LOGGER = logging.getLogger("tokenplace.api")
+
+CONTROL_PLANE_ROUTE_CLASS = "compute_node_control_plane"
+CONTROL_PLANE_DEFAULT_LIMIT_ENV = "API_RELAY_CONTROL_PLANE_RATE_LIMIT"
+CONTROL_PLANE_IP_LIMIT_ENV = "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT"
+CONTROL_PLANE_ROUTE_LIMIT_ENVS = {
+    "/api/v1/relay/servers/register": "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT",
+    "/api/v1/relay/servers/poll": "API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT",
+    "/api/v1/relay/responses": "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT",
+}
+CONTROL_PLANE_ROUTE_DEFAULT_LIMITS = {
+    "/api/v1/relay/servers/register": "240/hour",
+    "/api/v1/relay/servers/poll": "1200/hour",
+    "/api/v1/relay/responses": "1200/hour",
+}
+CONTROL_PLANE_DEFAULT_LIMIT = "1200/hour"
+CONTROL_PLANE_IP_DEFAULT_LIMIT = "10000/hour"
 
 # Paths that support operations, health checking, metrics scraping, and
 # diagnostics must not consume the public user API quota. Kubernetes readiness
@@ -39,17 +62,10 @@ CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS = frozenset(
     }
 )
 
-# API v1 compute-node control-plane routes should bypass the public user quota
-# only for authenticated compute-node traffic. When relay server tokens are not
-# configured, these mutation/long-poll routes remain rate-limited to prevent
-# anonymous callers from growing relay-owned state or occupying workers.
-AUTHENTICATED_RELAY_CONTROL_PLANE_RATE_LIMIT_EXEMPT_PATHS = frozenset(
-    {
-        "/api/v1/relay/servers/register",
-        "/api/v1/relay/servers/poll",
-        "/api/v1/relay/responses",
-    }
-)
+# API v1 compute-node control-plane routes bypass the low public user quota and
+# are protected by a separate, higher budget below. This keeps healthy desktop
+# nodes from being treated like user chat traffic while preserving abuse limits.
+RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS = frozenset(CONTROL_PLANE_ROUTE_LIMIT_ENVS)
 
 
 def _normalized_path(path: str) -> str:
@@ -98,28 +114,6 @@ def _load_relay_server_registration_tokens() -> list[str]:
     return [token for token in normalized if token]
 
 
-def _is_authenticated_relay_control_plane_request(path: str) -> bool:
-    """Return True for compute-node control-plane requests with a valid token."""
-
-    if (
-        _normalized_path(path)
-        not in AUTHENTICATED_RELAY_CONTROL_PLANE_RATE_LIMIT_EXEMPT_PATHS
-    ):
-        return False
-
-    relay_server_tokens = _load_relay_server_registration_tokens()
-    if not relay_server_tokens:
-        return False
-
-    provided = request.headers.get("X-Relay-Server-Token", "").strip()
-    if not provided:
-        return False
-
-    return any(
-        secrets.compare_digest(provided, token) for token in relay_server_tokens
-    )
-
-
 def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     """Return True when a route should not consume the public API quota."""
 
@@ -127,7 +121,7 @@ def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     return (
         normalized_path in RATE_LIMIT_EXEMPT_PATHS
         or normalized_path in CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS
-        or _is_authenticated_relay_control_plane_request(normalized_path)
+        or normalized_path in RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS
     )
 
 
@@ -135,6 +129,153 @@ def _resolve_rate_limit_storage_uri() -> str | None:
     raw_value = os.environ.get(RATE_LIMIT_STORAGE_URI_ENV, "")
     storage_uri = raw_value.strip()
     return storage_uri or None
+
+
+def _fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _parse_rate_limit_item(raw_limit: str, fallback: str):
+    candidate = (raw_limit or fallback).strip() or fallback
+    try:
+        return parse(candidate)
+    except ValueError:
+        LOGGER.warning(
+            "rate_limit.invalid_control_plane_limit",
+            extra={"limit": candidate, "fallback": fallback},
+        )
+        return parse(fallback)
+
+
+def _control_plane_limits_from_env() -> dict[str, dict[str, Any]]:
+    route_limits: dict[str, dict[str, Any]] = {}
+    inherited_default = os.environ.get(CONTROL_PLANE_DEFAULT_LIMIT_ENV)
+    ip_limit = _parse_rate_limit_item(
+        os.environ.get(CONTROL_PLANE_IP_LIMIT_ENV, CONTROL_PLANE_IP_DEFAULT_LIMIT),
+        CONTROL_PLANE_IP_DEFAULT_LIMIT,
+    )
+    for route, env_name in CONTROL_PLANE_ROUTE_LIMIT_ENVS.items():
+        route_default = CONTROL_PLANE_ROUTE_DEFAULT_LIMITS.get(
+            route,
+            inherited_default,
+        )
+        route_limit = _parse_rate_limit_item(
+            os.environ.get(env_name) or inherited_default or route_default,
+            route_default,
+        )
+        route_limits[route] = {"identity": route_limit, "ip": ip_limit}
+    return route_limits
+
+
+def _control_plane_identity_for_request(path: str, data: Any) -> tuple[str, str]:
+    if isinstance(data, dict):
+        if path in {"/api/v1/relay/servers/register", "/api/v1/relay/servers/poll"}:
+            server_public_key = data.get("server_public_key")
+            if isinstance(server_public_key, str) and server_public_key.strip():
+                return "server_public_key", server_public_key.strip()
+        if path == "/api/v1/relay/responses":
+            client_public_key = data.get("client_public_key")
+            request_id = data.get("request_id")
+            if isinstance(client_public_key, str) and client_public_key.strip():
+                return "client_public_key", client_public_key.strip()
+            if isinstance(request_id, str) and request_id.strip():
+                return "request_id", request_id.strip()
+    return "client_ip", get_remote_address()
+
+
+def _control_plane_window_seconds(limit_item: Any) -> int:
+    return int(limit_item.multiples * limit_item.GRANULARITY.seconds)
+
+
+def _check_control_plane_bucket(
+    buckets: dict[tuple[str, str, str], tuple[int, float]],
+    lock: threading.Lock,
+    *,
+    route: str,
+    bucket_kind: str,
+    bucket_value: str,
+    limit_item: Any,
+    now: float,
+) -> tuple[bool, int, str]:
+    window_seconds = _control_plane_window_seconds(limit_item)
+    bucket_key = (route, bucket_kind, bucket_value)
+    with lock:
+        count, reset_at = buckets.get(bucket_key, (0, now + window_seconds))
+        if now >= reset_at:
+            count = 0
+            reset_at = now + window_seconds
+        if count >= int(limit_item.amount):
+            retry_after = max(int(reset_at - now), 1)
+            return False, retry_after, ":".join(bucket_key)
+        buckets[bucket_key] = (count + 1, reset_at)
+    return True, 0, ":".join(bucket_key)
+
+
+def _build_control_plane_rate_limit_response(limit_item: Any, retry_after: int):
+    rate_limit_description = str(limit_item)
+    payload = {
+        "error": {
+            "message": (
+                f"Rate limit exceeded: {rate_limit_description}. "
+                f"Try again in {retry_after} seconds."
+            ),
+            "type": "rate_limit_error",
+            "code": "rate_limit_exceeded",
+            "param": None,
+        }
+    }
+    response = jsonify(payload)
+    response.status_code = 429
+    response.headers["Retry-After"] = str(retry_after)
+    return response
+
+
+def _install_control_plane_rate_limiter(app) -> None:
+    route_limits = _control_plane_limits_from_env()
+    buckets: dict[tuple[str, str, str], tuple[int, float]] = {}
+    lock = threading.Lock()
+    app.config["relay_control_plane_rate_limit_buckets"] = buckets
+    app.config["relay_control_plane_rate_limit_lock"] = lock
+
+    @app.before_request
+    def _enforce_control_plane_rate_limit():
+        route = _normalized_path(request.path)
+        route_limit = route_limits.get(route)
+        if route_limit is None:
+            return None
+
+        data = request.get_json(silent=True)
+        identity_kind, identity_value = _control_plane_identity_for_request(route, data)
+        remote_address = get_remote_address()
+        now = time.time()
+        checks = [(identity_kind, identity_value, route_limit["identity"])]
+        if identity_kind != "client_ip" or identity_value != remote_address:
+            checks.append(("client_ip", remote_address, route_limit["ip"]))
+        for bucket_kind, bucket_value, limit_item in checks:
+            allowed, retry_after, raw_bucket_key = _check_control_plane_bucket(
+                buckets,
+                lock,
+                route=route,
+                bucket_kind=bucket_kind,
+                bucket_value=bucket_value,
+                limit_item=limit_item,
+                now=now,
+            )
+            if allowed:
+                continue
+            bucket_fingerprint = _fingerprint(raw_bucket_key)
+            LOGGER.warning(
+                "relay_control_plane_rate_limited",
+                extra={
+                    "route": route,
+                    "route_class": CONTROL_PLANE_ROUTE_CLASS,
+                    "limiter_bucket_kind": bucket_kind,
+                    "limiter_bucket_fingerprint": bucket_fingerprint,
+                    "retry_after": retry_after,
+                },
+            )
+            return _build_control_plane_rate_limit_response(limit_item, retry_after)
+        return None
 
 
 def _build_rate_limit_response(exc: RateLimitExceeded):
@@ -189,6 +330,8 @@ def init_app(app):
     def _handle_rate_limit(exc: RateLimitExceeded):
         return _build_rate_limit_response(exc)
 
+    _install_control_plane_rate_limiter(app)
+
     PrometheusMetrics(app)
     app.register_blueprint(v1_routes.v1_bp)
     app.register_blueprint(v1_routes.openai_v1_bp)
@@ -198,6 +341,7 @@ def init_app(app):
     stream_limit_value = os.environ.get("API_STREAM_RATE_LIMIT", "30/minute").strip()
 
     if stream_limit_value:
+
         def _stream_limit_exempt() -> bool:
             data = request.get_json(silent=True)
             if not isinstance(data, dict):

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -246,8 +246,12 @@ Operational note: `/healthz`, `/livez`, `/metrics`, `/relay/diagnostics`, and AP
 heartbeat/control-plane routes are intentionally exempt from the public API rate-limit quota. A
 Kubernetes readiness probe that calls `/healthz` every 10 seconds must not exhaust the default
 `API_RATE_LIMIT=60/hour`; before this exemption, staging could return 429 to kube-probe and become
-externally unhealthy even while the relay process was running. User-facing chat/completion routes
-remain rate-limited.
+externally unhealthy even while the relay process was running. Compute-node register, poll, and
+encrypted response submission traffic is instead protected by dedicated control-plane budgets
+(`API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT`, `API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT`,
+`API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT`, and aggregate `API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT`)
+so multiple desktop nodes behind one NAT can poll normally without consuming chat/user quota.
+User-facing chat/completion routes remain rate-limited.
 
 ## v0.1.0 staging failure modes and operator runbook
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -242,16 +242,23 @@ Decision points:
 - If desktop logs show `kind=http_status_no_json_body` without Cloudflare headers, inspect ingress,
   tunnel, and upstream proxy logs before changing relay application code.
 
-Operational note: `/healthz`, `/livez`, `/metrics`, `/relay/diagnostics`, and API v1 compute-node
-heartbeat/control-plane routes are intentionally exempt from the public API rate-limit quota. A
-Kubernetes readiness probe that calls `/healthz` every 10 seconds must not exhaust the default
-`API_RATE_LIMIT=60/hour`; before this exemption, staging could return 429 to kube-probe and become
-externally unhealthy even while the relay process was running. Compute-node register, poll, and
-encrypted response submission traffic is instead protected by dedicated control-plane budgets
-(`API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT`, `API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT`,
+Operational note: `/healthz`, `/livez`, `/metrics`, and `/relay/diagnostics` are intentionally
+exempt from the public API rate-limit quota. API v1 compute-node heartbeat/control-plane POST
+routes are also exempt from the public quota after passing the relay token boundary: valid
+`X-Relay-Server-Token` when tokens are configured, or the documented tokenless behavior when no
+relay server tokens are configured. Invalid-token POSTs still consume the public quota and are only
+charged to the aggregate client-IP control-plane bucket, not to spoofable server/client identity
+buckets. A Kubernetes readiness probe that calls `/healthz` every 10 seconds must not exhaust the
+default `API_RATE_LIMIT=60/hour`; before this exemption, staging could return 429 to kube-probe and
+become externally unhealthy even while the relay process was running. Compute-node
+register, poll, and encrypted response submission traffic is instead protected by dedicated
+control-plane budgets (`API_RELAY_CONTROL_PLANE_RATE_LIMIT`,
+`API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT`, `API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT`,
 `API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT`, and aggregate `API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT`)
-so multiple desktop nodes behind one NAT can poll normally without consuming chat/user quota.
-User-facing chat/completion routes remain rate-limited.
+so multiple authenticated desktop nodes behind one NAT can poll normally without consuming chat/user
+quota. Configure `TOKENPLACE_RATE_LIMIT_STORAGE_URI` with a shared backend such as Redis or Memcached
+in multi-worker deployments so public and control-plane budgets are shared across workers. User-facing
+chat/completion routes remain rate-limited.
 
 ## v0.1.0 staging failure modes and operator runbook
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -251,10 +251,11 @@ charged to the aggregate client-IP control-plane bucket, not to spoofable server
 buckets. A Kubernetes readiness probe that calls `/healthz` every 10 seconds must not exhaust the
 default `API_RATE_LIMIT=60/hour`; before this exemption, staging could return 429 to kube-probe and
 become externally unhealthy even while the relay process was running. Compute-node
-register, poll, and encrypted response submission traffic is instead protected by dedicated
+register, unregister, poll, and encrypted response submission traffic is instead protected by dedicated
 control-plane budgets (`API_RELAY_CONTROL_PLANE_RATE_LIMIT`,
-`API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT`, `API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT`,
-`API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT`, and aggregate `API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT`)
+`API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT`, `API_RELAY_CONTROL_PLANE_UNREGISTER_RATE_LIMIT`,
+`API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT`, `API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT`,
+and aggregate `API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT`)
 so multiple authenticated desktop nodes behind one NAT can poll normally without consuming chat/user
 quota. Configure `TOKENPLACE_RATE_LIMIT_STORAGE_URI` with a shared backend such as Redis or Memcached
 in multi-worker deployments so public and control-plane budgets are shared across workers. User-facing

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -82,7 +82,7 @@ ensure_playwright_browsers() {
     if [ -z "$chromium_binary" ]; then
         echo "Installing Playwright Chromium browser binaries..."
 
-        # CI workflow already installs Playwright/browser deps in a dedicated step.
+        # CI workflow already installs Playwright browser and system deps in a dedicated step.
         if [ "${CI:-}" = "true" ]; then
             if ! playwright install chromium; then
                 echo "Warning: playwright browser installation failed"
@@ -108,7 +108,7 @@ ensure_playwright_browsers
 # landing-page desktop-bridge API v1 check can run in verification contexts
 # without requiring an extra export command.
 if [ -z "${TOKENPLACE_REAL_E2E_MODEL_PATH:-}" ] && [ -f ".ci-models/stories15M-q4_0.gguf" ]; then
-    TOKENPLACE_REAL_E2E_MODEL_PATH=".ci-models/stories15M-q4_0.gguf"
+    TOKENPLACE_REAL_E2E_MODEL_PATH="$PWD/.ci-models/stories15M-q4_0.gguf"
 fi
 if [ -n "${TOKENPLACE_REAL_E2E_MODEL_PATH:-}" ]; then
     export TOKENPLACE_REAL_E2E_MODEL_PATH

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -100,6 +100,51 @@ def test_api_v1_register_and_poll_are_not_rate_limited_by_public_quota(client, m
     assert {response.status_code for response in poll_responses} == {200}
 
 
+def test_two_api_v1_nodes_poll_and_round_robin_without_control_plane_429(client, monkeypatch):
+    """Two nodes behind one source can poll while next-server rotation remains intact."""
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS", "0")
+    server_a = _server_key("rate-node-a")
+    server_b = _server_key("rate-node-b")
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    for _ in range(65):
+        poll_a = client.post(
+            '/api/v1/relay/servers/poll', json={'server_public_key': server_a}
+        )
+        poll_b = client.post(
+            '/api/v1/relay/servers/poll', json={'server_public_key': server_b}
+        )
+        assert poll_a.status_code == 200
+        assert poll_b.status_code == 200
+
+    assert [_next_api_v1_server_key(client) for _ in range(4)] == [
+        server_a,
+        server_b,
+        server_a,
+        server_b,
+    ]
+    diagnostics = client.get('/relay/diagnostics')
+    assert diagnostics.status_code == 200
+    registered = diagnostics.get_json()['registered_compute_nodes']
+    assert {node['server_public_key'] for node in registered} == {server_a, server_b}
+
+
+def test_api_v1_response_submissions_do_not_use_public_quota(client):
+    """Encrypted response submissions have a higher control-plane budget."""
+
+    responses = [
+        client.post(
+            '/api/v1/relay/responses',
+            json=_api_v1_response_payload(f'rate-response-{index}'),
+        )
+        for index in range(65)
+    ]
+
+    assert {response.status_code for response in responses} == {200}
+
+
 def test_api_v1_client_relay_read_paths_are_not_rate_limited_by_public_quota(client):
     """Client discovery and response polling stay outside the public API quota."""
 

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -5,7 +5,7 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from flask import Flask
+from flask import Flask, request as flask_request
 
 from api import (
     _check_control_plane_limits,
@@ -373,8 +373,13 @@ def test_api_v1_relay_client_read_routes_do_not_inherit_public_quota():
     },
     clear=True,
 )
-def test_control_plane_routes_use_server_key_bucket_not_public_quota():
+def test_control_plane_routes_use_server_key_bucket_not_public_quota(monkeypatch):
     """Compute nodes behind one IP should not collide in the user API bucket."""
+    monkeypatch.setitem(
+        sys.modules,
+        "relay",
+        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
+    )
     app = Flask(__name__)
     init_app(app)
 
@@ -544,7 +549,7 @@ def test_invalid_relay_tokens_do_not_burn_server_identity_quota(monkeypatch):
         "API_RATE_LIMIT": "100/hour",
         "API_DAILY_QUOTA": "1000/day",
         "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT": "2/hour",
-        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "100/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "2/hour",
         "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
     },
     clear=True,
@@ -570,6 +575,7 @@ def test_invalid_relay_response_tokens_do_not_burn_client_identity_quota(monkeyp
                 "/api/v1/relay/responses",
                 json=payload,
                 headers={"X-Relay-Server-Token": "wrong-token"},
+                environ_overrides={"REMOTE_ADDR": "192.0.2.10"},
             )
             for _ in range(2)
         ]
@@ -578,11 +584,65 @@ def test_invalid_relay_response_tokens_do_not_burn_client_identity_quota(monkeyp
                 "/api/v1/relay/responses",
                 json=payload,
                 headers={"X-Relay-Server-Token": "relay-token"},
+                environ_overrides={"REMOTE_ADDR": "192.0.2.11"},
             )
             for _ in range(3)
         ]
 
     assert [response.status_code for response in invalid_attempts] == [200, 200]
+    assert [response.status_code for response in valid_attempts] == [200, 200, 429]
+
+
+@patch.dict(
+    os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT": "2/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "2/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_malformed_relay_responses_do_not_burn_victim_response_bucket(monkeypatch):
+    """Malformed response bodies cannot spoof-limit a victim client/request id."""
+    monkeypatch.setitem(
+        sys.modules,
+        "relay",
+        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
+    )
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/responses")
+    def relay_responses():
+        data = flask_request.get_json(silent=True) or {}
+        if "ciphertext" not in data:
+            return {"error": "malformed encrypted response envelope"}, 400
+        return {"status": "queued"}
+
+    victim_fields = {"client_public_key": "client-a", "request_id": "request-a"}
+    with app.test_client() as client:
+        malformed_attempts = [
+            client.post(
+                "/api/v1/relay/responses",
+                json=victim_fields,
+                headers={"X-Relay-Server-Token": "relay-token"},
+                environ_overrides={"REMOTE_ADDR": "192.0.2.10"},
+            )
+            for _ in range(2)
+        ]
+        valid_attempts = [
+            client.post(
+                "/api/v1/relay/responses",
+                json={**victim_fields, "ciphertext": f"sealed-{index}"},
+                headers={"X-Relay-Server-Token": "relay-token"},
+                environ_overrides={"REMOTE_ADDR": "192.0.2.11"},
+            )
+            for index in range(3)
+        ]
+
+    assert [response.status_code for response in malformed_attempts] == [400, 400]
     assert [response.status_code for response in valid_attempts] == [200, 200, 429]
 
 
@@ -683,8 +743,13 @@ def test_control_plane_identity_race_does_not_hit_aggregate_ip_bucket():
     },
     clear=True,
 )
-def test_identity_limited_rejections_do_not_burn_ip_quota():
+def test_identity_limited_rejections_do_not_burn_ip_quota(monkeypatch):
     """Identity-bucket 429s should roll back any aggregate-IP hit."""
+    monkeypatch.setitem(
+        sys.modules,
+        "relay",
+        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
+    )
     app = Flask(__name__)
     init_app(app)
 
@@ -749,11 +814,16 @@ def test_control_plane_limiter_only_applies_to_post_methods():
 
 @patch.dict(
     os.environ,
-    {"API_RATE_LIMIT": "2/hour", "API_DAILY_QUOTA": "1000/day"},
+    {
+        "API_RATE_LIMIT": "2/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "100/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "2/hour",
+    },
     clear=True,
 )
-def test_tokenless_control_plane_mutations_do_not_use_public_quota():
-    """Tokenless relay deployments keep the separate control-plane budget."""
+def test_tokenless_control_plane_mutations_use_ip_only_control_budget():
+    """Tokenless relay deployments stay off public quota without spoofable keys."""
     app = Flask(__name__)
     init_app(app)
 
@@ -765,12 +835,12 @@ def test_tokenless_control_plane_mutations_do_not_use_public_quota():
         responses = [
             client.post(
                 "/api/v1/relay/servers/register",
-                json={"server_public_key": "server-1"},
+                json={"server_public_key": f"spoofable-server-{index}"},
             )
-            for _ in range(3)
+            for index in range(3)
         ]
 
-    assert [response.status_code for response in responses] == [200, 200, 200]
+    assert [response.status_code for response in responses] == [200, 200, 429]
 
 
 @patch.dict(

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -568,7 +568,13 @@ def test_invalid_relay_response_tokens_do_not_burn_client_identity_quota(monkeyp
     def relay_responses():
         return {"status": "queued"}
 
-    payload = {"client_public_key": "client-a", "request_id": "request-a"}
+    payload = {
+        "client_public_key": "client-a",
+        "request_id": "request-a",
+        "ciphertext": "sealed-response",
+        "cipherkey": "sealed-key",
+        "iv": "sealed-iv",
+    }
     with app.test_client() as client:
         invalid_attempts = [
             client.post(
@@ -635,7 +641,12 @@ def test_malformed_relay_responses_do_not_burn_victim_response_bucket(monkeypatc
         valid_attempts = [
             client.post(
                 "/api/v1/relay/responses",
-                json={**victim_fields, "ciphertext": f"sealed-{index}"},
+                json={
+                    **victim_fields,
+                    "ciphertext": f"sealed-{index}",
+                    "cipherkey": f"sealed-key-{index}",
+                    "iv": f"sealed-iv-{index}",
+                },
                 headers={"X-Relay-Server-Token": "relay-token"},
                 environ_overrides={"REMOTE_ADDR": "192.0.2.11"},
             )
@@ -644,6 +655,51 @@ def test_malformed_relay_responses_do_not_burn_victim_response_bucket(monkeypatc
 
     assert [response.status_code for response in malformed_attempts] == [400, 400]
     assert [response.status_code for response in valid_attempts] == [200, 200, 429]
+
+
+@patch.dict(
+    os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT": "2/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "100/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_authenticated_relay_responses_use_response_identity_budget(monkeypatch):
+    """Valid response envelopes consume the response-specific client budget."""
+    monkeypatch.setitem(
+        sys.modules,
+        "relay",
+        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
+    )
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/responses")
+    def relay_responses():
+        return {"status": "queued"}
+
+    with app.test_client() as client:
+        responses = [
+            client.post(
+                "/api/v1/relay/responses",
+                json={
+                    "client_public_key": "client-a",
+                    "request_id": f"request-{index}",
+                    "ciphertext": f"sealed-{index}",
+                    "cipherkey": f"sealed-key-{index}",
+                    "iv": f"sealed-iv-{index}",
+                },
+                headers={"X-Relay-Server-Token": "relay-token"},
+                environ_overrides={"REMOTE_ADDR": f"192.0.2.{10 + index}"},
+            )
+            for index in range(3)
+        ]
+
+    assert [response.status_code for response in responses] == [200, 200, 429]
 
 
 @patch.dict(

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -342,17 +342,13 @@ def test_api_v1_relay_client_read_routes_do_not_inherit_public_quota():
     {
         "API_RATE_LIMIT": "2/hour",
         "API_DAILY_QUOTA": "1000/day",
-        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "rotated-token",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "2/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "100/hour",
     },
     clear=True,
 )
-def test_authenticated_relay_exemption_uses_loaded_relay_token_snapshot(monkeypatch):
-    """Limiter auth should not drift from relay.py's active token snapshot."""
-    monkeypatch.setitem(
-        sys.modules,
-        "relay",
-        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["active-token"]),
-    )
+def test_control_plane_routes_use_server_key_bucket_not_public_quota():
+    """Compute nodes behind one IP should not collide in the user API bucket."""
     app = Flask(__name__)
     init_app(app)
 
@@ -361,25 +357,29 @@ def test_authenticated_relay_exemption_uses_loaded_relay_token_snapshot(monkeypa
         return {"status": "registered"}
 
     with app.test_client() as client:
-        rotated_responses = [
+        server_a = [
             client.post(
                 "/api/v1/relay/servers/register",
-                json={"server_public_key": f"server-{index}"},
-                headers={"X-Relay-Server-Token": "rotated-token"},
+                json={"server_public_key": "server-a"},
             )
-            for index in range(3)
+            for _ in range(2)
         ]
-        active_responses = [
+        server_b = [
             client.post(
                 "/api/v1/relay/servers/register",
-                json={"server_public_key": f"active-server-{index}"},
-                headers={"X-Relay-Server-Token": "active-token"},
+                json={"server_public_key": "server-b"},
             )
-            for index in range(3)
+            for _ in range(2)
         ]
+        limited = client.post(
+            "/api/v1/relay/servers/register",
+            json={"server_public_key": "server-a"},
+        )
 
-    assert [response.status_code for response in rotated_responses] == [200, 200, 429]
-    assert {response.status_code for response in active_responses} == {200}
+    assert [response.status_code for response in server_a] == [200, 200]
+    assert [response.status_code for response in server_b] == [200, 200]
+    assert limited.status_code == 429
+    assert limited.get_json()["error"]["code"] == "rate_limit_exceeded"
 
 
 @patch.dict(
@@ -387,23 +387,18 @@ def test_authenticated_relay_exemption_uses_loaded_relay_token_snapshot(monkeypa
     {
         "API_RATE_LIMIT": "2/hour",
         "API_DAILY_QUOTA": "1000/day",
-        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "100/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "2/hour",
     },
     clear=True,
 )
-def test_relay_mutations_with_missing_token_header_keep_public_rate_limit(monkeypatch):
-    """Configured relay tokens should not exempt requests that omit the header."""
-
-    monkeypatch.setitem(
-        sys.modules,
-        "relay",
-        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
-    )
+def test_control_plane_routes_keep_aggregate_ip_abuse_budget():
+    """Unique anonymous server keys cannot bypass aggregate route protection."""
     app = Flask(__name__)
     init_app(app)
 
     @app.post("/api/v1/relay/servers/register")
-    def relay_servers_register_missing_header():
+    def relay_servers_register():
         return {"status": "registered"}
 
     with app.test_client() as client:
@@ -420,11 +415,55 @@ def test_relay_mutations_with_missing_token_header_keep_public_rate_limit(monkey
 
 @patch.dict(
     os.environ,
+    {
+        "API_RATE_LIMIT": "2/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT": "65/hour",
+        "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT": "65/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "1000/hour",
+    },
+    clear=True,
+)
+def test_poll_and_response_control_plane_routes_do_not_use_public_quota():
+    """Poll and encrypted response submissions allow healthy cadence above user quota."""
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/servers/poll")
+    def relay_servers_poll():
+        return {"status": "polling"}
+
+    @app.post("/api/v1/relay/responses")
+    def relay_responses():
+        return {"status": "queued"}
+
+    with app.test_client() as client:
+        poll_responses = [
+            client.post(
+                "/api/v1/relay/servers/poll",
+                json={"server_public_key": "server-a"},
+            )
+            for _ in range(65)
+        ]
+        response_submissions = [
+            client.post(
+                "/api/v1/relay/responses",
+                json={"client_public_key": "client-a", "request_id": f"req-{index}"},
+            )
+            for index in range(65)
+        ]
+
+    assert {response.status_code for response in poll_responses} == {200}
+    assert {response.status_code for response in response_submissions} == {200}
+
+
+@patch.dict(
+    os.environ,
     {"API_RATE_LIMIT": "2/hour", "API_DAILY_QUOTA": "1000/day"},
     clear=True,
 )
-def test_unauthenticated_api_v1_relay_mutations_keep_public_rate_limit():
-    """Anonymous relay mutations should retain quota protection when no token exists."""
+def test_unauthenticated_control_plane_mutations_do_not_use_public_quota():
+    """Staging without relay tokens still gets the separate control-plane budget."""
     app = Flask(__name__)
     init_app(app)
 
@@ -433,26 +472,15 @@ def test_unauthenticated_api_v1_relay_mutations_keep_public_rate_limit():
         return {"status": "registered"}
 
     with app.test_client() as client:
-        assert (
+        responses = [
             client.post(
-                "/api/v1/relay/servers/register", json={"server_public_key": "server-1"}
-            ).status_code
-            == 200
-        )
-        assert (
-            client.post(
-                "/api/v1/relay/servers/register", json={"server_public_key": "server-2"}
-            ).status_code
-            == 200
-        )
-        response = client.post(
-            "/api/v1/relay/servers/register", json={"server_public_key": "server-3"}
-        )
+                "/api/v1/relay/servers/register",
+                json={"server_public_key": "server-1"},
+            )
+            for _ in range(3)
+        ]
 
-    assert response.status_code == 429
-    body = response.get_json()
-    assert body is not None
-    assert body["error"]["code"] == "rate_limit_exceeded"
+    assert [response.status_code for response in responses] == [200, 200, 200]
 
 
 @patch.dict(

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, patch
 
 from flask import Flask
 
-from api import _load_relay_server_registration_tokens, init_app
+from api import (
+    _check_control_plane_limits,
+    _load_relay_server_registration_tokens,
+    init_app,
+)
 
 
 @patch.dict(os.environ, {"API_RATE_LIMIT": "1/minute"})
@@ -626,6 +630,46 @@ def test_ip_limited_rejections_do_not_burn_identity_quota():
 
     assert [response.status_code for response in first_ip] == [200, 429]
     assert [response.status_code for response in second_ip] == [200, 429]
+
+
+def test_control_plane_identity_race_does_not_hit_aggregate_ip_bucket():
+    """A concurrent identity rejection should fail before charging client IP."""
+
+    class FakeLimit:
+        def __init__(self, name: str):
+            self.name = name
+
+        def key_for(self, *identifiers):
+            return f"{self.name}:{':'.join(identifiers)}"
+
+    class FakeRateLimiter:
+        def __init__(self):
+            self.hit_calls = []
+            self.storage = MagicMock()
+
+        def test(self, limit_item, *identifiers):
+            return True
+
+        def hit(self, limit_item, *identifiers):
+            self.hit_calls.append((limit_item.name, identifiers))
+            return limit_item.name != "identity"
+
+        def get_window_stats(self, limit_item, *identifiers):
+            return SimpleNamespace(reset_time=9999999999)
+
+    fake_limiter = FakeRateLimiter()
+    allowed, _, bucket_kind, _, _ = _check_control_plane_limits(
+        fake_limiter,
+        [
+            ("client_ip", "192.0.2.10", FakeLimit("ip")),
+            ("server_public_key", "server-a", FakeLimit("identity")),
+        ],
+        route="/api/v1/relay/servers/register",
+    )
+
+    assert allowed is False
+    assert bucket_kind == "server_public_key"
+    assert [name for name, _ in fake_limiter.hit_calls] == ["identity"]
 
 
 @patch.dict(

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -634,6 +634,49 @@ def test_ip_limited_rejections_do_not_burn_identity_quota():
         "API_RATE_LIMIT": "100/hour",
         "API_DAILY_QUOTA": "1000/day",
         "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "1/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "2/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_identity_limited_rejections_do_not_burn_ip_quota():
+    """Identity-bucket 429s should roll back any aggregate-IP hit."""
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/servers/register")
+    def relay_servers_register():
+        return {"status": "registered"}
+
+    headers = {"X-Relay-Server-Token": "relay-token"}
+    with app.test_client() as client:
+        responses = [
+            client.post(
+                "/api/v1/relay/servers/register",
+                json={"server_public_key": "server-a"},
+                headers=headers,
+            ),
+            client.post(
+                "/api/v1/relay/servers/register",
+                json={"server_public_key": "server-a"},
+                headers=headers,
+            ),
+            client.post(
+                "/api/v1/relay/servers/register",
+                json={"server_public_key": "server-b"},
+                headers=headers,
+            ),
+        ]
+
+    assert [response.status_code for response in responses] == [200, 429, 200]
+
+
+@patch.dict(
+    os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "1/hour",
         "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "1/hour",
         "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
     },

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -184,11 +184,24 @@ def test_production_with_rate_limit_storage_uri_uses_explicit_backend():
     app = Flask(__name__)
     limiter_instance = MagicMock()
 
-    with patch("api.Limiter", return_value=limiter_instance) as limiter_cls:
+    control_plane_storage = MagicMock()
+    control_plane_limiter = MagicMock()
+    with (
+        patch("api.Limiter", return_value=limiter_instance) as limiter_cls,
+        patch(
+            "api.storage_from_string", return_value=control_plane_storage
+        ) as storage_cls,
+        patch(
+            "api.FixedWindowRateLimiter", return_value=control_plane_limiter
+        ) as control_limiter_cls,
+    ):
         limiter = init_app(app)
 
     assert limiter is limiter_instance
     assert limiter_cls.call_args.kwargs["storage_uri"] == "memcached://127.0.0.1:11211"
+    storage_cls.assert_called_once_with("memcached://127.0.0.1:11211")
+    control_limiter_cls.assert_called_once_with(control_plane_storage)
+    assert app.config["relay_control_plane_rate_limiter"] is control_plane_limiter
 
 
 @patch.dict(
@@ -344,6 +357,7 @@ def test_api_v1_relay_client_read_routes_do_not_inherit_public_quota():
         "API_DAILY_QUOTA": "1000/day",
         "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "2/hour",
         "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "100/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
     },
     clear=True,
 )
@@ -361,6 +375,7 @@ def test_control_plane_routes_use_server_key_bucket_not_public_quota():
             client.post(
                 "/api/v1/relay/servers/register",
                 json={"server_public_key": "server-a"},
+                headers={"X-Relay-Server-Token": "relay-token"},
             )
             for _ in range(2)
         ]
@@ -368,12 +383,14 @@ def test_control_plane_routes_use_server_key_bucket_not_public_quota():
             client.post(
                 "/api/v1/relay/servers/register",
                 json={"server_public_key": "server-b"},
+                headers={"X-Relay-Server-Token": "relay-token"},
             )
             for _ in range(2)
         ]
         limited = client.post(
             "/api/v1/relay/servers/register",
             json={"server_public_key": "server-a"},
+            headers={"X-Relay-Server-Token": "relay-token"},
         )
 
     assert [response.status_code for response in server_a] == [200, 200]
@@ -389,11 +406,12 @@ def test_control_plane_routes_use_server_key_bucket_not_public_quota():
         "API_DAILY_QUOTA": "1000/day",
         "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "100/hour",
         "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "2/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
     },
     clear=True,
 )
 def test_control_plane_routes_keep_aggregate_ip_abuse_budget():
-    """Unique anonymous server keys cannot bypass aggregate route protection."""
+    """Unique server keys cannot bypass aggregate route protection."""
     app = Flask(__name__)
     init_app(app)
 
@@ -406,6 +424,7 @@ def test_control_plane_routes_keep_aggregate_ip_abuse_budget():
             client.post(
                 "/api/v1/relay/servers/register",
                 json={"server_public_key": f"server-{index}"},
+                headers={"X-Relay-Server-Token": "relay-token"},
             )
             for index in range(3)
         ]
@@ -421,6 +440,7 @@ def test_control_plane_routes_keep_aggregate_ip_abuse_budget():
         "API_RELAY_CONTROL_PLANE_POLL_RATE_LIMIT": "65/hour",
         "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT": "65/hour",
         "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "1000/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
     },
     clear=True,
 )
@@ -442,6 +462,7 @@ def test_poll_and_response_control_plane_routes_do_not_use_public_quota():
             client.post(
                 "/api/v1/relay/servers/poll",
                 json={"server_public_key": "server-a"},
+                headers={"X-Relay-Server-Token": "relay-token"},
             )
             for _ in range(65)
         ]
@@ -449,6 +470,7 @@ def test_poll_and_response_control_plane_routes_do_not_use_public_quota():
             client.post(
                 "/api/v1/relay/responses",
                 json={"client_public_key": "client-a", "request_id": f"req-{index}"},
+                headers={"X-Relay-Server-Token": "relay-token"},
             )
             for index in range(65)
         ]
@@ -459,11 +481,184 @@ def test_poll_and_response_control_plane_routes_do_not_use_public_quota():
 
 @patch.dict(
     os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "2/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "100/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_invalid_relay_tokens_do_not_burn_server_identity_quota(monkeypatch):
+    """Unauthenticated callers cannot spoof-limit a victim server key."""
+    monkeypatch.setitem(
+        sys.modules,
+        "relay",
+        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
+    )
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/servers/register")
+    def relay_servers_register():
+        return {"status": "registered"}
+
+    with app.test_client() as client:
+        invalid_attempts = [
+            client.post(
+                "/api/v1/relay/servers/register",
+                json={"server_public_key": "server-a"},
+                headers={"X-Relay-Server-Token": "wrong-token"},
+            )
+            for _ in range(2)
+        ]
+        valid_attempts = [
+            client.post(
+                "/api/v1/relay/servers/register",
+                json={"server_public_key": "server-a"},
+                headers={"X-Relay-Server-Token": "relay-token"},
+            )
+            for _ in range(3)
+        ]
+
+    assert [response.status_code for response in invalid_attempts] == [200, 200]
+    assert [response.status_code for response in valid_attempts] == [200, 200, 429]
+
+
+@patch.dict(
+    os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_RESPONSE_RATE_LIMIT": "2/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "100/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_invalid_relay_response_tokens_do_not_burn_client_identity_quota(monkeypatch):
+    """Unauthenticated response submissions cannot spoof-limit a client bucket."""
+    monkeypatch.setitem(
+        sys.modules,
+        "relay",
+        SimpleNamespace(SERVER_REGISTRATION_TOKENS=["relay-token"]),
+    )
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/responses")
+    def relay_responses():
+        return {"status": "queued"}
+
+    payload = {"client_public_key": "client-a", "request_id": "request-a"}
+    with app.test_client() as client:
+        invalid_attempts = [
+            client.post(
+                "/api/v1/relay/responses",
+                json=payload,
+                headers={"X-Relay-Server-Token": "wrong-token"},
+            )
+            for _ in range(2)
+        ]
+        valid_attempts = [
+            client.post(
+                "/api/v1/relay/responses",
+                json=payload,
+                headers={"X-Relay-Server-Token": "relay-token"},
+            )
+            for _ in range(3)
+        ]
+
+    assert [response.status_code for response in invalid_attempts] == [200, 200]
+    assert [response.status_code for response in valid_attempts] == [200, 200, 429]
+
+
+@patch.dict(
+    os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "2/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "1/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_ip_limited_rejections_do_not_burn_identity_quota():
+    """Aggregate-IP 429s should not increment the server identity bucket."""
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/servers/register")
+    def relay_servers_register():
+        return {"status": "registered"}
+
+    headers = {"X-Relay-Server-Token": "relay-token"}
+    payload = {"server_public_key": "server-a"}
+    with app.test_client() as client:
+        first_ip = [
+            client.post(
+                "/api/v1/relay/servers/register",
+                json=payload,
+                headers=headers,
+                environ_overrides={"REMOTE_ADDR": "192.0.2.10"},
+            )
+            for _ in range(2)
+        ]
+        second_ip = [
+            client.post(
+                "/api/v1/relay/servers/register",
+                json=payload,
+                headers=headers,
+                environ_overrides={"REMOTE_ADDR": "192.0.2.11"},
+            )
+            for _ in range(2)
+        ]
+
+    assert [response.status_code for response in first_ip] == [200, 429]
+    assert [response.status_code for response in second_ip] == [200, 429]
+
+
+@patch.dict(
+    os.environ,
+    {
+        "API_RATE_LIMIT": "100/hour",
+        "API_DAILY_QUOTA": "1000/day",
+        "API_RELAY_CONTROL_PLANE_REGISTER_RATE_LIMIT": "1/hour",
+        "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT": "1/hour",
+        "TOKEN_PLACE_RELAY_SERVER_TOKEN": "relay-token",
+    },
+    clear=True,
+)
+def test_control_plane_limiter_only_applies_to_post_methods():
+    """GET/OPTIONS on POST-only control routes should not consume control budgets."""
+    app = Flask(__name__)
+    init_app(app)
+
+    @app.post("/api/v1/relay/servers/register")
+    def relay_servers_register():
+        return {"status": "registered"}
+
+    with app.test_client() as client:
+        get_responses = [client.get("/api/v1/relay/servers/register") for _ in range(3)]
+        post_response = client.post(
+            "/api/v1/relay/servers/register",
+            json={"server_public_key": "server-a"},
+            headers={"X-Relay-Server-Token": "relay-token"},
+        )
+
+    assert [response.status_code for response in get_responses] == [405, 405, 405]
+    assert post_response.status_code == 200
+
+
+@patch.dict(
+    os.environ,
     {"API_RATE_LIMIT": "2/hour", "API_DAILY_QUOTA": "1000/day"},
     clear=True,
 )
-def test_unauthenticated_control_plane_mutations_do_not_use_public_quota():
-    """Staging without relay tokens still gets the separate control-plane budget."""
+def test_tokenless_control_plane_mutations_do_not_use_public_quota():
+    """Tokenless relay deployments keep the separate control-plane budget."""
     app = Flask(__name__)
     init_app(app)
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -3414,6 +3414,38 @@ def test_unregister_from_relay_rechecks_registration_after_previous_empty_skip(m
 
 
 @patch('utils.networking.relay_client.requests.post')
+def test_unregister_from_relay_logs_control_plane_429_diagnostic(mock_post, caplog):
+    client = _standalone_relay_client()
+    client._registration_token = 'super-secret-token'
+    client._api_v1_registered_relays.add('http://localhost:5000')
+    client._api_v1_last_heartbeat_at['http://localhost:5000'] = 123.0
+
+    response = MagicMock(status_code=429)
+    response.headers = {
+        'content-type': 'application/json',
+        'retry-after': '41',
+    }
+    response.json.return_value = {
+        'error': {
+            'code': 'rate_limit_exceeded',
+            'message': 'Rate limit exceeded. Try again in 41 seconds.',
+            'type': 'rate_limit_error',
+        }
+    }
+    mock_post.return_value = response
+
+    with caplog.at_level('ERROR', logger='relay_client'):
+        result = client.unregister_from_relay()
+
+    assert result is False
+    assert client._unregister_complete is False
+    assert 'relay_control_plane_rate_limited' in caplog.text
+    assert 'path=/api/v1/relay/servers/unregister' in caplog.text
+    assert 'retry_after=41' in caplog.text
+    assert 'super-secret-token' not in caplog.text
+
+
+@patch('utils.networking.relay_client.requests.post')
 def test_start_after_unregister_clears_stale_registration_and_polls_cleanly(mock_post):
     client = _standalone_relay_client()
     client._api_v1_registered_relays.add('http://localhost:5000')

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1110,6 +1110,36 @@ class TestRelayClient:
             assert forbidden not in json.dumps(result, sort_keys=True)
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_register_api_v1_compute_node_logs_control_plane_429(self, mock_post, relay_client, caplog):
+        response = MagicMock(status_code=429)
+        response.headers = {
+            'content-type': 'application/json',
+            'retry-after': '37',
+        }
+        response.json.return_value = {
+            'error': {
+                'code': 'rate_limit_exceeded',
+                'message': 'Rate limit exceeded: 2 per 1 hour. Try again in 37 seconds.',
+                'type': 'rate_limit_error',
+            }
+        }
+        mock_post.return_value = response
+
+        with caplog.at_level('ERROR', logger='relay_client'):
+            result = relay_client.register_api_v1_compute_node('https://staging.token.place')
+
+        diagnostic = result['relay_http_diagnostic']
+        assert result['error'] == 'HTTP 429'
+        assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
+        assert diagnostic['path'] == '/api/v1/relay/servers/register'
+        assert diagnostic['route_class'] == 'compute_node_control_plane'
+        assert diagnostic['retry_after'] == '37'
+        assert diagnostic['headers']['retry-after'] == '37'
+        assert 'relay_control_plane_rate_limited' in caplog.text
+        assert 'retry_after=37' in caplog.text
+
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_register_api_v1_compute_node_401_json_logs_relay_error_safely(
         self, mock_post, relay_client, caplog
     ):

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-
 WORKFLOW_DIR = Path(".github/workflows")
 PR_REQUIRED_WORKFLOWS = {
     "ci.yml",
@@ -25,7 +24,9 @@ def _workflow_on_block(data: dict, workflow_name: str) -> dict:
     if on_block is None:
         # YAML 1.1 loaders can parse the key `on` as boolean `True`.
         on_block = data.get(True)
-    assert isinstance(on_block, dict), f"{workflow_name} must define a mapping under top-level `on:`"
+    assert isinstance(
+        on_block, dict
+    ), f"{workflow_name} must define a mapping under top-level `on:`"
     return on_block
 
 
@@ -47,19 +48,62 @@ def test_image_workflow_keeps_pull_request_validate_only() -> None:
     workflow_data = _load_workflow(WORKFLOW_DIR / "ci-image.yml")
     on_block = _workflow_on_block(workflow_data, "ci-image.yml")
 
-    assert "pull_request" in on_block, "ci-image.yml must validate relay image changes on PRs"
-    assert "workflow_dispatch" in on_block, "ci-image.yml should support manual validate-only builds"
+    assert (
+        "pull_request" in on_block
+    ), "ci-image.yml must validate relay image changes on PRs"
+    assert (
+        "workflow_dispatch" in on_block
+    ), "ci-image.yml should support manual validate-only builds"
 
     publish_job = workflow_data["jobs"]["publish"]
-    assert "github.event_name == 'push'" in publish_job["if"], (
-        "ci-image.yml publish job must stay push-only so PR and workflow_dispatch runs validate only"
-    )
+    assert (
+        "github.event_name == 'push'" in publish_job["if"]
+    ), "ci-image.yml publish job must stay push-only so PR and workflow_dispatch runs validate only"
 
 
 def test_canonical_chart_version_is_bumped_for_main_latest_default() -> None:
-    chart = yaml.safe_load(Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8"))
-    values = yaml.safe_load(Path("charts/tokenplace/values.yaml").read_text(encoding="utf-8"))
+    chart = yaml.safe_load(
+        Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8")
+    )
+    values = yaml.safe_load(
+        Path("charts/tokenplace/values.yaml").read_text(encoding="utf-8")
+    )
 
     assert chart["version"] == "0.1.1"
     assert values["image"]["tag"] == "main-latest"
     assert values["image"]["pullPolicy"] == "Always"
+
+
+def test_ci_installs_playwright_chromium_with_system_dependencies() -> None:
+    workflow_data = _load_workflow(WORKFLOW_DIR / "ci.yml")
+    steps = workflow_data["jobs"]["test"]["steps"]
+    install_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and str(step.get("name", "")).startswith("Install Playwright browsers")
+    ]
+
+    assert (
+        install_steps
+    ), "ci.yml must install Playwright before browser-based guardrails run"
+    assert any(
+        "playwright install --with-deps chromium" in str(step.get("run", ""))
+        for step in install_steps
+    ), (
+        "The CI browser install must include Playwright system dependencies so the "
+        "relay landing-page real desktop-bridge guardrail does not fail when the "
+        "runner image lacks Chromium shared libraries."
+    )
+
+
+def test_run_all_tests_uses_absolute_default_real_e2e_model_path() -> None:
+    runner = Path("run_all_tests.sh").read_text(encoding="utf-8")
+
+    assert (
+        'TOKENPLACE_REAL_E2E_MODEL_PATH="$PWD/.ci-models/stories15M-q4_0.gguf"'
+        in runner
+    ), (
+        "The default real desktop-bridge guardrail model path must be absolute so "
+        "subprocess runtime warm-load checks can resolve it after changing working directories."
+    )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -893,7 +893,13 @@ class RelayClient:
                     continue
 
                 failed_relays.add(candidate_url)
-                last_error = f"HTTP {response.status_code}"
+                diagnostic = self._api_v1_non_200_diagnostic(
+                    response,
+                    method="POST",
+                    url=unregister_url,
+                    token_sent=bool(headers),
+                )
+                last_error = f"HTTP {diagnostic['status_code']}"
                 log_error(
                     "Failed to unregister compute node from {}: {}",
                     candidate_url,
@@ -1087,6 +1093,7 @@ class RelayClient:
         retry_after = headers.get("retry-after")
         control_plane_paths = {
             "/api/v1/relay/servers/register",
+            "/api/v1/relay/servers/unregister",
             "/api/v1/relay/servers/poll",
             "/api/v1/relay/responses",
         }

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -114,6 +114,7 @@ _API_V1_DIAGNOSTIC_HEADER_NAMES = (
     "cf-cache-status",
     "content-type",
     "x-request-id",
+    "retry-after",
 )
 _API_V1_BODY_SNIPPET_LIMIT = 512
 _API_V1_REDACTED = "[redacted]"
@@ -1072,6 +1073,15 @@ class RelayClient:
         else:
             error_kind = "http_status_no_json_body"
 
+        retry_after = headers.get("retry-after")
+        control_plane_paths = {
+            "/api/v1/relay/servers/register",
+            "/api/v1/relay/servers/poll",
+            "/api/v1/relay/responses",
+        }
+        route_class = (
+            "compute_node_control_plane" if path in control_plane_paths else "api_v1_relay"
+        )
         diagnostic = {
             "method": method.upper(),
             "path": path,
@@ -1082,6 +1092,8 @@ class RelayClient:
             "relay_error": relay_error,
             "error_kind": error_kind,
             "probable_pre_app_rejection": probable_pre_app_rejection,
+            "route_class": route_class,
+            "retry_after": retry_after,
         }
 
         log_error(
@@ -1093,6 +1105,15 @@ class RelayClient:
             diagnostic["headers"],
             diagnostic["body_snippet"],
         )
+        if status_code == 429 and route_class == "compute_node_control_plane":
+            log_error(
+                "relay_control_plane_rate_limited method={} path={} status={} retry_after={} token_sent={}",
+                diagnostic["method"],
+                diagnostic["path"],
+                diagnostic["status_code"],
+                retry_after or "unknown",
+                diagnostic["token_sent"],
+            )
         if probable_pre_app_rejection:
             log_error(
                 "api_v1.relay_pre_app_rejection method={} path={} status={} cf_ray={} server={} token_sent={}",


### PR DESCRIPTION
### Motivation
- Compute-node control-plane traffic (register/poll/responses) was consuming the low public user/chat API quota and caused healthy desktop nodes to receive 429s when polling frequently or when multiple nodes shared an IP. 
- The intent is to preserve meaningful user-facing chat/completion limits while allowing trusted compute nodes to register, heartbeat, poll, and submit encrypted responses at an operational cadence.

### Description
- Add a dedicated control-plane rate limiter and route-specific budgets in `api/__init__.py`, with per-route defaults and environment knobs `API_RELAY_CONTROL_PLANE_*` and an aggregate per-IP budget `API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT`.
- Key control-plane buckets by server public key for `POST /api/v1/relay/servers/register` and `POST /api/v1/relay/servers/poll`, and by `client_public_key` / `request_id` when available for `POST /api/v1/relay/responses`, falling back to client IP when necessary.
- Install the control-plane limiter as a separate `@app.before_request` check so public user quotas (Flask-Limiter default limits) remain intact and the exempt-path logic continues to exempt operational/read routes.
- Improve diagnostics/logging in `utils/networking/relay_client.py` to surface `route_class`, `retry_after`, and emit a `relay_control_plane_rate_limited` warning when compute-node control-plane routes receive 429, while preserving safe redaction of secrets.
- Add and update tests to cover: exempt operational/read routes, control-plane route budgets (per-identity and per-IP), multi-node polling behind the same IP, encrypted response submissions, and relay-client 429 diagnostics; and update README/docs to document new env knobs and expected behavior.

### Testing
- Unit tests: ran `pytest tests/unit/test_rate_limit.py` and the new/updated rate-limit unit cases passed (`18 passed` in the focused run) and exercised control-plane limits and exemptions successfully.
- Relay tests: ran `pytest tests/test_relay.py -k "rate or register or poll or next or unregister or round_robin"` and the selected relay scenarios passed (including two-node poll/round-robin and response submission coverage).
- Relay client tests: ran `pytest tests/unit/test_relay_client.py -k "rate or poll or register or unregister or backoff"` and these passed (compute-node 429 diagnostics validated).
- Integration/e2e: ran `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py` and the desktop/bridge scenarios passed; ran the packaged/desktop parity e2e scripts used for operator parity checks and they completed in this environment.
- Pre-commit and project checks: ran `pre-commit run --all-files` and the repo checks passed.

All automated tests executed for this change succeeded in the verification environment; warnings about in-memory limiter backend are expected in tests and do not indicate regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23c7d067ac832f97773b79bd8fdb8f)