### PR TITLE
Add production promotion checklist and safe promotion smoke helper with tests

### DIFF
--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,0 +1,98 @@
+# token.place 0.1.0 production promotion checklist
+
+Use this checklist for every staging-to-prod promotion so high-risk launch
+behavior is verified the same way each time. The checks are intentionally
+operator-driven: they combine CI status, release-artifact provenance, desktop
+installer smoke tests, relay health checks, landing-chat routing checks, privacy
+invariants, and rollback readiness.
+
+## Before promoting
+
+- [ ] Confirm the promotion candidate is the exact commit, image digest, Helm
+      chart, and release artifact intended for production.
+- [ ] Confirm PR CI checks are green, including the Linux and macOS
+      `./run_all_tests.sh` pull-request checks.
+- [ ] Confirm desktop releases for Windows and macOS install successfully and
+      register as API v1 compute nodes against staging.
+- [ ] Confirm production secrets and relay registration tokens are present in the
+      production secret store and are not copied from staging logs or chat data.
+- [ ] Confirm rate-limit storage is configured for production persistence and
+      production environment settings are enabled.
+- [ ] Confirm the rollback path, including the previous production image/chart,
+      database or storage compatibility notes, and the operator who will execute
+      rollback if needed.
+
+## Staging smoke checks
+
+Run the read-only helper against staging when an externally reachable staging
+relay is available:
+
+```bash
+RUN_PROMOTION_SMOKE=1 TOKENPLACE_SMOKE_BASE_URL=https://staging.example.com \
+  python scripts/promotion_smoke.py
+```
+
+The helper is safe by default: without `RUN_PROMOTION_SMOKE=1` and an explicit
+`TOKENPLACE_SMOKE_BASE_URL` or `--base-url`, it skips instead of contacting live
+services. It only performs `GET` requests to JSON endpoints and never sends chat
+prompts, API keys, relay registration tokens, or user content.
+
+Manually verify the same candidate in staging:
+
+- [ ] Confirm `/livez` returns a healthy JSON response.
+- [ ] Confirm `/healthz` returns a healthy JSON response.
+- [ ] Confirm `/relay/diagnostics` reports the live compute-node count
+      accurately, including API v1 compute-node counts when present.
+- [ ] Confirm `/api/v1/models` returns exactly one public model:
+      `llama-3.1-8b-instruct`.
+- [ ] Confirm the landing-page model dropdown has exactly one model,
+      `llama-3.1-8b-instruct`.
+- [ ] Confirm the landing UI does not show `owned by token.place` or equivalent
+      model ownership copy.
+- [ ] Confirm two compute nodes round-robin across new browser clients.
+- [ ] Confirm one browser chat remains sticky to its selected compute server
+      across multiple turns.
+- [ ] Confirm stopping the sticky server causes automatic failover to another
+      live compute node without losing the visible chat history.
+- [ ] Confirm no full public key is rendered in the DOM; only short labels or
+      safe identifiers may appear.
+- [ ] Confirm landing-chat network traffic makes no `/api/v2` calls.
+- [ ] Confirm landing-chat network traffic makes no direct
+      `/api/v1/chat/completions` calls; the landing chat should use the API v1
+      E2EE relay envelope path.
+- [ ] Confirm relay-owned state, logs, diagnostics, and payloads remain
+      ciphertext-only plus safe routing metadata.
+
+## Production promotion
+
+- [ ] Promote the exact image digest, chart, and release artifact already smoked
+      in staging.
+- [ ] Confirm production `/livez`, `/healthz`, `/relay/diagnostics`, and
+      `/api/v1/models` using the optional helper or equivalent read-only checks:
+
+```bash
+RUN_PROMOTION_SMOKE=1 TOKENPLACE_SMOKE_BASE_URL=https://token.place \
+  python scripts/promotion_smoke.py
+```
+
+- [ ] Confirm desktop Windows and macOS compute nodes can register to production
+      using production relay registration tokens.
+- [ ] Repeat the landing-chat checks for model identity, absent ownership text,
+      sticky routing, automatic failover, no full DOM public key, no `/api/v2`
+      calls, and no direct `/api/v1/chat/completions` calls.
+- [ ] Record the production image/chart/artifact identifiers, smoke result,
+      current live node count, and rollback target in the release notes.
+
+## Rollback trigger examples
+
+Rollback rather than debug in production if any of these launch-contract checks
+fail after promotion:
+
+- `/api/v1/models` exposes anything other than the single public
+  `llama-3.1-8b-instruct` model.
+- Landing chat shows misleading ownership text such as `owned by token.place`.
+- Landing chat calls `/api/v2` or direct `/api/v1/chat/completions` paths.
+- Relay diagnostics expose plaintext prompt, response, tool, or model-output
+  content.
+- Sticky-server failover cannot move a chat to another live node without losing
+  history.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -207,6 +207,22 @@ Stress tests include:
 These tests are skipped by default in CI to keep build times reasonable, but can be
 enabled for release validation or when investigating performance regressions.
 
