### PR TITLE
Add repeatable staging→prod promotion checklist and opt-in smoke helper

### DIFF
--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,0 +1,113 @@
+# token.place 0.1.0 staging-to-production promotion checklist
+
+Use this checklist for every `v0.1.0` relay promotion from staging to production. It is intentionally
+repeatable and focused on the launch risks that have regressed before: API v1 model identity,
+landing-chat routing, relay-blind E2EE privacy, live compute-node diagnostics, production secrets,
+and rollback readiness.
+
+## Promotion rules
+
+- Promote only an already-verified staging artifact. Do not rebuild between staging sign-off and
+  production unless the new artifact repeats this checklist from the beginning.
+- Keep API v1 as the only active runtime target for `v0.1.0`; it is non-streaming by design.
+- Keep relay-owned state, logs, diagnostics, and payloads ciphertext-only plus safe routing metadata.
+  Never capture or paste plaintext prompts, messages, responses, tool arguments, or model output.
+- Use synthetic smoke prompts only; do not send sensitive, customer, or private content.
+- Record exact artifact identifiers, environment URLs, command output summaries, and rollback steps
+  in the release notes or promotion issue.
+
+## Pre-promotion gates
+
+- [ ] Confirm PR CI checks are green, including the Linux and macOS `run_all_tests.sh` PR checks.
+- [ ] Confirm the staging deployment image, chart, and release artifact are exactly the ones intended
+      for production promotion; prefer immutable image tags and chart versions, plus a digest where
+      available.
+- [ ] Confirm desktop releases for Windows and macOS install successfully and register as compute
+      nodes against staging.
+- [ ] Confirm production secrets and relay registration tokens are set for the production target.
+- [ ] Confirm rate-limit storage and production environment settings are configured for production,
+      not in-memory or development defaults unless an approved temporary launch exception is recorded.
+- [ ] Confirm the rollback path, including the previous known-good image/chart/artifact identifiers,
+      command owner, expected recovery time, and any data/state caveats.
+
+## Staging smoke checklist
+
+Run these checks against staging before production promotion:
+
+- [ ] `GET /livez` returns healthy JSON (`status: alive`).
+- [ ] `GET /healthz` returns healthy JSON (`status: ok`) and no unexpected degraded details.
+- [ ] `GET /relay/diagnostics` reports the live compute-node count accurately, including
+      `total_api_v1_registered_compute_nodes`.
+- [ ] `GET /api/v1/models` returns exactly one public model: `llama-3.1-8b-instruct`.
+- [ ] The landing page model dropdown has exactly one model.
+- [ ] The landing UI does not show `owned by token.place`.
+- [ ] Two compute nodes round-robin across new browser clients.
+- [ ] One browser chat remains sticky to its selected server across multiple turns.
+- [ ] Stopping the sticky server causes automatic failover to another available compute node without
+      losing chat history.
+- [ ] No full public key is rendered in the DOM; only safe key labels/fingerprints may appear.
+- [ ] Landing chat makes no `/api/v2` calls.
+- [ ] Landing chat makes no `/api/v1/chat/completions` calls; it must use the API v1 relay envelope
+      routes instead of the server-side chat-completions selector.
+- [ ] Relay logs and diagnostics remain relay-blind: ciphertext only plus safe routing metadata, with
+      no plaintext prompts, messages, responses, tool arguments, or model output.
+
+## Production post-promotion smoke checklist
+
+After production deployment, repeat the same external checks against production before announcing the
+promotion complete:
+
+- [ ] `GET /livez` returns healthy JSON (`status: alive`).
+- [ ] `GET /healthz` returns healthy JSON (`status: ok`) and no unexpected degraded details.
+- [ ] `GET /relay/diagnostics` reports the live compute-node count accurately, including
+      `total_api_v1_registered_compute_nodes`.
+- [ ] `GET /api/v1/models` returns exactly one public model: `llama-3.1-8b-instruct`.
+- [ ] The landing page model dropdown has exactly one model.
+- [ ] The landing UI does not show `owned by token.place`.
+- [ ] Two compute nodes round-robin across new browser clients.
+- [ ] One browser chat remains sticky to its selected server across multiple turns.
+- [ ] Stopping the sticky server causes automatic failover to another available compute node without
+      losing chat history.
+- [ ] No full public key is rendered in the DOM.
+- [ ] Landing chat makes no `/api/v2` calls.
+- [ ] Landing chat makes no `/api/v1/chat/completions` calls.
+- [ ] Prod secrets, relay registration tokens, rate-limit storage, and production environment settings
+      are still present after rollout.
+- [ ] Rollback remains available until the production smoke window is complete.
+
+## Optional JSON endpoint smoke helper
+
+`scripts/promotion_smoke.py` provides a small offline-testable harness for the JSON endpoint portion
+of the checklist. It does not run during normal tests and refuses to contact any live target unless it
+is explicitly enabled.
+
+Staging example:
+
+```bash
+RUN_PROMOTION_SMOKE=1 \
+TOKENPLACE_SMOKE_ENV=staging \
+TOKENPLACE_SMOKE_BASE_URL=https://staging.token.place \
+python scripts/promotion_smoke.py
+```
+
+Production requires an additional explicit acknowledgement:
+
+```bash
+RUN_PROMOTION_SMOKE=1 \
+TOKENPLACE_SMOKE_ENV=production \
+TOKENPLACE_SMOKE_ALLOW_PROD=1 \
+TOKENPLACE_SMOKE_BASE_URL=https://token.place \
+python scripts/promotion_smoke.py
+```
+
+The helper checks only safe JSON endpoints:
+
+- `/livez`
+- `/healthz`
+- `/relay/diagnostics`
+- `/api/v1/models`
+
+Browser-only checklist items such as dropdown count, missing owner text, no full public key in the
+DOM, no landing-chat `/api/v2` calls, no landing-chat `/api/v1/chat/completions` calls, sticky
+routing, two-node round-robin, and automatic history-preserving failover still require the Playwright
+or manual browser evidence listed above.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -355,6 +355,30 @@ To add a new visual test:
    ```
 5. Capture screenshots and compare with baselines or create new ones
 
+## Promotion smoke checks
+
+The repeatable `v0.1.0` staging-to-production checklist lives in
+[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md). It covers the release-specific
+smoke risks for API v1 model identity (`llama-3.1-8b-instruct` as the only public
+model), landing dropdown count, absence of `owned by token.place`, live
+compute-node diagnostics, two-node round-robin, sticky server routing, automatic
+history-preserving failover, relay-blind privacy invariants, production secrets,
+rate-limit storage, and rollback readiness.
+
+For endpoint-only external smoke checks, use the opt-in helper:
+
+```bash
+RUN_PROMOTION_SMOKE=1 \
+TOKENPLACE_SMOKE_ENV=staging \
+TOKENPLACE_SMOKE_BASE_URL=https://staging.token.place \
+python scripts/promotion_smoke.py
+```
+
+The helper is safe by default: normal test runs never contact live services, and
+production-looking targets require `TOKENPLACE_SMOKE_ALLOW_PROD=1`. It validates
+`/livez`, `/healthz`, `/relay/diagnostics`, and `/api/v1/models` without sending
+prompts or touching chat-completion routes.
+
 ## Test Coverage and Continuous Integration
 
 token.place uses pytest-cov to track test coverage:

--- a/scripts/promotion_smoke.py
+++ b/scripts/promotion_smoke.py
@@ -48,7 +48,7 @@ def _env_truthy(value: str | None) -> bool:
 
 
 def normalize_base_url(raw_base_url: str) -> str:
-    """Validate and normalize a configured HTTP(S) base URL."""
+    """Validate and normalize a configured HTTP(S) root base URL."""
     raw = raw_base_url.strip()
     if not raw:
         raise SmokeConfigError(f"{BASE_URL_ENV} must not be empty")
@@ -57,20 +57,35 @@ def normalize_base_url(raw_base_url: str) -> str:
         raise SmokeConfigError(f"{BASE_URL_ENV} must use http:// or https://")
     if not parsed.netloc:
         raise SmokeConfigError(f"{BASE_URL_ENV} must include a host")
-    return raw.rstrip("/") + "/"
+    if parsed.path.strip("/"):
+        raise SmokeConfigError(f"{BASE_URL_ENV} must not include a path")
+    if parsed.params or parsed.query or parsed.fragment:
+        raise SmokeConfigError(
+            f"{BASE_URL_ENV} must not include params, query, or fragment"
+        )
+    return f"{parsed.scheme}://{parsed.netloc.rstrip('/')}" + "/"
 
 
 def _looks_like_prod(base_url: str, environment: str) -> bool:
-    host = urlparse(base_url).hostname or ""
+    host = (urlparse(base_url).hostname or "").lower()
     env = environment.strip().lower()
-    return env in {"prod", "production"} or host in {"token.place", "www.token.place"}
+    labels = set(host.split("."))
+    production_hosts = {"token.place", "www.token.place"}
+    return (
+        env in {"prod", "production"}
+        or host in production_hosts
+        or (host.endswith(".token.place") and host != "staging.token.place")
+        or bool(labels & {"prod", "production"})
+    )
 
 
 def config_from_env(env: dict[str, str] | None = None) -> SmokeConfig:
     """Build a safe smoke configuration from environment variables."""
     values = os.environ if env is None else env
     if not _env_truthy(values.get(ENABLE_ENV)):
-        raise SmokeConfigError(f"Set {ENABLE_ENV}=1 to run external promotion smoke checks")
+        raise SmokeConfigError(
+            f"Set {ENABLE_ENV}=1 to run external promotion smoke checks"
+        )
     base_url = normalize_base_url(values.get(BASE_URL_ENV, ""))
     environment = values.get(ENVIRONMENT_ENV, "staging").strip().lower() or "staging"
     allow_prod = _env_truthy(values.get(ALLOW_PROD_ENV))
@@ -78,14 +93,16 @@ def config_from_env(env: dict[str, str] | None = None) -> SmokeConfig:
         raise SmokeConfigError(
             f"Refusing production-looking target without {ALLOW_PROD_ENV}=1"
         )
-    return SmokeConfig(base_url=base_url, environment=environment, allow_prod=allow_prod)
+    return SmokeConfig(
+        base_url=base_url, environment=environment, allow_prod=allow_prod
+    )
 
 
 def endpoint_url(base_url: str, endpoint: str) -> str:
     """Join a normalized or raw base URL with a root-relative endpoint."""
     if not endpoint.startswith("/"):
         raise SmokeConfigError("endpoint must be root-relative")
-    return urljoin(normalize_base_url(base_url), endpoint.lstrip("/"))
+    return urljoin(normalize_base_url(base_url), endpoint)
 
 
 def validate_livez(payload: Any) -> None:
@@ -96,20 +113,32 @@ def validate_livez(payload: Any) -> None:
 def validate_healthz(payload: Any) -> None:
     if not isinstance(payload, dict) or payload.get("status") != "ok":
         raise SmokeCheckError("/healthz must return JSON status=ok")
+    details = payload.get("details")
+    if details:
+        raise SmokeCheckError("/healthz must not include degraded details")
 
 
 def validate_diagnostics(payload: Any) -> None:
     if not isinstance(payload, dict):
         raise SmokeCheckError("/relay/diagnostics must return a JSON object")
-    required = ("total_registered_compute_nodes", "total_api_v1_registered_compute_nodes")
+    required = (
+        "total_registered_compute_nodes",
+        "total_api_v1_registered_compute_nodes",
+    )
     for key in required:
         value = payload.get(key)
         if not isinstance(value, int) or value < 0:
-            raise SmokeCheckError(f"/relay/diagnostics {key} must be a non-negative integer")
+            raise SmokeCheckError(
+                f"/relay/diagnostics {key} must be a non-negative integer"
+            )
     nodes = payload.get("api_v1_registered_compute_nodes")
     if nodes is not None and not isinstance(nodes, list):
-        raise SmokeCheckError("/relay/diagnostics api_v1_registered_compute_nodes must be a list")
-    if isinstance(nodes, list) and payload["total_api_v1_registered_compute_nodes"] != len(nodes):
+        raise SmokeCheckError(
+            "/relay/diagnostics api_v1_registered_compute_nodes must be a list"
+        )
+    if isinstance(nodes, list) and payload[
+        "total_api_v1_registered_compute_nodes"
+    ] != len(nodes):
         raise SmokeCheckError(
             "/relay/diagnostics total_api_v1_registered_compute_nodes must match listed nodes"
         )
@@ -117,11 +146,15 @@ def validate_diagnostics(payload: Any) -> None:
 
 def validate_models(payload: Any) -> None:
     if not isinstance(payload, dict) or payload.get("object") != "list":
-        raise SmokeCheckError("/api/v1/models must return an OpenAI-compatible list object")
+        raise SmokeCheckError(
+            "/api/v1/models must return an OpenAI-compatible list object"
+        )
     data = payload.get("data")
     if not isinstance(data, list):
         raise SmokeCheckError("/api/v1/models data must be a list")
-    ids = [model.get("id") for model in data if isinstance(model, dict)]
+    if not all(isinstance(model, dict) for model in data):
+        raise SmokeCheckError("/api/v1/models data entries must be objects")
+    ids = [model.get("id") for model in data]
     if ids != [EXPECTED_MODEL_ID]:
         raise SmokeCheckError(
             f"/api/v1/models must expose exactly [{EXPECTED_MODEL_ID!r}], got {ids!r}"
@@ -140,9 +173,17 @@ VALIDATORS = {
 
 
 def fetch_json(url: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> Any:
-    request = Request(url, headers={"Accept": "application/json", "User-Agent": "tokenplace-promotion-smoke/1"})
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "tokenplace-promotion-smoke/1",
+        },
+    )
     try:
-        with urlopen(request, timeout=timeout_seconds) as response:  # nosec B310 - explicit operator URL only
+        with urlopen(
+            request, timeout=timeout_seconds
+        ) as response:  # nosec B310 - explicit operator URL only
             status = getattr(response, "status", response.getcode())
             body = response.read().decode("utf-8")
     except HTTPError as exc:  # pragma: no cover - unit tests exercise via fake fetchers
@@ -166,8 +207,13 @@ def run_smoke_checks(
     """Run configured endpoint checks and return human-readable successes."""
     successes: list[str] = []
     for endpoint in endpoints:
-        payload = fetcher(endpoint_url(config.base_url, endpoint), config.timeout_seconds)
-        VALIDATORS[endpoint](payload)
+        validator = VALIDATORS.get(endpoint)
+        if validator is None:
+            raise SmokeConfigError(f"Unsupported smoke endpoint: {endpoint}")
+        payload = fetcher(
+            endpoint_url(config.base_url, endpoint), config.timeout_seconds
+        )
+        validator(payload)
         successes.append(f"{endpoint} ok")
     return successes
 

--- a/scripts/promotion_smoke.py
+++ b/scripts/promotion_smoke.py
@@ -121,27 +121,29 @@ def validate_healthz(payload: Any) -> None:
 def validate_diagnostics(payload: Any) -> None:
     if not isinstance(payload, dict):
         raise SmokeCheckError("/relay/diagnostics must return a JSON object")
-    required = (
+    required_totals = (
         "total_registered_compute_nodes",
         "total_api_v1_registered_compute_nodes",
     )
-    for key in required:
+    for key in required_totals:
         value = payload.get(key)
         if not isinstance(value, int) or value < 0:
             raise SmokeCheckError(
                 f"/relay/diagnostics {key} must be a non-negative integer"
             )
-    nodes = payload.get("api_v1_registered_compute_nodes")
-    if nodes is not None and not isinstance(nodes, list):
-        raise SmokeCheckError(
-            "/relay/diagnostics api_v1_registered_compute_nodes must be a list"
-        )
-    if isinstance(nodes, list) and payload[
-        "total_api_v1_registered_compute_nodes"
-    ] != len(nodes):
-        raise SmokeCheckError(
-            "/relay/diagnostics total_api_v1_registered_compute_nodes must match listed nodes"
-        )
+
+    required_lists = (
+        ("registered_compute_nodes", "total_registered_compute_nodes"),
+        ("api_v1_registered_compute_nodes", "total_api_v1_registered_compute_nodes"),
+    )
+    for list_key, total_key in required_lists:
+        nodes = payload.get(list_key)
+        if not isinstance(nodes, list):
+            raise SmokeCheckError(f"/relay/diagnostics {list_key} must be a list")
+        if payload[total_key] != len(nodes):
+            raise SmokeCheckError(
+                f"/relay/diagnostics {total_key} must match {list_key} length"
+            )
 
 
 def validate_models(payload: Any) -> None:

--- a/scripts/promotion_smoke.py
+++ b/scripts/promotion_smoke.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Optional external staging/prod smoke checks for token.place promotion.
+
+The module is safe to import in normal tests. The CLI intentionally refuses to
+contact live services unless RUN_PROMOTION_SMOKE=1 and TOKENPLACE_SMOKE_BASE_URL
+are both set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+EXPECTED_MODEL_ID = "llama-3.1-8b-instruct"
+ENABLE_ENV = "RUN_PROMOTION_SMOKE"
+BASE_URL_ENV = "TOKENPLACE_SMOKE_BASE_URL"
+ENVIRONMENT_ENV = "TOKENPLACE_SMOKE_ENV"
+ALLOW_PROD_ENV = "TOKENPLACE_SMOKE_ALLOW_PROD"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+JSON_ENDPOINTS = ("/livez", "/healthz", "/relay/diagnostics", "/api/v1/models")
+
+
+class SmokeConfigError(ValueError):
+    """Raised when smoke checks are not explicitly and safely configured."""
+
+
+class SmokeCheckError(AssertionError):
+    """Raised when an endpoint responds but violates the promotion contract."""
+
+
+@dataclass(frozen=True)
+class SmokeConfig:
+    base_url: str
+    environment: str
+    allow_prod: bool = False
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+
+
+def _env_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def normalize_base_url(raw_base_url: str) -> str:
+    """Validate and normalize a configured HTTP(S) base URL."""
+    raw = raw_base_url.strip()
+    if not raw:
+        raise SmokeConfigError(f"{BASE_URL_ENV} must not be empty")
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"}:
+        raise SmokeConfigError(f"{BASE_URL_ENV} must use http:// or https://")
+    if not parsed.netloc:
+        raise SmokeConfigError(f"{BASE_URL_ENV} must include a host")
+    return raw.rstrip("/") + "/"
+
+
+def _looks_like_prod(base_url: str, environment: str) -> bool:
+    host = urlparse(base_url).hostname or ""
+    env = environment.strip().lower()
+    return env in {"prod", "production"} or host in {"token.place", "www.token.place"}
+
+
+def config_from_env(env: dict[str, str] | None = None) -> SmokeConfig:
+    """Build a safe smoke configuration from environment variables."""
+    values = os.environ if env is None else env
+    if not _env_truthy(values.get(ENABLE_ENV)):
+        raise SmokeConfigError(f"Set {ENABLE_ENV}=1 to run external promotion smoke checks")
+    base_url = normalize_base_url(values.get(BASE_URL_ENV, ""))
+    environment = values.get(ENVIRONMENT_ENV, "staging").strip().lower() or "staging"
+    allow_prod = _env_truthy(values.get(ALLOW_PROD_ENV))
+    if _looks_like_prod(base_url, environment) and not allow_prod:
+        raise SmokeConfigError(
+            f"Refusing production-looking target without {ALLOW_PROD_ENV}=1"
+        )
+    return SmokeConfig(base_url=base_url, environment=environment, allow_prod=allow_prod)
+
+
+def endpoint_url(base_url: str, endpoint: str) -> str:
+    """Join a normalized or raw base URL with a root-relative endpoint."""
+    if not endpoint.startswith("/"):
+        raise SmokeConfigError("endpoint must be root-relative")
+    return urljoin(normalize_base_url(base_url), endpoint.lstrip("/"))
+
+
+def validate_livez(payload: Any) -> None:
+    if not isinstance(payload, dict) or payload.get("status") != "alive":
+        raise SmokeCheckError("/livez must return JSON status=alive")
+
+
+def validate_healthz(payload: Any) -> None:
+    if not isinstance(payload, dict) or payload.get("status") != "ok":
+        raise SmokeCheckError("/healthz must return JSON status=ok")
+
+
+def validate_diagnostics(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise SmokeCheckError("/relay/diagnostics must return a JSON object")
+    required = ("total_registered_compute_nodes", "total_api_v1_registered_compute_nodes")
+    for key in required:
+        value = payload.get(key)
+        if not isinstance(value, int) or value < 0:
+            raise SmokeCheckError(f"/relay/diagnostics {key} must be a non-negative integer")
+    nodes = payload.get("api_v1_registered_compute_nodes")
+    if nodes is not None and not isinstance(nodes, list):
+        raise SmokeCheckError("/relay/diagnostics api_v1_registered_compute_nodes must be a list")
+    if isinstance(nodes, list) and payload["total_api_v1_registered_compute_nodes"] != len(nodes):
+        raise SmokeCheckError(
+            "/relay/diagnostics total_api_v1_registered_compute_nodes must match listed nodes"
+        )
+
+
+def validate_models(payload: Any) -> None:
+    if not isinstance(payload, dict) or payload.get("object") != "list":
+        raise SmokeCheckError("/api/v1/models must return an OpenAI-compatible list object")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise SmokeCheckError("/api/v1/models data must be a list")
+    ids = [model.get("id") for model in data if isinstance(model, dict)]
+    if ids != [EXPECTED_MODEL_ID]:
+        raise SmokeCheckError(
+            f"/api/v1/models must expose exactly [{EXPECTED_MODEL_ID!r}], got {ids!r}"
+        )
+    owner = data[0].get("owned_by")
+    if owner != "Meta":
+        raise SmokeCheckError("/api/v1/models launch model must be owned_by=Meta")
+
+
+VALIDATORS = {
+    "/livez": validate_livez,
+    "/healthz": validate_healthz,
+    "/relay/diagnostics": validate_diagnostics,
+    "/api/v1/models": validate_models,
+}
+
+
+def fetch_json(url: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    request = Request(url, headers={"Accept": "application/json", "User-Agent": "tokenplace-promotion-smoke/1"})
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:  # nosec B310 - explicit operator URL only
+            status = getattr(response, "status", response.getcode())
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:  # pragma: no cover - unit tests exercise via fake fetchers
+        raise SmokeCheckError(f"{url} returned HTTP {exc.code}") from exc
+    except URLError as exc:  # pragma: no cover - unit tests exercise via fake fetchers
+        raise SmokeCheckError(f"{url} request failed: {exc.reason}") from exc
+    if status != 200:
+        raise SmokeCheckError(f"{url} returned HTTP {status}")
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SmokeCheckError(f"{url} did not return valid JSON") from exc
+
+
+def run_smoke_checks(
+    config: SmokeConfig,
+    *,
+    fetcher=fetch_json,
+    endpoints: tuple[str, ...] = JSON_ENDPOINTS,
+) -> list[str]:
+    """Run configured endpoint checks and return human-readable successes."""
+    successes: list[str] = []
+    for endpoint in endpoints:
+        payload = fetcher(endpoint_url(config.base_url, endpoint), config.timeout_seconds)
+        VALIDATORS[endpoint](payload)
+        successes.append(f"{endpoint} ok")
+    return successes
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="per-request timeout in seconds (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        config = config_from_env()
+        config = SmokeConfig(
+            base_url=config.base_url,
+            environment=config.environment,
+            allow_prod=config.allow_prod,
+            timeout_seconds=args.timeout,
+        )
+        successes = run_smoke_checks(config)
+    except (SmokeConfigError, SmokeCheckError) as exc:
+        print(f"promotion smoke failed: {exc}", file=sys.stderr)
+        return 2
+    for line in successes:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_docs_promotion.py
+++ b/tests/unit/test_docs_promotion.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROMOTION_DOC = Path("docs/PRODUCTION_PROMOTION.md")
+TESTING_DOC = Path("docs/TESTING.md")
+
+
+def test_production_promotion_checklist_captures_0_1_0_smoke_risks() -> None:
+    text = PROMOTION_DOC.read_text(encoding="utf-8")
+    required = (
+        "Linux and macOS `run_all_tests.sh` PR checks",
+        "staging deployment image, chart, and release artifact",
+        "desktop releases for Windows and macOS install successfully and register",
+        "`GET /livez` returns healthy JSON (`status: alive`)",
+        "`GET /healthz` returns healthy JSON (`status: ok`)",
+        "`GET /relay/diagnostics` reports the live compute-node count accurately",
+        "`GET /api/v1/models` returns exactly one public model: `llama-3.1-8b-instruct`",
+        "landing page model dropdown has exactly one model",
+        "landing UI does not show `owned by token.place`",
+        "Two compute nodes round-robin across new browser clients",
+        "chat remains sticky to its selected server across multiple turns",
+        "automatic failover to another available compute node without\n      losing chat history",
+        "No full public key is rendered in the DOM",
+        "Landing chat makes no `/api/v2` calls",
+        "Landing chat makes no `/api/v1/chat/completions` calls",
+        "production secrets and relay registration tokens",
+        "rate-limit storage and production environment settings",
+        "rollback path",
+    )
+    missing = [item for item in required if item not in text]
+    assert not missing
+
+
+def test_promotion_docs_preserve_relay_blind_and_opt_in_smoke_contract() -> None:
+    text = PROMOTION_DOC.read_text(encoding="utf-8")
+    required = (
+        "relay-owned state, logs, diagnostics, and payloads ciphertext-only",
+        "Never capture or paste plaintext prompts",
+        "RUN_PROMOTION_SMOKE=1",
+        "TOKENPLACE_SMOKE_BASE_URL=https://staging.token.place",
+        "TOKENPLACE_SMOKE_ALLOW_PROD=1",
+        "python scripts/promotion_smoke.py",
+        "The helper checks only safe JSON endpoints",
+        "`/api/v1/models`",
+        "Browser-only checklist items",
+    )
+    missing = [item for item in required if item not in text]
+    assert not missing
+
+
+def test_testing_guide_links_promotion_smoke_helper_and_offline_default() -> None:
+    text = TESTING_DOC.read_text(encoding="utf-8")
+    required = (
+        "[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md)",
+        "`llama-3.1-8b-instruct` as the only public\nmodel",
+        "absence of `owned by token.place`",
+        "automatic\nhistory-preserving failover",
+        "RUN_PROMOTION_SMOKE=1",
+        "TOKENPLACE_SMOKE_ALLOW_PROD=1",
+        "normal test runs never contact live services",
+        "`/livez`, `/healthz`, `/relay/diagnostics`, and `/api/v1/models`",
+    )
+    missing = [item for item in required if item not in text]
+    assert not missing

--- a/tests/unit/test_promotion_smoke.py
+++ b/tests/unit/test_promotion_smoke.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "promotion_smoke", Path("scripts/promotion_smoke.py")
+)
+promotion_smoke = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = promotion_smoke
+assert SPEC.loader is not None
+SPEC.loader.exec_module(promotion_smoke)
+
+
+def test_config_from_env_requires_explicit_enablement() -> None:
+    with pytest.raises(promotion_smoke.SmokeConfigError, match="RUN_PROMOTION_SMOKE"):
+        promotion_smoke.config_from_env(
+            {"TOKENPLACE_SMOKE_BASE_URL": "https://staging.token.place"}
+        )
+
+
+def test_config_from_env_normalizes_staging_url() -> None:
+    config = promotion_smoke.config_from_env(
+        {
+            "RUN_PROMOTION_SMOKE": "1",
+            "TOKENPLACE_SMOKE_ENV": "staging",
+            "TOKENPLACE_SMOKE_BASE_URL": "https://staging.token.place///",
+        }
+    )
+
+    assert config.base_url == "https://staging.token.place/"
+    assert config.environment == "staging"
+    assert config.allow_prod is False
+
+
+def test_config_from_env_refuses_production_without_acknowledgement() -> None:
+    with pytest.raises(promotion_smoke.SmokeConfigError, match="TOKENPLACE_SMOKE_ALLOW_PROD"):
+        promotion_smoke.config_from_env(
+            {
+                "RUN_PROMOTION_SMOKE": "1",
+                "TOKENPLACE_SMOKE_ENV": "production",
+                "TOKENPLACE_SMOKE_BASE_URL": "https://token.place",
+            }
+        )
+
+
+def test_config_from_env_allows_production_with_explicit_acknowledgement() -> None:
+    config = promotion_smoke.config_from_env(
+        {
+            "RUN_PROMOTION_SMOKE": "1",
+            "TOKENPLACE_SMOKE_ENV": "production",
+            "TOKENPLACE_SMOKE_ALLOW_PROD": "1",
+            "TOKENPLACE_SMOKE_BASE_URL": "https://token.place",
+        }
+    )
+
+    assert config.base_url == "https://token.place/"
+    assert config.environment == "production"
+    assert config.allow_prod is True
+
+
+def test_endpoint_url_rejects_relative_endpoint_without_leading_slash() -> None:
+    with pytest.raises(promotion_smoke.SmokeConfigError, match="root-relative"):
+        promotion_smoke.endpoint_url("https://staging.token.place", "api/v1/models")
+
+
+def test_validate_models_requires_exact_launch_model() -> None:
+    promotion_smoke.validate_models(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": "llama-3.1-8b-instruct",
+                    "object": "model",
+                    "owned_by": "Meta",
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(promotion_smoke.SmokeCheckError, match="exactly"):
+        promotion_smoke.validate_models(
+            {
+                "object": "list",
+                "data": [
+                    {"id": "llama-3.1-8b-instruct", "owned_by": "Meta"},
+                    {"id": "llama-3.1-8b-instruct:alignment", "owned_by": "Meta"},
+                ],
+            }
+        )
+
+    with pytest.raises(promotion_smoke.SmokeCheckError, match="owned_by=Meta"):
+        promotion_smoke.validate_models(
+            {
+                "object": "list",
+                "data": [
+                    {"id": "llama-3.1-8b-instruct", "owned_by": "token.place"},
+                ],
+            }
+        )
+
+
+def test_validate_diagnostics_requires_consistent_api_v1_live_node_count() -> None:
+    promotion_smoke.validate_diagnostics(
+        {
+            "total_registered_compute_nodes": 2,
+            "registered_compute_nodes": [{}, {}],
+            "total_api_v1_registered_compute_nodes": 1,
+            "api_v1_registered_compute_nodes": [{}],
+        }
+    )
+
+    with pytest.raises(promotion_smoke.SmokeCheckError, match="must match listed nodes"):
+        promotion_smoke.validate_diagnostics(
+            {
+                "total_registered_compute_nodes": 2,
+                "total_api_v1_registered_compute_nodes": 2,
+                "api_v1_registered_compute_nodes": [{}],
+            }
+        )
+
+
+def test_run_smoke_checks_uses_expected_json_endpoints_without_network() -> None:
+    config = promotion_smoke.SmokeConfig(base_url="https://staging.token.place/", environment="staging")
+    responses = {
+        "https://staging.token.place/livez": {"status": "alive"},
+        "https://staging.token.place/healthz": {"status": "ok"},
+        "https://staging.token.place/relay/diagnostics": {
+            "total_registered_compute_nodes": 2,
+            "total_api_v1_registered_compute_nodes": 2,
+            "api_v1_registered_compute_nodes": [{}, {}],
+        },
+        "https://staging.token.place/api/v1/models": {
+            "object": "list",
+            "data": [{"id": "llama-3.1-8b-instruct", "owned_by": "Meta"}],
+        },
+    }
+    called: list[str] = []
+
+    def fake_fetcher(url: str, timeout_seconds: float):
+        assert timeout_seconds == promotion_smoke.DEFAULT_TIMEOUT_SECONDS
+        called.append(url)
+        return responses[url]
+
+    successes = promotion_smoke.run_smoke_checks(config, fetcher=fake_fetcher)
+
+    assert called == list(responses)
+    assert successes == [
+        "/livez ok",
+        "/healthz ok",
+        "/relay/diagnostics ok",
+        "/api/v1/models ok",
+    ]

--- a/tests/unit/test_promotion_smoke.py
+++ b/tests/unit/test_promotion_smoke.py
@@ -105,7 +105,15 @@ def test_validate_models_requires_exact_launch_model() -> None:
         )
 
 
-def test_validate_diagnostics_requires_consistent_api_v1_live_node_count() -> None:
+def test_validate_diagnostics_accepts_matching_live_node_counts() -> None:
+    promotion_smoke.validate_diagnostics(
+        {
+            "total_registered_compute_nodes": 0,
+            "registered_compute_nodes": [],
+            "total_api_v1_registered_compute_nodes": 0,
+            "api_v1_registered_compute_nodes": [],
+        }
+    )
     promotion_smoke.validate_diagnostics(
         {
             "total_registered_compute_nodes": 2,
@@ -115,12 +123,61 @@ def test_validate_diagnostics_requires_consistent_api_v1_live_node_count() -> No
         }
     )
 
+
+def test_validate_diagnostics_requires_registered_compute_nodes_list() -> None:
     with pytest.raises(
-        promotion_smoke.SmokeCheckError, match="must match listed nodes"
+        promotion_smoke.SmokeCheckError, match="registered_compute_nodes must be a list"
+    ):
+        promotion_smoke.validate_diagnostics(
+            {
+                "total_registered_compute_nodes": 0,
+                "total_api_v1_registered_compute_nodes": 0,
+                "api_v1_registered_compute_nodes": [],
+            }
+        )
+
+
+def test_validate_diagnostics_requires_api_v1_registered_compute_nodes_list() -> None:
+    with pytest.raises(
+        promotion_smoke.SmokeCheckError,
+        match="api_v1_registered_compute_nodes must be a list",
+    ):
+        promotion_smoke.validate_diagnostics(
+            {
+                "total_registered_compute_nodes": 0,
+                "registered_compute_nodes": [],
+                "total_api_v1_registered_compute_nodes": 0,
+            }
+        )
+
+
+def test_validate_diagnostics_rejects_registered_total_mismatch() -> None:
+    with pytest.raises(
+        promotion_smoke.SmokeCheckError,
+        match="total_registered_compute_nodes must match registered_compute_nodes",
     ):
         promotion_smoke.validate_diagnostics(
             {
                 "total_registered_compute_nodes": 2,
+                "registered_compute_nodes": [{}],
+                "total_api_v1_registered_compute_nodes": 1,
+                "api_v1_registered_compute_nodes": [{}],
+            }
+        )
+
+
+def test_validate_diagnostics_rejects_api_v1_registered_total_mismatch() -> None:
+    with pytest.raises(
+        promotion_smoke.SmokeCheckError,
+        match=(
+            "total_api_v1_registered_compute_nodes "
+            "must match api_v1_registered_compute_nodes"
+        ),
+    ):
+        promotion_smoke.validate_diagnostics(
+            {
+                "total_registered_compute_nodes": 2,
+                "registered_compute_nodes": [{}, {}],
                 "total_api_v1_registered_compute_nodes": 2,
                 "api_v1_registered_compute_nodes": [{}],
             }
@@ -136,6 +193,7 @@ def test_run_smoke_checks_uses_expected_json_endpoints_without_network() -> None
         "https://staging.token.place/healthz": {"status": "ok"},
         "https://staging.token.place/relay/diagnostics": {
             "total_registered_compute_nodes": 2,
+            "registered_compute_nodes": [{}, {}],
             "total_api_v1_registered_compute_nodes": 2,
             "api_v1_registered_compute_nodes": [{}, {}],
         },

--- a/tests/unit/test_promotion_smoke.py
+++ b/tests/unit/test_promotion_smoke.py
@@ -316,3 +316,148 @@ def test_run_smoke_checks_rejects_unknown_endpoint_without_network() -> None:
         promotion_smoke.run_smoke_checks(
             config, fetcher=fail_fetcher, endpoints=("/unknown",)
         )
+
+
+@pytest.mark.parametrize(
+    ("invalid_base_url", "match"),
+    [
+        ("   ", "must not be empty"),
+        ("ftp://staging.token.place", "must use http:// or https://"),
+        ("https:///", "must include a host"),
+    ],
+)
+def test_normalize_base_url_rejects_invalid_roots(
+    invalid_base_url: str, match: str
+) -> None:
+    with pytest.raises(promotion_smoke.SmokeConfigError, match=match):
+        promotion_smoke.normalize_base_url(invalid_base_url)
+
+
+@pytest.mark.parametrize(
+    ("validator", "payload", "match"),
+    [
+        (promotion_smoke.validate_livez, {"status": "ok"}, "status=alive"),
+        (promotion_smoke.validate_healthz, {"status": "degraded"}, "status=ok"),
+        (promotion_smoke.validate_diagnostics, [], "JSON object"),
+        (
+            promotion_smoke.validate_diagnostics,
+            {
+                "total_registered_compute_nodes": -1,
+                "registered_compute_nodes": [],
+                "total_api_v1_registered_compute_nodes": 0,
+                "api_v1_registered_compute_nodes": [],
+            },
+            "non-negative integer",
+        ),
+        (promotion_smoke.validate_models, {"object": "model"}, "list object"),
+        (
+            promotion_smoke.validate_models,
+            {"object": "list", "data": {}},
+            "data must be a list",
+        ),
+    ],
+)
+def test_endpoint_validators_reject_malformed_payloads(
+    validator, payload, match: str
+) -> None:
+    with pytest.raises(promotion_smoke.SmokeCheckError, match=match):
+        validator(payload)
+
+
+class _FakeResponse:
+    def __init__(self, *, status: int = 200, body: str = "{}") -> None:
+        self.status = status
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        return None
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self) -> bytes:
+        return self._body.encode("utf-8")
+
+
+def test_fetch_json_returns_decoded_payload_without_live_network(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request, timeout: float):
+        captured["url"] = request.full_url
+        captured["accept"] = request.headers["Accept"]
+        captured["user_agent"] = request.headers["User-agent"]
+        captured["timeout"] = timeout
+        return _FakeResponse(body='{"status": "alive"}')
+
+    monkeypatch.setattr(promotion_smoke, "urlopen", fake_urlopen)
+
+    payload = promotion_smoke.fetch_json("https://staging.token.place/livez", 3.5)
+
+    assert payload == {"status": "alive"}
+    assert captured == {
+        "url": "https://staging.token.place/livez",
+        "accept": "application/json",
+        "user_agent": "tokenplace-promotion-smoke/1",
+        "timeout": 3.5,
+    }
+
+
+@pytest.mark.parametrize(
+    ("response", "match"),
+    [
+        (_FakeResponse(status=503, body='{"status": "down"}'), "returned HTTP 503"),
+        (_FakeResponse(body="not json"), "did not return valid JSON"),
+    ],
+)
+def test_fetch_json_rejects_bad_responses_without_live_network(
+    monkeypatch, response: _FakeResponse, match: str
+) -> None:
+    def fake_urlopen(request, timeout: float):
+        return response
+
+    monkeypatch.setattr(promotion_smoke, "urlopen", fake_urlopen)
+
+    with pytest.raises(promotion_smoke.SmokeCheckError, match=match):
+        promotion_smoke.fetch_json("https://staging.token.place/livez")
+
+
+def test_parse_args_accepts_timeout() -> None:
+    args = promotion_smoke.parse_args(["--timeout", "2.25"])
+
+    assert args.timeout == 2.25
+
+
+def test_main_reports_config_errors_without_live_network(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("RUN_PROMOTION_SMOKE", raising=False)
+
+    exit_code = promotion_smoke.main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "promotion smoke failed: Set RUN_PROMOTION_SMOKE=1" in captured.err
+    assert captured.out == ""
+
+
+def test_main_prints_successes_with_injected_offline_runner(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("RUN_PROMOTION_SMOKE", "1")
+    monkeypatch.setenv("TOKENPLACE_SMOKE_BASE_URL", "https://staging.token.place")
+
+    def fake_run_smoke_checks(config):
+        assert config.base_url == "https://staging.token.place/"
+        assert config.environment == "staging"
+        assert config.timeout_seconds == 1.5
+        return ["/livez ok", "/healthz ok"]
+
+    monkeypatch.setattr(promotion_smoke, "run_smoke_checks", fake_run_smoke_checks)
+
+    exit_code = promotion_smoke.main(["--timeout", "1.5"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == "/livez ok\n/healthz ok\n"
+    assert captured.err == ""

--- a/tests/unit/test_promotion_smoke.py
+++ b/tests/unit/test_promotion_smoke.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 SPEC = importlib.util.spec_from_file_location(
     "promotion_smoke", Path("scripts/promotion_smoke.py")
 )
@@ -38,7 +37,9 @@ def test_config_from_env_normalizes_staging_url() -> None:
 
 
 def test_config_from_env_refuses_production_without_acknowledgement() -> None:
-    with pytest.raises(promotion_smoke.SmokeConfigError, match="TOKENPLACE_SMOKE_ALLOW_PROD"):
+    with pytest.raises(
+        promotion_smoke.SmokeConfigError, match="TOKENPLACE_SMOKE_ALLOW_PROD"
+    ):
         promotion_smoke.config_from_env(
             {
                 "RUN_PROMOTION_SMOKE": "1",
@@ -114,7 +115,9 @@ def test_validate_diagnostics_requires_consistent_api_v1_live_node_count() -> No
         }
     )
 
-    with pytest.raises(promotion_smoke.SmokeCheckError, match="must match listed nodes"):
+    with pytest.raises(
+        promotion_smoke.SmokeCheckError, match="must match listed nodes"
+    ):
         promotion_smoke.validate_diagnostics(
             {
                 "total_registered_compute_nodes": 2,
@@ -125,7 +128,9 @@ def test_validate_diagnostics_requires_consistent_api_v1_live_node_count() -> No
 
 
 def test_run_smoke_checks_uses_expected_json_endpoints_without_network() -> None:
-    config = promotion_smoke.SmokeConfig(base_url="https://staging.token.place/", environment="staging")
+    config = promotion_smoke.SmokeConfig(
+        base_url="https://staging.token.place/", environment="staging"
+    )
     responses = {
         "https://staging.token.place/livez": {"status": "alive"},
         "https://staging.token.place/healthz": {"status": "ok"},
@@ -155,3 +160,101 @@ def test_run_smoke_checks_uses_expected_json_endpoints_without_network() -> None
         "/relay/diagnostics ok",
         "/api/v1/models ok",
     ]
+
+
+def test_config_from_env_rejects_pathful_base_url() -> None:
+    with pytest.raises(
+        promotion_smoke.SmokeConfigError, match="must not include a path"
+    ):
+        promotion_smoke.config_from_env(
+            {
+                "RUN_PROMOTION_SMOKE": "1",
+                "TOKENPLACE_SMOKE_BASE_URL": "https://staging.token.place/api",
+            }
+        )
+
+
+def test_config_from_env_rejects_query_or_fragment_base_url() -> None:
+    with pytest.raises(
+        promotion_smoke.SmokeConfigError, match="params, query, or fragment"
+    ):
+        promotion_smoke.config_from_env(
+            {
+                "RUN_PROMOTION_SMOKE": "1",
+                "TOKENPLACE_SMOKE_BASE_URL": "https://staging.token.place/?debug=1",
+            }
+        )
+
+
+def test_config_from_env_refuses_production_like_subdomain_without_acknowledgement() -> (
+    None
+):
+    with pytest.raises(
+        promotion_smoke.SmokeConfigError, match="TOKENPLACE_SMOKE_ALLOW_PROD"
+    ):
+        promotion_smoke.config_from_env(
+            {
+                "RUN_PROMOTION_SMOKE": "1",
+                "TOKENPLACE_SMOKE_BASE_URL": "https://prod.token.place",
+            }
+        )
+
+
+def test_config_from_env_refuses_production_like_cname_without_acknowledgement() -> (
+    None
+):
+    with pytest.raises(
+        promotion_smoke.SmokeConfigError, match="TOKENPLACE_SMOKE_ALLOW_PROD"
+    ):
+        promotion_smoke.config_from_env(
+            {
+                "RUN_PROMOTION_SMOKE": "1",
+                "TOKENPLACE_SMOKE_BASE_URL": "https://relay.prod.example.com",
+            }
+        )
+
+
+def test_endpoint_url_uses_root_relative_endpoint() -> None:
+    assert (
+        promotion_smoke.endpoint_url("https://staging.token.place/", "/livez")
+        == "https://staging.token.place/livez"
+    )
+
+
+def test_validate_healthz_rejects_degraded_details_even_when_status_ok() -> None:
+    with pytest.raises(promotion_smoke.SmokeCheckError, match="degraded details"):
+        promotion_smoke.validate_healthz(
+            {"status": "ok", "details": {"knownServers": "empty"}}
+        )
+
+
+def test_validate_models_rejects_non_object_entries() -> None:
+    with pytest.raises(
+        promotion_smoke.SmokeCheckError, match="entries must be objects"
+    ):
+        promotion_smoke.validate_models(
+            {
+                "object": "list",
+                "data": ["oops", {"id": "llama-3.1-8b-instruct", "owned_by": "Meta"}],
+            }
+        )
+
+
+def test_run_smoke_checks_rejects_unknown_endpoint_without_network() -> None:
+    config = promotion_smoke.SmokeConfig(
+        base_url="https://staging.token.place/", environment="staging"
+    )
+
+    def fail_fetcher(
+        url: str, timeout_seconds: float
+    ):  # pragma: no cover - must not run
+        raise AssertionError(
+            f"unexpected fetch of {url} with timeout {timeout_seconds}"
+        )
+
+    with pytest.raises(
+        promotion_smoke.SmokeConfigError, match="Unsupported smoke endpoint"
+    ):
+        promotion_smoke.run_smoke_checks(
+            config, fetcher=fail_fetcher, endpoints=("/unknown",)
+        )


### PR DESCRIPTION
### Motivation
- Provide a small, repeatable staging-to-production promotion checklist for the `v0.1.0` launch that captures the highest-risk checks (model identity, landing UI owner text, live compute-node diagnostics, sticky routing and failover, and relay privacy invariants).

### Description
- Add `docs/PRODUCTION_PROMOTION.md` containing a focused `v0.1.0` staging-to-prod checklist and explicit pre/post promotion gates and rules. 
- Add an opt-in smoke helper `scripts/promotion_smoke.py` that validates safe JSON endpoints (`/livez`, `/healthz`, `/relay/diagnostics`, `/api/v1/models`), refuses to target production unless explicitly allowed, and enforces the single-launch model `llama-3.1-8b-instruct` constraint. 
- Update `docs/TESTING.md` to reference the new promotion checklist and the opt-in smoke helper, and explain the helper is safe-by-default (it never contacts live targets unless explicitly configured). 
- Add unit tests `tests/unit/test_docs_promotion.py` and `tests/unit/test_promotion_smoke.py` to assert the checklist/document text and to exercise the smoke helper's config/validator logic without requiring network access.

### Testing
- Ran the documentation and smoke-unit suites with `python -m pytest tests/unit/test_docs_* tests/unit/test_testing_documentation.py -v` which passed (36 passed).
- Ran the smoke helper unit tests with `python -m pytest tests/unit/test_promotion_smoke.py -v` which passed (8 passed).
- Verified API v1 launch contract tests with `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` which passed (11 passed).
- Exercised the landing-page E2E scenarios selected by the prompt with `python -m pytest tests/e2e/test_ui.py -k "landing_chat or model or sticky or failover" -v`; Playwright browsers/deps were installed (`python -m playwright install chromium` and `python -m playwright install-deps chromium`) and the run completed successfully (`13 passed, 1 skipped, 8 deselected`).
- Ran JavaScript smoke tests with `npm run test:js` which completed successfully (all JS checks passed).
- Ran the repository test harness `./run_all_tests.sh` to exercise the broader suite; the run completed with the repository unit and focused E2E suites passing in this environment (many tests passed; no new regressions introduced by these doc/script changes).
- Notes and residual risks: the PR adds only documentation, an opt-in smoke script, and unit tests; browser-only checklist items (dropdown count, DOM owner text, sticky behavior visual evidence) still require Playwright/manual browser verification as noted in the docs; the smoke helper intentionally checks only safe JSON endpoints and will not contact live services unless `RUN_PROMOTION_SMOKE=1` and `TOKENPLACE_SMOKE_BASE_URL` (and for production `TOKENPLACE_SMOKE_ALLOW_PROD=1`) are set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29efef3144832f96b59ea5dc6af8f6)