### PR TITLE
Stabilize macOS desktop runtime tests

### DIFF
--- a/tests/unit/test_desktop_inference_sidecar.py
+++ b/tests/unit/test_desktop_inference_sidecar.py
@@ -609,7 +609,12 @@ def test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_
     monkeypatch.setattr(runtime_setup_module, 'sys', _WinSysStub)
     monkeypatch.delenv(runtime_setup_module.DISABLE_BOOTSTRAP_ENV, raising=False)
     monkeypatch.delenv(runtime_setup_module.ENABLE_BOOTSTRAP_ENV, raising=False)
-    monkeypatch.setattr(runtime_setup_module, '_probe_llama_runtime', lambda **_: probe)
+    monkeypatch.setattr(runtime_setup_module, '_probe_runtime', lambda _runtime_root: probe)
+    monkeypatch.setattr(
+        inference_sidecar,
+        'ensure_desktop_llama_runtime',
+        runtime_setup_module.ensure_desktop_llama_runtime,
+    )
     monkeypatch.setattr(
         runtime_setup_module,
         '_windows_cuda_source_repair',

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -602,12 +602,15 @@ def test_runtime_root_prefers_token_place_python_import_root_with_config_py(monk
     assert resolved == runtime_root.resolve()
 
 
-def test_runtime_root_with_invalid_env_var_warns_and_falls_back(monkeypatch, capsys):
-    script_path = Path('/tmp/token-place/python/desktop_runtime_setup.py')
-    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '/tmp/not-a-runtime-root')
+def test_runtime_root_with_invalid_env_var_warns_and_falls_back(monkeypatch, tmp_path, capsys):
+    script_path = tmp_path / 'isolated-runtime' / 'python' / 'desktop_runtime_setup.py'
+    invalid_env_root = tmp_path / 'not-a-runtime-root'
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(invalid_env_root))
     monkeypatch.setattr(desktop_runtime_setup, '__file__', str(script_path))
+
     resolved = desktop_runtime_setup._resolve_runtime_root()
     captured = capsys.readouterr()
+
     assert 'TOKEN_PLACE_PYTHON_IMPORT_ROOT was set but does not look like a runtime root' in captured.err
     assert resolved == script_path.resolve().parents[3]
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -603,12 +603,13 @@ def test_runtime_root_prefers_token_place_python_import_root_with_config_py(monk
 
 
 def test_runtime_root_with_invalid_env_var_warns_and_falls_back(monkeypatch, capsys):
+    script_path = Path('/tmp/token-place/python/desktop_runtime_setup.py')
     monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '/tmp/not-a-runtime-root')
-    monkeypatch.setattr(desktop_runtime_setup, '__file__', '/tmp/token-place/python/desktop_runtime_setup.py')
+    monkeypatch.setattr(desktop_runtime_setup, '__file__', str(script_path))
     resolved = desktop_runtime_setup._resolve_runtime_root()
     captured = capsys.readouterr()
     assert 'TOKEN_PLACE_PYTHON_IMPORT_ROOT was set but does not look like a runtime root' in captured.err
-    assert resolved == Path('/').resolve()
+    assert resolved == script_path.resolve().parents[3]
 
 
 def test_runtime_root_ignores_existing_but_invalid_env_path_and_falls_back_to_marker_ancestor(


### PR DESCRIPTION
### Motivation
- Prevent macOS Metal runtime probes from leaking into a Windows/probe-only unit test and make the runtime-root fallback expectation portable across macOS `/tmp` canonicalization.

### Description
- Update tests to stub the exact runtime seam used by `inference_sidecar.run` by monkeypatching `_probe_runtime` and wiring `inference_sidecar.ensure_desktop_llama_runtime` to the runtime module, and make the invalid `TOKEN_PLACE_PYTHON_IMPORT_ROOT` fallback assertion derive from the resolved script path instead of assuming `Path('/')`.

### Testing
- Ran the focused unit checks: `python -m pytest tests/unit/test_desktop_inference_sidecar.py::test_run_probe_only_windows_startup_emits_started_without_bootstrap_install_work -vv` and `python -m pytest tests/unit/test_desktop_runtime_setup.py::test_runtime_root_with_invalid_env_var_warns_and_falls_back -vv`, both passed.
- Verified broader subsets and CI scripts: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_runtime_setup.py -v`, `python -m pytest tests/unit/test_model_manager.py tests/unit/test_model_manager_llama_import_guard.py -v`, `python -m pytest tests/unit/test_dspace_integration_script.py tests/unit/test_sendemail_validate_hook.py tests/test_security_bandit.py -v`, `bash tests/test_cgroup.sh` (prints `Reboot required` but exits `0`), and `./run_all_tests.sh`, all completed successfully in the verification run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2703cbc26c832f9d913ef9823cf223)