### PR TITLE
Add visible PR `run_all_tests` workflow (Linux + macOS) and sentinel tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - name: Prepare Raspberry Pi cgroups
         id: prep
@@ -33,9 +33,11 @@ jobs:
           sudo bash scripts/prepare-pi-cgroups.sh
           echo "rc=$?" >> "$GITHUB_OUTPUT"
           exit 0
-      - name: Stop for reboot
+      - name: Fail if Raspberry Pi cgroup prep requires reboot
         if: steps.prep.outputs.rc == '2'
-        run: echo "Cgroup configuration updated. Reboot runner and re-run job."
+        run: |
+          echo "::error::Cgroup configuration updated and requires reboot; hosted CI cannot reboot and must not skip ./run_all_tests.sh."
+          exit 1
       - name: Validate dependency compatibility
         run: python scripts/validate_dependencies.py
         if: steps.prep.outputs.rc != '2'

--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -1,0 +1,183 @@
+name: run_all_tests PR
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: run-all-tests-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  linux-run-all-tests:
+    name: Linux run_all_tests.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Validate dependency compatibility
+        run: python scripts/validate_dependencies.py
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Install Playwright Chromium with Linux system dependencies
+        run: python -m playwright install --with-deps chromium
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        uses: actions/cache@v4
+        with:
+          path: .ci-models/stories15M-q4_0.gguf
+          key: run-all-tests-pr-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
+
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-models
+          MODEL_PATH="${GITHUB_WORKSPACE}/.ci-models/stories15M-q4_0.gguf"
+          MODEL_REV="99dd1a73db5a37100bd4ae633f4cfce6560e1567"
+          MODEL_SHA256="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"
+          if [ ! -s "$MODEL_PATH" ]; then
+            curl -fL \
+              "https://huggingface.co/ggml-org/tiny-llamas/resolve/${MODEL_REV}/stories15M-q4_0.gguf" \
+              -o "$MODEL_PATH.tmp"
+            printf '%s  %s\n' "$MODEL_SHA256" "$MODEL_PATH.tmp" | sha256sum --check
+            mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+          fi
+          test -s "$MODEL_PATH"
+
+      - name: Run ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
+        run: |
+          set -o pipefail
+          ./run_all_tests.sh 2>&1 | tee run-all-tests.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "## Linux run_all_tests.sh failed"
+              echo
+              echo "The visible PR full-suite signal ran \`./run_all_tests.sh\` and it exited with status \`$status\`."
+              echo
+              echo "### Last 80 log lines"
+              echo '```text'
+              tail -n 80 run-all-tests.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$status"
+
+      - name: Upload run_all_tests log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-run-all-tests-log
+          path: run-all-tests.log
+          if-no-files-found: warn
+
+  macos-run-all-tests:
+    name: macOS run_all_tests.sh
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Validate dependency compatibility
+        run: python scripts/validate_dependencies.py
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Install Playwright Chromium
+        run: python -m playwright install chromium
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        uses: actions/cache@v4
+        with:
+          path: .ci-models/stories15M-q4_0.gguf
+          key: run-all-tests-pr-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
+
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-models
+          MODEL_PATH="${GITHUB_WORKSPACE}/.ci-models/stories15M-q4_0.gguf"
+          MODEL_REV="99dd1a73db5a37100bd4ae633f4cfce6560e1567"
+          MODEL_SHA256="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"
+          if [ ! -s "$MODEL_PATH" ]; then
+            curl -fL \
+              "https://huggingface.co/ggml-org/tiny-llamas/resolve/${MODEL_REV}/stories15M-q4_0.gguf" \
+              -o "$MODEL_PATH.tmp"
+            shasum -a 256 -c - <<< "${MODEL_SHA256}  ${MODEL_PATH}.tmp"
+            mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+          fi
+          test -s "$MODEL_PATH"
+
+      - name: Run ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+          TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
+        run: |
+          set -o pipefail
+          ./run_all_tests.sh 2>&1 | tee run-all-tests.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "## macOS run_all_tests.sh failed"
+              echo
+              echo "The visible PR full-suite signal ran \`./run_all_tests.sh\` and it exited with status \`$status\`."
+              echo
+              echo "### Last 80 log lines"
+              echo '```text'
+              tail -n 80 run-all-tests.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$status"
+
+      - name: Upload run_all_tests log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-run-all-tests-log
+          path: run-all-tests.log
+          if-no-files-found: warn

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -5,11 +5,13 @@ from pathlib import Path
 import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
