### PR TITLE
API v1: expose Meta Llama 3.1 8B Instruct as canonical launch model; remove alignment adapter and owner badge

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,23 +103,30 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
+CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"
+
 MODEL_ALIASES: Dict[str, str] = {
-    # Temporary OpenAI-client compatibility aliases that route to the fixed
-    # Meta Llama 3.1 8B backend; these are not first-class GPT model support.
-    # Any removal should happen in a dedicated compatibility/deprecation PR.
-    "gpt-3.5-turbo": "llama-3-8b-instruct",
-    "gpt-5-chat-latest": "llama-3-8b-instruct",
+    # Invisible compatibility aliases that route to the fixed Meta Llama 3.1
+    # 8B launch backend. They are accepted by request paths but are not listed
+    # as first-class API v1 models.
+    "llama-3-8b-instruct": CANONICAL_LAUNCH_MODEL_ID,
+    "gpt-3.5-turbo": CANONICAL_LAUNCH_MODEL_ID,
+    "gpt-5-chat-latest": CANONICAL_LAUNCH_MODEL_ID,
 }
 
 
 AVAILABLE_MODELS = [
     {
-        "id": "llama-3-8b-instruct",
+        "id": CANONICAL_LAUNCH_MODEL_ID,
         "name": "Meta Llama 3.1 8B Instruct",
         "description": (
             "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
             "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
         ),
+        "owner": "Meta",
+        "owned_by": "Meta",
+        "provider": "meta",
+        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
         "parameters": "8B",
         "quantization": "Q4_K_M",
         "context_length": 8192,
@@ -128,22 +135,7 @@ AVAILABLE_MODELS = [
             "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
         ),
         "file_name": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "adapters": [
-            {
-                "id": "llama-3-8b-instruct:alignment",
-                "name": "Meta Llama 3.1 8B Alignment Assistant",
-                "description": (
-                    "Alignment-tuned variant emphasising helpful, honest, and harmless replies "
-                    "using constitutional guardrails."
-                ),
-                "instructions": (
-                    "You are the alignment-focused variant of Meta Llama 3.1 8B. Follow the "
-                    "provided safety charter to remain helpful, honest, harmless, and to call "
-                    "out uncertain answers."
-                ),
-                "share_base": True,
-            }
-        ],
+        "adapters": [],
     }
 ]
 
@@ -187,18 +179,6 @@ def _get_model_metadata(model_id: str) -> Optional[Dict[str, Any]]:
         if entry["id"] == model_id:
             return entry
 
-    # Fall back to the v2 catalogue so chat completions can load any model
-    # surfaced via the API v2 listings. Import lazily to avoid a hard dependency
-    # when the v2 module is unused (e.g. in legacy API v1 only deployments).
-    try:
-        from api.v2.models import get_models_info as get_v2_models_info  # type: ignore
-    except Exception as exc:  # pragma: no cover - defensive logging branch
-        log_warning(f"Unable to load API v2 catalogue: {exc}")
-        return None
-
-    for entry in get_v2_models_info():
-        if entry["id"] == model_id:
-            return entry
     return None
 
 
@@ -255,6 +235,8 @@ def get_model_instance(model_id):
     # Check input
     if not model_id:
         raise ModelError("Model ID cannot be empty", status_code=400, error_type="invalid_request_error")
+
+    model_id = resolve_model_alias(model_id) or model_id
 
     # First check if the model ID exists in available models
     model_meta = _get_model_metadata(model_id)
