### PR TITLE
Document API v1 launch contract and add regression tests

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any, Dict, Optional, Protocol
+from typing import Any, Callable, Dict, Optional, Protocol
 from urllib.parse import urlparse
 
 import requests
@@ -25,6 +25,9 @@ logger = logging.getLogger("api.v1.compute_provider")
 _last_backend_path: contextvars.ContextVar[str] = contextvars.ContextVar(
     "api_v1_last_backend_path",
     default="unknown",
+)
+_generate_response_override: contextvars.ContextVar[Callable[..., Any] | None] = (
+    contextvars.ContextVar("api_v1_generate_response_override", default=None)
 )
 
 
@@ -124,6 +127,24 @@ def _error_from_code(code: str, *, message: str) -> ComputeProviderError:
     )
 
 
+def set_api_v1_generate_response_override(generator: Callable[..., Any]):
+    """Set a request-local response generator override for compatibility tests."""
+
+    return _generate_response_override.set(generator)
+
+
+def reset_api_v1_generate_response_override(token) -> None:
+    """Reset a request-local response generator override token."""
+
+    _generate_response_override.reset(token)
+
+
+def _active_generate_response() -> Callable[..., Any]:
+    """Return the current request-local generator or the module default."""
+
+    return _generate_response_override.get() or generate_response
+
+
 class ApiV1ComputeProvider(Protocol):
     """Contract for API v1-compatible compute providers."""
 
@@ -148,7 +169,7 @@ class LocalApiV1ComputeProvider:
         messages: list[dict[str, Any]],
         options: Optional[Dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        updated_messages = generate_response(model_id, messages, **(options or {}))
+        updated_messages = _active_generate_response()(model_id, messages, **(options or {}))
         if not updated_messages:
             raise ComputeProviderError("model returned an empty message list")
         assistant_message = updated_messages[-1]

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -84,6 +84,44 @@ DEFAULT_SERVICE_NAME = 'token.place'
 SERVICE_NAME = os.getenv('SERVICE_NAME', DEFAULT_SERVICE_NAME)
 
 
+def _call_provider_complete_chat(provider, *, model_id, messages, options):
+    """Call a provider while honoring legacy route-level generate_response patches."""
+
+    from api.v1 import compute_provider as compute_provider_module
+
+    provider_generate_response = getattr(compute_provider_module, "generate_response", None)
+    should_bridge_legacy_patch = (
+        generate_response is not _generate_response
+        and provider_generate_response is _generate_response
+    )
+    if should_bridge_legacy_patch:
+        compute_provider_module.generate_response = generate_response
+    try:
+        return provider.complete_chat(
+            model_id=model_id,
+            messages=messages,
+            options=options,
+        )
+    finally:
+        if should_bridge_legacy_patch:
+            compute_provider_module.generate_response = provider_generate_response
+
+
+def _looks_like_model_error(exc: Exception) -> bool:
+    """Return True for ModelError instances, including reloaded module copies."""
+
+    return exc.__class__.__name__ == "ModelError" and hasattr(exc, "status_code")
+
+
+def _format_model_error_response(exc: Exception):
+    """Format model errors from the active or an equivalent reloaded module."""
+
+    return format_error_response(
+        getattr(exc, "message", str(exc)),
+        error_type=getattr(exc, "error_type", "invalid_request_error"),
+        status_code=getattr(exc, "status_code", 400),
+    )
+
 def _should_force_desktop_bridge_distributed(request_metadata, is_encrypted_request: bool) -> bool:
     """Allow desktop-bridge distributed override only for explicit API v1 E2EE intent."""
 
@@ -482,7 +520,8 @@ def _handle_chat_completion_request(data):
                     code="model_not_supported",
                     status_code=400,
                 )
