### PR TITLE
docs: enforce Sugarkube readiness gates for token.place (chart pin, Cloudflare, E2EE compute signoff)

### DIFF
--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -43,7 +43,8 @@ Use the values files and version file that live in Sugarkube for your environmen
 ## Ingress TLS + Cloudflare Tunnel contract
 
 - Cloudflare Tunnel still owns public DNS/Tunnel routing for `token.place` to Traefik.
-- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes.
+- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes, DNS, TLS edge policy, Access policy, or WAF/skip rules.
+- API v1 compute-node registration, poll, unregister, and encrypted response POST paths can be blocked before reaching `relay.py`; validate Cloudflare Security Events by `cf-ray` when desktop/compute nodes see pre-app 403s.
 - Production values must explicitly set `ingress.tls.enabled: true` or chart output omits `spec.tls`.
 - Assumption: cert-manager is installed and `cert-manager.io/cluster-issuer: letsencrypt-production` exists.
 
@@ -94,10 +95,28 @@ curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
 ```
 
-Optional note: true relay traffic validation requires a registered external compute node plus an
-E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
-See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" and run
-the same external compute-node validation pattern against production hostnames before sign-off.
+## Promotion/sign-off gate
+
+The validation commands above (`app-status`, `app-verify`, rendered/live YAML checks, `/livez`,
+`/healthz`, `/relay/diagnostics`, and `/`) are necessary but insufficient. Do not sign off from
+generic HTTP checks alone.
+
+Required gate for `token.place`:
+
+1. Use only the canonical GHCR image and OCI Helm chart path (`ghcr.io/futuroptimist/tokenplace-relay`
+   plus `oci://ghcr.io/futuroptimist/charts/tokenplace`), with chart package `0.1.1` and immutable
+   image tag `v0.1.0` or another approved immutable tag.
+2. Confirm a real external desktop/compute node registers to `token.place` and appears in both `/healthz`
+   and `/relay/diagnostics`. The exact compute-node command is operator/environment-specific; use
+   the desktop or compute-node runbook for the hardware under test.
+3. Complete a real encrypted API v1 relay/desktop-bridge E2EE request/response through that
+   registered node. Plaintext relay-dispatched API v1 payloads remain intentionally fail-closed and
+   are not production-readiness evidence.
+4. Capture evidence after the compute test: immutable image tag, chart version/digest when
+   available, `/tmp/tokenplace-prod-render.yaml` or live Deployment YAML, `/healthz`, `/relay/diagnostics`, and relay logs.
+
+Cloudflare/TLS/WAF routing is outside Helm. If compute-node registration sees a non-JSON `403` or
+`cf-ray`, check Cloudflare Security Events for that Ray ID before changing the chart or relay code.
 
 If operators override hostname/routing, use the equivalent production host in the same checks.
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -44,7 +44,8 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 ## Ingress TLS + Cloudflare Tunnel contract
 
 - Cloudflare Tunnel still owns public DNS/Tunnel routing for `staging.token.place` to Traefik.
-- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes.
+- Helm values only control Kubernetes resources; Helm does **not** create/manage Cloudflare routes, DNS, TLS edge policy, Access policy, or WAF/skip rules.
+- API v1 compute-node registration, poll, unregister, and encrypted response POST paths can be blocked before reaching `relay.py`; validate Cloudflare Security Events by `cf-ray` when desktop/compute nodes see pre-app 403s.
 - Staging values must explicitly set `ingress.tls.enabled: true` or chart output omits `spec.tls`.
 - Assumption: cert-manager is installed and `cert-manager.io/cluster-issuer: letsencrypt-production` exists.
 
