### PR TITLE
API v1: Make Meta Llama 3.1 8B the canonical launch model, remove hallucinated alignment adapter, and update landing UI/docs

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,19 +103,27 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
+CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"
+
 MODEL_ALIASES: Dict[str, str] = {
+    # Invisible compatibility alias for clients that integrated before the
+    # launch catalogue ID was corrected to match Meta Llama 3.1.
+    "llama-3-8b-instruct": CANONICAL_LAUNCH_MODEL_ID,
     # Temporary OpenAI-client compatibility aliases that route to the fixed
     # Meta Llama 3.1 8B backend; these are not first-class GPT model support.
     # Any removal should happen in a dedicated compatibility/deprecation PR.
-    "gpt-3.5-turbo": "llama-3-8b-instruct",
-    "gpt-5-chat-latest": "llama-3-8b-instruct",
+    "gpt-3.5-turbo": CANONICAL_LAUNCH_MODEL_ID,
+    "gpt-5-chat-latest": CANONICAL_LAUNCH_MODEL_ID,
 }
 
 
 AVAILABLE_MODELS = [
     {
-        "id": "llama-3-8b-instruct",
+        "id": CANONICAL_LAUNCH_MODEL_ID,
         "name": "Meta Llama 3.1 8B Instruct",
+        "owned_by": "Meta",
+        "provider": "meta",
+        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
         "description": (
             "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
             "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
@@ -128,22 +136,6 @@ AVAILABLE_MODELS = [
             "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
         ),
         "file_name": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "adapters": [
-            {
-                "id": "llama-3-8b-instruct:alignment",
-                "name": "Meta Llama 3.1 8B Alignment Assistant",
-                "description": (
-                    "Alignment-tuned variant emphasising helpful, honest, and harmless replies "
-                    "using constitutional guardrails."
-                ),
-                "instructions": (
-                    "You are the alignment-focused variant of Meta Llama 3.1 8B. Follow the "
-                    "provided safety charter to remain helpful, honest, harmless, and to call "
-                    "out uncertain answers."
-                ),
-                "share_base": True,
-            }
-        ],
     }
 ]
 
@@ -186,6 +178,9 @@ def _get_model_metadata(model_id: str) -> Optional[Dict[str, Any]]:
     for entry in _iter_model_entries():
         if entry["id"] == model_id:
             return entry
+
+    if ":" in model_id:
+        return None
 
     # Fall back to the v2 catalogue so chat completions can load any model
     # surfaced via the API v2 listings. Import lazily to avoid a hard dependency
@@ -255,6 +250,8 @@ def get_model_instance(model_id):
     # Check input
     if not model_id:
         raise ModelError("Model ID cannot be empty", status_code=400, error_type="invalid_request_error")
+
+    model_id = resolve_model_alias(model_id) or model_id
 
     # First check if the model ID exists in available models
     model_meta = _get_model_metadata(model_id)
@@ -334,6 +331,7 @@ def generate_response(model_id, messages, **options):
         ModelError: If there's an error with the model or input
     """
     start_time = time.time()
+    model_id = resolve_model_alias(model_id) or model_id
     logger.info(f"Generating response using model: {model_id}")
 
     # Validate input

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -645,7 +645,8 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
-        model_id = data.get("model")
+        requested_model_id = data.get("model")
+        model_id = resolve_model_alias(requested_model_id) or requested_model_id
         prompt = data.get("prompt", "")
         client_public_key = data.get("client_public_key")
         is_encrypted_request = data.get("encrypted", False)
@@ -717,7 +718,7 @@ def _handle_text_completion_request(data):
             "id": f"cmpl-{uuid.uuid4().hex[:12]}",
             "object": "text_completion",
             "created": int(time.time()),
-            "model": model_id,
+            "model": requested_model_id,
             "choices": [
                 {
                     "index": 0,
@@ -871,8 +872,9 @@ def get_model(model_id):
     """
     try:
         log_info(f"API request: GET /models/{model_id}")
+        resolved_model_id = resolve_model_alias(model_id) or model_id
         models = get_models_info()
-        model = next((m for m in models if m["id"] == model_id), None)
+        model = next((m for m in models if m["id"] == resolved_model_id), None)
 
         if not model:
             log_warning(f"Model '{model_id}' not found")
@@ -1199,7 +1201,7 @@ def _format_openai_model_payload(model: dict[str, str]) -> dict[str, object]:
         "id": model["id"],
         "object": "model",
         "created": created_ts,
-        "owned_by": "token.place",
+        "owned_by": model.get("owned_by") or model.get("provider") or "Meta",
         "permission": [{
             "id": f"modelperm-{model['id']}",
             "object": "model_permission",

--- a/static/chat.js
+++ b/static/chat.js
@@ -2,7 +2,7 @@ const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue genera
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
-const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
+const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 
 new Vue({
     el: '#app',
@@ -63,7 +63,6 @@ new Vue({
                 return {
                     id: EMERGENCY_MODEL_FALLBACK_ID,
                     object: 'model',
-                    owned_by: 'emergency-fallback',
                     root: EMERGENCY_MODEL_FALLBACK_ID
                 };
             }
@@ -74,14 +73,10 @@ new Vue({
             if (!model) {
                 return '';
             }
-            const fields = [];
-            if (model.owned_by) {
-                fields.push(`owned by ${model.owned_by}`);
-            }
             if (model.root && model.root !== model.id) {
-                fields.push(`root ${model.root}`);
+                return `root ${model.root}`;
             }
-            return fields.join(' · ');
+            return '';
         },
         hasClientKeypair() {
             return Boolean(this.clientPrivateKey && this.clientPublicKey);

--- a/static/index.html
+++ b/static/index.html
@@ -505,19 +505,19 @@
 
         <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/models</span></h3>
-            <p>Lists available API v1 models in OpenAI-compatible list format. API v1 returns stable OpenAI-style model objects, not the API v2 catalog schema.</p>
+            <p>Lists the single API v1 launch model in OpenAI-compatible list format. API v1 returns stable OpenAI-style model objects, not the API v2 catalog schema.</p>
             <p><strong>Example Response:</strong></p>
             <pre>{
   "object": "list",
   "data": [
     {
-      "id": "llama-3-8b-instruct",
+      "id": "llama-3.1-8b-instruct",
       "object": "model",
       "created": CREATED_UNIX_SECONDS,
-      "owned_by": "token.place",
+      "owned_by": "Meta",
       "permission": [
         {
-          "id": "modelperm-llama-3-8b-instruct",
+          "id": "modelperm-llama-3.1-8b-instruct",
           "object": "model_permission",
           "created": CREATED_UNIX_SECONDS,
           "allow_create_engine": false,
@@ -531,7 +531,7 @@
           "is_blocking": false
         }
       ],
-      "root": "llama-3-8b-instruct",
+      "root": "llama-3.1-8b-instruct",
       "parent": null
     }
   ]
@@ -562,7 +562,7 @@
             <p>Creates a non-streaming chat completion. API v1 rejects <code>stream: true</code>. Encrypted mode sends ciphertext under <code>messages</code> and includes the client public key so only the client can decrypt the response.</p>
             <p><strong>Encrypted Request Body:</strong></p>
             <pre>{
-  "model": "llama-3-8b-instruct",
+  "model": "llama-3.1-8b-instruct",
   "encrypted": true,
   "client_public_key": "CLIENT_PUBLIC_KEY_HERE",
   "messages": {

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -64,10 +64,10 @@ def route_landing_relay_chat(
         "object": "list",
         "data": [
             {
-                "id": "llama-3-8b-instruct",
+                "id": "llama-3.1-8b-instruct",
                 "object": "model",
-                "owned_by": "token.place",
-                "root": "llama-3-8b-instruct",
+                "owned_by": "Meta",
+                "root": "llama-3.1-8b-instruct",
             }
         ],
     }
@@ -485,7 +485,7 @@ def test_landing_chat_uses_api_v1_only_non_streaming(
     assert state["relay_requests"][0]["server_public_key"] == SERVER_PUBLIC_KEY_B64
     request_envelope = json.loads(state["relay_requests"][0]["ciphertext"])
     assert request_envelope["protocol"] == "tokenplace_api_v1_relay_e2ee"
-    assert request_envelope["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert request_envelope["api_v1_request"]["messages"] == [{"role": "user", "content": "hello"}]
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
@@ -527,7 +527,7 @@ def test_landing_chat_sticky_server_two_turns_and_key_label(page: Page, base_url
         {"role": "assistant", "content": "Sticky relay response."},
         {"role": "user", "content": "second turn"},
     ]
-    assert all(envelope["api_v1_request"]["model"] == "llama-3-8b-instruct" for envelope in envelopes)
+    assert all(envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct" for envelope in envelopes)
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 
@@ -612,34 +612,16 @@ def test_landing_chat_terminal_server_failure_requires_explicit_new_chat_retry(
     assert state["v2_requests"] == []
 
 
-def test_landing_chat_model_dropdown_uses_api_v1_models(
+def test_landing_chat_model_dropdown_uses_single_api_v1_launch_model(
     page: Page,
     base_url: str,
     setup_servers,
 ):
-    """The landing chat model selector is populated from API v1 and drives relay envelopes."""
+    """The landing chat exposes only the API v1 launch model and hides ownership copy."""
 
-    models_payload = {
-        "object": "list",
-        "data": [
-            {
-                "id": "api-v1-first-model",
-                "object": "model",
-                "owned_by": "token.place",
-                "root": "api-v1-first-model",
-            },
-            {
-                "id": "api-v1-second-model",
-                "object": "model",
-                "owned_by": "community",
-                "root": "api-v1-second-model",
-            },
-        ],
-    }
     state = route_landing_relay_chat(
         page,
         assistant_content="Selected model acknowledged.",
-        models_payload=models_payload,
     )
 
     page.goto(base_url)
@@ -648,13 +630,10 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
-    assert model_select.input_value() == "api-v1-first-model"
-    assert model_select.locator("option").all_inner_texts() == [
-        "api-v1-first-model",
-        "api-v1-second-model",
-    ]
-
-    model_select.select_option("api-v1-second-model")
+    assert model_select.input_value() == "llama-3.1-8b-instruct"
+    assert model_select.locator("option").all_inner_texts() == ["llama-3.1-8b-instruct"]
+    assert "owned by token.place" not in page.locator("body").inner_text().lower()
+    assert "owned by" not in page.locator(".model-selector-container").inner_text().lower()
 
     textarea = page.locator("textarea").first
     textarea.fill("Use the selected model")
@@ -663,7 +642,7 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
     page.locator(".assistant-message").last.wait_for(state="visible")
     assert state["relay_requests"], "expected the landing chat to POST an API v1 relay payload"
     request_envelope = json.loads(state["relay_requests"][-1]["ciphertext"])
-    assert request_envelope["api_v1_request"]["model"] == "api-v1-second-model"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 
@@ -740,8 +719,8 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
-    assert model_select.input_value() == "llama-3-8b-instruct"
-    assert "llama-3-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
+    assert model_select.input_value() == "llama-3.1-8b-instruct"
+    assert "llama-3.1-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
     assert "Could not load the API v1 model list" in page.locator(".model-error").inner_text()
 
     page.locator("textarea").first.fill("hello")
@@ -750,7 +729,7 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
     page.locator(".assistant-message").last.wait_for(state="visible")
     assert state["relay_requests"], "expected the landing chat to POST the API v1 fallback relay payload"
     request_envelope = json.loads(state["relay_requests"][-1]["ciphertext"])
-    assert request_envelope["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1073,11 +1073,11 @@ def test_v1_completions_reject_stream_flag(client, mock_llama):
 
 
 def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
-    """API v1 chat completions should execute using the canonical token.place model."""
+    """API v1 chat completions should execute using the canonical Meta Llama 3.1 model."""
 
     monkeypatch.setattr(
         "api.v1.routes.get_models_info",
-        lambda: [{"id": "llama-3-8b-instruct"}],
+        lambda: [{"id": "llama-3.1-8b-instruct"}],
     )
     monkeypatch.setattr("api.v1.routes.validate_chat_messages", lambda msgs: None)
 
@@ -1118,7 +1118,7 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
 
     body = response.get_json()
     assert body["model"] == "llama-3-8b-instruct"
-    assert captured["model_id"] == "llama-3-8b-instruct"
+    assert captured["model_id"] == "llama-3.1-8b-instruct"
     assert captured["messages"] == payload["messages"]
     assert body["choices"][0]["message"]["content"] == "Llama response"
 

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -138,7 +138,7 @@ def test_api_v1_chat_completions_rejects_stream_true(client):
     response = client.post(
         "/api/v1/chat/completions",
         json={
-            "model": "llama-3-8b-instruct",
+            "model": "llama-3.1-8b-instruct",
             "messages": [{"role": "user", "content": "hello"}],
             "stream": True,
         },
@@ -156,16 +156,30 @@ def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
     assert response.status_code == 200
     payload = response.get_json()
     assert payload["object"] == "list"
-    assert payload["data"]
+    assert len(payload["data"]) == 1
+    assert payload["data"][0]["id"] == "llama-3.1-8b-instruct"
     for model in payload["data"]:
         assert model["object"] == "model"
-        assert model["owned_by"] == "token.place"
+        assert model["owned_by"] == "Meta"
         assert "permission" in model
         assert isinstance(model["permission"], list)
         assert model["permission"]
         assert model["permission"][0]["object"] == "model_permission"
         assert "metadata" not in model
         assert "adapter" not in model
+
+
+
+def test_api_v1_model_detail_keeps_old_alias_invisible_and_rejects_alignment(client):
+    alias_response = client.get("/api/v1/models/llama-3-8b-instruct")
+    assert alias_response.status_code == 200
+    alias_payload = alias_response.get_json()
+    assert alias_payload["id"] == "llama-3.1-8b-instruct"
+    assert alias_payload["owned_by"] == "Meta"
+
+    alignment_response = client.get("/api/v1/models/llama-3-8b-instruct:alignment")
+    assert alignment_response.status_code == 404
+    assert alignment_response.get_json()["error"]["code"] == "model_not_found"
 
 
 def test_landing_page_model_example_documents_openai_permission_objects():
@@ -178,13 +192,17 @@ def test_landing_page_model_example_documents_openai_permission_objects():
     assert '"allow_sampling": true' in models_section
     assert '"created": CREATED_UNIX_SECONDS' in models_section
     assert '"created": 1700000000' not in models_section
+    assert '"id": "llama-3.1-8b-instruct"' in models_section
+    assert '"owned_by": "Meta"' in models_section
+    assert "llama-3-8b-instruct:alignment" not in html
+    assert "owned by token.place" not in html.lower()
 
 
 def test_route_level_generate_response_bridge_is_request_local(monkeypatch):
     original_compute_generator = compute_provider.generate_response
 
     def fake_generate_response(model_id, messages, **options):
-        assert model_id == "llama-3-8b-instruct"
+        assert model_id == "llama-3.1-8b-instruct"
         assert options == {"temperature": 0.2}
         return messages + [{"role": "assistant", "content": "request-local bridge"}]
 
@@ -192,7 +210,7 @@ def test_route_level_generate_response_bridge_is_request_local(monkeypatch):
 
     result = routes._call_provider_complete_chat(
         compute_provider.LocalApiV1ComputeProvider(),
-        model_id="llama-3-8b-instruct",
+        model_id="llama-3.1-8b-instruct",
         messages=[{"role": "user", "content": "hello"}],
         options={"temperature": 0.2},
     )

--- a/tests/unit/test_api_v1_models.py
+++ b/tests/unit/test_api_v1_models.py
@@ -18,7 +18,7 @@ def test_generate_response_uses_real_model():
             mock_llama.return_value = mock_instance
 
             messages = [{'role': 'user', 'content': 'hi'}]
-            result = models.generate_response('llama-3-8b-instruct', messages, temperature=0.7)
+            result = models.generate_response('llama-3.1-8b-instruct', messages, temperature=0.7)
 
             mock_instance.create_chat_completion.assert_called_once_with(
                 messages=messages,

--- a/tests/unit/test_api_v1_models_adapters.py
+++ b/tests/unit/test_api_v1_models_adapters.py
@@ -1,10 +1,12 @@
-"""Adapter support tests for api.v1.models."""
+"""Regression tests ensuring hallucinated API v1 adapters stay removed."""
 
 import importlib
 from typing import Dict
 
+import pytest
+
 ADAPTER_ID = "llama-3-8b-instruct:alignment"
-BASE_ID = "llama-3-8b-instruct"
+BASE_ID = "llama-3.1-8b-instruct"
 
 
 def _reload_models(monkeypatch, env: Dict[str, str] | None = None):
@@ -18,25 +20,19 @@ def _reload_models(monkeypatch, env: Dict[str, str] | None = None):
     return models
 
 
-def test_get_models_info_exposes_adapter_metadata(monkeypatch):
+def test_get_models_info_does_not_expose_alignment_adapter(monkeypatch):
     models = _reload_models(monkeypatch, {"USE_MOCK_LLM": "1"})
 
     info = models.get_models_info()
-    adapter_entry = next((item for item in info if item["id"] == ADAPTER_ID), None)
 
-    assert adapter_entry is not None, "adapter should be listed alongside base models"
-    assert adapter_entry["base_model_id"] == BASE_ID
-    assert adapter_entry.get("adapter", {}).get("instructions"), "instructions are required"
+    assert [item["id"] for item in info] == [BASE_ID]
+    assert all(item.get("adapter") is None for item in info)
 
 
-def test_generate_response_injects_adapter_prompt(monkeypatch):
+def test_generate_response_rejects_removed_alignment_adapter(monkeypatch):
     models = _reload_models(monkeypatch, {"USE_MOCK_LLM": "1"})
-    monkeypatch.setattr(models.random, "choice", lambda seq: seq[0])
 
-    messages = [{"role": "user", "content": "hello"}]
-    response = models.generate_response(ADAPTER_ID, messages)
+    with pytest.raises(models.ModelError) as exc:
+        models.generate_response(ADAPTER_ID, [{"role": "user", "content": "hello"}])
 
-    assert response[0]["role"] == "system"
-    assert response[0]["name"].startswith("adapter:")
-    assert "alignment" in response[0]["content"].lower()
-    assert response[-1]["role"] == "assistant"
+    assert exc.value.error_type == "model_not_found"

--- a/tests/unit/test_api_v1_models_additional.py
+++ b/tests/unit/test_api_v1_models_additional.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 def test_get_model_instance_mock():
     import api.v1.models as models
     importlib.reload(models)
-    inst = models.get_model_instance('llama-3-8b-instruct')
+    inst = models.get_model_instance('llama-3.1-8b-instruct')
     assert inst == "MOCK_MODEL"
 
 
@@ -42,7 +42,7 @@ def test_generate_response_mock(monkeypatch):
     # Force deterministic choice
     monkeypatch.setattr(random, 'choice', lambda seq: seq[0])
     messages = [{'role': 'user', 'content': 'hi'}]
-    resp = models.generate_response('llama-3-8b-instruct', messages)
+    resp = models.generate_response('llama-3.1-8b-instruct', messages)
     assert resp[-1]['role'] == 'assistant'
     assert 'Mock response:' in resp[-1]['content']
 
@@ -52,10 +52,10 @@ def test_generate_response_validation_errors():
     import api.v1.models as models
     importlib.reload(models)
     with pytest.raises(models.ModelError):
-        models.generate_response('llama-3-8b-instruct', [])
+        models.generate_response('llama-3.1-8b-instruct', [])
     bad_messages = [{'role': 'user'}]
     with pytest.raises(models.ModelError):
-        models.generate_response('llama-3-8b-instruct', bad_messages)
+        models.generate_response('llama-3.1-8b-instruct', bad_messages)
 
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
@@ -79,7 +79,7 @@ def test_get_model_instance_load_error(monkeypatch):
 
     monkeypatch.setattr(models, "Llama", lambda *a, **k: boom())
     with pytest.raises(models.ModelError) as exc:
-        models.get_model_instance("llama-3-8b-instruct")
+        models.get_model_instance("llama-3.1-8b-instruct")
     assert "Failed to load model" in str(exc.value)
 
 

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -23,8 +23,9 @@ def _reload_models(env=None):
 
 def test_resolve_model_alias_returns_canonical_id_for_compat_aliases():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
-    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("llama-3-8b-instruct") == "llama-3.1-8b-instruct"
+    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3.1-8b-instruct"
+    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3.1-8b-instruct"
 
 
 def test_resolve_model_alias_rejects_unsupported_gpt_id():

--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 
 @mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
-def test_api_v1_catalog_is_restricted_to_llama_3_8b():
+def test_api_v1_catalog_is_restricted_to_single_llama_3_1_8b_launch_model():
     import api.v1.models as models
 
     importlib.reload(models)
@@ -14,17 +14,13 @@ def test_api_v1_catalog_is_restricted_to_llama_3_8b():
     entries = models.get_models_info()
     model_ids = {entry["id"] for entry in entries}
 
-    assert model_ids == {
-        "llama-3-8b-instruct",
-        "llama-3-8b-instruct:alignment",
-    }
+    assert model_ids == {"llama-3.1-8b-instruct"}
 
-    base_entry = next(entry for entry in entries if entry["id"] == "llama-3-8b-instruct")
-    assert base_entry["base_model_id"] == "llama-3-8b-instruct"
-
-    adapter_entry = next(entry for entry in entries if entry["id"] == "llama-3-8b-instruct:alignment")
-    assert adapter_entry["adapter"]["share_base"] is True
-    assert adapter_entry["base_model_id"] == "llama-3-8b-instruct"
+    base_entry = next(entry for entry in entries if entry["id"] == "llama-3.1-8b-instruct")
+    assert base_entry["base_model_id"] == "llama-3.1-8b-instruct"
+    assert base_entry["owned_by"] == "Meta"
+    assert base_entry["provider"] == "meta"
+    assert base_entry["source_model"] == "meta-llama/Llama-3.1-8B-Instruct"
 
 
 @mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
@@ -34,7 +30,7 @@ def test_llama_catalog_targets_latest_4090_ready_release():
     importlib.reload(models)
 
     base_entry = next(
-        entry for entry in models.get_models_info() if entry["id"] == "llama-3-8b-instruct"
+        entry for entry in models.get_models_info() if entry["id"] == "llama-3.1-8b-instruct"
     )
 
     assert base_entry["name"] == "Meta Llama 3.1 8B Instruct"

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -220,7 +220,7 @@ def test_chat_completion_echoes_request_metadata(client, monkeypatch):
 def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "Paris"}
 
@@ -281,7 +281,7 @@ def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
 def test_chat_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "Paris"}
 
@@ -330,7 +330,7 @@ def test_chat_completion_encrypted_response_sets_provider_headers(client, monkey
 def test_legacy_completion_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "hello"}
@@ -381,7 +381,7 @@ def test_legacy_completion_rejects_streaming_for_api_v1(client, monkeypatch):
 def test_legacy_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "hello"}

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1954,14 +1954,14 @@ class TestRelayClient:
         assert RelayClient._valid_api_v1_assistant_message(message) == message
 
     @patch('utils.networking.relay_client.requests.post')
-    def test_process_client_request_api_v1_adapter_model_uses_shared_llama_runtime(
+    def test_process_client_request_api_v1_removed_adapter_model_returns_error(
         self,
         mock_post,
         relay_client,
         mock_crypto_manager,
         mock_model_manager,
     ):
-        """API v1 adapter IDs should share the local Llama base runtime."""
+        """Removed API v1 adapter IDs should fail closed at the compute node."""
 
         request_data = TEST_VALID_RESPONSE.copy()
         mock_model_manager.use_mock_llm = False
@@ -1987,15 +1987,9 @@ class TestRelayClient:
         assert relay_client.process_client_request(request_data) is True
 
         mock_model_manager.llama_cpp_get_response.assert_not_called()
-        runtime_messages = mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
-            "messages"
-        ]
-        assert runtime_messages[0]["role"] == "system"
-        assert runtime_messages[0]["name"] == "adapter:llama-3-8b-instruct:alignment"
-        assert "alignment-focused variant" in runtime_messages[0]["content"]
-        assert runtime_messages[1] == {"role": "user", "content": "Hello"}
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
-        assert "error" not in encrypted_envelope["api_v1_response"]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == "compute_node_model_unsupported"
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_normalises_multipart_content_blocks(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -479,6 +479,7 @@ class RelayClient:
     """
 
     _API_V1_LOCAL_LLAMA_RUNTIME_IDS = {
+        "llama-3.1-8b-instruct",
         "llama-3-8b-instruct",
         "meta/llama-3.1-8b-instruct",
         "meta-llama-3.1-8b-instruct-q4_k_m.gguf",
@@ -486,12 +487,11 @@ class RelayClient:
         "meta-llama-3-8b-instruct-q4_k_m.gguf",
     }
     _API_V1_LOCAL_MODEL_ALIASES = {
-        "gpt-3.5-turbo": "llama-3-8b-instruct",
-        "gpt-5-chat-latest": "llama-3-8b-instruct",
+        "llama-3-8b-instruct": "llama-3.1-8b-instruct",
+        "gpt-3.5-turbo": "llama-3.1-8b-instruct",
+        "gpt-5-chat-latest": "llama-3.1-8b-instruct",
     }
-    _API_V1_LOCAL_ADAPTER_BASE_MODELS = {
-        "llama-3-8b-instruct:alignment": "llama-3-8b-instruct",
-    }
+    _API_V1_LOCAL_ADAPTER_BASE_MODELS: Dict[str, str] = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant", "function"}
 
     def __init__(
@@ -1733,13 +1733,7 @@ class RelayClient:
     def _api_v1_adapter_system_message(model_id: str) -> Optional[Dict[str, str]]:
         """Return local API v1 adapter instructions that do not require server imports."""
 
-        adapter_instructions = {
-            "llama-3-8b-instruct:alignment": (
-                "You are the alignment-focused variant of Meta Llama 3.1 8B. "
-                "Follow the provided safety charter to remain helpful, honest, "
-                "harmless, and to call out uncertain answers."
-            ),
-        }
+        adapter_instructions: Dict[str, str] = {}
         instructions = adapter_instructions.get(model_id.strip().lower())
         if not instructions:
             return None
@@ -1821,8 +1815,6 @@ class RelayClient:
         adapter_base = cls._API_V1_LOCAL_ADAPTER_BASE_MODELS.get(normalized_model)
         if adapter_base:
             ids.add(adapter_base)
-        if ":" in normalized_model:
-            ids.add(normalized_model.split(":", 1)[0])
         ids.add(cls._api_v1_catalogue_resolved_model_id(normalized_model))
         return {value for value in ids if value}
 


### PR DESCRIPTION
### Motivation
- Fix the public API v1 launch catalog so the single, canonical launch model is exactly `llama-3.1-8b-instruct` and not a repo-owned or misnamed id. 
- Remove the hallucinated alignment adapter from public API v1 surfaces so it cannot be selected or listed. 
- Remove misleading "owned by token.place" copy from the landing UI and update landing-page docs/examples to attribute the model to Meta and show the corrected id.

### Description
- Introduced `CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"` and updated the v1 model catalogue to expose only that id with `owned_by: "Meta"`, `provider: "meta"`, and `source_model: "meta-llama/Llama-3.1-8B-Instruct"` in `api/v1/models.py`.
- Removed the hallucinated `:alignment` adapter from the public `AVAILABLE_MODELS` and added an invisible compatibility alias mapping (`"llama-3-8b-instruct" -> "llama-3.1-8b-instruct"`) plus existing OpenAI-compatible GPT aliases mapping to the canonical id in `MODEL_ALIASES`.
- Prevented adapter-style ids (containing `:`) from being silently satisfied by falling back to the API v2 catalogue so adapter ids like `llama-3-8b-instruct:alignment` return `model_not_found` in API v1.
- Route-level and runtime alias resolution: resolve aliases early in `get_model_instance`, `generate_response`, text-completions handlers and `GET /models/<model_id>` so the canonical model is used at runtime while preserving the requested id in legacy response shapes where appropriate.
- Update OpenAI-compatible payload formatting to attribute `owned_by` from model metadata (or `provider`) instead of hardcoding `token.place` in `api/v1/routes.py`.
- Landing UI updates in `static/chat.js` and `static/index.html`: emergency fallback id set to `llama-3.1-8b-instruct`, UI no longer renders an "owned by …" line, and examples/docs updated to reference `llama-3.1-8b-instruct` and `Meta` ownership.
- Tests updated to reflect the corrected launch contract and invisibility of the old id and alignment adapter: added/modified unit tests under `tests/unit/` and updated e2e expectations in `tests/e2e/test_ui.py` to assert a single selectable model and that no "owned by token.place" string is rendered.

### Testing
- Ran unit launch-contract tests: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` — all tests passed (9 passed, 2 warnings). 
- Ran focused unit model tests: `python -m pytest tests/unit/test_api_v1_models.py tests/unit/test_api_v1_models_additional.py tests/unit/test_api_v1_models_catalog_minimal.py tests/unit/test_api_v1_models_adapters.py tests/unit/test_api_v1_models_aliases.py -v` — all selected unit tests passed (16 passed, 1 warning across runs).
- Ran the JS smoke/test suite: `npm run test:js` — JS tests passed (all JS checks reported passing). 
- Attempted e2e/Playwright subset: `python -m pytest tests/e2e/test_ui.py -k "model or landing_chat" -v` initially failed because Playwright browser binaries were not installed in the environment; then `./run_all_tests.sh` installed Playwright browsers and proceeded to run the larger test matrix.
- Result summary: unit test coverage for the modified v1 launch contract and model catalog changes passed; JavaScript tests passed; full browser-driven e2e runs require Playwright browser installation and a proper headless environment (the runner installed browsers during `./run_all_tests.sh`, but Playwright headless execution may still be environment-sensitive and can error outside CI if browsers are missing or Playwright sync API is used within an active asyncio loop). 

Residual risks and follow-ups: Playwright-driven e2e tests depend on system browser binaries and the test runner environment; CI should run `./run_all_tests.sh` or `playwright install` as part of the pipeline to ensure e2e checks execute reliably. Also verify any external artifacts or desktop parity expectations (desktop-tauri metadata) remain consistent with the canonical id as a separate smoke parity step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2849c1f82c832f8b52ea7bee75484e)