### PR TITLE
Make Helm chart publish idempotent and only fail on real chart-release problems

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -343,7 +343,8 @@ jobs:
               action=publish
               reason="Publishing new chart version ${CHART_VERSION} to ${CHART_REF} from manual dispatch."
             elif [[ "${MANUAL_PUBLISH}" == "true" && "${chart_exists}" == "true" ]]; then
-              reason="Publish skipped: manual publish requested but chart version ${CHART_VERSION} already exists; immutable OCI artifacts are never overwritten."
+              action=fail
+              reason="Publish failed: manual publish requested but chart version ${CHART_VERSION} already exists; refusing to overwrite immutable OCI artifact."
             elif [[ "${chart_exists}" == "true" ]]; then
               reason="Publish skipped: manual dispatch validate/package only; chart version ${CHART_VERSION} already exists."
             else

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -279,13 +279,23 @@ jobs:
             "docs/RPI_DEPLOYMENT_GUIDE.md"
           )
 
+          is_confirmed_missing_chart() {
+            local lookup_log="$1"
+
+            if grep -Eiq '(unauthorized|forbidden|denied|rate limit|too many requests|timeout|timed out|tls|certificate|connection|connection reset|connection refused|i/o timeout|temporary failure|server error|internal server error|bad gateway|service unavailable|gateway timeout|^[[:space:]]*<html)' "${lookup_log}"; then
+              return 1
+            fi
+
+            grep -Eiq '(^|[[:space:]:])((MANIFEST|NAME)_UNKNOWN|manifest unknown|name unknown|version[[:space:]]+[^[:space:]]+[[:space:]]+not found|chart version[[:space:]]+[^[:space:]]+[[:space:]]+not found)([[:space:].:]|$)' "${lookup_log}"
+          }
+
           chart_exists=false
           chart_lookup_status=error
           chart_lookup_log="$(mktemp)"
           if helm show chart "${CHART_REF}" --version "${CHART_VERSION}" >"${chart_lookup_log}" 2>&1; then
             chart_exists=true
             chart_lookup_status=found
-          elif grep -Eiq '(not found|404|manifest unknown|name unknown)' "${chart_lookup_log}"; then
+          elif is_confirmed_missing_chart "${chart_lookup_log}"; then
             chart_exists=false
             chart_lookup_status=not_found
           else

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -12,9 +12,14 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Branch, tag, or SHA to publish
+        description: Branch, tag, or SHA to validate/package
         required: false
         default: main
+      publish:
+        description: Publish this ref when the chart version is new
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   validate-and-package:
@@ -32,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -228,11 +234,11 @@ jobs:
       packages: write
 
     steps:
