### PR TITLE
Stabilize macOS desktop runtime tests

### DIFF
--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -589,13 +589,14 @@ def test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_
     manager = FakeManager()
     _install_fake_manager_module(manager)
 
-    runtime_setup_module = sys.modules['desktop_runtime_setup']
+    original_ensure_runtime = inference_sidecar.ensure_desktop_llama_runtime
+    runtime_setup_globals = original_ensure_runtime.__globals__
 
     class _WinSysStub:
         platform = 'win32'
         executable = sys.executable
 
-    probe = runtime_setup_module.RuntimeProbe(
+    probe = runtime_setup_globals['RuntimeProbe'](
         backend='cpu',
         detected_device='cpu',
         gpu_offload_supported=False,
@@ -606,25 +607,30 @@ def test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_
     )
     repair_calls = {'source': 0, 'retry_gate': 0}
 
-    monkeypatch.setattr(runtime_setup_module, 'sys', _WinSysStub)
-    monkeypatch.delenv(runtime_setup_module.DISABLE_BOOTSTRAP_ENV, raising=False)
-    monkeypatch.delenv(runtime_setup_module.ENABLE_BOOTSTRAP_ENV, raising=False)
-    monkeypatch.setattr(runtime_setup_module, '_probe_llama_runtime', lambda **_: probe)
-    monkeypatch.setattr(
-        runtime_setup_module,
+    monkeypatch.setitem(runtime_setup_globals, 'sys', _WinSysStub)
+    monkeypatch.delenv(runtime_setup_globals['DISABLE_BOOTSTRAP_ENV'], raising=False)
+    monkeypatch.delenv(runtime_setup_globals['ENABLE_BOOTSTRAP_ENV'], raising=False)
+    monkeypatch.setitem(runtime_setup_globals, '_probe_llama_runtime', lambda **_: probe)
+    monkeypatch.setitem(
+        runtime_setup_globals,
         '_windows_cuda_source_repair',
         lambda _requirements_path: (
             repair_calls.__setitem__('source', repair_calls['source'] + 1) or True,
             'ok',
         ),
     )
-    monkeypatch.setattr(
-        runtime_setup_module,
+    monkeypatch.setitem(
+        runtime_setup_globals,
         '_should_attempt_source_repair',
         lambda: (
             repair_calls.__setitem__('retry_gate', repair_calls['retry_gate'] + 1) or True,
             '',
         ),
+    )
+    monkeypatch.setattr(
+        inference_sidecar,
+        'ensure_desktop_llama_runtime',
+        lambda mode: original_ensure_runtime(mode),
     )
 
     args = SimpleNamespace(model=str(model_path), mode='auto', prompt='hello')

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -608,7 +608,10 @@ def test_runtime_root_with_invalid_env_var_warns_and_falls_back(monkeypatch, cap
     resolved = desktop_runtime_setup._resolve_runtime_root()
     captured = capsys.readouterr()
     assert 'TOKEN_PLACE_PYTHON_IMPORT_ROOT was set but does not look like a runtime root' in captured.err
-    assert resolved == Path('/').resolve()
+    expected_fallback = desktop_runtime_setup._safe_resolve_path(
+        '/tmp/token-place/python/desktop_runtime_setup.py'
+    ).parents[3]
+    assert resolved == expected_fallback
 
 
 def test_runtime_root_ignores_existing_but_invalid_env_path_and_falls_back_to_marker_ancestor(


### PR DESCRIPTION
### Motivation
- Finish macOS `run_all_tests.sh` cleanup by making remaining desktop/runtime unit tests deterministic on macOS Apple Silicon so they exercise the intended mocked paths instead of the real runtime probe.

### Description
- Patch tests to target the exact `inference_sidecar.ensure_desktop_llama_runtime` callable and use its function `__globals__` when injecting `RuntimeProbe` and related symbols so the Windows probe-only path is exercised reliably on macOS.  
- Replace fragile `sys.modules['desktop_runtime_setup']` monkeypatching with `monkeypatch.setitem` into the runtime-ensure function globals to avoid hitting the real macOS Metal probe.  
- Make the invalid `TOKEN_PLACE_PYTHON_IMPORT_ROOT` fallback assertion portable by deriving the expected fallback from `desktop_runtime_setup._safe_resolve_path(...).parents[3]` instead of `Path('/').resolve()` so macOS `/tmp` -> `/private/tmp` canonicalization is handled.  
- Only test changes: `tests/unit/test_desktop_inference_sidecar.py` and `tests/unit/test_desktop_runtime_setup.py`.

### Testing
- `python -m pytest tests/unit/test_desktop_inference_sidecar.py::test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_work -vv` — passed.  
- `python -m pytest tests/unit/test_desktop_runtime_setup.py::test_runtime_root_with_invalid_env_var_warns_and_falls_back -vv` — passed.  
- `bash tests/test_cgroup.sh; echo $?` — printed the expected "Reboot required" messages and exited `0`.  
- Focused suites: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_runtime_setup.py -v`, `python -m pytest tests/unit/test_model_manager.py tests/unit/test_model_manager_llama_import_guard.py -v`, and `python -m pytest tests/unit/test_dspace_integration_script.py tests/unit/test_sendemail_validate_hook.py tests/test_security_bandit.py -v` — all passed.  
- Full verification: `./run_all_tests.sh` and `pre-commit run --all-files` — completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2703cbc26c832f9d913ef9823cf223)