@@ -91,12 +92,28 @@ curl -fsS https://staging.token.place/healthz
 curl -fsS https://staging.token.place/
 ```
 
-Optional note: true relay traffic validation requires a registered external compute node plus an
-E2EE client-flow probe; health/root checks alone do not prove register/poll/request/response flow.
-See `relay_sugarkube_onboarding.md` "v0.1.0 staging failure modes and operator runbook" for
-required checks covering stale OCI chart detection, Recreate strategy verification, XDG
-read-only-root safeguards, duplicate env detection, and external compute-node long-poll flow
-validation.
+## Promotion/sign-off gate
+
+The validation commands above (`app-status`, `app-verify`, rendered/live YAML checks, `/livez`,
+`/healthz`, `/relay/diagnostics`, and `/`) are necessary but insufficient. Do not sign off from
+generic HTTP checks alone.
+
+Required gate for `staging.token.place`:
+
+1. Use only the canonical GHCR image and OCI Helm chart path (`ghcr.io/futuroptimist/tokenplace-relay`
+   plus `oci://ghcr.io/futuroptimist/charts/tokenplace`), with chart package `0.1.1` and immutable
+   image tag `main-REPLACE_SHORTSHA` or another approved immutable tag.
+2. Confirm a real external desktop/compute node registers to `staging.token.place` and appears in both `/healthz`
+   and `/relay/diagnostics`. The exact compute-node command is operator/environment-specific; use
+   the desktop or compute-node runbook for the hardware under test.
+3. Complete a real encrypted API v1 relay/desktop-bridge E2EE request/response through that
+   registered node. Plaintext relay-dispatched API v1 payloads remain intentionally fail-closed and
+   are not production-readiness evidence.
+4. Capture evidence after the compute test: immutable image tag, chart version/digest when
+   available, `/tmp/tokenplace-staging-render.yaml` or live Deployment YAML, `/healthz`, `/relay/diagnostics`, and relay logs.
+
+Cloudflare/TLS/WAF routing is outside Helm. If compute-node registration sees a non-JSON `403` or
+`cf-ray`, check Cloudflare Security Events for that Ray ID before changing the chart or relay code.
 
 If operators use a non-default staging hostname, apply the same checks with that host.
 

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -95,7 +95,10 @@ Otherwise leave the chart defaults in place; staging should not require a manual
 ## Ingress TLS expectations for staging/prod
 
 Cloudflare Tunnel continues to route public hostnames to Traefik, while Helm values control only
-Kubernetes objects. Helm does not manage Cloudflare routes.
+Kubernetes objects. Helm does not manage Cloudflare routes, DNS, TLS edge policy, Access policy, or
+WAF/skip rules. Treat Cloudflare route/TLS/WAF validation as an external release gate, especially
+for API v1 compute-node registration, poll, unregister, and encrypted response POST paths that can
+be blocked before reaching `relay.py`.
 
 Staging/prod overlays must set `ingress.tls.enabled: true`; cert-manager annotation/secret names
 alone are not enough to render `spec.tls` in the chart. Operators must verify the rendered Ingress
@@ -178,8 +181,80 @@ curl -fsS https://token.place/healthz
 curl -fsS https://token.place/
 ~~~
 
