### PR TITLE
Enforce Sugarkube tokenplace release gates

### DIFF
--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -28,7 +28,8 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Current deployable chart package version: `0.1.1` (the v0.1.0 runtime remains chart `appVersion: "0.1.0"`)
+- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; deploy with chart package version `0.1.1`
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only and not production sign-off
@@ -43,7 +44,7 @@ Use the values files and version file that live in Sugarkube for your environmen
 ## Ingress TLS + Cloudflare Tunnel contract
 
 - Cloudflare Tunnel still owns public DNS/Tunnel routing for `token.place` to Traefik.
-- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes.
+- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes, DNS, Tunnel ingress rules, TLS edge policy, or WAF/bot rules.
 - Production values must explicitly set `ingress.tls.enabled: true` or chart output omits `spec.tls`.
 - Assumption: cert-manager is installed and `cert-manager.io/cluster-issuer: letsencrypt-production` exists.
 
@@ -91,6 +92,7 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
 curl -fsS https://token.place/
 ```
 
@@ -98,6 +100,46 @@ Optional note: true relay traffic validation requires a registered external comp
 E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
 See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" and run
 the same external compute-node validation pattern against production hostnames before sign-off.
+
+## External relay-compute E2EE sign-off gate
+
+The HTTP checklist above is necessary but **not sufficient**. Sign-off also requires a real external
+desktop/compute node to register against `https://token.place` and complete one encrypted API v1
+relay/desktop-bridge E2EE request/response through that node. The compute-node command is
+operator/environment-specific; capture the actual command and redacted config used rather than
+inventing a generic one.
+
+Evidence to archive after the compute test:
+
+- immutable image tag (`v0.1.0` or the approved replacement)
+- chart version `0.1.1` and chart digest when available from Helm/Sugarkube output
+- rendered manifest or live Deployment YAML showing one replica and one worker
+- `/healthz` and `/relay/diagnostics` output showing the registered external node after the test
+- relay logs captured after the encrypted request/response completes
+
+Cloudflare/TLS/WAF validation is an external gate because Helm cannot prove public routing reaches
+Traefik or that compute-node POSTs are allowed through Cloudflare:
+
+```bash
+# Confirm Cloudflare/DNS routes the public hostname to the expected edge/Tunnel path.
+dig +short token.place
+curl -vI https://token.place/
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
+
+# Safely reproduce compute-node registration shape with a placeholder token and redacted body.
+# A 401 JSON response means the request reached relay.py but the placeholder token was invalid;
+# a 403 with server: cloudflare or cf-ray usually means Cloudflare/WAF blocked it before the app.
+curl -i -X POST https://token.place/api/v1/relay/servers/register \
+  -H 'content-type: application/json' \
+  -H 'X-Relay-Server-Token: REPLACE_WITH_ENVIRONMENT_TEST_TOKEN' \
+  --data '{"server_public_key":"redacted-placeholder-public-key"}'
+
+# If a desktop/compute node records a pre-app 403, look up the Ray ID in Cloudflare Security Events.
+CF_RAY=REPLACE_CF_RAY
+printf 'Cloudflare Security > Events: filter Ray ID %s for host token.place and review WAF/bot/firewall action\n' "$CF_RAY"
+```
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -29,7 +29,8 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Current deployable chart package version: `0.1.1` (the v0.1.0 runtime remains chart `appVersion: "0.1.0"`)
+- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; deploy with chart package version `0.1.1`
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only
@@ -44,7 +45,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 ## Ingress TLS + Cloudflare Tunnel contract
 
 - Cloudflare Tunnel still owns public DNS/Tunnel routing for `staging.token.place` to Traefik.
-- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes.
+- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes, DNS, Tunnel ingress rules, TLS edge policy, or WAF/bot rules.
 - Staging values must explicitly set `ingress.tls.enabled: true` or chart output omits `spec.tls`.
 - Assumption: cert-manager is installed and `cert-manager.io/cluster-issuer: letsencrypt-production` exists.
 
