### PR TITLE
Landing chat: bounded sticky-server failover (preserve history)

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -2,6 +2,9 @@ const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue genera
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
+const MAX_STICKY_SERVER_FAILOVERS_PER_SEND = 3;
+const STICKY_SERVER_FAILOVER_STATUS_MESSAGE = 'The previous LLM server disconnected. Continuing with another available server.';
+const NO_LLM_SERVERS_AVAILABLE_MESSAGE = 'No LLM servers are available right now. Your chat history is still here.';
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 
 new Vue({
@@ -76,8 +79,7 @@ new Vue({
                 this.newMessage.trim() &&
                 this.hasClientKeypair &&
                 this.selectedModel &&
-                !this.isGeneratingResponse &&
-                !this.selectedServerTerminalFailure
+                !this.isGeneratingResponse
             );
         }
     },
@@ -223,14 +225,6 @@ new Vue({
         },
 
         async ensureSelectedServer() {
-            if (this.selectedServerTerminalFailure) {
-                return {
-                    error: {
-                        userMessage: this.selectedServerTerminalFailure
-                    }
-                };
-            }
-
             if (this.selectedServerPublicKey && this.selectedServerPublicKeyB64) {
                 return true;
             }
@@ -246,7 +240,7 @@ new Vue({
                     }
                     return {
                         error: {
-                            userMessage: this.getUserFacingApiError(errorData)
+                            userMessage: this.getUserFacingApiError(errorData, { noServersKeepsHistory: true })
                         }
                     };
                 }
@@ -265,13 +259,12 @@ new Vue({
                     ? this.encodePemToBase64(normalizedKey)
                     : rawKeyText.replace(/\s+/g, '');
                 this.selectedServerKeyLabel = this.createServerKeyLabel(this.selectedServerPublicKeyB64);
-                this.selectedServerTerminalFailure = '';
                 return true;
             } catch (error) {
                 console.error('Error selecting API v1 compute node:', error);
                 return {
                     error: {
-                        userMessage: 'Unable to select an LLM server right now. Please start a new chat session and try again.'
+                        userMessage: 'Unable to select an LLM server right now. Your chat history is still here.'
                     }
                 };
             }
@@ -297,7 +290,25 @@ new Vue({
         },
 
         markSelectedServerTerminalFailure(message) {
-            this.selectedServerTerminalFailure = message || 'The selected LLM server is unavailable or expired. Start a new chat to select another server.';
+            this.selectedServerTerminalFailure = message || STICKY_SERVER_FAILOVER_STATUS_MESSAGE;
+        },
+
+        beginStickyServerFailoverStatus() {
+            this.markSelectedServerTerminalFailure(STICKY_SERVER_FAILOVER_STATUS_MESSAGE);
+            this.clearSelectedServer();
+        },
+
+        finishStickyServerFailoverStatus() {
+            if (this.selectedServerTerminalFailure === STICKY_SERVER_FAILOVER_STATUS_MESSAGE) {
+                this.selectedServerTerminalFailure = '';
+            }
+        },
+
+        calculateMaxStickyServerFailovers() {
+            const liveNodeCount = Number.isInteger(this.computeNodeCount) && this.computeNodeCount > 0
+                ? this.computeNodeCount
+                : 1;
+            return Math.max(1, Math.min(liveNodeCount, MAX_STICKY_SERVER_FAILOVERS_PER_SEND));
         },
 
         startNewChatAfterSelectedServerFailure() {
@@ -604,20 +615,20 @@ new Vue({
             }
         },
 
-        getUserFacingRelayRetrieveError(status) {
+        getUserFacingRelayRetrieveError(status, errorPayload) {
             if (status === 202) {
                 return null;
             }
             if (status === 404) {
-                return 'The selected LLM server response was not found. Start a new chat to select another server.';
+                return 'The selected LLM server response was not found.';
             }
             if (status === 410) {
-                return 'The selected LLM server request expired. Start a new chat to select another server.';
+                return 'The selected LLM server request expired.';
             }
             if (status >= 500) {
                 return 'The relay is unavailable right now. Please try again later.';
             }
-            return ASSISTANT_GENERIC_FALLBACK_MESSAGE;
+            return this.getUserFacingApiError(errorPayload);
         },
 
         async cancelRelayRequest(clientPublicKeyB64, requestId, cancelToken) {
@@ -643,6 +654,26 @@ new Vue({
             }
         },
 
+        isTerminalSelectedServerRelayError(status, errorPayload) {
+            if (status === 404 || status === 410) {
+                return true;
+            }
+
+            const error = errorPayload && typeof errorPayload === 'object' ? errorPayload.error : null;
+            const code = error && typeof error.code === 'string' ? error.code : '';
+            const terminalCodes = new Set([
+                'server_unavailable',
+                'selected_server_terminal',
+                'selected_server_unavailable',
+                'selected_server_expired',
+                'server_expired',
+                'server_removed',
+                'expired',
+                'cancelled'
+            ]);
+            return terminalCodes.has(code);
+        },
+
         async retrieveRelayResponse(clientPublicKeyB64, requestId, cancelToken) {
             const timeoutMs = RELAY_RESPONSE_POLL_TIMEOUT_MS;
             const pollIntervalMs = 500;
@@ -666,13 +697,16 @@ new Vue({
                 }
 
                 if (!response.ok) {
-                    const userMessage = this.getUserFacingRelayRetrieveError(response.status);
-                    if (response.status === 404 || response.status === 410) {
-                        this.markSelectedServerTerminalFailure(userMessage);
+                    let errorData = null;
+                    try {
+                        errorData = await response.json();
+                    } catch (_jsonError) {
+                        errorData = null;
                     }
                     return {
                         error: {
-                            userMessage
+                            userMessage: this.getUserFacingRelayRetrieveError(response.status, errorData),
+                            terminalSelectedServer: this.isTerminalSelectedServerRelayError(response.status, errorData)
                         }
                     };
                 }
@@ -688,18 +722,7 @@ new Vue({
             };
         },
 
-        // Send a message through the relay-blind API v1 E2EE request routes.
-        async sendMessageApi(messageContent) {
-            if (!this.selectedModel) {
-                console.error('No API v1 catalogue model selected');
-                return null;
-            }
-
-            const selectedServer = await this.ensureSelectedServer();
-            if (selectedServer !== true) {
-                return selectedServer;
-            }
-
+        async dispatchApiV1RelayRequest(messageContent) {
             const requestId = this.createRequestId();
             const cancelToken = this.createRequestId();
             const clientPublicKeyB64 = this.encodeClientPublicKeyForApi();
@@ -715,92 +738,127 @@ new Vue({
                 }
             };
 
-            try {
-                const encryptedData = await this.encrypt(
-                    JSON.stringify(plaintextEnvelope),
-                    this.selectedServerPublicKey
-                );
+            const encryptedData = await this.encrypt(
+                JSON.stringify(plaintextEnvelope),
+                this.selectedServerPublicKey
+            );
 
-                if (!encryptedData) {
-                    throw new Error('Failed to encrypt relay request envelope');
-                }
-
-                const relayPayload = {
-                    server_public_key: this.selectedServerPublicKeyB64,
-                    client_public_key: clientPublicKeyB64,
-                    request_id: requestId,
-                    protocol: 'tokenplace_api_v1_relay_e2ee',
-                    version: 1,
-                    ciphertext: encryptedData.ciphertext,
-                    cipherkey: encryptedData.cipherkey,
-                    iv: encryptedData.iv,
-                    cancel_token: cancelToken
-                };
-
-                const dispatchResponse = await fetch('/api/v1/relay/requests', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(relayPayload)
-                });
-
-                if (!dispatchResponse.ok) {
-                    let errorData = null;
-                    try {
-                        errorData = await dispatchResponse.json();
-                    } catch (_jsonError) {
-                        errorData = null;
-                    }
-                    const unavailable = dispatchResponse.status === 404 || dispatchResponse.status === 410;
-                    const userMessage = unavailable
-                        ? 'The selected LLM server is unavailable or expired. Start a new chat to select another server.'
-                        : this.getUserFacingApiError(errorData);
-                    if (unavailable) {
-                        this.markSelectedServerTerminalFailure(userMessage);
-                    }
-                    return {
-                        error: {
-                            userMessage
-                        }
-                    };
-                }
-
-                const encryptedResponse = await this.retrieveRelayResponse(clientPublicKeyB64, requestId, cancelToken);
-                if (encryptedResponse && encryptedResponse.error) {
-                    return encryptedResponse;
-                }
-
-                const responseCiphertext = encryptedResponse.chat_history || encryptedResponse.ciphertext;
-                const decryptedJson = await this.decrypt(
-                    responseCiphertext,
-                    encryptedResponse.cipherkey,
-                    encryptedResponse.iv
-                );
-
-                if (!decryptedJson) {
-                    throw new Error('Failed to decrypt relay response');
-                }
-
-                const responseEnvelope = JSON.parse(decryptedJson);
-                if (
-                    !responseEnvelope ||
-                    responseEnvelope.protocol !== 'tokenplace_api_v1_relay_e2ee' ||
-                    responseEnvelope.version !== 1 ||
-                    responseEnvelope.request_id !== requestId ||
-                    responseEnvelope.client_public_key !== clientPublicKeyB64 ||
-                    !responseEnvelope.api_v1_response
-                ) {
-                    throw new Error('Invalid relay response envelope');
-                }
-
-                return responseEnvelope.api_v1_response;
-            } catch (error) {
-                console.error('API v1 relay request error:', error);
-                return null;
+            if (!encryptedData) {
+                throw new Error('Failed to encrypt relay request envelope');
             }
+
+            const relayPayload = {
+                server_public_key: this.selectedServerPublicKeyB64,
+                client_public_key: clientPublicKeyB64,
+                request_id: requestId,
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                ciphertext: encryptedData.ciphertext,
+                cipherkey: encryptedData.cipherkey,
+                iv: encryptedData.iv,
+                cancel_token: cancelToken
+            };
+
+            const dispatchResponse = await fetch('/api/v1/relay/requests', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(relayPayload)
+            });
+
+            if (!dispatchResponse.ok) {
+                let errorData = null;
+                try {
+                    errorData = await dispatchResponse.json();
+                } catch (_jsonError) {
+                    errorData = null;
+                }
+                return {
+                    error: {
+                        userMessage: this.isTerminalSelectedServerRelayError(dispatchResponse.status, errorData)
+                            ? 'The selected LLM server is unavailable or expired.'
+                            : this.getUserFacingApiError(errorData),
+                        terminalSelectedServer: this.isTerminalSelectedServerRelayError(dispatchResponse.status, errorData)
+                    }
+                };
+            }
+
+            const encryptedResponse = await this.retrieveRelayResponse(clientPublicKeyB64, requestId, cancelToken);
+            if (encryptedResponse && encryptedResponse.error) {
+                return encryptedResponse;
+            }
+
+            const responseCiphertext = encryptedResponse.chat_history || encryptedResponse.ciphertext;
+            const decryptedJson = await this.decrypt(
+                responseCiphertext,
+                encryptedResponse.cipherkey,
+                encryptedResponse.iv
+            );
+
+            if (!decryptedJson) {
+                throw new Error('Failed to decrypt relay response');
+            }
+
+            const responseEnvelope = JSON.parse(decryptedJson);
+            if (
+                !responseEnvelope ||
+                responseEnvelope.protocol !== 'tokenplace_api_v1_relay_e2ee' ||
+                responseEnvelope.version !== 1 ||
+                responseEnvelope.request_id !== requestId ||
+                responseEnvelope.client_public_key !== clientPublicKeyB64 ||
+                !responseEnvelope.api_v1_response
+            ) {
+                throw new Error('Invalid relay response envelope');
+            }
+
+            return responseEnvelope.api_v1_response;
         },
 
+        // Send a message through the relay-blind API v1 E2EE request routes.
+        async sendMessageApi(messageContent) {
+            if (!this.selectedModel) {
+                console.error('No API v1 catalogue model selected');
+                return null;
+            }
+
+            const maxFailovers = this.calculateMaxStickyServerFailovers();
+            let failoverAttempts = 0;
+
+            while (failoverAttempts <= maxFailovers) {
+                const selectedServer = await this.ensureSelectedServer();
+                if (selectedServer !== true) {
+                    return selectedServer;
+                }
+
+                try {
+                    const response = await this.dispatchApiV1RelayRequest(messageContent);
+                    if (response && response.error && response.error.terminalSelectedServer) {
+                        if (failoverAttempts >= maxFailovers) {
+                            return {
+                                error: {
+                                    userMessage: 'The selected LLM server is unavailable or expired. Your chat history is still here.'
+                                }
+                            };
+                        }
+                        failoverAttempts += 1;
+                        this.beginStickyServerFailoverStatus();
+                        continue;
+                    }
+                    this.finishStickyServerFailoverStatus();
+                    return response;
+                } catch (error) {
+                    console.error('API v1 relay request error:', error);
+                    return null;
+                }
+            }
+
+            return {
+                error: {
+                    userMessage: 'The selected LLM server is unavailable or expired. Your chat history is still here.'
+                }
+            };
+        },
 
         calculateTypingChunkSize(content) {
             if (!content || typeof content !== 'string') {
@@ -847,13 +905,15 @@ new Vue({
             return message.content;
         },
 
-        getUserFacingApiError(errorPayload) {
+        getUserFacingApiError(errorPayload, options = {}) {
             const error = errorPayload && typeof errorPayload === 'object' ? errorPayload.error : null;
             const errorCode = error && typeof error.code === 'string' ? error.code : '';
             const fallbackMessage = ASSISTANT_GENERIC_FALLBACK_MESSAGE;
 
             const codeToMessage = {
-                no_registered_compute_nodes: 'No LLM servers are available right now.',
+                no_registered_compute_nodes: options.noServersKeepsHistory
+                    ? NO_LLM_SERVERS_AVAILABLE_MESSAGE
+                    : 'No LLM servers are available right now.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_bridge_timeout: 'The LLM server took too long to respond. Please try again.',
                 compute_node_unreachable: 'The LLM server is unavailable right now. Please try again.',

--- a/static/index.html
+++ b/static/index.html
@@ -462,7 +462,7 @@
                     data-testid="landing-new-chat-retry"
                     @click="startNewChatAfterSelectedServerFailure"
                 >
-                    Start a new chat and retry
+                    Start a new chat
                 </button>
             </div>
             <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,9 +182,13 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "root_page_loads",
+        "landing_chat",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_sticky_server_two_turns_and_key_label",
         "landing_chat_terminal_server_failure_requires_explicit_new_chat_retry",
+        "landing_chat_automatically_fails_over_sticky_server_without_losing_history",
+        "landing_chat_no_server_available_after_failover_keeps_history",
+        "failover",
         "sticky",
         "server_key",
         "landing_chat_model_dropdown_uses_api_v1_models",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import json
 import os
 import pytest
@@ -45,8 +46,10 @@ def route_landing_relay_chat(
     page: Page,
     *,
     assistant_content: str = "Relay chat path restored.",
+    assistant_contents: list[str] | None = None,
     models_payload: dict | None = None,
     next_status: int = 200,
+    next_statuses: list[int] | None = None,
     next_server_keys: list[str] | None = None,
     request_statuses: list[int] | None = None,
     retrieve_statuses: list[int] | None = None,
@@ -56,6 +59,7 @@ def route_landing_relay_chat(
         "next_calls": 0,
         "relay_requests": [],
         "retrieve_requests": [],
+        "successful_retrieves": 0,
         "cancel_requests": [],
         "chat_completions": [],
         "v2_requests": [],
@@ -83,9 +87,12 @@ def route_landing_relay_chat(
 
     def handle_next(route):
         state["next_calls"] += 1
-        if next_status != 200:
+        current_next_status = next_status
+        if next_statuses:
+            current_next_status = next_statuses[min(state["next_calls"] - 1, len(next_statuses) - 1)]
+        if current_next_status != 200:
             route.fulfill(
-                status=next_status,
+                status=current_next_status,
                 headers={"Content-Type": "application/json"},
                 body=json.dumps({"error": {"code": "no_registered_compute_nodes"}}),
             )
@@ -130,6 +137,10 @@ def route_landing_relay_chat(
                 body=json.dumps({"error": {"code": "selected_server_terminal"}}),
             )
             return
+        state["successful_retrieves"] += 1
+        content = assistant_content
+        if assistant_contents:
+            content = assistant_contents[min(state["successful_retrieves"] - 1, len(assistant_contents) - 1)]
         route.fulfill(
             status=200,
             headers={"Content-Type": "application/json"},
@@ -144,7 +155,7 @@ def route_landing_relay_chat(
                             "api_v1_response": {
                                 "message": {
                                     "role": "assistant",
-                                    "content": assistant_content,
+                                    "content": content,
                                 }
                             },
                         }
@@ -547,57 +558,62 @@ def test_landing_chat_sticky_server_two_turns_and_key_label(page: Page, base_url
         ("retrieve", 410),
     ],
 )
-def test_landing_chat_terminal_server_failure_requires_explicit_new_chat_retry(
+def test_landing_chat_automatically_fails_over_sticky_server_without_losing_history(
     page: Page,
     base_url: str,
     setup_servers,
     terminal_endpoint: str,
     terminal_status: int,
 ):
-    """A terminal selected-server error locks the chat until the user explicitly starts fresh."""
+    """A terminal selected-server error retries the current turn on the next node in-place."""
 
     route_kwargs = {
-        "request_statuses": [terminal_status, 200] if terminal_endpoint == "dispatch" else None,
-        "retrieve_statuses": [terminal_status, 200] if terminal_endpoint == "retrieve" else None,
+        "request_statuses": [200, 200, terminal_status, 200, 200] if terminal_endpoint == "dispatch" else None,
+        "retrieve_statuses": [200, 200, terminal_status, 200, 200] if terminal_endpoint == "retrieve" else None,
     }
     state = route_landing_relay_chat(
         page,
-        assistant_content="Replacement server answered.",
+        assistant_contents=[
+            "First sticky response.",
+            "Second sticky response.",
+            "Replacement server answered.",
+            "Replacement server stayed sticky.",
+        ],
         next_server_keys=[SERVER_PUBLIC_KEY_B64, ALT_SERVER_PUBLIC_KEY_B64],
         **route_kwargs,
     )
+    navigations_after_load = []
+    page.on("framenavigated", lambda frame: navigations_after_load.append(frame.url) if frame == page.main_frame else None)
 
     page.goto(base_url)
     page.wait_for_load_state("networkidle")
+    navigations_after_load.clear()
     patch_landing_crypto_for_visible_envelopes(page)
 
     textarea = page.locator("textarea").first
-    textarea.fill("first attempt")
+
+    textarea.fill("first turn")
     wait_for_landing_send_enabled(page).click()
     page.locator(".assistant-message").last.wait_for(state="visible")
 
-    failure = page.get_by_test_id("landing-selected-server-failure")
-    failure.wait_for(state="visible")
-    assert "Start a new chat to select another server" in failure.inner_text()
-    assert page.locator(".assistant-message").last.inner_text().count("Start a new chat") == 1
+    initial_label = page.get_by_test_id("landing-server-key-label")
+    initial_label.wait_for(state="visible")
+    initial_label_text = initial_label.inner_text()
+
+    textarea.fill("second turn")
+    wait_for_landing_send_enabled(page).click()
+    page.wait_for_function(
+        """
+        () => Array.from(document.querySelectorAll('.assistant-message'))
+            .some((node) => node.textContent.includes('Second sticky response.'))
+        """
+    )
+
     assert state["next_calls"] == 1
-    assert len(state["relay_requests"]) == 1
-    if terminal_endpoint == "retrieve":
-        assert len(state["retrieve_requests"]) == 1
+    assert len(state["relay_requests"]) == 2
+    assert {payload["server_public_key"] for payload in state["relay_requests"]} == {SERVER_PUBLIC_KEY_B64}
 
-    textarea.fill("second attempt without explicit retry")
-    page.evaluate("() => document.querySelector('#app').__vue__.sendMessage()")
-    page.wait_for_timeout(250)
-    assert state["next_calls"] == 1
-    assert len(state["relay_requests"]) == 1
-    if terminal_endpoint == "retrieve":
-        assert len(state["retrieve_requests"]) == 1
-
-    page.get_by_test_id("landing-new-chat-retry").click()
-    failure.wait_for(state="hidden")
-    assert page.locator(".message").count() == 0
-
-    textarea.fill("fresh attempt")
+    textarea.fill("failover turn")
     wait_for_landing_send_enabled(page).click()
     page.wait_for_function(
         """
@@ -606,13 +622,95 @@ def test_landing_chat_terminal_server_failure_requires_explicit_new_chat_retry(
         """
     )
 
+    updated_label_text = page.get_by_test_id("landing-server-key-label").inner_text()
+    alt_digest = hashlib.sha256(ALT_SERVER_PUBLIC_KEY_B64.encode("utf-8")).hexdigest()
+    assert updated_label_text == f"Server: {alt_digest[:8]}…{alt_digest[-8:]}"
+    assert updated_label_text != initial_label_text
+
+    body_text = page.locator("body").inner_text()
+    assert "first turn" in body_text
+    assert "First sticky response." in body_text
+    assert "second turn" in body_text
+    assert "Second sticky response." in body_text
+    assert "failover turn" in body_text
+    assert "Replacement server answered." in body_text
+    assert "Start a new chat to select another server" not in body_text
+
     assert state["next_calls"] == 2
-    assert [payload["server_public_key"] for payload in state["relay_requests"]] == [
+    assert [payload["server_public_key"] for payload in state["relay_requests"][:4]] == [
+        SERVER_PUBLIC_KEY_B64,
+        SERVER_PUBLIC_KEY_B64,
         SERVER_PUBLIC_KEY_B64,
         ALT_SERVER_PUBLIC_KEY_B64,
     ]
-    fresh_envelope = json.loads(state["relay_requests"][1]["ciphertext"])
-    assert fresh_envelope["api_v1_request"]["messages"] == [{"role": "user", "content": "fresh attempt"}]
+    retry_envelope = json.loads(state["relay_requests"][3]["ciphertext"])
+    failed_envelope = json.loads(state["relay_requests"][2]["ciphertext"])
+    assert retry_envelope["request_id"] != failed_envelope["request_id"]
+    assert retry_envelope["api_v1_request"]["messages"] == [
+        {"role": "user", "content": "first turn"},
+        {"role": "assistant", "content": "First sticky response."},
+        {"role": "user", "content": "second turn"},
+        {"role": "assistant", "content": "Second sticky response."},
+        {"role": "user", "content": "failover turn"},
+    ]
+
+    textarea.fill("post failover turn")
+    wait_for_landing_send_enabled(page).click()
+    page.wait_for_function(
+        """
+        () => Array.from(document.querySelectorAll('.assistant-message'))
+            .some((node) => node.textContent.includes('Replacement server stayed sticky.'))
+        """
+    )
+
+    assert state["next_calls"] == 2
+    assert state["relay_requests"][-1]["server_public_key"] == ALT_SERVER_PUBLIC_KEY_B64
+    assert navigations_after_load == []
+    assert state["chat_completions"] == []
+    assert state["v2_requests"] == []
+
+
+@pytest.mark.e2e
+def test_landing_chat_no_server_available_after_failover_keeps_history(
+    page: Page,
+    base_url: str,
+    setup_servers,
+):
+    """If failover has no replacement node, the UI keeps the transcript and shows a calm error."""
+
+    state = route_landing_relay_chat(
+        page,
+        assistant_content="Initial answer before outage.",
+        next_statuses=[200, 503],
+        request_statuses=[200, 404],
+        next_server_keys=[SERVER_PUBLIC_KEY_B64],
+    )
+
+    page.goto(base_url)
+    page.wait_for_load_state("networkidle")
+    patch_landing_crypto_for_visible_envelopes(page)
+
+    textarea = page.locator("textarea").first
+    textarea.fill("first turn")
+    wait_for_landing_send_enabled(page).click()
+    page.locator(".assistant-message").last.wait_for(state="visible")
+
+    textarea.fill("message during outage")
+    wait_for_landing_send_enabled(page).click()
+    page.wait_for_function(
+        """
+        () => Array.from(document.querySelectorAll('.assistant-message'))
+            .some((node) => node.textContent.includes('No LLM servers are available right now. Your chat history is still here.'))
+        """
+    )
+
+    body_text = page.locator("body").inner_text()
+    assert "first turn" in body_text
+    assert "Initial answer before outage." in body_text
+    assert "message during outage" in body_text
+    assert "No LLM servers are available right now. Your chat history is still here." in body_text
+    assert state["next_calls"] == 2
+    assert len(state["relay_requests"]) == 2
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []
 

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -80,8 +80,15 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
 def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000" in chat_js
+    assert "MAX_STICKY_SERVER_FAILOVERS_PER_SEND" in chat_js
     assert "cancelRelayRequest" in chat_js
     assert "/api/v1/relay/requests/cancel" in chat_js
     assert "cancel_token: cancelToken" in chat_js
-    assert "dispatchResponse.status === 404 || dispatchResponse.status === 410" in chat_js
+    assert "isTerminalSelectedServerRelayError" in chat_js
+    assert "dispatchResponse.status, errorData" in chat_js
+    assert "terminalSelectedServer" in chat_js
+    assert "beginStickyServerFailoverStatus" in chat_js
     assert "this.clearSelectedServer()" in chat_js
+    assert "STICKY_SERVER_FAILOVER_STATUS_MESSAGE" in chat_js
+    assert "The previous LLM server disconnected. Continuing with another available server." in chat_js
+    assert "No LLM servers are available right now. Your chat history is still here." in chat_js


### PR DESCRIPTION
### Motivation
- Preserve the landing chat transcript when a sticky API v1 compute node disappears so users do not lose context during terminal node failures. 
- Keep the client sticky to a healthy selected node and only fail over when the selected node is terminally unavailable or expired. 
- Provide calm, non-destructive user messaging and bounded retry behavior to avoid fanning out history across many nodes.

### Description
- Implemented bounded in-client failover in `static/chat.js`: detect terminal dispatch/retrieve errors, request the next server from `/api/v1/relay/servers/next`, generate a fresh `request_id`, re-encrypt the current API v1 envelope to the new server key, and resend the request while preserving the visible chat history and updated server label. 
- Added helpers and limits: `MAX_STICKY_SERVER_FAILOVERS_PER_SEND`, `calculateMaxStickyServerFailovers()`, `isTerminalSelectedServerRelayError()`, `beginStickyServerFailoverStatus()` / `finishStickyServerFailoverStatus()` to control UI status and bound failovers. 
- Adjusted failure copy and UX: replaced forced "Start a new chat and retry" flow with an optional "Start a new chat" control and added a non-destructive no-node message (`NO_LLM_SERVERS_AVAILABLE_MESSAGE`). 
- Expanded test harness and E2E mocks in `tests/e2e/test_ui.py` and updated focused E2E gating in `tests/conftest.py` and unit assertions in `tests/unit/test_touch_ui.py` to cover automatic failover, replacement server key selection, preserved history, label update, and no page reload or API v2 usage.

### Testing
- Ran the focused unit tests: `python -m pytest tests/unit/test_touch_ui.py -v` and they passed (all assertions in this file succeeded). 
- Ran targeted E2E coverage for landing chat and failover: `python -m pytest tests/e2e/test_ui.py -k "landing_chat or sticky or server_key or failover" -v` (installed Playwright browsers and system deps when required) and the landing-chat failover scenarios passed. 
- Verified relay behavior and invariants: `python -m pytest tests/test_relay.py tests/unit/test_e2ee_relay_invariant.py -v` and these passed. 
- Ran JavaScript checks: `npm run test:js` and `pre-commit run --all-files` and they passed. 
- Executed the full project test runner `./run_all_tests.sh` and it completed successfully (integration, API, and unit suites passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e42505bc832fb43dd0b8b7c04263)