### PR TITLE
Add guarded integration test for server.py CLI, ensure graceful shutdown unregisters, and document CLI validation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -46,6 +46,31 @@ Integration tests verify that components work together correctly:
 python -m pytest tests/integration/
 ```
 
+#### Headless CLI compute-node validation
+
+The desktop Tauri app is the preferred operator experience, but repository-root
+`server.py` remains the canonical simple headless equivalent for running a compute
+node against a relay. A local mock run does not require a GPU, llama.cpp model
+download, GGUF file, or desktop bridge:
+
+```bash
+USE_MOCK_LLM=1 python server.py --relay_url http://127.0.0.1:5010 --server_port 3001
+```
+
+Operators can confirm registration and live counts from the relay diagnostics
+endpoint:
+
+```bash
+curl http://127.0.0.1:5010/relay/diagnostics
+```
+
+The process-level regression test launches `relay.py` plus one or more `server.py`
+subprocesses, so it is guarded behind `RUN_RELAY_REGISTRATION_TESTS=1`:
+
+```bash
+RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest tests/integration -k "server_py or compute_node_cli" -v
+```
+
 ### End-to-End (E2E) Tests
 
 **Pytest marker**: `e2e`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -57,6 +57,10 @@ download, GGUF file, or desktop bridge:
 USE_MOCK_LLM=1 python server.py --relay_url http://127.0.0.1:5010 --server_port 3001
 ```
 
+An explicit `--relay_url` is authoritative for this CLI command, so stale
+relay environment variables from another deployment should not redirect this
+local validation run.
+
 Operators can confirm registration and live counts from the relay diagnostics
 endpoint:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,7 +54,9 @@ node against a relay. A local mock run does not require a GPU, llama.cpp model
 download, GGUF file, or desktop bridge:
 
 ```bash
+python relay.py --host 127.0.0.1 --port 5010 --use_mock_llm
 USE_MOCK_LLM=1 python server.py --relay_url http://127.0.0.1:5010 --server_port 3001
+curl http://127.0.0.1:5010/relay/diagnostics
 ```
 
 An explicit `--relay_url` is authoritative for this CLI command, so stale
@@ -62,11 +64,7 @@ relay environment variables from another deployment should not redirect this
 local validation run.
 
 Operators can confirm registration and live counts from the relay diagnostics
-endpoint:
-
-```bash
-curl http://127.0.0.1:5010/relay/diagnostics
-```
+endpoint shown in the example above.
 
 The process-level regression test launches `relay.py` plus one or more `server.py`
 subprocesses, so it is guarded behind `RUN_RELAY_REGISTRATION_TESTS=1`:

--- a/server.py
+++ b/server.py
@@ -156,13 +156,16 @@ class ServerApp:
         # Start relay polling in a background thread
         self.start_relay_polling()
 
-        # Run the Flask app
-        self.app.run(
-            host=self.server_host,
-            port=self.server_port,
-            debug=not config.is_production,
-            use_reloader=False  # Disable reloader to avoid duplicate threads
-        )
+        # Run the Flask app and best-effort unregister on graceful shutdown.
+        try:
+            self.app.run(
+                host=self.server_host,
+                port=self.server_port,
+                debug=not config.is_production,
+                use_reloader=False  # Disable reloader to avoid duplicate threads
+            )
+        finally:
+            self.runtime.stop()
 
 def parse_args():
     """Parse command line arguments."""

--- a/server.py
+++ b/server.py
@@ -55,16 +55,18 @@ def _first_env(keys):
     return first_env(keys)
 
 
-def _resolve_relay_url(cli_default: str) -> str:
+def _resolve_relay_url(cli_default: str, *, prefer_cli: bool = False) -> str:
     """Backward-compatible wrapper for runtime relay URL resolution."""
 
-    return resolve_relay_url(cli_default)
+    return resolve_relay_url(cli_default, prefer_cli=prefer_cli)
 
 
-def _resolve_relay_port(cli_default: Optional[int], relay_url: str) -> Optional[int]:
+def _resolve_relay_port(
+    cli_default: Optional[int], relay_url: str, *, prefer_cli: bool = False
+) -> Optional[int]:
     """Backward-compatible wrapper for runtime relay port resolution."""
 