+
+### Promotion smoke checks
+
+Before promoting the 0.1.0 staging candidate to production, follow the repeatable
+[production promotion checklist](PRODUCTION_PROMOTION.md). When an external
+staging or production relay is available, the optional smoke helper can verify
+read-only JSON endpoints without sending prompts or secrets:
+
+```bash
+RUN_PROMOTION_SMOKE=1 TOKENPLACE_SMOKE_BASE_URL=https://staging.example.com \
+  python scripts/promotion_smoke.py
+```
+
+Normal local and CI test runs remain offline because the helper skips unless
+`RUN_PROMOTION_SMOKE=1` and an explicit target URL are configured.
+
 ## User Journeys and E2E Testing
 
 token.place tests are organized around key user journeys that represent how users interact with the system:

--- a/scripts/promotion_smoke.py
+++ b/scripts/promotion_smoke.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Optional staging/prod promotion smoke checks for token.place.
+
+The helper is safe-by-default: it only runs when RUN_PROMOTION_SMOKE=1 and a
+TOKENPLACE_SMOKE_BASE_URL target are both supplied. It checks read-only JSON
+endpoints and avoids sending prompts or secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+EXPECTED_MODEL_ID = "llama-3.1-8b-instruct"
+JSON_ENDPOINTS = ("/livez", "/healthz", "/relay/diagnostics", "/api/v1/models")
+
+
+class SmokeError(RuntimeError):
+    """Raised when a promotion smoke check fails."""
+
+
+@dataclass(frozen=True)
+class EndpointResult:
+    path: str
+    status: int
+    payload: Any
+
+
+def normalize_base_url(raw_url: str) -> str:
+    """Return a normalized http(s) base URL without query, fragment, or path."""
+    value = raw_url.strip()
+    if not value:
+        raise SmokeError("TOKENPLACE_SMOKE_BASE_URL must not be empty")
+
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise SmokeError("TOKENPLACE_SMOKE_BASE_URL must be an absolute http(s) URL")
+    if parsed.username or parsed.password:
+        raise SmokeError("TOKENPLACE_SMOKE_BASE_URL must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise SmokeError("TOKENPLACE_SMOKE_BASE_URL must not contain query strings or fragments")
+
+    return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+
+
+def endpoint_url(base_url: str, path: str) -> str:
+    """Build a smoke endpoint URL from a normalized base and absolute path."""
+    if not path.startswith("/"):
+        raise SmokeError(f"Smoke endpoint path must be absolute: {path}")
+    return urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+
+
+def fetch_json(base_url: str, path: str, timeout: float = 10.0) -> EndpointResult:
+    """Fetch a JSON endpoint and return the decoded payload."""
+    request = Request(
+        endpoint_url(base_url, path),
+        headers={"Accept": "application/json", "User-Agent": "tokenplace-promotion-smoke/0.1"},
+        method="GET",
+    )
+    try:
+        # normalize_base_url restricts smoke targets to operator-supplied http(s) URLs.
+        with urlopen(request, timeout=timeout) as response:  # nosec B310
+            status = int(response.status)
+            content_type = response.headers.get("Content-Type", "")
+            body = response.read()
+    except HTTPError as exc:
+        raise SmokeError(f"{path} returned HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise SmokeError(f"{path} request failed: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise SmokeError(f"{path} request timed out") from exc
+
+    if not 200 <= status < 300:
+        raise SmokeError(f"{path} returned HTTP {status}")
+    if "json" not in content_type.lower():
+        raise SmokeError(f"{path} did not return JSON content (Content-Type: {content_type or 'missing'})")
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SmokeError(f"{path} returned invalid JSON") from exc
+    return EndpointResult(path=path, status=status, payload=payload)
+
+
+def assert_health_payload(path: str, payload: Any) -> None:
+    """Validate a lightweight health/liveness payload."""
+    if not isinstance(payload, dict):
+        raise SmokeError(f"{path} payload must be a JSON object")
+    status = str(payload.get("status", "")).lower()
+    if status and status not in {"ok", "healthy", "live"}:
+        raise SmokeError(f"{path} reported unhealthy status: {payload.get('status')!r}")
+
+
+def assert_diagnostics_payload(payload: Any) -> None:
+    """Validate relay diagnostics count shape without exposing private material."""
+    if not isinstance(payload, dict):
+        raise SmokeError("/relay/diagnostics payload must be a JSON object")
+    for field in ("registered_compute_nodes", "total_registered_compute_nodes"):
+        if field not in payload:
+            raise SmokeError(f"/relay/diagnostics missing {field}")
+    nodes = payload["registered_compute_nodes"]
+    total = payload["total_registered_compute_nodes"]
+    if not isinstance(nodes, list):
+        raise SmokeError("/relay/diagnostics registered_compute_nodes must be a list")
+    if not isinstance(total, int) or total < 0:
+        raise SmokeError("/relay/diagnostics total_registered_compute_nodes must be a non-negative integer")
+    if total != len(nodes):
+        raise SmokeError("/relay/diagnostics total_registered_compute_nodes does not match registered_compute_nodes length")
+    api_v1_total = payload.get("total_api_v1_registered_compute_nodes")
+    api_v1_nodes = payload.get("api_v1_registered_compute_nodes")
+    if api_v1_total is not None and (not isinstance(api_v1_total, int) or api_v1_total < 0):
+        raise SmokeError("/relay/diagnostics total_api_v1_registered_compute_nodes must be non-negative when present")
+    if api_v1_nodes is not None and not isinstance(api_v1_nodes, list):
+        raise SmokeError("/relay/diagnostics api_v1_registered_compute_nodes must be a list when present")
+    if isinstance(api_v1_nodes, list) and isinstance(api_v1_total, int) and api_v1_total != len(api_v1_nodes):
+        raise SmokeError("/relay/diagnostics total_api_v1_registered_compute_nodes does not match api_v1_registered_compute_nodes length")
+
+
+def assert_models_payload(payload: Any) -> None:
+    """Validate the frozen public API v1 launch model catalog."""
+    if not isinstance(payload, dict):
+        raise SmokeError("/api/v1/models payload must be a JSON object")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise SmokeError("/api/v1/models data must be a list")
+    ids = [model.get("id") for model in data if isinstance(model, dict)]
+    if ids != [EXPECTED_MODEL_ID]:
+        raise SmokeError(
+            "/api/v1/models must return exactly one public model: "
+            f"{EXPECTED_MODEL_ID}; got {ids!r}"
+        )
+    owner = data[0].get("owned_by")
+    if isinstance(owner, str) and "token.place" in owner.lower():
+        raise SmokeError('/api/v1/models must not claim the launch model is "owned by token.place"')
+
+
+def validate_endpoint_result(result: EndpointResult) -> None:
+    if result.path in {"/livez", "/healthz"}:
+        assert_health_payload(result.path, result.payload)
+    elif result.path == "/relay/diagnostics":
+        assert_diagnostics_payload(result.payload)
+    elif result.path == "/api/v1/models":
+        assert_models_payload(result.payload)
+    else:
+        raise SmokeError(f"Unexpected smoke endpoint: {result.path}")
+
+
+def run_smoke(base_url: str, timeout: float = 10.0) -> list[EndpointResult]:
+    normalized = normalize_base_url(base_url)
+    results = [fetch_json(normalized, path, timeout=timeout) for path in JSON_ENDPOINTS]
+    for result in results:
+        validate_endpoint_result(result)
+    return results
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run optional token.place promotion smoke checks.")
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("TOKENPLACE_SMOKE_BASE_URL", ""),
+        help="Staging/prod relay base URL. Defaults to TOKENPLACE_SMOKE_BASE_URL.",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0, help="Per-request timeout in seconds.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    if os.environ.get("RUN_PROMOTION_SMOKE") != "1":
+        print("Skipping promotion smoke checks: set RUN_PROMOTION_SMOKE=1 to enable.")
+        return 0
+
+    args = _build_parser().parse_args(argv)
+    if not args.base_url:
+        print("Skipping promotion smoke checks: set TOKENPLACE_SMOKE_BASE_URL or pass --base-url.")
+        return 0
+
+    try:
+        results = run_smoke(args.base_url, timeout=args.timeout)
+    except SmokeError as exc:
+        print(f"Promotion smoke failed: {exc}", file=sys.stderr)
+        return 1
+
+    for result in results:
+        print(f"ok {result.path} HTTP {result.status}")
+    print("Promotion smoke checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_promotion_smoke.py
+++ b/tests/unit/test_promotion_smoke.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "promotion_smoke.py"
+spec = importlib.util.spec_from_file_location("promotion_smoke", MODULE_PATH)
+promotion_smoke = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = promotion_smoke
+spec.loader.exec_module(promotion_smoke)
+
+
+def test_normalize_base_url_accepts_http_and_strips_path() -> None:
+    assert promotion_smoke.normalize_base_url(" https://staging.example.com/relay ") == "https://staging.example.com"
+    assert promotion_smoke.endpoint_url("https://staging.example.com", "/api/v1/models") == "https://staging.example.com/api/v1/models"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "staging.example.com",
+        "ftp://staging.example.com",
+        "https://user:secret@staging.example.com",
+        "https://staging.example.com?token=secret",
+        "https://staging.example.com/#fragment",
+    ],
+)
+def test_normalize_base_url_rejects_unsafe_or_ambiguous_targets(url: str) -> None:
+    with pytest.raises(promotion_smoke.SmokeError):
+        promotion_smoke.normalize_base_url(url)
+
+
+def test_diagnostics_payload_requires_count_to_match_node_list() -> None:
+    promotion_smoke.assert_diagnostics_payload(
+        {
+            "registered_compute_nodes": [{"server_public_key": "short-safe-label"}],
+            "total_registered_compute_nodes": 1,
+            "api_v1_registered_compute_nodes": [{"server_public_key": "short-safe-label"}],
+            "total_api_v1_registered_compute_nodes": 1,
+        }
+    )
+
+    with pytest.raises(promotion_smoke.SmokeError, match="does not match"):
+        promotion_smoke.assert_diagnostics_payload(
+            {"registered_compute_nodes": [], "total_registered_compute_nodes": 1}
+        )
+
+
+def test_models_payload_freezes_single_public_launch_model() -> None:
+    promotion_smoke.assert_models_payload(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": "llama-3.1-8b-instruct",
+                    "object": "model",
+                    "owned_by": "Meta",
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(promotion_smoke.SmokeError, match="exactly one public model"):
+        promotion_smoke.assert_models_payload(
+            {
+                "object": "list",
+                "data": [
+                    {"id": "llama-3.1-8b-instruct", "object": "model"},
+                    {"id": "llama-3.1-8b-instruct:alignment", "object": "model"},
+                ],
+            }
+        )
+
+    with pytest.raises(promotion_smoke.SmokeError, match="owned by token.place"):
+        promotion_smoke.assert_models_payload(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "llama-3.1-8b-instruct",
+                        "object": "model",
+                        "owned_by": "owned by token.place",
+                    }
+                ],
+            }
+        )
+
+
+def test_main_skips_without_explicit_enablement(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.delenv("RUN_PROMOTION_SMOKE", raising=False)
+    monkeypatch.setenv("TOKENPLACE_SMOKE_BASE_URL", "https://staging.example.com")
+
+    assert promotion_smoke.main([]) == 0
+    assert "Skipping promotion smoke checks" in capsys.readouterr().out

--- a/tests/unit/test_testing_documentation.py
+++ b/tests/unit/test_testing_documentation.py
@@ -24,3 +24,45 @@ def test_testing_guide_mentions_all_markers() -> None:
     assert not missing, (
         "docs/TESTING.md should document each pytest marker. Missing: " + ", ".join(missing)
     )
+
+
+def test_production_promotion_checklist_covers_0_1_0_smoke_risks() -> None:
+    promotion_doc = Path("docs/PRODUCTION_PROMOTION.md").read_text(encoding="utf-8")
+
+    required_phrases = [
+        "Linux and macOS",
+        "./run_all_tests.sh",
+        "Windows and macOS",
+        "/livez",
+        "/healthz",
+        "/relay/diagnostics",
+        "live compute-node count",
+        "/api/v1/models",
+        "exactly one public model",
+        "llama-3.1-8b-instruct",
+        "landing-page model dropdown has exactly one model",
+        "owned by token.place",
+        "round-robin",
+        "sticky",
+        "automatic failover",
+        "without losing the visible chat history",
+        "no full public key is rendered in the DOM",
+        "no `/api/v2` calls",
+        "no direct `/api/v1/chat/completions` calls",
+        "production secrets and relay registration tokens",
+        "rate-limit storage",
+        "rollback path",
+        "ciphertext-only plus safe routing metadata",
+    ]
+    missing = [phrase for phrase in required_phrases if phrase not in promotion_doc]
+    assert not missing, "docs/PRODUCTION_PROMOTION.md is missing: " + ", ".join(missing)
+
+
+def test_testing_guide_links_safe_promotion_smoke_helper() -> None:
+    testing_doc = Path("docs/TESTING.md").read_text(encoding="utf-8")
+
+    assert "PRODUCTION_PROMOTION.md" in testing_doc
+    assert "RUN_PROMOTION_SMOKE=1" in testing_doc
+    assert "TOKENPLACE_SMOKE_BASE_URL" in testing_doc
+    assert "python scripts/promotion_smoke.py" in testing_doc
+    assert "remain offline" in testing_doc


### PR DESCRIPTION
### Motivation

- Provide a repeatable, operator-driven staging→prod promotion checklist for v0.1.0 that captures high-risk launch invariants (model identity, landing UI copy, live node counts, sticky routing, failover, and relay privacy). 
- Offer a lightweight, opt-in smoke helper so operators can run the same read-only checks against staging or prod without sending prompts or secrets.

### Description

- Added a safe-by-default smoke helper at `scripts/promotion_smoke.py` which only runs when `RUN_PROMOTION_SMOKE=1` and `TOKENPLACE_SMOKE_BASE_URL` (or `--base-url`) are set, and which polls JSON endpoints `/livez`, `/healthz`, `/relay/diagnostics`, and `/api/v1/models` and validates expected shapes and invariants (including exactly one public model `llama-3.1-8b-instruct` and absence of `owned by token.place`).
- Added formal promotion documentation at `docs/PRODUCTION_PROMOTION.md` with a staging smoke checklist and recommended operator steps, and added a short cross-reference/usage blurb into `docs/TESTING.md`.
- Added unit tests `tests/unit/test_promotion_smoke.py` for URL normalization, endpoint validators, and the main skip-guard, and augmented `tests/unit/test_testing_documentation.py` with `test_production_promotion_checklist_covers_0_1_0_smoke_risks` and a test to assert `docs/TESTING.md` links to the helper.
- Kept the helper read-only and non-invasive (only `GET` JSON endpoints, no prompts/keys), and did not change runtime product behavior or CI gates.

### Testing

- Ran the new unit tests with `python -m pytest tests/unit/test_promotion_smoke.py tests/unit/test_testing_documentation.py -v` and they passed (all tests in those files succeeded after a minor import guard in the test harness). 
- Ran documentation-focused tests with `python -m pytest tests/unit/test_docs_* tests/unit/test_testing_documentation.py -v` and they passed. 
- Executed `python -m pytest tests/unit/test_promotion_smoke.py -v && python -m pytest tests/unit/test_api_v1_launch_contract.py -v` and both suites passed. 
- Ran the repo-standard integration and full-suite runner (`npm run test:js` and `./run_all_tests.sh`), which installed Playwright browsers as needed and completed; the test runs completed successfully (Python unit suite and integration suites run by `./run_all_tests.sh` finished without failures: e.g. full unit run reported `1421 passed, 1 skipped`, integration `20 passed, 1 skipped`).

Residual notes and follow-ups: Playwright-based e2e browser tests require local Playwright browser binaries; `./run_all_tests.sh` installs these automatically (the smoke helper does not rely on Playwright). No production behavior was changed by this PR; the helper and docs are opt-in and safe-by-default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29efef3144832f96b59ea5dc6af8f6)