### PR TITLE
Add visible PR run_all_tests workflow (Linux + macOS) and sentinel checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,47 +17,42 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - name: Prepare Raspberry Pi cgroups
-        id: prep
         run: |
           set +e
           sudo bash scripts/prepare-pi-cgroups.sh
-          echo "rc=$?" >> "$GITHUB_OUTPUT"
-          exit 0
-      - name: Stop for reboot
-        if: steps.prep.outputs.rc == '2'
-        run: echo "Cgroup configuration updated. Reboot runner and re-run job."
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "::error::Cgroup configuration updated but a reboot would be required; hosted CI cannot reboot, so this run_all_tests signal must fail instead of skipping the suite."
+            exit 1
+          fi
+          exit "$rc"
       - name: Validate dependency compatibility
         run: python scripts/validate_dependencies.py
-        if: steps.prep.outputs.rc != '2'
       - name: Install Python dependencies
-        if: steps.prep.outputs.rc != '2'
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
       - name: Install Playwright browsers and system dependencies
-        if: steps.prep.outputs.rc != '2'
-        run: playwright install --with-deps chromium
+        run: python -m playwright install --with-deps chromium
       - name: Install Node.js dependencies
-        if: steps.prep.outputs.rc != '2'
         run: npm ci
       - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
-        if: steps.prep.outputs.rc != '2'
         uses: actions/cache@v4
         with:
           path: .ci-models/stories15M-q4_0.gguf
           key: ci-relay-landing-page-real-desktop-bridge-api-v1-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
       - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
-        if: steps.prep.outputs.rc != '2'
         run: |
           set -euo pipefail
           mkdir -p .ci-models
@@ -75,21 +70,35 @@ jobs:
           fi
           test -s "$MODEL_PATH"
       - name: Verify tiny real GGUF loads via relay landing-page desktop-bridge API v1 guardrail
-        if: steps.prep.outputs.rc != '2'
         env:
           TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
           RUN_RELAY_REGISTRATION_TESTS: '1'
         run: python -m pytest -q tests/e2e/test_ui.py -k 'landing_chat_real_inference_with_desktop_bridge_api_v1'
       - name: Run tests
-        if: steps.prep.outputs.rc != '2'
-        run: ./run_all_tests.sh
         env:
           TEST_COVERAGE: '1'
           # Keep the relay landing-page desktop-bridge API v1 guardrail always-on in CI.
           # This tiny real model avoids fake inference while keeping CI fast and cache-friendly.
           TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