+RUN_ALL_TESTS_PR_WORKFLOW = "run-all-tests-pr.yml"
 PR_REQUIRED_WORKFLOWS = {
     "ci.yml",
     "ci-image.yml",
     "desktop-operator-e2e.yml",
     "desktop-release.yml",
+    RUN_ALL_TESTS_PR_WORKFLOW,
 }
 
 
@@ -28,6 +30,34 @@ def _workflow_on_block(data: dict, workflow_name: str) -> dict:
         on_block, dict
     ), f"{workflow_name} must define a mapping under top-level `on:`"
     return on_block
+
+
+def _run_all_tests_workflow() -> dict:
+    return _load_workflow(WORKFLOW_DIR / RUN_ALL_TESTS_PR_WORKFLOW)
+
+
+def _job_steps(job: dict) -> list[dict]:
+    steps = job.get("steps")
+    assert isinstance(steps, list), "workflow job must define steps"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step_runs(step: dict, needle: str) -> bool:
+    return needle in str(step.get("run", ""))
+
+
+def _job_invokes_run_all_tests(job: dict) -> bool:
+    return any(_step_runs(step, "./run_all_tests.sh") for step in _job_steps(job))
+
+
+def _run_all_tests_jobs(workflow_data: dict) -> dict[str, dict]:
+    jobs = workflow_data.get("jobs")
+    assert isinstance(jobs, dict), "workflow must define jobs"
+    return {
+        job_id: job
+        for job_id, job in jobs.items()
+        if isinstance(job, dict) and _job_invokes_run_all_tests(job)
+    }
 
 
 def test_required_workflows_trigger_on_pull_requests() -> None:
@@ -107,3 +137,151 @@ def test_run_all_tests_uses_absolute_default_real_e2e_model_path() -> None:
         "The default real desktop-bridge guardrail model path must be absolute so "
         "subprocess runtime warm-load checks can resolve it after changing working directories."
     )
