### PR TITLE
Make Helm chart publish idempotent

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -12,9 +12,14 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Branch, tag, or SHA to publish
+        description: Branch, tag, or SHA to validate or publish
         required: false
         default: main
+      publish:
+        description: Publish this ref when the chart version is not already present
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   validate-and-package:
@@ -32,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -228,11 +234,11 @@ jobs:
       packages: write
 
     steps:
-      - name: Download packaged chart artifact
-        uses: actions/download-artifact@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          name: tokenplace-chart-package
-          path: dist
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -245,7 +251,162 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
+      - name: Decide whether to publish chart
+        id: decision
+        env:
+          CHART_REF: ${{ needs.validate-and-package.outputs.chart_ref }}
+          CHART_VERSION: ${{ needs.validate-and-package.outputs.chart_version }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BEFORE: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+          MANUAL_PUBLISH: ${{ inputs.publish && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+
+          chart_changed=false
+          related_changed=false
+          changed_chart_files=""
+          changed_related_files=""
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            zero_sha=0000000000000000000000000000000000000000
+            if [[ -n "${GITHUB_BEFORE}" && "${GITHUB_BEFORE}" != "${zero_sha}" ]]; then
+              base_ref="${GITHUB_BEFORE}"
+            elif git rev-parse "${GITHUB_SHA}^" >/dev/null 2>&1; then
+              base_ref="${GITHUB_SHA}^"
+            else
+              base_ref=""
+            fi
+
+            if [[ -n "${base_ref}" ]]; then
+              changed_chart_files="$(git diff --name-only "${base_ref}" "${GITHUB_SHA}" -- \
+                charts/tokenplace || true)"
+              changed_related_files="$(git diff --name-only "${base_ref}" "${GITHUB_SHA}" -- \
+                charts/tokenplace \
+                .github/workflows/ci-helm.yml || true)"
+            else
+              changed_chart_files="$(git diff-tree --no-commit-id --name-only -r "${GITHUB_SHA}" -- \
+                charts/tokenplace || true)"
+              changed_related_files="$(git diff-tree --no-commit-id --name-only -r "${GITHUB_SHA}" -- \
+                charts/tokenplace \
+                .github/workflows/ci-helm.yml || true)"
+            fi
+
+            # Only packaged chart source changes require a new immutable chart
+            # version. Workflow changes are chart-related for summaries and
+            # diff visibility, but do not alter the packaged chart artifact.
+            if [[ -n "${changed_chart_files}" ]]; then
+              chart_changed=true
+            fi
+            if [[ -n "${changed_related_files}" ]]; then
+              related_changed=true
+            fi
+          fi
+
+          chart_exists=false
+          show_output="$(mktemp)"
+          if helm show chart "${CHART_REF}" --version "${CHART_VERSION}" >"${show_output}" 2>&1; then
+            chart_exists=true
+          elif grep -Eiq 'not found|404|manifest unknown|name unknown' "${show_output}"; then
+            chart_exists=false
+          else
+            {
+              echo "## Helm chart publish decision"
+              echo ""
+              echo "Publish failed: unable to determine whether chart version ${CHART_VERSION} exists at ${CHART_REF}."
+              echo ""
+              echo '```'
+              cat "${show_output}"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            cat "${show_output}" >&2
+            exit 1
+          fi
+
+          should_publish=false
+          decision=""
+          case "${EVENT_NAME}" in
+            push)
+              if [[ "${chart_changed}" == "true" && "${chart_exists}" == "false" ]]; then
+                should_publish=true
+                decision="Publishing new chart version ${CHART_VERSION} to ${CHART_REF}."
+              elif [[ "${chart_changed}" == "true" && "${chart_exists}" == "true" ]]; then
+                decision="Publish failed: chart files changed but chart version ${CHART_VERSION} already exists; bump charts/tokenplace/Chart.yaml version."
+                {
+                  echo "## Helm chart publish decision"
+                  echo ""
+                  echo "${decision}"
+                  echo ""
+                  echo "Changed chart source files:"
+                  printf '%s\n' "${changed_chart_files}" | sed '/^$/d; s/^/- `/' | sed 's/$/`/'
+                } >> "$GITHUB_STEP_SUMMARY"
+                echo "${decision}" >&2
+                exit 1
+              elif [[ "${chart_changed}" == "false" && "${chart_exists}" == "true" ]]; then
+                decision="Publish skipped: chart version ${CHART_VERSION} already exists and no chart files changed."
+              else
+                decision="Publish skipped: chart version ${CHART_VERSION} is not present, but no chart files changed in this push."
+              fi
+              ;;
+            workflow_dispatch)
+              if [[ "${MANUAL_PUBLISH}" == "true" && "${chart_exists}" == "false" ]]; then
+                should_publish=true
+                decision="Publishing new chart version ${CHART_VERSION} to ${CHART_REF}."
+              elif [[ "${MANUAL_PUBLISH}" == "true" && "${chart_exists}" == "true" ]]; then
+                decision="Publish failed: manual publish requested, but chart version ${CHART_VERSION} already exists at ${CHART_REF}; refusing to overwrite immutable OCI artifact."
+                {
+                  echo "## Helm chart publish decision"
+                  echo ""
+                  echo "${decision}"
+                } >> "$GITHUB_STEP_SUMMARY"
+                echo "${decision}" >&2
+                exit 1
+              else
+                decision="Publish skipped: manual dispatch publish input was false; validation/package completed without publishing."
+              fi
+              ;;
+            *)
+              decision="Publish skipped: event ${EVENT_NAME} is not configured for chart publishing."
+              ;;
+          esac
+
+          {
+            echo "should_publish=${should_publish}"
+            echo "chart_exists=${chart_exists}"
+            echo "chart_changed=${chart_changed}"
+            echo "related_changed=${related_changed}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Helm chart publish decision"
+            echo ""
+            echo "${decision}"
+            echo ""
+            echo "Chart reference: \`${CHART_REF}\`"
+            echo "Chart version: \`${CHART_VERSION}\`"
+            echo "Chart version already exists: \`${chart_exists}\`"
+            echo "Chart source files changed: \`${chart_changed}\`"
+            echo "Chart-related files changed: \`${related_changed}\`"
+            if [[ -n "${changed_chart_files}" ]]; then
+              echo ""
+              echo "Changed chart source files:"
+              printf '%s\n' "${changed_chart_files}" | sed '/^$/d; s/^/- `/' | sed 's/$/`/'
+            fi
+            if [[ -n "${changed_related_files}" ]]; then
+              echo ""
+              echo "Changed chart-related files:"
+              printf '%s\n' "${changed_related_files}" | sed '/^$/d; s/^/- `/' | sed 's/$/`/'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download packaged chart artifact
+        if: steps.decision.outputs.should_publish == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: tokenplace-chart-package
+          path: dist
+
       - name: Push chart to OCI registry
+        if: steps.decision.outputs.should_publish == 'true'
         id: push
         run: |
           set -euo pipefail
@@ -254,14 +415,11 @@ jobs:
           test -f "${package_file}"
           chart_ref="${{ needs.validate-and-package.outputs.chart_ref }}"
           chart_registry="${chart_ref%/*}"
-          if helm show chart "${chart_ref}" --version "${{ needs.validate-and-package.outputs.chart_version }}" >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${{ needs.validate-and-package.outputs.chart_version }} already exists. Refusing to overwrite immutable OCI artifact; stop and resolve manually." >&2
-            exit 1
-          fi
           helm push "${package_file}" "${chart_registry}"
           echo "chart_ref=${chart_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Publish chart summary
+        if: steps.decision.outputs.should_publish == 'true'
         run: |
           {
             echo "## Helm chart published"


### PR DESCRIPTION
### Motivation
- Avoid CI failures when the workflow tries to publish an immutable chart version that already exists in GHCR while preserving validation/package checks on PRs and main pushes.
- Ensure we only publish when the packaged chart truly changed and the chart `version` is new, and fail clearly when chart sources changed without a version bump.

### Description
- Modified `.github/workflows/ci-helm.yml` to add a `workflow_dispatch` boolean input `publish` (default `false`) so manual dispatches validate/package by default without publishing.
- Use full-history checkouts (`fetch-depth: 0`) where diffs are computed so push diffs and `github.event.before` cases behave reliably.
- Added a publish-decision step that computes `changed_chart_files` (actual chart source changes) and `changed_related_files` (workflow/docs related to chart), probes GHCR with `helm show chart ... --version`, and sets `should_publish` accordingly.
- Conditionalize downloading the packaged artifact and `helm push` on the decision output, and emit clear summary lines and actionable failure messages when chart files changed but the immutable chart version already exists.

### Testing
- Ran `helm lint charts/tokenplace` — passed.
- Ran `helm template tokenplace charts/tokenplace --namespace tokenplace --set ingress.enabled=true --set ingress.host=staging.token.place --set image.tag=main-deadbee > /tmp/tokenplace-render.yaml` — rendered successfully.
- Ran `helm package charts/tokenplace --destination dist` which produced `dist/tokenplace-0.1.1.tgz` — succeeded.
- Validated workflow YAML with `python` YAML load and `actionlint .github/workflows/ci-helm.yml` — passed.
- Executed the publish-decision logic locally (mocking `GITHUB_*` env and GHCR probe) to verify the no-op path: existing `0.1.1` + no chart source changes => `Publish skipped` — succeeded.
- Ran `pre-commit run --all-files` (repository checks) — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29f2817fd0832fa3713d21fc4fd93a)