@@ -334,6 +316,7 @@ def generate_response(model_id, messages, **options):
         ModelError: If there's an error with the model or input
     """
     start_time = time.time()
+    model_id = resolve_model_alias(model_id) or model_id
     logger.info(f"Generating response using model: {model_id}")
 
     # Validate input

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -388,6 +388,7 @@ def _handle_chat_completion_request(data):
                 status_code=400,
             )
 
+        validate_field_type(data, "model", str)
         requested_model_id = data["model"]
         response_model_id = requested_model_id
         model_id = resolve_model_alias(requested_model_id) or requested_model_id
@@ -645,12 +646,10 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
-        requested_model_id = data.get("model")
-        model_id = (
-            resolve_model_alias(requested_model_id) or requested_model_id
-            if requested_model_id
-            else requested_model_id
-        )
+        validate_required_fields(data, ["model"])
+        validate_field_type(data, "model", str)
+        requested_model_id = data["model"]
+        model_id = resolve_model_alias(requested_model_id) or requested_model_id
         prompt = data.get("prompt", "")
         client_public_key = data.get("client_public_key")
         is_encrypted_request = data.get("encrypted", False)
@@ -761,6 +760,13 @@ def _handle_text_completion_request(data):
         response.headers["X-Tokenplace-API-V1-Stream-Mode"] = "non-streaming"
         return response
 
+    except ValidationError as e:
+        return format_error_response(
+            e.message,
+            param=e.field,
+            code=e.code,
+            status_code=400,
+        )
     except ModelError as e:
         log_warning(f"Model error during response generation: {e.message}")
         return format_error_response(

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -646,9 +646,9 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
+        requested_model_id = data.get("model")
         validate_required_fields(data, ["model"])
         validate_field_type(data, "model", str)
-        requested_model_id = data["model"]
         model_id = resolve_model_alias(requested_model_id) or requested_model_id
         prompt = data.get("prompt", "")
         client_public_key = data.get("client_public_key")

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -645,7 +645,12 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
-        model_id = data.get("model")
+        requested_model_id = data.get("model")
+        model_id = (
+            resolve_model_alias(requested_model_id) or requested_model_id
+            if requested_model_id
+            else requested_model_id
+        )
         prompt = data.get("prompt", "")
         client_public_key = data.get("client_public_key")
         is_encrypted_request = data.get("encrypted", False)
@@ -717,7 +722,7 @@ def _handle_text_completion_request(data):
             "id": f"cmpl-{uuid.uuid4().hex[:12]}",
             "object": "text_completion",
             "created": int(time.time()),
-            "model": model_id,
+            "model": requested_model_id,
             "choices": [
                 {
                     "index": 0,
@@ -872,7 +877,8 @@ def get_model(model_id):
     try:
         log_info(f"API request: GET /models/{model_id}")
         models = get_models_info()
-        model = next((m for m in models if m["id"] == model_id), None)
+        resolved_model_id = resolve_model_alias(model_id) or model_id
+        model = next((m for m in models if m["id"] == resolved_model_id), None)
 
         if not model:
             log_warning(f"Model '{model_id}' not found")
@@ -1191,7 +1197,7 @@ def _stable_openai_model_created(model_id: str) -> int:
     return 1_700_000_000 + (zlib.crc32(model_id.encode("utf-8")) % 31_536_000)
 
 
-def _format_openai_model_payload(model: dict[str, str]) -> dict[str, object]:
+def _format_openai_model_payload(model: dict[str, object]) -> dict[str, object]:
     """Build a stable OpenAI-compatible model payload."""
 
     created_ts = _stable_openai_model_created(model["id"])
@@ -1199,7 +1205,7 @@ def _format_openai_model_payload(model: dict[str, str]) -> dict[str, object]:
         "id": model["id"],
         "object": "model",
         "created": created_ts,
-        "owned_by": "token.place",
+        "owned_by": model.get("owned_by") or model.get("owner") or model.get("provider") or "unknown",
         "permission": [{
             "id": f"modelperm-{model['id']}",
             "object": "model_permission",

--- a/static/chat.js
+++ b/static/chat.js
@@ -2,7 +2,7 @@ const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue genera
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
-const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
+const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 
 new Vue({
     el: '#app',
@@ -63,25 +63,10 @@ new Vue({
                 return {
                     id: EMERGENCY_MODEL_FALLBACK_ID,
                     object: 'model',
-                    owned_by: 'emergency-fallback',
                     root: EMERGENCY_MODEL_FALLBACK_ID
                 };
             }
             return null;
-        },
-        selectedModelSummary() {
-            const model = this.selectedModel;
-            if (!model) {
-                return '';
-            }
-            const fields = [];
-            if (model.owned_by) {
-                fields.push(`owned by ${model.owned_by}`);
-            }
-            if (model.root && model.root !== model.id) {
-                fields.push(`root ${model.root}`);
-            }
-            return fields.join(' · ');
         },
         hasClientKeypair() {
             return Boolean(this.clientPrivateKey && this.clientPublicKey);

--- a/static/index.html
+++ b/static/index.html
@@ -447,7 +447,6 @@
                 </select>
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>
                 <p v-else-if="modelsError" class="model-status model-error">{{ modelsError }}</p>
-                <p v-else-if="selectedModelSummary" class="model-status">{{ selectedModelSummary }}</p>
             </div>
             <p v-if="selectedServerKeyLabel" class="server-key-label" data-testid="landing-server-key-label">{{ selectedServerKeyLabel }}</p>
             <div
@@ -511,13 +510,13 @@
   "object": "list",
   "data": [
     {
-      "id": "llama-3-8b-instruct",
+      "id": "llama-3.1-8b-instruct",
       "object": "model",
       "created": CREATED_UNIX_SECONDS,
-      "owned_by": "token.place",
+      "owned_by": "Meta",
       "permission": [
         {
-          "id": "modelperm-llama-3-8b-instruct",
+          "id": "modelperm-llama-3.1-8b-instruct",
           "object": "model_permission",
           "created": CREATED_UNIX_SECONDS,
           "allow_create_engine": false,
@@ -531,7 +530,7 @@
           "is_blocking": false
         }
       ],
-      "root": "llama-3-8b-instruct",
+      "root": "llama-3.1-8b-instruct",
       "parent": null
     }
   ]
@@ -562,7 +561,7 @@
             <p>Creates a non-streaming chat completion. API v1 rejects <code>stream: true</code>. Encrypted mode sends ciphertext under <code>messages</code> and includes the client public key so only the client can decrypt the response.</p>
             <p><strong>Encrypted Request Body:</strong></p>
             <pre>{
-  "model": "llama-3-8b-instruct",
+  "model": "llama-3.1-8b-instruct",
   "encrypted": true,
   "client_public_key": "CLIENT_PUBLIC_KEY_HERE",
   "messages": {

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -64,10 +64,10 @@ def route_landing_relay_chat(
         "object": "list",
         "data": [
             {
-                "id": "llama-3-8b-instruct",
+                "id": "llama-3.1-8b-instruct",
                 "object": "model",
-                "owned_by": "token.place",
-                "root": "llama-3-8b-instruct",
+                "owned_by": "Meta",
+                "root": "llama-3.1-8b-instruct",
             }
         ],
     }
@@ -461,6 +461,11 @@ def test_landing_chat_uses_api_v1_only_non_streaming(
     page.wait_for_load_state("networkidle")
     patch_landing_crypto_for_visible_envelopes(page)
 
+    model_select = page.get_by_test_id("landing-model-select")
+    model_select.wait_for(state="visible")
+    assert model_select.locator("option").all_inner_texts() == ["llama-3.1-8b-instruct"]
+    assert "owned by token.place" not in page.locator("body").inner_text().lower()
+
     textarea = page.locator("textarea").first
     textarea.fill("hello")
     wait_for_landing_send_enabled(page).click()
@@ -485,7 +490,7 @@ def test_landing_chat_uses_api_v1_only_non_streaming(
     assert state["relay_requests"][0]["server_public_key"] == SERVER_PUBLIC_KEY_B64
     request_envelope = json.loads(state["relay_requests"][0]["ciphertext"])
     assert request_envelope["protocol"] == "tokenplace_api_v1_relay_e2ee"
-    assert request_envelope["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert request_envelope["api_v1_request"]["messages"] == [{"role": "user", "content": "hello"}]
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
@@ -527,7 +532,7 @@ def test_landing_chat_sticky_server_two_turns_and_key_label(page: Page, base_url
         {"role": "assistant", "content": "Sticky relay response."},
         {"role": "user", "content": "second turn"},
     ]
-    assert all(envelope["api_v1_request"]["model"] == "llama-3-8b-instruct" for envelope in envelopes)
+    assert all(envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct" for envelope in envelopes)
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 
@@ -625,7 +630,7 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
             {
                 "id": "api-v1-first-model",
                 "object": "model",
-                "owned_by": "token.place",
+                "owned_by": "Meta",
                 "root": "api-v1-first-model",
             },
             {
@@ -653,6 +658,7 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
         "api-v1-first-model",
         "api-v1-second-model",
     ]
+    assert "owned by token.place" not in page.locator("body").inner_text().lower()
 
     model_select.select_option("api-v1-second-model")
 
@@ -740,8 +746,8 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
-    assert model_select.input_value() == "llama-3-8b-instruct"
-    assert "llama-3-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
+    assert model_select.input_value() == "llama-3.1-8b-instruct"
+    assert "llama-3.1-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
     assert "Could not load the API v1 model list" in page.locator(".model-error").inner_text()
 
     page.locator("textarea").first.fill("hello")
@@ -750,7 +756,7 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
     page.locator(".assistant-message").last.wait_for(state="visible")
     assert state["relay_requests"], "expected the landing chat to POST the API v1 fallback relay payload"
     request_envelope = json.loads(state["relay_requests"][-1]["ciphertext"])
-    assert request_envelope["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -691,6 +691,61 @@ def test_api_v1_completions_local_provider_rejects_unsupported_model(client, mon
     assert body['error']['code'] == 'model_not_supported'
 
 
+def test_v1_completions_rejects_non_string_model_without_500(client, monkeypatch):
+    alias = MagicMock(return_value='llama-3.1-8b-instruct')
+    monkeypatch.setattr('api.v1.routes.resolve_model_alias', alias)
+
+    response = client.post('/api/v1/completions', json={
+        'model': {},
+        'prompt': 'hello',
+    })
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body['error']['type'] == 'invalid_request_error'
+    assert body['error']['param'] == 'model'
+    assert 'Invalid type for model: expected str' in body['error']['message']
+    alias.assert_not_called()
+
+
+def test_v1_completions_legacy_alias_routes_canonical_but_echoes_requested_model(
+    client, monkeypatch
+):
+    requested_model_id = 'llama-3-8b-instruct'
+    canonical_model_id = 'llama-3.1-8b-instruct'
+    captured = {}
+
+    class FakeLocalProvider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            captured['model_id'] = model_id
+            captured['messages'] = messages
+            return {'role': 'assistant', 'content': 'alias routed'}
+
+    monkeypatch.setattr(
+        'api.v1.routes.get_models_info', lambda: [{'id': canonical_model_id}]
+    )
+    monkeypatch.setattr(
+        'api.v1.routes.get_api_v1_compute_provider', lambda: FakeLocalProvider()
+    )
+    monkeypatch.setattr(
+        'api.v1.routes.get_api_v1_resolved_provider_path',
+        lambda _provider: 'local',
+    )
+    monkeypatch.setattr('api.v1.routes.get_api_v1_last_backend_path', lambda: 'local')
+
+    response = client.post('/api/v1/completions', json={
+        'model': requested_model_id,
+        'prompt': 'hello',
+    })
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert captured['model_id'] == canonical_model_id
+    assert captured['messages'] == [{'role': 'user', 'content': 'hello'}]
+    assert body['model'] == requested_model_id
+    assert body['choices'][0]['text'] == 'alias routed'
+
+
 def test_chat_completion_rejects_empty_messages(client):
     """Empty chat message arrays should be rejected as invalid input."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -503,7 +503,7 @@ def test_api_v1_chat_completion_staging_no_nodes_returns_clear_503(client, monke
     response = client.post(
         "/api/v1/chat/completions",
         json={
-            "model": "llama-3-8b-instruct",
+            "model": "llama-3.1-8b-instruct",
             "messages": [{"role": "user", "content": "hello staging"}],
         },
     )