+
+
+def test_pr_run_all_tests_workflow_exists_and_is_manually_runnable() -> None:
+    workflow_path = WORKFLOW_DIR / RUN_ALL_TESTS_PR_WORKFLOW
+    assert workflow_path.exists(), "PRs need a dedicated visible run_all_tests workflow"
+
+    workflow_data = _run_all_tests_workflow()
+    on_block = _workflow_on_block(workflow_data, RUN_ALL_TESTS_PR_WORKFLOW)
+
+    assert "pull_request" in on_block, "run_all_tests PR workflow must run on PRs"
+    assert (
+        "workflow_dispatch" in on_block
+    ), "run_all_tests PR workflow should be manually rerunnable for diagnosis"
+    assert workflow_data.get("concurrency", {}).get("cancel-in-progress") == "true", (
+        "run_all_tests PR workflow should cancel obsolete PR attempts, especially "
+        "to avoid wasting macOS minutes"
+    )
+
+
+def test_pr_run_all_tests_workflow_has_visible_linux_and_macos_jobs() -> None:
+    workflow_data = _run_all_tests_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+
+    linux_jobs = [
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("ubuntu")
+    ]
+    macos_jobs = [
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("macos")
+    ]
+
+    assert linux_jobs, "PR run_all_tests workflow must include a Linux job"
+    assert macos_jobs, "PR run_all_tests workflow must include a macOS job"
+    assert any(
+        job.get("name") == "Linux run_all_tests.sh" for job in linux_jobs
+    ), "Linux run_all_tests job needs a clear PR checks name"
+    assert any(
+        job.get("name") == "macOS run_all_tests.sh" for job in macos_jobs
+    ), "macOS run_all_tests job needs a clear PR checks name"
+
+
+def test_pr_run_all_tests_jobs_use_modern_python_node_and_playwright() -> None:
+    workflow_data = _run_all_tests_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+    assert jobs, "workflow must have jobs that invoke ./run_all_tests.sh"
+
+    for job_id, job in jobs.items():
+        steps = _job_steps(job)
+        combined_steps = "\n".join(str(step) for step in steps)
+        assert (
+            "python-version': '3.12" in combined_steps
+            or "python-version': 3.12" in combined_steps
+        ), f"{job_id} must use Python 3.12 so PR CI mirrors modern local debugging"
+        assert (
+            "node-version': '20" in combined_steps
+            or "node-version': 20" in combined_steps
+        ), f"{job_id} must use Node 20 so PR CI mirrors modern local debugging"
+        assert (
+            "python -m pip install -r requirements.txt" in combined_steps
+        ), f"{job_id} must install Python dependencies before running the suite"
+        assert (
+            "npm ci" in combined_steps
+        ), f"{job_id} must install locked Node dependencies before running the suite"
+
+    linux_job = next(
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("ubuntu")
+    )
+    macos_job = next(
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("macos")
+    )
+    assert "python -m playwright install --with-deps chromium" in "\n".join(
+        str(step) for step in _job_steps(linux_job)
+    )
+    assert "python -m playwright install chromium" in "\n".join(
+        str(step) for step in _job_steps(macos_job)
+    )
+
+
+def test_run_all_tests_jobs_do_not_hide_or_skip_suite_failures() -> None:
+    workflow_data = _run_all_tests_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+    assert jobs, "workflow must have jobs that invoke ./run_all_tests.sh"
+
+    forbidden_skip_markers = (
+        "continue-on-error",
+        "steps.prep.outputs.rc",
+        "prepare-pi-cgroups",
+        "Stop for reboot",
+        "requires reboot; hosted CI cannot reboot and must not skip",
+    )
+    for job_id, job in jobs.items():
+        assert (
+            str(job.get("continue-on-error", "false")).lower() != "true"
+        ), f"{job_id} must not be marked continue-on-error"
+        for step in _job_steps(job):
+            assert (
+                str(step.get("continue-on-error", "false")).lower() != "true"
+            ), f"{job_id} run_all_tests path must not use continue-on-error"
+        job_text = "\n".join(str(step) for step in _job_steps(job))
+        for marker in forbidden_skip_markers:
+            assert (
+                marker not in job_text
+            ), f"{job_id} must not have a green skip/prep branch around ./run_all_tests.sh"
+        run_steps = [
+            step for step in _job_steps(job) if _step_runs(step, "./run_all_tests.sh")
+        ]
+        assert run_steps, f"{job_id} must run ./run_all_tests.sh"
+        assert all(
+            'exit "$status"' in str(step.get("run", "")) for step in run_steps
+        ), f"{job_id} must propagate ./run_all_tests.sh exit status"
+
+
+def test_run_all_tests_jobs_keep_tiny_gguf_guardrail_absolute_and_visible() -> None:
+    workflow_data = _run_all_tests_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+    assert jobs, "workflow must have jobs that invoke ./run_all_tests.sh"
+
+    for job_id, job in jobs.items():
+        job_text = "\n".join(str(step) for step in _job_steps(job))
+        assert (
+            "stories15M-q4_0.gguf" in job_text
+        ), f"{job_id} must provision the tiny real GGUF guardrail model"
+        assert (
+            "${GITHUB_WORKSPACE}/.ci-models/stories15M-q4_0.gguf" in job_text
+        ), f"{job_id} must provision the model using an absolute github.workspace path"
+        assert (
+            "TOKENPLACE_REAL_E2E_MODEL_PATH" in job_text
+        ), f"{job_id} must pass the tiny GGUF path into run_all_tests.sh"
+        assert (
+            "${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf" in job_text
+        ), f"{job_id} must derive TOKENPLACE_REAL_E2E_MODEL_PATH from github.workspace"
+
+
+def test_run_all_tests_jobs_append_failure_summary_and_upload_logs() -> None:
+    workflow_data = _run_all_tests_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+    assert jobs, "workflow must have jobs that invoke ./run_all_tests.sh"
+
+    for job_id, job in jobs.items():
+        job_text = "\n".join(str(step) for step in _job_steps(job))
+        assert (
+            "GITHUB_STEP_SUMMARY" in job_text
+        ), f"{job_id} must append run_all_tests failure context to the job summary"
+        assert (
+            "tail -n 80 run-all-tests.log" in job_text
+        ), f"{job_id} should include concise log tail in the job summary"
+        assert (
+            "actions/upload-artifact@v4" in job_text
+        ), f"{job_id} should upload run_all_tests logs on failure for PR diagnosis"