@@ -88,6 +89,7 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/
 ```
 
@@ -97,6 +99,46 @@ See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator r
 required checks covering stale OCI chart detection, Recreate strategy verification, XDG
 read-only-root safeguards, duplicate env detection, and external compute-node long-poll flow
 validation.
+
+## External relay-compute E2EE sign-off gate
+
+The HTTP checklist above is necessary but **not sufficient**. Sign-off also requires a real external
+desktop/compute node to register against `https://staging.token.place` and complete one encrypted API v1
+relay/desktop-bridge E2EE request/response through that node. The compute-node command is
+operator/environment-specific; capture the actual command and redacted config used rather than
+inventing a generic one.
+
+Evidence to archive after the compute test:
+
+- immutable image tag (`main-REPLACE_SHORTSHA` or the approved replacement)
+- chart version `0.1.1` and chart digest when available from Helm/Sugarkube output
+- rendered manifest or live Deployment YAML showing one replica and one worker
+- `/healthz` and `/relay/diagnostics` output showing the registered external node after the test
+- relay logs captured after the encrypted request/response completes
+
+Cloudflare/TLS/WAF validation is an external gate because Helm cannot prove public routing reaches
+Traefik or that compute-node POSTs are allowed through Cloudflare:
+
+```bash
+# Confirm Cloudflare/DNS routes the public hostname to the expected edge/Tunnel path.
+dig +short staging.token.place
+curl -vI https://staging.token.place/
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
+
+# Safely reproduce compute-node registration shape with a placeholder token and redacted body.
+# A 401 JSON response means the request reached relay.py but the placeholder token was invalid;
+# a 403 with server: cloudflare or cf-ray usually means Cloudflare/WAF blocked it before the app.
+curl -i -X POST https://staging.token.place/api/v1/relay/servers/register \
+  -H 'content-type: application/json' \
+  -H 'X-Relay-Server-Token: REPLACE_WITH_ENVIRONMENT_TEST_TOKEN' \
+  --data '{"server_public_key":"redacted-placeholder-public-key"}'
+
+# If a desktop/compute node records a pre-app 403, look up the Ray ID in Cloudflare Security Events.
+CF_RAY=REPLACE_CF_RAY
+printf 'Cloudflare Security > Events: filter Ray ID %s for host staging.token.place and review WAF/bot/firewall action\n' "$CF_RAY"
+```
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -14,6 +14,7 @@ chart version.
 - Helm chart workflow: `.github/workflows/ci-helm.yml`
 - OCI chart ref: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Chart name: `tokenplace`
+- Current deployable chart package version: `0.1.1` (the chart `appVersion` remains `"0.1.0"` for the v0.1.0 relay runtime)
 
 The retired image workflows (`build.yml` and `relay-oci.yml`) are removed. Do
 not publish or deploy the retired democratizedspace relay package for
@@ -42,7 +43,10 @@ ghcr.io/futuroptimist/tokenplace-relay:sha-<shortsha>
 
 Use `main-<shortsha>` or `vX.Y.Z` for Sugarkube deploys. `main-latest` exists
 only as a chart lint/render convenience and a quick human smoke-test pointer;
-it is not the staging or production promotion tag.
+it is not the staging or production promotion tag. Sugarkube's `docs/apps/tokenplace.prod.tag`
+may intentionally be empty; in that state production promotion must pass an explicit immutable
+tag at deploy time. Mutable tags such as `latest`, `main-latest`, `staging`, `prod`, and
+`production` are never valid promotion tags.
 
 ## Chart contract
 