-      - name: Download packaged chart artifact
-        uses: actions/download-artifact@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          name: tokenplace-chart-package
-          path: dist
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -245,8 +251,124 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
+      - name: Decide whether to publish chart
+        id: publish_decision
+        env:
+          CHART_REF: ${{ needs.validate-and-package.outputs.chart_ref }}
+          CHART_VERSION: ${{ needs.validate-and-package.outputs.chart_version }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_SHA: ${{ github.sha }}
+          MANUAL_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && inputs.publish || 'false' }}
+        run: |
+          set -euo pipefail
+
+          chart_source_paths=(
+            "charts/tokenplace/**"
+          )
+          chart_related_paths=(
+            "${chart_source_paths[@]}"
+            ".github/workflows/ci-helm.yml"
+            "README.md"
+            "docs/k3s-sugarkube-dev.md"
+            "docs/k3s-sugarkube-prod.md"
+            "docs/k3s-sugarkube-staging.md"
+            "docs/ops/sugarkube-release.md"
+            "docs/relay-deploy.md"
+            "docs/relay_sugarkube_onboarding.md"
+            "docs/RPI_DEPLOYMENT_GUIDE.md"
+          )
+
+          chart_exists=false
+          if helm show chart "${CHART_REF}" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+            chart_exists=true
+          fi
+
+          chart_source_changed=false
+          chart_related_changed=false
+          compare_note="not evaluated for ${EVENT_NAME}"
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            before="${EVENT_BEFORE}"
+            after="${EVENT_SHA}"
+            if [[ -n "${before}" && ! "${before}" =~ ^0+$ ]] && git cat-file -e "${before}^{commit}" 2>/dev/null; then
+              compare_note="${before}..${after}"
+              if git diff --quiet "${before}" "${after}" -- "${chart_source_paths[@]}"; then
+                chart_source_changed=false
+              else
+                chart_source_changed=true
+              fi
+              if git diff --quiet "${before}" "${after}" -- "${chart_related_paths[@]}"; then
+                chart_related_changed=false
+              else
+                chart_related_changed=true
+              fi
+            else
+              compare_note="first-parent fallback for ${after}"
+              if git rev-parse "${after}^" >/dev/null 2>&1; then
+                if git diff --quiet "${after}^" "${after}" -- "${chart_source_paths[@]}"; then
+                  chart_source_changed=false
+                else
+                  chart_source_changed=true
+                fi
+                if git diff --quiet "${after}^" "${after}" -- "${chart_related_paths[@]}"; then
+                  chart_related_changed=false
+                else
+                  chart_related_changed=true
+                fi
+              else
+                compare_note="unable to compare; treating chart paths as changed"
+                chart_source_changed=true
+                chart_related_changed=true
+              fi
+            fi
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            compare_note="manual dispatch publish=${MANUAL_PUBLISH}"
+          fi
+
+          action=skip
+          reason="Publish skipped: ${EVENT_NAME} does not request chart publishing."
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            if [[ "${chart_source_changed}" == "true" && "${chart_exists}" == "false" ]]; then
+              action=publish
+              reason="Publishing new chart version ${CHART_VERSION} to ${CHART_REF}."
+            elif [[ "${chart_source_changed}" == "true" && "${chart_exists}" == "true" ]]; then
+              action=fail
+              reason="Publish failed: chart files changed but chart version ${CHART_VERSION} already exists; bump charts/tokenplace/Chart.yaml version."
+            elif [[ "${chart_exists}" == "true" ]]; then
+              reason="Publish skipped: chart version ${CHART_VERSION} already exists and no chart files changed."
+            else
+              reason="Publish skipped: chart files did not change and chart version ${CHART_VERSION} is not present; push a chart change or use manual publish to release this ref."
+            fi
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${MANUAL_PUBLISH}" == "true" && "${chart_exists}" == "false" ]]; then
+              action=publish
+              reason="Publishing new chart version ${CHART_VERSION} to ${CHART_REF} from manual dispatch."
+            elif [[ "${MANUAL_PUBLISH}" == "true" && "${chart_exists}" == "true" ]]; then
+              reason="Publish skipped: manual publish requested but chart version ${CHART_VERSION} already exists; immutable OCI artifacts are never overwritten."
+            elif [[ "${chart_exists}" == "true" ]]; then
+              reason="Publish skipped: manual dispatch validate/package only; chart version ${CHART_VERSION} already exists."
+            else
+              reason="Publish skipped: manual dispatch validate/package only; set publish=true to publish new chart version ${CHART_VERSION}."
+            fi
+          fi
+
+          echo "action=${action}" >> "$GITHUB_OUTPUT"
+          echo "chart_exists=${chart_exists}" >> "$GITHUB_OUTPUT"
+          echo "chart_changed=${chart_source_changed}" >> "$GITHUB_OUTPUT"
+          echo "chart_related_changed=${chart_related_changed}" >> "$GITHUB_OUTPUT"
+          echo "compare_note=${compare_note}" >> "$GITHUB_OUTPUT"
+          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
+
+      - name: Download packaged chart artifact
+        if: steps.publish_decision.outputs.action == 'publish'
+        uses: actions/download-artifact@v4
+        with:
+          name: tokenplace-chart-package
+          path: dist
+
       - name: Push chart to OCI registry
         id: push
+        if: steps.publish_decision.outputs.action == 'publish'
         run: |
           set -euo pipefail
           package_file="$(find dist -maxdepth 1 -type f -name '*.tgz' | head -n 1)"
@@ -254,18 +376,28 @@ jobs:
           test -f "${package_file}"
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
-          if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Refusing to overwrite immutable OCI artifact; stop and resolve manually." >&2
-            exit 1
-          fi
           helm push "${package_file}" "${chart_registry}"
           echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Publish chart summary