@@ -523,7 +523,7 @@ def test_api_v1_chat_completion_returns_503_when_distributed_has_no_registered_n
     monkeypatch.setenv('TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK', '0')
 
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'messages': [{'role': 'user', 'content': 'Ping distributed runtime'}],
         'temperature': 0.2,
         'stop': ['END'],
@@ -552,7 +552,7 @@ def test_api_v1_chat_completion_distributed_provider_falls_back_to_local(client,
     response = client.post(
         '/api/v1/chat/completions',
         json={
-            'model': 'llama-3-8b-instruct',
+            'model': 'llama-3.1-8b-instruct',
             'messages': [{'role': 'user', 'content': 'fallback please'}],
         },
     )
@@ -579,7 +579,7 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
     response = client.post(
         '/api/v1/chat/completions',
         json={
-            'model': 'llama-3-8b-instruct',
+            'model': 'llama-3.1-8b-instruct',
             'messages': [{'role': 'user', 'content': 'no fallback please'}],
         },
     )
@@ -595,7 +595,7 @@ def test_api_v1_chat_completion_distributed_no_fallback_returns_503(client, monk
 
 
 def test_api_v1_chat_completion_local_provider_rejects_unsupported_model(client, monkeypatch):
-    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3.1-8b-instruct'}])
 
     class ProviderShouldNotRun:
         def complete_chat(self, **kwargs):
@@ -616,7 +616,7 @@ def test_api_v1_chat_completion_local_provider_rejects_unsupported_model(client,
 
 
 def test_api_v1_chat_completion_distributed_with_fallback_allows_model_absent_from_local_catalogue(client, monkeypatch):
-    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3.1-8b-instruct'}])
     monkeypatch.setattr('api.v1.routes.validate_chat_messages', lambda msgs: None)
 
     captured = {}
@@ -645,7 +645,7 @@ def test_api_v1_chat_completion_distributed_with_fallback_allows_model_absent_fr
 
 
 def test_api_v1_completions_distributed_with_fallback_allows_model_absent_from_local_catalogue(client, monkeypatch):
-    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3.1-8b-instruct'}])
 
     captured = {}
 
@@ -671,7 +671,7 @@ def test_api_v1_completions_distributed_with_fallback_allows_model_absent_from_l
 
 
 def test_api_v1_completions_local_provider_rejects_unsupported_model(client, monkeypatch):
-    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3.1-8b-instruct'}])
 
     class ProviderShouldNotRun:
         def complete_chat(self, **kwargs):
@@ -1037,7 +1037,7 @@ def test_v1_chat_completion_rejects_stream_flag(client, mock_llama):
     """API v1 chat completions should reject the stream flag with a clear error."""
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Count from 1 to 5"}
@@ -1058,7 +1058,7 @@ def test_v1_completions_reject_stream_flag(client, mock_llama):
     """Legacy completions endpoint should also reject streaming attempts."""
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "prompt": "Return a short response.",
         "stream": True,
     }
@@ -1077,7 +1077,7 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
 
     monkeypatch.setattr(
         "api.v1.routes.get_models_info",
-        lambda: [{"id": "llama-3-8b-instruct"}],
+        lambda: [{"id": "llama-3.1-8b-instruct"}],
     )
     monkeypatch.setattr("api.v1.routes.validate_chat_messages", lambda msgs: None)
 
@@ -1107,7 +1107,7 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
     )
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "messages": [{"role": "user", "content": "Hello"}],
     }
 
@@ -1117,8 +1117,8 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
     assert response.is_json
 
     body = response.get_json()
-    assert body["model"] == "llama-3-8b-instruct"
-    assert captured["model_id"] == "llama-3-8b-instruct"
+    assert body["model"] == "llama-3.1-8b-instruct"
+    assert captured["model_id"] == "llama-3.1-8b-instruct"
     assert captured["messages"] == payload["messages"]
     assert body["choices"][0]["message"]["content"] == "Llama response"
 
@@ -1128,7 +1128,7 @@ def test_v1_chat_completion_rejects_unsupported_gpt_model_ids(client, monkeypatc
 
     monkeypatch.setattr(
         "api.v1.routes.get_models_info",
-        lambda: [{"id": "llama-3-8b-instruct"}],
+        lambda: [{"id": "llama-3.1-8b-instruct"}],
     )
 
     class ProviderShouldNotBeCalled:
@@ -1206,7 +1206,7 @@ def test_v1_encrypted_chat_completion_rejects_stream_flag(client, client_keys, m
     ciphertext_dict, cipherkey, iv = encrypt(json.dumps(messages).encode('utf-8'), server_public_key_bytes)
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "encrypted": True,
         "stream": True,
         "client_public_key": client_keys['public_key_b64'],
@@ -1228,7 +1228,7 @@ def test_v1_encrypted_chat_completion_rejects_stream_flag(client, client_keys, m
 def test_completions_endpoint(client, mock_llama):
     """Test the regular completions endpoint (redirects to chat)"""
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "prompt": "What is the capital of France?",
         "max_tokens": 100
     }
@@ -1290,7 +1290,7 @@ def test_get_model_not_found(client):
 
 def test_completions_encryption_error(client, monkeypatch, mock_llama):
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'prompt': 'hi',
         'encrypted': True,
         'client_public_key': 'bogus'
@@ -1309,7 +1309,7 @@ def test_create_completion_encrypted_success(client, monkeypatch, mock_llama):
         lambda m, msgs, **kwargs: msgs + [{'role':'assistant','content':'ok'}],
     )
     monkeypatch.setattr('api.v1.routes.encryption_manager.encrypt_message', lambda data, key: {'ciphertext':'a','cipherkey':'b','iv':'c'})
-    payload = {'model':'llama-3-8b-instruct','prompt':'hi','encrypted':True,'client_public_key':'x'}
+    payload = {'model':'llama-3.1-8b-instruct','prompt':'hi','encrypted':True,'client_public_key':'x'}
     res = client.post('/api/v1/completions', json=payload)
     assert res.status_code == 200
     d = res.get_json()
@@ -1324,7 +1324,7 @@ def test_create_chat_completion_model_error(client, monkeypatch, mock_llama):
             ModelError('boom', status_code=404, error_type='model_not_found')
         ),
     )
-    payload = {'model':'llama-3-8b-instruct','messages':[{'role':'user','content':'hi'}]}
+    payload = {'model':'llama-3.1-8b-instruct','messages':[{'role':'user','content':'hi'}]}
     res = client.post('/api/v1/chat/completions', json=payload)
     assert res.status_code == 404
     body = res.get_json()
@@ -1337,7 +1337,7 @@ def test_create_completion_exception(client, monkeypatch, mock_llama):
         'api.v1.compute_provider.generate_response',
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError('oops')),
     )
-    payload = {'model':'llama-3-8b-instruct','prompt':'hi'}
+    payload = {'model':'llama-3.1-8b-instruct','prompt':'hi'}
     res = client.post('/api/v1/completions', json=payload)
     assert res.status_code == 400
     assert 'error' in res.get_json()
