### PR TITLE
Show live compute-node count on landing page

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -778,7 +778,7 @@ def _log_request(response: Response):
     if getattr(g, "request_id", None):
         response.headers.setdefault("X-Request-Id", g.request_id)
 
-    if endpoint == "metrics":
+    if endpoint in {"metrics", "relay_diagnostics"}:
         response.headers.setdefault("Cache-Control", "no-store")
 
     return response

--- a/static/chat.js
+++ b/static/chat.js
@@ -11,10 +11,39 @@ new Vue({
         clientPublicKey: null,
         isGeneratingResponse: false,
         isTouchInput: false,
-        relayApiV1NonStreaming: true
+        relayApiV1NonStreaming: true,
+        computeNodeCount: null,
+        computeNodeStatus: 'loading',
+        computeNodeLastUpdated: null,
+        computeNodePollIntervalId: null
+    },
+    computed: {
+        computeNodeCountLabel() {
+            if (this.computeNodeStatus === 'ok' && Number.isInteger(this.computeNodeCount)) {
+                return String(this.computeNodeCount);
+            }
+            if (this.computeNodeStatus === 'error') {
+                return 'Unavailable';
+            }
+            return 'Loading…';
+        },
+
+        computeNodeStatusMeta() {
+            if (this.computeNodeStatus === 'ok' && this.computeNodeLastUpdated instanceof Date) {
+                return `last updated ${this.computeNodeLastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+            }
+            if (this.computeNodeStatus === 'error') {
+                return 'diagnostics unavailable';
+            }
+            return 'checking relay diagnostics';
+        }
     },
     mounted() {
         this.detectTouchInput();
+        this.fetchComputeNodeCount();
+        this.computeNodePollIntervalId = setInterval(() => {
+            this.fetchComputeNodeCount();
+        }, 30000);
         this.getServerPublicKey().then(() => {
             this.generateClientKeys();
         });
@@ -23,6 +52,26 @@ new Vue({
         });
     },
     methods: {
+        async fetchComputeNodeCount() {
+            try {
+                const response = await fetch('/relay/diagnostics', { cache: 'no-store' });
+                if (!response.ok) {
+                    throw new Error(`Diagnostics returned ${response.status}`);
+                }
+                const data = await response.json();
+                const count = data && data.total_registered_compute_nodes;
+                if (!Number.isInteger(count) || count < 0) {
+                    throw new Error('Diagnostics response did not include a valid compute-node count');
+                }
+                this.computeNodeCount = count;
+                this.computeNodeStatus = 'ok';
+                this.computeNodeLastUpdated = new Date();
+            } catch (error) {
+                console.warn('Unable to refresh relay compute-node diagnostics:', error);
+                this.computeNodeStatus = 'error';
+            }
+        },
+
         detectTouchInput() {
             try {
                 const hasWindow = typeof window !== 'undefined';
@@ -593,6 +642,10 @@ new Vue({
         }
     },
     beforeDestroy() {
+        if (this.computeNodePollIntervalId) {
+            clearInterval(this.computeNodePollIntervalId);
+            this.computeNodePollIntervalId = null;
+        }
         if (!Array.isArray(this.chatHistory)) {
             return;
         }

--- a/static/index.html
+++ b/static/index.html
@@ -109,6 +109,34 @@
             text-align: left;
             background-color: rgba(255, 255, 255, 0.1);
         }
+        .compute-node-status {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            gap: 8px;
+            margin-top: 24px;
+            margin-bottom: -14px;
+            padding: 12px 16px;
+            border: 1px solid rgba(0, 255, 255, 0.35);
+            border-radius: 8px;
+            background-color: rgba(0, 255, 255, 0.08);
+            color: #ffffff;
+        }
+        .compute-node-status-label {
+            color: #00ffff;
+            font-size: 14px;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        .compute-node-status-value {
+            font-size: 18px;
+            font-weight: 600;
+        }
+        .compute-node-status-meta {
+            color: #cccccc;
+            font-size: 13px;
+        }
         .input-container {
             display: flex;
             gap: 12px;
@@ -258,6 +286,20 @@
             color: #333333;
         }
 
+        body.light-mode .compute-node-status {
+            background-color: #eefbff;
+            border-color: #007bff;
+            color: #333333;
+        }
+
+        body.light-mode .compute-node-status-label {
+            color: #007bff;
+        }
+
+        body.light-mode .compute-node-status-meta {
+            color: #555555;
+        }
+
         body.light-mode .message-input {
             background-color: #ffffff;
             color: #333333;
@@ -316,6 +358,11 @@
         <hr>
 
         <h2>Try it out:</h2>
+        <div class="compute-node-status" v-cloak aria-live="polite">
+            <span class="compute-node-status-label">Live compute nodes</span>
+            <span class="compute-node-status-value">{{ computeNodeCountLabel }}</span>
+            <span class="compute-node-status-meta">{{ computeNodeStatusMeta }}</span>
+        </div>
         <div class="chat-container" v-cloak>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,9 @@ E2E_RELAY_PORT = 5010
 E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
+    "tests/e2e/test_ui.py::test_root_page_loads",
+    "tests/e2e/test_ui.py::test_compute_node_count_renders_and_updates",
+    "tests/e2e/test_ui.py::test_compute_node_count_failure_is_graceful",
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
@@ -167,6 +170,9 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
 
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
+        "root_page_loads",
+        "compute_node_count_renders_and_updates",
+        "compute_node_count_failure_is_graceful",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_shows_no_servers_available_message",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -82,6 +82,58 @@ def test_multi_turn_conversation(page: Page, base_url: str, setup_servers):
 # Add more E2E tests here as the UI evolves
 
 
+def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):
+    """Landing page should render diagnostics count and refresh it without reload."""
+
+    diagnostics_counts = iter([2, 5])
+
+    def handle_diagnostics(route):
+        count = next(diagnostics_counts, 5)
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"total_registered_compute_nodes": count}),
+        )
+
+    page.route("**/relay/diagnostics", handle_diagnostics)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    widget = page.locator(".compute-node-status")
+    assert widget.is_visible()
+    assert "live compute nodes" in widget.inner_text().lower()
+    assert "2" in widget.inner_text()
+
+    page.evaluate(
+        """async () => {
+            const vm = document.querySelector('#app').__vue__;
+            await vm.fetchComputeNodeCount();
+        }"""
+    )
+
+    assert "5" in widget.inner_text()
+    assert "last updated" in widget.inner_text().lower()
+
+
+def test_compute_node_count_failure_is_graceful(page: Page, base_url: str, setup_servers):
+    """Diagnostics failures should not break the landing chat controls."""
+
+    def handle_diagnostics(route):
+        route.fulfill(status=503, headers={"Content-Type": "application/json"}, body="{}")
+
+    page.route("**/relay/diagnostics", handle_diagnostics)
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+
+    widget = page.locator(".compute-node-status")
+    assert widget.is_visible()
+    assert "Unavailable" in widget.inner_text()
+    assert "diagnostics unavailable" in widget.inner_text().lower()
+    assert page.locator("textarea").first.is_visible()
+    assert page.locator("button", has_text="Send").is_visible()
+
 def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_servers):
     """The chat UI should render markdown formatting returned by the assistant."""
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -996,6 +996,86 @@ def test_faucet_unknown_server(client):
     assert data['error'] == {'message': 'Server with the specified public key not found', 'code': 404}
 
 
+
+def test_relay_diagnostics_reports_zero_live_compute_nodes(client):
+    """Empty relay diagnostics should report a zero live compute-node count."""
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert payload["registered_compute_nodes"] == []
+    assert payload["total_registered_compute_nodes"] == 0
+
+
+def test_relay_diagnostics_counts_live_api_v1_compute_nodes(client):
+    """Diagnostics count should include live API v1 compute-node registrations."""
+
+    server_a = _server_key("diagnostics-live-a")
+    server_b = _server_key("diagnostics-live-b")
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["total_registered_compute_nodes"] == 2
+    assert {node["server_public_key"] for node in payload["registered_compute_nodes"]} == {
+        server_a,
+        server_b,
+    }
+
+
+def test_relay_diagnostics_evicts_stale_compute_nodes_before_counting(client):
+    """Diagnostics should run relay TTL eviction before calculating the count."""
+
+    live_server = _server_key("diagnostics-live")
+    stale_server = _server_key("diagnostics-stale")
+    _register_api_v1_server(client, live_server)
+    known_servers[stale_server] = {
+        "public_key": stale_server,
+        "last_ping": datetime.now() - timedelta(seconds=120),
+        "last_ping_duration": 1,
+        relay_module.API_V1_SERVER_MARKER: True,
+    }
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["total_registered_compute_nodes"] == 1
+    assert [node["server_public_key"] for node in payload["registered_compute_nodes"]] == [
+        live_server
+    ]
+    assert stale_server not in known_servers
+
+
+def test_relay_diagnostics_does_not_expose_private_material(client):
+    """Diagnostics must stay limited to safe routing metadata and no private keys."""
+
+    _register_api_v1_server(client, DUMMY_SERVER_PUB_KEY)
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+    payload_text = json.dumps(payload).lower()
+
+    def walk_keys(value):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                yield str(key).lower()
+                yield from walk_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from walk_keys(child)
+
+    assert response.status_code == 200
+    assert "private" not in payload_text
+    assert "secret" not in payload_text
+    assert not any("token" in key for key in walk_keys(payload))
+
+
 def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monkeypatch):
     """Diagnostics should expose configured URLs and live compute registrations."""
     monkeypatch.delenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", raising=False)


### PR DESCRIPTION
### Motivation
- Surface the live number of registered compute nodes near the landing chat so operators can see capacity at a glance without changing the frozen API v1 contract. 
- Use the existing relay diagnostics source (the legacy `/relay/diagnostics` output) and the relay’s eviction/TTL behavior so stale nodes are not counted.

### Description
- Add a compact above-the-fold widget to `static/index.html` showing "Live compute nodes: N" plus a loading/last-updated/error cue and light/dark styles.
- Implement polling and fetch logic in `static/chat.js` with `fetch('/relay/diagnostics', { cache: 'no-store' })`, immediate fetch on mount, 30s interval polling, robust error handling, and interval cleanup in `beforeDestroy`.
- Mark diagnostics responses cache-control-safe by setting `Cache-Control: no-store` for the diagnostics path in `relay.py` (via the global after-request hook) while preserving the existing diagnostics payload and behavior (including TTL eviction which is already invoked by `relay_diagnostics`).
- Add tests: unit tests in `tests/test_relay.py` to assert diagnostics count semantics (zero, live API v1 registrations, stale eviction, and that private/secret/token-like keys are not exposed), e2e Playwright tests in `tests/e2e/test_ui.py` to assert widget render, update without reload, and graceful failure handling, and a small `tests/conftest.py` update to allow focused relay landing tests to run under the focused test guard.

### Testing
- Ran targeted Python unit tests: `python -m pytest tests/test_relay.py tests/unit/test_relay_configured_nodes.py -k "diagnostics or compute_node or server" -v` — all selected tests passed.
- Ran UI Playwright tests: `python -m pytest tests/e2e/test_ui.py -k "compute_node_count or root_page_loads" -v` — the new compute-node-count e2e tests passed (Playwright browsers and deps were installed as part of the run where needed).
- Ran JavaScript checks: `npm run test:js` — JS tests passed.
- Ran full suite: `./run_all_tests.sh` — full test runner succeeded (unit, integration, API, and crypto compatibility suites passed in CI-like run).
- Ran pre-commit checks: `pre-commit run --all-files` — hooks passed.

All changes preserve the API v1 contract and only consume the existing diagnostics endpoint; no new public API routes were added. A screenshot of the landing page with the widget was captured at `/tmp/tokenplace-compute-node-count.png` during verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2603a8a020832fbdebabe283cacd0a)