### PR TITLE
Harden Sugarkube tokenplace release gates

### DIFF
--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -29,7 +29,11 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
-- Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
+- Chart package version for current deployments: `0.1.1` (read from Sugarkube `docs/apps/tokenplace.version`)
+- Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact).
+  If Sugarkube `docs/apps/tokenplace.prod.tag` is empty, promotion must pass an explicit immutable
+  tag; mutable tags such as `latest`, `main-latest`, `staging`, `prod`, or `production` are not
+  valid.
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only and not production sign-off
 - Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`; if chart `0.1.1` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.1` does not exist, proceed with publishing chart package version `0.1.1`.
@@ -79,6 +83,13 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 
 ## Validation checklist
 
+The HTTP checks below are required post-promotion checks, but they are **necessary and
+insufficient** for production readiness. Production sign-off requires a separate real external
+production desktop/compute node registration to `https://token.place` and a successful encrypted
+API v1 relay/desktop-bridge E2EE request/response through that registered node. Do not reuse
+staging registration evidence for production. The exact node command is operator/environment-specific;
+capture the command actually used.
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
@@ -91,13 +102,25 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
 curl -fsS https://token.place/
 ```
 
-Optional note: true relay traffic validation requires a registered external compute node plus an
-E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
-See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" and run
-the same external compute-node validation pattern against production hostnames before sign-off.
+Required production evidence after the production compute/E2EE test:
+
+- immutable production image tag (`vX.Y.Z`, or explicitly approved `main-<shortsha>` during a
+  controlled pre-release promotion) and chart version `0.1.1` plus OCI chart digest when available
+- rendered or live Deployment/Ingress YAML showing one replica, `strategy.type: Recreate`, one
+  Gunicorn worker, TLS, public relay URL, and internal relay URL
+- `/livez`, `/healthz`, and `/relay/diagnostics` output captured after the production compute test
+- relay logs from the same UTC window after the production compute test, preserving the
+  relay-blind rule: ciphertext-only plus safe routing metadata; no plaintext payloads, tokens,
+  private keys, or model output text
+
+The required external production compute-node gate above is the production readiness gate; generic
+HTTP health checks alone must never be reported as relay production readiness. See
+`relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" for the
+shared validation pattern.
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 
@@ -110,7 +133,8 @@ If operators override hostname/routing, use the equivalent production host in th
 ## Notes
 
 - Preserve API v1 relay-blind E2EE guardrails (relay sees ciphertext + routing metadata only).