+        if: always()
         run: |
           {
-            echo "## Helm chart published"
+            echo "## Helm chart publish decision"
             echo ""
-            echo "Chart reference: \`${{ steps.push.outputs.chart_ref }}\`"
+            echo "Chart reference: \`${{ needs.validate-and-package.outputs.chart_ref }}\`"
             echo "Chart version: \`${{ needs.validate-and-package.outputs.chart_version }}\`"
+            echo "Chart exists in GHCR: \`${{ steps.publish_decision.outputs.chart_exists }}\`"
+            echo "Chart source files changed: \`${{ steps.publish_decision.outputs.chart_changed }}\`"
+            echo "Chart-related files changed: \`${{ steps.publish_decision.outputs.chart_related_changed }}\`"
+            echo "Comparison: \`${{ steps.publish_decision.outputs.compare_note }}\`"
+            echo "Decision: \`${{ steps.publish_decision.outputs.action }}\`"
+            echo ""
+            echo "${{ steps.publish_decision.outputs.reason }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail when changed chart files need a new version
+        if: steps.publish_decision.outputs.action == 'fail'
+        run: |
+          echo "${{ steps.publish_decision.outputs.reason }}" >&2
+          exit 1

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -281,9 +281,17 @@ jobs:
 
           is_confirmed_missing_chart() {
             local lookup_log="$1"
+            local chart_version="$2"
 
             if grep -Eiq '(unauthorized|forbidden|denied|rate limit|too many requests|timeout|timed out|tls|certificate|connection|connection reset|connection refused|i/o timeout|temporary failure|server error|internal server error|bad gateway|service unavailable|gateway timeout|^[[:space:]]*<html)' "${lookup_log}"; then
               return 1
+            fi
+
+            if grep -Fq ":${chart_version}: not found" "${lookup_log}"; then
+              return 0
+            fi
+            if grep -Fq "/manifests/${chart_version} not found:" "${lookup_log}"; then
+              return 0
             fi
 
             grep -Eiq '(^|[[:space:]:])((MANIFEST|NAME)_UNKNOWN|manifest unknown|name unknown|version[[:space:]]+[^[:space:]]+[[:space:]]+not found|chart version[[:space:]]+[^[:space:]]+[[:space:]]+not found)([[:space:].:]|$)' "${lookup_log}"
@@ -295,7 +303,7 @@ jobs:
           if helm show chart "${CHART_REF}" --version "${CHART_VERSION}" >"${chart_lookup_log}" 2>&1; then
             chart_exists=true
             chart_lookup_status=found
-          elif is_confirmed_missing_chart "${chart_lookup_log}"; then
+          elif is_confirmed_missing_chart "${chart_lookup_log}" "${CHART_VERSION}"; then
             chart_exists=false
             chart_lookup_status=not_found
           else

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
           fetch-depth: 0
 
       - name: Set up Helm
@@ -237,7 +237,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
           fetch-depth: 0
 
       - name: Set up Helm
@@ -280,9 +280,19 @@ jobs:
           )
 
           chart_exists=false
-          if helm show chart "${CHART_REF}" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+          chart_lookup_status=error
+          chart_lookup_log="$(mktemp)"
+          if helm show chart "${CHART_REF}" --version "${CHART_VERSION}" >"${chart_lookup_log}" 2>&1; then
             chart_exists=true
+            chart_lookup_status=found
+          elif grep -Eiq '(not found|404|manifest unknown|name unknown)' "${chart_lookup_log}"; then
+            chart_exists=false
+            chart_lookup_status=not_found
+          else
+            chart_lookup_status=error
           fi
+          chart_lookup_details="$(tr '\n' ' ' <"${chart_lookup_log}" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+          rm -f "${chart_lookup_log}"
 
           chart_source_changed=false
           chart_related_changed=false
@@ -303,23 +313,9 @@ jobs:
                 chart_related_changed=true
               fi
             else
-              compare_note="first-parent fallback for ${after}"
-              if git rev-parse "${after}^" >/dev/null 2>&1; then
-                if git diff --quiet "${after}^" "${after}" -- "${chart_source_paths[@]}"; then
-                  chart_source_changed=false
-                else
-                  chart_source_changed=true
-                fi
-                if git diff --quiet "${after}^" "${after}" -- "${chart_related_paths[@]}"; then
-                  chart_related_changed=false
-                else
-                  chart_related_changed=true
-                fi
-              else
-                compare_note="unable to compare; treating chart paths as changed"
-                chart_source_changed=true
-                chart_related_changed=true
-              fi
+              compare_note="unable to compare full pushed range; treating chart paths as changed"
+              chart_source_changed=true
+              chart_related_changed=true
             fi
           elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             compare_note="manual dispatch publish=${MANUAL_PUBLISH}"
@@ -327,7 +323,10 @@ jobs:
 
           action=skip
           reason="Publish skipped: ${EVENT_NAME} does not request chart publishing."
-          if [[ "${EVENT_NAME}" == "push" ]]; then
+          if [[ "${chart_lookup_status}" == "error" ]]; then
+            action=fail
+            reason="Publish failed: could not determine whether chart version ${CHART_VERSION} exists in ${CHART_REF}; registry lookup must succeed or return a confirmed not-found response before publishing. ${chart_lookup_details}"
+          elif [[ "${EVENT_NAME}" == "push" ]]; then
             if [[ "${chart_source_changed}" == "true" && "${chart_exists}" == "false" ]]; then
               action=publish
               reason="Publishing new chart version ${CHART_VERSION} to ${CHART_REF}."
@@ -354,6 +353,7 @@ jobs:
 
           echo "action=${action}" >> "$GITHUB_OUTPUT"
           echo "chart_exists=${chart_exists}" >> "$GITHUB_OUTPUT"
+          echo "chart_lookup_status=${chart_lookup_status}" >> "$GITHUB_OUTPUT"
           echo "chart_changed=${chart_source_changed}" >> "$GITHUB_OUTPUT"
           echo "chart_related_changed=${chart_related_changed}" >> "$GITHUB_OUTPUT"
           echo "compare_note=${compare_note}" >> "$GITHUB_OUTPUT"
@@ -388,6 +388,7 @@ jobs:
             echo "Chart reference: \`${{ needs.validate-and-package.outputs.chart_ref }}\`"
             echo "Chart version: \`${{ needs.validate-and-package.outputs.chart_version }}\`"
             echo "Chart exists in GHCR: \`${{ steps.publish_decision.outputs.chart_exists }}\`"
+            echo "Chart lookup status: \`${{ steps.publish_decision.outputs.chart_lookup_status }}\`"
             echo "Chart source files changed: \`${{ steps.publish_decision.outputs.chart_changed }}\`"
             echo "Chart-related files changed: \`${{ steps.publish_decision.outputs.chart_related_changed }}\`"
             echo "Comparison: \`${{ steps.publish_decision.outputs.compare_note }}\`"

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Artifact references:
 - v0.1.0 runtime/release alignment: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
 - Preferred staging/prod tag: immutable `main-<shortsha>` copied from the `ci-image.yml` workflow summary (`main-latest` is convenience-only)
 - Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- Pre-publish gate: run `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`; if chart `0.1.1` already exists and contents are stale/mismatched, do not overwrite or re-push it; stop and decide manually. If chart `0.1.1` does not exist, proceed with publishing chart package version `0.1.1`.
+- Pre-publish gate: `ci-helm.yml` checks whether the current chart version already exists at `oci://ghcr.io/futuroptimist/charts/tokenplace`. It publishes only new chart versions when chart source files changed, skips unchanged already-published versions as a no-op, and fails changed chart source with an already-published version so maintainers bump `charts/tokenplace/Chart.yaml`.
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo. The current app-specific deploy command is:
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -50,9 +50,13 @@ default.
 
 ## Chart contract
 
-`ci-helm.yml` validates `charts/tokenplace`, packages it, and publishes the
-chart to GHCR as an immutable OCI artifact. The publish job refuses to overwrite
-an existing chart version.
+`ci-helm.yml` validates `charts/tokenplace` and packages it on pull requests,
+main-branch pushes, and manual dispatches. Pushes to `main` publish to GHCR only
+when chart source files changed and the `charts/tokenplace/Chart.yaml` version is
+not already present as an immutable OCI artifact. If the chart source changed but
+the version already exists, the workflow fails with a version-bump message; if no
+chart source changed, an already-published version is a successful no-op. Manual
+dispatches are validate/package-only unless the `publish` input is set.
 
 Before deploying, confirm the chart version you intend to use:
 

--- a/docs/relay-deploy.md
+++ b/docs/relay-deploy.md
@@ -97,8 +97,10 @@ Kubernetes continuously verifies the relay’s health:
 
 Sugarkube is the canonical deploy surface. The chart source is `charts/tokenplace`
 and the OCI chart ref is `oci://ghcr.io/futuroptimist/charts/tokenplace`.
-`ci-helm.yml` validates, packages, and publishes immutable chart versions; the
-publish job refuses to overwrite an existing chart version.
+`ci-helm.yml` validates and packages the chart on PRs, main pushes, and manual
+runs. Main pushes publish immutable chart versions only when chart source files
+changed and the chart version is new; unchanged chart source with an existing
+version is reported as a successful no-op.
 
 1. Find a successful `ci-image.yml` run and copy the immutable Sugarkube tag from
    the workflow summary.

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -178,6 +178,34 @@ def test_helm_workflow_publish_decision_is_idempotent() -> None:
         "unable to compare full pushed range; treating chart paths as changed"
         in publish_runs
     )