@@ -1371,7 +1371,7 @@ def test_chat_completion_invalid_body(client):
 def test_chat_completion_decrypt_failure(client, monkeypatch):
     monkeypatch.setattr('api.v1.routes.encryption_manager.decrypt_message', lambda *a, **k: None)
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'encrypted': True,
         'client_public_key': base64.b64encode(b'x').decode(),
         'messages': {'ciphertext': base64.b64encode(b'c').decode(), 'cipherkey': base64.b64encode(b'k').decode(), 'iv': base64.b64encode(b'i').decode()}
@@ -1384,7 +1384,7 @@ def test_chat_completion_decrypt_failure(client, monkeypatch):
 def test_chat_completion_json_error(client, monkeypatch):
     monkeypatch.setattr('api.v1.routes.encryption_manager.decrypt_message', lambda *a, **k: b'not-json')
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'encrypted': True,
         'client_public_key': base64.b64encode(b'x').decode(),
         'messages': {'ciphertext': base64.b64encode(b'c').decode(), 'cipherkey': base64.b64encode(b'k').decode(), 'iv': base64.b64encode(b'i').decode()}
@@ -1394,7 +1394,7 @@ def test_chat_completion_json_error(client, monkeypatch):
     assert 'Failed to parse JSON' in res.get_json()['error']['message']
 
 def test_chat_completion_missing_messages(client):
-    payload = {"model": "llama-3-8b-instruct"}
+    payload = {"model": "llama-3.1-8b-instruct"}
     res = client.post("/api/v1/chat/completions", json=payload)
     assert res.status_code == 400
     data = res.get_json()
@@ -1402,14 +1402,14 @@ def test_chat_completion_missing_messages(client):
 
 
 def test_chat_completion_messages_wrong_type(client):
-    payload = {"model": "llama-3-8b-instruct", "messages": "not-a-list"}
+    payload = {"model": "llama-3.1-8b-instruct", "messages": "not-a-list"}
     res = client.post("/api/v1/chat/completions", json=payload)
     assert res.status_code == 400
     assert 'Invalid type for messages' in res.get_json()['error']['message']
 
 
 def test_chat_completion_invalid_role(client):
-    payload = {"model": "llama-3-8b-instruct", "messages": [{"role": "bad", "content": "hi"}]}
+    payload = {"model": "llama-3.1-8b-instruct", "messages": [{"role": "bad", "content": "hi"}]}
     res = client.post("/api/v1/chat/completions", json=payload)
     assert res.status_code == 400
     assert 'Invalid role' in res.get_json()['error']['message']
