### PR TITLE
Add opt-in integration test for repository-root server.py compute-node, graceful shutdown, and docs

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -46,6 +46,34 @@ Integration tests verify that components work together correctly:
 python -m pytest tests/integration/
 ```
 
+#### Headless `server.py` compute-node CLI validation
+
+The desktop Tauri app is the preferred operator experience, but the repository-root
+`server.py` file remains the canonical simple headless compute-node entrypoint and
+is the CLI analogue of the desktop bridge. For local mock validation, start a relay
+and then launch a compute node with only a relay URL and a local server port:
+
+```bash
+python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm
+USE_MOCK_LLM=1 python server.py --relay_url http://127.0.0.1:5010 --server_port 3001
+```
+
+Operators can verify live registration counts without exposing model payload
+plaintext by querying relay diagnostics:
+
+```bash
+curl http://127.0.0.1:5010/relay/diagnostics
+```
+
+The process-level regression test launches `relay.py` plus one or more plain
+`server.py` processes, verifies the live API v1 compute-node count, and completes a
+mock encrypted API v1 chat through the relay. Because it creates multiple child
+processes and local ports, it is opt-in:
+
+```bash
+RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest tests/integration -k "server_py or compute_node_cli" -v
+```
+
 ### End-to-End (E2E) Tests
 
 **Pytest marker**: `e2e`

--- a/server.py
+++ b/server.py
@@ -5,7 +5,9 @@ Main server application module that integrates all components.
 """
 import os
 import argparse
+import atexit
 import logging
+import signal
 import sys
 from flask import Flask, request, jsonify
 from typing import Optional
@@ -149,6 +151,10 @@ class ServerApp:
         """Start polling the relay in a background thread."""
         self.runtime.start_relay_polling()
 
+    def stop(self):
+        """Stop relay polling and best-effort unregister this compute node."""
+        self.runtime.stop()
+
     def run(self):
         """Run the server application."""
         log_info(f"Starting server on port {self.server_port}")
@@ -203,6 +209,27 @@ def main():
         relay_port=relay_port,
         relay_url=relay_url
     )
+    stopped = False
+
+    def _stop_server_once():
+        nonlocal stopped
+        if stopped:
+            return
+        stopped = True
+        server.stop()
+
+    def _handle_shutdown(signum, _frame):
+        log_info(f"Received shutdown signal {signum}; unregistering compute node")
+        _stop_server_once()
+        raise SystemExit(0)
+
+    atexit.register(_stop_server_once)
+    for shutdown_signal in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(shutdown_signal, _handle_shutdown)
+        except (OSError, RuntimeError, ValueError, AttributeError):
+            log_error(f"Failed to install shutdown handler for signal {shutdown_signal}")
+
     server.run()
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/integration/test_server_py_compute_node_cli.py
+++ b/tests/integration/test_server_py_compute_node_cli.py
@@ -1,0 +1,229 @@
+"""Process-level regression tests for the canonical ``server.py`` compute node."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from api.v1.encryption import EncryptionManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_http_ok(url: str, *, timeout: float = 10.0) -> dict:
+    deadline = time.time() + timeout
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(url, timeout=0.5)
+            if response.status_code == 200:
+                return response.json()
+        except (requests.RequestException, ValueError) as exc:
+            last_error = exc
+        time.sleep(0.05)
+    raise AssertionError(f"Timed out waiting for {url}: {last_error}")
+
+
+def _wait_for_compute_count(relay_url: str, expected: int, *, timeout: float = 10.0) -> dict:
+    deadline = time.time() + timeout
+    last_payload: dict | None = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"{relay_url}/relay/diagnostics", timeout=1)
+            response.raise_for_status()
+            payload = response.json()
+            last_payload = payload
+            if payload.get("total_api_v1_registered_compute_nodes") == expected:
+                return payload
+        except (requests.RequestException, ValueError):
+            pass
+        time.sleep(0.05)
+    raise AssertionError(
+        f"Timed out waiting for {expected} compute nodes; last diagnostics={last_payload}"
+    )
+
+
+def _terminate_process(process: subprocess.Popen[str], *, timeout: float = 5.0) -> str:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            return process.communicate(timeout=timeout)[0]
+        except subprocess.TimeoutExpired:
+            process.kill()
+            return process.communicate(timeout=timeout)[0]
+    return process.communicate(timeout=timeout)[0]
+
+
+def _start_relay_process(relay_port: int) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "TOKEN_PLACE_ENV": "testing",
+            "ENVIRONMENT": "test",
+            "USE_MOCK_LLM": "1",
+            "CONTENT_MODERATION_MODE": "off",
+            "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.05",
+            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
+            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+            "TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS": "8",
+            "TOKENPLACE_PENDING_REQUEST_TTL_SECONDS": "8",
+            "TOKENPLACE_TERMINAL_REQUEST_TTL_SECONDS": "8",
+        }
+    )
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "relay.py",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(relay_port),
+            "--use_mock_llm",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _start_server_py_process(relay_url: str, server_port: int) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "TOKEN_PLACE_ENV": "testing",
+            "ENVIRONMENT": "test",
+            "USE_MOCK_LLM": "1",
+            "TOKENPLACE_MAX_POLL_FAILURES": "200",
+            "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.05",
+            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
+            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+        }
+    )
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "server.py",
+            "--relay_url",
+            relay_url,
+            "--server_host",
+            "127.0.0.1",
+            "--server_port",
+            str(server_port),
+            "--use_mock_llm",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _encrypt_messages(messages: list[dict], relay_public_key: str) -> tuple[EncryptionManager, dict]:
+    browser_crypto = EncryptionManager()
+    encrypted = browser_crypto.encrypt_message(messages, relay_public_key)
+    assert encrypted is not None
+    return browser_crypto, {
+        "ciphertext": encrypted["ciphertext"],
+        "cipherkey": encrypted["cipherkey"],
+        "iv": encrypted["iv"],
+    }
+
+
+def _decrypt_completion(browser_crypto: EncryptionManager, response_body: dict) -> dict:
+    encrypted = response_body["data"]
+    decrypted = browser_crypto.decrypt_message(
+        {
+            "ciphertext": base64.b64decode(encrypted["ciphertext"]),
+            "iv": base64.b64decode(encrypted["iv"]),
+        },
+        base64.b64decode(encrypted["cipherkey"]),
+    )
+    assert decrypted is not None
+    return json.loads(decrypted.decode("utf-8"))
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_RELAY_REGISTRATION_TESTS") != "1",
+    reason="process-level relay/server.py e2e test is opt-in; set RUN_RELAY_REGISTRATION_TESTS=1",
+)
+def test_server_py_cli_registers_counts_and_completes_api_v1_e2ee_work():
+    relay_port = _free_port()
+    relay_url = f"http://127.0.0.1:{relay_port}"
+    relay_process = _start_relay_process(relay_port)
+    server_processes: list[subprocess.Popen[str]] = []
+    process_logs: list[str] = []
+
+    try:
+        _wait_for_http_ok(f"{relay_url}/healthz", timeout=10)
+        initial = _wait_for_compute_count(relay_url, 0, timeout=5)
+        assert initial["registered_compute_nodes"] == []
+
+        first_server = _start_server_py_process(relay_url, _free_port())
+        server_processes.append(first_server)
+        first_count = _wait_for_compute_count(relay_url, 1, timeout=10)
+        assert len(first_count["api_v1_registered_compute_nodes"]) == 1
+
+        relay_public_key = requests.get(f"{relay_url}/api/v1/public-key", timeout=2).json()[
+            "public_key"
+        ]
+        browser_crypto, encrypted_messages = _encrypt_messages(
+            [{"role": "user", "content": "hello from server.py cli e2e"}],
+            relay_public_key,
+        )
+        response = requests.post(
+            f"{relay_url}/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "encrypted": True,
+                "client_public_key": browser_crypto.public_key_b64,
+                "messages": encrypted_messages,
+                "metadata": {
+                    "inference_target": "desktop_bridge_api_v1_e2ee",
+                    "relay_path": "api_v1_e2ee",
+                },
+            },
+            timeout=12,
+        )
+        assert response.status_code == 200, response.text
+        completion = _decrypt_completion(browser_crypto, response.json())
+        assert completion["choices"][0]["message"]["content"] == (
+            "Mock Response: The capital of France is Paris."
+        )
+
+        second_server = _start_server_py_process(relay_url, _free_port())
+        server_processes.append(second_server)
+        second_count = _wait_for_compute_count(relay_url, 2, timeout=10)
+        assert len(second_count["api_v1_registered_compute_nodes"]) == 2
+
+        process_logs.append(_terminate_process(server_processes.pop(), timeout=5))
+        _wait_for_compute_count(relay_url, 1, timeout=10)
+        process_logs.append(_terminate_process(server_processes.pop(), timeout=5))
+        _wait_for_compute_count(relay_url, 0, timeout=10)
+    finally:
+        for process in reversed(server_processes):
+            process_logs.append(_terminate_process(process, timeout=5))
+        relay_output = _terminate_process(relay_process, timeout=5)
+        if relay_process.returncode not in (0, -15) and relay_process.returncode is not None:
+            pytest.fail(f"relay.py exited with {relay_process.returncode}:\n{relay_output}")
+        for output in process_logs:
+            if "Traceback" in output:
+                pytest.fail(f"server.py emitted traceback:\n{output}")


### PR DESCRIPTION
### Motivation
- Ensure the simple CLI compute-node entrypoint `server.py` remains a fully functional API v1 compute node (registers with relay, polls API v1 E2EE work, answers a request, and appears in relay diagnostics). 
- Add an automated end-to-end regression that exercises the plain `server.py` process-level flow without requiring desktop Tauri or real model binaries. 
- Make shutdown/unregister behavior testable and robust so CI and local operators can start/stop headless compute nodes reliably.

### Description
- Added graceful shutdown and best-effort unregister wiring to the canonical CLI `server.py` by registering `atexit` and `SIGTERM`/`SIGINT` handlers and exposing a `stop()` method that delegates to the runtime stop/unregister logic. 
- Added an opt-in process-level integration test `tests/integration/test_server_py_compute_node_cli.py` that launches `relay.py` and one or more `server.py` processes (mock LLM), verifies `/relay/diagnostics` counts, submits an encrypted API v1 chat, and cleans up child processes; the test is gated behind `RUN_RELAY_REGISTRATION_TESTS=1`. 
- Updated `docs/TESTING.md` with a short CLI compute-node example and instructions to run the opt-in regression, and noted the diagnostics `curl` check. 

### Testing
- Ran the opt-in integration test with: `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest tests/integration/test_server_py_compute_node_cli.py -q` and it passed when enabled (the test is skipped by default). 
- Exercised related unit/integration suites with: `python -m pytest tests/unit/test_compute_node_runtime.py tests/unit/test_relay_client.py tests/test_relay.py -v` and the targeted tests passed. 
- Ran full pipeline via `./run_all_tests.sh` which installs Playwright browsers as needed and completed successfully (observed 303 passed during the run). 
- Notes: Playwright-based UI tests require browser binaries; an initial run of the e2e UI subset failed until `./run_all_tests.sh` installed the Playwright browsers, after which the full test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262a36cfa8832f93de0248f2002b63)