-- Do not rely on local chart path deployment (`./deploy/charts/tokenplace-relay`) for
-  Sugarkube steady-state operations.
+- Use only the GHCR image plus OCI Helm chart path for Sugarkube production. Do not promote the
+  repository-root `docker-compose.yml`, local Compose variants, raw `k8s/` manifests, or local chart
+  path deployment (`./deploy/charts/tokenplace-relay`) into production operations.
 - Do not require `gpuExternalName` or `TOKENPLACE_RELAY_UPSTREAM_URL` for production relay
   readiness in this relay-only phase.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -30,6 +30,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Chart package version for current deployments: `0.1.1` (read from Sugarkube `docs/apps/tokenplace.version`)
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest` is convenience-only
@@ -76,6 +77,13 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 
 ## Validation checklist
 
+The HTTP checks below are required deployment checks, but they are **necessary and insufficient**
+for staging sign-off. Staging may be promoted only after a real external desktop/compute node
+registers to `https://staging.token.place`, appears in `/healthz` and `/relay/diagnostics`, and
+completes a real encrypted API v1 relay/desktop-bridge E2EE request/response through that
+registered node. The exact node command is operator/environment-specific; capture the command that
+was actually run instead of substituting a generic placeholder.
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
@@ -88,12 +96,22 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/
 ```
 
-Optional note: true relay traffic validation requires a registered external compute node plus an
-E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
-See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" for
+Required staging promotion evidence after the external compute/E2EE test:
+
+- immutable image tag (`main-<shortsha>` or later `vX.Y.Z`) and chart version `0.1.1` plus OCI
+  chart digest when available from Helm/registry output
+- rendered or live Deployment/Ingress YAML showing `replicaCount: 1`, `strategy.type: Recreate`,
+  one Gunicorn worker, TLS, public relay URL, and internal relay URL
+- `/livez`, `/healthz`, and `/relay/diagnostics` output captured after the compute node test
+- relay logs from the same UTC window after the compute node test, with no plaintext prompt,
+  response, token, key, ciphertext, or model payload content copied into the evidence
+
+The required external compute-node gate above is the staging promotion gate; generic HTTP health
+checks alone must never be reported as relay production readiness. See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" for
 required checks covering stale OCI chart detection, Recreate strategy verification, XDG
 read-only-root safeguards, duplicate env detection, and external compute-node long-poll flow
 validation.
@@ -109,6 +127,7 @@ If operators use a non-default staging hostname, apply the same checks with that
 ## Notes
 
 - Keep API v1 relay-blind E2EE guardrails intact.
-- Do not depend on local chart path deployment (`./deploy/charts/tokenplace-relay`) for
-  Sugarkube steady-state operations.
+- Use only the GHCR image plus OCI Helm chart path for Sugarkube staging. Do not promote the
+  repository-root `docker-compose.yml`, local Compose variants, raw `k8s/` manifests, or local chart
+  path deployment (`./deploy/charts/tokenplace-relay`) into the production runbook.
 - Do not require `gpuExternalName` or `TOKENPLACE_RELAY_UPSTREAM_URL` for staging relay readiness.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,7 +1,7 @@
 # Sugarkube release workflow for token.place
 
 This is the canonical release path for deploying token.place on Sugarkube. It is
-GHCR-first: GitHub Actions builds the relay image from the repository-root
+GHCR + OCI Helm chart first: GitHub Actions builds the relay image from the repository-root
 `Dockerfile`, GitHub Actions validates and publishes the Helm chart from
 `charts/tokenplace`, and Sugarkube deploys an immutable image tag with an OCI
 chart version.
@@ -42,7 +42,10 @@ ghcr.io/futuroptimist/tokenplace-relay:sha-<shortsha>
 
 Use `main-<shortsha>` or `vX.Y.Z` for Sugarkube deploys. `main-latest` exists
 only as a chart lint/render convenience and a quick human smoke-test pointer;
-it is not the staging or production promotion tag.
+it is not the staging or production promotion tag. When Sugarkube
+`docs/apps/tokenplace.prod.tag` is empty, production promotion must pass an
+explicit immutable tag. Mutable tags such as `latest`, `main-latest`, `staging`,
+`prod`, and `production` are invalid for promotion.
 
 ## Chart contract
 
@@ -57,7 +60,9 @@ helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version CHART_VE
 ```
 
 Replace `CHART_VERSION` with the version recorded in the successful
-`ci-helm.yml` run summary or in the Sugarkube app config/version file.
+`ci-helm.yml` run summary or in the Sugarkube app config/version file. Current
+token.place chart source and Sugarkube pin expectation are `0.1.1`; chart package version
+`0.1.1`; chart `appVersion` remains `"0.1.0"` for the v0.1.0 runtime.
 
 ## Staging deploy path
 
@@ -91,10 +96,35 @@ before copying commands.
 For semver release validation, replace `main-REPLACE_SHORTSHA` with the release
 tag, for example `v0.1.0`.
 
+## Release readiness gates
+
+Staging `app-status`, `app-verify`, `/livez`, `/healthz`, `/relay/diagnostics`,
+and root-page checks are necessary but insufficient. Before promoting staging, a
+real external desktop/compute node must register to `https://staging.token.place`
+and complete a real encrypted API v1 relay/desktop-bridge E2EE request/response.
+After production promotion, repeat the registration and E2EE request/response
+with a separate real production node against `https://token.place`. The exact
+compute-node command is operator/environment-specific; record the actual command
+and environment used.
+
+Evidence for each environment must include the immutable image tag, chart
+version/digest where available, rendered or live Deployment/Ingress YAML,
+`/livez`, `/healthz`, and `/relay/diagnostics` output after the compute test,
+and relay logs after the compute test. Preserve the current relay caveat in all
+release notes: relay-only in cluster, external compute plane, one replica, one Gunicorn worker,
+in-memory registrations/queues/replies, accepted state loss on pod restart/replacement, and no
+HA/durable queue claim until shared state ships. Cloudflare Tunnel/DNS/TLS/WAF validation is an
+external release gate; if a compute node sees a pre-app 403 with a `cf-ray`, check Cloudflare
+Security Events before changing relay application code.
+
+Plaintext relay-dispatched API v1 paths are intentionally fail-closed. Production
+readiness claims apply only to the encrypted API v1 relay/desktop-bridge E2EE
+flow.
+
 ## Local-development appendix
 
