### PR TITLE
API v1: use Meta Llama 3.1 8B as canonical launch model; remove alignment adapter and hide owner from landing UI

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -103,23 +103,29 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
+CANONICAL_MODEL_ID = "llama-3.1-8b-instruct"
+LEGACY_LLAMA_3_MODEL_ID = "llama-3-8b-instruct"
+
 MODEL_ALIASES: Dict[str, str] = {
-    # Temporary OpenAI-client compatibility aliases that route to the fixed
-    # Meta Llama 3.1 8B backend; these are not first-class GPT model support.
-    # Any removal should happen in a dedicated compatibility/deprecation PR.
-    "gpt-3.5-turbo": "llama-3-8b-instruct",
-    "gpt-5-chat-latest": "llama-3-8b-instruct",
+    # Invisible compatibility aliases that route to the fixed Meta Llama 3.1
+    # 8B launch model; these are not listed as public API v1 catalogue items.
+    LEGACY_LLAMA_3_MODEL_ID: CANONICAL_MODEL_ID,
+    "gpt-3.5-turbo": CANONICAL_MODEL_ID,
+    "gpt-5-chat-latest": CANONICAL_MODEL_ID,
 }
 
 
 AVAILABLE_MODELS = [
     {
-        "id": "llama-3-8b-instruct",
+        "id": CANONICAL_MODEL_ID,
         "name": "Meta Llama 3.1 8B Instruct",
         "description": (
             "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
             "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
         ),
+        "owned_by": "Meta",
+        "provider": "meta",
+        "source": "meta-llama/Llama-3.1-8B-Instruct",
         "parameters": "8B",
         "quantization": "Q4_K_M",
         "context_length": 8192,
@@ -128,22 +134,6 @@ AVAILABLE_MODELS = [
             "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
         ),
         "file_name": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "adapters": [
-            {
-                "id": "llama-3-8b-instruct:alignment",
-                "name": "Meta Llama 3.1 8B Alignment Assistant",
-                "description": (
-                    "Alignment-tuned variant emphasising helpful, honest, and harmless replies "
-                    "using constitutional guardrails."
-                ),
-                "instructions": (
-                    "You are the alignment-focused variant of Meta Llama 3.1 8B. Follow the "
-                    "provided safety charter to remain helpful, honest, harmless, and to call "
-                    "out uncertain answers."
-                ),
-                "share_base": True,
-            }
-        ],
     }
 ]
 
@@ -187,18 +177,8 @@ def _get_model_metadata(model_id: str) -> Optional[Dict[str, Any]]:
         if entry["id"] == model_id:
             return entry
 
-    # Fall back to the v2 catalogue so chat completions can load any model
-    # surfaced via the API v2 listings. Import lazily to avoid a hard dependency
-    # when the v2 module is unused (e.g. in legacy API v1 only deployments).
-    try:
-        from api.v2.models import get_models_info as get_v2_models_info  # type: ignore
-    except Exception as exc:  # pragma: no cover - defensive logging branch
-        log_warning(f"Unable to load API v2 catalogue: {exc}")
-        return None
-
-    for entry in get_v2_models_info():
-        if entry["id"] == model_id:
-            return entry
+    # API v1 launch catalog is intentionally separate from API v2. Do not
+    # silently pull API v2 model IDs into API v1 runtime validation.
     return None
 
 
@@ -256,13 +236,16 @@ def get_model_instance(model_id):
     if not model_id:
         raise ModelError("Model ID cannot be empty", status_code=400, error_type="invalid_request_error")
 
-    # First check if the model ID exists in available models
+    # First check if the model ID exists in available models, accepting
+    # documented invisible compatibility aliases without listing them publicly.
+    requested_model_id = model_id
+    model_id = resolve_model_alias(model_id) or model_id
     model_meta = _get_model_metadata(model_id)
     if not model_meta:
         available_ids = [m["id"] for m in _iter_model_entries()]
-        logger.warning(f"Model {model_id} not found. Available models: {available_ids}")
+        logger.warning(f"Model {requested_model_id} not found. Available models: {available_ids}")
         raise ModelError(
-            f"Model '{model_id}' not found. Available models: {', '.join(available_ids)}",
+            f"Model '{requested_model_id}' not found. Available models: {', '.join(available_ids)}",
             status_code=400,
             error_type="model_not_found"
         )