@@ -1424,7 +1424,7 @@ def test_chat_completion_encrypt_failure_on_response(client, monkeypatch):
     monkeypatch.setattr('api.v1.routes.encryption_manager.decrypt_message', lambda *a, **k: b'[{"role":"user","content":"hi"}]')
     monkeypatch.setattr('api.v1.validation.validate_encrypted_request', lambda data: None)
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'encrypted': True,
         'client_public_key': base64.b64encode(b'x').decode(),
         'messages': {
@@ -1448,9 +1448,9 @@ def test_openai_alias_routes_extended(client):
     for alias, api in endpoints:
         if 'completions' in alias:
             if alias.endswith('/completions'):
-                payload = {'model': 'llama-3-8b-instruct', 'prompt': 'hi'}
+                payload = {'model': 'llama-3.1-8b-instruct', 'prompt': 'hi'}
             else:
-                payload = {'model': 'llama-3-8b-instruct', 'messages': [{'role': 'user', 'content': 'hi'}]}
+                payload = {'model': 'llama-3.1-8b-instruct', 'messages': [{'role': 'user', 'content': 'hi'}]}
             res_alias = client.post(alias, json=payload)
             res_api = client.post(api, json=payload)
         else:
@@ -1509,11 +1509,11 @@ def test_get_public_key_exception(client, monkeypatch):
 
 
 def test_chat_completion_validation_error(client, monkeypatch):
-    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr('api.v1.routes.get_models_info', lambda: [{'id': 'llama-3.1-8b-instruct'}])
     from api.v1.validation import ValidationError
     monkeypatch.setattr('api.v1.routes.validate_encrypted_request', lambda d: (_ for _ in ()).throw(ValidationError('bad', field='f', code='c')))
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'encrypted': True,
         'client_public_key': base64.b64encode(b'x').decode(),
         'messages': {
@@ -1648,7 +1648,7 @@ def test_desktop_bridge_metadata_routes_to_same_origin_api_v1_relay_when_env_uns
     response = client.post(
         "/api/v1/chat/completions",
         json={
-            "model": "llama-3-8b-instruct",
+            "model": "llama-3.1-8b-instruct",
             "encrypted": True,
             "client_public_key": client_keys["public_key_b64"],
             "messages": encrypted_messages,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -692,7 +692,13 @@ def test_api_v1_completions_local_provider_rejects_unsupported_model(client, mon
 
 
 def test_v1_completions_rejects_non_string_model_without_500(client, monkeypatch):
-    alias = MagicMock(return_value='llama-3.1-8b-instruct')
+    alias_called = False
+
+    def alias(_model_id):
+        nonlocal alias_called
+        alias_called = True
+        raise AssertionError('resolve_model_alias should not be called')
+
     monkeypatch.setattr('api.v1.routes.resolve_model_alias', alias)
 
     response = client.post('/api/v1/completions', json={
@@ -705,7 +711,7 @@ def test_v1_completions_rejects_non_string_model_without_500(client, monkeypatch
     assert body['error']['type'] == 'invalid_request_error'
     assert body['error']['param'] == 'model'
     assert 'Invalid type for model: expected str' in body['error']['message']
-    alias.assert_not_called()
+    assert alias_called is False
 
 
 def test_v1_completions_legacy_alias_routes_canonical_but_echoes_requested_model(

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -146,7 +146,7 @@ def test_distributed_compute_provider_round_trip_uses_e2ee_envelope(monkeypatch)
 
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     response = provider.complete_chat(
-        model_id="llama-3-8b-instruct",
+        model_id="llama-3.1-8b-instruct",
         messages=[{"role": "user", "content": "hi"}],
         options={"temperature": 0.2},
     )
@@ -197,7 +197,7 @@ def test_distributed_compute_provider_treats_retrieve_404_as_unknown_request(mon
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -252,7 +252,7 @@ def test_distributed_compute_provider_rejects_response_client_key_binding_mismat
         provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
         try:
             provider.complete_chat(
-                model_id="llama-3-8b-instruct",
+                model_id="llama-3.1-8b-instruct",
                 messages=[{"role": "user", "content": "hi"}],
             )
             raise AssertionError("expected ComputeProviderError")
@@ -281,7 +281,7 @@ def test_fallback_compute_provider_uses_local_adapter_when_distributed_fails(mon
     )
 
     result = provider.complete_chat(
-        model_id="llama-3-8b-instruct",
+        model_id="llama-3.1-8b-instruct",
         messages=[{"role": "user", "content": "hello"}],
     )
 
@@ -311,7 +311,7 @@ def test_distributed_compute_provider_maps_faucet_404_to_no_registered_nodes(mon
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -338,7 +338,7 @@ def test_distributed_compute_provider_maps_encryption_failure_to_provider_error(
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -365,7 +365,7 @@ def test_distributed_compute_provider_maps_next_server_json_error(monkeypatch):
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -391,7 +391,7 @@ def test_distributed_compute_provider_maps_next_server_5xx(monkeypatch):
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -430,7 +430,7 @@ def test_distributed_compute_provider_applies_end_to_end_timeout_budget(monkeypa
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -471,7 +471,7 @@ def test_distributed_compute_provider_maps_decrypted_payload_shape_errors(monkey
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -529,7 +529,7 @@ def test_distributed_compute_provider_maps_compute_node_payload_errors(monkeypat
 
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "first"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -539,7 +539,7 @@ def test_distributed_compute_provider_maps_compute_node_payload_errors(monkeypat
 
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "second"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -605,7 +605,7 @@ def test_api_v1_chat_completion_emits_execution_backend_path_header_for_fallback
         response = client.post(
             "/api/v1/chat/completions",
             json={
-                "model": "llama-3-8b-instruct",
+                "model": "llama-3.1-8b-instruct",
                 "messages": [{"role": "user", "content": "hello"}],
             },
         )
@@ -636,7 +636,7 @@ def test_api_v1_chat_completion_returns_structured_error_when_distributed_only(m
         response = client.post(
             "/api/v1/chat/completions",
             json={
-                "model": "llama-3-8b-instruct",
+                "model": "llama-3.1-8b-instruct",
                 "messages": [{"role": "user", "content": "hello"}],
             },
         )
@@ -667,7 +667,7 @@ def test_distributed_compute_provider_maps_next_server_request_exception(monkeyp
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -699,7 +699,7 @@ def test_distributed_compute_provider_maps_faucet_request_exception(monkeypatch)
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -743,7 +743,7 @@ def test_distributed_compute_provider_maps_missing_assistant_message(monkeypatch
     provider = DistributedApiV1ComputeProvider(base_url="https://node-a.example", timeout_seconds=5)
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -807,7 +807,7 @@ def test_distributed_compute_provider_timeout_after_enqueue_posts_single_cancel(
     )
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -867,7 +867,7 @@ def test_distributed_compute_provider_cancel_failure_does_not_mask_timeout(monke
     )
     try:
         provider.complete_chat(
-            model_id="llama-3-8b-instruct",
+            model_id="llama-3.1-8b-instruct",
             messages=[{"role": "user", "content": "hi"}],
         )
         raise AssertionError("expected ComputeProviderError")
@@ -912,7 +912,7 @@ def test_distributed_compute_provider_maps_relay_410_cancelled_and_expired(monke
         )
         try:
             provider.complete_chat(
-                model_id="llama-3-8b-instruct",
+                model_id="llama-3.1-8b-instruct",
                 messages=[{"role": "user", "content": terminal_code}],
             )
             raise AssertionError("expected ComputeProviderError")

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -119,6 +119,16 @@ def test_landing_page_documents_openai_aliases_and_excludes_api_v2_launch_docs()
     assert "API v2 is intentionally outside this launch contract" in html
 
 
+def test_landing_page_freezes_single_meta_llama_model_without_owner_display():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "llama-3.1-8b-instruct" in html
+    assert "llama-3-8b-instruct:alignment" not in html
+    assert "llama-3.1-8b-instruct:alignment" not in html
+    assert "owned by token.place" not in html
+    assert "selectedModelSummary" not in html
+
+
 def test_compute_node_control_plane_routes_are_documented_separately():
     html = INDEX_HTML.read_text(encoding="utf-8")
     public_section, internal_section = html.split("Internal relay control-plane routes", 1)
@@ -138,7 +148,7 @@ def test_api_v1_chat_completions_rejects_stream_true(client):
     response = client.post(
         "/api/v1/chat/completions",
         json={
-            "model": "llama-3-8b-instruct",
+            "model": "llama-3.1-8b-instruct",
             "messages": [{"role": "user", "content": "hello"}],
             "stream": True,
         },
@@ -156,16 +166,35 @@ def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
     assert response.status_code == 200
     payload = response.get_json()
     assert payload["object"] == "list"
-    assert payload["data"]
-    for model in payload["data"]:
-        assert model["object"] == "model"
-        assert model["owned_by"] == "token.place"
-        assert "permission" in model
-        assert isinstance(model["permission"], list)
-        assert model["permission"]
-        assert model["permission"][0]["object"] == "model_permission"
-        assert "metadata" not in model
-        assert "adapter" not in model
+    assert len(payload["data"]) == 1
+    model = payload["data"][0]
+    assert model["id"] == "llama-3.1-8b-instruct"
+    assert model["object"] == "model"
+    assert model["owned_by"] == "Meta"
+    assert "token.place" not in model["owned_by"]
+    assert "permission" in model
+    assert isinstance(model["permission"], list)
+    assert model["permission"]
+    assert model["permission"][0]["object"] == "model_permission"
+    assert "metadata" not in model
+    assert "adapter" not in model
+
+
+def test_api_v1_model_aliases_are_invisible_and_alignment_is_rejected(client):
+    listing = client.get("/api/v1/models").get_json()["data"]
+    listed_ids = [model["id"] for model in listing]
+
+    assert listed_ids == ["llama-3.1-8b-instruct"]
+    assert "llama-3-8b-instruct" not in listed_ids
+    assert "llama-3-8b-instruct:alignment" not in listed_ids
+
+    alias_response = client.get("/api/v1/models/llama-3-8b-instruct")
+    assert alias_response.status_code == 200
+    assert alias_response.get_json()["id"] == "llama-3.1-8b-instruct"
+
+    alignment_response = client.get("/api/v1/models/llama-3-8b-instruct:alignment")
+    assert alignment_response.status_code == 404
+    assert alignment_response.get_json()["error"]["code"] == "model_not_found"
 
 
 def test_landing_page_model_example_documents_openai_permission_objects():
@@ -184,7 +213,7 @@ def test_route_level_generate_response_bridge_is_request_local(monkeypatch):
     original_compute_generator = compute_provider.generate_response
 
     def fake_generate_response(model_id, messages, **options):
-        assert model_id == "llama-3-8b-instruct"
+        assert model_id == "llama-3.1-8b-instruct"
         assert options == {"temperature": 0.2}
         return messages + [{"role": "assistant", "content": "request-local bridge"}]
 
@@ -192,7 +221,7 @@ def test_route_level_generate_response_bridge_is_request_local(monkeypatch):
 
     result = routes._call_provider_complete_chat(
         compute_provider.LocalApiV1ComputeProvider(),
-        model_id="llama-3-8b-instruct",
+        model_id="llama-3.1-8b-instruct",
         messages=[{"role": "user", "content": "hello"}],
         options={"temperature": 0.2},
     )

--- a/tests/unit/test_api_v1_models.py
+++ b/tests/unit/test_api_v1_models.py
@@ -18,7 +18,7 @@ def test_generate_response_uses_real_model():
             mock_llama.return_value = mock_instance
 
             messages = [{'role': 'user', 'content': 'hi'}]
-            result = models.generate_response('llama-3-8b-instruct', messages, temperature=0.7)
+            result = models.generate_response('llama-3.1-8b-instruct', messages, temperature=0.7)
 
             mock_instance.create_chat_completion.assert_called_once_with(
                 messages=messages,

--- a/tests/unit/test_api_v1_models_adapters.py
+++ b/tests/unit/test_api_v1_models_adapters.py
@@ -1,10 +1,11 @@
-"""Adapter support tests for api.v1.models."""
+"""Guardrails ensuring the removed API v1 alignment adapter stays unavailable."""
 
 import importlib
 from typing import Dict
 
 ADAPTER_ID = "llama-3-8b-instruct:alignment"
-BASE_ID = "llama-3-8b-instruct"
+CANONICAL_ADAPTER_ID = "llama-3.1-8b-instruct:alignment"
+BASE_ID = "llama-3.1-8b-instruct"
 
 
 def _reload_models(monkeypatch, env: Dict[str, str] | None = None):
@@ -18,25 +19,25 @@ def _reload_models(monkeypatch, env: Dict[str, str] | None = None):
     return models
 
 
-def test_get_models_info_exposes_adapter_metadata(monkeypatch):
+def test_get_models_info_does_not_expose_alignment_adapter(monkeypatch):
     models = _reload_models(monkeypatch, {"USE_MOCK_LLM": "1"})
 
-    info = models.get_models_info()
-    adapter_entry = next((item for item in info if item["id"] == ADAPTER_ID), None)
+    ids = [item["id"] for item in models.get_models_info()]
 
-    assert adapter_entry is not None, "adapter should be listed alongside base models"
-    assert adapter_entry["base_model_id"] == BASE_ID
-    assert adapter_entry.get("adapter", {}).get("instructions"), "instructions are required"
+    assert ids == [BASE_ID]
+    assert ADAPTER_ID not in ids
+    assert CANONICAL_ADAPTER_ID not in ids
 
 
-def test_generate_response_injects_adapter_prompt(monkeypatch):
+def test_generate_response_rejects_removed_alignment_adapter(monkeypatch):
     models = _reload_models(monkeypatch, {"USE_MOCK_LLM": "1"})
-    monkeypatch.setattr(models.random, "choice", lambda seq: seq[0])
 
-    messages = [{"role": "user", "content": "hello"}]
-    response = models.generate_response(ADAPTER_ID, messages)
-
-    assert response[0]["role"] == "system"
-    assert response[0]["name"].startswith("adapter:")
-    assert "alignment" in response[0]["content"].lower()
-    assert response[-1]["role"] == "assistant"
+    with monkeypatch.context() as _context:
+        messages = [{"role": "user", "content": "hello"}]
+        for removed_id in (ADAPTER_ID, CANONICAL_ADAPTER_ID):
+            try:
+                models.generate_response(removed_id, list(messages))
+            except models.ModelError as exc:
+                assert exc.error_type == "model_not_found"
+            else:  # pragma: no cover - assertion branch
+                raise AssertionError(f"{removed_id} should not be accepted")

--- a/tests/unit/test_api_v1_models_additional.py
+++ b/tests/unit/test_api_v1_models_additional.py
@@ -9,22 +9,23 @@ from unittest.mock import MagicMock, patch
 def test_get_model_instance_mock():
     import api.v1.models as models
     importlib.reload(models)
-    inst = models.get_model_instance('llama-3-8b-instruct')
+    inst = models.get_model_instance('llama-3.1-8b-instruct')
     assert inst == "MOCK_MODEL"
 
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
-def test_get_model_instance_v2_catalogue():
+def test_get_model_instance_does_not_fall_back_to_v2_catalogue():
     import api.v1.models as models
     import api.v2.models as models_v2
 
-    # Reload both catalogues so the environment flag is picked up and the
-    # fallback to the v2 listings is available within the v1 loader.
+    # API v1 launch model loading must stay isolated from the incomplete API v2
+    # catalogue even when v2 exposes additional IDs.
     importlib.reload(models_v2)
     importlib.reload(models)
 
-    inst = models.get_model_instance('mistral-7b-instruct')
-    assert inst == "MOCK_MODEL"
+    with pytest.raises(models.ModelError) as exc:
+        models.get_model_instance('mistral-7b-instruct')
+    assert exc.value.error_type == "model_not_found"
 
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
@@ -42,7 +43,7 @@ def test_generate_response_mock(monkeypatch):
     # Force deterministic choice
     monkeypatch.setattr(random, 'choice', lambda seq: seq[0])
     messages = [{'role': 'user', 'content': 'hi'}]
-    resp = models.generate_response('llama-3-8b-instruct', messages)
+    resp = models.generate_response('llama-3.1-8b-instruct', messages)
     assert resp[-1]['role'] == 'assistant'
     assert 'Mock response:' in resp[-1]['content']
 
@@ -52,10 +53,10 @@ def test_generate_response_validation_errors():
     import api.v1.models as models
     importlib.reload(models)
     with pytest.raises(models.ModelError):
-        models.generate_response('llama-3-8b-instruct', [])
+        models.generate_response('llama-3.1-8b-instruct', [])
     bad_messages = [{'role': 'user'}]
     with pytest.raises(models.ModelError):
-        models.generate_response('llama-3-8b-instruct', bad_messages)
+        models.generate_response('llama-3.1-8b-instruct', bad_messages)
 
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
@@ -79,7 +80,7 @@ def test_get_model_instance_load_error(monkeypatch):
 
     monkeypatch.setattr(models, "Llama", lambda *a, **k: boom())
     with pytest.raises(models.ModelError) as exc:
-        models.get_model_instance("llama-3-8b-instruct")
+        models.get_model_instance("llama-3.1-8b-instruct")
     assert "Failed to load model" in str(exc.value)
 
 

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -23,8 +23,9 @@ def _reload_models(env=None):
 
 def test_resolve_model_alias_returns_canonical_id_for_compat_aliases():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
-    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("llama-3-8b-instruct") == "llama-3.1-8b-instruct"
+    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3.1-8b-instruct"
+    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3.1-8b-instruct"
 
 
 def test_resolve_model_alias_rejects_unsupported_gpt_id():

--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -6,25 +6,21 @@ from unittest import mock
 
 
 @mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
-def test_api_v1_catalog_is_restricted_to_llama_3_8b():
+def test_api_v1_catalog_is_restricted_to_single_llama_3_1_8b_model():
     import api.v1.models as models
 
     importlib.reload(models)
 
     entries = models.get_models_info()
-    model_ids = {entry["id"] for entry in entries}
+    assert [entry["id"] for entry in entries] == ["llama-3.1-8b-instruct"]
 
-    assert model_ids == {
-        "llama-3-8b-instruct",
-        "llama-3-8b-instruct:alignment",
-    }
-
-    base_entry = next(entry for entry in entries if entry["id"] == "llama-3-8b-instruct")
-    assert base_entry["base_model_id"] == "llama-3-8b-instruct"
-
-    adapter_entry = next(entry for entry in entries if entry["id"] == "llama-3-8b-instruct:alignment")
-    assert adapter_entry["adapter"]["share_base"] is True
-    assert adapter_entry["base_model_id"] == "llama-3-8b-instruct"
+    base_entry = entries[0]
+    assert base_entry["base_model_id"] == "llama-3.1-8b-instruct"
+    assert base_entry["owned_by"] == "Meta"
+    assert base_entry["owner"] == "Meta"
+    assert base_entry["provider"] == "meta"
+    assert base_entry["source_model"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert "adapter" not in base_entry
 
 
 @mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
@@ -34,7 +30,7 @@ def test_llama_catalog_targets_latest_4090_ready_release():
     importlib.reload(models)
 
     base_entry = next(
-        entry for entry in models.get_models_info() if entry["id"] == "llama-3-8b-instruct"
+        entry for entry in models.get_models_info() if entry["id"] == "llama-3.1-8b-instruct"
     )
 
     assert base_entry["name"] == "Meta Llama 3.1 8B Instruct"

--- a/tests/unit/test_api_v1_models_errors.py
+++ b/tests/unit/test_api_v1_models_errors.py
@@ -14,7 +14,7 @@ def test_invalid_response_structure(monkeypatch):
     monkeypatch.setattr(models, "get_model_instance", lambda _mid: Dummy())
     messages = [{"role": "user", "content": "hi"}]
     with pytest.raises(models.ModelError) as exc:
-        models.generate_response("llama-3-8b-instruct", messages)
+        models.generate_response("llama-3.1-8b-instruct", messages)
     assert exc.value.error_type == "model_response_error"
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "0"})
@@ -27,5 +27,5 @@ def test_model_exception(monkeypatch):
     monkeypatch.setattr(models, "get_model_instance", lambda _mid: Dummy())
     messages = [{"role": "user", "content": "hi"}]
     with pytest.raises(models.ModelError) as exc:
-        models.generate_response("llama-3-8b-instruct", messages)
+        models.generate_response("llama-3.1-8b-instruct", messages)
     assert exc.value.error_type == "model_inference_error"

--- a/tests/unit/test_api_v1_models_text_content.py
+++ b/tests/unit/test_api_v1_models_text_content.py
@@ -31,7 +31,7 @@ def test_generate_response_rejects_image_content_blocks(monkeypatch):
     ]
 
     with pytest.raises(models.ModelError) as exc:
-        models.generate_response("llama-3-8b-instruct", messages)
+        models.generate_response("llama-3.1-8b-instruct", messages)
 
     assert exc.value.status_code == 400
     assert "do not support image content" in exc.value.message
@@ -92,7 +92,7 @@ def test_generate_response_normalises_text_blocks(monkeypatch):
         }
     ]
 
-    result = models.generate_response("llama-3-8b-instruct", messages)
+    result = models.generate_response("llama-3.1-8b-instruct", messages)
 
     assert captured["messages"][0]["content"] == "First segment\n\nSecond segment"
     assert result[-1]["role"] == "assistant"
@@ -116,7 +116,7 @@ def test_generate_response_rejects_invalid_text_content_shapes(monkeypatch, cont
 
     with pytest.raises(models.ModelError) as exc:
         models.generate_response(
-            "llama-3-8b-instruct",
+            "llama-3.1-8b-instruct",
             [{"role": "user", "content": content}],
         )
 

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -27,7 +27,7 @@ def test_get_public_key_exception(client, monkeypatch):
 
 def test_chat_completion_encrypted_validation_error(client, monkeypatch):
     monkeypatch.setattr(routes, 'validate_encrypted_request', MagicMock(side_effect=ValidationError('bad', 'field', 'code')))
-    payload = {'model': 'llama-3-8b-instruct', 'encrypted': True, 'client_public_key': 'x', 'messages': {}}
+    payload = {'model': 'llama-3.1-8b-instruct', 'encrypted': True, 'client_public_key': 'x', 'messages': {}}
     resp = client.post('/api/v1/chat/completions', json=payload)
     assert resp.status_code == 400
     data = resp.get_json()
@@ -118,7 +118,7 @@ def test_relay_unregister_openai_alias_delegates(client, monkeypatch):
 
 
 def test_chat_completion_alias_reroutes_to_canonical_model(client, monkeypatch):
-    canonical_id = 'llama-3-8b-instruct'
+    canonical_id = 'llama-3.1-8b-instruct'
     payload = {
         'model': 'gpt-5-chat-latest',
         'messages': [
@@ -156,7 +156,7 @@ def test_chat_completion_alias_reroutes_to_canonical_model(client, monkeypatch):
 
 
 def test_chat_completion_model_error_preserves_status_and_type(client, monkeypatch):
-    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3.1-8b-instruct"}])
     monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
     monkeypatch.setattr(routes, "resolve_model_alias", lambda model_id: None)
     monkeypatch.setattr(
@@ -176,7 +176,7 @@ def test_chat_completion_model_error_preserves_status_and_type(client, monkeypat
     monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _Provider())
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "messages": [{"role": "user", "content": "Hello"}],
     }
     response = client.post("/api/v1/chat/completions", json=payload)
@@ -189,12 +189,12 @@ def test_chat_completion_model_error_preserves_status_and_type(client, monkeypat
 
 def test_chat_completion_echoes_request_metadata(client, monkeypatch):
     payload = {
-        'model': 'llama-3-8b-instruct',
+        'model': 'llama-3.1-8b-instruct',
         'messages': [{'role': 'user', 'content': 'Hello'}],
         'metadata': {'client': 'dspace', 'conversation_id': 'conv-99'},
     }
 
-    monkeypatch.setattr(routes, 'get_models_info', lambda: [{'id': 'llama-3-8b-instruct'}])
+    monkeypatch.setattr(routes, 'get_models_info', lambda: [{'id': 'llama-3.1-8b-instruct'}])
     monkeypatch.setattr(routes, 'validate_model_name', lambda *args, **kwargs: None)
     monkeypatch.setattr(routes, 'resolve_model_alias', lambda model_id: None)
     monkeypatch.setattr(
@@ -205,7 +205,7 @@ def test_chat_completion_echoes_request_metadata(client, monkeypatch):
 
     class _Provider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == 'llama-3-8b-instruct'
+            assert model_id == 'llama-3.1-8b-instruct'
             return {'role': 'assistant', 'content': 'Mock reply'}
 
     monkeypatch.setattr(routes, 'get_api_v1_compute_provider', lambda: _Provider())
@@ -220,16 +220,16 @@ def test_chat_completion_echoes_request_metadata(client, monkeypatch):
 def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "Paris"}
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "messages": [{"role": "user", "content": "Capital of France?"}],
     }
 
-    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3.1-8b-instruct"}])
     monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
     monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
     monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _DistributedProvider())
@@ -260,12 +260,12 @@ def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
             return {"role": "assistant", "content": "Paris"}
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "messages": [{"role": "user", "content": "Capital of France?"}],
         "stream": True,
     }
 
-    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3.1-8b-instruct"}])
     monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
     monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
 
@@ -281,7 +281,7 @@ def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
 def test_chat_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "Paris"}
 
@@ -294,13 +294,13 @@ def test_chat_completion_encrypted_response_sets_provider_headers(client, monkey
     }
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "messages": encrypted_payload,
         "encrypted": True,
         "client_public_key": "client-key",
     }
 
-    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3-8b-instruct"}])
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3.1-8b-instruct"}])
     monkeypatch.setattr(routes, "validate_model_name", lambda *args, **kwargs: None)
     monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
     monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: _DistributedProvider())
@@ -330,13 +330,13 @@ def test_chat_completion_encrypted_response_sets_provider_headers(client, monkey
 def test_legacy_completion_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "hello"}
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "prompt": "hi",
     }
 
@@ -361,7 +361,7 @@ def test_legacy_completion_rejects_streaming_for_api_v1(client, monkeypatch):
             return {"role": "assistant", "content": "hello"}
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "prompt": "hi",
         "stream": True,
     }
@@ -381,13 +381,13 @@ def test_legacy_completion_rejects_streaming_for_api_v1(client, monkeypatch):
 def test_legacy_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "hello"}
 
     payload = {
-        "model": "llama-3-8b-instruct",
+        "model": "llama-3.1-8b-instruct",
         "prompt": "hi",
         "encrypted": True,
         "client_public_key": "client-key",

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -117,6 +117,41 @@ def test_relay_unregister_openai_alias_delegates(client, monkeypatch):
     assert response.get_json()["error"]["message"] == "ok"
 
 
+def test_chat_completion_rejects_non_string_model_before_alias_resolution(client, monkeypatch):
+    alias = MagicMock(return_value='llama-3.1-8b-instruct')
+    monkeypatch.setattr(routes, 'resolve_model_alias', alias)
+
+    response = client.post(
+        '/api/v1/chat/completions',
+        json={
+            'model': {'id': 'gpt-5-chat-latest'},
+            'messages': [{'role': 'user', 'content': 'Hello'}],
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body['error']['param'] == 'model'
+    assert 'Invalid type for model: expected str' in body['error']['message']
+    alias.assert_not_called()
+
+
+def test_legacy_completion_rejects_non_string_model_before_alias_resolution(client, monkeypatch):
+    alias = MagicMock(return_value='llama-3.1-8b-instruct')
+    monkeypatch.setattr(routes, 'resolve_model_alias', alias)
+
+    response = client.post(
+        '/api/v1/completions',
+        json={'model': {'id': 'gpt-5-chat-latest'}, 'prompt': 'hi'},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body['error']['param'] == 'model'
+    assert 'Invalid type for model: expected str' in body['error']['message']
+    alias.assert_not_called()
+
+
 def test_chat_completion_alias_reroutes_to_canonical_model(client, monkeypatch):
     canonical_id = 'llama-3.1-8b-instruct'
     payload = {

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1954,14 +1954,14 @@ class TestRelayClient:
         assert RelayClient._valid_api_v1_assistant_message(message) == message
 
     @patch('utils.networking.relay_client.requests.post')
-    def test_process_client_request_api_v1_adapter_model_uses_shared_llama_runtime(
+    def test_process_client_request_api_v1_alignment_adapter_is_rejected(
         self,
         mock_post,
         relay_client,
         mock_crypto_manager,
         mock_model_manager,
     ):
-        """API v1 adapter IDs should share the local Llama base runtime."""
+        """The removed API v1 alignment adapter must not run on the local runtime."""
 
         request_data = TEST_VALID_RESPONSE.copy()
         mock_model_manager.use_mock_llm = False
@@ -1987,15 +1987,9 @@ class TestRelayClient:
         assert relay_client.process_client_request(request_data) is True
 
         mock_model_manager.llama_cpp_get_response.assert_not_called()
-        runtime_messages = mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
-            "messages"
-        ]
-        assert runtime_messages[0]["role"] == "system"
-        assert runtime_messages[0]["name"] == "adapter:llama-3-8b-instruct:alignment"
-        assert "alignment-focused variant" in runtime_messages[0]["content"]
-        assert runtime_messages[1] == {"role": "user", "content": "Hello"}
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
-        assert "error" not in encrypted_envelope["api_v1_response"]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == "compute_node_model_unsupported"
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_normalises_multipart_content_blocks(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -479,6 +479,7 @@ class RelayClient:
     """
 
     _API_V1_LOCAL_LLAMA_RUNTIME_IDS = {
+        "llama-3.1-8b-instruct",
         "llama-3-8b-instruct",
         "meta/llama-3.1-8b-instruct",
         "meta-llama-3.1-8b-instruct-q4_k_m.gguf",
@@ -486,12 +487,11 @@ class RelayClient:
         "meta-llama-3-8b-instruct-q4_k_m.gguf",
     }
     _API_V1_LOCAL_MODEL_ALIASES = {
-        "gpt-3.5-turbo": "llama-3-8b-instruct",
-        "gpt-5-chat-latest": "llama-3-8b-instruct",
+        "llama-3-8b-instruct": "llama-3.1-8b-instruct",
+        "gpt-3.5-turbo": "llama-3.1-8b-instruct",
+        "gpt-5-chat-latest": "llama-3.1-8b-instruct",
     }
-    _API_V1_LOCAL_ADAPTER_BASE_MODELS = {
-        "llama-3-8b-instruct:alignment": "llama-3-8b-instruct",
-    }
+    _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant", "function"}
 
     def __init__(
@@ -1733,13 +1733,7 @@ class RelayClient:
     def _api_v1_adapter_system_message(model_id: str) -> Optional[Dict[str, str]]:
         """Return local API v1 adapter instructions that do not require server imports."""
 
-        adapter_instructions = {
-            "llama-3-8b-instruct:alignment": (
-                "You are the alignment-focused variant of Meta Llama 3.1 8B. "
-                "Follow the provided safety charter to remain helpful, honest, "
-                "harmless, and to call out uncertain answers."
-            ),
-        }
+        adapter_instructions = {}
         instructions = adapter_instructions.get(model_id.strip().lower())
         if not instructions:
             return None
@@ -1821,8 +1815,6 @@ class RelayClient:
         adapter_base = cls._API_V1_LOCAL_ADAPTER_BASE_MODELS.get(normalized_model)
         if adapter_base:
             ids.add(adapter_base)
-        if ":" in normalized_model:
-            ids.add(normalized_model.split(":", 1)[0])
         ids.add(cls._api_v1_catalogue_resolved_model_id(normalized_model))
         return {value for value in ids if value}
 


### PR DESCRIPTION
### Motivation
- Fix API v1 launch catalog and landing UI so the public launch model is exactly Meta Llama 3.1 8B Instruct and the UI/docs do not incorrectly show a token.place ownership claim or a hallucinated alignment adapter.\
- Preserve backwards-compatible invisible aliases for existing clients while making the aliases invisible in the public listing.\
- Freeze API v1 launch docs/examples to reflect the single-model contract for pre-prod promotion.

### Description
- api/v1/models.py: Introduced `CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"`, replaced the previous base entry with a single canonical model exposing `owner`/`owned_by`/`provider`/`source_model` set to Meta, removed the alignment adapter from the public `AVAILABLE_MODELS`, and converted legacy ids (including `llama-3-8b-instruct` and GPT compatibility ids) into invisible aliases mapping to the canonical id. Also removed the V2 fallback lookup from the v1 metadata resolver to keep v1 isolated. Added alias resolution into `get_model_instance` and `generate_response`.\
- api/v1/routes.py: `GET /api/v1/models/{model_id}` now resolves aliases before lookup, and `_format_openai_model_payload` sets `owned_by` from the model metadata (prefer `owned_by`/`owner`/`provider`) instead of hardcoding `token.place`.\
- static/chat.js: Changed emergency fallback constant to the canonical id `llama-3.1-8b-instruct`, removed the owner display from the landing chat summary so the UI no longer renders "owned by ...".\
- static/index.html: Updated example API v1 docs to use `llama-3.1-8b-instruct` and attribute the model to `Meta` in examples. Removed displayed owner text in the landing selector markup.\
- Tests: Updated and added unit and e2e tests to assert the new contract: the public API v1 model list exposes exactly one model (`llama-3.1-8b-instruct`), the alignment adapter is not listed and requests for it fail with `model_not_found`, `llama-3-8b-instruct` is accepted only as an invisible alias, the landing UI does not render "owned by token.place", and docs/examples reference the canonical id and Meta attribution. Files updated include the v1 model tests and relevant e2e landing-chat tests.\
- Kept compatibility: invisible aliases remain accepted by request paths (via `MODEL_ALIASES`) but are not enumerated in `GET /api/v1/models`.

### Testing
- Ran unit launch-contract tests: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` — PASS (all assertions for the frozen launch contract passed).\
- Ran focused v1 model unit suites: `python -m pytest tests/unit/test_api_v1_models.py tests/unit/test_api_v1_models_additional.py tests/unit/test_api_v1_models_catalog_minimal.py tests/unit/test_api_v1_models_adapters.py tests/unit/test_api_v1_models_aliases.py -v` — PASS (all tests in these suites passed after updates).\
- Ran JS tests: `npm run test:js` — PASS (all JavaScript smoke/unit checks passed).\
- Attempted targeted e2e UI checks: `python -m pytest tests/e2e/test_ui.py -k "model or landing_chat" -v` — initial runs error out in this environment because Playwright browser binaries were not present; `./run_all_tests.sh` downloads and installs Playwright browsers and then ran the full test sweep (unit suites completed successfully in this environment). Full Playwright-driven browser e2e verification is environment-dependent and may require `playwright install` or CI-provided browser images; those steps were invoked by `./run_all_tests.sh` but long-running browser installation and headless invocation are environment-reliant and may need CI to finish.\

Residual notes and follow-ups: the change intentionally isolates API v1 from v2 catalogue fallbacks and removes the v1 alignment adapter from public surfaces; if a future compatibility path is required to expose adapters under v1, make it an explicit, documented opt-in with tests. E2E Playwright checks depend on browser binaries; CI should run the full e2e suite after browsers are installed (or use a Playwright-ready CI image).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2849c1f82c832f8b52ea7bee75484e)