-Local image builds are for developer iteration only. They are not the staging or
-production release path.
+Local image builds, root `docker-compose.yml`, and raw `k8s/` manifests are for developer or
+legacy/local iteration only. They are not the staging or production release path.
 
 ```bash
 docker build -t tokenplace-relay:dev -f Dockerfile .

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -39,8 +39,13 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Current chart package version pin: `0.1.1` (Sugarkube `docs/apps/tokenplace.version`; chart
+  `appVersion` remains `"0.1.0"` for the v0.1.0 runtime)
 - Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
+- Production promotion: if Sugarkube `docs/apps/tokenplace.prod.tag` is empty, the operator must
+  pass an explicit immutable tag; mutable tags (`latest`, `main-latest`, `staging`, `prod`,
+  `production`) are invalid.
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest` is convenience-only and not production sign-off material
 - Before publishing, run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`; if chart `0.1.1` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.1` does not exist, proceed with publishing chart package version `0.1.1`.
@@ -107,6 +112,51 @@ Assumption: cert-manager is installed and the configured ClusterIssuer (for exam
 - Staging: host `staging.token.place`, TLS secret `tokenplace-staging-tls`
 - Production: host `token.place`, TLS secret `tokenplace-prod-tls`
 
+
+## Cloudflare route, TLS, and WAF validation gate
+
+Cloudflare Tunnel, DNS, TLS edge behavior, Access/Bot/WAF policies, and Security Events are
+external to Helm. Helm can render an Ingress for Traefik, but it cannot prove that
+`staging.token.place` or `token.place` is routed through Cloudflare to Traefik or that
+compute-node control-plane requests are allowed through pre-app filtering.
+
+Copy-pasteable external gate checks (replace placeholders; do not paste real secrets into notes):
+
+~~~bash
+# Confirm Cloudflare/Tunnel routing resolves the public host and reaches the expected edge.
+# Then compare the Traefik/Ingress backend separately from Kubernetes output.
+dig +short staging.token.place
+dig +short token.place
+kubectl -n tokenplace get ingress tokenplace -o wide
+kubectl -n tokenplace get ingress tokenplace -o yaml
+
+# Verify public HTTPS routes that must reach the relay through Cloudflare -> Traefik.
+for host in staging.token.place token.place; do
+  curl -vI "https://${host}/"
+  curl -fsS "https://${host}/livez"
+  curl -fsS "https://${host}/healthz"
+  curl -fsS "https://${host}/relay/diagnostics"
+done
+
+# Safely reproduce the compute-node registration request shape without exposing a real token.
+# A 401 JSON response means the request reached relay.py with an invalid/placeholder token.
+# A non-JSON 403 with server=cloudflare/cf-ray means Cloudflare or another pre-app layer blocked it.
+HOST=staging.token.place
+curl -i -X POST "https://${HOST}/api/v1/relay/servers/register" \
+  -H 'content-type: application/json' \
+  -H 'X-Relay-Server-Token: REPLACE_WITH_THROWAWAY_OR_REDACTED_TOKEN' \
+  --data '{"server_public_key":"diagnostic-public-key-placeholder"}'
+
+# If a desktop/compute node reports a pre-app 403, capture its cf-ray and inspect Cloudflare.
+# In Cloudflare: Security > Events, filter by Ray ID and the affected hostname/path.
+CF_RAY=REPLACE_CF_RAY
+printf 'Check Cloudflare Security Events for Ray ID: %s\n' "$CF_RAY"
+~~~
+
+Do not relax relay.py token handling to work around Cloudflare failures. If the relay logs have no
+matching `POST /api/v1/relay/servers/register`/`poll` line for the same UTC window, fix the
+Cloudflare/Tunnel/WAF route first.
+
 ## Sugarkube deployment command patterns
 
 > Run the following from a **Sugarkube checkout**, not from token.place.
@@ -141,6 +191,9 @@ Production pattern uses `PATH/TO/tokenplace.values.prod.yaml` with the same appr
 immutable tag.
 
 ## Validation (staging example)
+
+These HTTP checks are necessary deployment checks, but they are **insufficient** for staging
+promotion or production readiness.
 
 ~~~bash
 kubectl -n tokenplace get deploy,po,svc,ingress
@@ -178,8 +231,33 @@ curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
 ~~~
 
-Optional note: true relay traffic validation requires a registered external compute node and an
-E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`). For desktop release candidates, use the shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging, production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics, queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
+### Required relay-compute/E2EE release gates
+
+Staging promotion gate:
+
+1. A real external desktop/compute node registers to `https://staging.token.place`.
+2. `/healthz` and `/relay/diagnostics` show the registered node after registration.
+3. A real encrypted API v1 relay/desktop-bridge E2EE request/response succeeds through that node.
+4. Evidence includes immutable image tag, chart version `0.1.1` and digest where available, rendered
+   or live Deployment/Ingress YAML, health/diagnostics output after the compute test, and relay logs
+   after the compute test.
+
+Production post-promotion gate:
+
+1. A separate real production desktop/compute node registers to `https://token.place`.
+2. `/healthz` and `/relay/diagnostics` show the production registered node after registration.
+3. A real encrypted API v1 relay/desktop-bridge E2EE request/response succeeds through production.
+4. Evidence includes the immutable production image tag, chart version/digest where available,
+   rendered or live Deployment/Ingress YAML, health/diagnostics output after the production compute
+   test, and relay logs after the production compute test.
+
+The exact compute-node startup/probe command is operator/environment-specific; record what was
+actually used rather than inventing a universal command. Keep all evidence relay-blind: no plaintext
+prompts/responses/tool arguments/model output, private keys, relay tokens, or payload ciphertext.
+Plaintext relay-dispatched API v1 paths are intentionally fail-closed; readiness claims apply only
+to the encrypted API v1 relay/desktop-bridge E2EE flow. For desktop release candidates, use the
+shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging,
+production, two-node, or round-robin claims.
 
 ### Desktop compute-node HTTP 403 / pre-app rejection diagnostics
 
@@ -385,7 +463,7 @@ Verification focus:
 ### 6) Health checks green before true relay flow validation
 
 Warning:
-- `/livez`, `/healthz`, `/`, and `/metrics` are necessary checks but **not sufficient** for
+- `/livez`, `/healthz`, `/`, and `/metrics` are necessary checks but **insufficient** for
   production sign-off.
 - Sign-off requires successful encrypted relay flow with a real external compute node.
 
@@ -473,5 +551,6 @@ Interpretation:
 - Keep API v1 relay-blind E2EE invariants intact (ciphertext only + safe routing metadata).
 - Do not treat legacy relay endpoints as active production path.
 - Do not require `TOKENPLACE_RELAY_UPSTREAM_URL` for relay-only Sugarkube readiness.
-- Do not use local chart path deployment (`./deploy/charts/tokenplace-relay`) for Sugarkube
-  steady-state operations.
+- Sugarkube steady-state deployment is GHCR image + OCI Helm chart only. Do not use the
+  repository-root `docker-compose.yml`, local Compose files, raw `k8s/` manifests, or local chart
+  path deployment (`./deploy/charts/tokenplace-relay`) as the staging/prod runbook path.

--- a/tests/unit/test_sugarkube_release_gates.py
+++ b/tests/unit/test_sugarkube_release_gates.py
@@ -1,0 +1,103 @@
+"""Regression checks for token.place Sugarkube release gates."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+CHART_PATH = Path("charts/tokenplace/Chart.yaml")
+SUGARKUBE_VERSION_PATH = Path("docs/apps/tokenplace.version")
+SUGARKUBE_PROD_TAG_PATH = Path("docs/apps/tokenplace.prod.tag")
+STAGING_RUNBOOK = Path("docs/k3s-sugarkube-staging.md")
+PROD_RUNBOOK = Path("docs/k3s-sugarkube-prod.md")
+ONBOARDING_RUNBOOK = Path("docs/relay_sugarkube_onboarding.md")
+RELEASE_RUNBOOK = Path("docs/ops/sugarkube-release.md")
+
+
+IMMUTABLE_TAG_RE = re.compile(r"^(?:main-[0-9a-f]{7,40}|sha-[0-9a-f]{7,40}|v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$")
+MUTABLE_TAGS = {"latest", "main-latest", "staging", "prod", "production"}
+
+
+def _is_immutable_release_tag(tag: str) -> bool:
+    return bool(IMMUTABLE_TAG_RE.fullmatch(tag)) and tag not in MUTABLE_TAGS
+
+
+def _squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_sugarkube_chart_pin_matches_current_chart_source() -> None:
+    """The documented Sugarkube chart pin must not drift from the chart source."""
+    chart = yaml.safe_load(CHART_PATH.read_text(encoding="utf-8"))
+    sugarkube_pin = SUGARKUBE_VERSION_PATH.read_text(encoding="utf-8").strip()
+
+    assert chart["version"] == "0.1.1"
+    assert sugarkube_pin == chart["version"]
+
+    for runbook in (STAGING_RUNBOOK, PROD_RUNBOOK, ONBOARDING_RUNBOOK, RELEASE_RUNBOOK):
+        text = _squash(runbook.read_text(encoding="utf-8"))
+        assert "chart version `0.1.1`" in text or "chart package version `0.1.1`" in text
+
+
+def test_prod_tag_file_is_empty_and_docs_require_explicit_immutable_tag() -> None:
+    """An empty prod tag file is allowed only with an explicit immutable promotion tag."""
+    assert SUGARKUBE_PROD_TAG_PATH.exists()
+    assert SUGARKUBE_PROD_TAG_PATH.read_text(encoding="utf-8").strip() == ""
+
+    release_text = _squash(RELEASE_RUNBOOK.read_text(encoding="utf-8"))
+    prod_text = _squash(PROD_RUNBOOK.read_text(encoding="utf-8"))
+
+    assert "explicit immutable tag" in release_text
+    assert "explicit immutable tag" in prod_text
+    for mutable in MUTABLE_TAGS:
+        assert mutable in release_text
+        assert mutable in prod_text
+
+
+def test_documented_prod_tag_policy_rejects_mutable_tags() -> None:
+    """Keep the Sugarkube promotion contract aligned with app_config tag policy."""
+    for tag in MUTABLE_TAGS:
+        assert not _is_immutable_release_tag(tag)
+
+    assert _is_immutable_release_tag("main-deadbee")
+    assert _is_immutable_release_tag("v0.1.0")
+
+
+def test_runbooks_require_external_compute_e2ee_not_generic_health_only() -> None:
+    """Staging/prod readiness must require a real compute node and E2EE flow."""
+    for runbook in (STAGING_RUNBOOK, PROD_RUNBOOK, ONBOARDING_RUNBOOK, RELEASE_RUNBOOK):
+        text = _squash(runbook.read_text(encoding="utf-8"))
+        assert "necessary" in text and "insufficient" in text
+        assert "real external" in text
+        assert "encrypted API v1 relay/desktop-bridge E2EE request/response" in text
+        assert "/relay/diagnostics" in text
+        assert "relay logs" in text
+
+
+def test_runbooks_preserve_single_pod_in_memory_relay_caveat_and_canonical_path() -> None:
+    """Production docs must not imply HA, durable queue, or local manifest deployment."""
+    for runbook in (STAGING_RUNBOOK, PROD_RUNBOOK, ONBOARDING_RUNBOOK, RELEASE_RUNBOOK):
+        text = _squash(runbook.read_text(encoding="utf-8"))
+        assert "one replica" in text
+        assert "one Gunicorn worker" in text
+        assert "in-memory" in text
+        assert "future work" in text or "no HA/durable queue claim" in text
+        assert "GHCR" in text
+        assert "OCI Helm chart" in text
+        assert "docker-compose.yml" in text
+        assert "raw `k8s/` manifests" in text
+
+
+def test_runbooks_capture_cloudflare_and_fail_closed_api_path_gates() -> None:
+    """Cloudflare/WAF is external to Helm and plaintext API v1 relay paths fail closed."""
+    onboarding_text = ONBOARDING_RUNBOOK.read_text(encoding="utf-8")
+    release_text = RELEASE_RUNBOOK.read_text(encoding="utf-8")
+
+    for text in (_squash(onboarding_text), _squash(release_text)):
+        assert "Cloudflare" in text
+        assert "external" in text
+        assert "cf-ray" in text
+        assert "Security Events" in text
+        assert "Plaintext relay-dispatched API v1 paths are intentionally fail-closed" in text


### PR DESCRIPTION
### Motivation
- Close remaining Sugarkube production-readiness objections by making chart pins, prod-tag policy, Cloudflare/TLS/WAF checks, and compute-node E2EE gates explicit and verifiable in repo artifacts and tests.
- Prevent accidental promotion with mutable image tags and avoid implying HA/durable-queue semantics for the intentionally single-pod, in-memory relay.
- Capture external routing/WAF validation and operator evidence requirements in runbooks so Helm-only checks are not mistaken for full readiness.

### Description
- Aligned Sugarkube-facing wording to the current chart package pin (`0.1.1`) while preserving the chart `appVersion` context; added explicit references to the chart package version where runbooks mention chart pins.
- Introduced an explicit, intentionally-empty prod tag file `docs/apps/tokenplace.prod.tag` and documented that production promotion must pass an explicit immutable tag when that file is empty; documented and rejected mutable tags (`latest`, `main-latest`, `staging`, `prod`, `production`).
- Strengthened staging and production runbooks (`docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`, `docs/ops/sugarkube-release.md`, `docs/relay_sugarkube_onboarding.md`) to state that generic HTTP checks (`/`, `/livez`, `/healthz`, `/relay/diagnostics`) are necessary but insufficient and that staging/prod promotion requires a real external compute/desktop node registration plus a successful encrypted API v1 relay/desktop-bridge E2EE request/response and captured evidence.
- Added Cloudflare/TLS/WAF external-gate guidance and copy-pasteable diagnostic steps (dig, curl, safe placeholder `POST /api/v1/relay/servers/register` shape, and `cf-ray` Security Events triage) to the onboarding/runbook docs.
- Emphasized canonical Sugarkube deploy path is GHCR image + OCI Helm chart only and warned against promoting `docker-compose.yml`, local Compose variants, raw `k8s/` manifests, or local chart paths into production runbooks.
- Made the single-pod, one-Gunicorn-worker, in-memory relay caveat explicit in runbooks and release notes so no doc implies HA/durable queue behavior.
- Added focused unit test `tests/unit/test_sugarkube_release_gates.py` that enforces chart-pin alignment, empty prod-tag behavior, immutable-tag policy, runbook gate wording, Cloudflare guidance presence, and single-pod/in-memory caveats.

### Testing
- Ran the new focused unit tests: `python3 -m pytest tests/unit/test_sugarkube_release_gates.py tests/unit/test_sugarkube_bundle.py` — result: all tests passed (9 passed).
- Verified chart/version pin: `test "$(cat docs/apps/tokenplace.version)" = "0.1.1"` — result: pass.
- Verified prod tag file exists and is empty: `test -f docs/apps/tokenplace.prod.tag && test "$(cat docs/apps/tokenplace.prod.tag)" = ""` — result: pass.
- Validated immutable/mutable tag regex checks via inline Python (examples `main-deadbee`, `v0.1.0`, and rejects `latest`,`main-latest`,`staging`,`prod`,`production`) — result: pass.
- Searched docs to confirm presence of key terms and pins: `rg "tokenplace\.version" docs scripts tests` and `rg "relay-compute|E2EE|Cloudflare|main-latest|tokenplace" docs/apps docs/k3s-tokenplace-*.md docs/relay_sugarkube_onboarding.md docs/ops/sugarkube-release.md` — result: matches found (performed and recorded to /tmp/tokenplace-rg-check.txt).
- Ran repository checks: `pre-commit run --all-files` — result: pass.

Residual notes and follow-ups
- Sugarkube-specific `scripts/app_config.py` and `tests/test_generic_app_just_recipes.py` referenced in the objective live in the Sugarkube repo, not in this token.place checkout; this change adds focused token.place runbook assertions and tests here instead of editing Sugarkube repo files.
- Operators must run the external compute-node registration + E2EE evidence steps against real environments (the docs intentionally avoid inventing a universal compute-node command).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24eb2d0c44832f974cb8665b0ff1d9)