### PR DESCRIPTION
### Motivation
- Ensure every PR surfaces a visible, honest `./run_all_tests.sh` check that runs the full suite on environments that catch real failures.
- Mirror local macOS debugging environment (Python 3.12 + Node 20 + Playwright) in PR CI so platform-specific failures are visible.
- Prevent silent skips/continue-on-error branches and provide concise failure diagnostics on the PR checks page.

### Description
- Add a dedicated workflow `.github/workflows/run-all-tests-pr.yml` that triggers on `pull_request` and `workflow_dispatch`, with `cancel-in-progress` concurrency and two clear jobs named `Linux run_all_tests.sh` and `macOS run_all_tests.sh` that invoke `./run_all_tests.sh`. 
- Configure both jobs to use Python 3.12 and Node 20, install Python and npm deps, install Playwright Chromium (Linux uses `--with-deps`), and restore/provision the tiny GGUF guardrail model at an absolute `${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf` path which is passed into the test run via `TOKENPLACE_REAL_E2E_MODEL_PATH`.
- Make each job stream and `tee` the `run_all_tests` output, propagate the suite exit status, append a concise failure summary (last 80 lines) to `GITHUB_STEP_SUMMARY` on failure, and upload the run log as an artifact for diagnosis.
- Update existing `.github/workflows/ci.yml` to use Python 3.12 / Node 20 and change the Raspberry Pi cgroup prep path so the job fails with a clear error if a reboot would otherwise be required (fail-closed instead of silently skipping the suite).
- Extend `tests/unit/test_workflow_ci_sentinel.py` to require the new PR workflow, assert it triggers on `pull_request`, assert both Linux and macOS run-all-tests jobs exist and use Python 3.12/Node 20/Playwright installs, forbid `continue-on-error` or green-skip prep branches, require absolute github.workspace GGUF provisioning, and require the failure-summary + artifact upload behavior.

### Testing
- Ran the new sentinel unit tests: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -v` — all tests passed (11 passed).
- Ran the full project unit/integration suites used by CI: `./run_all_tests.sh` — completed successfully with `All tests passed!` and produced the normal coverage/log outputs (summary: 1401 passed unit tests, integration and API suites passed; full run completed without errors).
- Ran focused pytest commands used during verification: `python -m pytest tests/unit/test_dspace_integration_script.py tests/unit/test_sendemail_validate_hook.py tests/test_security_bandit.py -v` and larger unit groups listed in the prompt — all passed.
- Ran pre-commit checks: `pre-commit run --all-files` — passed.

All automated checks that were run during development passed; the change is scoped to workflows and the sentinel test guard so future PRs will keep the run_all_tests PR check visible and non-skippable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270b722388832f91f26e0d6c25c43c)