### PR TITLE
Add visible PR workflow that runs ./run_all_tests.sh on Linux and macOS and tighten CI sentinel tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,71 +17,53 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - name: Prepare Raspberry Pi cgroups
-        id: prep
         run: |
           set +e
           sudo bash scripts/prepare-pi-cgroups.sh
-          echo "rc=$?" >> "$GITHUB_OUTPUT"
-          exit 0
-      - name: Stop for reboot
-        if: steps.prep.outputs.rc == '2'
-        run: echo "Cgroup configuration updated. Reboot runner and re-run job."
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            {
+              echo '## Raspberry Pi cgroup preparation requires a reboot'
+              echo ''
+              echo 'The full test suite cannot run until cgroup setup is complete, so this job fails instead of going green without running `./run_all_tests.sh`.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          exit "$rc"
       - name: Validate dependency compatibility
         run: python scripts/validate_dependencies.py
-        if: steps.prep.outputs.rc != '2'
       - name: Install Python dependencies
-        if: steps.prep.outputs.rc != '2'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Install Playwright browsers and system dependencies
-        if: steps.prep.outputs.rc != '2'
         run: playwright install --with-deps chromium
       - name: Install Node.js dependencies
-        if: steps.prep.outputs.rc != '2'
         run: npm ci
       - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
-        if: steps.prep.outputs.rc != '2'
         uses: actions/cache@v4
         with:
           path: .ci-models/stories15M-q4_0.gguf
           key: ci-relay-landing-page-real-desktop-bridge-api-v1-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
       - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
-        if: steps.prep.outputs.rc != '2'
-        run: |
-          set -euo pipefail
-          mkdir -p .ci-models
-          MODEL_PATH=".ci-models/stories15M-q4_0.gguf"
-          MODEL_REV="99dd1a73db5a37100bd4ae633f4cfce6560e1567"
-          MODEL_SHA256="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"
-          if [ ! -s "$MODEL_PATH" ]; then
-            # Keep this guardrail real (not mocked) while staying lightweight:
-            # a tiny GGUF still exercises end-to-end llama.cpp inference behavior.
-            curl -fL \
-              "https://huggingface.co/ggml-org/tiny-llamas/resolve/${MODEL_REV}/stories15M-q4_0.gguf" \
-              -o "$MODEL_PATH.tmp"
-            printf '%s  %s\n' "$MODEL_SHA256" "$MODEL_PATH.tmp" | sha256sum --check
-            mv "$MODEL_PATH.tmp" "$MODEL_PATH"
-          fi
-          test -s "$MODEL_PATH"
+        run: bash scripts/ci/provision_tiny_gguf.sh
       - name: Verify tiny real GGUF loads via relay landing-page desktop-bridge API v1 guardrail
-        if: steps.prep.outputs.rc != '2'
         env:
           TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
           RUN_RELAY_REGISTRATION_TESTS: '1'
         run: python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'
       - name: Run tests
-        if: steps.prep.outputs.rc != '2'
         run: ./run_all_tests.sh
         env:
           TEST_COVERAGE: '1'
@@ -89,7 +71,6 @@ jobs:
           # This tiny real model avoids fake inference while keeping CI fast and cache-friendly.
           TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
       - name: Upload coverage reports to Codecov
-        if: steps.prep.outputs.rc != '2'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -1,0 +1,165 @@
+name: run_all_tests.sh PR
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: run-all-tests-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  linux-run-all-tests:
+    name: Linux run_all_tests.sh
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Validate dependency compatibility
+        run: python scripts/validate_dependencies.py
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium and Linux system dependencies
+        run: python -m playwright install --with-deps chromium
+
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        uses: actions/cache@v4
+        with:
+          path: .ci-models/stories15M-q4_0.gguf
+          key: ci-relay-landing-page-real-desktop-bridge-api-v1-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
+
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        run: bash scripts/ci/provision_tiny_gguf.sh
+
+      - name: Run ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
+        run: |
+          set -o pipefail
+          ./run_all_tests.sh 2>&1 | tee run_all_tests.log
+
+      - name: Summarize run_all_tests.sh failure
+        if: failure()
+        run: |
+          {
+            echo '## run_all_tests.sh failed on Linux'
+            echo ''
+            echo 'The visible PR check failed because `./run_all_tests.sh` or a required setup step failed.'
+            echo 'Review the job log and the uploaded `linux-run_all_tests-log` artifact.'
+            if [ -f run_all_tests.log ]; then
+              echo ''
+              echo '### Last 120 log lines'
+              echo '```text'
+              tail -n 120 run_all_tests.log
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload run_all_tests.sh log
+        if: failure() && hashFiles('run_all_tests.log') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-run_all_tests-log
+          path: run_all_tests.log
+          if-no-files-found: error
+
+  macos-run-all-tests:
+    name: macOS run_all_tests.sh
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Validate dependency compatibility
+        run: python scripts/validate_dependencies.py
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: python -m playwright install chromium
+
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        uses: actions/cache@v4
+        with:
+          path: .ci-models/stories15M-q4_0.gguf
+          key: ci-relay-landing-page-real-desktop-bridge-api-v1-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
+
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        run: bash scripts/ci/provision_tiny_gguf.sh
+
+      - name: Run ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
+        run: |
+          set -o pipefail
+          ./run_all_tests.sh 2>&1 | tee run_all_tests.log
+
+      - name: Summarize run_all_tests.sh failure
+        if: failure()
+        run: |
+          {
+            echo '## run_all_tests.sh failed on macOS'
+            echo ''
+            echo 'The visible PR check failed because `./run_all_tests.sh` or a required setup step failed.'
+            echo 'Review the job log and the uploaded `macos-run_all_tests-log` artifact.'
+            if [ -f run_all_tests.log ]; then
+              echo ''
+              echo '### Last 120 log lines'
+              echo '```text'
+              tail -n 120 run_all_tests.log
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload run_all_tests.sh log
+        if: failure() && hashFiles('run_all_tests.log') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-run_all_tests-log
+          path: run_all_tests.log
+          if-no-files-found: error

--- a/scripts/ci/provision_tiny_gguf.sh
+++ b/scripts/ci/provision_tiny_gguf.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_PATH="${TOKENPLACE_CI_TINY_GGUF_PATH:-.ci-models/stories15M-q4_0.gguf}"
+MODEL_REV="99dd1a73db5a37100bd4ae633f4cfce6560e1567"
+MODEL_SHA256="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"
+MODEL_URL="https://huggingface.co/ggml-org/tiny-llamas/resolve/${MODEL_REV}/stories15M-q4_0.gguf"
+
+mkdir -p "$(dirname "$MODEL_PATH")"
+
+if [ ! -s "$MODEL_PATH" ]; then
+    echo "Downloading tiny real GGUF model for relay landing-page desktop-bridge API v1 guardrail..."
+    curl -fL "$MODEL_URL" -o "$MODEL_PATH.tmp"
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s  %s\n' "$MODEL_SHA256" "$MODEL_PATH.tmp" | sha256sum --check
+    else
+        printf '%s  %s\n' "$MODEL_SHA256" "$MODEL_PATH.tmp" | shasum -a 256 --check
+    fi
+    mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+else
+    echo "Using cached tiny real GGUF model at $MODEL_PATH"
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s  %s\n' "$MODEL_SHA256" "$MODEL_PATH" | sha256sum --check
+    else
+        printf '%s  %s\n' "$MODEL_SHA256" "$MODEL_PATH" | shasum -a 256 --check
+    fi
+fi
+
+test -s "$MODEL_PATH"
+echo "Tiny real GGUF model is ready at $MODEL_PATH"

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -10,6 +11,7 @@ PR_REQUIRED_WORKFLOWS = {
     "ci-image.yml",
     "desktop-operator-e2e.yml",
     "desktop-release.yml",
+    "run-all-tests-pr.yml",
 }
 
 
@@ -28,6 +30,46 @@ def _workflow_on_block(data: dict, workflow_name: str) -> dict:
         on_block, dict
     ), f"{workflow_name} must define a mapping under top-level `on:`"
     return on_block
+
+
+RUN_ALL_TESTS_PR_WORKFLOW = "run-all-tests-pr.yml"
+
+
+def _workflow_jobs(workflow_name: str) -> dict:
+    workflow_data = _load_workflow(WORKFLOW_DIR / workflow_name)
+    jobs = workflow_data.get("jobs")
+    assert isinstance(jobs, dict), f"{workflow_name} must define workflow jobs"
+    return jobs
+
+
+def _step_run_text(step: dict) -> str:
+    return str(step.get("run", "")) if isinstance(step, dict) else ""
+
+
+def _step_invokes_run_all_tests(step: dict) -> bool:
+    return bool(
+        re.search(
+            r"^\s*\./run_all_tests\.sh(?:\s|$)", _step_run_text(step), re.MULTILINE
+        )
+    )
+
+
+def _job_invokes_run_all_tests(job: dict) -> bool:
+    return any(
+        _step_invokes_run_all_tests(step)
+        for step in job.get("steps", [])
+        if isinstance(step, dict)
+    )
+
+
+def _run_all_test_jobs() -> list[tuple[str, str, dict]]:
+    jobs = []
+    for workflow_path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        workflow_data = _load_workflow(workflow_path)
+        for job_id, job in workflow_data.get("jobs", {}).items():
+            if isinstance(job, dict) and _job_invokes_run_all_tests(job):
+                jobs.append((workflow_path.name, str(job_id), job))
+    return jobs
 
 
 def test_required_workflows_trigger_on_pull_requests() -> None:
@@ -106,4 +148,148 @@ def test_run_all_tests_uses_absolute_default_real_e2e_model_path() -> None:
     ), (
         "The default real desktop-bridge guardrail model path must be absolute so "
         "subprocess runtime warm-load checks can resolve it after changing working directories."
+    )
+
+
+def test_pr_run_all_tests_workflow_exists_and_triggers_on_pull_requests() -> None:
+    workflow_path = WORKFLOW_DIR / RUN_ALL_TESTS_PR_WORKFLOW
+    assert (
+        workflow_path.exists()
+    ), "A dedicated PR-visible run_all_tests workflow must exist"
+
+    workflow_data = _load_workflow(workflow_path)
+    on_block = _workflow_on_block(workflow_data, RUN_ALL_TESTS_PR_WORKFLOW)
+
+    assert (
+        "pull_request" in on_block
+    ), "run_all_tests PR workflow must run on pull_request"
+    assert (
+        "workflow_dispatch" in on_block
+    ), "run_all_tests workflow should allow manual reruns"
+
+
+def test_pr_run_all_tests_workflow_has_visible_linux_and_macos_jobs() -> None:
+    jobs = _workflow_jobs(RUN_ALL_TESTS_PR_WORKFLOW)
+
+    linux_job = jobs.get("linux-run-all-tests")
+    macos_job = jobs.get("macos-run-all-tests")
+
+    assert isinstance(
+        linux_job, dict
+    ), "PR workflow must include a Linux run_all_tests job"
+    assert isinstance(
+        macos_job, dict
+    ), "PR workflow must include a macOS run_all_tests job"
+
+    assert linux_job.get("name") == "Linux run_all_tests.sh"
+    assert macos_job.get("name") == "macOS run_all_tests.sh"
+    assert linux_job.get("runs-on") == "ubuntu-latest"
+    assert macos_job.get("runs-on") == "macos-latest"
+
+    assert _job_invokes_run_all_tests(
+        linux_job
+    ), "Linux job must invoke ./run_all_tests.sh"
+    assert _job_invokes_run_all_tests(
+        macos_job
+    ), "macOS job must invoke ./run_all_tests.sh"
+
+
+def test_pr_run_all_tests_macos_uses_python_312_and_node_20() -> None:
+    macos_job = _workflow_jobs(RUN_ALL_TESTS_PR_WORKFLOW)["macos-run-all-tests"]
+    steps = macos_job["steps"]
+
+    python_setup_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("uses") == "actions/setup-python@v5"
+    ]
+    node_setup_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("uses") == "actions/setup-node@v4"
+    ]
+
+    assert any(
+        step.get("with", {}).get("python-version") == "3.12"
+        for step in python_setup_steps
+    ), "macOS run_all_tests job must use Python 3.12"
+    assert any(
+        step.get("with", {}).get("node-version") == "20" for step in node_setup_steps
+    ), "macOS run_all_tests job must use Node 20"
+
+
+def test_run_all_tests_jobs_do_not_continue_on_error_or_skip_reboot_prep() -> None:
+    run_all_jobs = _run_all_test_jobs()
+    assert run_all_jobs, "At least one workflow job must invoke ./run_all_tests.sh"
+
+    offenders = []
+    skip_offenders = []
+    for workflow_name, job_id, job in run_all_jobs:
+        if str(job.get("continue-on-error", "")).lower() == "true":
+            offenders.append(f"{workflow_name}:{job_id}")
+        for step in job.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            if str(step.get("continue-on-error", "")).lower() == "true":
+                offenders.append(
+                    f"{workflow_name}:{job_id}:{step.get('name', '<unnamed step>')}"
+                )
+            step_text = "\n".join(
+                str(step.get(key, "")) for key in ("name", "if", "run")
+            ).lower()
+            if "steps.prep.outputs" in step_text or (
+                "cgroup" in step_text and "exit 0" in step_text
+            ):
+                skip_offenders.append(
+                    f"{workflow_name}:{job_id}:{step.get('name', '<unnamed step>')}"
+                )
+
+    assert (
+        not offenders
+    ), "run_all_tests jobs must not use continue-on-error: " + ", ".join(offenders)
+    assert not skip_offenders, (
+        "run_all_tests jobs must fail rather than going green through reboot/cgroup/prep "
+        "skip branches: " + ", ".join(skip_offenders)
+    )
+
+
+def test_pr_run_all_tests_failure_summary_and_log_artifacts_are_in_jobs() -> None:
+    jobs = _workflow_jobs(RUN_ALL_TESTS_PR_WORKFLOW)
+
+    for job_id in ("linux-run-all-tests", "macos-run-all-tests"):
+        job = jobs[job_id]
+        steps = job["steps"]
+        assert any(
+            "GITHUB_STEP_SUMMARY" in _step_run_text(step)
+            and "run_all_tests.sh failed" in _step_run_text(step)
+            for step in steps
+            if isinstance(step, dict)
+        ), f"{job_id} must append a concise failure summary to GITHUB_STEP_SUMMARY"
+        assert any(
+            step.get("uses") == "actions/upload-artifact@v4"
+            and "run_all_tests.log" in str(step.get("with", {}).get("path", ""))
+            for step in steps
+            if isinstance(step, dict)
+        ), f"{job_id} must upload the run_all_tests log on failure"
+
+
+def test_run_all_tests_jobs_use_absolute_tiny_gguf_path() -> None:
+    run_all_jobs = _run_all_test_jobs()
+
+    missing_absolute_model_path = []
+    for workflow_name, job_id, job in run_all_jobs:
+        for step in job.get("steps", []):
+            if not isinstance(step, dict) or not _step_invokes_run_all_tests(step):
+                continue
+            env = step.get("env", {})
+            model_path = str(env.get("TOKENPLACE_REAL_E2E_MODEL_PATH", ""))
+            if "stories15M-q4_0.gguf" not in model_path or not (
+                model_path.startswith("${{ github.workspace }}")
+                or model_path.startswith("/")
+            ):
+                missing_absolute_model_path.append(f"{workflow_name}:{job_id}")
+
+    assert not missing_absolute_model_path, (
+        "run_all_tests jobs must pass an absolute tiny GGUF guardrail model path "
+        "derived from github.workspace: " + ", ".join(missing_absolute_model_path)
     )


