### PR TITLE
Harden Sugarkube token.place release gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ On macOS, use `python3` / `pip3` (or the venv’s `python` / `pip` after activat
   fork-specific defaults and updates repo metadata for your clone.
 - **Run the services locally** — `python relay.py` and `python server.py` keep iteration tight when
   changing Python code.
-- **Run via containers** — `docker compose up --build` matches the relay + server layout exercised
-  by CI and production deployments.
+- **Run via containers** — `docker compose up --build` is for local relay + server iteration;
+  Sugarkube production uses the GHCR relay image plus OCI Helm chart instead.
 - **Format & lint** — `pre-commit run --all-files` (or `make lint`) mirrors the CI bot's
   formatting, linting, and quick tests.
 - **Full test sweep** — `./run_all_tests.sh` (or `make test`) calls pytest, Playwright, npm checks,
   and Bandit just like CI.
-- **Deploy Kubernetes manifests** — `make k8s-deploy` applies everything under `k8s/` to the active
-  cluster context.
+- **Deploy Kubernetes manifests** — `make k8s-deploy` applies legacy/local manifests under `k8s/`
+  to the active cluster context; do not use it as the Sugarkube production path.
 
 Make targets surface the same workflows in shorthand:
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -31,7 +31,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- `main-latest` is convenience-only and not production sign-off
+- `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and not production sign-off
 - Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`; if chart `0.1.1` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.1` does not exist, proceed with publishing chart package version `0.1.1`.
 
 ## Deployment commands (run from Sugarkube repo)
@@ -43,7 +43,8 @@ Use the values files and version file that live in Sugarkube for your environmen
 ## Ingress TLS + Cloudflare Tunnel contract
 
 - Cloudflare Tunnel still owns public DNS/Tunnel routing for `token.place` to Traefik.
-- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes.
+- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes, DNS, WAF, or Access policies.
+- Cloudflare route/TLS/WAF validation is an external release gate because desktop/compute-node registration can be blocked before the request reaches `relay.py`.
 - Production values must explicitly set `ingress.tls.enabled: true` or chart output omits `spec.tls`.
 - Assumption: cert-manager is installed and `cert-manager.io/cluster-issuer: letsencrypt-production` exists.
 
@@ -91,13 +92,28 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
 curl -fsS https://token.place/
 ```
 
-Optional note: true relay traffic validation requires a registered external compute node plus an
-E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
-See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" and run
-the same external compute-node validation pattern against production hostnames before sign-off.
+The generic Sugarkube status, `app-status`, `app-verify`, `/livez`, `/healthz`,
+`/relay/diagnostics`, and root HTTP checks are necessary but insufficient for production sign-off.
+After promotion, production must repeat the external relay proof instead of reusing staging
+evidence:
+
+- A separate real production desktop/compute node registers to `https://token.place` and appears in
+  both `/healthz` and `/relay/diagnostics`; the exact compute-node start command is
+  operator/environment-specific, so record the command actually used instead of inventing a
+  universal one.
+- A real encrypted API v1 relay/desktop-bridge E2EE request/response succeeds through that
+  registered production node. Plaintext relay-dispatched API v1 paths are intentionally fail-closed
+  and are not production-readiness evidence.
+- Captured evidence includes the immutable image tag, chart version and digest where available,
+  rendered or live deployment YAML, `/healthz` and `/relay/diagnostics` output after the compute
+  test, and relay logs after the compute test.
+
+See `relay_sugarkube_onboarding.md` and run the same external compute-node validation pattern
+against production hostnames before sign-off.
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -32,7 +32,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- `main-latest` is convenience-only
+- `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and must not be used for staging sign-off or production promotion
 - Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`; if chart `0.1.1` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.1` does not exist, proceed with publishing chart package version `0.1.1`.
 
 ## Deployment commands (run from Sugarkube repo)
@@ -44,7 +44,8 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 ## Ingress TLS + Cloudflare Tunnel contract
 
 - Cloudflare Tunnel still owns public DNS/Tunnel routing for `staging.token.place` to Traefik.
-- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes.
+- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes, DNS, WAF, or Access policies.
+- Cloudflare route/TLS/WAF validation is an external release gate because desktop/compute-node registration can be blocked before the request reaches `relay.py`.
 - Staging values must explicitly set `ingress.tls.enabled: true` or chart output omits `spec.tls`.
 - Assumption: cert-manager is installed and `cert-manager.io/cluster-issuer: letsencrypt-production` exists.
 
@@ -88,15 +89,28 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/
 ```
 
-Optional note: true relay traffic validation requires a registered external compute node plus an
-E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
-See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" for
-required checks covering stale OCI chart detection, Recreate strategy verification, XDG
-read-only-root safeguards, duplicate env detection, and external compute-node long-poll flow
-validation.
+The generic Sugarkube status, `app-status`, `app-verify`, `/livez`, `/healthz`,
+`/relay/diagnostics`, and root HTTP checks are necessary but insufficient for staging sign-off.
+Promotion from staging also requires all of the following evidence:
+
+- A real external desktop/compute node registers to `https://staging.token.place` and appears in
+  both `/healthz` and `/relay/diagnostics`; the exact compute-node start command is
+  operator/environment-specific, so record the command actually used instead of inventing a
+  universal one.
+- A real encrypted API v1 relay/desktop-bridge E2EE request/response succeeds through that
+  registered node. Plaintext relay-dispatched API v1 paths are intentionally fail-closed and are
+  not production-readiness evidence.
+- Captured evidence includes the immutable image tag, chart version and digest where available,
+  rendered or live deployment YAML, `/healthz` and `/relay/diagnostics` output after the compute
+  test, and relay logs after the compute test.
+
+See `relay_sugarkube_onboarding.md` for required checks covering stale OCI chart detection,
+Recreate strategy verification, XDG read-only-root safeguards, duplicate env detection,
+Cloudflare/TLS/WAF gates, and external compute-node E2EE flow validation.
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -40,9 +40,13 @@ ghcr.io/futuroptimist/tokenplace-relay:vX.Y.Z
 ghcr.io/futuroptimist/tokenplace-relay:sha-<shortsha>
 ```
 
-Use `main-<shortsha>` or `vX.Y.Z` for Sugarkube deploys. `main-latest` exists
-only as a chart lint/render convenience and a quick human smoke-test pointer;
-it is not the staging or production promotion tag.
+Use `main-<shortsha>` or `vX.Y.Z` for Sugarkube deploys. `main-latest`,
+`latest`, `staging`, `prod`, and `production` are mutable/convenience labels;
+they must be rejected by Sugarkube deploy/promotion checks and are not staging
+or production promotion tags. If Sugarkube keeps `docs/apps/tokenplace.prod.tag`
+empty, production promotion must supply an explicit immutable tag on the command
+line; populating that file is a deliberate release-management decision, not a
+default.
 
 ## Chart contract
 
@@ -57,7 +61,10 @@ helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version CHART_VE
 ```
 
 Replace `CHART_VERSION` with the version recorded in the successful
-`ci-helm.yml` run summary or in the Sugarkube app config/version file.
+`ci-helm.yml` run summary or in the Sugarkube app config/version file. The
+current token.place chart source is `0.1.1`; Sugarkube `docs/apps/tokenplace.version`
+should pin `0.1.1` unless an operator explicitly documents why a different
+package is being held back.
 
 ## Staging deploy path
 
@@ -89,12 +96,41 @@ before copying commands.
    ```
 
 For semver release validation, replace `main-REPLACE_SHORTSHA` with the release
-tag, for example `v0.1.0`.
+tag, for example `v0.1.0`. Staging may not be promoted from these generic HTTP
+checks alone: a real external desktop/compute node must register to staging,
+appear in `/healthz` and `/relay/diagnostics`, and complete an encrypted API v1
+relay/desktop-bridge E2EE request/response. Capture the immutable image tag,
+chart version and digest where available, rendered or live deployment YAML,
+health/diagnostics output after the compute test, and relay logs after the
+compute test. The exact compute-node launch command is operator/environment
+specific, so record the command actually used rather than inventing one here.
+
+## Production promotion gate
+
+Production uses the same GHCR image and OCI Helm chart path, with release and
+namespace `tokenplace/tokenplace`, host `token.place`, and an explicit immutable
+image tag. After promotion, repeat the real external proof against production:
+
+- A separate production desktop/compute node registers to `https://token.place`
+  and appears in `/healthz` and `/relay/diagnostics`.
+- A real encrypted API v1 relay/desktop-bridge E2EE request/response succeeds
+  through that registered production node.
+- Plaintext relay-dispatched API v1 paths are intentionally fail-closed and are
+  not production readiness evidence.
+- Evidence includes the immutable image tag, chart version and digest where
+  available, rendered or live deployment YAML, health/diagnostics output after
+  the compute test, and relay logs after the compute test.
+
+Cloudflare Tunnel/DNS/WAF routing is external to Helm; validate HTTPS `/`,
+`/livez`, `/healthz`, and `/relay/diagnostics`, and check Cloudflare Security
+Events by `cf-ray` when a desktop/compute node sees a pre-app 403 before changing
+relay code.
 
 ## Local-development appendix
 
-Local image builds are for developer iteration only. They are not the staging or
-production release path.
+Local image builds, root `docker-compose.yml`, and raw `k8s/` manifests are for
+developer iteration or legacy compatibility only. They are not the staging or
+production Sugarkube release path.
 
 ```bash
 docker build -t tokenplace-relay:dev -f Dockerfile .
@@ -103,4 +139,7 @@ docker run --rm -p 127.0.0.1:5010:5010 \
   tokenplace-relay:dev
 ```
 
-Use GitHub Actions and GHCR for deployable Sugarkube artifacts.
+Use GitHub Actions, the GHCR relay image, and the OCI Helm chart for deployable
+Sugarkube artifacts. The production relay remains intentionally single-pod,
+one-worker, and in-memory for registrations, queues, and replies; state loss on
+pod restart/replacement is accepted for this phase, and HA/durable queues are future work.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -96,9 +96,10 @@ before copying commands.
    ```
 
 For semver release validation, replace `main-REPLACE_SHORTSHA` with the release
-tag, for example `v0.1.0`. Staging may not be promoted from these generic HTTP
-checks alone: a real external desktop/compute node must register to staging,
-appear in `/healthz` and `/relay/diagnostics`, and complete an encrypted API v1
+tag, for example `v0.1.0`. Generic HTTP checks are necessary but insufficient:
+staging may not be promoted from those checks alone. A real external
+desktop/compute node must register to staging, appear in `/healthz` and
+`/relay/diagnostics`, and complete an encrypted API v1
 relay/desktop-bridge E2EE request/response. Capture the immutable image tag,
 chart version and digest where available, rendered or live deployment YAML,
 health/diagnostics output after the compute test, and relay logs after the
@@ -121,10 +122,11 @@ image tag. After promotion, repeat the real external proof against production:
   available, rendered or live deployment YAML, health/diagnostics output after
   the compute test, and relay logs after the compute test.
 
-Cloudflare Tunnel/DNS/WAF routing is external to Helm; validate HTTPS `/`,
-`/livez`, `/healthz`, and `/relay/diagnostics`, and check Cloudflare Security
-Events by `cf-ray` when a desktop/compute node sees a pre-app 403 before changing
-relay code.
+Cloudflare Tunnel/DNS/WAF routing is external to Helm and remains an external
+release gate because desktop/compute-node registration can be blocked before it
+reaches `relay.py`; validate HTTPS `/`, `/livez`, `/healthz`, and
+`/relay/diagnostics`, and check Cloudflare Security Events by `cf-ray` when a
+desktop/compute node sees a pre-app 403 before changing relay code.
 
 ## Local-development appendix
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -114,7 +114,9 @@ Copy-pasteable external route checks:
 ~~~bash
 # Cloudflare Tunnel/DNS must point these public hosts at Traefik; inspect the
 # Cloudflare dashboard or your tunnel config for the exact tunnel name/UUID.
-# These HTTPS probes verify the route from the public edge to the app.
+# These DNS and HTTPS probes verify the route from the public edge to the app.
+dig +short staging.token.place
+dig +short token.place
 for host in staging.token.place token.place; do
   curl -vI "https://${host}/"
   curl -fsS "https://${host}/livez"
@@ -123,28 +125,34 @@ for host in staging.token.place token.place; do
 done
 
 # Safely reproduce the compute-node registration request shape without using
-# a real desktop token or payload. Keep the token intentionally invalid for
-# route-only checks; if a relay accepts the request anyway (for example a
-# tokenless test relay), immediately unregister the unique diagnostic key.
-# A non-JSON 403 with server: cloudflare or a cf-ray header means the request
-# may have been stopped before relay.py.
+# a real desktop token or payload. This pre-app route probe is intentionally
+# non-mutating: it uses a clearly fake token and an empty server_public_key so
+# it cannot register a fake compute node even against tokenless relays.
 HOST=staging.token.place
-DIAG_KEY="diagnostic-public-key-$(date +%s)-$$"
-DIAG_TOKEN="intentionally-invalid-diagnostic-token"
+DIAG_TOKEN="DO_NOT_USE_REAL_TOKEN_ROUTE_PROBE"
 curl -i -X POST "https://${HOST}/api/v1/relay/servers/register" \
   -H 'content-type: application/json' \
   -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
-  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")"
-curl -i -X POST "https://${HOST}/api/v1/relay/servers/unregister" \
-  -H 'content-type: application/json' \
-  -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
-  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")" || true
+  --data '{"server_public_key":""}'
+
+# Interpret the route probe only as Cloudflare/DNS/TLS/WAF evidence:
+# - JSON 400 or 401 means the request reached relay.py and was rejected by the app.
+# - A non-JSON 403 with server: cloudflare or a cf-ray header means the request
+#   likely stopped in a pre-app Cloudflare/WAF/Access layer.
+# Operators must not replace this pre-app route probe with a real accepted
+# token or a non-empty public key. Real compute-node registration remains a
+# separate sign-off gate using the actual operator/environment-specific node
+# command.
 
 # If a desktop/compute node reports a pre-app 403, capture cf-ray from the
 # client log/response and filter Cloudflare Security Events by that Ray ID.
 CF_RAY=REPLACE_CF_RAY
 printf 'Check Cloudflare Security Events for Ray ID: %s\n' "$CF_RAY"
 ~~~
+
+The route probe is intentionally diagnostic-only: operators must not replace this pre-app route
+probe with a real accepted token or a non-empty public key. Real compute-node registration remains
+a separate sign-off gate using the actual operator/environment-specific node command.
 
 ## Sugarkube deployment command patterns
 
@@ -270,40 +278,36 @@ CF_RAY=REPLACE_CF_RAY
 # Check which WAF, bot, firewall, or access rule produced the 403.
 
 # 3. Reproduce the compute-node registration shape without exposing the real desktop token.
-# Keep the token intentionally invalid for route-only checks. If you must use a
-# relay-accepted staging token, keep DIAG_KEY unique and run the unregister call
-# immediately so the diagnostic node cannot be selected for real E2EE traffic.
-DIAG_KEY="diagnostic-public-key-$(date +%s)-$$"
-DIAG_TOKEN="intentionally-invalid-diagnostic-token"
+# This route-shape probe is intentionally non-mutating: it uses a clearly fake
+# token and an empty server_public_key so it cannot register a fake compute node
+# even if the relay is running in tokenless mode. Operators must not replace this
+# pre-app route probe with a real accepted token or a non-empty public key; real
+# compute-node registration remains a separate sign-off gate using the actual
+# operator/environment-specific node command.
+DIAG_TOKEN="DO_NOT_USE_REAL_TOKEN_ROUTE_PROBE"
 curl -i -X POST https://staging.token.place/api/v1/relay/servers/register \
   -H 'content-type: application/json' \
   -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
-  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")"
-curl -i -X POST https://staging.token.place/api/v1/relay/servers/unregister \
-  -H 'content-type: application/json' \
-  -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
-  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")" || true
+  --data '{"server_public_key":""}'
+
+# An app-level JSON 400 or 401 means the request reached relay.py. A non-JSON
+# 403 with server: cloudflare or a cf-ray header means Cloudflare/WAF/Access
+# likely blocked the request before relay.py.
 
 # 4. Reproduce with Python requests to compare headers/body with desktop behavior.
 python - <<'PY'
-import time
 import requests
 
 base_url = 'https://staging.token.place/api/v1/relay/servers'
 headers = {
     'content-type': 'application/json',
-    'X-Relay-Server-Token': 'intentionally-invalid-diagnostic-token',
+    'X-Relay-Server-Token': 'DO_NOT_USE_REAL_TOKEN_ROUTE_PROBE',
 }
-payload = {'server_public_key': f'diagnostic-public-key-{int(time.time())}'}
+payload = {'server_public_key': ''}
 response = requests.post(f'{base_url}/register', headers=headers, json=payload, timeout=15)
 print('status', response.status_code)
 print('headers', {k: response.headers.get(k) for k in ['server', 'cf-ray', 'cf-cache-status', 'content-type', 'x-request-id']})
 print('body', response.text[:512])
-try:
-    cleanup = requests.post(f'{base_url}/unregister', headers=headers, json=payload, timeout=15)
-    print('cleanup_status', cleanup.status_code)
-except requests.RequestException as exc:
-    print('cleanup_error', exc)
 PY
 
 # 5. Compare relay app logs with desktop diagnostics for the same UTC window.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -42,7 +42,7 @@ operator workflow.
 - Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- `main-latest` is convenience-only and not production sign-off material
+- `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and not staging sign-off or production promotion material
 - Before publishing, run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`; if chart `0.1.1` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.1` does not exist, proceed with publishing chart package version `0.1.1`.
 
 ## Default hostnames
@@ -95,7 +95,9 @@ Otherwise leave the chart defaults in place; staging should not require a manual
 ## Ingress TLS expectations for staging/prod
 
 Cloudflare Tunnel continues to route public hostnames to Traefik, while Helm values control only
-Kubernetes objects. Helm does not manage Cloudflare routes.
+Kubernetes objects. Helm does not manage Cloudflare routes, DNS, WAF, or Access policies. Treat
+Cloudflare route/TLS/WAF validation as an external release gate because a desktop/compute-node
+registration can be blocked before it reaches `relay.py`.
 
 Staging/prod overlays must set `ingress.tls.enabled: true`; cert-manager annotation/secret names
 alone are not enough to render `spec.tls` in the chart. Operators must verify the rendered Ingress
@@ -106,6 +108,34 @@ Assumption: cert-manager is installed and the configured ClusterIssuer (for exam
 
 - Staging: host `staging.token.place`, TLS secret `tokenplace-staging-tls`
 - Production: host `token.place`, TLS secret `tokenplace-prod-tls`
+
+Copy-pasteable external route checks:
+
+~~~bash
+# Cloudflare Tunnel/DNS must point these public hosts at Traefik; inspect the
+# Cloudflare dashboard or your tunnel config for the exact tunnel name/UUID.
+# These HTTPS probes verify the route from the public edge to the app.
+for host in staging.token.place token.place; do
+  curl -vI "https://${host}/"
+  curl -fsS "https://${host}/livez"
+  curl -fsS "https://${host}/healthz"
+  curl -fsS "https://${host}/relay/diagnostics"
+done
+
+# Safely reproduce the compute-node registration request shape without using
+# a real desktop token or payload. A non-JSON 403 with server: cloudflare or a
+# cf-ray header means the request may have been stopped before relay.py.
+HOST=staging.token.place
+curl -i -X POST "https://${HOST}/api/v1/relay/servers/register" \
+  -H 'content-type: application/json' \
+  -H 'X-Relay-Server-Token: REPLACE_WITH_STAGING_TEST_TOKEN' \
+  --data '{"server_public_key":"diagnostic-public-key-placeholder"}'
+
+# If a desktop/compute node reports a pre-app 403, capture cf-ray from the
+# client log/response and filter Cloudflare Security Events by that Ray ID.
+CF_RAY=REPLACE_CF_RAY
+printf 'Check Cloudflare Security Events for Ray ID: %s\n' "$CF_RAY"
+~~~
 
 ## Sugarkube deployment command patterns
 
@@ -140,7 +170,28 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Production pattern uses `PATH/TO/tokenplace.values.prod.yaml` with the same approved
 immutable tag.
 
-## Validation (staging example)
+## Validation gates
+
+Generic Sugarkube status, `app-status`, `app-verify`, `/livez`, `/healthz`,
+`/relay/diagnostics`, and root HTTP checks are necessary but insufficient. Staging promotion and
+production sign-off require a real external relay-compute proof:
+
+- Staging promotion gate: a real external desktop/compute node registers to
+  `https://staging.token.place` and appears in both `/healthz` and `/relay/diagnostics`.
+- Staging promotion gate: a real encrypted API v1 relay/desktop-bridge E2EE request/response
+  succeeds through that registered staging node.
+- Production post-promotion gate: a separate real production desktop/compute-node registration and
+  encrypted API v1 relay/desktop-bridge E2EE request/response succeeds against
+  `https://token.place`.
+- Evidence must include the immutable image tag, chart version and digest where available, rendered
+  or live deployment YAML, health/diagnostics output after the compute test, and relay logs after
+  the compute test.
+
+The exact desktop/compute-node launch command is operator/environment-specific; record the command
+actually used, but do not invent a universal runbook command. Plaintext relay-dispatched API v1
+paths are intentionally fail-closed and are not staging or production readiness evidence.
+
+### Staging generic HTTP checks
 
 ~~~bash
 kubectl -n tokenplace get deploy,po,svc,ingress
@@ -157,10 +208,11 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/
 ~~~
 
-Production validation:
+### Production generic HTTP checks
 
 ~~~bash
 CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' PATH/TO/tokenplace.version | head -n1)"
@@ -175,11 +227,11 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
 curl -fsS https://token.place/
 ~~~
 
-Optional note: true relay traffic validation requires a registered external compute node and an
-E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`). For desktop release candidates, use the shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging, production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics, queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
+For desktop release candidates, use the shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging, production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics, queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
 
 ### Desktop compute-node HTTP 403 / pre-app rejection diagnostics
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -123,13 +123,22 @@ for host in staging.token.place token.place; do
 done
 
 # Safely reproduce the compute-node registration request shape without using
-# a real desktop token or payload. A non-JSON 403 with server: cloudflare or a
-# cf-ray header means the request may have been stopped before relay.py.
+# a real desktop token or payload. Keep the token intentionally invalid for
+# route-only checks; if a relay accepts the request anyway (for example a
+# tokenless test relay), immediately unregister the unique diagnostic key.
+# A non-JSON 403 with server: cloudflare or a cf-ray header means the request
+# may have been stopped before relay.py.
 HOST=staging.token.place
+DIAG_KEY="diagnostic-public-key-$(date +%s)-$$"
+DIAG_TOKEN="intentionally-invalid-diagnostic-token"
 curl -i -X POST "https://${HOST}/api/v1/relay/servers/register" \
   -H 'content-type: application/json' \
-  -H 'X-Relay-Server-Token: REPLACE_WITH_STAGING_TEST_TOKEN' \
-  --data '{"server_public_key":"diagnostic-public-key-placeholder"}'
+  -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
+  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")"
+curl -i -X POST "https://${HOST}/api/v1/relay/servers/unregister" \
+  -H 'content-type: application/json' \
+  -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
+  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")" || true
 
 # If a desktop/compute node reports a pre-app 403, capture cf-ray from the
 # client log/response and filter Cloudflare Security Events by that Ray ID.
@@ -261,24 +270,40 @@ CF_RAY=REPLACE_CF_RAY
 # Check which WAF, bot, firewall, or access rule produced the 403.
 
 # 3. Reproduce the compute-node registration shape without exposing the real desktop token.
-# Use a staging-safe throwaway token value or omit the header when validating routing only.
+# Keep the token intentionally invalid for route-only checks. If you must use a
+# relay-accepted staging token, keep DIAG_KEY unique and run the unregister call
+# immediately so the diagnostic node cannot be selected for real E2EE traffic.
+DIAG_KEY="diagnostic-public-key-$(date +%s)-$$"
+DIAG_TOKEN="intentionally-invalid-diagnostic-token"
 curl -i -X POST https://staging.token.place/api/v1/relay/servers/register \
   -H 'content-type: application/json' \
-  -H 'X-Relay-Server-Token: REPLACE_WITH_STAGING_TEST_TOKEN' \
-  --data '{"server_public_key":"diagnostic-public-key-placeholder"}'
+  -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
+  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")"
+curl -i -X POST https://staging.token.place/api/v1/relay/servers/unregister \
+  -H 'content-type: application/json' \
+  -H "X-Relay-Server-Token: ${DIAG_TOKEN}" \
+  --data "$(printf '{"server_public_key":"%s"}' "${DIAG_KEY}")" || true
 
 # 4. Reproduce with Python requests to compare headers/body with desktop behavior.
 python - <<'PY'
+import time
 import requests
-url = 'https://staging.token.place/api/v1/relay/servers/register'
+
+base_url = 'https://staging.token.place/api/v1/relay/servers'
 headers = {
     'content-type': 'application/json',
-    'X-Relay-Server-Token': 'REPLACE_WITH_STAGING_TEST_TOKEN',
+    'X-Relay-Server-Token': 'intentionally-invalid-diagnostic-token',
 }
-response = requests.post(url, headers=headers, json={'server_public_key': 'diagnostic-public-key-placeholder'}, timeout=15)
+payload = {'server_public_key': f'diagnostic-public-key-{int(time.time())}'}
+response = requests.post(f'{base_url}/register', headers=headers, json=payload, timeout=15)
 print('status', response.status_code)
 print('headers', {k: response.headers.get(k) for k in ['server', 'cf-ray', 'cf-cache-status', 'content-type', 'x-request-id']})
 print('body', response.text[:512])
+try:
+    cleanup = requests.post(f'{base_url}/unregister', headers=headers, json=payload, timeout=15)
+    print('cleanup_status', cleanup.status_code)
+except requests.RequestException as exc:
+    print('cleanup_error', exc)
 PY
 
 # 5. Compare relay app logs with desktop diagnostics for the same UTC window.

--- a/tests/unit/test_sugarkube_bundle.py
+++ b/tests/unit/test_sugarkube_bundle.py
@@ -6,6 +6,16 @@ import yaml
 
 BUNDLE_ENV_PATH = Path("k8s/sugarkube/token-place.env")
 BUNDLE_VALUES_PATH = Path("k8s/sugarkube/token-place-values.yaml")
+SUGARKUBE_RUNBOOKS = (
+    Path("docs/k3s-sugarkube-staging.md"),
+    Path("docs/k3s-sugarkube-prod.md"),
+    Path("docs/relay_sugarkube_onboarding.md"),
+    Path("docs/ops/sugarkube-release.md"),
+)
+OPERATOR_ENVIRONMENT_RUNBOOKS = (
+    Path("docs/k3s-sugarkube-staging.md"),
+    Path("docs/k3s-sugarkube-prod.md"),
+)
 
 
 def _load_env(path: Path) -> dict[str, str]:
@@ -19,6 +29,20 @@ def _load_env(path: Path) -> dict[str, str]:
         key, value = line.split("=", 1)
         env[key] = value
     return env
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _assert_contains_all(path: Path, phrases: tuple[str, ...]) -> None:
+    content = _normalize_whitespace(path.read_text())
+    missing = [
+        phrase
+        for phrase in phrases
+        if _normalize_whitespace(phrase) not in content
+    ]
+    assert not missing, f"{path} missing required phrases: {missing}"
 
 
 def test_bundle_env_targets_canonical_oci_chart():
@@ -59,62 +83,104 @@ def test_bundle_values_do_not_pin_redis_storage_backend():
 def test_sugarkube_chart_version_docs_track_canonical_chart_source():
     """Runbook chart pins should track the canonical chart package version."""
     chart = yaml.safe_load(Path("charts/tokenplace/Chart.yaml").read_text())
+    chart_version = chart["version"]
     app_version = Path("docs/apps/tokenplace.version").read_text().strip()
     release_doc = Path("docs/ops/sugarkube-release.md").read_text()
 
-    assert chart["version"] == "0.1.1"
-    assert app_version == chart["version"]
-    assert "docs/apps/tokenplace.version`\nshould pin `0.1.1`" in release_doc
+    assert app_version == chart_version
+    assert f"current token.place chart source is `{chart_version}`" in release_doc
+    assert "Sugarkube `docs/apps/tokenplace.version`" in release_doc
+    assert "should pin" in release_doc
 
 
-def test_sugarkube_runbooks_require_real_external_e2ee_proof():
-    """Generic HTTP checks must not be documented as sufficient for sign-off."""
-    docs = "\n".join(
-        Path(path).read_text()
-        for path in (
-            "docs/k3s-sugarkube-staging.md",
-            "docs/k3s-sugarkube-prod.md",
-            "docs/relay_sugarkube_onboarding.md",
-            "docs/ops/sugarkube-release.md",
-        )
-    )
-
-    required_phrases = [
+def test_sugarkube_environment_runbooks_require_external_e2ee_proof():
+    """Each environment runbook must keep real E2EE sign-off gates explicit."""
+    shared_required_phrases = (
         "necessary but insufficient",
-        "real external desktop/compute node registers",
         "encrypted API v1 relay/desktop-bridge E2EE request/response",
         "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
         "immutable image tag, chart version and digest where available",
         "rendered or live deployment YAML",
         "relay logs after the compute test",
-    ]
-    for phrase in required_phrases:
-        assert phrase in docs
-
-
-def test_sugarkube_docs_keep_cloudflare_and_stateful_caveats_explicit():
-    """Cloudflare gates and non-HA relay limitations should stay visible."""
-    docs = "\n".join(
-        Path(path).read_text()
-        for path in (
-            "docs/k3s-sugarkube-staging.md",
-            "docs/k3s-sugarkube-prod.md",
-            "docs/relay_sugarkube_onboarding.md",
-            "docs/ops/sugarkube-release.md",
-        )
     )
 
-    for phrase in (
-        "Helm does **not** create/manage Cloudflare routes, DNS, WAF, or Access policies",
-        "cf-ray",
-        "before it reaches `relay.py`",
-        "single-pod",
-        "one-worker",
-        "in-memory",
-        "state loss on",
-        "HA/durable queues are future work",
-    ):
-        assert phrase in docs
+    for path in OPERATOR_ENVIRONMENT_RUNBOOKS:
+        _assert_contains_all(path, shared_required_phrases)
+
+    _assert_contains_all(
+        Path("docs/k3s-sugarkube-staging.md"),
+        ("real external desktop/compute node registers",),
+    )
+    _assert_contains_all(
+        Path("docs/k3s-sugarkube-prod.md"),
+        ("real production desktop/compute node registers", "instead of reusing staging evidence"),
+    )
+
+
+def test_sugarkube_onboarding_and_release_docs_require_external_e2ee_proof():
+    """Cross-environment docs must preserve staging and production proof details."""
+    release_phrases = (
+        "necessary but insufficient",
+        "real external desktop/compute node must register to staging",
+        "repeat the real external proof against production",
+        "encrypted API v1\nrelay/desktop-bridge E2EE request/response",
+        "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
+        "immutable image tag,\nchart version and digest where available",
+        "rendered or live deployment YAML",
+        "relay logs after the\ncompute test",
+    )
+    onboarding_phrases = (
+        "necessary but insufficient",
+        "real external relay-compute proof",
+        "real external desktop/compute node registers",
+        "encrypted API v1 relay/desktop-bridge E2EE request/response",
+        "paths are intentionally fail-closed",
+        "immutable image tag, chart version and digest where available",
+        "rendered\n  or live deployment YAML",
+        "relay logs after",
+    )
+
+    _assert_contains_all(Path("docs/ops/sugarkube-release.md"), release_phrases)
+    _assert_contains_all(Path("docs/relay_sugarkube_onboarding.md"), onboarding_phrases)
+
+
+def test_sugarkube_docs_keep_cloudflare_gate_explicit_per_runbook():
+    """Every operator runbook should keep Cloudflare/TLS/WAF caveats visible."""
+    for path in SUGARKUBE_RUNBOOKS:
+        _assert_contains_all(
+            path,
+            (
+                "Cloudflare",
+                "WAF",
+                "external release gate",
+                "before",
+                "reaches `relay.py`",
+            ),
+        )
+
+    _assert_contains_all(
+        Path("docs/relay_sugarkube_onboarding.md"),
+        ("cf-ray", "intentionally invalid", "unregister the unique diagnostic key"),
+    )
+    _assert_contains_all(Path("docs/ops/sugarkube-release.md"), ("cf-ray",))
+
+
+def test_sugarkube_docs_keep_stateful_relay_caveats_explicit_per_runbook():
+    """Every operator runbook should keep non-HA relay limitations visible."""
+    for path in SUGARKUBE_RUNBOOKS:
+        _assert_contains_all(path, ("single-pod", "in-memory", "future work"))
+
+    for path in OPERATOR_ENVIRONMENT_RUNBOOKS:
+        _assert_contains_all(path, ("one pod", "one Gunicorn worker", "one replica", "State loss"))
+
+    _assert_contains_all(
+        Path("docs/ops/sugarkube-release.md"),
+        ("one-worker", "state loss", "HA/durable queues are future work"),
+    )
+    _assert_contains_all(
+        Path("docs/relay_sugarkube_onboarding.md"),
+        ("state loss", "one Gunicorn worker", "Multi-replica"),
+    )
 
 
 def test_sugarkube_release_docs_reject_mutable_prod_tags_and_legacy_paths():

--- a/tests/unit/test_sugarkube_bundle.py
+++ b/tests/unit/test_sugarkube_bundle.py
@@ -54,3 +54,76 @@ def test_bundle_values_do_not_pin_redis_storage_backend():
     content = BUNDLE_VALUES_PATH.read_text()
     assert "redis://" not in content
     assert "TOKENPLACE_RATE_LIMIT_STORAGE_URI" not in content
+
+
+def test_sugarkube_chart_version_docs_track_canonical_chart_source():
+    """Runbook chart pins should track the canonical chart package version."""
+    chart = yaml.safe_load(Path("charts/tokenplace/Chart.yaml").read_text())
+    app_version = Path("docs/apps/tokenplace.version").read_text().strip()
+    release_doc = Path("docs/ops/sugarkube-release.md").read_text()
+
+    assert chart["version"] == "0.1.1"
+    assert app_version == chart["version"]
+    assert "docs/apps/tokenplace.version`\nshould pin `0.1.1`" in release_doc
+
+
+def test_sugarkube_runbooks_require_real_external_e2ee_proof():
+    """Generic HTTP checks must not be documented as sufficient for sign-off."""
+    docs = "\n".join(
+        Path(path).read_text()
+        for path in (
+            "docs/k3s-sugarkube-staging.md",
+            "docs/k3s-sugarkube-prod.md",
+            "docs/relay_sugarkube_onboarding.md",
+            "docs/ops/sugarkube-release.md",
+        )
+    )
+
+    required_phrases = [
+        "necessary but insufficient",
+        "real external desktop/compute node registers",
+        "encrypted API v1 relay/desktop-bridge E2EE request/response",
+        "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
+        "immutable image tag, chart version and digest where available",
+        "rendered or live deployment YAML",
+        "relay logs after the compute test",
+    ]
+    for phrase in required_phrases:
+        assert phrase in docs
+
+
+def test_sugarkube_docs_keep_cloudflare_and_stateful_caveats_explicit():
+    """Cloudflare gates and non-HA relay limitations should stay visible."""
+    docs = "\n".join(
+        Path(path).read_text()
+        for path in (
+            "docs/k3s-sugarkube-staging.md",
+            "docs/k3s-sugarkube-prod.md",
+            "docs/relay_sugarkube_onboarding.md",
+            "docs/ops/sugarkube-release.md",
+        )
+    )
+
+    for phrase in (
+        "Helm does **not** create/manage Cloudflare routes, DNS, WAF, or Access policies",
+        "cf-ray",
+        "before it reaches `relay.py`",
+        "single-pod",
+        "one-worker",
+        "in-memory",
+        "state loss on",
+        "HA/durable queues are future work",
+    ):
+        assert phrase in docs
+
+
+def test_sugarkube_release_docs_reject_mutable_prod_tags_and_legacy_paths():
+    """Production docs must require immutable tags and the GHCR + OCI path."""
+    release_doc = Path("docs/ops/sugarkube-release.md").read_text()
+
+    for mutable_tag in ("main-latest", "latest", "staging", "prod", "production"):
+        assert mutable_tag in release_doc
+    assert "docs/apps/tokenplace.prod.tag`\nempty" in release_doc
+    assert "production promotion must supply an explicit immutable tag" in release_doc
+    assert "root `docker-compose.yml`, and raw `k8s/` manifests" in release_doc
+    assert "GHCR relay image, and the OCI Helm chart" in release_doc

--- a/tests/unit/test_sugarkube_bundle.py
+++ b/tests/unit/test_sugarkube_bundle.py
@@ -93,55 +93,80 @@ def test_sugarkube_chart_version_docs_track_canonical_chart_source():
     assert "should pin" in release_doc
 
 
-def test_sugarkube_environment_runbooks_require_external_e2ee_proof():
-    """Each environment runbook must keep real E2EE sign-off gates explicit."""
-    shared_required_phrases = (
-        "necessary but insufficient",
-        "encrypted API v1 relay/desktop-bridge E2EE request/response",
-        "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
-        "immutable image tag, chart version and digest where available",
-        "rendered or live deployment YAML",
-        "relay logs after the compute test",
-    )
-
-    for path in OPERATOR_ENVIRONMENT_RUNBOOKS:
-        _assert_contains_all(path, shared_required_phrases)
-
+def test_staging_runbook_requires_real_external_e2ee_evidence():
+    """Staging runbook must keep every staging sign-off gate explicit."""
     _assert_contains_all(
         Path("docs/k3s-sugarkube-staging.md"),
-        ("real external desktop/compute node registers",),
+        (
+            "necessary but insufficient",
+            "real external desktop/compute node registers",
+            "encrypted API v1 relay/desktop-bridge E2EE request/response",
+            "`/healthz` and `/relay/diagnostics` output after the compute test",
+            "relay logs after the compute test",
+            "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
+            "operator/environment-specific",
+        ),
     )
+
+
+def test_prod_runbook_requires_fresh_production_e2ee_evidence():
+    """Production runbook must not allow staging evidence reuse."""
     _assert_contains_all(
         Path("docs/k3s-sugarkube-prod.md"),
-        ("real production desktop/compute node registers", "instead of reusing staging evidence"),
+        (
+            "necessary but insufficient",
+            "real production desktop/compute node registers",
+            "instead of reusing staging evidence",
+            "encrypted API v1 relay/desktop-bridge E2EE request/response",
+            "`/healthz` and `/relay/diagnostics` output after the compute test",
+            "relay logs after the compute test",
+            "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
+            "operator/environment-specific",
+        ),
     )
 
 
-def test_sugarkube_onboarding_and_release_docs_require_external_e2ee_proof():
-    """Cross-environment docs must preserve staging and production proof details."""
-    release_phrases = (
-        "necessary but insufficient",
-        "real external desktop/compute node must register to staging",
-        "repeat the real external proof against production",
-        "encrypted API v1\nrelay/desktop-bridge E2EE request/response",
-        "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
-        "immutable image tag,\nchart version and digest where available",
-        "rendered or live deployment YAML",
-        "relay logs after the\ncompute test",
-    )
-    onboarding_phrases = (
-        "necessary but insufficient",
-        "real external relay-compute proof",
-        "real external desktop/compute node registers",
-        "encrypted API v1 relay/desktop-bridge E2EE request/response",
-        "paths are intentionally fail-closed",
-        "immutable image tag, chart version and digest where available",
-        "rendered\n  or live deployment YAML",
-        "relay logs after",
+def test_onboarding_doc_requires_cloudflare_probe_and_real_e2ee_gate():
+    """Onboarding doc must separate safe route probes from real E2EE gates."""
+    _assert_contains_all(
+        Path("docs/relay_sugarkube_onboarding.md"),
+        (
+            "Cloudflare route/TLS/WAF validation as an external release gate",
+            "dig +short staging.token.place",
+            "dig +short token.place",
+            "DO_NOT_USE_REAL_TOKEN_ROUTE_PROBE",
+            '"server_public_key":""',
+            "intentionally non-mutating",
+            "JSON 400 or 401 means the request reached relay.py",
+            "non-JSON 403 with server: cloudflare or a cf-ray header",
+            "must not replace this pre-app route probe with a real accepted token",
+            "Real compute-node registration remains a separate sign-off gate",
+            "Cloudflare Security Events by that Ray ID",
+            "real external relay-compute proof",
+            "encrypted API v1 relay/desktop-bridge E2EE request/response",
+            "operator/environment-specific",
+        ),
     )
 
-    _assert_contains_all(Path("docs/ops/sugarkube-release.md"), release_phrases)
-    _assert_contains_all(Path("docs/relay_sugarkube_onboarding.md"), onboarding_phrases)
+
+def test_release_doc_requires_promotion_contract_and_external_e2ee_evidence():
+    """Release runbook must document token.place contracts without Sugarkube code."""
+    _assert_contains_all(
+        Path("docs/ops/sugarkube-release.md"),
+        (
+            "necessary but insufficient",
+            "real external desktop/compute node must register to staging",
+            "repeat the real external proof against production",
+            "encrypted API v1 relay/desktop-bridge E2EE request/response",
+            "Plaintext relay-dispatched API v1 paths are intentionally fail-closed",
+            "immutable image tag, chart version and digest where available",
+            "rendered or live deployment YAML",
+            "relay logs after the compute test",
+            "Cloudflare Tunnel/DNS/WAF routing is external to Helm",
+            "single-pod, one-worker, and in-memory",
+            "GHCR relay image, and the OCI Helm chart",
+        ),
+    )
 
 
 def test_sugarkube_docs_keep_cloudflare_gate_explicit_per_runbook():
@@ -160,7 +185,12 @@ def test_sugarkube_docs_keep_cloudflare_gate_explicit_per_runbook():
 
     _assert_contains_all(
         Path("docs/relay_sugarkube_onboarding.md"),
-        ("cf-ray", "intentionally invalid", "unregister the unique diagnostic key"),
+        (
+            "cf-ray",
+            "DO_NOT_USE_REAL_TOKEN_ROUTE_PROBE",
+            '"server_public_key":""',
+            "intentionally non-mutating",
+        ),
     )
     _assert_contains_all(Path("docs/ops/sugarkube-release.md"), ("cf-ray",))
 


### PR DESCRIPTION
### Motivation
- Align Sugarkube runbooks and checks with the current token.place chart/package and make the expected chart pin explicit. 
- Ensure production promotion requires an explicit immutable image tag when `docs/apps/tokenplace.prod.tag` is left empty and disallow mutable labels for promotion. 
- Treat generic HTTP checks as necessary but insufficient by requiring a real external compute/desktop node registration and an encrypted API v1 relay/desktop-bridge E2EE request/response as staging/prod gates, and record Cloudflare/TLS/WAF as an external gate. 
- Preserve and make explicit the current relay operational model: relay-only, single-pod, one-worker, in-memory state with state-loss accepted for this phase, and mark HA/durable queues as future work.

### Description
- Updated Sugarkube-facing runbooks and validation text in `docs/ops/sugarkube-release.md`, `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`, and `README.md` to: pin/track chart package `0.1.1`, reject mutable promotion tags (`main-latest`, `latest`, `staging`, `prod`, `production`), add explicit Cloudflare/TLS/WAF validation steps, add `/relay/diagnostics` to health checks, and make external E2EE proof requirements unambiguous. 
- Added copy-pasteable Cloudflare/TLS/WAF diagnostic probes and a safe registration-shape curl example (placeholder token and redacted body) to document pre-app rejection debugging and `cf-ray` guidance. 
- Clarified canonical Sugarkube deployment path as GHCR image + OCI Helm chart and warned that local Docker Compose and raw `k8s/` manifests are legacy/local-only paths. 
- Added focused documentation tests in `tests/unit/test_sugarkube_bundle.py` that assert chart version alignment with `charts/tokenplace/Chart.yaml`, require the external E2EE proof wording, check for Cloudflare/stateful caveats, mutable-tag rejection language, and legacy-path warnings.

### Testing
- `python3 -m pytest tests/unit/test_sugarkube_bundle.py tests/unit/test_workflow_ci_sentinel.py` — Result: all tests passed (12 passed). 
- `test "$(cat docs/apps/tokenplace.version)" = "0.1.1" && python3 - <<'PY'
import yaml
print(yaml.safe_load(open('charts/tokenplace/Chart.yaml'))['version'])
PY` — Result: both the docs file and chart package version are `0.1.1` (check succeeded). 
- `pre-commit run --all-files` — Result: pre-commit hooks completed with no failures (Passed). 
- `rg`/grep checks for required phrases (chart pin, E2EE wording, Cloudflare, mutable tags, stateful caveats, `/relay/diagnostics`) across the edited docs — Result: expected phrases present in updated files (matches found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24eb2d0c44832f974cb8665b0ff1d9)