+        run: |
+          set -uo pipefail
+          ./run_all_tests.sh 2>&1 | tee run-all-tests.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "## ./run_all_tests.sh failed"
+              echo
+              echo "The CI check is red because ./run_all_tests.sh exited with status $status."
+              echo
+              echo "### Last 80 log lines"
+              echo '```'
+              tail -n 80 run-all-tests.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit "$status"
+          fi
+          echo "## ./run_all_tests.sh passed" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage reports to Codecov
-        if: steps.prep.outputs.rc != '2'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -1,0 +1,186 @@
+name: run_all_tests PR
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
+
+jobs:
+  linux-run-all-tests:
+    name: Linux run_all_tests.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Validate dependency compatibility
+        run: python scripts/validate_dependencies.py
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Install Playwright Chromium with Linux system dependencies
+        run: python -m playwright install --with-deps chromium
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        uses: actions/cache@v4
+        with:
+          path: .ci-models/stories15M-q4_0.gguf
+          key: run-all-tests-${{ runner.os }}-relay-landing-page-real-desktop-bridge-api-v1-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-models
+          MODEL_PATH=".ci-models/stories15M-q4_0.gguf"
+          MODEL_REV="99dd1a73db5a37100bd4ae633f4cfce6560e1567"
+          MODEL_SHA256="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"
+          if [ ! -s "$MODEL_PATH" ]; then
+            curl -fL \
+              "https://huggingface.co/ggml-org/tiny-llamas/resolve/${MODEL_REV}/stories15M-q4_0.gguf" \
+              -o "$MODEL_PATH.tmp"
+            python -c 'import hashlib, pathlib, sys; expected="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"; actual=hashlib.sha256(pathlib.Path(".ci-models/stories15M-q4_0.gguf.tmp").read_bytes()).hexdigest(); sys.exit(0 if actual == expected else f"tiny GGUF SHA256 mismatch: expected {expected}, got {actual}")'
+            mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+          fi
+          test -s "$MODEL_PATH"
+      - name: Preflight full-suite inputs
+        run: |
+          set -euo pipefail
+          test -x ./run_all_tests.sh
+          case "$TOKENPLACE_REAL_E2E_MODEL_PATH" in
+            "$GITHUB_WORKSPACE"/*) ;;
+            *) echo "::error::TOKENPLACE_REAL_E2E_MODEL_PATH must be absolute and rooted in github.workspace"; exit 1 ;;
+          esac
+          test -s "$TOKENPLACE_REAL_E2E_MODEL_PATH"
+      - name: Run ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+          RUN_RELAY_REGISTRATION_TESTS: '1'
+        run: |
+          set -uo pipefail
+          ./run_all_tests.sh 2>&1 | tee run-all-tests.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "## ./run_all_tests.sh failed on Linux"
+              echo
+              echo "The full-suite PR check is red because ./run_all_tests.sh exited with status $status."
+              echo
+              echo "### Last 80 log lines"
+              echo '```'
+              tail -n 80 run-all-tests.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit "$status"
+          fi
+          echo "## ./run_all_tests.sh passed on Linux" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload run_all_tests log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-run-all-tests-log
+          path: run-all-tests.log
+          if-no-files-found: error
+
+  macos-run-all-tests:
+    name: macOS run_all_tests.sh
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Validate dependency compatibility
+        run: python scripts/validate_dependencies.py
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Install Playwright Chromium
+        run: python -m playwright install chromium
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Restore cached tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        uses: actions/cache@v4
+        with:
+          path: .ci-models/stories15M-q4_0.gguf
+          key: run-all-tests-${{ runner.os }}-relay-landing-page-real-desktop-bridge-api-v1-stories15m-q4-rev-99dd1a73db5a37100bd4ae633f4cfce6560e1567-sha256-6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04
+      - name: Provision tiny real GGUF for relay landing-page desktop-bridge API v1 guardrail
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-models
+          MODEL_PATH=".ci-models/stories15M-q4_0.gguf"
+          MODEL_REV="99dd1a73db5a37100bd4ae633f4cfce6560e1567"
+          MODEL_SHA256="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"
+          if [ ! -s "$MODEL_PATH" ]; then
+            curl -fL \
+              "https://huggingface.co/ggml-org/tiny-llamas/resolve/${MODEL_REV}/stories15M-q4_0.gguf" \
+              -o "$MODEL_PATH.tmp"
+            python -c 'import hashlib, pathlib, sys; expected="6151b1929d7f5aa3385d9ddef3393e55587c0a55de661562322bc51dfda93a04"; actual=hashlib.sha256(pathlib.Path(".ci-models/stories15M-q4_0.gguf.tmp").read_bytes()).hexdigest(); sys.exit(0 if actual == expected else f"tiny GGUF SHA256 mismatch: expected {expected}, got {actual}")'
+            mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+          fi
+          test -s "$MODEL_PATH"
+      - name: Preflight full-suite inputs
+        run: |
+          set -euo pipefail
+          test -x ./run_all_tests.sh
+          case "$TOKENPLACE_REAL_E2E_MODEL_PATH" in
+            "$GITHUB_WORKSPACE"/*) ;;
+            *) echo "::error::TOKENPLACE_REAL_E2E_MODEL_PATH must be absolute and rooted in github.workspace"; exit 1 ;;
+          esac
+          test -s "$TOKENPLACE_REAL_E2E_MODEL_PATH"
+      - name: Run ./run_all_tests.sh
+        env:
+          TEST_COVERAGE: '1'
+          RUN_RELAY_REGISTRATION_TESTS: '1'
+        run: |
+          set -uo pipefail
+          ./run_all_tests.sh 2>&1 | tee run-all-tests.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "## ./run_all_tests.sh failed on macOS"
+              echo
+              echo "The full-suite PR check is red because ./run_all_tests.sh exited with status $status."
+              echo
+              echo "### Last 80 log lines"
+              echo '```'
+              tail -n 80 run-all-tests.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit "$status"
+          fi
+          echo "## ./run_all_tests.sh passed on macOS" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload run_all_tests log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-run-all-tests-log
+          path: run-all-tests.log
+          if-no-files-found: error

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -10,13 +10,47 @@ PR_REQUIRED_WORKFLOWS = {
     "ci-image.yml",
     "desktop-operator-e2e.yml",
     "desktop-release.yml",
+    "run-all-tests-pr.yml",
 }
+RUN_ALL_TESTS_PR_WORKFLOW = "run-all-tests-pr.yml"
 
 
 def _load_workflow(path: Path) -> dict:
     data = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
     assert isinstance(data, dict), f"{path} should parse as a YAML mapping"
     return data
+
+
+def _step_runs_run_all_tests(step: dict) -> bool:
+    return any(
+        line.strip().startswith("./run_all_tests.sh")
+        for line in str(step.get("run", "")).splitlines()
+    )
+
+
+def _job_invokes_run_all_tests(job: dict) -> bool:
+    return any(
+        isinstance(step, dict) and _step_runs_run_all_tests(step)
+        for step in job.get("steps", [])
+    )
+
+
+def _run_all_tests_pr_workflow() -> dict:
+    return _load_workflow(WORKFLOW_DIR / RUN_ALL_TESTS_PR_WORKFLOW)
+
+
+def _run_all_tests_jobs(workflow_data: dict) -> dict[str, dict]:
+    jobs = workflow_data.get("jobs", {})
+    assert isinstance(jobs, dict), "run_all_tests PR workflow must define jobs"
+    selected = {
+        job_id: job
+        for job_id, job in jobs.items()
+        if isinstance(job, dict) and _job_invokes_run_all_tests(job)
+    }
+    assert (
+        selected
+    ), "run_all_tests PR workflow must have jobs that invoke ./run_all_tests.sh"
+    return selected
 
 
 def _workflow_on_block(data: dict, workflow_name: str) -> dict:
@@ -107,3 +141,142 @@ def test_run_all_tests_uses_absolute_default_real_e2e_model_path() -> None:
         "The default real desktop-bridge guardrail model path must be absolute so "
         "subprocess runtime warm-load checks can resolve it after changing working directories."
     )
+
+
+def test_pr_run_all_tests_workflow_exists_and_triggers_on_pull_requests() -> None:
+    workflow_path = WORKFLOW_DIR / RUN_ALL_TESTS_PR_WORKFLOW
+
+    assert (
+        workflow_path.exists()
+    ), "A dedicated PR-visible run_all_tests workflow must exist"
+
+    workflow_data = _run_all_tests_pr_workflow()
+    on_block = _workflow_on_block(workflow_data, RUN_ALL_TESTS_PR_WORKFLOW)
+
+    assert "pull_request" in on_block
+    assert "workflow_dispatch" in on_block
+
+
+def test_pr_run_all_tests_workflow_has_visible_linux_and_macos_jobs() -> None:
+    workflow_data = _run_all_tests_pr_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+
+    linux_jobs = [
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("ubuntu")
+    ]
+    macos_jobs = [
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("macos")
+    ]
+
+    assert (
+        linux_jobs
+    ), "The PR workflow must expose a Linux job that runs ./run_all_tests.sh"
+    assert (
+        macos_jobs
+    ), "The PR workflow must expose a macOS job that runs ./run_all_tests.sh"
+    assert any(job.get("name") == "Linux run_all_tests.sh" for job in linux_jobs)
+    assert any(job.get("name") == "macOS run_all_tests.sh" for job in macos_jobs)
+
+
+def _assert_job_uses_python_312_and_node_20(job: dict, label: str) -> None:
+    steps = job.get("steps", [])
+    python_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("uses") == "actions/setup-python@v5"
+    ]
+    node_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("uses") == "actions/setup-node@v4"
+    ]
+
+    assert any(
+        step.get("with", {}).get("python-version") == "3.12" for step in python_steps
+    ), f"{label} run_all_tests job must use Python 3.12"
+    assert any(
+        step.get("with", {}).get("node-version") == "20" for step in node_steps
+    ), f"{label} run_all_tests job must use Node 20"
+
+
+def test_pr_run_all_tests_linux_job_uses_python_312_and_node_20() -> None:
+    workflow_data = _run_all_tests_pr_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+    linux_jobs = [
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("ubuntu")
+    ]
+    assert linux_jobs, "The PR workflow must include a Linux run_all_tests job"
+
+    for job in linux_jobs:
+        _assert_job_uses_python_312_and_node_20(job, "Linux")
+
+
+def test_pr_run_all_tests_macos_job_uses_python_312_and_node_20() -> None:
+    workflow_data = _run_all_tests_pr_workflow()
+    jobs = _run_all_tests_jobs(workflow_data)
+    macos_jobs = [
+        job for job in jobs.values() if str(job.get("runs-on", "")).startswith("macos")
+    ]
+    assert macos_jobs, "The PR workflow must include a macOS run_all_tests job"
+
+    for job in macos_jobs:
+        _assert_job_uses_python_312_and_node_20(job, "macOS")
+
+
+def test_pr_run_all_tests_jobs_do_not_hide_or_skip_suite_failures() -> None:
+    workflow_data = _run_all_tests_pr_workflow()
+
+    for job_id, job in _run_all_tests_jobs(workflow_data).items():
+        assert (
+            job.get("continue-on-error") != "true"
+        ), f"{job_id} must fail visibly when ./run_all_tests.sh fails"
+
+        steps = job.get("steps", [])
+        run_all_steps = [
+            step
+            for step in steps
+            if isinstance(step, dict) and _step_runs_run_all_tests(step)
+        ]
+        assert run_all_steps, f"{job_id} must include a ./run_all_tests.sh step"
+
+        for step in run_all_steps:
+            assert (
+                step.get("continue-on-error") != "true"
+            ), f"{job_id} must not mark the ./run_all_tests.sh step continue-on-error"
+            run_script = str(step.get("run", ""))
+            assert (
+                'exit "$status"' in run_script or "exit $status" in run_script
+            ), f"{job_id} must propagate the ./run_all_tests.sh exit status"
+            assert (
+                "GITHUB_STEP_SUMMARY" in run_script
+            ), f"{job_id} must append diagnostic context to the job summary"
+
+        combined_runs = "\n".join(
+            str(step.get("run", "")) for step in steps if isinstance(step, dict)
+        )
+        assert "steps.prep.outputs.rc != '2'" not in combined_runs
+        assert "steps.prep.outputs.rc == '2'" not in combined_runs
+        assert "Stop for reboot" not in combined_runs
+
+
+def test_pr_run_all_tests_tiny_gguf_guardrail_uses_github_workspace_path() -> None:
+    workflow_data = _run_all_tests_pr_workflow()
+    env = workflow_data.get("env", {})
+
+    assert (
+        env.get("TOKENPLACE_REAL_E2E_MODEL_PATH")
+        == "${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf"
+    ), (
+        "The PR workflow must provide an absolute tiny GGUF path derived from "
+        "github.workspace so run_all_tests cannot silently skip the real guardrail."
+    )
+
+    for job_id, job in _run_all_tests_jobs(workflow_data).items():
+        combined_runs = "\n".join(
+            str(step.get("run", ""))
+            for step in job.get("steps", [])
+            if isinstance(step, dict)
+        )
+        assert (
+            'test -s "$TOKENPLACE_REAL_E2E_MODEL_PATH"' in combined_runs
+        ), f"{job_id} must fail preflight if the tiny GGUF was not provisioned"


### PR DESCRIPTION
### Motivation

- Ensure every PR surfaces a clear, visible GitHub Actions check that actually runs `./run_all_tests.sh` (not skipped or swallowed). 
- Represent local macOS failure modes (Python 3.12 + Node 20 + macos-latest) in PR CI so debugging locally mirrors CI. 
- Preserve the tiny GGUF relay landing-page desktop-bridge guardrail while making its presence explicit and fail the job if missing. 
- Prevent hosted-runner branches (cgroup reboot required) from silently skipping the full-suite signal.

### Description

- Add a dedicated PR workflow `.github/workflows/run-all-tests-pr.yml` that triggers on `pull_request` and `workflow_dispatch`, uses concurrency cancellation, and exposes two clearly named jobs: `Linux run_all_tests.sh` and `macOS run_all_tests.sh`. Each job uses Python 3.12 and Node 20, installs dependencies, installs Playwright Chromium, restores/provisions the tiny GGUF model cache, performs an absolute-path preflight for `TOKENPLACE_REAL_E2E_MODEL_PATH`, runs `./run_all_tests.sh`, appends concise failure diagnostics to `GITHUB_STEP_SUMMARY` on nonzero exit, and uploads the job log as an artifact on failure.
- Tighten the existing `.github/workflows/ci.yml` run_all_tests path to use Python 3.12 and Node 20, convert the cgroup "reboot required" branch into a visible failure (hosted CI cannot reboot), ensure Playwright is installed via `python -m playwright install --with-deps chromium`, and wrap the `./run_all_tests.sh` invocation so the step tees output to a log, appends a summary on failure, and exits with the suite status (no `continue-on-error`).
- Add preflight checks in PR workflow jobs to require `TOKENPLACE_REAL_E2E_MODEL_PATH` to be absolute and rooted under `${{ github.workspace }}` and to fail if the tiny GGUF was not provisioned, so the tiny real-guardrail cannot be silently skipped.
- Extend `tests/unit/test_workflow_ci_sentinel.py` to enforce the PR workflow exists, triggers on `pull_request`, contains visible Linux and macOS jobs that invoke `./run_all_tests.sh`, require Python 3.12 and Node 20 in the macOS job (and added Linux check), assert no `continue-on-error` is used for the run_all_tests steps, assert preflight cannot silently skip due to reboot/cgroup branches, and assert the tiny GGUF guardrail path is derived from `github.workspace`.
- Keep the existing tiny GGUF guardrail behavior (real tiny model) and caching/provisioning logic but make its preflight and failure modes explicit to CI.

### Testing

- Ran the sentinel/unit checks: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -v` — PASSED.
- Ran the project unit/integration/security sets invoked by `./run_all_tests.sh` and related smoke tests: `python -m pytest tests/unit/test_dspace_integration_script.py tests/unit/test_sendemail_validate_hook.py tests/test_security_bandit.py -v`, `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_inference_sidecar.py tests/unit/test_desktop_runtime_setup.py -v`, and `python -m pytest tests/unit/test_model_manager.py tests/unit/test_model_manager_llama_import_guard.py -v` — all passed.
- Executed the full local runner: `./run_all_tests.sh` (with `TEST_COVERAGE=1`/Playwright installs performed by workflow), which completed successfully in this environment (the run produced `All tests passed! 🎉`).
- Verified workflow YAMLs parse: `yaml.safe_load` checks on `.github/workflows/ci.yml` and `.github/workflows/run-all-tests-pr.yml` passed during test runs.
- Ran repository lint and hooks: `pre-commit run --all-files` — PASSED.

All automated checks exercised in this change passed in the verification environment; the sentinel tests now protect the PR-visible workflow from accidental removal or weakening. Follow-ups: monitor GH Actions runs for duration/runner-cost and consider fine-grained selective gating of particularly heavy E2E pieces if CI bill or minutes become an issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270b722388832f91f26e0d6c25c43c)