+    assert (
+        "Publish failed: manual publish requested but chart version ${CHART_VERSION} already exists; "
+        "refusing to overwrite immutable OCI artifact."
+    ) in workflow_text
+
+
+def test_helm_manual_publish_existing_chart_fails_instead_of_skipping() -> None:
+    workflow_text = (WORKFLOW_DIR / "ci-helm.yml").read_text(encoding="utf-8")
+    workflow_data = _load_workflow(WORKFLOW_DIR / "ci-helm.yml")
+    publish_runs = _step_runs(workflow_data["jobs"]["publish"])
+
+    assert (
+        'elif [[ "${MANUAL_PUBLISH}" == "true" && "${chart_exists}" == "true" ]]; then'
+        in publish_runs
+    )
+    assert (
+        "action=fail\n"
+        '    reason="Publish failed: manual publish requested but chart version '
+        '${CHART_VERSION} already exists; refusing to overwrite immutable OCI artifact."'
+        in publish_runs
+    ), (
+        "Manual publish must fail closed instead of skipping when the immutable chart "
+        "already exists"
+    )
+    assert (
+        "Publish skipped: manual dispatch validate/package only; chart version ${CHART_VERSION} already exists."
+        in workflow_text
+    ), "Manual validate/package-only dispatches must still succeed without publishing"
 
 
 def test_helm_workflow_checkout_has_history_for_push_diff() -> None:

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -156,16 +156,28 @@ def test_helm_workflow_publish_decision_is_idempotent() -> None:
     assert "chart_related_paths=(" in publish_runs
     assert '".github/workflows/ci-helm.yml"' in publish_runs
     assert "helm show chart \"${CHART_REF}\" --version \"${CHART_VERSION}\"" in publish_runs
