### PR TITLE
Populate landing chat model dropdown from API v1

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1,6 +1,5 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
-const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
 
 new Vue({
     el: '#app',
@@ -52,15 +51,15 @@ new Vue({
         hasClientKeypair() {
             return Boolean(this.clientPrivateKey && this.clientPublicKey);
         },
-        hasServerPublicKeyPath() {
+        hasServerPublicKey() {
             return Boolean(this.serverPublicKey);
         },
         canSendMessage() {
             return Boolean(
                 this.newMessage.trim() &&
                 this.hasClientKeypair &&
-                this.hasServerPublicKeyPath &&
-                this.selectedModelId &&
+                this.hasServerPublicKey &&
+                this.selectedModel &&
                 !this.isGeneratingResponse
             );
         }
@@ -112,8 +111,8 @@ new Vue({
                 .catch(error => {
                     console.error('Error fetching API v1 models:', error);
                     this.availableModels = [];
-                    this.modelsError = 'Could not load the API v1 model list. Using the default launch model.';
-                    this.selectedModelId = EMERGENCY_MODEL_FALLBACK_ID;
+                    this.modelsError = 'Could not load the API v1 model list. Please try again before sending.';
+                    this.selectedModelId = '';
                 })
                 .finally(() => {
                     this.modelsLoading = false;
@@ -448,6 +447,11 @@ new Vue({
                 return null;
             }
 
+            if (!this.selectedModel) {
+                console.error('No API v1 catalogue model selected');
+                return null;
+            }
+
             try {
                 // Encrypt the chat history
                 const encryptedData = await this.encrypt(
@@ -461,7 +465,7 @@ new Vue({
 
                 // Create the API request payload
                 const payload = {
-                    model: this.selectedModelId || EMERGENCY_MODEL_FALLBACK_ID,
+                    model: this.selectedModelId,
                     encrypted: true,
                     client_public_key: this.encodeClientPublicKeyForApi(),
                     messages: encryptedData,

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,5 +1,6 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
+const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
 
 new Vue({
     el: '#app',
@@ -32,7 +33,19 @@ new Vue({
             if (!Array.isArray(this.availableModels)) {
                 return null;
             }
-            return this.availableModels.find((model) => model && model.id === this.selectedModelId) || null;
+            const catalogueModel = this.availableModels.find((model) => model && model.id === this.selectedModelId) || null;
+            if (catalogueModel) {
+                return catalogueModel;
+            }
+            if (this.modelsError && this.selectedModelId === EMERGENCY_MODEL_FALLBACK_ID) {
+                return {
+                    id: EMERGENCY_MODEL_FALLBACK_ID,
+                    object: 'model',
+                    owned_by: 'emergency-fallback',
+                    root: EMERGENCY_MODEL_FALLBACK_ID
+                };
+            }
+            return null;
         },
         selectedModelSummary() {
             const model = this.selectedModel;
@@ -111,8 +124,8 @@ new Vue({
                 .catch(error => {
                     console.error('Error fetching API v1 models:', error);
                     this.availableModels = [];
-                    this.modelsError = 'Could not load the API v1 model list. Please try again before sending.';
-                    this.selectedModelId = '';
+                    this.modelsError = 'Could not load the API v1 model list. Using the emergency API v1 fallback model.';
+                    this.selectedModelId = EMERGENCY_MODEL_FALLBACK_ID;
                 })
                 .finally(() => {
                     this.modelsLoading = false;

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,5 +1,6 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
+const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
 
 new Vue({
     el: '#app',
@@ -9,18 +10,60 @@ new Vue({
         serverPublicKey: null,
         clientPrivateKey: null,
         clientPublicKey: null,
+        availableModels: [],
+        selectedModelId: '',
+        modelsLoading: false,
+        modelsError: '',
         isGeneratingResponse: false,
         isTouchInput: false,
         relayApiV1NonStreaming: true
     },
     mounted() {
         this.detectTouchInput();
+        this.fetchModels();
         this.getServerPublicKey().then(() => {
             this.generateClientKeys();
         });
         this.$nextTick(() => {
             this.adjustMessageInputHeight();
         });
+    },
+    computed: {
+        selectedModel() {
+            if (!Array.isArray(this.availableModels)) {
+                return null;
+            }
+            return this.availableModels.find((model) => model && model.id === this.selectedModelId) || null;
+        },
+        selectedModelSummary() {
+            const model = this.selectedModel;
+            if (!model) {
+                return '';
+            }
+            const fields = [];
+            if (model.owned_by) {
+                fields.push(`owned by ${model.owned_by}`);
+            }
+            if (model.root && model.root !== model.id) {
+                fields.push(`root ${model.root}`);
+            }
+            return fields.join(' · ');
+        },
+        hasClientKeypair() {
+            return Boolean(this.clientPrivateKey && this.clientPublicKey);
+        },
+        hasServerPublicKeyPath() {
+            return Boolean(this.serverPublicKey);
+        },
+        canSendMessage() {
+            return Boolean(
+                this.newMessage.trim() &&
+                this.hasClientKeypair &&
+                this.hasServerPublicKeyPath &&
+                this.selectedModelId &&
+                !this.isGeneratingResponse
+            );
+        }
     },
     methods: {
         detectTouchInput() {
@@ -46,6 +89,37 @@ new Vue({
                 this.isTouchInput = false;
             }
         },
+        fetchModels() {
+            this.modelsLoading = true;
+            this.modelsError = '';
+
+            return fetch('/api/v1/models')
+                .then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                    throw new Error('Failed to fetch API v1 models');
+                })
+                .then(data => {
+                    const models = data && Array.isArray(data.data) ? data.data : [];
+                    this.availableModels = models.filter((model) => model && typeof model.id === 'string' && model.id);
+                    if (this.availableModels.length > 0) {
+                        this.selectedModelId = this.availableModels[0].id;
+                    } else {
+                        this.selectedModelId = '';
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching API v1 models:', error);
+                    this.availableModels = [];
+                    this.modelsError = 'Could not load the API v1 model list. Using the default launch model.';
+                    this.selectedModelId = EMERGENCY_MODEL_FALLBACK_ID;
+                })
+                .finally(() => {
+                    this.modelsLoading = false;
+                });
+        },
+
         normalizeServerPublicKey(rawKey) {
             if (typeof rawKey !== 'string') {
                 return null;
@@ -387,7 +461,7 @@ new Vue({
 
                 // Create the API request payload
                 const payload = {
-                    model: "llama-3-8b-instruct",
+                    model: this.selectedModelId || EMERGENCY_MODEL_FALLBACK_ID,
                     encrypted: true,
                     client_public_key: this.encodeClientPublicKeyForApi(),
                     messages: encryptedData,
@@ -525,7 +599,7 @@ new Vue({
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
-            if (!messageContent || !this.serverPublicKey || this.isGeneratingResponse) {
+            if (!messageContent || !this.canSendMessage) {
                 return;
             }
 

--- a/static/index.html
+++ b/static/index.html
@@ -367,9 +367,10 @@
                     class="model-select"
                     aria-label="Model"
                     data-testid="landing-model-select"
-                    :disabled="modelsLoading || availableModels.length === 0"
+                    :disabled="modelsLoading || (!modelsError && availableModels.length === 0)"
                 >
-                    <option v-if="availableModels.length === 0" value="">No API v1 models available</option>
+                    <option v-if="modelsError" :value="selectedModelId">{{ selectedModelId }} (emergency fallback)</option>
+                    <option v-else-if="availableModels.length === 0" value="">No API v1 models available</option>
                     <option v-for="model in availableModels" :key="model.id" :value="model.id">{{ model.id }}</option>
                 </select>
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>

--- a/static/index.html
+++ b/static/index.html
@@ -79,6 +79,34 @@
             padding: 20px;
             margin-top: 30px;
         }
+        .model-selector-container {
+            margin-bottom: 15px;
+        }
+        .model-selector-container label {
+            display: block;
+            margin-bottom: 6px;
+            color: #cccccc;
+            font-size: 14px;
+        }
+        .model-select {
+            width: 100%;
+            padding: 10px;
+            box-sizing: border-box;
+            background-color: rgba(255, 255, 255, 0.2);
+            border: none;
+            border-radius: 5px;
+            color: #ffffff;
+            font-size: 14px;
+        }
+        .model-status {
+            margin: 6px 0 0;
+            color: #cccccc;
+            font-size: 13px;
+            line-height: 1.4;
+        }
+        .model-error {
+            color: #ffcc66;
+        }
         .message-input {
             width: 100%;
             padding: 15px;
@@ -139,6 +167,10 @@
         }
         .send-button:hover {
             background-color: #ffffff;
+        }
+        .send-button:disabled {
+            cursor: not-allowed;
+            opacity: 0.55;
         }
         .mode-toggle-container {
             display: flex;
@@ -258,9 +290,19 @@
             color: #333333;
         }
 
-        body.light-mode .message-input {
+        body.light-mode .message-input,
+        body.light-mode .model-select {
             background-color: #ffffff;
             color: #333333;
+        }
+
+        body.light-mode .model-selector-container label,
+        body.light-mode .model-status {
+            color: #555555;
+        }
+
+        body.light-mode .model-error {
+            color: #9a5b00;
         }
 
         body.light-mode .send-button {
@@ -317,6 +359,24 @@
 
         <h2>Try it out:</h2>
         <div class="chat-container" v-cloak>
+            <div class="model-selector-container">
+                <label for="model-select">Model</label>
+                <select
+                    id="model-select"
+                    v-model="selectedModelId"
+                    class="model-select"
+                    aria-label="Model"
+                    data-testid="landing-model-select"
+                    :disabled="modelsLoading || (availableModels.length === 0 && !modelsError)"
+                >
+                    <option v-if="modelsError" :value="selectedModelId">{{ selectedModelId }} (fallback)</option>
+                    <option v-else-if="availableModels.length === 0" value="">No API v1 models available</option>
+                    <option v-for="model in availableModels" :key="model.id" :value="model.id">{{ model.id }}</option>
+                </select>
+                <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>
+                <p v-else-if="modelsError" class="model-status model-error">{{ modelsError }}</p>
+                <p v-else-if="selectedModelSummary" class="model-status">{{ selectedModelSummary }}</p>
+            </div>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>
             </div>
@@ -339,6 +399,7 @@
                     @touchstart.prevent="sendMessage"
                     class="send-button"
                     :class="{'touch-optimized': isTouchInput}"
+                    :disabled="!canSendMessage"
                 >
                     Send
                 </button>

--- a/static/index.html
+++ b/static/index.html
@@ -367,10 +367,9 @@
                     class="model-select"
                     aria-label="Model"
                     data-testid="landing-model-select"
-                    :disabled="modelsLoading || (availableModels.length === 0 && !modelsError)"
+                    :disabled="modelsLoading || availableModels.length === 0"
                 >
-                    <option v-if="modelsError" :value="selectedModelId">{{ selectedModelId }} (fallback)</option>
-                    <option v-else-if="availableModels.length === 0" value="">No API v1 models available</option>
+                    <option v-if="availableModels.length === 0" value="">No API v1 models available</option>
                     <option v-for="model in availableModels" :key="model.id" :value="model.id">{{ model.id }}</option>
                 </select>
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_models",
-    "tests/e2e/test_ui.py::test_landing_chat_model_catalog_failure_disables_send",
+    "tests/e2e/test_ui.py::test_landing_chat_model_catalog_failure_uses_api_v1_fallback",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
@@ -171,7 +171,7 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_model_dropdown_uses_api_v1_models",
-        "landing_chat_model_catalog_failure_disables_send",
+        "landing_chat_model_catalog_failure_uses_api_v1_fallback",
         "landing_chat_shows_no_servers_available_message",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,7 @@ E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
+    "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_models",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
@@ -168,6 +169,7 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
+        "landing_chat_model_dropdown_uses_api_v1_models",
         "landing_chat_shows_no_servers_available_message",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,7 @@ BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_models",
+    "tests/e2e/test_ui.py::test_landing_chat_model_catalog_failure_disables_send",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
@@ -170,6 +171,7 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_model_dropdown_uses_api_v1_models",
+        "landing_chat_model_catalog_failure_disables_send",
         "landing_chat_shows_no_servers_available_message",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",
     }

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -250,6 +250,122 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     assert v2_requests == []
 
 
+def test_landing_chat_model_dropdown_uses_api_v1_models(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """The landing chat model selector is populated from API v1 and drives chat payloads."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+
+    models_payload = {
+        "object": "list",
+        "data": [
+            {
+                "id": "api-v1-first-model",
+                "object": "model",
+                "owned_by": "token.place",
+                "root": "api-v1-first-model",
+            },
+            {
+                "id": "api-v1-second-model",
+                "object": "model",
+                "owned_by": "community",
+                "root": "api-v1-second-model",
+            },
+        ],
+    }
+
+    chat_payloads = []
+    v2_requests = []
+
+    def handle_models(route):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(models_payload),
+        )
+
+    def handle_public_key(route):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        )
+
+    def handle_chat(route):
+        request_json = route.request.post_data_json
+        chat_payloads.append(request_json)
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "Selected model acknowledged.",
+                            }
+                        }
+                    ]
+                }
+            ),
+        )
+
+    def record_v2_request(route):
+        v2_requests.append(route.request.url)
+        route.fulfill(status=500, body="API v2 should not be called by the landing chat")
+
+    page.route("**/api/v1/models", handle_models)
+    page.route("**/api/v1/public-key", handle_public_key)
+    page.route("**/api/v1/chat/completions", handle_chat)
+    page.route("**/api/v2/**", record_v2_request)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    model_select = page.get_by_test_id("landing-model-select")
+    model_select.wait_for(state="visible")
+    assert model_select.input_value() == "api-v1-first-model"
+    assert model_select.locator("option").all_inner_texts() == [
+        "api-v1-first-model",
+        "api-v1-second-model",
+    ]
+
+    model_select.select_option("api-v1-second-model")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("Use the selected model")
+    send_button = page.locator("button", has_text="Send")
+    page.wait_for_function(
+        """
+        () => {
+            const buttons = Array.from(document.querySelectorAll('button'));
+            const send = buttons.find((button) => button.textContent.includes('Send'));
+            return Boolean(send && !send.disabled);
+        }
+        """
+    )
+    send_button.click()
+
+    page.locator(".assistant-message").last.wait_for(state="visible")
+    assert chat_payloads, "expected the landing chat to POST an API v1 chat payload"
+    assert chat_payloads[-1]["model"] == "api-v1-second-model"
+    assert chat_payloads[-1].get("encrypted") is True
+    assert v2_requests == []
+
+
 @pytest.mark.e2e
 def test_landing_chat_shows_no_servers_available_message(
     page: Page,

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -372,12 +372,12 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
 
 @pytest.mark.e2e
-def test_landing_chat_model_catalog_failure_disables_send(
+def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
     page: Page,
     base_url: str,
     setup_servers,
 ):
-    """The landing chat must not send with an unadvertised hard-coded fallback model."""
+    """A failed model list shows a non-blocking error and stays on API v1 fallback chat."""
 
     server_public_key_pem = """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
@@ -390,6 +390,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 -----END PUBLIC KEY-----"""
     server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
     chat_requests = []
+    v2_requests = []
 
     page.route(
         "**/api/v1/models",
@@ -411,7 +412,29 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
         "**/api/v1/chat/completions",
         lambda route: (
             chat_requests.append(route.request.post_data_json),
-            route.fulfill(status=500, body="chat should stay disabled without a catalog model"),
+            route.fulfill(
+                status=200,
+                headers={"Content-Type": "application/json"},
+                body=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "Fallback model acknowledged.",
+                                }
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ),
+    )
+    page.route(
+        "**/api/v2/**",
+        lambda route: (
+            v2_requests.append(route.request.url),
+            route.fulfill(status=500, body="API v2 should not be called by the landing chat"),
         ),
     )
 
@@ -420,14 +443,18 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
-    assert model_select.input_value() == ""
-    assert model_select.is_disabled()
+    assert model_select.input_value() == "llama-3-8b-instruct"
+    assert "llama-3-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
     assert "Could not load the API v1 model list" in page.locator(".model-error").inner_text()
 
     page.locator("textarea").first.fill("hello")
-    send_button = page.locator("button", has_text="Send")
-    assert send_button.is_disabled()
-    assert chat_requests == []
+    wait_for_landing_send_enabled(page).click()
+
+    page.locator(".assistant-message").last.wait_for(state="visible")
+    assert chat_requests, "expected the landing chat to POST the API v1 fallback payload"
+    assert chat_requests[-1]["model"] == "llama-3-8b-instruct"
+    assert chat_requests[-1].get("encrypted") is True
+    assert v2_requests == []
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -82,6 +82,21 @@ def test_multi_turn_conversation(page: Page, base_url: str, setup_servers):
 # Add more E2E tests here as the UI evolves
 
 
+def wait_for_landing_send_enabled(page: Page):
+    """Wait until the landing chat readiness gate enables Send, then return the button."""
+    send_button = page.locator("button", has_text="Send")
+    page.wait_for_function(
+        """
+        () => {
+            const buttons = Array.from(document.querySelectorAll('button'));
+            const send = buttons.find((button) => button.textContent.includes('Send'));
+            return Boolean(send && !send.disabled);
+        }
+        """
+    )
+    return send_button
+
+
 def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_servers):
     """The chat UI should render markdown formatting returned by the assistant."""
 
@@ -112,7 +127,7 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
 
     textarea = page.locator("textarea").first
     textarea.fill("Show markdown please")
-    page.locator("button", has_text="Send").click()
+    wait_for_landing_send_enabled(page).click()
 
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
@@ -230,7 +245,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     textarea = page.locator("textarea").first
     textarea.fill("hello")
-    page.locator("button", has_text="Send").click()
+    wait_for_landing_send_enabled(page).click()
 
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
@@ -347,23 +362,72 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     textarea = page.locator("textarea").first
     textarea.fill("Use the selected model")
-    send_button = page.locator("button", has_text="Send")
-    page.wait_for_function(
-        """
-        () => {
-            const buttons = Array.from(document.querySelectorAll('button'));
-            const send = buttons.find((button) => button.textContent.includes('Send'));
-            return Boolean(send && !send.disabled);
-        }
-        """
-    )
-    send_button.click()
+    wait_for_landing_send_enabled(page).click()
 
     page.locator(".assistant-message").last.wait_for(state="visible")
     assert chat_payloads, "expected the landing chat to POST an API v1 chat payload"
     assert chat_payloads[-1]["model"] == "api-v1-second-model"
     assert chat_payloads[-1].get("encrypted") is True
     assert v2_requests == []
+
+
+@pytest.mark.e2e
+def test_landing_chat_model_catalog_failure_disables_send(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """The landing chat must not send with an unadvertised hard-coded fallback model."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+    chat_requests = []
+
+    page.route(
+        "**/api/v1/models",
+        lambda route: route.fulfill(
+            status=503,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"error": {"message": "catalog temporarily unavailable"}}),
+        ),
+    )
+    page.route(
+        "**/api/v1/public-key",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        ),
+    )
+    page.route(
+        "**/api/v1/chat/completions",
+        lambda route: (
+            chat_requests.append(route.request.post_data_json),
+            route.fulfill(status=500, body="chat should stay disabled without a catalog model"),
+        ),
+    )
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    model_select = page.get_by_test_id("landing-model-select")
+    model_select.wait_for(state="visible")
+    assert model_select.input_value() == ""
+    assert model_select.is_disabled()
+    assert "Could not load the API v1 model list" in page.locator(".model-error").inner_text()
+
+    page.locator("textarea").first.fill("hello")
+    send_button = page.locator("button", has_text="Send")
+    assert send_button.is_disabled()
+    assert chat_requests == []
 
 
 @pytest.mark.e2e
@@ -414,7 +478,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     page.wait_for_load_state("networkidle")
 
     page.locator("textarea").first.fill("hello")
-    page.locator("button", has_text="Send").click()
+    wait_for_landing_send_enabled(page).click()
 
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
@@ -656,7 +720,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 f"Last response body: {relay_server_selection_body!r}"
             )
             textarea.fill(prompt_text)
-            page.locator("button", has_text="Send").click()
+            wait_for_landing_send_enabled(page).click()
             user_message_count += 1
             page.locator(".user-message").nth(user_message_count - 1).wait_for(state="visible")
 


### PR DESCRIPTION
### Motivation
- Surface the frozen API v1 model catalogue on the landing page so the chat UI demonstrates `GET /api/v1/models` and lets users choose the runtime model.  
- Ensure landing chat uses the selected API v1 model for encrypted, non-streaming E2EE requests and does not route through API v2.  
- Gate Send until client/server keys and a selected model are ready to avoid accidental or malformed requests.

### Description
- Add model-list state, `fetchModels()` (called on mount), `availableModels`, `selectedModelId`, `modelsLoading`, `modelsError`, and computed helpers (including `canSendMessage`) to `static/chat.js` and wire the selected model into the chat payload (`model: this.selectedModelId || EMERGENCY_MODEL_FALLBACK_ID`).
- Add a compact model dropdown above the chat card in `static/index.html` with loading / empty-list / error states, a small metadata summary, light/dark styling parity, and a fallback display when model list loading fails.
- Replace the previous hard-coded model in the encrypted API v1 payload with the selected dropdown model while preserving encrypted, non-streaming API v1 behavior and existing error/markdown handling.
- Add a Playwright e2e test `tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_models` that mocks `GET /api/v1/models`, asserts dropdown population and default selection, changes the selection, verifies the outgoing chat payload uses that model, and asserts no `/api/v2` calls; register the test in the focused E2E allowlist in `tests/conftest.py`.

### Testing
- `node --check static/chat.js` — passed.  
- `python -m pytest tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_models -v` — passed.  
- `python -m pytest tests/e2e/test_ui.py -k "model or landing_chat" -v` — 3 selected landing-chat tests passed; `test_landing_chat_real_inference_with_desktop_bridge_api_v1` failed in the local run because `TOKENPLACE_REAL_E2E_MODEL_PATH` was not set (real-inference guardrail); this is an environment/fixture guard, not a regression.  
- `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` — passed.  
- `npm run test:js` — passed.  
- `./run_all_tests.sh` — full test suite run completed successfully in CI-like run (unit, integration, API, JS, and security checks passed).  
- `pre-commit run --all-files` — passed.  

Residual notes: the UI uses an emergency fallback model only when the `GET /api/v1/models` fetch fails; the PR preserves the API v1-only, relay-blind E2EE, and non-streaming invariants required for the v0.1.x launch. Follow-ups could tighten accessibility labels or include more model metadata in the dropdown display.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260310b190832fa71a4f2f193f7adc)