### PR TITLE
Add 0.1.0 staging→prod promotion checklist and opt-in smoke helper

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -60,6 +60,7 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - [CONTRIBUTING.md](../CONTRIBUTING.md): Contribution guidelines for developers
 - [STYLE_GUIDE.md](STYLE_GUIDE.md): Style and branding guidelines, including proper name stylization
 - [TESTING.md](TESTING.md): Comprehensive guide to the testing approach
+- [PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md): Repeatable 0.1.0 staging-to-prod checklist and smoke helper
 - [TESTING_IMPROVEMENTS.md](TESTING_IMPROVEMENTS.md): Ideas for further testing improvements
 - [ARCHITECTURE.md](ARCHITECTURE.md): Detailed architectural overview of the system
 - [LLM_ASSISTANT_GUIDE.md](LLM_ASSISTANT_GUIDE.md): Guide for AI assistants working with this codebase

--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,0 +1,110 @@
+# token.place 0.1.0 staging-to-prod promotion checklist
+
+Use this checklist every time a staging relay build is promoted to production. The goal is to make
+high-risk launch behavior repeatable without changing the runtime or sending sensitive prompts.
+Record links to CI runs, release artifacts, deployment revisions, smoke output, and rollback notes in
+the release ticket before promotion.
+
+## Scope and invariants
+
+- `v0.1.0` production promotion is API v1-only for public relay inference paths.
+- API v1 relay inference remains non-streaming; do not add a streaming promotion exception.
+- Relay-owned diagnostics, logs, queues, and state must remain relay-blind: ciphertext only plus safe routing metadata. Never expose plaintext prompts, tool arguments, messages, or model output.
+- The public launch model catalog is intentionally minimal: `/api/v1/models` must return exactly one
+  public model, `llama-3.1-8b-instruct`, owned by `Meta`.
+- The landing chat uses API v1 relay E2EE routes, remains sticky to one selected compute node while
+  it is available, and automatically fails over to another live node without losing visible chat
+  history when the selected node becomes unavailable.
+
+## Pre-promotion release gates
+
+- [ ] Confirm the promotion candidate PR has green CI checks, including Linux and macOS
+  `run_all_tests.sh` PR checks.
+- [ ] Confirm the staging deployment image, Helm chart, and release artifact digests/tags are the
+  exact immutable artifacts intended for production.
+- [ ] Confirm Windows and macOS desktop release candidates install successfully and register as
+  compute nodes against the staging relay.
+- [ ] Confirm production secrets are present in the deployment environment.
+- [ ] Confirm relay registration tokens are configured for production compute nodes.
+- [ ] Confirm rate-limit storage is configured for the production environment.
+- [ ] Confirm production environment settings are set, including public base URL, ingress/TLS,
+  resource limits, and upstream/relay-only health policy.
+- [ ] Confirm the rollback path: previous image/chart versions, data/config compatibility notes,
+  operator contact, and the exact command or platform action to revert.
+
+## Staging smoke checklist
+
+Run these checks against the staging host before production promotion. Use only non-sensitive smoke
+prompts if a manual browser chat is required.
+
+- [ ] `GET /livez` returns a healthy liveness response.
+- [ ] `GET /healthz` returns a healthy readiness response.
+- [ ] `GET /relay/diagnostics` reports live compute-node counts accurately:
+  `total_registered_compute_nodes` matches `registered_compute_nodes.length`, and
+  `total_api_v1_registered_compute_nodes` matches `api_v1_registered_compute_nodes.length`.
+- [ ] `GET /api/v1/models` returns exactly one public model: `llama-3.1-8b-instruct`.
+- [ ] The landing dropdown has exactly one model option: `llama-3.1-8b-instruct`.
+- [ ] The landing UI does not show `owned by token.place` or any equivalent owner line.
+- [ ] With two registered compute nodes, two new browser clients round-robin across different
+  selected server keys.
+- [ ] One browser chat remains sticky to its selected server across multiple turns while that server
+  stays available.
+- [ ] Stopping the sticky server causes automatic failover to another available compute node without losing visible chat history.
+- [ ] No full public key is rendered in the DOM; only shortened/fingerprinted server-key labels are
+  acceptable.
+- [ ] The landing chat makes no `/api/v2` calls.
+- [ ] The landing chat makes no `/api/v1/chat/completions` calls; relay chat dispatch must use the
+  API v1 E2EE relay request/retrieve flow.
+- [ ] Relay logs and diagnostics do not expose plaintext prompts, messages, responses, tool
+  arguments, model output, or full public keys.
+
+## Production post-promotion smoke checklist
+
+Repeat the safe endpoint checks against production after the deployment completes. Browser and
+compute-node checks should be repeated only by an authorized operator using non-sensitive prompts.
+
+- [ ] `GET /livez` returns a healthy liveness response.
+- [ ] `GET /healthz` returns a healthy readiness response.
+- [ ] `GET /relay/diagnostics` live counts match the registered-node arrays.
+- [ ] `GET /api/v1/models` returns exactly one public model: `llama-3.1-8b-instruct`.
+- [ ] Production desktop compute nodes can register with the configured relay registration token.
+- [ ] Landing chat continues to avoid `/api/v2` and `/api/v1/chat/completions` calls.
+- [ ] Sticky routing and automatic failover remain history-preserving with two live production
+  compute nodes.
+- [ ] Confirm the rollback command/action remains viable after the promotion.
+
+## Optional endpoint smoke helper
+
+`scripts/promotion_smoke.py` provides an opt-in JSON endpoint harness for staging or production. It
+checks only `/livez`, `/healthz`, `/relay/diagnostics`, and `/api/v1/models`; it does not send chat
+prompts and does not require live network access during normal tests.
+
+Staging example:
+
+```bash
+RUN_PROMOTION_SMOKE=1 \
+TOKENPLACE_SMOKE_BASE_URL=https://staging.token.place \
+python scripts/promotion_smoke.py
+```
+
+Production is blocked unless explicitly allowed:
+
+```bash
+RUN_PROMOTION_SMOKE=1 \
+TOKENPLACE_SMOKE_BASE_URL=https://token.place \
+TOKENPLACE_SMOKE_ALLOW_PROD=1 \
+python scripts/promotion_smoke.py
+```
+
+If `RUN_PROMOTION_SMOKE=1` is not set, the script exits without making network requests. Keep that
+behavior so routine local and CI test runs remain deterministic and offline.
+
+## Suggested verification before sign-off
+
+```bash
+python -m pytest tests/unit/test_docs_* tests/unit/test_testing_documentation.py -v
+python -m pytest tests/unit/test_api_v1_launch_contract.py -v
+python -m pytest tests/e2e/test_ui.py -k "landing_chat or model or sticky or failover" -v
+npm run test:js
+./run_all_tests.sh
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,8 @@ testing, and deploying token.place. For an expanded overview of every directory,
     [relay_sugarkube_onboarding.md](relay_sugarkube_onboarding.md),
     [k3s-sugarkube-dev.md](k3s-sugarkube-dev.md),
     [k3s-sugarkube-staging.md](k3s-sugarkube-staging.md),
-    [k3s-sugarkube-prod.md](k3s-sugarkube-prod.md)
+    [k3s-sugarkube-prod.md](k3s-sugarkube-prod.md),
+    [PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md)
 - **Learn the encryption model**
   - Start here: [encrypt.py](../encrypt.py)
   - Also see: [SECURITY_PRIVACY_AUDIT.md](SECURITY_PRIVACY_AUDIT.md),
@@ -39,6 +40,8 @@ testing, and deploying token.place. For an expanded overview of every directory,
 ## Key checklists
 
 - **Testing:** [TESTING.md](TESTING.md) summarises the suites executed by `run_all_tests.sh`.
+- **Production promotion:** [PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md) captures the
+  repeatable 0.1.0 staging-to-prod checklist and opt-in smoke helper.
 - **Security:** [SECURITY_PRIVACY_AUDIT.md](SECURITY_PRIVACY_AUDIT.md) contains the rolling
   hardening checklist and threat model; use
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -207,6 +207,26 @@ Stress tests include:
 These tests are skipped by default in CI to keep build times reasonable, but can be
 enabled for release validation or when investigating performance regressions.
 
+
+### Promotion smoke checks
+
+The staging-to-prod promotion guide includes an optional endpoint-only smoke helper that is safe by
+default. Normal local and CI test runs do not contact staging or production because the script exits
+without network requests unless `RUN_PROMOTION_SMOKE=1` is set.
+
+```bash
+RUN_PROMOTION_SMOKE=1 \
+TOKENPLACE_SMOKE_BASE_URL=https://staging.token.place \
+python scripts/promotion_smoke.py
+```
+
+The helper validates `/livez`, `/healthz`, `/relay/diagnostics`, and `/api/v1/models`; it asserts the
+0.1.0 launch catalog has exactly one public model, `llama-3.1-8b-instruct`. Production smoke runs
+also require `TOKENPLACE_SMOKE_ALLOW_PROD=1`. See
+[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md) for the full manual checklist covering desktop
+registration, landing dropdown model count, sticky routing, automatic failover, DOM public-key
+redaction, and the landing chat's API v1-only E2EE route usage.
+
 ## User Journeys and E2E Testing
 
 token.place tests are organized around key user journeys that represent how users interact with the system:

--- a/scripts/promotion_smoke.py
+++ b/scripts/promotion_smoke.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Optional staging/prod promotion smoke checks for token.place.
+
+The harness is intentionally opt-in. It only performs network requests when
+RUN_PROMOTION_SMOKE=1 is set and TOKENPLACE_SMOKE_BASE_URL points at the target
+relay. Production additionally requires TOKENPLACE_SMOKE_ALLOW_PROD=1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+EXPECTED_MODEL_ID = "llama-3.1-8b-instruct"
+PRODUCTION_HOSTS = {"token.place", "www.token.place"}
+JSON_ENDPOINTS = ("/livez", "/healthz", "/relay/diagnostics", "/api/v1/models")
+
+
+class SmokeCheckError(RuntimeError):
+    """Raised when a smoke check response violates the promotion contract."""
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    endpoint: str
+    status: str
+
+
+def normalize_base_url(raw_url: str) -> str:
+    """Return a scheme/netloc-only base URL with trailing slash and path removed."""
+
+    candidate = raw_url.strip()
+    if not candidate:
+        raise SmokeCheckError("TOKENPLACE_SMOKE_BASE_URL must not be empty")
+    parsed = urllib.parse.urlparse(candidate)
+    if not parsed.scheme:
+        candidate = f"https://{candidate}"
+        parsed = urllib.parse.urlparse(candidate)
+    if parsed.scheme not in {"http", "https"}:
+        raise SmokeCheckError(f"unsupported URL scheme: {parsed.scheme}")
+    if not parsed.netloc:
+        raise SmokeCheckError("base URL must include a host")
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+
+def is_production_url(base_url: str) -> bool:
+    """Return True when the base URL targets the public production host."""
+
+    host = urllib.parse.urlparse(base_url).hostname or ""
+    return host.lower() in PRODUCTION_HOSTS
+
+
+def endpoint_url(base_url: str, endpoint: str) -> str:
+    """Join a normalized base URL and an absolute endpoint path."""
+
+    if not endpoint.startswith("/"):
+        raise SmokeCheckError(f"endpoint must start with '/': {endpoint}")
+    return urllib.parse.urljoin(f"{base_url}/", endpoint.lstrip("/"))
+
+
+def fetch_json(base_url: str, endpoint: str, *, timeout: float = 10.0) -> dict[str, Any]:
+    """Fetch one smoke endpoint as JSON."""
+
+    url = endpoint_url(base_url, endpoint)
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310 - explicit opt-in smoke target.
+            status = getattr(response, "status", response.getcode())
+            content_type = response.headers.get("Content-Type", "")
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:  # pragma: no cover - exercised by integration use.
+        raise SmokeCheckError(f"{endpoint} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - exercised by integration use.
+        raise SmokeCheckError(f"{endpoint} request failed: {exc.reason}") from exc
+
+    if status != 200:
+        raise SmokeCheckError(f"{endpoint} returned HTTP {status}")
+    if "json" not in content_type.lower():
+        raise SmokeCheckError(f"{endpoint} returned non-JSON content type {content_type!r}")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SmokeCheckError(f"{endpoint} returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise SmokeCheckError(f"{endpoint} returned a non-object JSON payload")
+    return payload
+
+
+def validate_livez(payload: dict[str, Any]) -> None:
+    if payload.get("status") != "alive":
+        raise SmokeCheckError("/livez status must be 'alive'")
+
+
+def validate_healthz(payload: dict[str, Any]) -> None:
+    if payload.get("status") != "ok":
+        raise SmokeCheckError("/healthz status must be 'ok'")
+    registered = payload.get("registeredServers")
+    if not isinstance(registered, list):
+        raise SmokeCheckError("/healthz registeredServers must be a list")
+
+
+def validate_diagnostics(payload: dict[str, Any]) -> None:
+    registered = payload.get("registered_compute_nodes")
+    api_v1_registered = payload.get("api_v1_registered_compute_nodes")
+    total = payload.get("total_registered_compute_nodes")
+    api_v1_total = payload.get("total_api_v1_registered_compute_nodes")
+    if not isinstance(registered, list):
+        raise SmokeCheckError("/relay/diagnostics registered_compute_nodes must be a list")
+    if not isinstance(api_v1_registered, list):
+        raise SmokeCheckError("/relay/diagnostics api_v1_registered_compute_nodes must be a list")
+    if total != len(registered):
+        raise SmokeCheckError("/relay/diagnostics total_registered_compute_nodes does not match node list")
+    if api_v1_total != len(api_v1_registered):
+        raise SmokeCheckError("/relay/diagnostics total_api_v1_registered_compute_nodes does not match node list")
+    if api_v1_total > total:
+        raise SmokeCheckError("/relay/diagnostics API v1 node count cannot exceed total live node count")
+
+
+def validate_models(payload: dict[str, Any]) -> None:
+    if payload.get("object") != "list":
+        raise SmokeCheckError("/api/v1/models object must be 'list'")
+    models = payload.get("data")
+    if not isinstance(models, list):
+        raise SmokeCheckError("/api/v1/models data must be a list")
+    if len(models) != 1:
+        raise SmokeCheckError("/api/v1/models must expose exactly one public model")
+    model = models[0]
+    if not isinstance(model, dict):
+        raise SmokeCheckError("/api/v1/models data[0] must be an object")
+    if model.get("id") != EXPECTED_MODEL_ID:
+        raise SmokeCheckError(f"/api/v1/models must expose {EXPECTED_MODEL_ID}")
+    owner = str(model.get("owned_by", ""))
+    if owner != "Meta":
+        raise SmokeCheckError("/api/v1/models owned_by must be 'Meta'")
+    if "token.place" in owner.lower():
+        raise SmokeCheckError("/api/v1/models must not claim token.place owns the launch model")
+    model_ids = [str(item.get("id", "")) for item in models if isinstance(item, dict)]
+    if any(":alignment" in model_id for model_id in model_ids):
+        raise SmokeCheckError("/api/v1/models must not expose alignment model variants")
+
+
+def run_smoke(base_url: str, *, timeout: float = 10.0) -> list[SmokeResult]:
+    normalized = normalize_base_url(base_url)
+    validators = {
+        "/livez": validate_livez,
+        "/healthz": validate_healthz,
+        "/relay/diagnostics": validate_diagnostics,
+        "/api/v1/models": validate_models,
+    }
+    results: list[SmokeResult] = []
+    for endpoint in JSON_ENDPOINTS:
+        payload = fetch_json(normalized, endpoint, timeout=timeout)
+        validators[endpoint](payload)
+        results.append(SmokeResult(endpoint=endpoint, status="ok"))
+    return results
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run opt-in token.place promotion smoke checks")
+    parser.add_argument("--base-url", default=os.environ.get("TOKENPLACE_SMOKE_BASE_URL", ""))
+    parser.add_argument("--timeout", type=float, default=float(os.environ.get("TOKENPLACE_SMOKE_TIMEOUT", "10")))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if os.environ.get("RUN_PROMOTION_SMOKE") != "1":
+        print("SKIP: set RUN_PROMOTION_SMOKE=1 and TOKENPLACE_SMOKE_BASE_URL to run promotion smoke checks")
+        return 0
+
+    try:
+        base_url = normalize_base_url(args.base_url)
+        if is_production_url(base_url) and os.environ.get("TOKENPLACE_SMOKE_ALLOW_PROD") != "1":
+            raise SmokeCheckError(
+                "refusing to smoke-test production without TOKENPLACE_SMOKE_ALLOW_PROD=1"
+            )
+        results = run_smoke(base_url, timeout=args.timeout)
+    except SmokeCheckError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    for result in results:
+        print(f"PASS: {result.endpoint} {result.status}")
+    print(f"PASS: promotion smoke checks completed for {base_url}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_docs_promotion.py
+++ b/tests/unit/test_docs_promotion.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+PROMOTION_DOC = Path("docs/PRODUCTION_PROMOTION.md")
+
+
+def test_production_promotion_checklist_covers_0_1_0_guardrails() -> None:
+    text = PROMOTION_DOC.read_text(encoding="utf-8")
+
+    required_phrases = [
+        "green CI checks, including Linux and macOS",
+        "run_all_tests.sh",
+        "staging deployment image, Helm chart, and release artifact",
+        "Windows and macOS desktop release candidates install successfully",
+        "GET /livez",
+        "GET /healthz",
+        "GET /relay/diagnostics",
+        "total_registered_compute_nodes",
+        "total_api_v1_registered_compute_nodes",
+        "GET /api/v1/models",
+        "exactly one public model: `llama-3.1-8b-instruct`",
+        "landing dropdown has exactly one model option",
+        "does not show `owned by token.place`",
+        "two new browser clients round-robin",
+        "remains sticky to its selected server across multiple turns",
+        "automatic failover to another available compute node without losing visible chat history",
+        "No full public key is rendered in the DOM",
+        "no `/api/v2` calls",
+        "no `/api/v1/chat/completions` calls",
+        "production secrets",
+        "relay registration tokens",
+        "rate-limit storage",
+        "rollback path",
+        "ciphertext only plus safe routing metadata",
+    ]
+
+    missing = [phrase for phrase in required_phrases if phrase not in text]
+    assert not missing, "Promotion checklist missing required guardrails: " + ", ".join(missing)
+
+
+def test_promotion_smoke_helper_is_documented_as_opt_in_and_offline_by_default() -> None:
+    text = PROMOTION_DOC.read_text(encoding="utf-8")
+
+    assert "scripts/promotion_smoke.py" in text
+    assert "RUN_PROMOTION_SMOKE=1" in text
+    assert "TOKENPLACE_SMOKE_BASE_URL=https://staging.token.place" in text
+    assert "TOKENPLACE_SMOKE_ALLOW_PROD=1" in text
+    assert "exits without making network requests" in text
+    assert "does not send chat" in text

--- a/tests/unit/test_promotion_smoke.py
+++ b/tests/unit/test_promotion_smoke.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+
+from scripts import promotion_smoke
+
+
+def test_normalize_base_url_defaults_https_and_strips_paths() -> None:
+    assert promotion_smoke.normalize_base_url("staging.token.place/smoke?x=1") == "https://staging.token.place"
+    assert promotion_smoke.normalize_base_url("https://staging.token.place/path/") == "https://staging.token.place"
+    assert promotion_smoke.endpoint_url("https://staging.token.place", "/livez") == "https://staging.token.place/livez"
+
+
+@pytest.mark.parametrize("raw_url", ["", "ftp://token.place", "https://"])
+def test_normalize_base_url_rejects_unsafe_values(raw_url: str) -> None:
+    with pytest.raises(promotion_smoke.SmokeCheckError):
+        promotion_smoke.normalize_base_url(raw_url)
+
+
+def test_production_url_requires_explicit_allowance() -> None:
+    assert promotion_smoke.is_production_url("https://token.place")
+    assert promotion_smoke.is_production_url("https://www.token.place")
+    assert not promotion_smoke.is_production_url("https://staging.token.place")
+
+
+def test_validate_models_requires_single_launch_model() -> None:
+    promotion_smoke.validate_models(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": "llama-3.1-8b-instruct",
+                    "object": "model",
+                    "owned_by": "Meta",
+                    "root": "llama-3.1-8b-instruct",
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"object": "list", "data": []},
+        {
+            "object": "list",
+            "data": [
+                {"id": "llama-3.1-8b-instruct", "owned_by": "Meta"},
+                {"id": "llama-3.1-8b-instruct:alignment", "owned_by": "token.place"},
+            ],
+        },
+        {"object": "list", "data": [{"id": "llama-3.1-8b-instruct", "owned_by": "token.place"}]},
+        {"object": "list", "data": [{"id": "llama-3-8b-instruct", "owned_by": "Meta"}]},
+    ],
+)
+def test_validate_models_rejects_promotion_contract_drift(payload: dict) -> None:
+    with pytest.raises(promotion_smoke.SmokeCheckError):
+        promotion_smoke.validate_models(payload)
+
+
+def test_validate_diagnostics_requires_accurate_live_counts() -> None:
+    promotion_smoke.validate_diagnostics(
+        {
+            "registered_compute_nodes": [{"server_public_key_fingerprint": "abc"}],
+            "total_registered_compute_nodes": 1,
+            "api_v1_registered_compute_nodes": [{"server_public_key_fingerprint": "abc"}],
+            "total_api_v1_registered_compute_nodes": 1,
+        }
+    )
+
+    with pytest.raises(promotion_smoke.SmokeCheckError):
+        promotion_smoke.validate_diagnostics(
+            {
+                "registered_compute_nodes": [],
+                "total_registered_compute_nodes": 1,
+                "api_v1_registered_compute_nodes": [],
+                "total_api_v1_registered_compute_nodes": 0,
+            }
+        )
+
+
+def test_run_smoke_uses_only_json_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    payloads = {
+        "/livez": {"status": "alive"},
+        "/healthz": {"status": "ok", "registeredServers": []},
+        "/relay/diagnostics": {
+            "registered_compute_nodes": [],
+            "total_registered_compute_nodes": 0,
+            "api_v1_registered_compute_nodes": [],
+            "total_api_v1_registered_compute_nodes": 0,
+        },
+        "/api/v1/models": {
+            "object": "list",
+            "data": [{"id": "llama-3.1-8b-instruct", "owned_by": "Meta"}],
+        },
+    }
+    calls: list[str] = []
+
+    def fake_fetch_json(base_url: str, endpoint: str, *, timeout: float = 10.0) -> dict:
+        assert base_url == "https://staging.token.place"
+        assert timeout == 3.0
+        calls.append(endpoint)
+        return payloads[endpoint]
+
+    monkeypatch.setattr(promotion_smoke, "fetch_json", fake_fetch_json)
+
+    results = promotion_smoke.run_smoke("https://staging.token.place/ignored", timeout=3.0)
+
+    assert calls == list(promotion_smoke.JSON_ENDPOINTS)
+    assert [result.endpoint for result in results] == list(promotion_smoke.JSON_ENDPOINTS)
+
+
+def test_fetch_json_rejects_non_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        status = 200
+        headers = {"Content-Type": "text/plain"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def getcode(self) -> int:
+            return 200
+
+        def read(self) -> bytes:
+            return b"ok"
+
+    monkeypatch.setattr(promotion_smoke.urllib.request, "urlopen", lambda request, timeout: FakeResponse())
+
+    with pytest.raises(promotion_smoke.SmokeCheckError):
+        promotion_smoke.fetch_json("https://staging.token.place", "/livez")
+
+
+def test_fetch_json_rejects_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        status = 200
+        headers = {"Content-Type": "application/json"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def getcode(self) -> int:
+            return 200
+
+        def read(self) -> bytes:
+            return b"not json"
+
+    monkeypatch.setattr(promotion_smoke.urllib.request, "urlopen", lambda request, timeout: FakeResponse())
+
+    with pytest.raises(promotion_smoke.SmokeCheckError):
+        promotion_smoke.fetch_json("https://staging.token.place", "/livez")
+
+
+def test_fetch_json_returns_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        status = 200
+        headers = {"Content-Type": "application/json; charset=utf-8"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def getcode(self) -> int:
+            return 200
+
+        def read(self) -> bytes:
+            return json.dumps({"status": "alive"}).encode("utf-8")
+
+    monkeypatch.setattr(promotion_smoke.urllib.request, "urlopen", lambda request, timeout: FakeResponse())
+
+    assert promotion_smoke.fetch_json("https://staging.token.place", "/livez") == {"status": "alive"}
+
+
+def test_fetch_json_reports_http_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*args, **kwargs):
+        raise urllib.error.HTTPError("https://staging.token.place/livez", 503, "down", {}, None)
+
+    monkeypatch.setattr(promotion_smoke.urllib.request, "urlopen", fail)
+
+    with pytest.raises(promotion_smoke.SmokeCheckError, match="HTTP 503"):
+        promotion_smoke.fetch_json("https://staging.token.place", "/livez")


### PR DESCRIPTION
### Motivation

- Provide a repeatable, lightweight staging-to-production checklist for v0.1.0 that captures high-risk launch invariants (model identity, owner text, live node counts, sticky routing/failover, and relay E2EE privacy). 
- Offer an opt-in, non-invasive smoke helper to automate safe JSON endpoint checks for staging/prod promotion without sending chat prompts or running by default.

### Description

- Added a manual promotion guide at `docs/PRODUCTION_PROMOTION.md` describing the 0.1.0 promotion checklist and invariants (includes the exact model id `llama-3.1-8b-instruct`, owner redaction, sticky-server failover behavior, and relay E2EE privacy guardrails). 
- Added an opt-in smoke harness `scripts/promotion_smoke.py` which validates `/livez`, `/healthz`, `/relay/diagnostics`, and `/api/v1/models`; it is safe-by-default and requires `RUN_PROMOTION_SMOKE=1` and `TOKENPLACE_SMOKE_BASE_URL`; production is blocked unless `TOKENPLACE_SMOKE_ALLOW_PROD=1`. 
- Added unit tests: `tests/unit/test_promotion_smoke.py` (URL handling, endpoint validation, model assertions) and `tests/unit/test_docs_promotion.py` (sentinel coverage that the checklist documents required guardrails); updated docs index references in `docs/README.md`, `docs/TESTING.md`, and `docs/AGENTS.md`. 
- Small test hygiene tweak in the smoke test helpers to satisfy `vulture` (changed `__exit__` signatures to use `*args`) so pre-commit checks pass.

### Testing

- Ran unit and doc tests: `python -m pytest tests/unit/test_promotion_smoke.py tests/unit/test_docs_promotion.py tests/unit/test_testing_documentation.py -v` — all passed. 
- Verified API launch contract/regressions: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` — passed. 
- Ran targeted E2E UI checks: `python -m pytest tests/e2e/test_ui.py -k "landing_chat or model or sticky or failover" -v` after installing Playwright browsers (`playwright install chromium` and `playwright install-deps chromium`) — selected E2E tests passed (Playwright setup completed). 
- Ran JS tests: `npm run test:js` — passed. 
- Ran full repo test runner: `./run_all_tests.sh` — the entire test suite completed successfully (unit, integration, API, security, crypto compatibility, and integration suites passed). 
- Ran `pre-commit run --all-files` and fixed a small linter/test-signature issue; final `pre-commit` completed successfully.

Notes and residual risks

- The smoke helper intentionally only exercises safe JSON endpoints and does not perform browser chat interactions; operators must still perform the checklist browser/desktop registration steps manually or via documented procedures when required. 
- Playwright browser binaries and native system dependencies must be available where Playwright E2E checks are run (CI jobs should continue to install Playwright browsers and deps). 
- The helper refuses to target production unless `TOKENPLACE_SMOKE_ALLOW_PROD=1` is explicitly set to avoid accidental production probing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29efef3144832f96b59ea5dc6af8f6)