### PR TITLE
Load landing chat models from API v1 and use selection for chat requests

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -11,16 +11,39 @@ new Vue({
         clientPublicKey: null,
         isGeneratingResponse: false,
         isTouchInput: false,
-        relayApiV1NonStreaming: true
+        relayApiV1NonStreaming: true,
+        models: [],
+        selectedModelId: '',
+        isLoadingModels: false,
+        modelListError: ''
     },
     mounted() {
         this.detectTouchInput();
         this.getServerPublicKey().then(() => {
             this.generateClientKeys();
         });
+        this.fetchModels();
         this.$nextTick(() => {
             this.adjustMessageInputHeight();
         });
+    },
+    computed: {
+        canSendMessage() {
+            return Boolean(
+                this.clientPrivateKey &&
+                this.clientPublicKey &&
+                this.serverPublicKey &&
+                this.selectedModelId &&
+                !this.isGeneratingResponse
+            );
+        },
+        selectedModel() {
+            if (!Array.isArray(this.models) || !this.selectedModelId) {
+                return null;
+            }
+
+            return this.models.find((model) => model && model.id === this.selectedModelId) || null;
+        }
     },
     methods: {
         detectTouchInput() {
@@ -99,6 +122,62 @@ new Vue({
             crypt.getKey();
             this.clientPrivateKey = crypt.getPrivateKey();
             this.clientPublicKey = crypt.getPublicKey();
+        },
+
+        fetchModels() {
+            this.isLoadingModels = true;
+            this.modelListError = '';
+
+            return fetch('/api/v1/models')
+                .then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                    throw new Error('Failed to fetch API v1 models');
+                })
+                .then(payload => {
+                    const entries = payload && Array.isArray(payload.data) ? payload.data : [];
+                    this.models = entries.filter((model) => model && typeof model.id === 'string' && model.id.trim());
+                    this.selectedModelId = this.models.length > 0 ? this.models[0].id : '';
+                })
+                .catch(error => {
+                    console.error('Error fetching API v1 models:', error);
+                    this.models = [];
+                    this.selectedModelId = 'llama-3-8b-instruct';
+                    this.modelListError = 'Unable to load the API v1 model list. Using the default launch model.';
+                })
+                .finally(() => {
+                    this.isLoadingModels = false;
+                });
+        },
+
+        formatModelLabel(model) {
+            if (!model || typeof model !== 'object') {
+                return '';
+            }
+
+            const name = typeof model.name === 'string' && model.name.trim() ? model.name.trim() : model.id;
+            return name === model.id ? model.id : `${name} (${model.id})`;
+        },
+
+        selectedModelMetadata() {
+            const model = this.selectedModel;
+            if (!model) {
+                return '';
+            }
+
+            const parts = [];
+            if (typeof model.owned_by === 'string' && model.owned_by.trim()) {
+                parts.push(`owned by ${model.owned_by.trim()}`);
+            }
+            if (typeof model.root === 'string' && model.root.trim() && model.root !== model.id) {
+                parts.push(`root ${model.root.trim()}`);
+            }
+            if (typeof model.description === 'string' && model.description.trim()) {
+                parts.push(model.description.trim());
+            }
+
+            return parts.join(' · ');
         },
 
         // Convert Base64 string to ArrayBuffer
@@ -387,7 +466,7 @@ new Vue({
 
                 // Create the API request payload
                 const payload = {
-                    model: "llama-3-8b-instruct",
+                    model: this.selectedModelId,
                     encrypted: true,
                     client_public_key: this.encodeClientPublicKeyForApi(),
                     messages: encryptedData,
@@ -525,7 +604,7 @@ new Vue({
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
-            if (!messageContent || !this.serverPublicKey || this.isGeneratingResponse) {
+            if (!messageContent || !this.canSendMessage) {
                 return;
             }
 

--- a/static/index.html
+++ b/static/index.html
@@ -109,6 +109,38 @@
             text-align: left;
             background-color: rgba(255, 255, 255, 0.1);
         }
+        .model-picker {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 12px;
+        }
+        .model-picker label {
+            color: #00ffff;
+            font-size: 14px;
+            font-weight: 600;
+        }
+        .model-select {
+            width: 100%;
+            padding: 10px;
+            border: none;
+            border-radius: 5px;
+            background-color: rgba(255, 255, 255, 0.2);
+            color: #ffffff;
+            font-size: 16px;
+        }
+        .model-select option {
+            color: #111111;
+        }
+        .model-status {
+            margin: 0;
+            font-size: 14px;
+            line-height: 1.4;
+            color: #cccccc;
+        }
+        .model-error {
+            color: #ffcc66;
+        }
         .input-container {
             display: flex;
             gap: 12px;
@@ -258,9 +290,22 @@
             color: #333333;
         }
 
-        body.light-mode .message-input {
+        body.light-mode .message-input,
+        body.light-mode .model-select {
             background-color: #ffffff;
             color: #333333;
+        }
+
+        body.light-mode .model-picker label {
+            color: #007bff;
+        }
+
+        body.light-mode .model-status {
+            color: #555555;
+        }
+
+        body.light-mode .model-error {
+            color: #8a5a00;
         }
 
         body.light-mode .send-button {
@@ -317,6 +362,27 @@
 
         <h2>Try it out:</h2>
         <div class="chat-container" v-cloak>
+            <div class="model-picker">
+                <label for="landing-chat-model">Model</label>
+                <select
+                    id="landing-chat-model"
+                    v-model="selectedModelId"
+                    class="model-select"
+                    aria-label="Model"
+                    data-testid="landing-chat-model-select"
+                    :disabled="isLoadingModels || models.length === 0"
+                >
+                    <option v-if="isLoadingModels" value="">Loading API v1 models…</option>
+                    <option v-else-if="models.length === 0" value="">No API v1 models returned</option>
+                    <option v-for="model in models" :key="model.id" :value="model.id">
+                        {{ formatModelLabel(model) }}
+                    </option>
+                </select>
+                <p v-if="isLoadingModels" class="model-status">Loading API v1 models…</p>
+                <p v-else-if="modelListError" class="model-status model-error">{{ modelListError }}</p>
+                <p v-else-if="selectedModelMetadata()" class="model-status">{{ selectedModelMetadata() }}</p>
+                <p v-else-if="models.length === 0" class="model-status">No models are currently advertised by API v1.</p>
+            </div>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>
             </div>
@@ -339,6 +405,7 @@
                     @touchstart.prevent="sendMessage"
                     class="send-button"
                     :class="{'touch-optimized': isTouchInput}"
+                    :disabled="!canSendMessage"
                 >
                     Send
                 </button>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,8 @@ E2E_RELAY_PORT = 5010
 E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
+    "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_selection",
+    "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_falls_back_when_api_v1_models_fail",
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
@@ -167,6 +169,9 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
 
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
+        "model or landing_chat",
+        "landing_chat_model_dropdown_uses_api_v1_selection",
+        "landing_chat_model_dropdown_falls_back_when_api_v1_models_fail",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_shows_no_servers_available_message",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -82,6 +82,128 @@ def test_multi_turn_conversation(page: Page, base_url: str, setup_servers):
 # Add more E2E tests here as the UI evolves
 
 
+def test_landing_chat_model_dropdown_uses_api_v1_selection(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """The landing chat model dropdown should be driven by GET /api/v1/models."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+    requested_models = []
+    v2_requests = []
+
+    page.route(
+        "**/api/v1/public-key",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        ),
+    )
+    page.route(
+        "**/api/v1/models",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "first-api-v1-model",
+                            "object": "model",
+                            "owned_by": "token.place",
+                            "root": "first-api-v1-model",
+                            "description": "First model from the mocked API v1 list.",
+                        },
+                        {
+                            "id": "second-api-v1-model",
+                            "object": "model",
+                            "name": "Second test model",
+                            "owned_by": "community",
+                            "root": "second-api-v1-model",
+                            "description": "Second model from the mocked API v1 list.",
+                        },
+                    ],
+                }
+            ),
+        ),
+    )
+
+    def handle_chat_request(route):
+        request_json = route.request.post_data_json
+        requested_models.append(request_json.get("model"))
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": f"Used {request_json.get('model')}",
+                            }
+                        }
+                    ]
+                }
+            ),
+        )
+
+    def record_v2_request(route):
+        v2_requests.append(route.request.url)
+        route.fulfill(status=500, body="v2 should not be called")
+
+    page.route("**/api/v1/chat/completions", handle_chat_request)
+    page.route("**/api/v2/**", record_v2_request)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    model_select = page.get_by_test_id("landing-chat-model-select")
+    assert model_select.input_value() == "first-api-v1-model"
+    assert model_select.locator("option").nth(0).get_attribute("value") == "first-api-v1-model"
+    assert model_select.locator("option").nth(1).get_attribute("value") == "second-api-v1-model"
+
+    model_select.select_option("second-api-v1-model")
+    send_button = page.locator("button", has_text="Send")
+    send_button.wait_for(state="visible")
+    page.wait_for_function("button => !button.disabled", arg=send_button.element_handle())
+
+    page.locator("textarea").first.fill("hello selected model")
+    send_button.click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+    assert "Used second-api-v1-model" in assistant_message.inner_text()
+    assert requested_models == ["second-api-v1-model"]
+    assert v2_requests == []
+
+
+def test_landing_chat_model_dropdown_falls_back_when_api_v1_models_fail(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """A /api/v1/models failure should show a non-blocking fallback message."""
+
+    page.route("**/api/v1/models", lambda route: route.fulfill(status=503, body="unavailable"))
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    assert page.get_by_text("Unable to load the API v1 model list.").is_visible()
+
+
 def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_servers):
     """The chat UI should render markdown formatting returned by the assistant."""
 


### PR DESCRIPTION
### Motivation
- Demonstrate the frozen API v1 model-list contract on the landing page and let users choose the active model for chat requests instead of a hard-coded model.
- Keep the landing chat E2EE behavior and non-streaming API v1 flow intact while making the UI resilient when the model list is empty or the list fetch fails.
- Provide deterministic, testable UI hooks (data-testid) and focused e2e coverage so the dropdown behavior is validated by Playwright tests.

### Description
- Added model-list state and selection to the Vue app in `static/chat.js`: `models`, `selectedModelId`, `isLoadingModels`, `modelListError`, `fetchModels()` on mount, computed `canSendMessage` gating, and `selectedModel` helpers.
- Replaced the hard-coded model in the encrypted API v1 payload with the selected model id (`model: this.selectedModelId`) while preserving encrypted, non-streaming API v1 behavior in `sendMessageApi()`.
- Added a minimal above-the-fold model dropdown UI in `static/index.html` (loading / empty / error states, compact metadata display, stable `data-testid=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260310b190832fa71a4f2f193f7adc)