-    return resolve_relay_port(cli_default, relay_url)
+    return resolve_relay_port(cli_default, relay_url, prefer_cli=prefer_cli)
 
 
 def _format_relay_target(relay_url: str, relay_port: Optional[int]) -> str:
@@ -153,11 +155,10 @@ class ServerApp:
         """Run the server application."""
         log_info(f"Starting server on port {self.server_port}")
 
-        # Start relay polling in a background thread
-        self.start_relay_polling()
-
-        # Run the Flask app and best-effort unregister on graceful shutdown.
+        # Start relay polling and run the Flask app with best-effort unregister
+        # for any failure after run() begins, including polling startup errors.
         try:
+            self.start_relay_polling()
             self.app.run(
                 host=self.server_host,
                 port=self.server_port,
@@ -181,7 +182,7 @@ def parse_args():
     parser.add_argument(
         "--relay_url",
         type=str,
-        default=config.get("relay.server_url", "https://token.place"),
+        default=None,
         help="URL of the relay server",
     )
     parser.add_argument("--use_mock_llm", action="store_true", help="Use mock LLM for testing")
@@ -196,8 +197,14 @@ def main():
         os.environ['USE_MOCK_LLM'] = '1'
         print("Running in mock LLM mode")
 
-    relay_url = _resolve_relay_url(args.relay_url)
-    relay_port = _resolve_relay_port(args.relay_port, relay_url)
+    relay_url_arg = args.relay_url or config.get("relay.server_url", "https://token.place")
+    prefer_cli_relay = args.relay_url is not None
+    relay_url = _resolve_relay_url(relay_url_arg, prefer_cli=prefer_cli_relay)
+    relay_port = _resolve_relay_port(
+        args.relay_port,
+        relay_url,
+        prefer_cli=prefer_cli_relay or args.relay_port is not None,
+    )
 
     # Create and run the server
     server = ServerApp(

--- a/tests/integration/test_server_py_compute_node_cli.py
+++ b/tests/integration/test_server_py_compute_node_cli.py
@@ -75,55 +75,95 @@ def _terminate_process(proc: subprocess.Popen[str]) -> None:
         proc.wait(timeout=5)
 
 
+def _process_output(proc: subprocess.Popen[str]) -> str:
+    log_path = getattr(proc, "_tokenplace_log_path", None)
+    if isinstance(log_path, Path) and log_path.exists():
+        return log_path.read_text(encoding="utf-8", errors="replace")
+    if proc.stdout:
+        return proc.stdout.read()
+    return ""
+
+
 def _assert_process_still_running(proc: subprocess.Popen[str], label: str) -> None:
     if proc.poll() is None:
         return
-    stdout = proc.stdout.read() if proc.stdout else ""
+    stdout = _process_output(proc)
     raise AssertionError(f"{label} exited early with {proc.returncode}:\n{stdout}")
 
 
-def _start_relay(relay_port: int) -> subprocess.Popen[str]:
-    relay_url = f"http://127.0.0.1:{relay_port}"
-    env = os.environ.copy()
-    env.update(
-        {
-            "TOKEN_PLACE_ENV": "testing",
-            "ENVIRONMENT": "testing",
-            "USE_MOCK_LLM": "1",
-            "TOKENPLACE_API_V1_COMPUTE_PROVIDER": "distributed",
-            "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK": "0",
-            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL": relay_url,
-            "TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS": "10",
-            "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.1",
-            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
-            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
-            "TOKENPLACE_MAX_POLL_FAILURES": "3",
-            "TOKENPLACE_LOG_LEVEL": "WARNING",
-            "PYTHONUNBUFFERED": "1",
-        }
-    )
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            "relay.py",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(relay_port),
-            "--use_mock_llm",
-        ],
-        cwd=REPO_ROOT,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    _wait_for_json(f"{relay_url}/relay/diagnostics", timeout=10)
-    _assert_process_still_running(proc, "relay.py")
+def _bind_failure(output: str) -> bool:
+    return "address already in use" in output.lower() or "errno 98" in output.lower()
+
+
+def _start_process_with_log(
+    args: list[str], *, env: dict[str, str], log_path: Path
+) -> subprocess.Popen[str]:
+    log_handle = log_path.open("w", encoding="utf-8")
+    try:
+        proc = subprocess.Popen(
+            args,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    finally:
+        log_handle.close()
+    setattr(proc, "_tokenplace_log_path", log_path)
     return proc
 
 
-def _start_server(relay_url: str, server_port: int) -> subprocess.Popen[str]:
+def _start_relay(tmp_path: Path) -> tuple[subprocess.Popen[str], str]:
+    last_error: Exception | None = None
+    for attempt in range(5):
+        relay_port = _free_port()
+        relay_url = f"http://127.0.0.1:{relay_port}"
+        env = os.environ.copy()
+        env.update(
+            {
+                "TOKEN_PLACE_ENV": "testing",
+                "ENVIRONMENT": "testing",
+                "USE_MOCK_LLM": "1",
+                "TOKENPLACE_API_V1_COMPUTE_PROVIDER": "distributed",
+                "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK": "0",
+                "TOKENPLACE_DISTRIBUTED_COMPUTE_URL": relay_url,
+                "TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS": "10",
+                "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.1",
+                "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
+                "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+                "TOKENPLACE_MAX_POLL_FAILURES": "3",
+                "TOKENPLACE_LOG_LEVEL": "WARNING",
+                "PYTHONUNBUFFERED": "1",
+            }
+        )
+        proc = _start_process_with_log(
+            [
+                sys.executable,
+                "relay.py",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(relay_port),
+                "--use_mock_llm",
+            ],
+            env=env,
+            log_path=tmp_path / f"relay-{attempt}.log",
+        )
+        try:
+            _wait_for_json(f"{relay_url}/relay/diagnostics", timeout=10)
+            _assert_process_still_running(proc, "relay.py")
+            return proc, relay_url
+        except AssertionError as exc:
+            last_error = exc
+            output = _process_output(proc)
+            _terminate_process(proc)
+            if not _bind_failure(output):
+                raise
+    raise AssertionError(f"relay.py failed to bind after retries: {last_error}")
+
+
+def _server_env() -> dict[str, str]:
     env = os.environ.copy()
     env.update(
         {
@@ -150,8 +190,13 @@ def _start_server(relay_url: str, server_port: int) -> subprocess.Popen[str]:
         "RELAY_PORT",
     ):
         env.pop(key, None)
+    return env
 
-    return subprocess.Popen(
+
+def _start_server(
+    relay_url: str, server_port: int, log_path: Path
+) -> subprocess.Popen[str]:
+    return _start_process_with_log(
         [
             sys.executable,
             "server.py",
@@ -163,12 +208,32 @@ def _start_server(relay_url: str, server_port: int) -> subprocess.Popen[str]:
             str(server_port),
             "--use_mock_llm",
         ],
-        cwd=REPO_ROOT,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
+        env=_server_env(),
+        log_path=log_path,
     )
+
+
+def _start_server_and_wait_for_count(
+    relay_url: str, expected_count: int, tmp_path: Path, label: str
+) -> tuple[subprocess.Popen[str], dict[str, Any]]:
+    last_error: Exception | None = None
+    for attempt in range(5):
+        proc = _start_server(
+            relay_url,
+            _free_port(),
+            tmp_path / f"server-{label}-{attempt}.log",
+        )
+        try:
+            diagnostics = _wait_for_count(relay_url, expected_count, timeout=10)
+            _assert_process_still_running(proc, label)
+            return proc, diagnostics
+        except AssertionError as exc:
+            last_error = exc
+            output = _process_output(proc)
+            _terminate_process(proc)
+            if not _bind_failure(output):
+                raise
+    raise AssertionError(f"{label} failed to bind after retries: {last_error}")
 
 
 def _encrypt_messages_for_relay(
@@ -206,23 +271,22 @@ def _decrypt_chat_completion(
     os.environ.get("RUN_RELAY_REGISTRATION_TESTS") != "1",
     reason="set RUN_RELAY_REGISTRATION_TESTS=1 to launch relay.py and server.py subprocesses",
 )
-def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_work():
-    relay_port = _free_port()
-    server_port_a = _free_port()
-    server_port_b = _free_port()
-    relay_url = f"http://127.0.0.1:{relay_port}"
+def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_work(
+    tmp_path: Path,
+):
+    relay_url = ""
     relay_proc: subprocess.Popen[str] | None = None
     server_proc_a: subprocess.Popen[str] | None = None
     server_proc_b: subprocess.Popen[str] | None = None
 
     try:
-        relay_proc = _start_relay(relay_port)
+        relay_proc, relay_url = _start_relay(tmp_path)
         initial = _wait_for_count(relay_url, 0, timeout=5)
         assert initial["total_registered_compute_nodes"] == 0
 
-        server_proc_a = _start_server(relay_url, server_port_a)
-        diagnostics_one = _wait_for_count(relay_url, 1, timeout=10)
-        _assert_process_still_running(server_proc_a, "server.py A")
+        server_proc_a, diagnostics_one = _start_server_and_wait_for_count(
+            relay_url, 1, tmp_path, "server.py A"
+        )
         assert diagnostics_one["total_registered_compute_nodes"] == 1
 
         browser_crypto = EncryptionManager()
@@ -251,9 +315,9 @@ def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_wor
         content = completion["choices"][0]["message"]["content"]
         assert "Mock Response" in content
 
-        server_proc_b = _start_server(relay_url, server_port_b)
-        diagnostics_two = _wait_for_count(relay_url, 2, timeout=10)
-        _assert_process_still_running(server_proc_b, "server.py B")
+        server_proc_b, diagnostics_two = _start_server_and_wait_for_count(
+            relay_url, 2, tmp_path, "server.py B"
+        )
         assert diagnostics_two["total_registered_compute_nodes"] == 2
 
     finally:
@@ -262,6 +326,7 @@ def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_wor
                 _terminate_process(proc)
         if relay_proc is not None:
             try:
-                _wait_for_count(relay_url, 0, timeout=8)
+                if sys.exc_info()[0] is None:
+                    _wait_for_count(relay_url, 0, timeout=8)
             finally:
                 _terminate_process(relay_proc)

--- a/tests/integration/test_server_py_compute_node_cli.py
+++ b/tests/integration/test_server_py_compute_node_cli.py
@@ -1,0 +1,267 @@
+"""Process-level e2e coverage for the canonical server.py compute-node CLI."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+from api.v1.encryption import EncryptionManager
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_json(url: str, *, timeout: float = 10.0) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(url, timeout=1)
+            if response.status_code == 200:
+                payload = response.json()
+                if isinstance(payload, dict):
+                    return payload
+        except Exception as exc:  # pragma: no cover - diagnostic path only
+            last_error = exc
+        time.sleep(0.1)
+    raise AssertionError(f"timed out waiting for JSON from {url}: {last_error}")
+
+
+def _wait_for_count(
+    base_url: str, expected: int, *, timeout: float = 10.0
+) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last_payload: dict[str, Any] | None = None
+    while time.time() < deadline:
+        last_payload = _wait_for_json(f"{base_url}/relay/diagnostics", timeout=2)
+        if last_payload.get("total_api_v1_registered_compute_nodes") == expected:
+            return last_payload
+        time.sleep(0.1)
+    raise AssertionError(
+        f"expected {expected} API v1 compute nodes; last diagnostics={last_payload}"
+    )
+
+
+def _terminate_process(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGINT)
+    try:
+        proc.wait(timeout=8)
+        return
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+    try:
+        proc.wait(timeout=5)
+        return
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def _assert_process_still_running(proc: subprocess.Popen[str], label: str) -> None:
+    if proc.poll() is None:
+        return
+    stdout = proc.stdout.read() if proc.stdout else ""
+    raise AssertionError(f"{label} exited early with {proc.returncode}:\n{stdout}")
+
+
+def _start_relay(relay_port: int) -> subprocess.Popen[str]:
+    relay_url = f"http://127.0.0.1:{relay_port}"
+    env = os.environ.copy()
+    env.update(
+        {
+            "TOKEN_PLACE_ENV": "testing",
+            "ENVIRONMENT": "testing",
+            "USE_MOCK_LLM": "1",
+            "TOKENPLACE_API_V1_COMPUTE_PROVIDER": "distributed",
+            "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK": "0",
+            "TOKENPLACE_DISTRIBUTED_COMPUTE_URL": relay_url,
+            "TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS": "10",
+            "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.1",
+            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
+            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+            "TOKENPLACE_MAX_POLL_FAILURES": "3",
+            "TOKENPLACE_LOG_LEVEL": "WARNING",
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "relay.py",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(relay_port),
+            "--use_mock_llm",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    _wait_for_json(f"{relay_url}/relay/diagnostics", timeout=10)
+    _assert_process_still_running(proc, "relay.py")
+    return proc
+
+
+def _start_server(relay_url: str, server_port: int) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "TOKEN_PLACE_ENV": "testing",
+            "ENVIRONMENT": "testing",
+            "USE_MOCK_LLM": "1",
+            "TOKENPLACE_MAX_POLL_FAILURES": "3",
+            "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.1",
+            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
+            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    for key in (
+        "TOKENPLACE_RELAY_URL",
+        "TOKEN_PLACE_RELAY_URL",
+        "TOKENPLACE_RELAY_BASE_URL",
+        "TOKEN_PLACE_RELAY_BASE_URL",
+        "TOKENPLACE_RELAY_UPSTREAM_URL",
+        "TOKEN_PLACE_RELAY_UPSTREAM_URL",
+        "RELAY_URL",
+        "TOKENPLACE_RELAY_PORT",
+        "TOKEN_PLACE_RELAY_PORT",
+        "RELAY_PORT",
+    ):
+        env.pop(key, None)
+
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "server.py",
+            "--relay_url",
+            relay_url,
+            "--server_host",
+            "127.0.0.1",
+            "--server_port",
+            str(server_port),
+            "--use_mock_llm",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _encrypt_messages_for_relay(
+    relay_url: str, browser_crypto: EncryptionManager, messages: list[dict[str, str]]
+) -> dict[str, str]:
+    public_key_response = requests.get(f"{relay_url}/api/v1/public-key", timeout=5)
+    assert public_key_response.status_code == 200, public_key_response.text
+    relay_public_key = public_key_response.json()["public_key"]
+    encrypted = browser_crypto.encrypt_message(messages, relay_public_key)
+    assert encrypted is not None
+    return {
+        "ciphertext": encrypted["ciphertext"],
+        "cipherkey": encrypted["cipherkey"],
+        "iv": encrypted["iv"],
+    }
+
+
+def _decrypt_chat_completion(
+    browser_crypto: EncryptionManager, response_body: dict[str, Any]
+) -> dict[str, Any]:
+    encrypted = response_body["data"]
+    decrypted = browser_crypto.decrypt_message(
+        {
+            "ciphertext": base64.b64decode(encrypted["ciphertext"]),
+            "iv": base64.b64decode(encrypted["iv"]),
+        },
+        base64.b64decode(encrypted["cipherkey"]),
+    )
+    assert decrypted is not None
+    return json.loads(decrypted.decode("utf-8"))
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.environ.get("RUN_RELAY_REGISTRATION_TESTS") != "1",
+    reason="set RUN_RELAY_REGISTRATION_TESTS=1 to launch relay.py and server.py subprocesses",
+)
+def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_work():
+    relay_port = _free_port()
+    server_port_a = _free_port()
+    server_port_b = _free_port()
+    relay_url = f"http://127.0.0.1:{relay_port}"
+    relay_proc: subprocess.Popen[str] | None = None
+    server_proc_a: subprocess.Popen[str] | None = None
+    server_proc_b: subprocess.Popen[str] | None = None
+
+    try:
+        relay_proc = _start_relay(relay_port)
+        initial = _wait_for_count(relay_url, 0, timeout=5)
+        assert initial["total_registered_compute_nodes"] == 0
+
+        server_proc_a = _start_server(relay_url, server_port_a)
+        diagnostics_one = _wait_for_count(relay_url, 1, timeout=10)
+        _assert_process_still_running(server_proc_a, "server.py A")
+        assert diagnostics_one["total_registered_compute_nodes"] == 1
+
+        browser_crypto = EncryptionManager()
+        user_text = "ping from server.py compute node"
+        response = requests.post(
+            f"{relay_url}/api/v1/chat/completions",
+            json={
+                "model": "llama-3-8b-instruct",
+                "encrypted": True,
+                "client_public_key": browser_crypto.public_key_b64,
+                "messages": _encrypt_messages_for_relay(
+                    relay_url,
+                    browser_crypto,
+                    [{"role": "user", "content": user_text}],
+                ),
+                "metadata": {
+                    "inference_target": "desktop_bridge_api_v1_e2ee",
+                    "relay_path": "api_v1_e2ee",
+                },
+            },
+            timeout=15,
+        )
+        assert response.status_code == 200, response.text
+        completion = _decrypt_chat_completion(browser_crypto, response.json())
+        assert completion["object"] == "chat.completion"
+        content = completion["choices"][0]["message"]["content"]
+        assert "Mock Response" in content
+
+        server_proc_b = _start_server(relay_url, server_port_b)
+        diagnostics_two = _wait_for_count(relay_url, 2, timeout=10)
+        _assert_process_still_running(server_proc_b, "server.py B")
+        assert diagnostics_two["total_registered_compute_nodes"] == 2
+
+    finally:
+        for proc in (server_proc_b, server_proc_a):
+            if proc is not None:
+                _terminate_process(proc)
+        if relay_proc is not None:
+            try:
+                _wait_for_count(relay_url, 0, timeout=8)
+            finally:
+                _terminate_process(relay_proc)

--- a/tests/integration/test_server_py_compute_node_cli.py
+++ b/tests/integration/test_server_py_compute_node_cli.py
@@ -19,6 +19,8 @@ import requests
 from api.v1.encryption import EncryptionManager
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+RELAY_SERVER_LEASE_SECONDS = "120"
+REGISTRATION_COUNT_TIMEOUT_SECONDS = 8.0
 
 
 def _free_port() -> int:
@@ -58,21 +60,28 @@ def _wait_for_count(
     )
 
 
-def _terminate_process(proc: subprocess.Popen[str]) -> None:
+def _terminate_process(
+    proc: subprocess.Popen[str], *, label: str, fail_on_sigkill: bool = False
+) -> bool:
     if proc.poll() is not None:
-        return
+        return False
     proc.send_signal(signal.SIGINT)
     try:
         proc.wait(timeout=8)
-        return
+        return False
     except subprocess.TimeoutExpired:
         proc.terminate()
     try:
         proc.wait(timeout=5)
-        return
+        return False
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait(timeout=5)
+        output = _process_output(proc)
+        message = f"{label} required SIGKILL during shutdown:\n{output}"
+        if fail_on_sigkill:
+            raise AssertionError(message)
+        return True
 
 
 def _process_output(proc: subprocess.Popen[str]) -> str:
@@ -130,8 +139,8 @@ def _start_relay(tmp_path: Path) -> tuple[subprocess.Popen[str], str]:
                 "TOKENPLACE_DISTRIBUTED_COMPUTE_URL": relay_url,
                 "TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS": "10",
                 "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.1",
-                "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
-                "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+                "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": RELAY_SERVER_LEASE_SECONDS,
+                "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": RELAY_SERVER_LEASE_SECONDS,
                 "TOKENPLACE_MAX_POLL_FAILURES": "3",
                 "TOKENPLACE_LOG_LEVEL": "WARNING",
                 "PYTHONUNBUFFERED": "1",
@@ -157,7 +166,7 @@ def _start_relay(tmp_path: Path) -> tuple[subprocess.Popen[str], str]:
         except AssertionError as exc:
             last_error = exc
             output = _process_output(proc)
-            _terminate_process(proc)
+            _terminate_process(proc, label="relay.py")
             if not _bind_failure(output):
                 raise
     raise AssertionError(f"relay.py failed to bind after retries: {last_error}")
@@ -172,8 +181,8 @@ def _server_env() -> dict[str, str]:
             "USE_MOCK_LLM": "1",
             "TOKENPLACE_MAX_POLL_FAILURES": "3",
             "TOKEN_PLACE_API_V1_RELAY_POLL_WAIT_SECONDS": "0.1",
-            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": "2",
-            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": "2",
+            "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS": RELAY_SERVER_LEASE_SECONDS,
+            "TOKEN_PLACE_RELAY_SERVER_TTL_SECONDS": RELAY_SERVER_LEASE_SECONDS,
             "PYTHONUNBUFFERED": "1",
         }
     )
@@ -230,7 +239,7 @@ def _start_server_and_wait_for_count(
         except AssertionError as exc:
             last_error = exc
             output = _process_output(proc)
-            _terminate_process(proc)
+            _terminate_process(proc, label=label, fail_on_sigkill=True)
             if not _bind_failure(output):
                 raise
     raise AssertionError(f"{label} failed to bind after retries: {last_error}")
@@ -310,6 +319,15 @@ def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_wor
             timeout=15,
         )
         assert response.status_code == 200, response.text
+        assert (
+            response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"]
+            == "distributed"
+        )
+        assert (
+            response.headers["X-Tokenplace-API-V1-Execution-Backend-Path"]
+            == "distributed_relay_e2ee"
+        )
+        assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
         completion = _decrypt_chat_completion(browser_crypto, response.json())
         assert completion["object"] == "chat.completion"
         content = completion["choices"][0]["message"]["content"]
@@ -321,12 +339,29 @@ def test_server_py_compute_node_cli_registers_scales_and_handles_api_v1_e2ee_wor
         assert diagnostics_two["total_registered_compute_nodes"] == 2
 
     finally:
-        for proc in (server_proc_b, server_proc_a):
-            if proc is not None:
-                _terminate_process(proc)
+        original_exception = sys.exc_info()[0]
+        if original_exception is None:
+            shutdown_failures: list[str] = []
+            if server_proc_b is not None:
+                if _terminate_process(server_proc_b, label="server.py B"):
+                    shutdown_failures.append("server.py B required SIGKILL")
+                _wait_for_count(
+                    relay_url, 1, timeout=REGISTRATION_COUNT_TIMEOUT_SECONDS
+                )
+            if server_proc_a is not None:
+                if _terminate_process(server_proc_a, label="server.py A"):
+                    shutdown_failures.append("server.py A required SIGKILL")
+                _wait_for_count(
+                    relay_url, 0, timeout=REGISTRATION_COUNT_TIMEOUT_SECONDS
+                )
+            if shutdown_failures:
+                raise AssertionError("; ".join(shutdown_failures))
+        else:
+            for proc, label in (
+                (server_proc_b, "server.py B"),
+                (server_proc_a, "server.py A"),
+            ):
+                if proc is not None:
+                    _terminate_process(proc, label=label)
         if relay_proc is not None:
-            try:
-                if sys.exc_info()[0] is None:
-                    _wait_for_count(relay_url, 0, timeout=8)
-            finally:
-                _terminate_process(relay_proc)
+            _terminate_process(relay_proc, label="relay.py")

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -623,6 +623,14 @@ def test_compute_node_runtime_relay_resolution_prefers_explicit_cli_value(monkey
     assert relay_url == "http://127.0.0.1:5010"
 
 
+def test_compute_node_runtime_relay_port_prefers_explicit_url_port(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELAY_PORT", "9999")
+
+    relay_port = resolve_relay_port(None, "http://127.0.0.1:5010", prefer_cli=True)
+
+    assert relay_port == 5010
+
+
 def test_compute_node_runtime_resolve_relay_port_accepts_explicit_zero_port():
     assert resolve_relay_port(None, "https://token.place:0") == 0
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -631,6 +631,14 @@ def test_compute_node_runtime_relay_port_prefers_explicit_url_port(monkeypatch):
     assert relay_port == 5010
 
 
+def test_compute_node_runtime_relay_port_prefers_explicit_cli_port(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELAY_PORT", "9999")
+
+    relay_port = resolve_relay_port(5010, "http://127.0.0.1", prefer_cli=True)
+
+    assert relay_port == 5010
+
+
 def test_compute_node_runtime_resolve_relay_port_accepts_explicit_zero_port():
     assert resolve_relay_port(None, "https://token.place:0") == 0
 

--- a/tests/unit/test_server_relay_resolution.py
+++ b/tests/unit/test_server_relay_resolution.py
@@ -36,3 +36,23 @@ def test_resolve_relay_port_respects_cli_port_override_for_https():
     relay_port = server._resolve_relay_port(7443, "https://token.place")
     assert relay_port == 7443
     assert server.RelayClient._compose_relay_url("https://token.place", relay_port) == "https://token.place:7443"
+
+
+def test_resolve_relay_url_prefers_cli_when_requested(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELAY_URL", "https://relay.example")
+    server = _load_server_script()
+
+    assert (
+        server._resolve_relay_url("http://127.0.0.1:5010", prefer_cli=True)
+        == "http://127.0.0.1:5010"
+    )
+
+
+def test_resolve_relay_port_prefers_cli_url_port_when_requested(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELAY_PORT", "9999")
+    server = _load_server_script()
+
+    assert (
+        server._resolve_relay_port(None, "http://127.0.0.1:5010", prefer_cli=True)
+        == 5010
+    )

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -148,8 +148,16 @@ def resolve_relay_url(cli_default: str, *, prefer_cli: bool = False) -> str:
     return env_override or cli_default
 
 
-def resolve_relay_port(cli_default: Optional[int], relay_url: str) -> Optional[int]:
+def resolve_relay_port(
+    cli_default: Optional[int], relay_url: str, *, prefer_cli: bool = False
+) -> Optional[int]:
     """Resolve the relay port from CLI, env, or the relay URL."""
+
+    parsed = urlparse(relay_url if "://" in relay_url else f"http://{relay_url}")
+    if prefer_cli and parsed.port is not None:
+        return parsed.port
+    if prefer_cli and cli_default is not None:
+        return cli_default
 
     env_port = first_env(["TOKENPLACE_RELAY_PORT", "TOKEN_PLACE_RELAY_PORT", "RELAY_PORT"])
 
@@ -160,7 +168,6 @@ def resolve_relay_port(cli_default: Optional[int], relay_url: str) -> Optional[i
             _log_error(f"Invalid relay port override: {env_port}")
             return cli_default
 
-    parsed = urlparse(relay_url if "://" in relay_url else f"http://{relay_url}")
     if parsed.port is not None:
         return parsed.port
 


### PR DESCRIPTION
### Motivation

- Verify repository-root `server.py` remains a fully-functional headless compute-node that registers with a relay, processes API v1 E2EE work (mock LLM), and is observable in relay diagnostics.

### Description

- Added a process-level integration test `tests/integration/test_server_py_compute_node_cli.py` that launches `relay.py` and one or two `server.py` processes (with `--use_mock_llm`) and asserts the relay `total_api_v1_registered_compute_nodes` count moves 0→1→2 and that a mock encrypted API v1 chat round-trip completes.
- Ensure `server.py` performs best-effort unregister/stop on shutdown by wrapping `self.app.run(...)` in a `try/finally` and calling `self.runtime.stop()` in `finally` so the compute node unregisters cleanly.
- Add a short CLI compute-node section to `docs/TESTING.md` with an example `USE_MOCK_LLM=1 python server.py --relay_url http://127.0.0.1:5010 --server_port 3001` and document the guarded integration test invocation (`RUN_RELAY_REGISTRATION_TESTS=1 ...`).

### Testing

- Ran the guarded integration scenario with registration test: `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest tests/integration -k "server_py or compute_node_cli" -v` — PASSED.
- Ran targeted unit and relay suites: `python -m pytest tests/unit/test_compute_node_runtime.py tests/unit/test_relay_client.py tests/test_relay.py -v` — PASSED (all tests in those suites passed).
- Ran full project test runner: `./run_all_tests.sh` — unit/integration suites completed (303 tests passed in this environment); note Playwright-driven browser E2E UI tests may fail unless Playwright browsers are installed and required system libraries are present.
- Ran `pre-commit run --all-files` — PASSED.

Residual risks and notes: Playwright-based E2E UI tests depend on `playwright install` and OS-level libraries (e.g., `libatk-1.0.so.0`) in the test environment; those are environmental prerequisites and not required to validate the new CLI compute-node integration test, which is guarded behind `RUN_RELAY_REGISTRATION_TESTS=1` to avoid heavy infrastructure in default CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262a36cfa8832f93de0248f2002b63)