-        assistant_message = provider.complete_chat(
+        assistant_message = _call_provider_complete_chat(
+            provider,
             model_id=model_id,
             messages=messages,
             options=_extract_chat_completion_options(data),
@@ -583,6 +622,9 @@ def _handle_chat_completion_request(data):
             status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
+        if _looks_like_model_error(e):
+            log_warning(f"Model error during chat completion: {getattr(e, 'message', str(e))}")
+            return _format_model_error_response(e)
         log_error("Unexpected error in create_chat_completion endpoint", exc_info=True)
         return format_error_response(
             f"Internal server error: {str(e)}",
@@ -665,7 +707,8 @@ def _handle_text_completion_request(data):
                     code="model_not_supported",
                     status_code=400,
                 )
-        assistant_message = provider.complete_chat(
+        assistant_message = _call_provider_complete_chat(
+            provider,
             model_id=model_id,
             messages=messages,
             options=_extract_chat_completion_options(data),
@@ -731,6 +774,9 @@ def _handle_text_completion_request(data):
             status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors
+        if _looks_like_model_error(e):
+            log_warning(f"Model error during response generation: {getattr(e, 'message', str(e))}")
+            return _format_model_error_response(e)
         log_error("Unexpected error in create_completion endpoint")
         return format_error_response(f"Internal server error: {str(e)}")
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -44,6 +44,8 @@ from api.v1.compute_provider import (
     get_api_v1_distributed_target_selection,
     get_api_v1_last_backend_path,
     get_api_v1_resolved_provider_path,
+    reset_api_v1_generate_response_override,
+    set_api_v1_generate_response_override,
     ComputeProviderError,
 )
 from api.v1.validation import (
@@ -87,15 +89,10 @@ SERVICE_NAME = os.getenv('SERVICE_NAME', DEFAULT_SERVICE_NAME)
 def _call_provider_complete_chat(provider, *, model_id, messages, options):
     """Call a provider while honoring legacy route-level generate_response patches."""
 
-    from api.v1 import compute_provider as compute_provider_module
-
-    provider_generate_response = getattr(compute_provider_module, "generate_response", None)
-    should_bridge_legacy_patch = (
-        generate_response is not _generate_response
-        and provider_generate_response is _generate_response
-    )
+    should_bridge_legacy_patch = generate_response is not _generate_response
+    override_token = None
     if should_bridge_legacy_patch:
-        compute_provider_module.generate_response = generate_response
+        override_token = set_api_v1_generate_response_override(generate_response)
     try:
         return provider.complete_chat(
             model_id=model_id,
@@ -103,8 +100,8 @@ def _call_provider_complete_chat(provider, *, model_id, messages, options):
             options=options,
         )
     finally:
-        if should_bridge_legacy_patch:
-            compute_provider_module.generate_response = provider_generate_response
+        if override_token is not None:
+            reset_api_v1_generate_response_override(override_token)
 
 
 def _looks_like_model_error(exc: Exception) -> bool:

--- a/static/index.html
+++ b/static/index.html
@@ -363,13 +363,13 @@
     {
       "id": "llama-3-8b-instruct",
       "object": "model",
-      "created": 1700000000,
+      "created": CREATED_UNIX_SECONDS,
       "owned_by": "token.place",
       "permission": [
         {
           "id": "modelperm-llama-3-8b-instruct",
           "object": "model_permission",
-          "created": 1700000000,
+          "created": CREATED_UNIX_SECONDS,
           "allow_create_engine": false,
           "allow_sampling": true,
           "allow_logprobs": true,

--- a/static/index.html
+++ b/static/index.html
@@ -365,7 +365,22 @@
       "object": "model",
       "created": 1700000000,
       "owned_by": "token.place",
-      "permission": ["..."],
+      "permission": [
+        {
+          "id": "modelperm-llama-3-8b-instruct",
+          "object": "model_permission",
+          "created": 1700000000,
+          "allow_create_engine": false,
+          "allow_sampling": true,
+          "allow_logprobs": true,
+          "allow_search_indices": false,
+          "allow_view": true,
+          "allow_fine_tuning": false,
+          "organization": "*",
+          "group": null,
+          "is_blocking": false
+        }
+      ],
       "root": "llama-3-8b-instruct",
       "parent": null
     }

--- a/static/index.html
+++ b/static/index.html
@@ -348,11 +348,14 @@
         <hr>
 
         <h2>API</h2>
-        <p>The token.place API is designed to be compatible with the OpenAI API format, making it easy to integrate with existing applications that use OpenAI's services.</p>
+        <p>The token.place <strong>API v1 launch contract for 0.1.0/0.1.x is frozen</strong>: API v1 is non-streaming, ciphertext-envelope-first for relay-blind E2EE paths, and is the active production API. API v2 is intentionally outside this launch contract.</p>
+        <p>OpenAI-compatible aliases are also registered at <code>/v1/models</code>, <code>/v1/models/{model_id}</code>, <code>/v1/public-key</code>, <code>/v1/public-key/rotate</code>, <code>/v1/chat/completions</code>, <code>/v1/completions</code>, <code>/v1/images/generations</code>, <code>/v1/health</code>, and <code>/v1/relay/unregister</code>.</p>
+
+        <h3>Public/client API v1 launch contract</h3>
 
         <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/models</span></h3>
-            <p>Lists the available models.</p>
+            <p>Lists available API v1 models in OpenAI-compatible list format. API v1 returns stable OpenAI-style model objects, not the API v2 catalog schema.</p>
             <p><strong>Example Response:</strong></p>
             <pre>{
   "object": "list",
@@ -360,9 +363,9 @@
     {
       "id": "llama-3-8b-instruct",
       "object": "model",
-      "created": 1679351277,
+      "created": 1700000000,
       "owned_by": "token.place",
-      "permission": [...],
+      "permission": ["..."],
       "root": "llama-3-8b-instruct",
       "parent": null
     }
@@ -372,23 +375,27 @@
 
         <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/models/{model_id}</span></h3>
-            <p>Retrieves information about a specific model.</p>
+            <p>Retrieves one API v1 model object by ID using the same OpenAI-compatible shape returned by the model list.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/public-key</span></h3>
+            <p>Retrieves the server public key used by encrypted API v1 request mode.</p>
             <p><strong>Example Response:</strong></p>
             <pre>{
-  "id": "llama-3-8b-instruct",
-  "object": "model",
-  "created": 1679351277,
-  "owned_by": "token.place",
-  "permission": [...],
-  "root": "llama-3-8b-instruct",
-  "parent": null
+  "public_key": "SERVER_PUBLIC_KEY_HERE"
 }</pre>
         </div>
 
         <div class="api-endpoint">
+            <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/public-key/rotate</span></h3>
+            <p><strong>Operator-gated.</strong> Rotates the server RSA key pair and returns the refreshed public key. Requires an operator token when operator auth is configured.</p>
+        </div>
+
+        <div class="api-endpoint">
             <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/chat/completions</span></h3>
-            <p>Creates a completion for the chat message.</p>
-            <p><strong>Request Body:</strong></p>
+            <p>Creates a non-streaming chat completion. API v1 rejects <code>stream: true</code>. Encrypted mode sends ciphertext under <code>messages</code> and includes the client public key so only the client can decrypt the response.</p>
+            <p><strong>Encrypted Request Body:</strong></p>
             <pre>{
   "model": "llama-3-8b-instruct",
   "encrypted": true,
@@ -413,39 +420,94 @@
 
         <div class="api-endpoint">
             <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/completions</span></h3>
-            <p>Creates a completion for a legacy plaintext prompt payload. For ciphertext-envelope-first API v1 usage, prefer <code>/api/v1/chat/completions</code> with encrypted request mode.</p>
-            <p><strong>Note:</strong> This endpoint is retained for compatibility with legacy clients that send a plaintext <code>prompt</code>. Relay-blind E2EE deployments should use <code>/api/v1/chat/completions</code> encrypted mode and relay ciphertext envelopes.</p>
-            <p><strong>Response format:</strong> Same schema family as chat/completions (text completion object).</p>
+            <p>Creates a non-streaming legacy text completion response for OpenAI-compatible clients. API v1 rejects <code>stream: true</code>; relay-blind E2EE deployments should prefer encrypted <code>/api/v1/chat/completions</code>.</p>
         </div>
 
         <div class="api-endpoint">
-            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/public-key</span></h3>
-            <p>Retrieves the server's public key for end-to-end encryption.</p>
-            <p><strong>Example Response:</strong></p>
-            <pre>{
-  "public_key": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUl..."
-}</pre>
+            <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/images/generations</span></h3>
+            <p>Generates a local placeholder image from a validated prompt and size. The response includes <code>created</code>, <code>data[].b64_json</code>, <code>data[].revised_prompt</code>, <code>size</code>, and optional <code>seed</code>.</p>
         </div>
 
-        <h3>E2EE Usage and Relay Envelope</h3>
-        <p>API v1 relay traffic is mandatory end-to-end encrypted: relay endpoints are ciphertext-only and reject plaintext-like or unexpected top-level fields. Use ciphertext envelope payloads in API-facing examples.</p>
-        <ol>
-            <li>Get the server's public key from <code>/api/v1/public-key</code></li>
-            <li>Generate your own RSA key pair on the client</li>
-            <li>Encrypt payload data with the server's public key</li>
-            <li>For API v1 relay routes, send only ciphertext envelope keys</li>
-            <li>Do not send plaintext top-level keys such as <code>messages</code>, <code>prompt</code>, <code>input</code>, <code>content</code>, <code>response</code>, or <code>text</code></li>
-        </ol>
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/health</span></h3>
+            <p>Returns API health metadata: <code>status</code>, <code>version</code>, <code>service</code>, and a current <code>timestamp</code>.</p>
+        </div>
 
-        <p><strong>Example API v1 Relay Request Envelope:</strong></p>
-        <pre>{
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/providers</span></h3>
+            <p>Lists community-operated relay and server providers as <code>{"object":"list","data":[...]}</code>, with optional metadata.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/leaderboard</span></h3>
+            <p>Returns the community model feedback leaderboard. An optional positive integer <code>limit</code> query parameter limits results.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/community/contributions</span></h3>
+            <p>Queues a community compute contribution offer and returns <code>{"status":"queued","submission_id":"..."}</code> with HTTP 202 when accepted.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/contributions/summary</span></h3>
+            <p>Summarizes queued contribution offers for maintainers.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/server-providers</span></h3>
+            <p>Lists the self-hosted relay provider registry as <code>{"object":"list","data":[...]}</code>, with optional metadata.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/relay/server-nodes</span></h3>
+            <p>Returns configured relay server-node URLs for diagnostics and onboarding: <code>configured_servers</code>, <code>primary</code>, <code>secondary</code>, and <code>total</code>.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/relay/unregister</span></h3>
+            <p><strong>Operator-gated.</strong> Removes a registered compute node by <code>server_public_key</code>. This operator endpoint is distinct from compute-node self-unregister control-plane routes.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/relay/servers/next</span></h3>
+            <p>Selects the next registered API v1 compute node for encrypted relay work and returns its <code>server_public_key</code>.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/relay/requests</span></h3>
+            <p>Queues a ciphertext envelope for a selected compute node. Relay-owned state remains ciphertext-only plus safe routing metadata.</p>
+            <p><strong>Ciphertext Envelope:</strong></p>
+            <pre>{
   "server_public_key": "SERVER_PUBLIC_KEY_HERE",
   "client_public_key": "CLIENT_PUBLIC_KEY_HERE",
+  "request_id": "REQUEST_ID_HERE",
   "ciphertext": "ENCRYPTED_DATA_HERE",
   "cipherkey": "ENCRYPTED_AES_KEY_HERE",
   "iv": "INITIALIZATION_VECTOR_HERE"
 }</pre>
+        </div>
 
+        <div class="api-endpoint">
+            <h3><span class="api-method method-post">POST</span> <span class="api-path">/api/v1/relay/responses/retrieve</span></h3>
+            <p>Retrieves an encrypted response envelope by <code>client_public_key</code> and optional <code>request_id</code>. Returns <code>{"status":"pending"}</code> with HTTP 202 while queued work is still pending.</p>
+        </div>
+
+        <h3>Internal relay control-plane routes</h3>
+        <p>These API v1 routes are accounted for in the launch contract but are not general user-facing API endpoints. They are for registered compute nodes or internal relay lifecycle management and must stay ciphertext-only where payload envelopes are exchanged.</p>
+        <table>
+            <thead><tr><th>Route</th><th>Purpose</th></tr></thead>
+            <tbody>
+                <tr><td><code>POST /api/v1/relay/servers/register</code></td><td>Compute node registration and heartbeat lease setup.</td></tr>
+                <tr><td><code>POST /api/v1/relay/servers/unregister</code></td><td>Compute node self-unregister with relay registration authentication.</td></tr>
+                <tr><td><code>POST /api/v1/relay/servers/poll</code></td><td>Compute node long-poll for the next encrypted workload envelope.</td></tr>
+                <tr><td><code>POST /api/v1/relay/requests/cancel</code></td><td>Client request cancellation with a requester proof token.</td></tr>
+                <tr><td><code>POST /api/v1/relay/responses</code></td><td>Compute node stores an encrypted response envelope for client retrieval.</td></tr>
+            </tbody>
+        </table>
+        <p>Internal fail-closed relay dispatch routes <code>POST /relay/api/v1/chat/completions</code> and <code>POST /relay/api/v1/source</code> intentionally reject plaintext distributed API v1 payloads.</p>
+
+        <h3>E2EE Usage and Relay Envelope</h3>
+        <p>API v1 relay traffic is mandatory end-to-end encrypted: relay endpoints are ciphertext-only and reject plaintext-like or unexpected top-level fields. Do not send plaintext top-level keys such as <code>messages</code>, <code>prompt</code>, <code>input</code>, <code>content</code>, <code>response</code>, or <code>text</code> to relay envelope routes.</p>
         <hr>
 
         <h2>Roadmap</h2>

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import relay
+from api.v1 import compute_provider, routes
 
 INDEX_HTML = Path(relay.INDEX_HTML_PATH)
 
@@ -159,5 +160,39 @@ def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
         assert model["object"] == "model"
         assert model["owned_by"] == "token.place"
         assert "permission" in model
+        assert isinstance(model["permission"], list)
+        assert model["permission"]
+        assert model["permission"][0]["object"] == "model_permission"
         assert "metadata" not in model
         assert "adapter" not in model
+
+
+def test_landing_page_model_example_documents_openai_permission_objects():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    models_section = html.split("/api/v1/models/{model_id}", 1)[0]
+
+    assert '"permission": [' in models_section
+    assert '"object": "model_permission"' in models_section
+    assert '"allow_sampling": true' in models_section
+
+
+def test_route_level_generate_response_bridge_is_request_local(monkeypatch):
+    original_compute_generator = compute_provider.generate_response
+
+    def fake_generate_response(model_id, messages, **options):
+        assert model_id == "llama-3-8b-instruct"
+        assert options == {"temperature": 0.2}
+        return messages + [{"role": "assistant", "content": "request-local bridge"}]
+
+    monkeypatch.setattr(routes, "generate_response", fake_generate_response)
+
+    result = routes._call_provider_complete_chat(
+        compute_provider.LocalApiV1ComputeProvider(),
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"temperature": 0.2},
+    )
+
+    assert result == {"role": "assistant", "content": "request-local bridge"}
+    assert compute_provider.generate_response is original_compute_generator
+    assert compute_provider._active_generate_response() is original_compute_generator

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -127,10 +127,11 @@ def test_compute_node_control_plane_routes_are_documented_separately():
         assert f"{method} {path}" not in public_section
         assert f"{method} {path}" in internal_section
 
+    for method, path in sorted(INTERNAL_RELAY_LIFECYCLE_ROUTES):
+        assert f"{method} {path}" not in public_section
+        assert f"{method} {path}" in internal_section
+
     assert "not general user-facing API endpoints" in internal_section
-    assert "POST /api/v1/relay/requests/cancel" in internal_section
-    assert "POST /relay/api/v1/chat/completions" in internal_section
-    assert "POST /relay/api/v1/source" in internal_section
 
 
 def test_api_v1_chat_completions_rejects_stream_true(client):
@@ -172,8 +173,11 @@ def test_landing_page_model_example_documents_openai_permission_objects():
     models_section = html.split("/api/v1/models/{model_id}", 1)[0]
 
     assert '"permission": [' in models_section
+    assert '"permission": ["..."]' not in models_section
     assert '"object": "model_permission"' in models_section
     assert '"allow_sampling": true' in models_section
+    assert '"created": CREATED_UNIX_SECONDS' in models_section
+    assert '"created": 1700000000' not in models_section
 
 
 def test_route_level_generate_response_bridge_is_request_local(monkeypatch):

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -1,0 +1,163 @@
+"""Regression guardrails for the frozen API v1 launch contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import relay
+
+INDEX_HTML = Path(relay.INDEX_HTML_PATH)
+
+PUBLIC_CLIENT_ROUTES = {
+    ("GET", "/api/v1/models"),
+    ("GET", "/api/v1/models/{model_id}"),
+    ("GET", "/api/v1/public-key"),
+    ("POST", "/api/v1/public-key/rotate"),
+    ("POST", "/api/v1/chat/completions"),
+    ("POST", "/api/v1/completions"),
+    ("POST", "/api/v1/images/generations"),
+    ("GET", "/api/v1/health"),
+    ("GET", "/api/v1/community/providers"),
+    ("GET", "/api/v1/community/leaderboard"),
+    ("POST", "/api/v1/community/contributions"),
+    ("GET", "/api/v1/community/contributions/summary"),
+    ("GET", "/api/v1/server-providers"),
+    ("GET", "/api/v1/relay/server-nodes"),
+    ("POST", "/api/v1/relay/unregister"),
+    ("GET", "/api/v1/relay/servers/next"),
+    ("POST", "/api/v1/relay/requests"),
+    ("POST", "/api/v1/relay/responses/retrieve"),
+}
+
+OPENAI_V1_ALIASES = {
+    ("GET", "/v1/models"),
+    ("GET", "/v1/models/{model_id}"),
+    ("GET", "/v1/public-key"),
+    ("POST", "/v1/public-key/rotate"),
+    ("POST", "/v1/relay/unregister"),
+    ("POST", "/v1/chat/completions"),
+    ("POST", "/v1/completions"),
+    ("POST", "/v1/images/generations"),
+    ("GET", "/v1/health"),
+}
+
+COMPUTE_NODE_CONTROL_PLANE_ROUTES = {
+    ("POST", "/api/v1/relay/servers/register"),
+    ("POST", "/api/v1/relay/servers/unregister"),
+    ("POST", "/api/v1/relay/servers/poll"),
+    ("POST", "/api/v1/relay/responses"),
+}
+
+INTERNAL_RELAY_LIFECYCLE_ROUTES = {
+    ("POST", "/api/v1/relay/requests/cancel"),
+    ("POST", "/relay/api/v1/chat/completions"),
+    ("POST", "/relay/api/v1/source"),
+}
+
+DOCUMENTED_INTERNAL_ROUTES = COMPUTE_NODE_CONTROL_PLANE_ROUTES | INTERNAL_RELAY_LIFECYCLE_ROUTES
+
+
+def _normalise_rule(rule: str) -> str:
+    return rule.replace("<model_id>", "{model_id}")
+
+
+def _registered_routes() -> set[tuple[str, str]]:
+    routes: set[tuple[str, str]] = set()
+    for rule in relay.app.url_map.iter_rules():
+        path = _normalise_rule(rule.rule)
+        for method in sorted(rule.methods - {"HEAD", "OPTIONS"}):
+            routes.add((method, path))
+    return routes
+
+
+@pytest.fixture
+def client():
+    relay.app.config["TESTING"] = True
+    with relay.app.test_client() as test_client:
+        yield test_client
+
+
+def test_frozen_api_v1_launch_routes_are_registered_from_flask_url_map():
+    registered = _registered_routes()
+
+    assert PUBLIC_CLIENT_ROUTES <= registered
+    assert OPENAI_V1_ALIASES <= registered
+    assert DOCUMENTED_INTERNAL_ROUTES <= registered
+
+
+def test_no_unclassified_api_v1_routes_leak_into_launch_contract():
+    registered_api_v1 = {
+        (method, path)
+        for method, path in _registered_routes()
+        if path.startswith("/api/v1/") or path.startswith("/v1/") or path.startswith("/relay/api/v1/")
+    }
+    expected = PUBLIC_CLIENT_ROUTES | OPENAI_V1_ALIASES | DOCUMENTED_INTERNAL_ROUTES
+
+    assert registered_api_v1 == expected
+
+
+def test_landing_page_documents_every_public_client_api_v1_route():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "Public/client API v1 launch contract" in html
+    assert "Internal relay control-plane routes" in html
+    public_section = html.split("Internal relay control-plane routes", 1)[0]
+
+    for method, path in sorted(PUBLIC_CLIENT_ROUTES):
+        assert f"{method}</span> <span class=\"api-path\">{path}</span>" in public_section
+
+
+def test_landing_page_documents_openai_aliases_and_excludes_api_v2_launch_docs():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    for _method, path in sorted(OPENAI_V1_ALIASES):
+        assert path in html
+    assert "/api/v2" not in html
+    assert "API v2 is intentionally outside this launch contract" in html
+
+
+def test_compute_node_control_plane_routes_are_documented_separately():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    public_section, internal_section = html.split("Internal relay control-plane routes", 1)
+
+    for method, path in sorted(COMPUTE_NODE_CONTROL_PLANE_ROUTES):
+        assert f"{method} {path}" not in public_section
+        assert f"{method} {path}" in internal_section
+
+    assert "not general user-facing API endpoints" in internal_section
+    assert "POST /api/v1/relay/requests/cancel" in internal_section
+    assert "POST /relay/api/v1/chat/completions" in internal_section
+    assert "POST /relay/api/v1/source" in internal_section
+
+
+def test_api_v1_chat_completions_rejects_stream_true(client):
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"]["param"] == "stream"
+    assert "Streaming is not supported" in payload["error"]["message"]
+
+
+def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
+    response = client.get("/api/v1/models")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["object"] == "list"
+    assert payload["data"]
+    for model in payload["data"]:
+        assert model["object"] == "model"
+        assert model["owned_by"] == "token.place"
+        assert "permission" in model
+        assert "metadata" not in model
+        assert "adapter" not in model


### PR DESCRIPTION
### Motivation
- Freeze and explicitly document the API v1 launch contract for the 0.1.0/0.1.x release so the landing page and tests reflect the production API surface (API v1 only, non-streaming, relay-blind E2EE for relay paths). 
- Surface OpenAI-compatible `/v1` aliases while keeping API v2 out of the v1 launch documentation, and ensure compute-node control-plane routes are accounted for but not presented as user-facing endpoints. 
- Add regression guardrails so accidental route removal, docs drift, or inadvertent API v1 streaming/surface changes fail CI. 

### Description
- Updated `static/index.html` to include a dedicated API v1 launch contract section documenting the public/client v1 routes, `/v1` aliases, operator-gated routes (key rotation, unregister), ciphertext-envelope examples for relay E2EE, and a separate internal control-plane table. 
- Added `tests/unit/test_api_v1_launch_contract.py` which inventories registered Flask routes from the app, asserts that the documented public routes and `/v1` aliases are registered, verifies the landing page documents each public route, ensures internal compute-node control-plane routes are documented separately, asserts `stream=true` is rejected for API v1 chat/completions, and protects the v1 model listing from becoming an API v2 catalog dump. 
- Introduced a small compatibility helper in `api/v1/routes.py` (`_call_provider_complete_chat`) to honor legacy route-level `generate_response` monkeypatches for tests and bridged handling for reloaded `ModelError` objects by formatting them consistently when they originate from reloaded modules. 
- Kept changes narrowly scoped to docs, tests, and a small compatibility/error-handling helper; no API v1 request/response schemas were changed. 

### Testing
- Ran the focused new test: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` and it passed. 
- Ran unit and API suites: `python -m pytest tests/unit/test_api_v1_* tests/test_api.py -v` and `python -m pytest tests/unit -q` and the full Python unit suite passed (summary: all unit tests passed, some Playwright/E2E tests were skipped by default). 
- Ran integration and API checks: `python -m pytest tests/integration` / `python -m pytest tests/test_api.py` and they passed, and `npm run test:js` passed. 
- Verified end-to-end runner: `./run_all_tests.sh` (including JS, Python unit/integration, crypto compatibility) completed successfully in this environment. 
- Ran `pre-commit run --all-files` which passed; captured a landing-page screenshot at `/tmp/tokenplace-api-v1-launch-contract.png` for reviewer preview. 

Notes: E2E relay registration smoke tests remain skipped by default unless `RUN_RELAY_REGISTRATION_TESTS=1` is set; no API v2 content was added to the v1 launch docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25bda0ebc8832f84914fe06d77bbcb)