### PR DESCRIPTION
### Motivation
- Ensure every PR surfaces a visible, actionable `./run_all_tests.sh` check on GitHub that actually runs the full suite (not skipped or swallowed). 
- Mirror local macOS debugging environment in PR CI (Python 3.12 + Node 20 + macos-latest) so PRs can catch platform-specific failures.
- Keep the tiny GGUF relay landing-page desktop-bridge guardrail real and cacheable while factoring provisioning for reuse.

### Description
- Added a dedicated PR workflow `.github/workflows/run-all-tests-pr.yml` that triggers on `pull_request` and `workflow_dispatch`, provides cancel-in-progress concurrency, and exposes two clear jobs named `Linux run_all_tests.sh` and `macOS run_all_tests.sh` which run `./run_all_tests.sh` on `ubuntu-latest` and `macos-latest` respectively using Python 3.12 and Node 20. 
- Factored GGUF provisioning into `scripts/ci/provision_tiny_gguf.sh` which downloads and verifies the tiny GGUF model (uses `sha256sum` or `shasum -a 256`) so both Linux and macOS jobs can restore/cache and provision the model without duplicating logic. 
- Updated existing CI `.github/workflows/ci.yml` to modern tool versions (Python 3.12 / Node 20), to reuse the new provisioning script, and to fail the job early (with a concise GITHUB_STEP_SUMMARY message) when `prepare-pi-cgroups.sh` reports a reboot-required state instead of exiting green without running the suite. 
- Extended the workflow sentinel tests `tests/unit/test_workflow_ci_sentinel.py` to require the new workflow, assert both OS jobs exist and invoke `./run_all_tests.sh`, enforce macOS uses Python `3.12` and Node `20`, ban `continue-on-error`/skip-green prep branches, require in-job failure summaries and log artifacts, and require absolute/derived `TOKENPLACE_REAL_E2E_MODEL_PATH` values.