-Optional note: true relay traffic validation requires a registered external compute node and an
-E2EE client-flow probe (for example encrypted `/api/v1/chat/completions`). For desktop release candidates, use the shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging, production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics, queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
+## Cloudflare/TLS/WAF external gate
+
+Run these checks for both `staging.token.place` and `token.place` before signing off. They validate
+public routing to Traefik and help distinguish pre-app Cloudflare/WAF blocks from relay app errors
+without exposing secrets.
+
+~~~bash
+# Confirm public DNS/edge routing resolves before debugging Helm.
+dig +short staging.token.place
+dig +short token.place
+
+# Confirm HTTPS and app health over the public hostnames.
+for host in staging.token.place token.place; do
+  curl -vI "https://${host}/"
+  curl -fsS "https://${host}/livez"
+  curl -fsS "https://${host}/healthz"
+  curl -fsS "https://${host}/relay/diagnostics"
+done
+
+# Safely reproduce the API v1 compute-node registration request shape. This placeholder token
+# and diagnostic public key are not secrets; replace only in a controlled operator shell.
+HOST=staging.token.place
+curl -i -X POST "https://${HOST}/api/v1/relay/servers/register" \
+  -H 'content-type: application/json' \
+  -H 'X-Relay-Server-Token: REPLACE_WITH_STAGING_TEST_TOKEN' \
+  --data '{"server_public_key":"diagnostic-public-key-placeholder"}'
+
+# If a desktop/compute node reports a pre-app 403, capture cf-ray and filter Cloudflare
+# Security > Events by that Ray ID for the matching zone.
+CF_RAY=REPLACE_CF_RAY
+printf 'Check Cloudflare Security > Events for Ray ID: %s\n' "$CF_RAY"
+~~~
+
+A relay JSON `401` indicates the request reached `relay.py` and failed the registration-token
+boundary. A non-JSON `403` with `server: cloudflare` or a `cf-ray` header indicates a Cloudflare,
+Access, WAF, bot, tunnel, or other pre-app routing problem; fix that external route before changing
+Helm or relay code.
+
+## Release gates: health checks are necessary but insufficient
+
+`app-status`, `app-verify`, `/`, `/livez`, `/healthz`, and `/relay/diagnostics` are required
+smoke checks, but they do **not** prove production readiness by themselves. Sign-off requires a
+real external desktop/compute node using the encrypted API v1 relay/desktop-bridge E2EE path; the
+exact node launch command is operator/environment-specific, so use the desktop or compute-node
+runbook for the hardware under test rather than inventing a universal command here.
+
+Staging promotion gate:
+
+1. Deploy the immutable image tag (`main-<shortsha>` or release `vX.Y.Z`) with chart package
+   version `0.1.1` from `oci://ghcr.io/futuroptimist/charts/tokenplace`.
+2. Confirm a real external compute node registers against `https://staging.token.place` and appears
+   in both `/healthz` and `/relay/diagnostics`.
+3. Send a real encrypted API v1 relay/desktop-bridge request through that registered node and verify
+   the encrypted response is returned to the client.
+4. Capture evidence after the compute test: immutable image tag, chart version/digest when
+   available, rendered or live Deployment YAML, `/healthz`, `/relay/diagnostics`, and relay logs.
+
+Production post-promotion gate:
+
+1. Promote only the staging-approved immutable image tag; if Sugarkube's
+   `docs/apps/tokenplace.prod.tag` is intentionally empty, the prod operator must provide an
+   explicit immutable tag at promotion time.
+2. Repeat a separate real compute-node registration against `https://token.place`; staging evidence
+   is not a substitute for production host/TLS/WAF validation.
+3. Repeat the real encrypted API v1 relay/desktop-bridge request/response through the production
+   registered node.
+4. Capture the same evidence after the production compute test: immutable image tag, chart
+   version/digest when available, rendered or live Deployment YAML, `/healthz`,
+   `/relay/diagnostics`, and relay logs.
+
+Plaintext relay-dispatched API v1 payloads remain intentionally fail-closed; production readiness
+claims must refer only to the encrypted API v1 relay/desktop-bridge E2EE flow.
+
+For desktop release candidates, use the shared [desktop parity validation checklist](desktop_parity_validation.md) before making staging, production, two-node, or round-robin claims. That checklist includes copy-paste staging diagnostics, queue-depth, Stop/Start, Windows CUDA, macOS Metal, and CPU fallback commands.
 
 ### Desktop compute-node HTTP 403 / pre-app rejection diagnostics
 
@@ -280,10 +355,13 @@ Why this matters:
 - For relay's in-memory queue/registration state, rollout behavior must stay single-pod-safe.
 - A stale chart can silently remove safety defaults and invalidate staging confidence.
 
-Decision rule for v0.1.0:
-- Because launch identifiers are intentionally pinned at `0.1.0`, pre-launch chart package
-  deletion/re-publish may be required when GHCR `0.1.0` content is stale or incorrect.
-- Keep this as a deliberate operator action with notes (who/when/why), not an automatic overwrite.
+Decision rule for v0.1.0 runtime with chart package `0.1.1`:
+- Sugarkube must pin chart package `0.1.1` for the current deployable chart. Do not treat stale
+  GHCR chart package `0.1.0` content as the current deployable chart.
+- The runtime/app alignment remains `appVersion: "0.1.0"` and image tag `v0.1.0`; the chart
+  package version that carries the current rollout defaults is `0.1.1`.
+- If an already-published `0.1.1` package is stale or mismatched, stop and decide manually with
+  operator notes (who/when/why). Do not automatically overwrite an immutable chart artifact.
 
 Verification commands:
 