+    assert "chart_lookup_status=not_found" in publish_runs
+    assert "grep -Eiq '(not found|404|manifest unknown|name unknown)'" in publish_runs
+    assert "chart_lookup_status=error" in publish_runs
     assert "action=fail" in publish_runs
     assert (
         "Publish failed: chart files changed but chart version ${CHART_VERSION} already exists; "
         "bump charts/tokenplace/Chart.yaml version."
     ) in workflow_text
     assert (
+        "Publish failed: could not determine whether chart version ${CHART_VERSION} exists"
+        in workflow_text
+    )
+    assert (
         "Publish skipped: chart version ${CHART_VERSION} already exists and no chart files changed."
     ) in workflow_text
     assert "steps.publish_decision.outputs.action == 'publish'" in workflow_text
     assert "helm push \"${package_file}\" \"${chart_registry}\"" in publish_runs
+    assert "first-parent fallback" not in publish_runs
+    assert (
+        "unable to compare full pushed range; treating chart paths as changed"
+        in publish_runs
+    )
 
 
 def test_helm_workflow_checkout_has_history_for_push_diff() -> None:
@@ -175,9 +187,13 @@ def test_helm_workflow_checkout_has_history_for_push_diff() -> None:
         steps = _job_steps(workflow_data["jobs"][job_name])
         checkout_steps = [step for step in steps if step.get("uses") == "actions/checkout@v4"]
         assert checkout_steps, f"{job_name} must check out the repository"
-        assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0", (
+        checkout_with = checkout_steps[0].get("with", {})
+        assert checkout_with.get("fetch-depth") == "0", (
             f"{job_name} must fetch enough history for chart publish diff decisions"
         )
