### PR TITLE
Show live compute-node count on landing page

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -778,7 +778,7 @@ def _log_request(response: Response):
     if getattr(g, "request_id", None):
         response.headers.setdefault("X-Request-Id", g.request_id)
 
-    if endpoint == "metrics":
+    if endpoint in {"metrics", "relay_diagnostics"}:
         response.headers.setdefault("Cache-Control", "no-store")
 
     return response

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,5 +1,6 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
+const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 
 new Vue({
     el: '#app',
@@ -11,7 +12,11 @@ new Vue({
         clientPublicKey: null,
         isGeneratingResponse: false,
         isTouchInput: false,
-        relayApiV1NonStreaming: true
+        relayApiV1NonStreaming: true,
+        computeNodeCount: null,
+        computeNodeCountStatus: 'loading',
+        computeNodeCountLastUpdated: null,
+        computeNodeCountPoller: null
     },
     mounted() {
         this.detectTouchInput();
@@ -21,8 +26,43 @@ new Vue({
         this.$nextTick(() => {
             this.adjustMessageInputHeight();
         });
+        this.fetchComputeNodeCount();
+        this.computeNodeCountPoller = setInterval(() => {
+            this.fetchComputeNodeCount();
+        }, COMPUTE_NODE_COUNT_POLL_INTERVAL_MS);
     },
     methods: {
+        async fetchComputeNodeCount() {
+            try {
+                const response = await fetch('/relay/diagnostics', { cache: 'no-store' });
+                if (!response.ok) {
+                    throw new Error(`Diagnostics request failed with status ${response.status}`);
+                }
+
+                const diagnostics = await response.json();
+                let count = diagnostics && diagnostics.total_registered_compute_nodes;
+                if (typeof count !== 'number' && Array.isArray(diagnostics && diagnostics.registered_compute_nodes)) {
+                    count = diagnostics.registered_compute_nodes.length;
+                }
+                if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) {
+                    throw new Error('Diagnostics response did not include a valid compute-node count');
+                }
+
+                this.computeNodeCount = Math.floor(count);
+                this.computeNodeCountStatus = 'ready';
+                this.computeNodeCountLastUpdated = new Date().toLocaleTimeString([], {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
+                });
+            } catch (error) {
+                console.warn('Unable to refresh compute-node diagnostics:', error);
+                this.computeNodeCount = null;
+                this.computeNodeCountStatus = 'error';
+                this.computeNodeCountLastUpdated = null;
+            }
+        },
+
         detectTouchInput() {
             try {
                 const hasWindow = typeof window !== 'undefined';
@@ -593,6 +633,10 @@ new Vue({
         }
     },
     beforeDestroy() {
+        if (this.computeNodeCountPoller) {
+            clearInterval(this.computeNodeCountPoller);
+            this.computeNodeCountPoller = null;
+        }
         if (!Array.isArray(this.chatHistory)) {
             return;
         }

--- a/static/index.html
+++ b/static/index.html
@@ -79,6 +79,32 @@
             padding: 20px;
             margin-top: 30px;
         }
+        .compute-node-status {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 16px;
+            padding: 10px 12px;
+            border: 1px solid rgba(0, 255, 255, 0.35);
+            border-radius: 8px;
+            background-color: rgba(0, 255, 255, 0.08);
+            color: #ffffff;
+            font-size: 15px;
+        }
+        .compute-node-status strong {
+            color: #00ffff;
+            font-weight: 500;
+        }
+        .compute-node-status small {
+            color: #bbbbbb;
+            font-size: 12px;
+        }
+        .compute-node-status.error {
+            border-color: rgba(255, 255, 255, 0.18);
+            background-color: rgba(255, 255, 255, 0.06);
+        }
         .message-input {
             width: 100%;
             padding: 15px;
@@ -243,6 +269,20 @@
             background-color: #ffffff;
         }
 
+        body.light-mode .compute-node-status {
+            border-color: rgba(0, 123, 255, 0.35);
+            background-color: rgba(0, 123, 255, 0.08);
+            color: #333333;
+        }
+
+        body.light-mode .compute-node-status strong {
+            color: #007bff;
+        }
+
+        body.light-mode .compute-node-status small {
+            color: #666666;
+        }
+
         body.light-mode .message {
             background-color: #eeeeee;
             color: #333333;
@@ -317,6 +357,20 @@
 
         <h2>Try it out:</h2>
         <div class="chat-container" v-cloak>
+            <div
+                class="compute-node-status"
+                :class="{error: computeNodeCountStatus === 'error'}"
+                data-testid="compute-node-count"
+                aria-live="polite"
+            >
+                <span>
+                    <strong>Live compute nodes:</strong>
+                    <span v-if="computeNodeCountStatus === 'loading'">Loading…</span>
+                    <span v-else-if="computeNodeCountStatus === 'ready'">{{ computeNodeCount }}</span>
+                    <span v-else>temporarily unavailable</span>
+                </span>
+                <small v-if="computeNodeCountLastUpdated">Last updated {{ computeNodeCountLastUpdated }}</small>
+            </div>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>
             </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,10 @@ E2E_RELAY_PORT = 5010
 E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
+    "tests/e2e/test_ui.py::test_root_page_loads",
+    "tests/e2e/test_ui.py::test_compute_node_count_renders_diagnostics_count",
+    "tests/e2e/test_ui.py::test_compute_node_count_updates_on_refresh_without_page_reload",
+    "tests/e2e/test_ui.py::test_compute_node_count_failure_is_graceful",
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_shows_no_servers_available_message",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
@@ -167,6 +171,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
 
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
+        "root_page_loads",
+        "compute_node_count",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_shows_no_servers_available_message",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",
@@ -185,8 +191,10 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
         return False
 
     for i, arg in enumerate(invocation_args):
-        if arg == "-k" and i + 1 < len(invocation_args) and invocation_args[i + 1] in target_names:
-            return True
+        if arg == "-k" and i + 1 < len(invocation_args):
+            selected_expression = invocation_args[i + 1]
+            if any(target_name in selected_expression for target_name in target_names):
+                return True
 
     return False
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 import sys
 import threading
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 import time
 
 from encrypt import encrypt
@@ -36,6 +36,74 @@ def test_root_page_loads(page: Page, base_url: str, setup_servers):
     headings = page.locator("h1, h2, h3").all()
     assert len(headings) > 0, "Page should contain at least one heading"
     print(f"✓ Found {len(headings)} headings on the page")
+
+
+def test_compute_node_count_renders_diagnostics_count(page: Page, base_url: str, setup_servers):
+    """Landing page should render the relay diagnostics compute-node count."""
+
+    page.route(
+        "**/relay/diagnostics",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json", "Cache-Control": "no-store"},
+            body=json.dumps({"total_registered_compute_nodes": 3}),
+        ),
+    )
+
+    page.goto(base_url)
+    widget = page.locator('[data-testid="compute-node-count"]')
+    widget.wait_for(state="visible")
+    expect(widget).to_contain_text(re.compile(r"Live compute nodes:\s*3"))
+    assert "Last updated" in widget.inner_text()
+
+
+def test_compute_node_count_updates_on_refresh_without_page_reload(
+    page: Page, base_url: str, setup_servers
+):
+    """The diagnostics widget should update when its Vue refresh method runs."""
+
+    current_count = {"value": 1}
+
+    def handle_diagnostics(route):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json", "Cache-Control": "no-store"},
+            body=json.dumps({"total_registered_compute_nodes": current_count["value"]}),
+        )
+
+    page.route("**/relay/diagnostics", handle_diagnostics)
+
+    page.goto(base_url)
+    selector = '[data-testid="compute-node-count"]'
+    expect(page.locator(selector)).to_contain_text(re.compile(r"Live compute nodes:\s*1"))
+
+    current_count["value"] = 5
+    page.evaluate("() => document.querySelector('#app').__vue__.fetchComputeNodeCount()")
+    expect(page.locator(selector)).to_contain_text(re.compile(r"Live compute nodes:\s*5"))
+
+
+def test_compute_node_count_failure_is_graceful(page: Page, base_url: str, setup_servers):
+    """Diagnostics failures should show a non-alarming status and leave chat UI usable."""
+
+    page.route(
+        "**/relay/diagnostics",
+        lambda route: route.fulfill(
+            status=503,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"error": "diagnostics unavailable"}),
+        ),
+    )
+
+    page.goto(base_url)
+    widget = page.locator('[data-testid="compute-node-count"]')
+    widget.wait_for(state="visible")
+    page.wait_for_function(
+        "selector => document.querySelector(selector)?.textContent.includes('temporarily unavailable')",
+        arg='[data-testid="compute-node-count"]',
+    )
+    assert page.locator("textarea").first.is_enabled()
+    assert page.locator("button", has_text="Send").is_enabled()
+
 
 def test_send_message(page: Page, base_url: str, setup_servers):
     """Test basic page interaction."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -261,6 +261,90 @@ def _queue_api_v1_request(client, *, server_public_key, request_id, client_publi
     assert response.status_code == 200
     return response
 
+
+def test_relay_diagnostics_count_includes_live_api_v1_compute_nodes(client):
+    """Diagnostics should expose the live registered compute-node total operators curl."""
+
+    server_a = _server_key("diag-live-a")
+    server_b = _server_key("diag-live-b")
+    _register_api_v1_server(client, server_a)
+    _register_api_v1_server(client, server_b)
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert payload["total_registered_compute_nodes"] == 2
+    assert {node["server_public_key"] for node in payload["registered_compute_nodes"]} == {
+        server_a,
+        server_b,
+    }
+
+
+def test_relay_diagnostics_empty_relay_returns_zero(client):
+    """Diagnostics should report zero, not an error, when no compute nodes are live."""
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["total_registered_compute_nodes"] == 0
+    assert payload["registered_compute_nodes"] == []
+
+
+def test_relay_diagnostics_evicts_stale_compute_nodes_before_count(client):
+    """Stale registrations should be evicted before diagnostics calculates the count."""
+
+    live_server = _server_key("diag-live")
+    stale_server = _server_key("diag-stale")
+    _register_api_v1_server(client, live_server)
+    _register_api_v1_server(client, stale_server)
+    known_servers[stale_server]["last_ping"] = datetime.now() - timedelta(seconds=120)
+    known_servers[stale_server]["last_ping_duration"] = 1
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["total_registered_compute_nodes"] == 1
+    assert [node["server_public_key"] for node in payload["registered_compute_nodes"]] == [
+        live_server
+    ]
+    assert stale_server not in known_servers
+
+
+def test_relay_diagnostics_does_not_expose_private_material(client):
+    """Diagnostics must stay safe for operator curl usage and avoid private fields."""
+
+    server_public_key = _server_key("diag-safe")
+    known_servers[server_public_key] = {
+        "public_key": server_public_key,
+        "last_ping": datetime.now(),
+        "last_ping_duration": 10,
+        relay_module.API_V1_SERVER_MARKER: True,
+        "private_key": "should-not-leak",
+        "api_key": "secret-token",
+        "cipherkey": "opaque-but-not-needed",
+    }
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+    encoded = json.dumps(payload)
+
+    assert response.status_code == 200
+    assert payload["total_registered_compute_nodes"] == 1
+    assert "should-not-leak" not in encoded
+    assert "secret-token" not in encoded
+    assert "private_key" not in encoded
+    assert "api_key" not in encoded
+    assert set(payload["registered_compute_nodes"][0]) == {
+        "server_public_key",
+        "age_seconds",
+        "next_ping_in_x_seconds",
+        "queue_depth",
+    }
+
 # --- Test /sink ---
 
 def test_sink_register_new_server(client):


### PR DESCRIPTION
### Motivation
- Surface the live number of registered API v1 compute nodes above the landing chat without changing the frozen API v1 contract by reusing the existing relay diagnostics source.
- Keep the widget non-blocking for chat flows, avoid exposing private relay internals, and ensure stale nodes are evicted per existing relay TTL/eviction behavior.

### Description
- Add a compact above-the-fold compute-node status widget and styles to `static/index.html` that shows loading / ready / error states and a small “Last updated” timestamp.
- Implement polling in `static/chat.js` with an immediate fetch, a 30s interval (`COMPUTE_NODE_COUNT_POLL_INTERVAL_MS`), `fetch('/relay/diagnostics', { cache: 'no-store' })`, robust parsing (fallback to `registered_compute_nodes.length`), error handling, and interval cleanup in `beforeDestroy`.
- Harden the diagnostics response caching by setting `Cache-Control: no-store` for diagnostics responses in `relay.py` (keeps metrics behaviour unchanged and remains backward compatible for operator curl users).
- Add tests: unit tests in `tests/test_relay.py` that assert `total_registered_compute_nodes`, eviction of stale nodes, empty case, `no-store` behavior and that diagnostics do not leak private fields; Playwright e2e tests in `tests/e2e/test_ui.py` that mock `/relay/diagnostics` to assert rendering, in-page refresh updates, and graceful failure; small focused test fixture change in `tests/conftest.py` to allow running the landing-page focused e2e checks.

### Testing
- Ran unit and relay tests: `python -m pytest tests/test_relay.py tests/unit/test_relay_configured_nodes.py -k "diagnostics or compute_node or server" -v` (passed).
- Ran focused e2e UI tests: `python -m pytest tests/e2e/test_ui.py -k "compute_node_count or root_page_loads" -v` (Playwright tests for the compute-node widget passed in the focused runs; browser dependencies were installed as needed during CI-local verification).
- Ran full project checks: `./run_all_tests.sh` and `npm run test:js` (JavaScript tests passed) and `pre-commit run --all-files` (passed); overall test suite passed in the verification run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2603a8a020832fbdebabe283cacd0a)