### Testing
- Ran the CI sentinel unit tests: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -v` — all tests passed. 
- Ran several focused test groups used for verification: 
  - `python -m pytest tests/unit/test_dspace_integration_script.py tests/unit/test_sendemail_validate_hook.py tests/test_security_bandit.py -v` — passed. 
  - `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_runtime_setup.py -v` — passed. 
  - `python -m pytest tests/unit/test_model_manager.py tests/unit/test_model_manager_llama_import_guard.py -v` — passed. 
- Validated new workflow YAML parses and shell script syntax: `bash -n scripts/ci/provision_tiny_gguf.sh` and `python - <<'PY'
import yaml
from pathlib import Path
for workflow in ['.github/workflows/ci.yml', '.github/workflows/run-all-tests-pr.yml']:
    yaml.safe_load(Path(workflow).read_text())
print('workflow yaml ok')
PY` — succeeded. 
- Ran the full local test runner: `./run_all_tests.sh` — completed with `All tests passed!` and produced logs; Playwright and other install steps executed as expected. 
- Ran repository hooks: `pre-commit run --all-files` — passed.

Files changed (summary):
- Added: `.github/workflows/run-all-tests-pr.yml`, `scripts/ci/provision_tiny_gguf.sh`.
- Modified: `.github/workflows/ci.yml` (Python/Node upgrade, fail-fast prep behavior, reuse provision script).
- Modified: `tests/unit/test_workflow_ci_sentinel.py` (added assertions for the PR workflow and run_all_tests job properties).

Residual notes and follow-ups: the workflow intentionally does not change branch protection settings (these are controlled in GitHub); CI minutes on macOS are consumable — concurrency with `cancel-in-progress` is enabled to reduce waste; if Playwright or large asset downloads are problematic in a given environment, the provisioning step is explicit and will fail the job (visible) rather than allow silent skip.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270b722388832f91f26e0d6c25c43c)