@@ -334,6 +317,7 @@ def generate_response(model_id, messages, **options):
         ModelError: If there's an error with the model or input
     """
     start_time = time.time()
+    model_id = resolve_model_alias(model_id) or model_id
     logger.info(f"Generating response using model: {model_id}")
 
     # Validate input

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -110,6 +110,17 @@ def _looks_like_model_error(exc: Exception) -> bool:
     return exc.__class__.__name__ == "ModelError" and hasattr(exc, "status_code")
 
 
+def _is_supported_api_v1_model_request(
+    *, requested_model_id: str | None, resolved_model_id: str | None
+) -> bool:
+    """Return True when a requested/canonical model is in the public v1 catalog."""
+
+    supported_model_ids = {
+        entry.get("id") for entry in get_models_info() if isinstance(entry, dict)
+    }
+    return resolved_model_id in supported_model_ids or requested_model_id in supported_model_ids
+
+
 def _format_model_error_response(exc: Exception):
     """Format model errors from the active or an equivalent reloaded module."""
 
@@ -508,8 +519,10 @@ def _handle_chat_completion_request(data):
             % (resolved_provider_name, resolved_provider_path)
         )
         if not _is_relay_capable_provider_path(resolved_provider_path):
-            supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
-            if model_id not in supported_model_ids:
+            if not _is_supported_api_v1_model_request(
+                requested_model_id=requested_model_id,
+                resolved_model_id=model_id,
+            ):
                 return format_error_response(
                     f"Model '{model_id}' is not supported by API v1.",
                     error_type="invalid_request_error",
@@ -645,7 +658,12 @@ def _handle_text_completion_request(data):
                 status_code=400,
             )
 
-        model_id = data.get("model")
+        requested_model_id = data.get("model")
+        model_id = (
+            (resolve_model_alias(requested_model_id) or requested_model_id)
+            if requested_model_id
+            else requested_model_id
+        )
         prompt = data.get("prompt", "")
         client_public_key = data.get("client_public_key")
         is_encrypted_request = data.get("encrypted", False)
@@ -695,8 +713,10 @@ def _handle_text_completion_request(data):
             % (resolved_provider_name, resolved_provider_path)
         )
         if not _is_relay_capable_provider_path(resolved_provider_path):
-            supported_model_ids = {entry.get("id") for entry in get_models_info() if isinstance(entry, dict)}
-            if model_id not in supported_model_ids:
+            if not _is_supported_api_v1_model_request(
+                requested_model_id=requested_model_id,
+                resolved_model_id=model_id,
+            ):
                 return format_error_response(
                     f"Model '{model_id}' is not supported by API v1.",
                     error_type="invalid_request_error",
@@ -1195,11 +1215,11 @@ def _format_openai_model_payload(model: dict[str, str]) -> dict[str, object]:
     """Build a stable OpenAI-compatible model payload."""
 
     created_ts = _stable_openai_model_created(model["id"])
-    return {
+    payload = {
         "id": model["id"],
         "object": "model",
         "created": created_ts,
-        "owned_by": "token.place",
+        "owned_by": model.get("owned_by", "Meta"),
         "permission": [{
             "id": f"modelperm-{model['id']}",
             "object": "model_permission",
@@ -1217,6 +1237,11 @@ def _format_openai_model_payload(model: dict[str, str]) -> dict[str, object]:
         "root": model["id"],
         "parent": None
     }
+    if model.get("provider"):
+        payload["provider"] = model["provider"]
+    if model.get("source"):
+        payload["source"] = model["source"]
+    return payload
 
 
 @v1_bp.route('/health', methods=['GET'])

--- a/static/chat.js
+++ b/static/chat.js
@@ -2,7 +2,7 @@ const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue genera
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
-const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3-8b-instruct';
+const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 
 new Vue({
     el: '#app',
@@ -63,7 +63,6 @@ new Vue({
                 return {
                     id: EMERGENCY_MODEL_FALLBACK_ID,
                     object: 'model',
-                    owned_by: 'emergency-fallback',
                     root: EMERGENCY_MODEL_FALLBACK_ID
                 };
             }
@@ -75,9 +74,6 @@ new Vue({
                 return '';
             }
             const fields = [];
-            if (model.owned_by) {
-                fields.push(`owned by ${model.owned_by}`);
-            }
             if (model.root && model.root !== model.id) {
                 fields.push(`root ${model.root}`);
             }

--- a/static/index.html
+++ b/static/index.html
@@ -511,13 +511,13 @@
   "object": "list",
   "data": [
     {
-      "id": "llama-3-8b-instruct",
+      "id": "llama-3.1-8b-instruct",
       "object": "model",
       "created": CREATED_UNIX_SECONDS,
-      "owned_by": "token.place",
+      "owned_by": "Meta",
       "permission": [
         {
-          "id": "modelperm-llama-3-8b-instruct",
+          "id": "modelperm-llama-3.1-8b-instruct",
           "object": "model_permission",
           "created": CREATED_UNIX_SECONDS,
           "allow_create_engine": false,
@@ -531,7 +531,7 @@
           "is_blocking": false
         }
       ],
-      "root": "llama-3-8b-instruct",
+      "root": "llama-3.1-8b-instruct",
       "parent": null
     }
   ]
@@ -562,7 +562,7 @@
             <p>Creates a non-streaming chat completion. API v1 rejects <code>stream: true</code>. Encrypted mode sends ciphertext under <code>messages</code> and includes the client public key so only the client can decrypt the response.</p>
             <p><strong>Encrypted Request Body:</strong></p>
             <pre>{
-  "model": "llama-3-8b-instruct",
+  "model": "llama-3.1-8b-instruct",
   "encrypted": true,
   "client_public_key": "CLIENT_PUBLIC_KEY_HERE",
   "messages": {

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -64,10 +64,10 @@ def route_landing_relay_chat(
         "object": "list",
         "data": [
             {
-                "id": "llama-3-8b-instruct",
+                "id": "llama-3.1-8b-instruct",
                 "object": "model",
-                "owned_by": "token.place",
-                "root": "llama-3-8b-instruct",
+                "owned_by": "Meta",
+                "root": "llama-3.1-8b-instruct",
             }
         ],
     }
@@ -480,12 +480,15 @@ def test_landing_chat_uses_api_v1_only_non_streaming(
     )
     assert "Relay chat path restored." in assistant_message.inner_text()
     assert "Sorry, I encountered an issue generating a response." not in page.content()
+    model_select = page.get_by_test_id("landing-model-select")
+    assert model_select.locator("option").all_inner_texts() == ["llama-3.1-8b-instruct"]
+    assert "owned by token.place" not in page.locator("body").inner_text().lower()
     assert state["next_calls"] == 1
     assert len(state["relay_requests"]) == 1
     assert state["relay_requests"][0]["server_public_key"] == SERVER_PUBLIC_KEY_B64
     request_envelope = json.loads(state["relay_requests"][0]["ciphertext"])
     assert request_envelope["protocol"] == "tokenplace_api_v1_relay_e2ee"
-    assert request_envelope["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert request_envelope["api_v1_request"]["messages"] == [{"role": "user", "content": "hello"}]
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
@@ -527,7 +530,7 @@ def test_landing_chat_sticky_server_two_turns_and_key_label(page: Page, base_url
         {"role": "assistant", "content": "Sticky relay response."},
         {"role": "user", "content": "second turn"},
     ]
-    assert all(envelope["api_v1_request"]["model"] == "llama-3-8b-instruct" for envelope in envelopes)
+    assert all(envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct" for envelope in envelopes)
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 
@@ -653,6 +656,7 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
         "api-v1-first-model",
         "api-v1-second-model",
     ]
+    assert "owned by token.place" not in page.locator("body").inner_text().lower()
 
     model_select.select_option("api-v1-second-model")
 
@@ -740,8 +744,8 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
 
     model_select = page.get_by_test_id("landing-model-select")
     model_select.wait_for(state="visible")
-    assert model_select.input_value() == "llama-3-8b-instruct"
-    assert "llama-3-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
+    assert model_select.input_value() == "llama-3.1-8b-instruct"
+    assert "llama-3.1-8b-instruct (emergency fallback)" in model_select.locator("option").inner_text()
     assert "Could not load the API v1 model list" in page.locator(".model-error").inner_text()
 
     page.locator("textarea").first.fill("hello")
@@ -750,7 +754,7 @@ def test_landing_chat_model_catalog_failure_uses_api_v1_fallback(
     page.locator(".assistant-message").last.wait_for(state="visible")
     assert state["relay_requests"], "expected the landing chat to POST the API v1 fallback relay payload"
     request_envelope = json.loads(state["relay_requests"][-1]["ciphertext"])
-    assert request_envelope["api_v1_request"]["model"] == "llama-3-8b-instruct"
+    assert request_envelope["api_v1_request"]["model"] == "llama-3.1-8b-instruct"
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1077,7 +1077,7 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
 
     monkeypatch.setattr(
         "api.v1.routes.get_models_info",
-        lambda: [{"id": "llama-3-8b-instruct"}],
+        lambda: [{"id": "llama-3.1-8b-instruct"}],
     )
     monkeypatch.setattr("api.v1.routes.validate_chat_messages", lambda msgs: None)
 
@@ -1118,7 +1118,7 @@ def test_v1_chat_completion_uses_fixed_llama_3_1_8b_model(client, monkeypatch):
 
     body = response.get_json()
     assert body["model"] == "llama-3-8b-instruct"
-    assert captured["model_id"] == "llama-3-8b-instruct"
+    assert captured["model_id"] == "llama-3.1-8b-instruct"
     assert captured["messages"] == payload["messages"]
     assert body["choices"][0]["message"]["content"] == "Llama response"
 

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -138,7 +138,7 @@ def test_api_v1_chat_completions_rejects_stream_true(client):
     response = client.post(
         "/api/v1/chat/completions",
         json={
-            "model": "llama-3-8b-instruct",
+            "model": "llama-3.1-8b-instruct",
             "messages": [{"role": "user", "content": "hello"}],
             "stream": True,
         },
@@ -156,10 +156,12 @@ def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
     assert response.status_code == 200
     payload = response.get_json()
     assert payload["object"] == "list"
-    assert payload["data"]
+    assert [model["id"] for model in payload["data"]] == ["llama-3.1-8b-instruct"]
     for model in payload["data"]:
         assert model["object"] == "model"
-        assert model["owned_by"] == "token.place"
+        assert model["owned_by"] == "Meta"
+        assert model["provider"] == "meta"
+        assert model["source"] == "meta-llama/Llama-3.1-8B-Instruct"
         assert "permission" in model
         assert isinstance(model["permission"], list)
         assert model["permission"]

--- a/tests/unit/test_api_v1_models_adapters.py
+++ b/tests/unit/test_api_v1_models_adapters.py
@@ -1,10 +1,12 @@
-"""Adapter support tests for api.v1.models."""
+"""Guardrails ensuring removed launch-only API v1 adapters stay unavailable."""
 
 import importlib
 from typing import Dict
 
+import pytest
+
 ADAPTER_ID = "llama-3-8b-instruct:alignment"
-BASE_ID = "llama-3-8b-instruct"
+CANONICAL_ID = "llama-3.1-8b-instruct"
 
 
 def _reload_models(monkeypatch, env: Dict[str, str] | None = None):
@@ -18,25 +20,19 @@ def _reload_models(monkeypatch, env: Dict[str, str] | None = None):
     return models
 
 
-def test_get_models_info_exposes_adapter_metadata(monkeypatch):
+def test_get_models_info_does_not_expose_alignment_adapter(monkeypatch):
     models = _reload_models(monkeypatch, {"USE_MOCK_LLM": "1"})
 
     info = models.get_models_info()
-    adapter_entry = next((item for item in info if item["id"] == ADAPTER_ID), None)
 
-    assert adapter_entry is not None, "adapter should be listed alongside base models"
-    assert adapter_entry["base_model_id"] == BASE_ID
-    assert adapter_entry.get("adapter", {}).get("instructions"), "instructions are required"
+    assert [item["id"] for item in info] == [CANONICAL_ID]
+    assert all(item["id"] != ADAPTER_ID for item in info)
 
 
-def test_generate_response_injects_adapter_prompt(monkeypatch):
+def test_generate_response_rejects_removed_alignment_adapter(monkeypatch):
     models = _reload_models(monkeypatch, {"USE_MOCK_LLM": "1"})
-    monkeypatch.setattr(models.random, "choice", lambda seq: seq[0])
 
-    messages = [{"role": "user", "content": "hello"}]
-    response = models.generate_response(ADAPTER_ID, messages)
+    with pytest.raises(models.ModelError) as exc:
+        models.generate_response(ADAPTER_ID, [{"role": "user", "content": "hello"}])
 
-    assert response[0]["role"] == "system"
-    assert response[0]["name"].startswith("adapter:")
-    assert "alignment" in response[0]["content"].lower()
-    assert response[-1]["role"] == "assistant"
+    assert exc.value.error_type == "model_not_found"

--- a/tests/unit/test_api_v1_models_additional.py
+++ b/tests/unit/test_api_v1_models_additional.py
@@ -14,17 +14,17 @@ def test_get_model_instance_mock():
 
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
-def test_get_model_instance_v2_catalogue():
+def test_get_model_instance_keeps_api_v2_catalogue_separate():
     import api.v1.models as models
     import api.v2.models as models_v2
 
-    # Reload both catalogues so the environment flag is picked up and the
-    # fallback to the v2 listings is available within the v1 loader.
     importlib.reload(models_v2)
     importlib.reload(models)
 
-    inst = models.get_model_instance('mistral-7b-instruct')
-    assert inst == "MOCK_MODEL"
+    assert any(entry["id"] == "mistral-7b-instruct" for entry in models_v2.get_models_info())
+    with pytest.raises(models.ModelError) as exc:
+        models.get_model_instance('mistral-7b-instruct')
+    assert exc.value.error_type == "model_not_found"
 
 
 @patch.dict(os.environ, {"USE_MOCK_LLM": "1"})

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -23,8 +23,9 @@ def _reload_models(env=None):
 
 def test_resolve_model_alias_returns_canonical_id_for_compat_aliases():
     models = _reload_models()
-    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3-8b-instruct"
-    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3-8b-instruct"
+    assert models.resolve_model_alias("llama-3-8b-instruct") == "llama-3.1-8b-instruct"
+    assert models.resolve_model_alias("gpt-5-chat-latest") == "llama-3.1-8b-instruct"
+    assert models.resolve_model_alias("gpt-3.5-turbo") == "llama-3.1-8b-instruct"
 
 
 def test_resolve_model_alias_rejects_unsupported_gpt_id():
@@ -40,3 +41,8 @@ def test_resolve_model_alias_missing_target_logs_and_returns_none():
                 result = models.resolve_model_alias("local-alias")
     assert result is None
     mock_log_warning.assert_called_once()
+
+
+def test_resolve_model_alias_does_not_keep_alignment_adapter():
+    models = _reload_models()
+    assert models.resolve_model_alias("llama-3-8b-instruct:alignment") is None

--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -5,26 +5,29 @@ import os
 from unittest import mock
 
 
+CANONICAL_ID = "llama-3.1-8b-instruct"
+LEGACY_ID = "llama-3-8b-instruct"
+ALIGNMENT_ID = "llama-3-8b-instruct:alignment"
+
+
 @mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
-def test_api_v1_catalog_is_restricted_to_llama_3_8b():
+def test_api_v1_catalog_is_restricted_to_canonical_llama_3_1_8b():
     import api.v1.models as models
 
     importlib.reload(models)
 
     entries = models.get_models_info()
-    model_ids = {entry["id"] for entry in entries}
+    model_ids = [entry["id"] for entry in entries]
 
-    assert model_ids == {
-        "llama-3-8b-instruct",
-        "llama-3-8b-instruct:alignment",
-    }
+    assert model_ids == [CANONICAL_ID]
+    assert LEGACY_ID not in model_ids
+    assert ALIGNMENT_ID not in model_ids
 
-    base_entry = next(entry for entry in entries if entry["id"] == "llama-3-8b-instruct")
-    assert base_entry["base_model_id"] == "llama-3-8b-instruct"
-
-    adapter_entry = next(entry for entry in entries if entry["id"] == "llama-3-8b-instruct:alignment")
-    assert adapter_entry["adapter"]["share_base"] is True
-    assert adapter_entry["base_model_id"] == "llama-3-8b-instruct"
+    base_entry = entries[0]
+    assert base_entry["base_model_id"] == CANONICAL_ID
+    assert base_entry["owned_by"] == "Meta"
+    assert base_entry["provider"] == "meta"
+    assert base_entry["source"] == "meta-llama/Llama-3.1-8B-Instruct"
 
 
 @mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
@@ -33,10 +36,9 @@ def test_llama_catalog_targets_latest_4090_ready_release():
 
     importlib.reload(models)
 
-    base_entry = next(
-        entry for entry in models.get_models_info() if entry["id"] == "llama-3-8b-instruct"
-    )
+    base_entry = models.get_models_info()[0]
 
+    assert base_entry["id"] == CANONICAL_ID
     assert base_entry["name"] == "Meta Llama 3.1 8B Instruct"
     assert base_entry["file_name"] == "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
     assert base_entry["file_name"] in base_entry["url"]

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -220,7 +220,7 @@ def test_chat_completion_echoes_request_metadata(client, monkeypatch):
 def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "Paris"}
 
@@ -281,7 +281,7 @@ def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
 def test_chat_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _DistributedProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "Paris"}
 
@@ -330,7 +330,7 @@ def test_chat_completion_encrypted_response_sets_provider_headers(client, monkey
 def test_legacy_completion_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "hello"}
@@ -381,7 +381,7 @@ def test_legacy_completion_rejects_streaming_for_api_v1(client, monkeypatch):
 def test_legacy_completion_encrypted_response_sets_provider_headers(client, monkeypatch):
     class _LocalProvider:
         def complete_chat(self, model_id, messages, options):
-            assert model_id == "llama-3-8b-instruct"
+            assert model_id == "llama-3.1-8b-instruct"
             assert messages == [{"role": "user", "content": "hi"}]
             assert isinstance(options, dict)
             return {"role": "assistant", "content": "hello"}

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1954,14 +1954,14 @@ class TestRelayClient:
         assert RelayClient._valid_api_v1_assistant_message(message) == message
 
     @patch('utils.networking.relay_client.requests.post')
-    def test_process_client_request_api_v1_adapter_model_uses_shared_llama_runtime(
+    def test_process_client_request_api_v1_alignment_adapter_is_rejected(
         self,
         mock_post,
         relay_client,
         mock_crypto_manager,
         mock_model_manager,
     ):
-        """API v1 adapter IDs should share the local Llama base runtime."""
+        """The removed API v1 alignment adapter should fail closed in desktop runtime."""
 
         request_data = TEST_VALID_RESPONSE.copy()
         mock_model_manager.use_mock_llm = False
@@ -1987,15 +1987,11 @@ class TestRelayClient:
         assert relay_client.process_client_request(request_data) is True
 
         mock_model_manager.llama_cpp_get_response.assert_not_called()
-        runtime_messages = mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
-            "messages"
-        ]
-        assert runtime_messages[0]["role"] == "system"
-        assert runtime_messages[0]["name"] == "adapter:llama-3-8b-instruct:alignment"
-        assert "alignment-focused variant" in runtime_messages[0]["content"]
-        assert runtime_messages[1] == {"role": "user", "content": "Hello"}
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
-        assert "error" not in encrypted_envelope["api_v1_response"]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_model_unsupported"
+        )
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_normalises_multipart_content_blocks(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -479,19 +479,18 @@ class RelayClient:
     """
 
     _API_V1_LOCAL_LLAMA_RUNTIME_IDS = {
-        "llama-3-8b-instruct",
+        "llama-3.1-8b-instruct",
         "meta/llama-3.1-8b-instruct",
         "meta-llama-3.1-8b-instruct-q4_k_m.gguf",
         "meta-llama-3-8b-instruct.q4_k_m.gguf",
         "meta-llama-3-8b-instruct-q4_k_m.gguf",
     }
     _API_V1_LOCAL_MODEL_ALIASES = {
-        "gpt-3.5-turbo": "llama-3-8b-instruct",
-        "gpt-5-chat-latest": "llama-3-8b-instruct",
+        "llama-3-8b-instruct": "llama-3.1-8b-instruct",
+        "gpt-3.5-turbo": "llama-3.1-8b-instruct",
+        "gpt-5-chat-latest": "llama-3.1-8b-instruct",
     }