--- a/tests/unit/test_sugarkube_bundle.py
+++ b/tests/unit/test_sugarkube_bundle.py
@@ -54,3 +54,106 @@ def test_bundle_values_do_not_pin_redis_storage_backend():
     content = BUNDLE_VALUES_PATH.read_text()
     assert "redis://" not in content
     assert "TOKENPLACE_RATE_LIMIT_STORAGE_URI" not in content
+
+
+def test_sugarkube_chart_pin_matches_current_canonical_chart():
+    """Sugarkube version pin docs should match the canonical OCI chart package."""
+    chart = yaml.safe_load(Path("charts/tokenplace/Chart.yaml").read_text())
+    version_pin = Path("docs/apps/tokenplace.version").read_text().strip()
+
+    assert chart["version"] == "0.1.1"
+    assert chart["appVersion"] == "0.1.0"
+    assert version_pin == chart["version"]
+
+    onboarding = Path("docs/relay_sugarkube_onboarding.md").read_text()
+    assert "Sugarkube must pin chart package `0.1.1`" in onboarding
+    assert (
+        "Do not treat stale\n  GHCR chart package `0.1.0` content "
+        "as the current deployable chart"
+        in onboarding
+    )
+
+
+def test_sugarkube_runbooks_require_real_e2ee_compute_signoff():
+    """Runbooks must not equate generic HTTP health with production readiness."""
+    for runbook in (
+        Path("docs/k3s-sugarkube-staging.md"),
+        Path("docs/k3s-sugarkube-prod.md"),
+        Path("docs/relay_sugarkube_onboarding.md"),
+    ):
+        text = runbook.read_text()
+        assert "necessary but insufficient" in text
+        assert (
+            "generic HTTP checks alone" in text
+            or "do **not** prove production readiness" in text
+        )
+        assert "real external" in text
+        assert "encrypted API v1 relay/desktop-bridge E2EE" in text
+        assert "Plaintext relay-dispatched API v1" in text
+        assert "intentionally fail-closed" in text
+        assert "chart version/digest" in text
+        assert "/relay/diagnostics" in text
+        assert "relay logs" in text
+
+
+def test_sugarkube_runbooks_document_cloudflare_as_external_gate():
+    """Cloudflare route/TLS/WAF validation is outside Helm and must remain explicit."""
+    onboarding = Path("docs/relay_sugarkube_onboarding.md").read_text()
+    for expected in (
+        (
+            "Helm does not manage Cloudflare routes, DNS, TLS edge policy, "
+            "Access policy, or\nWAF/skip rules"
+        ),
+        "dig +short staging.token.place",
+        "dig +short token.place",
+        "curl -fsS \"https://${host}/relay/diagnostics\"",
+        "X-Relay-Server-Token: REPLACE_WITH_STAGING_TEST_TOKEN",
+        "diagnostic-public-key-placeholder",
+        "Cloudflare Security > Events",
+        "cf-ray",
+        "non-JSON `403`",
+    ):
+        assert expected in onboarding
+
+    for runbook in (
+        Path("docs/k3s-sugarkube-staging.md"),
+        Path("docs/k3s-sugarkube-prod.md"),
+    ):
+        text = runbook.read_text()
+        assert "Cloudflare/TLS/WAF routing is outside Helm" in text
+        assert "check Cloudflare Security Events for that Ray ID" in text
+
+
+def test_sugarkube_runbooks_preserve_single_pod_in_memory_scope():
+    """Production docs must keep the relay-only, non-HA state caveat visible."""
+    for runbook in (
+        Path("docs/k3s-sugarkube-staging.md"),
+        Path("docs/k3s-sugarkube-prod.md"),
+        Path("docs/relay_sugarkube_onboarding.md"),
+    ):
+        text = runbook.read_text()
+        assert "relay.py only" in text or "`relay.py` only" in text
+        assert "server.py" in text
+        assert "one pod" in text
+        assert "one Gunicorn worker" in text
+        assert "one replica" in text
+        assert "in-memory" in text
+        assert "State loss" in text or "accepted state loss" in text
+        assert "future work" in text
+
+
+def test_sugarkube_runbooks_keep_canonical_ghcr_oci_path_clear():
+    """Sugarkube production docs should not promote Compose or local charts."""
+    for runbook in (
+        Path("docs/k3s-sugarkube-staging.md"),
+        Path("docs/k3s-sugarkube-prod.md"),
+        Path("docs/relay_sugarkube_onboarding.md"),
+        Path("docs/ops/sugarkube-release.md"),
+    ):
+        text = runbook.read_text()
+        assert "ghcr.io/futuroptimist/tokenplace-relay" in text
+        assert "oci://ghcr.io/futuroptimist/charts/tokenplace" in text
+
+    release = Path("docs/ops/sugarkube-release.md").read_text()
+    assert "Use GitHub Actions and GHCR for deployable Sugarkube artifacts" in release
+    assert "not the staging or\nproduction release path" in release


