### PR TITLE
Add landing chat model selector

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -11,10 +11,15 @@ new Vue({
         clientPublicKey: null,
         isGeneratingResponse: false,
         isTouchInput: false,
-        relayApiV1NonStreaming: true
+        relayApiV1NonStreaming: true,
+        models: [],
+        selectedModelId: '',
+        modelsLoading: false,
+        modelsError: ''
     },
     mounted() {
         this.detectTouchInput();
+        this.fetchModels();
         this.getServerPublicKey().then(() => {
             this.generateClientKeys();
         });
@@ -22,7 +27,83 @@ new Vue({
             this.adjustMessageInputHeight();
         });
     },
+    computed: {
+        selectedModel() {
+            if (!this.selectedModelId || !Array.isArray(this.models)) {
+                return null;
+            }
+            return this.models.find((model) => model && model.id === this.selectedModelId) || null;
+        },
+
+        selectedModelSummary() {
+            const model = this.selectedModel;
+            if (!model) {
+                return '';
+            }
+
+            const details = [];
+            if (model.owned_by) {
+                details.push(`by ${model.owned_by}`);
+            }
+            if (model.root && model.root !== model.id) {
+                details.push(`root ${model.root}`);
+            }
+
+            return details.join(' · ');
+        },
+
+        canSendMessage() {
+            return Boolean(
+                this.newMessage.trim() &&
+                this.clientPrivateKey &&
+                this.clientPublicKey &&
+                this.serverPublicKey &&
+                this.selectedModelId &&
+                !this.isGeneratingResponse
+            );
+        }
+    },
     methods: {
+
+        fetchModels() {
+            this.modelsLoading = true;
+            this.modelsError = '';
+
+            return fetch('/api/v1/models')
+                .then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                    throw new Error('Failed to fetch API v1 models');
+                })
+                .then(data => {
+                    const entries = data && Array.isArray(data.data) ? data.data : [];
+                    this.models = entries.filter((model) => model && typeof model.id === 'string' && model.id.trim());
+                    if (this.models.length > 0) {
+                        this.selectedModelId = this.models[0].id;
+                    } else {
+                        this.selectedModelId = '';
+                        this.modelsError = 'No models are available right now.';
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching API v1 models:', error);
+                    this.models = [];
+                    this.selectedModelId = 'llama-3-8b-instruct';
+                    this.modelsError = 'Could not load models; using the API v1 fallback model.';
+                })
+                .finally(() => {
+                    this.modelsLoading = false;
+                });
+        },
+
+        formatModelLabel(model) {
+            if (!model || typeof model !== 'object') {
+                return '';
+            }
+            return model.name || model.id;
+        },
+
         detectTouchInput() {
             try {
                 const hasWindow = typeof window !== 'undefined';
@@ -369,6 +450,11 @@ new Vue({
 
         // Send a message to the server using the new API
         async sendMessageApi() {
+            if (!this.selectedModelId) {
+                console.error('Model selection not available');
+                return null;
+            }
+
             if (!this.serverPublicKey) {
                 console.error('Server public key not available');
                 return null;
@@ -387,7 +473,7 @@ new Vue({
 
                 // Create the API request payload
                 const payload = {
-                    model: "llama-3-8b-instruct",
+                    model: this.selectedModelId,
                     encrypted: true,
                     client_public_key: this.encodeClientPublicKeyForApi(),
                     messages: encryptedData,
@@ -525,7 +611,7 @@ new Vue({
         // Send a message to the server
         async sendMessage() {
             const messageContent = this.newMessage.trim();
-            if (!messageContent || !this.serverPublicKey || this.isGeneratingResponse) {
+            if (!messageContent || !this.canSendMessage) {
                 return;
             }
 

--- a/static/index.html
+++ b/static/index.html
@@ -79,6 +79,36 @@
             padding: 20px;
             margin-top: 30px;
         }
+        .model-picker {
+            margin-bottom: 15px;
+        }
+        .model-picker label {
+            display: block;
+            margin-bottom: 6px;
+            color: #cccccc;
+            font-size: 14px;
+        }
+        .model-select {
+            width: 100%;
+            padding: 10px;
+            border: none;
+            border-radius: 5px;
+            background-color: rgba(255, 255, 255, 0.2);
+            color: #ffffff;
+            font-size: 16px;
+        }
+        .model-select option {
+            color: #111111;
+        }
+        .model-status {
+            margin: 8px 0 0;
+            color: #cccccc;
+            font-size: 14px;
+            line-height: 1.4;
+        }
+        .model-error {
+            color: #ffcc66;
+        }
         .message-input {
             width: 100%;
             padding: 15px;
@@ -258,6 +288,20 @@
             color: #333333;
         }
 
+        body.light-mode .model-picker label,
+        body.light-mode .model-status {
+            color: #555555;
+        }
+
+        body.light-mode .model-select {
+            background-color: #ffffff;
+            color: #333333;
+        }
+
+        body.light-mode .model-error {
+            color: #8a5a00;
+        }
+
         body.light-mode .message-input {
             background-color: #ffffff;
             color: #333333;
@@ -317,6 +361,26 @@
 
         <h2>Try it out:</h2>
         <div class="chat-container" v-cloak>
+            <div class="model-picker">
+                <label for="landing-chat-model">Model</label>
+                <select
+                    id="landing-chat-model"
+                    v-model="selectedModelId"
+                    class="model-select"
+                    aria-label="Model"
+                    data-testid="landing-chat-model"
+                    :disabled="modelsLoading || (!selectedModelId && models.length === 0)"
+                >
+                    <option v-if="modelsLoading" value="">Loading models…</option>
+                    <option v-else-if="models.length === 0 && selectedModelId" :value="selectedModelId">API v1 fallback ({{ selectedModelId }})</option>
+                    <option v-else-if="models.length === 0" value="">No models available</option>
+                    <option v-for="model in models" :key="model.id" :value="model.id">
+                        {{ formatModelLabel(model) }}
+                    </option>
+                </select>
+                <p v-if="selectedModelSummary" class="model-status" data-testid="landing-chat-model-summary">{{ selectedModelSummary }}</p>
+                <p v-if="modelsError" class="model-status model-error" data-testid="landing-chat-model-error">{{ modelsError }}</p>
+            </div>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>
             </div>
@@ -339,6 +403,7 @@
                     @touchstart.prevent="sendMessage"
                     class="send-button"
                     :class="{'touch-optimized': isTouchInput}"
+                    :disabled="!canSendMessage"
                 >
                     Send
                 </button>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,8 @@ BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
+    "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_uses_api_v1_models_and_selected_payload",
+    "tests/e2e/test_ui.py::test_landing_chat_model_dropdown_handles_models_failure_with_v1_fallback",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
 REAL_DESKTOP_BRIDGE_E2E_NODEID = "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1"
@@ -169,6 +171,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     target_names = {
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_shows_no_servers_available_message",
+        "landing_chat_model_dropdown_uses_api_v1_models_and_selected_payload",
+        "landing_chat_model_dropdown_handles_models_failure_with_v1_fallback",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",
     }
     target_path = "tests/e2e/test_ui.py"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -12,6 +12,20 @@ import time
 
 from encrypt import encrypt
 
+
+def wait_for_landing_chat_send_ready(page: Page) -> None:
+    """Wait until Vue has all API v1 landing-chat prerequisites for Send."""
+
+    page.wait_for_function(
+        """
+        () => {
+            const appEl = document.querySelector('#app');
+            const vm = appEl && appEl.__vue__;
+            return Boolean(vm && vm.canSendMessage === true);
+        }
+        """
+    )
+
 # This test now implicitly uses the `setup_servers` and `page` fixtures
 # defined in tests/conftest.py
 
@@ -112,6 +126,7 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
 
     textarea = page.locator("textarea").first
     textarea.fill("Show markdown please")
+    wait_for_landing_chat_send_ready(page)
     page.locator("button", has_text="Send").click()
 
     assistant_message = page.locator(".assistant-message").last
@@ -230,6 +245,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     textarea = page.locator("textarea").first
     textarea.fill("hello")
+    wait_for_landing_chat_send_ready(page)
     page.locator("button", has_text="Send").click()
 
     assistant_message = page.locator(".assistant-message").last
@@ -247,6 +263,153 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     )
     assert "Relay chat path restored." in assistant_message.inner_text()
     assert "Sorry, I encountered an issue generating a response." not in page.content()
+    assert v2_requests == []
+
+
+def test_landing_chat_model_dropdown_uses_api_v1_models_and_selected_payload(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """Landing chat populates model choices from API v1 and sends the selected model."""
+
+    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
+    model_payload = {
+        "object": "list",
+        "data": [
+            {
+                "id": "first-api-v1-model",
+                "object": "model",
+                "owned_by": "token.place",
+                "root": "first-api-v1-model",
+            },
+            {
+                "id": "second-api-v1-model",
+                "object": "model",
+                "owned_by": "community-node",
+                "root": "second-root",
+            },
+        ],
+    }
+    chat_requests = []
+    v2_requests = []
+
+    page.route(
+        "**/api/v1/public-key",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"public_key": server_public_key_b64}),
+        ),
+    )
+    page.route(
+        "**/api/v1/models",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(model_payload),
+        ),
+    )
+
+    def record_v2_request(route):
+        v2_requests.append(route.request.url)
+        route.fulfill(status=500, body="API v2 should not be called by landing chat")
+
+    def handle_chat_request(route):
+        chat_requests.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "selected model received",
+                            }
+                        }
+                    ]
+                }
+            ),
+        )
+
+    page.route("**/api/v2/**", record_v2_request)
+    page.route("**/api/v1/chat/completions", handle_chat_request)
+
+    page.goto(base_url)
+
+    model_select = page.get_by_test_id("landing-chat-model")
+    model_select.wait_for(state="visible")
+    page.wait_for_function(
+        """
+        () => {
+            const select = document.querySelector('[data-testid="landing-chat-model"]');
+            return Boolean(select && select.options.length === 2 && select.value === 'first-api-v1-model');
+        }
+        """
+    )
+
+    option_values = model_select.locator("option").evaluate_all("options => options.map(option => option.value)")
+    assert option_values == ["first-api-v1-model", "second-api-v1-model"]
+    assert model_select.input_value() == "first-api-v1-model"
+
+    model_select.select_option("second-api-v1-model")
+    page.locator("textarea").first.fill("hello selected model")
+    wait_for_landing_chat_send_ready(page)
+    page.locator("button", has_text="Send").click()
+
+    assistant_message = page.locator(".assistant-message").last
+    assistant_message.wait_for(state="visible")
+    assert "selected model received" in assistant_message.inner_text()
+
+    assert len(chat_requests) == 1
+    assert chat_requests[0]["model"] == "second-api-v1-model"
+    assert chat_requests[0].get("encrypted") is True
+    assert chat_requests[0].get("stream") in (None, False)
+    assert isinstance(chat_requests[0].get("messages"), dict)
+    assert v2_requests == []
+
+
+def test_landing_chat_model_dropdown_handles_models_failure_with_v1_fallback(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """A model-list failure should show a non-blocking error and stay on API v1."""
+
+    v2_requests = []
+
+    page.route(
+        "**/api/v1/models",
+        lambda route: route.fulfill(
+            status=503,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"error": {"message": "model list unavailable"}}),
+        ),
+    )
+
+    def record_v2_request(route):
+        v2_requests.append(route.request.url)
+        route.fulfill(status=500, body="API v2 should not be called by landing chat")
+
+    page.route("**/api/v2/**", record_v2_request)
+
+    page.goto(base_url)
+
+    model_error = page.get_by_test_id("landing-chat-model-error")
+    model_error.wait_for(state="visible")
+    assert "Could not load models" in model_error.inner_text()
+    assert page.get_by_test_id("landing-chat-model").input_value() == "llama-3-8b-instruct"
     assert v2_requests == []
 
 
@@ -298,6 +461,7 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     page.wait_for_load_state("networkidle")
 
     page.locator("textarea").first.fill("hello")
+    wait_for_landing_chat_send_ready(page)
     page.locator("button", has_text="Send").click()
 
     assistant_message = page.locator(".assistant-message").last
@@ -540,6 +704,7 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 f"Last response body: {relay_server_selection_body!r}"
             )
             textarea.fill(prompt_text)
+            wait_for_landing_chat_send_ready(page)
             page.locator("button", has_text="Send").click()
             user_message_count += 1
             page.locator(".user-message").nth(user_message_count - 1).wait_for(state="visible")


### PR DESCRIPTION
### Motivation
- Surface the API v1 model list on the landing chat so users can pick which API v1 model to use for chat requests.
- Keep the landing chat strictly on API v1 non-streaming E2EE behavior and avoid introducing any API v2 paths.

### Description
- Add model-list state and UI: introduce `models`, `selectedModelId`, `modelsLoading`, and `modelsError` to the Vue app and fetch `GET /api/v1/models` on mount. (static/chat.js, static/index.html)
- Add a compact above-the-fold model dropdown labeled "Model" with loading/empty/error states and a small metadata summary. (static/index.html)
- Use the selected model id (`selectedModelId`) in encrypted API v1 chat requests instead of the hard-coded model, preserving encrypted non-streaming metadata. (static/chat.js)
- Gate the Send button behind a computed `canSendMessage` that requires user input, client/server keys, a selected model, and no in-flight response. (static/chat.js, static/index.html)
- E2E tests: add two focused Playwright tests that mock `/api/v1/models` to verify dropdown population, default-first selection, changing selection affects outgoing `model` payload, fallback on models failure, and that API v2 is not called. Add a helper wait and include the new tests in the focused landing-chat allowlist. (tests/e2e/test_ui.py, tests/conftest.py)

### Testing
- Ran focused Playwright tests: `python -m pytest tests/e2e/test_ui.py -k "landing_chat_model" -v` — 2 tests passed (mocked landing-chat scenarios).
- Ran broader E2E selection: `python -m pytest tests/e2e/test_ui.py -k "model or landing_chat" -v` — selected landing-chat tests passed or were skipped per environment guardrails; one real desktop-bridge guardrail test failed when run without `TOKENPLACE_REAL_E2E_MODEL_PATH` (expected guardrail behavior).
- Unit/API test suites: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` and `python -m pytest tests/test_api.py -v` — passed.
- Integration and full test runner: `./run_all_tests.sh` — completed with all unit/integration/API/js checks passing in this environment (E2E real-bridge guardrail skipped unless configured); JavaScript tests via `npm run test:js` passed.
- Pre-commit checks: `pre-commit run --all-files` completed successfully.

Notes/risks: The UI uses the first returned model as the default selection and falls back to the documented API v1 model id `llama-3-8b-instruct` only when the model list request fails; this fallback is explicitly guarded for test/resilience scenarios and does not add API v2 behavior. Follow-ups: consider exposing model descriptions or richer metadata in the dropdown if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260310b190832fa71a4f2f193f7adc)