+        assert checkout_with.get("ref") == (
+            "${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}"
+        ), f"{job_name} must pin push checkouts to the triggering commit"
 
 
 def test_canonical_chart_version_is_bumped_for_main_latest_default() -> None:

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -157,7 +157,8 @@ def test_helm_workflow_publish_decision_is_idempotent() -> None:
     assert '".github/workflows/ci-helm.yml"' in publish_runs
     assert "helm show chart \"${CHART_REF}\" --version \"${CHART_VERSION}\"" in publish_runs
     assert "chart_lookup_status=not_found" in publish_runs
-    assert "grep -Eiq '(not found|404|manifest unknown|name unknown)'" in publish_runs
+    assert "is_confirmed_missing_chart" in publish_runs
+    assert "grep -Eiq '(not found|404|manifest unknown|name unknown)'" not in publish_runs
     assert "chart_lookup_status=error" in publish_runs
     assert "action=fail" in publish_runs
     assert (
@@ -182,6 +183,44 @@ def test_helm_workflow_publish_decision_is_idempotent() -> None:
         "Publish failed: manual publish requested but chart version ${CHART_VERSION} already exists; "
         "refusing to overwrite immutable OCI artifact."
     ) in workflow_text
+
+
+def test_helm_chart_lookup_only_confirms_canonical_missing_errors() -> None:
+    workflow_data = _load_workflow(WORKFLOW_DIR / "ci-helm.yml")
+    publish_runs = _step_runs(workflow_data["jobs"]["publish"])
+
+    assert "is_confirmed_missing_chart()" in publish_runs
+    assert 'elif is_confirmed_missing_chart "${chart_lookup_log}"; then' in publish_runs
+    assert "grep -Eiq '(not found|404|manifest unknown|name unknown)'" not in publish_runs
+    assert "404" not in publish_runs, (
+        "A bare HTTP 404 must not be sufficient to classify chart lookup output "
+        "as a confirmed missing chart"
+    )
+    assert "version[[:space:]]+[^[:space:]]+[[:space:]]+not found" in publish_runs
+    assert "chart version[[:space:]]+[^[:space:]]+[[:space:]]+not found" in publish_runs
+    assert "manifest unknown" in publish_runs
+    assert "name unknown" in publish_runs
+    assert "unauthorized" in publish_runs
+    assert "forbidden" in publish_runs
+    assert "rate limit" in publish_runs
+    assert "service unavailable" in publish_runs
+
+
+def test_helm_chart_lookup_errors_fail_closed_before_push() -> None:
+    workflow_text = (WORKFLOW_DIR / "ci-helm.yml").read_text(encoding="utf-8")
+    workflow_data = _load_workflow(WORKFLOW_DIR / "ci-helm.yml")
+    publish_runs = _step_runs(workflow_data["jobs"]["publish"])
+
+    assert 'if [[ "${chart_lookup_status}" == "error" ]]; then' in publish_runs
+    assert (
+        "registry lookup must succeed or return a confirmed not-found response before publishing"
+        in workflow_text
+    )
+    error_branch = publish_runs.split('if [[ "${chart_lookup_status}" == "error" ]]; then', 1)[1].split(
+        'elif [[ "${EVENT_NAME}" == "push" ]]; then', 1
+    )[0]
+    assert "action=fail" in error_branch
+    assert "action=publish" not in error_branch
 
 
 def test_helm_manual_publish_existing_chart_fails_instead_of_skipping() -> None:

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -190,12 +190,17 @@ def test_helm_chart_lookup_only_confirms_canonical_missing_errors() -> None:
     publish_runs = _step_runs(workflow_data["jobs"]["publish"])
 
     assert "is_confirmed_missing_chart()" in publish_runs
-    assert 'elif is_confirmed_missing_chart "${chart_lookup_log}"; then' in publish_runs
+    assert (
+        'elif is_confirmed_missing_chart "${chart_lookup_log}" "${CHART_VERSION}"; then'
+        in publish_runs
+    )
     assert "grep -Eiq '(not found|404|manifest unknown|name unknown)'" not in publish_runs
     assert "404" not in publish_runs, (
         "A bare HTTP 404 must not be sufficient to classify chart lookup output "
         "as a confirmed missing chart"
     )