-    _API_V1_LOCAL_ADAPTER_BASE_MODELS = {
-        "llama-3-8b-instruct:alignment": "llama-3-8b-instruct",
-    }
+    _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant", "function"}
 
     def __init__(
@@ -1733,13 +1732,7 @@ class RelayClient:
     def _api_v1_adapter_system_message(model_id: str) -> Optional[Dict[str, str]]:
         """Return local API v1 adapter instructions that do not require server imports."""
 
-        adapter_instructions = {
-            "llama-3-8b-instruct:alignment": (
-                "You are the alignment-focused variant of Meta Llama 3.1 8B. "
-                "Follow the provided safety charter to remain helpful, honest, "
-                "harmless, and to call out uncertain answers."
-            ),
-        }
+        adapter_instructions = {}
         instructions = adapter_instructions.get(model_id.strip().lower())
         if not instructions:
             return None
@@ -1821,8 +1814,6 @@ class RelayClient:
         adapter_base = cls._API_V1_LOCAL_ADAPTER_BASE_MODELS.get(normalized_model)
         if adapter_base:
             ids.add(adapter_base)
-        if ":" in normalized_model:
-            ids.add(normalized_model.split(":", 1)[0])
         ids.add(cls._api_v1_catalogue_resolved_model_id(normalized_model))
         return {value for value in ids if value}
 


### PR DESCRIPTION
### Motivation

- Correct the API v1 launch catalogue and landing UI so the public launch model is the Meta Llama 3.1 8B Instruct build rather than a token.place-branded or hallucinated model entry, and remove the misleading alignment adapter from public v1 surfaces.
- Keep backwards-compatible invisible aliases for existing clients/tests while ensuring the landing UI does not render an "owned by token.place" line.
- Update docs/examples and tests to freeze the corrected API v1 launch contract.

### Description

- Replace the API v1 public model id with the canonical `llama-3.1-8b-instruct` and update its metadata to attribute ownership/provider to Meta and include a `source` field (`meta-llama/Llama-3.1-8B-Instruct`).
- Remove the alignment adapter from the API v1 public `AVAILABLE_MODELS` listing so it no longer appears in `GET /api/v1/models` or in the landing dropdown, and ensure requests for `llama-3-8b-instruct:alignment` return `model_not_found` unless an explicit compatibility alias exists.
- Add invisible compatibility aliases mapping legacy ids to the canonical id (e.g. `llama-3-8b-instruct` -> `llama-3.1-8b-instruct`, `gpt-3.5-turbo` / `gpt-5-chat-latest` -> canonical), resolved at request time but not listed in the public catalogue.
- Ensure `get_model_instance` and `generate_response` resolve aliases before validation and error messages so clients using legacy ids are routed transparently.
- Update OpenAI-compatible payload formatting in `api/v1/routes.py` to use `model.get('owned_by', 'Meta')` and to include `provider`/`source` when present.
- Remove rendering of the owner line from the landing-chat UI and change the emergency fallback id to `llama-3.1-8b-instruct` in `static/chat.js` so the page never shows "owned by token.place" while preserving the API's `owned_by` field for compatibility.
- Update landing-page docs/examples in `static/index.html` to reference `llama-3.1-8b-instruct` and Meta attribution (no token.place ownership claims).
- Add and update focused tests to assert the corrected launch contract (catalog contains exactly the canonical model, owner/provider attribution to Meta, alignment adapter absent, legacy id is an invisible alias, landing UI does not render "owned by token.place").

### Testing

- Ran the focused unit tests for the launch contract with `python -m pytest tests/unit/test_api_v1_launch_contract.py -v`, which passed (`9 passed`).
- Ran the v1 models unit suite with `python -m pytest tests/unit/test_api_v1_models.py tests/unit/test_api_v1_models_additional.py tests/unit/test_api_v1_models_catalog_minimal.py tests/unit/test_api_v1_models_adapters.py tests/unit/test_api_v1_models_aliases.py -v`, which passed after the changes (`17 passed`).
- Executed the landing-page E2E subset with Playwright via `python -m pytest tests/e2e/test_ui.py -k "model or landing_chat" -v`; after installing Playwright browsers and deps (`python -m playwright install chromium` and `python -m playwright install-deps chromium`) the targeted e2e tests passed (`9 passed, 1 skipped`).
- Ran the JavaScript unit smoke tests with `npm run test:js`, which completed successfully (JS tests passed).
- Ran the repository-wide test runner `./run_all_tests.sh` during verification; the run produced many passing tests across unit and integration suites (observed large test sweep with no new regressions in v1 model surfaces). Note: full monolithic run is lengthy; verification focused on the v1 model / landing UI related suites described above.

All modified tests that assert the API v1 model contract and landing UI expectations now pass locally. Follow-ups: monitor any downstream integration tests that rely on the old visible `llama-3-8b-instruct:alignment` adapter rendering; if a deliberate public adapter is required later, reintroduce it intentionally with an explicit docs/compat note.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2849c1f82c832f8b52ea7bee75484e)