### PR TITLE
Landing chat: sticky compute-node affinity, browser E2EE relay envelopes, and shortened server key label

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1,6 +1,9 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
+const RELAY_RESPONSE_POLL_INTERVAL_MS = 500;
+const RELAY_RESPONSE_TIMEOUT_MS = 30000;
+const RELAY_E2EE_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
 
 new Vue({
@@ -8,7 +11,10 @@ new Vue({
     data: {
         newMessage: '',
         chatHistory: [],
-        serverPublicKey: null,
+        selectedServerPublicKeyB64: '',
+        selectedServerPublicKey: null,
+        selectedServerKeyLabel: '',
+        selectedServerUnavailable: false,
         clientPrivateKey: null,
         clientPublicKey: null,
         availableModels: [],
@@ -27,9 +33,7 @@ new Vue({
     mounted() {
         this.detectTouchInput();
         this.fetchModels();
-        this.getServerPublicKey().then(() => {
-            this.generateClientKeys();
-        });
+        this.generateClientKeys();
         this.refreshComputeNodeCount();
         this.computeNodeCountPoller = setInterval(() => {
             this.refreshComputeNodeCount();
@@ -84,14 +88,14 @@ new Vue({
             return Boolean(this.clientPrivateKey && this.clientPublicKey);
         },
         hasServerPublicKey() {
-            return Boolean(this.serverPublicKey);
+            return Boolean(this.selectedServerPublicKey && this.selectedServerPublicKeyB64);
         },
         canSendMessage() {
             return Boolean(
                 this.newMessage.trim() &&
                 this.hasClientKeypair &&
-                this.hasServerPublicKey &&
                 this.selectedModel &&
+                !this.selectedServerUnavailable &&
                 !this.isGeneratingResponse
             );
         }
@@ -221,27 +225,64 @@ new Vue({
             return null;
         },
 
-        getServerPublicKey() {
-            // Fetch the server's public key from the API
-            return fetch('/api/v1/public-key')
-                .then(response => {
-                    if (response.ok) {
-                        return response.json();
-                    }
-                    throw new Error('Failed to fetch server public key');
-                })
-                .then(data => {
-                    const normalizedKey = this.normalizeServerPublicKey(data && data.public_key);
-                    if (normalizedKey) {
-                        this.serverPublicKey = normalizedKey;
-                    } else {
-                        console.error('Unexpected server public key format:', data);
-                    }
-                })
-                .catch(error => {
-                    console.error('Error fetching server public key:', error);
-                });
+        createServerKeyLabel(rawKey) {
+            if (typeof rawKey !== 'string') {
+                return '';
+            }
+
+            const compact = rawKey.replace(/-----[^-]+-----/g, '').replace(/[^A-Za-z0-9]/g, '');
+            if (compact.length <= 16) {
+                return compact ? `Server: ${compact}` : '';
+            }
+            return `Server: ${compact.slice(0, 8)}…${compact.slice(-8)}`;
         },
+
+        async ensureSelectedServer() {
+            if (this.hasServerPublicKey) {
+                return true;
+            }
+
+            if (this.selectedServerUnavailable) {
+                throw new Error('selected_server_unavailable');
+            }
+
+            const response = await fetch('/api/v1/relay/servers/next', { cache: 'no-store' });
+            if (!response.ok) {
+                let errorData = null;
+                try {
+                    errorData = await response.json();
+                } catch (_jsonError) {
+                    errorData = null;
+                }
+                return {
+                    error: {
+                        userMessage: this.getUserFacingApiError(errorData, response.status)
+                    }
+                };
+            }
+
+            const data = await response.json();
+            const selectedServerPublicKeyB64 = data && data.server_public_key;
+            const normalizedKey = this.normalizeServerPublicKey(selectedServerPublicKeyB64);
+            if (!selectedServerPublicKeyB64 || !normalizedKey) {
+                throw new Error('invalid_selected_server_public_key');
+            }
+
+            this.selectedServerPublicKeyB64 = selectedServerPublicKeyB64;
+            this.selectedServerPublicKey = normalizedKey;
+            this.selectedServerKeyLabel = this.createServerKeyLabel(selectedServerPublicKeyB64);
+            this.selectedServerUnavailable = false;
+            return true;
+        },
+
+        startNewChatSession() {
+            this.chatHistory = [];
+            this.selectedServerPublicKeyB64 = '';
+            this.selectedServerPublicKey = null;
+            this.selectedServerKeyLabel = '';
+            this.selectedServerUnavailable = false;
+        },
+
         generateClientKeys() {
             const crypt = new JSEncrypt({ default_key_size: 2048 });
             crypt.getKey();
@@ -515,49 +556,94 @@ new Vue({
             }
         },
 
-        // Send a message to the server using the new API
-        async sendMessageApi() {
-            if (!this.serverPublicKey) {
-                console.error('Server public key not available');
-                return null;
+        createRequestId() {
+            if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+                return crypto.randomUUID();
             }
+            const randomPart = Math.random().toString(36).slice(2);
+            return `landing-${Date.now()}-${randomPart}`;
+        },
 
-            if (!this.selectedModel) {
-                console.error('No API v1 catalogue model selected');
-                return null;
-            }
+        sleep(ms) {
+            return new Promise((resolve) => setTimeout(resolve, ms));
+        },
 
-            try {
-                // Encrypt the chat history
-                const encryptedData = await this.encrypt(
-                    JSON.stringify(this.chatHistory),
-                    this.serverPublicKey
-                );
-
-                if (!encryptedData) {
-                    throw new Error('Failed to encrypt chat history');
-                }
-
-                // Create the API request payload
-                const payload = {
+        buildApiV1RelayPlaintextEnvelope(requestId, messageContent) {
+            return {
+                protocol: RELAY_E2EE_PROTOCOL,
+                version: 1,
+                request_id: requestId,
+                client_public_key: this.encodeClientPublicKeyForApi(),
+                api_v1_request: {
                     model: this.selectedModelId,
-                    encrypted: true,
-                    client_public_key: this.encodeClientPublicKeyForApi(),
-                    messages: encryptedData,
-                    metadata: {
-                        inference_target: "desktop_bridge_api_v1_e2ee",
-                        relay_path: "api_v1_e2ee"
-                    }
-                };
+                    messages: [
+                        { role: 'user', content: messageContent }
+                    ],
+                    options: {}
+                }
+            };
+        },
 
-                // Send the request to the API
-                const response = await fetch('/api/v1/chat/completions', {
+        buildSelectedServerUnavailableError() {
+            this.selectedServerUnavailable = true;
+            return {
+                error: {
+                    userMessage: 'The selected LLM server is unavailable. Start a new chat to choose another compute node.'
+                }
+            };
+        },
+
+        async postRelayRequest(payload) {
+            const response = await fetch('/api/v1/relay/requests', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(payload)
+            });
+
+            if (response.ok) {
+                return null;
+            }
+
+            let errorData = null;
+            try {
+                errorData = await response.json();
+            } catch (_jsonError) {
+                errorData = null;
+            }
+
+            if (response.status === 404 || response.status === 410) {
+                return this.buildSelectedServerUnavailableError();
+            }
+
+            return {
+                error: {
+                    userMessage: this.getUserFacingApiError(errorData, response.status)
+                }
+            };
+        },
+
+        async retrieveRelayResponse(requestId) {
+            const startedAt = Date.now();
+            const clientPublicKey = this.encodeClientPublicKeyForApi();
+
+            while (Date.now() - startedAt < RELAY_RESPONSE_TIMEOUT_MS) {
+                const response = await fetch('/api/v1/relay/responses/retrieve', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify(payload)
+                    body: JSON.stringify({
+                        client_public_key: clientPublicKey,
+                        request_id: requestId
+                    })
                 });
+
+                if (response.status === 202) {
+                    await this.sleep(RELAY_RESPONSE_POLL_INTERVAL_MS);
+                    continue;
+                }
 
                 if (!response.ok) {
                     let errorData = null;
@@ -566,34 +652,114 @@ new Vue({
                     } catch (_jsonError) {
                         errorData = null;
                     }
+                    if (response.status === 404 || response.status === 410) {
+                        return this.buildSelectedServerUnavailableError();
+                    }
                     return {
                         error: {
-                            userMessage: this.getUserFacingApiError(errorData)
+                            userMessage: this.getUserFacingApiError(errorData, response.status)
                         }
                     };
                 }
 
-                const responseData = await response.json();
+                return response.json();
+            }
 
-                // Handle encrypted response
-                if (responseData.encrypted && responseData.data) {
-                    const decryptedJson = await this.decrypt(
-                        responseData.data.ciphertext,
-                        responseData.data.cipherkey,
-                        responseData.data.iv
-                    );
+            return {
+                error: {
+                    userMessage: 'The LLM server took too long to respond. Please try again.'
+                }
+            };
+        },
 
-                    if (!decryptedJson) {
-                        throw new Error('Failed to decrypt response');
-                    }
+        validateRelayResponseEnvelope(envelope, requestId) {
+            if (!envelope || typeof envelope !== 'object') {
+                throw new Error('invalid_relay_response_envelope');
+            }
+            if (envelope.protocol !== RELAY_E2EE_PROTOCOL) {
+                throw new Error('invalid_relay_response_protocol');
+            }
+            if (envelope.request_id !== requestId) {
+                throw new Error('relay_response_request_id_mismatch');
+            }
+            if (envelope.client_public_key !== this.encodeClientPublicKeyForApi()) {
+                throw new Error('relay_response_client_public_key_mismatch');
+            }
+            if (!envelope.api_v1_response || typeof envelope.api_v1_response !== 'object') {
+                throw new Error('missing_api_v1_response');
+            }
+            if (Array.isArray(envelope.api_v1_response.choices)) {
+                return envelope.api_v1_response;
+            }
+            if (envelope.api_v1_response.message && typeof envelope.api_v1_response.message === 'object') {
+                return {
+                    choices: [
+                        { message: envelope.api_v1_response.message }
+                    ]
+                };
+            }
+            throw new Error('missing_api_v1_response_choices');
+        },
 
-                    return JSON.parse(decryptedJson);
+        // Send a message to the selected compute node using relay-blind API v1 E2EE envelopes.
+        async sendMessageApi(messageContent) {
+            if (!this.selectedModel) {
+                console.error('No API v1 catalogue model selected');
+                return null;
+            }
+
+            try {
+                const selected = await this.ensureSelectedServer();
+                if (selected && selected.error) {
+                    return selected;
                 }
 
-                // Handle unencrypted response (should not happen with encrypted=true)
-                return responseData;
+                const requestId = this.createRequestId();
+                const clientPublicKey = this.encodeClientPublicKeyForApi();
+                const plaintextEnvelope = this.buildApiV1RelayPlaintextEnvelope(requestId, messageContent);
+                const encryptedData = await this.encrypt(
+                    JSON.stringify(plaintextEnvelope),
+                    this.selectedServerPublicKey
+                );
+
+                if (!encryptedData) {
+                    throw new Error('Failed to encrypt relay request envelope');
+                }
+
+                const relayPayload = {
+                    server_public_key: this.selectedServerPublicKeyB64,
+                    client_public_key: clientPublicKey,
+                    request_id: requestId,
+                    protocol: RELAY_E2EE_PROTOCOL,
+                    version: 1,
+                    ciphertext: encryptedData.ciphertext,
+                    cipherkey: encryptedData.cipherkey,
+                    iv: encryptedData.iv
+                };
+
+                const postError = await this.postRelayRequest(relayPayload);
+                if (postError) {
+                    return postError;
+                }
+
+                const responseEnvelope = await this.retrieveRelayResponse(requestId);
+                if (responseEnvelope && responseEnvelope.error) {
+                    return responseEnvelope;
+                }
+
+                const decryptedJson = await this.decrypt(
+                    responseEnvelope.ciphertext || responseEnvelope.chat_history,
+                    responseEnvelope.cipherkey,
+                    responseEnvelope.iv
+                );
+
+                if (!decryptedJson) {
+                    throw new Error('Failed to decrypt relay response');
+                }
+
+                return this.validateRelayResponseEnvelope(JSON.parse(decryptedJson), requestId);
             } catch (error) {
-                console.error('API request error:', error);
+                console.error('API relay request error:', error);
                 return null;
             }
         },
@@ -644,7 +810,7 @@ new Vue({
             return message.content;
         },
 
-        getUserFacingApiError(errorPayload) {
+        getUserFacingApiError(errorPayload, statusCode) {
             const error = errorPayload && typeof errorPayload === 'object' ? errorPayload.error : null;
             const errorCode = error && typeof error.code === 'string' ? error.code : '';
             const fallbackMessage = ASSISTANT_GENERIC_FALLBACK_MESSAGE;
@@ -655,8 +821,14 @@ new Vue({
                 compute_node_bridge_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_unreachable: 'The LLM server is unavailable right now. Please try again.',
                 compute_node_bridge_error: 'Unable to contact the LLM server right now. Please try again.',
-                compute_node_invalid_payload: 'The LLM server returned an invalid response. Please try again.'
+                compute_node_invalid_payload: 'The LLM server returned an invalid response. Please try again.',
+                expired: 'The selected LLM server is unavailable. Start a new chat to choose another compute node.',
+                cancelled: 'The selected LLM server is unavailable. Start a new chat to choose another compute node.'
             };
+
+            if (statusCode === 404 || statusCode === 410) {
+                return 'The selected LLM server is unavailable. Start a new chat to choose another compute node.';
+            }
 
             return codeToMessage[errorCode] || fallbackMessage;
         },
@@ -691,7 +863,7 @@ new Vue({
 
             try {
                 // Relay-path landing chat in v0.1.0 is API v1-only and non-streaming.
-                let response = await this.sendMessageApi();
+                let response = await this.sendMessageApi(messageContent);
 
                 // Process the response
                 if (response) {

--- a/static/index.html
+++ b/static/index.html
@@ -125,11 +125,24 @@
             color: #ffffff;
             font-size: 14px;
         }
-        .model-status {
+        .model-status,
+        .server-key-status {
             margin: 6px 0 0;
             color: #cccccc;
             font-size: 13px;
             line-height: 1.4;
+        }
+        .server-key-status strong {
+            color: #00ffff;
+            font-weight: 600;
+        }
+        .new-chat-button {
+            padding: 8px 10px;
+            border-radius: 5px;
+            border: 1px solid rgba(0, 255, 255, 0.5);
+            background-color: transparent;
+            color: #00ffff;
+            cursor: pointer;
         }
         .model-error {
             color: #ffcc66;
@@ -335,12 +348,22 @@
         }
 
         body.light-mode .model-selector-container label,
-        body.light-mode .model-status {
+        body.light-mode .model-status,
+        body.light-mode .server-key-status {
             color: #555555;
         }
 
         body.light-mode .model-error {
             color: #9a5b00;
+        }
+
+        body.light-mode .server-key-status strong,
+        body.light-mode .new-chat-button {
+            color: #007bff;
+        }
+
+        body.light-mode .new-chat-button {
+            border-color: rgba(0, 123, 255, 0.5);
         }
 
         body.light-mode .send-button {
@@ -423,6 +446,17 @@
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>
                 <p v-else-if="modelsError" class="model-status model-error">{{ modelsError }}</p>
                 <p v-else-if="selectedModelSummary" class="model-status">{{ selectedModelSummary }}</p>
+                <p v-if="selectedServerKeyLabel" class="server-key-status" data-testid="landing-server-key-label"><strong>{{ selectedServerKeyLabel }}</strong></p>
+                <p v-else class="server-key-status">Server: selected on first send</p>
+                <button
+                    v-if="selectedServerUnavailable || selectedServerKeyLabel"
+                    type="button"
+                    class="new-chat-button"
+                    data-testid="landing-new-chat-button"
+                    @click="startNewChatSession"
+                >
+                    New chat / choose another node
+                </button>
             </div>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
                 <span v-html="renderMarkdown(getDisplayContent(message))"></span>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,10 +179,15 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "root_page_loads",
+        "landing_chat",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_model_dropdown_uses_api_v1_models",
         "landing_chat_model_catalog_failure_uses_api_v1_fallback",
         "landing_chat_shows_no_servers_available_message",
+        "landing_chat_sticks_to_one_server_across_two_turns",
+        "landing_chat_server_key_label_is_shortened",
+        "sticky",
+        "server_key",
         "compute_node_count",
         "compute_node_count_renders_and_updates",
         "compute_node_count_failure_is_graceful",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -248,33 +248,167 @@ def wait_for_landing_send_enabled(page: Page):
     return send_button
 
 
+
+SERVER_PUBLIC_KEY_PEM = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
+VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
+7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
+xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
+CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
++6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
+0QIDAQAB
+-----END PUBLIC KEY-----"""
+SERVER_PUBLIC_KEY_B64 = base64.b64encode(SERVER_PUBLIC_KEY_PEM.encode("utf-8")).decode("ascii")
+
+
+def mock_landing_relay_routes(page: Page, *, replies=None, models=None, next_status=200):
+    relay_request_bodies = []
+    retrieve_bodies = []
+    next_server_calls = []
+    chat_completion_calls = []
+    v2_calls = []
+    replies = list(replies or ["Relay chat path restored."])
+    models_payload = models or {
+        "object": "list",
+        "data": [
+            {
+                "id": "api-v1-first-model",
+                "object": "model",
+                "owned_by": "token.place",
+                "root": "api-v1-first-model",
+            },
+            {
+                "id": "api-v1-second-model",
+                "object": "model",
+                "owned_by": "community",
+                "root": "api-v1-second-model",
+            },
+        ],
+    }
+
+    page.route(
+        "**/api/v1/models",
+        lambda route: route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(models_payload),
+        ),
+    )
+
+    def handle_next_server(route):
+        next_server_calls.append(route.request.url)
+        if next_status != 200:
+            route.fulfill(
+                status=next_status,
+                headers={"Content-Type": "application/json"},
+                body=json.dumps(
+                    {
+                        "error": {
+                            "type": "service_unavailable_error",
+                            "code": "no_registered_compute_nodes",
+                            "message": "No registered compute nodes available",
+                        }
+                    }
+                ),
+            )
+            return
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"server_public_key": SERVER_PUBLIC_KEY_B64}),
+        )
+
+    def handle_relay_request(route):
+        relay_request_bodies.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"message": "Request received"}),
+        )
+
+    def handle_retrieve(route):
+        retrieve_bodies.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"ciphertext": "response-ciphertext", "cipherkey": "response-cipherkey", "iv": "response-iv"}),
+        )
+
+    page.route("**/api/v1/relay/servers/next", handle_next_server)
+    page.route("**/api/v1/relay/requests", handle_relay_request)
+    page.route("**/api/v1/relay/responses/retrieve", handle_retrieve)
+    page.route(
+        "**/api/v1/chat/completions",
+        lambda route: (
+            chat_completion_calls.append(route.request.url),
+            route.fulfill(status=500, body="landing chat should not call chat/completions"),
+        ),
+    )
+    page.route(
+        "**/api/v2/**",
+        lambda route: (
+            v2_calls.append(route.request.url),
+            route.fulfill(status=500, body="API v2 should not be called by the landing chat"),
+        ),
+    )
+
+    return {
+        "relay_request_bodies": relay_request_bodies,
+        "retrieve_bodies": retrieve_bodies,
+        "next_server_calls": next_server_calls,
+        "chat_completion_calls": chat_completion_calls,
+        "v2_calls": v2_calls,
+        "replies": replies,
+    }
+
+
+def install_landing_crypto_stubs(page: Page, *, replies):
+    page.wait_for_function("document.querySelector('#app') && document.querySelector('#app').__vue__")
+    page.evaluate(
+        """
+        (replies) => {
+            window.__landingRelayPlaintexts = [];
+            window.__landingRelayReplies = replies.slice();
+            const vm = document.querySelector('#app').__vue__;
+            vm.encrypt = async (plaintext, publicKeyPem) => {
+                const parsed = JSON.parse(plaintext);
+                window.__landingRelayPlaintexts.push({ plaintext: parsed, publicKeyPem });
+                window.__landingLastRequestId = parsed.request_id;
+                return { ciphertext: `ciphertext-${parsed.request_id}`, cipherkey: 'cipherkey', iv: 'iv' };
+            };
+            vm.decrypt = async () => {
+                const reply = window.__landingRelayReplies.shift() || 'stubbed reply';
+                return JSON.stringify({
+                    protocol: 'tokenplace_api_v1_relay_e2ee',
+                    version: 1,
+                    request_id: window.__landingLastRequestId,
+                    client_public_key: vm.encodeClientPublicKeyForApi(),
+                    api_v1_response: {
+                        choices: [
+                            { message: { role: 'assistant', content: reply } }
+                        ]
+                    }
+                });
+            };
+        }
+        """,
+        replies,
+    )
+
+
+def get_landing_plaintexts(page: Page):
+    return page.evaluate("window.__landingRelayPlaintexts.map((entry) => entry.plaintext)")
+
+
 def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_servers):
     """The chat UI should render markdown formatting returned by the assistant."""
 
     markdown_reply = "**Bold** introduction\n\n- First item\n- Second item\n\nHere is `inline` code and:\n```\nblock example\n```"
-
-    def handle_chat_request(route):
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(
-                {
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": markdown_reply,
-                            }
-                        }
-                    ]
-                }
-            ),
-        )
-
-    page.route("**/api/v1/chat/completions", handle_chat_request)
+    routes = mock_landing_relay_routes(page, replies=[markdown_reply])
 
     page.goto(base_url)
     page.wait_for_load_state("networkidle")
+    install_landing_crypto_stubs(page, replies=routes["replies"])
 
     textarea = page.locator("textarea").first
     textarea.fill("Show markdown please")
@@ -296,8 +430,9 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
     block_code = assistant_message.locator("pre code").first
     assert "block example" in block_code.inner_text()
 
-    # Ensure raw HTML isn't rendered unsanitized
     assert assistant_message.locator("script").count() == 0
+    assert routes["chat_completion_calls"] == []
+    assert routes["v2_calls"] == []
 
 
 def test_landing_chat_uses_api_v1_only_non_streaming(
@@ -305,94 +440,13 @@ def test_landing_chat_uses_api_v1_only_non_streaming(
     base_url: str,
     setup_servers,
 ):
-    """Landing chat must stay on API v1 JSON chat completions only."""
+    """Landing chat must use API v1 relay E2EE request/retrieve routes only."""
 
-    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
-VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
-7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
-xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
-CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
-+6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
-0QIDAQAB
------END PUBLIC KEY-----"""
-    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
-
-    def handle_public_key(route):
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"public_key": server_public_key_b64}),
-        )
-
-    def handle_next_server(route):
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"server_public_key": server_public_key_b64}),
-        )
-
-    def handle_v1_chat(route):
-        request_json = route.request.post_data_json
-        assert request_json.get("encrypted") is True
-        assert isinstance(request_json.get("client_public_key"), str) and request_json[
-            "client_public_key"
-        ]
-
-        encrypted_request = request_json.get("messages")
-        assert isinstance(encrypted_request, dict)
-        assert isinstance(encrypted_request.get("ciphertext"), str) and encrypted_request["ciphertext"]
-        assert isinstance(encrypted_request.get("cipherkey"), str) and encrypted_request["cipherkey"]
-        assert isinstance(encrypted_request.get("iv"), str) and encrypted_request["iv"]
-
-        client_public_key_pem = base64.b64decode(request_json["client_public_key"], validate=True)
-        assert b"-----BEGIN PUBLIC KEY-----" in client_public_key_pem
-
-        encrypted_response_body, encrypted_key, iv = encrypt(
-            json.dumps(
-                {
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": "Relay chat path restored.",
-                            }
-                        }
-                    ]
-                }
-            ).encode("utf-8"),
-            client_public_key_pem,
-            use_pkcs1v15=True,
-        )
-
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(
-                {
-                    "encrypted": True,
-                    "data": {
-                        "ciphertext": base64.b64encode(encrypted_response_body["ciphertext"]).decode("utf-8"),
-                        "cipherkey": base64.b64encode(encrypted_key).decode("utf-8"),
-                        "iv": base64.b64encode(iv).decode("utf-8"),
-                    },
-                }
-            ),
-        )
-
-    v2_requests = []
-
-    def record_v2_request(route):
-        v2_requests.append(route.request.url)
-        route.fulfill(status=500, body="v2 should not be called")
-
-    page.route("**/api/v1/public-key", handle_public_key)
-    page.route("**/next_server", handle_next_server)
-    page.route("**/api/v2/chat/completions", record_v2_request)
-    page.route("**/api/v1/chat/completions", handle_v1_chat)
+    routes = mock_landing_relay_routes(page, replies=["Relay chat path restored."])
 
     page.goto(base_url)
     page.wait_for_load_state("networkidle")
+    install_landing_crypto_stubs(page, replies=routes["replies"])
 
     textarea = page.locator("textarea").first
     textarea.fill("hello")
@@ -400,20 +454,13 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
 
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
-    page.wait_for_function(
-        """
-        ({ selector, expectedText }) => {
-            const nodes = document.querySelectorAll(selector);
-            if (!nodes.length) return false;
-            const latest = nodes[nodes.length - 1];
-            return latest.textContent.includes(expectedText);
-        }
-        """,
-        arg={"selector": ".assistant-message", "expectedText": "Relay chat path restored."},
-    )
     assert "Relay chat path restored." in assistant_message.inner_text()
     assert "Sorry, I encountered an issue generating a response." not in page.content()
-    assert v2_requests == []
+    assert len(routes["next_server_calls"]) == 1
+    assert len(routes["relay_request_bodies"]) == 1
+    assert len(routes["retrieve_bodies"]) == 1
+    assert routes["chat_completion_calls"] == []
+    assert routes["v2_calls"] == []
 
 
 def test_landing_chat_model_dropdown_uses_api_v1_models(
@@ -421,85 +468,13 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
     base_url: str,
     setup_servers,
 ):
-    """The landing chat model selector is populated from API v1 and drives chat payloads."""
+    """The landing chat model selector is populated from API v1 and drives relay envelopes."""
 
-    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
-VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
-7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
-xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
-CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
-+6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
-0QIDAQAB
------END PUBLIC KEY-----"""
-    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
-
-    models_payload = {
-        "object": "list",
-        "data": [
-            {
-                "id": "api-v1-first-model",
-                "object": "model",
-                "owned_by": "token.place",
-                "root": "api-v1-first-model",
-            },
-            {
-                "id": "api-v1-second-model",
-                "object": "model",
-                "owned_by": "community",
-                "root": "api-v1-second-model",
-            },
-        ],
-    }
-
-    chat_payloads = []
-    v2_requests = []
-
-    def handle_models(route):
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(models_payload),
-        )
-
-    def handle_public_key(route):
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"public_key": server_public_key_b64}),
-        )
-
-    def handle_chat(route):
-        request_json = route.request.post_data_json
-        chat_payloads.append(request_json)
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(
-                {
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": "Selected model acknowledged.",
-                            }
-                        }
-                    ]
-                }
-            ),
-        )
-
-    def record_v2_request(route):
-        v2_requests.append(route.request.url)
-        route.fulfill(status=500, body="API v2 should not be called by the landing chat")
-
-    page.route("**/api/v1/models", handle_models)
-    page.route("**/api/v1/public-key", handle_public_key)
-    page.route("**/api/v1/chat/completions", handle_chat)
-    page.route("**/api/v2/**", record_v2_request)
+    routes = mock_landing_relay_routes(page, replies=["Selected model acknowledged."])
 
     page.goto(base_url)
     page.wait_for_load_state("networkidle")
+    install_landing_crypto_stubs(page, replies=routes["replies"])
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
@@ -516,10 +491,83 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     wait_for_landing_send_enabled(page).click()
 
     page.locator(".assistant-message").last.wait_for(state="visible")
-    assert chat_payloads, "expected the landing chat to POST an API v1 chat payload"
-    assert chat_payloads[-1]["model"] == "api-v1-second-model"
-    assert chat_payloads[-1].get("encrypted") is True
-    assert v2_requests == []
+    plaintexts = get_landing_plaintexts(page)
+    assert plaintexts, "expected an encrypted API v1 relay plaintext envelope before encryption"
+    assert plaintexts[-1]["api_v1_request"]["model"] == "api-v1-second-model"
+    assert plaintexts[-1]["api_v1_request"]["messages"] == [
+        {"role": "user", "content": "Use the selected model"}
+    ]
+    assert routes["relay_request_bodies"][-1]["server_public_key"] == SERVER_PUBLIC_KEY_B64
+    assert routes["chat_completion_calls"] == []
+    assert routes["v2_calls"] == []
+
+
+@pytest.mark.e2e
+def test_landing_chat_sticks_to_one_server_across_two_turns(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """A browser chat session should select one compute node and reuse it for later turns."""
+
+    routes = mock_landing_relay_routes(page, replies=["first", "second"])
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+    install_landing_crypto_stubs(page, replies=routes["replies"])
+    page.get_by_test_id("landing-model-select").select_option("api-v1-second-model")
+
+    textarea = page.locator("textarea").first
+    textarea.fill("first turn")
+    wait_for_landing_send_enabled(page).click()
+    page.locator(".assistant-message").nth(0).wait_for(state="visible")
+
+    textarea.fill("second turn")
+    wait_for_landing_send_enabled(page).click()
+    page.locator(".assistant-message").nth(1).wait_for(state="visible")
+
+    assert len(routes["next_server_calls"]) == 1
+    assert len(routes["relay_request_bodies"]) == 2
+    assert {body["server_public_key"] for body in routes["relay_request_bodies"]} == {SERVER_PUBLIC_KEY_B64}
+    plaintexts = get_landing_plaintexts(page)
+    assert [entry["api_v1_request"]["model"] for entry in plaintexts] == [
+        "api-v1-second-model",
+        "api-v1-second-model",
+    ]
+    assert [entry["api_v1_request"]["messages"] for entry in plaintexts] == [
+        [{"role": "user", "content": "first turn"}],
+        [{"role": "user", "content": "second turn"}],
+    ]
+    assert routes["chat_completion_calls"] == []
+    assert routes["v2_calls"] == []
+
+
+@pytest.mark.e2e
+def test_landing_chat_server_key_label_is_shortened(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """The landing chat should display only a shortened compute-node public-key label."""
+
+    routes = mock_landing_relay_routes(page, replies=["label ok"])
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+    install_landing_crypto_stubs(page, replies=routes["replies"])
+
+    page.locator("textarea").first.fill("hello")
+    wait_for_landing_send_enabled(page).click()
+
+    label = page.get_by_test_id("landing-server-key-label")
+    label.wait_for(state="visible")
+    label_text = label.inner_text()
+    compact = re.sub(r"[^A-Za-z0-9]", "", SERVER_PUBLIC_KEY_B64)
+    assert label_text == f"Server: {compact[:8]}…{compact[-8:]}"
+    assert SERVER_PUBLIC_KEY_B64 not in page.locator("body").inner_text()
+    assert SERVER_PUBLIC_KEY_PEM not in page.locator("body").inner_text()
+    assert routes["chat_completion_calls"] == []
+    assert routes["v2_calls"] == []
 
 
 @pytest.mark.e2e
@@ -528,21 +576,10 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
     base_url: str,
     setup_servers,
 ):
-    """A failed model list shows a non-blocking error and stays on API v1 fallback chat."""
+    """A failed model list shows a non-blocking error and still uses API v1 relay E2EE."""
 
-    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
-VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
-7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
-xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
-CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
-+6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
-0QIDAQAB
------END PUBLIC KEY-----"""
-    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
-    chat_requests = []
-    v2_requests = []
-
+    routes = mock_landing_relay_routes(page, replies=["Fallback model acknowledged."])
+    page.unroute("**/api/v1/models")
     page.route(
         "**/api/v1/models",
         lambda route: route.fulfill(
@@ -551,46 +588,10 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
             body=json.dumps({"error": {"message": "catalog temporarily unavailable"}}),
         ),
     )
-    page.route(
-        "**/api/v1/public-key",
-        lambda route: route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"public_key": server_public_key_b64}),
-        ),
-    )
-    page.route(
-        "**/api/v1/chat/completions",
-        lambda route: (
-            chat_requests.append(route.request.post_data_json),
-            route.fulfill(
-                status=200,
-                headers={"Content-Type": "application/json"},
-                body=json.dumps(
-                    {
-                        "choices": [
-                            {
-                                "message": {
-                                    "role": "assistant",
-                                    "content": "Fallback model acknowledged.",
-                                }
-                            }
-                        ]
-                    }
-                ),
-            ),
-        ),
-    )
-    page.route(
-        "**/api/v2/**",
-        lambda route: (
-            v2_requests.append(route.request.url),
-            route.fulfill(status=500, body="API v2 should not be called by the landing chat"),
-        ),
-    )
 
     page.goto(base_url)
     page.wait_for_load_state("networkidle")
+    install_landing_crypto_stubs(page, replies=routes["replies"])
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
@@ -602,10 +603,10 @@ CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
     wait_for_landing_send_enabled(page).click()
 
     page.locator(".assistant-message").last.wait_for(state="visible")
-    assert chat_requests, "expected the landing chat to POST the API v1 fallback payload"
-    assert chat_requests[-1]["model"] == "llama-3-8b-instruct"
-    assert chat_requests[-1].get("encrypted") is True
-    assert v2_requests == []
+    plaintexts = get_landing_plaintexts(page)
+    assert plaintexts[-1]["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert routes["chat_completion_calls"] == []
+    assert routes["v2_calls"] == []
 
 
 @pytest.mark.e2e
@@ -616,41 +617,7 @@ def test_landing_chat_shows_no_servers_available_message(
 ):
     """Structured API v1 no-server errors should render a clear landing-chat message."""
 
-    server_public_key_pem = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnFBKDAvTZEd+IlS59FKV
-VFp4DT28sL1iHwZ94dJ5x5lf+Kq4Wxcl8COEQ3rp3QseM2MkAdZ1VvWbUmsonFux
-7pVLQDyE+ANQkNd4K840zWV+CghTz34jxK59pb6cifSto7J8Wy7EqhUru7YLhnqZ
-xz/AuHBPrq0RUS7f+ycJtfA6vj9Isp0BYpvgwOP97Ey+nCLiR5C/3IazOZblHQ7R
-CbfZqP+encMwRbH/IvrXrz6/vecuIrq60fFtyZIbs7dASpfuSL6atIABu6CiSlXy
-+6EhlEdmAXaCOPlQMYjc4u2ZNrOUTjuh3Yw8hMGezsTfTYZd2rrbGZRlkpfKbIdX
-0QIDAQAB
------END PUBLIC KEY-----"""
-    server_public_key_b64 = base64.b64encode(server_public_key_pem.encode("utf-8")).decode("ascii")
-
-    page.route(
-        "**/api/v1/public-key",
-        lambda route: route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"public_key": server_public_key_b64}),
-        ),
-    )
-    page.route(
-        "**/api/v1/chat/completions",
-        lambda route: route.fulfill(
-            status=503,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(
-                {
-                    "error": {
-                        "type": "service_unavailable_error",
-                        "code": "no_registered_compute_nodes",
-                        "message": "No registered compute nodes available",
-                    }
-                }
-            ),
-        ),
-    )
+    mock_landing_relay_routes(page, next_status=503)
 
     page.goto(base_url)
     page.wait_for_load_state("networkidle")
@@ -839,8 +806,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
                 const vm = appEl && appEl.__vue__;
                 return Boolean(
                     vm &&
-                    typeof vm.serverPublicKey === 'string' &&
-                    vm.serverPublicKey.trim().length > 0 &&
                     typeof vm.clientPublicKey === 'string' &&
                     vm.clientPublicKey.trim().length > 0
                 );
@@ -943,14 +908,6 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
 
         assert len(v1_requests) >= 1
         assert v2_requests == []
-        assert v1_response_headers, "expected at least one API v1 response"
-        latest_headers = v1_response_headers[-1]
-        provider_class = latest_headers.get("x-tokenplace-api-v1-provider")
-        resolved_provider_path = latest_headers.get("x-tokenplace-api-v1-resolved-provider-path")
-        execution_backend_path = latest_headers.get("x-tokenplace-api-v1-execution-backend-path")
-        assert provider_class == "DistributedApiV1ComputeProvider"
-        assert resolved_provider_path == "distributed"
-        assert execution_backend_path == "distributed_relay_e2ee"
 
         page.wait_for_timeout(300)
         non_streaming_state = page.evaluate(
@@ -1016,12 +973,14 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
         )
 
         encrypted_request = v1_requests[0].post_data_json
-        assert encrypted_request.get("encrypted") is True
+        assert encrypted_request.get("protocol") == "tokenplace_api_v1_relay_e2ee"
+        assert encrypted_request.get("version") == 1
+        assert isinstance(encrypted_request.get("request_id"), str) and encrypted_request["request_id"]
+        assert encrypted_request.get("server_public_key")
+        assert encrypted_request.get("ciphertext")
+        assert encrypted_request.get("cipherkey")
+        assert encrypted_request.get("iv")
         assert encrypted_request.get("stream") in (None, False)
-        metadata = encrypted_request.get("metadata")
-        assert isinstance(metadata, dict)
-        assert metadata.get("inference_target") == "desktop_bridge_api_v1_e2ee"
-        assert metadata.get("relay_path") == "api_v1_e2ee"
         client_public_key = encrypted_request.get("client_public_key")
         assert isinstance(client_public_key, str) and client_public_key
         client_public_key_pem = base64.b64decode(client_public_key, validate=True)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2804,6 +2804,33 @@ def test_api_v1_next_keeps_server_alive_while_any_in_flight_request_remains(clie
     assert next_response.get_json().get('server_public_key') == DUMMY_SERVER_PUB_KEY
 
 
+
+
+def test_api_v1_servers_next_uses_registration_order_round_robin_for_new_clients(client):
+    server_keys = [
+        base64.b64encode(f"server_public_key_rr_{idx}".encode("utf-8")).decode("ascii")
+        for idx in range(3)
+    ]
+    for server_key in server_keys:
+        response = client.post('/api/v1/relay/servers/register', json={'server_public_key': server_key})
+        assert response.status_code == 200
+
+    selected = [
+        client.get('/api/v1/relay/servers/next').get_json()['server_public_key']
+        for _ in range(7)
+    ]
+
+    assert selected == [
+        server_keys[0],
+        server_keys[1],
+        server_keys[2],
+        server_keys[0],
+        server_keys[1],
+        server_keys[2],
+        server_keys[0],
+    ]
+
+
 def test_api_v1_unregister_removes_known_server_and_next_skips_it(client):
     server_payload = {'server_public_key': DUMMY_SERVER_PUB_KEY}
     assert client.post('/api/v1/relay/servers/register', json=server_payload).status_code == 200

--- a/tests/unit/test_e2ee_relay_invariant.py
+++ b/tests/unit/test_e2ee_relay_invariant.py
@@ -252,30 +252,36 @@ def test_logs_and_diagnostics_do_not_echo_plaintext_sentinel(monkeypatch, caplog
     assert _to_text(sink_response.get_json()).find(E2EE_SENTINEL_LOGS) == -1
 
 
-def test_api_v1_relay_rejects_plaintext_fields_on_request_envelope(relay_client):
+@pytest.mark.parametrize("field", ["messages", "prompt", "content", "response", "text"])
+def test_api_v1_relay_rejects_plaintext_fields_on_request_envelope(relay_client, field):
     relay.known_servers["server-key"] = {
         "public_key": "server-key",
         "last_ping": relay.datetime.now(),
         "last_ping_duration": 10,
     }
 
-    resp = relay_client.post(
-        "/api/v1/relay/requests",
-        json={
-            "server_public_key": "server-key",
-            "client_public_key": "client-key",
-            "ciphertext": "c",
-            "cipherkey": "k",
-            "iv": "i",
-            "messages": [{"role": "user", "content": E2EE_SENTINEL_RELAY_STATE}],
-        },
+    plaintext_value = (
+        [{"role": "user", "content": E2EE_SENTINEL_RELAY_STATE}]
+        if field == "messages"
+        else E2EE_SENTINEL_RELAY_STATE
     )
+    payload = {
+        "server_public_key": "server-key",
+        "client_public_key": "client-key",
+        "ciphertext": "c",
+        "cipherkey": "k",
+        "iv": "i",
+        field: plaintext_value,
+    }
+
+    resp = relay_client.post("/api/v1/relay/requests", json=payload)
 
     assert resp.status_code == 400
     assert "forbidden" in resp.get_json()["error"]["message"]
 
 
-def test_api_v1_relay_rejects_plaintext_fields_on_response_envelope(monkeypatch, relay_client):
+@pytest.mark.parametrize("field", ["messages", "prompt", "content", "response", "text"])
+def test_api_v1_relay_rejects_plaintext_fields_on_response_envelope(monkeypatch, relay_client, field):
     monkeypatch.setenv("TOKENPLACE_RELAY_SERVER_BEARER_TOKEN", "token")
     relay.known_servers["server-key"] = {
         "public_key": "server-key",
@@ -290,7 +296,7 @@ def test_api_v1_relay_rejects_plaintext_fields_on_response_envelope(monkeypatch,
             "ciphertext": "c",
             "cipherkey": "k",
             "iv": "i",
-            "content": E2EE_SENTINEL_RELAY_STATE,
+            field: ([{"role": "assistant", "content": E2EE_SENTINEL_RELAY_STATE}] if field == "messages" else E2EE_SENTINEL_RELAY_STATE),
         },
         headers={"Authorization": "Bearer token"},
     )

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -18,8 +18,17 @@ def test_chat_js_defines_touch_detection_hook():
 
 def test_landing_chat_js_avoids_relay_v2_streaming_path():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
-    assert "/api/v1/chat/completions" in chat_js, (
-        "landing chat must call relay API v1 chat completions endpoint"
+    assert "/api/v1/relay/servers/next" in chat_js, (
+        "landing chat must select one API v1 relay compute node before sending"
+    )
+    assert "/api/v1/relay/requests" in chat_js, (
+        "landing chat must submit relay-blind API v1 E2EE request envelopes"
+    )
+    assert "/api/v1/relay/responses/retrieve" in chat_js, (
+        "landing chat must retrieve API v1 relay E2EE responses"
+    )
+    assert "/api/v1/chat/completions" not in chat_js, (
+        "landing chat must not use server-side API v1 chat completion node selection"
     )
     assert "/api/v1/completions" not in chat_js, (
         "landing chat must not call legacy API v1 text completions endpoint"


### PR DESCRIPTION
### Motivation
- Prevent accidental broadcast of full conversation history by selecting a single compute node per browser chat session and keeping the relay strictly ciphertext-only for routing metadata. 
- Surface a compact, non-secret server identifier in the UI so users know which node answered without exposing full public keys in the DOM or logs. 
- Move the landing demo to relay-blind API v1 E2EE envelopes so the browser owns affinity and the relay remains a simple round-robin selector for new clients.

### Description
- Client: replaced landing chat server-selection and transport logic in `static/chat.js` to: discover a server once via `GET /api/v1/relay/servers/next`, persist `selectedServerPublicKeyB64`, keep a normalized PEM `selectedServerPublicKey` for encryption, and expose a shortened `selectedServerKeyLabel` for the UI; build and encrypt API v1 relay plaintext envelopes (`protocol: tokenplace_api_v1_relay_e2ee`) per-turn, POST ciphertext-only payloads to `/api/v1/relay/requests`, and poll `/api/v1/relay/responses/retrieve` until a terminal or successful encrypted response is returned. 
- UI: added a shortened server key label and a `New chat / choose another node` button to `static/index.html` so the full public key is never rendered in the page text. 
- Tests: updated and added E2E and unit tests in `tests/e2e/test_ui.py`, added a relay round-robin regression test to `tests/test_relay.py`, and parameterized plaintext-field invariant tests in `tests/unit/test_e2ee_relay_invariant.py` to cover multiple forbidden fields; tests mock relay routes and include client-side crypto stubs to assert: a single `GET /api/v1/relay/servers/next` per chat session, same `server_public_key` used across turns, the selected model appears inside the encrypted API v1 plaintext envelope, no `/api/v2` or landing `POST /api/v1/chat/completions` calls are made, and the shortened server key label renders while the full key does not appear in page text. 
- No behavioral changes were made to relay selection logic in `relay.py` (round-robin selection helper already present); the relay-side contract and ciphertext-only invariants were preserved. 

### Testing
- Ran unit and relay suites with `python -m pytest tests/test_relay.py tests/unit/test_e2ee_relay_invariant.py -v` and `python -m pytest tests/unit/test_api_v1_launch_contract.py -v`; all targeted unit/relay tests passed (134 passed across relay tests, and relevant unit suites passed). 
- Executed JS checks with `npm run test:js`; local JS crypto and mock-server tests passed (all JS smoke tests passed). 
- Ran focused integration `RUN_RELAY_REGISTRATION_TESTS=1 python -m pytest tests/integration -k "server_py or compute_node_cli" -v` and the selected integration guardrail test passed. 
- Attempted landing-page E2E subset with Playwright via `python -m pytest tests/e2e/test_ui.py -k "landing_chat or sticky or server_key" -v`; these tests exercise the browser-side flows and the new landing-chat mocks, but they failed to run to completion in this environment due to Playwright browser runtime constraints (initially missing browser binaries, then missing system libraries when launching Chromium). The test code and Playwright mocks are present and locally executable in a full Playwright-enabled environment, but CI or a developer machine must have `playwright install` and the platform dependencies (or `playwright install-deps`) available for the E2E browser tests to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26412d626c832fb92db0ad15499038)