+    assert 'grep -Fq ":${chart_version}: not found"' in publish_runs
+    assert 'grep -Fq "/manifests/${chart_version} not found:"' in publish_runs
     assert "version[[:space:]]+[^[:space:]]+[[:space:]]+not found" in publish_runs
     assert "chart version[[:space:]]+[^[:space:]]+[[:space:]]+not found" in publish_runs
     assert "manifest unknown" in publish_runs

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -138,6 +138,48 @@ def test_image_workflow_keeps_pull_request_validate_only() -> None:
     ), "ci-image.yml publish job must stay push-only so PR and workflow_dispatch runs validate only"
 
 
+def test_helm_workflow_publish_decision_is_idempotent() -> None:
+    workflow_text = (WORKFLOW_DIR / "ci-helm.yml").read_text(encoding="utf-8")
+    workflow_data = _load_workflow(WORKFLOW_DIR / "ci-helm.yml")
+    on_block = _workflow_on_block(workflow_data, "ci-helm.yml")
+
+    publish_input = on_block["workflow_dispatch"]["inputs"]["publish"]
+    assert publish_input["type"] == "boolean"
+    assert publish_input["default"] == "false"
+
+    publish_job = workflow_data["jobs"]["publish"]
+    publish_runs = _step_runs(publish_job)
+
+    assert "github.event_name != 'pull_request'" in publish_job["if"]
+    assert "chart_source_paths=(" in publish_runs
+    assert '"charts/tokenplace/**"' in publish_runs
+    assert "chart_related_paths=(" in publish_runs
+    assert '".github/workflows/ci-helm.yml"' in publish_runs
+    assert "helm show chart \"${CHART_REF}\" --version \"${CHART_VERSION}\"" in publish_runs
+    assert "action=fail" in publish_runs
+    assert (
+        "Publish failed: chart files changed but chart version ${CHART_VERSION} already exists; "
+        "bump charts/tokenplace/Chart.yaml version."
+    ) in workflow_text
+    assert (
+        "Publish skipped: chart version ${CHART_VERSION} already exists and no chart files changed."
+    ) in workflow_text
+    assert "steps.publish_decision.outputs.action == 'publish'" in workflow_text
+    assert "helm push \"${package_file}\" \"${chart_registry}\"" in publish_runs
+
+
+def test_helm_workflow_checkout_has_history_for_push_diff() -> None:
+    workflow_data = _load_workflow(WORKFLOW_DIR / "ci-helm.yml")
+
+    for job_name in ("validate-and-package", "publish"):
+        steps = _job_steps(workflow_data["jobs"][job_name])
+        checkout_steps = [step for step in steps if step.get("uses") == "actions/checkout@v4"]
+        assert checkout_steps, f"{job_name} must check out the repository"
+        assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0", (
+            f"{job_name} must fetch enough history for chart publish diff decisions"
+        )
+
+
 def test_canonical_chart_version_is_bumped_for_main_latest_default() -> None:
     chart = yaml.safe_load(
         Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Main-branch `ci-helm.yml` runs were failing when the current chart version already existed in GHCR even though the push did not introduce a chart release.  
- The workflow must keep validate/package coverage on PRs and manual runs while only publishing when a real new chart version was introduced.

### Description
- Add a `workflow_dispatch` boolean input `publish` and make manual dispatch default to validate/package-only, keeping publishing explicit via `publish=true` when desired.  
- Ensure full git history is fetched (`fetch-depth: 0`) in both `validate-and-package` and `publish` jobs so the workflow can diff `charts/tokenplace/**` and related docs to detect changes.  
- Add a `publish_decision` step that checks current chart version, whether that version exists in GHCR (`helm show chart`), whether chart source files changed, and whether chart-related files changed, then sets an action: `publish`, `skip`, or `fail`.  
- Only run `helm push` when the decision is `publish`; when chart files changed but the immutable version already exists the job fails with an actionable message; when nothing relevant changed and the version already exists the publish is a successful no-op; a summary is written to the workflow step summary in all cases.

### Testing
- Ran `python3 -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and all tests passed (`17 passed`).  
- Ran Helm checks locally: `helm lint charts/tokenplace`, `helm template ... > /tmp/tokenplace-render.yaml`, and `helm package charts/tokenplace --destination dist`, and they succeeded (chart packaged as `dist/tokenplace-0.1.1.tgz`).  
- Verified remote chart existence with `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.1`, which succeeded and returned the published chart metadata.  
- Ran `pre-commit run --all-files` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29f2817fd0832fa3713d21fc4fd93a)