### PR DESCRIPTION
### Motivation

- Close remaining Sugarkube production-readiness objections by making chart pinning, Cloudflare/TLS/WAF checks, and real compute-node E2EE validation explicit in the runbooks.
- Prevent accidental promotions using mutable tags by documenting that production promotion requires an explicit immutable image tag when `docs/apps/tokenplace.prod.tag` is empty.
- Ensure operators understand relay runtime constraints (single-pod, one worker, in-memory state) and that generic HTTP health is necessary but not sufficient for sign-off.

### Description

- Updated Sugarkube-facing runbooks: `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, and `docs/k3s-sugarkube-prod.md` to: require chart package `0.1.1` as the canonical OCI package, add a Promotion/Sign-off gate that mandates a real external compute-node registration plus an encrypted API v1 relay/desktop-bridge E2EE request/response, and document Cloudflare/TLS/WAF validation as an external gate with safe diagnostic steps.
- Clarified that Helm/values do not manage Cloudflare DNS/TLS/WAF rules and added copy-paste diagnostics (DNS/HTTPS/health endpoints, a safe registration POST shape and `cf-ray` guidance) so operators can distinguish pre-app Cloudflare rejections from relay issues.
- Preserved and re-emphasized relay-only operational caveats (one pod, one Gunicorn worker, in-memory registrations/queues, accepted state loss) across staging/prod docs so no HA/durable-queue semantics are implied.
- Added focused unit tests in `tests/unit/test_sugarkube_bundle.py` that assert the chart/package pin, the new runbook wording (real-E2EE signoff and Cloudflare gate), the single-pod in-memory caveat, and the canonical GHCR + OCI Helm path are present.

### Testing

- Ran unit tests: `python3 -m pytest tests/unit/test_sugarkube_bundle.py -q` — result: `8 passed`.
- Ran repository checks: `pre-commit run --all-files` — result: all hooks passed after the small formatting fix applied by `end-of-file-fixer`.
- Local verification commands used during work: `git diff --stat` and `git status --short` to review changes, and the branch commit used for the PR is `69800fb`.

Files changed: `docs/relay_sugarkube_onboarding.md`, `docs/k3s-sugarkube-staging.md`, `docs/k3s-sugarkube-prod.md`, and `tests/unit/test_sugarkube_bundle.py`.

Residual notes: this PR is documentation + test focused and does not alter runtime validation code such as `scripts/app_config.py`; if enforcing mutable-tag rejection in programmatic checks is required, follow-up work should add targeted `app_config` validation and CI tests that invoke `scripts/app_config.py validate-tag`/`shell --require-tag` as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24eb2d0c44832f974cb8665b0ff1d9)