@@ -57,7 +61,10 @@ helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version CHART_VE
 ```
 
 Replace `CHART_VERSION` with the version recorded in the successful
-`ci-helm.yml` run summary or in the Sugarkube app config/version file.
+`ci-helm.yml` run summary or in the Sugarkube app config/version file. For the current
+token.place Sugarkube candidate this should align with `docs/apps/tokenplace.version` value
+`0.1.1`; a `0.1.0` chart package pin is stale unless an operator has explicitly recorded
+why that older package is being validated.
 
 ## Staging deploy path
 
@@ -90,6 +97,23 @@ before copying commands.
 
 For semver release validation, replace `main-REPLACE_SHORTSHA` with the release
 tag, for example `v0.1.0`.
+
+## Release sign-off gates
+
+Generic HTTP checks (`app-status`, `app-verify`, `/livez`, `/healthz`, `/relay/diagnostics`,
+and `/`) are necessary but insufficient for staging or production readiness. Staging promotion
+must also prove that a real external desktop/compute node registers to `https://staging.token.place`,
+appears in `/healthz` and `/relay/diagnostics`, and completes a real encrypted API v1
+relay/desktop-bridge E2EE request/response. After production promotion, repeat the same proof
+with a separate real production compute-node registration against `https://token.place`.
+
+Archive release evidence for both gates: immutable image tag, chart version and digest when
+available, rendered or live Deployment YAML, health and diagnostics output captured after the
+compute-node E2EE test, and relay logs captured after that test. The exact compute-node command is
+operator/environment-specific; do not replace this gate with a synthetic HTTP-only probe.
+
+Cloudflare Tunnel, DNS, TLS routing, and WAF policy are outside Helm. If a desktop/compute node sees
+a pre-app `403`, use the `cf-ray` in Cloudflare Security Events before changing relay code.
 
 ## Local-development appendix
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -39,7 +39,7 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; current deployable chart package version is `0.1.1`
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
@@ -95,7 +95,7 @@ Otherwise leave the chart defaults in place; staging should not require a manual
 ## Ingress TLS expectations for staging/prod
 
 Cloudflare Tunnel continues to route public hostnames to Traefik, while Helm values control only
-Kubernetes objects. Helm does not manage Cloudflare routes.
+Kubernetes objects. Helm does not manage Cloudflare routes, DNS, edge TLS policy, or WAF/bot rules.
 
 Staging/prod overlays must set `ingress.tls.enabled: true`; cert-manager annotation/secret names
 alone are not enough to render `spec.tls` in the chart. Operators must verify the rendered Ingress
@@ -178,8 +178,22 @@ curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
 ~~~
 
-Optional note: true relay traffic validation requires a registered external compute node and an
-E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`). For desktop release candidates, use the shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging, production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics, queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
+Required gate: true relay traffic validation requires a registered external compute node and an
+encrypted API v1 relay/desktop-bridge E2EE client-flow probe (for example encrypted
+`/api/v1/chat/completions`). `app-status`, `app-verify`, `/livez`, `/healthz`, `/relay/diagnostics`,
+and `/` are necessary but insufficient by themselves. For desktop release candidates, use the shared
+[desktop parity validation checklist](desktop_parity_validation.md) before making staging,
+production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics,
+queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
+
+Staging promotion requires a real external compute/desktop node to register to
+`https://staging.token.place`, appear in `/healthz` and `/relay/diagnostics`, and complete one real
+encrypted request/response. Production post-promotion requires a separate real production
+compute-node registration and encrypted request/response against `https://token.place`. Archive the
+immutable image tag, chart version and digest where available, rendered or live Deployment YAML,
+health/diagnostics output after the compute test, and relay logs after the compute test. The exact
+compute-node command is operator/environment-specific; record the actual command and redacted config
+rather than inventing a universal command.
 
 ### Desktop compute-node HTTP 403 / pre-app rejection diagnostics
 
@@ -273,17 +287,20 @@ pre-launch runbook for future operators.
 ### 1) Stale OCI chart package (`0.1.0`) in GHCR
 
 Symptom:
-- Deployed manifests from OCI chart `0.1.0` do not include expected rollout safety defaults
+- Deployed manifests from a stale OCI chart pin such as `0.1.0` do not include expected rollout safety defaults
   (especially `strategy.type: Recreate`), even though local chart sources do.
 
 Why this matters:
 - For relay's in-memory queue/registration state, rollout behavior must stay single-pod-safe.
 - A stale chart can silently remove safety defaults and invalidate staging confidence.
 
-Decision rule for v0.1.0:
-- Because launch identifiers are intentionally pinned at `0.1.0`, pre-launch chart package
-  deletion/re-publish may be required when GHCR `0.1.0` content is stale or incorrect.
-- Keep this as a deliberate operator action with notes (who/when/why), not an automatic overwrite.
+Decision rule for the current chart:
+- Sugarkube should deploy chart package `0.1.1` for the current token.place chart defaults; a
+  `0.1.0` chart package pin is stale unless an operator explicitly records why that older package is
+  under validation.
+- Never overwrite an existing GHCR chart package automatically. If stale content is discovered, stop
+  and record the deliberate operator decision (who/when/why) before deleting/re-publishing or moving
+  to a new chart version.
 
 Verification commands:
 

--- a/tests/unit/test_sugarkube_runbooks.py
+++ b/tests/unit/test_sugarkube_runbooks.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import yaml
+
+
+RUNBOOKS = [
+    Path("docs/ops/sugarkube-release.md"),
+    Path("docs/relay_sugarkube_onboarding.md"),
+    Path("docs/k3s-sugarkube-staging.md"),
+    Path("docs/k3s-sugarkube-prod.md"),
+]
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_tokenplace_chart_pin_documents_current_oci_version() -> None:
+    version_file = _text(Path("docs/apps/tokenplace.version")).strip()
+    chart = yaml.safe_load(Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8"))
+
+    assert version_file == "0.1.1"
+    assert chart["version"] == version_file
+
+    for path in RUNBOOKS:
+        text = _text(path)
+        assert "Current deployable chart package version" in text or "current deployable chart package version" in text
+        assert "0.1.1" in text
+
+
+def test_sugarkube_runbooks_require_immutable_prod_tags() -> None:
+    release = _text(Path("docs/ops/sugarkube-release.md"))
+
+    assert "tokenplace.prod.tag" in release
+    assert "explicit immutable" in release
+    for mutable_tag in ["latest", "main-latest", "staging", "prod", "production"]:
+        assert mutable_tag in release
+    for immutable_tag in ["main-<shortsha>", "vX.Y.Z"]:
+        assert immutable_tag in release
+
+
+def test_sugarkube_runbooks_distinguish_http_health_from_e2ee_signoff() -> None:
+    for path in RUNBOOKS:
+        text = _text(path)
+        assert "necessary" in text
+        assert "insufficient" in text or "not sufficient" in text
+        assert "/livez" in text
+        assert "/healthz" in text
+        assert "/relay/diagnostics" in text
+        assert "real external" in text
+        assert "encrypted" in text
+        assert "E2EE" in text
+        assert "relay/desktop-bridge" in text
+
+
+def test_environment_runbooks_capture_cloudflare_external_gate_and_evidence() -> None:
+    for path in [Path("docs/k3s-sugarkube-staging.md"), Path("docs/k3s-sugarkube-prod.md")]:
+        text = _text(path)
+        assert "Helm cannot prove public routing" in text
+        assert "Cloudflare Security Events" in text
+        assert "CF_RAY=REPLACE_CF_RAY" in text
+        assert "REPLACE_WITH_ENVIRONMENT_TEST_TOKEN" in text
+        assert "redacted-placeholder-public-key" in text
+        assert "immutable image tag" in text
+        assert "chart version" in text
+        assert "live Deployment YAML" in text
+        assert "relay logs captured after" in text
+
+
+def test_sugarkube_runbooks_preserve_single_pod_in_memory_caveat() -> None:
+    for path in [Path("docs/relay_sugarkube_onboarding.md"), Path("docs/k3s-sugarkube-staging.md"), Path("docs/k3s-sugarkube-prod.md")]:
+        text = _text(path)
+        assert "relay.py only" in text or "`relay.py` only" in text
+        assert "server.py" in text
+        assert "one pod" in text
+        assert "one Gunicorn worker" in text
+        assert "one replica" in text
+        assert "in-memory" in text
+        assert "State loss" in text or "state loss" in text
+        assert "future work" in text


### PR DESCRIPTION
### Motivation

- Close remaining Sugarkube production-readiness objections by turning release concerns into enforceable repo checks and clearer runbook gates. 
- Ensure Sugarkube deploy path, chart pin, immutable-prod-tag policy, E2EE compute-node signoff, Cloudflare/TLS/WAF validation, and the single-pod in-memory relay caveat are explicit and testable in the token.place repository docs/tests.

### Description

- Document/runtime alignment: add explicit text calling out the current deployable OCI chart package version `0.1.1` (while leaving the v0.1.0 runtime `appVersion` semantics) in `docs/ops/sugarkube-release.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md`.
- Immutable prod tag gate: update Sugarkube release doc wording to require an explicit immutable tag for production promotion when `docs/apps/tokenplace.prod.tag` is empty and to call out rejected mutable tags (`latest`, `main-latest`, `staging`, `prod`, `production`).
- External E2EE sign-off gates: add operator runbook language and copy-paste validation steps showing that HTTP health checks are necessary but insufficient, and require a real external compute/desktop node registration plus an encrypted API v1 relay/desktop-bridge E2EE request/response for staging sign-off and again post-prod promotion; list required evidence to archive.
- Cloudflare/TLS/WAF gate: document that Cloudflare/DNS/Tunnel/edge TLS/WAF are external to Helm and include safe, redacted diagnostic commands and cf-ray lookup guidance to reproduce compute-node registration shapes without real secrets.
- Stateful relay caveat and canonical path: explicitly preserve and clarify the single-pod, one-worker, in-memory state caveat and restate the canonical Sugarkube deployment path remains the GHCR image + OCI Helm chart (do not promote local Compose or raw manifests to the canonical runbook).
- Tests: add `tests/unit/test_sugarkube_runbooks.py` which verifies the docs include the chart pin, immutable-tag guidance, E2EE sign-off language, Cloudflare evidence snippets, and the single-pod/in-memory caveat.

### Testing

- `python3 -m pytest tests/unit/test_sugarkube_runbooks.py -q` — PASS (all new runbook guardrail assertions passed).
- `python3 -m pytest tests/unit/test_sugarkube_runbooks.py tests/unit/test_sugarkube_bundle.py tests/unit/test_workflow_ci_sentinel.py -q` — PASS (13 tests ran and passed in combined run).
- Text/grep checks used to confirm doc fingerprints and references: `rg -n "tokenplace\.version" docs scripts tests && rg -n "relay-compute|E2EE|Cloudflare|main-latest|tokenplace" docs/apps docs/k3s-sugarkube-*.md docs/ops/sugarkube-release.md docs/relay_sugarkube_onboarding.md tests/unit/test_sugarkube_runbooks.py` — PASS (expected matches found).
- `pre-commit run --all-files` — PASS (pre-commit hooks and repo checks passed).

Notes and residuals:
- `scripts/app_config.py` and `tests/test_generic_app_just_recipes.py` are not present in this token.place checkout, so the immutable-prod-tag behavior is enforced here via documentation guardrail tests rather than a Sugarkube-side `app_config.py` validation test; Sugarkube-side deploy wrappers should still validate `require-tag` behavior in their repo as part of the canonical process.
- No secrets, secrets-like values, or production tokens were added to the repo; Cloudflare/compute-node diagnostics use placeholder/redacted values only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24eb2d0c44832f974cb8665b0ff1d9)