### PR TITLE
docs: close out v0.1.0 launch and make production promotion checklist evergreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- v0.1.0 runtime/release alignment: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
-- Preferred staging/prod tag: immutable `main-<shortsha>` copied from the `ci-image.yml` workflow summary (`main-latest` is convenience-only)
+- Release alignment: Git semver tag `vX.Y.Z`, chart `appVersion`, chart package version, and release image tag should be recorded together for each production promotion.
+- Preferred staging/prod tag: immutable `main-<shortsha>` copied from the `ci-image.yml` workflow summary (`main-latest` is convenience-only). The v0.1.0 production launch promoted `main-d94c243`; see [`docs/releases/v0.1.0.md`](docs/releases/v0.1.0.md).
 - Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - Pre-publish gate: `ci-helm.yml` checks whether the current chart version already exists at `oci://ghcr.io/futuroptimist/charts/tokenplace`. It publishes only new chart versions when chart source files changed, skips unchanged already-published versions as a no-op, and fails changed chart source with an already-published version so maintainers bump `charts/tokenplace/Chart.yaml`.
 
@@ -298,7 +298,9 @@ Once Sugarkube P5 lands, the equivalent generic command is:
 just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
 ```
 
+- Production promotion checklist: [`docs/PRODUCTION_PROMOTION.md`](docs/PRODUCTION_PROMOTION.md)
 - GHCR-first release workflow: [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md)
+- v0.1.0 historical launch record: [`docs/releases/v0.1.0.md`](docs/releases/v0.1.0.md)
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:
   - [`docs/k3s-sugarkube-dev.md`](docs/k3s-sugarkube-dev.md)

--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,32 +1,103 @@
-# token.place 0.1.0 staging-to-production promotion checklist
+# token.place production promotion checklist
 
-Use this checklist for every `v0.1.0` relay promotion from staging to production. It is intentionally
-repeatable and focused on the launch risks that have regressed before: API v1 model identity,
+Use this checklist for every relay promotion from staging to production. It is intentionally
+repeatable and focused on risks that have regressed before: API v1 model identity,
 landing-chat routing, relay-blind E2EE privacy, live compute-node diagnostics, production secrets,
-and rollback readiness.
+cluster/tunnel targeting, and rollback readiness. For the historical v0.1.0 launch evidence, see
+[releases/v0.1.0.md](releases/v0.1.0.md).
 
 ## Promotion rules
 
 - Promote only an already-verified staging artifact. Do not rebuild between staging sign-off and
   production unless the new artifact repeats this checklist from the beginning.
-- Keep API v1 as the only active runtime target for `v0.1.0`; it is non-streaming by design.
+- Keep API v1 as the only active runtime target for the current production relay; it is
+  non-streaming by design.
 - Keep relay-owned state, logs, diagnostics, and payloads ciphertext-only plus safe routing metadata.
   Never capture or paste plaintext prompts, messages, responses, tool arguments, or model output.
 - Use synthetic smoke prompts only; do not send sensitive, customer, or private content.
 - Record exact artifact identifiers, environment URLs, command output summaries, and rollback steps
   in the release notes or promotion issue.
 
+## Environment targeting guardrail
+
+Staging and production are separate Sugarkube clusters and separate Cloudflare Tunnel connectors.
+Do not run production promotion from the staging cluster. Doing so repoints the staging cluster's
+single `tokenplace` release to production host values and makes `staging.token.place` return 404,
+while `token.place` still routes to the separate production tunnel and cluster.
+
+Before staging deploys, verify hostname/node context is `sugarkube3`-`sugarkube5` and the tunnel is
+`sugarkube-staging` for `staging.token.place`. Before production deploys, verify hostname/node
+context is `sugarkube0`-`sugarkube2` and the tunnel is `sugarkube-prod` for `token.place`.
+
+```bash
+hostname
+kubectl get nodes -o wide
+kubectl -n cloudflare get deploy,pod -l app.kubernetes.io/name=cloudflare-tunnel
+```
+
+## Artifact and tag verification
+
+Confirm the staging deployment image, chart, and release artifact are exactly the ones intended for
+production promotion; prefer immutable image tags and chart versions, plus a digest where available.
+For semver releases, verify Git tags before announcing the release:
+
+```bash
+git fetch --tags origin
+git ls-remote --tags origin v0.1.0 desktop-v0.1.0
+git rev-parse v0.1.0 desktop-v0.1.0
+```
+
+If release and desktop tags point to the same commit, record that in the release notes. If they point
+to different commits, do not retag from this checklist; record the actual SHAs and ask maintainers to
+review.
+
+## Cloudflare Browser Integrity Check skip rules
+
+Do not disable Browser Integrity Check globally. Desktop compute nodes are non-browser API clients,
+and Cloudflare can return a pre-app `403` with `error code: 1010` when BIC blocks registration or
+polling. Instead, add targeted custom WAF skip rules for relay API paths only, preserving the normal
+browser security posture elsewhere.
+
+Staging custom WAF skip rule:
+
+- Name: `Skip BIC for staging token.place relay API`
+- Expression: `(http.host eq "staging.token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+- Action: `Skip`
+- WAF component skipped: `Browser Integrity Check`
+- Log matching requests: enabled
+
+Production custom WAF skip rule:
+
+- Name: `Skip BIC for prod token.place relay API`
+- Expression: `(http.host eq "token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+- Action: `Skip`
+- WAF component skipped: `Browser Integrity Check`
+- Log matching requests: enabled
+
+Quick validation after the production skip is active:
+
+```bash
+curl -i -X POST https://token.place/api/v1/relay/servers/register \
+  -H 'Content-Type: application/json' \
+  --data '{}'
+```
+
+Expected result: not a Cloudflare `403 error code: 1010`. An app-level validation error is acceptable
+because `{}` is intentionally invalid.
+
 ## Pre-promotion gates
 
 - [ ] Confirm PR CI checks are green, including the Linux and macOS `run_all_tests.sh` PR checks.
-- [ ] Confirm the staging deployment image, chart, and release artifact are exactly the ones intended
-      for production promotion; prefer immutable image tags and chart versions, plus a digest where
+- [ ] Confirm the immutable image tag, chart reference, chart version, and chart digest where
       available.
+- [ ] Confirm Git release tags as described above when promoting a semver release.
 - [ ] Confirm desktop releases for Windows and macOS install successfully and register as compute
       nodes against staging.
 - [ ] Confirm production secrets and relay registration tokens are set for the production target.
 - [ ] Confirm rate-limit storage and production environment settings are configured for production,
       not in-memory or development defaults unless an approved temporary launch exception is recorded.
+- [ ] Confirm the Cloudflare BIC skip rule is present for the target relay API path and does not
+      apply globally.
 - [ ] Confirm the rollback path, including the previous known-good image/chart/artifact identifiers,
       command owner, expected recovery time, and any data/state caveats.
 
@@ -111,3 +182,10 @@ Browser-only checklist items such as dropdown count, missing owner text, no full
 DOM, no landing-chat `/api/v2` calls, no landing-chat `/api/v1/chat/completions` calls, sticky
 routing, two-node round-robin, and automatic history-preserving failover still require the Playwright
 or manual browser evidence listed above.
+
+## Post-launch backlog
+
+- Shorten public keys in health, diagnostics, and log output to fingerprints.
+- Keep Cloudflare BIC skip rules documented for staging and production relay API paths.
+- Consider making staging/prod release separation harder to misuse with clearer recipes, guardrails,
+  or separate release names.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ testing, and deploying token.place. For an expanded overview of every directory,
   - Also see: [RPI_DEPLOYMENT_GUIDE.md](RPI_DEPLOYMENT_GUIDE.md),
     [docker-compose.yml](../docker-compose.yml), [k8s/](../k8s/),
     [relay_sugarkube_onboarding.md](relay_sugarkube_onboarding.md),
+    [PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md),
     [k3s-sugarkube-dev.md](k3s-sugarkube-dev.md),
     [k3s-sugarkube-staging.md](k3s-sugarkube-staging.md),
     [k3s-sugarkube-prod.md](k3s-sugarkube-prod.md)
@@ -42,8 +43,9 @@ testing, and deploying token.place. For an expanded overview of every directory,
 - **Security:** [SECURITY_PRIVACY_AUDIT.md](SECURITY_PRIVACY_AUDIT.md) contains the rolling
   hardening checklist and threat model; use
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
-- **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
-  [CHANGELOG_STEP.md](CHANGELOG_STEP.md).
+- **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md), stepwise updates in
+  [CHANGELOG_STEP.md](CHANGELOG_STEP.md), and historical launch records such as
+  [releases/v0.1.0.md](releases/v0.1.0.md).
 
 ## Prompt docs
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -28,7 +28,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Release alignment: record the Git semver tag, chart `appVersion`, chart package version, and immutable relay image tag together for each promotion; the v0.1.0 launch record is in [releases/v0.1.0.md](releases/v0.1.0.md).
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and not production sign-off

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -29,7 +29,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Release alignment: record the Git semver tag, chart `appVersion`, chart package version, and immutable relay image tag together for each promotion; the v0.1.0 launch record is in [releases/v0.1.0.md](releases/v0.1.0.md).
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and must not be used for staging sign-off or production promotion

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -132,6 +132,55 @@ reaches `relay.py`; validate HTTPS `/`, `/livez`, `/healthz`, and
 `/relay/diagnostics`, and check Cloudflare Security Events by `cf-ray` when a
 desktop/compute node sees a pre-app 403 before changing relay code.
 
+### Cluster and tunnel context guardrail
+
+Staging and production are separate Sugarkube clusters and separate Cloudflare Tunnel
+connectors:
+
+- Staging: `sugarkube3`-`sugarkube5`, tunnel `sugarkube-staging`, host
+  `staging.token.place`.
+- Production: `sugarkube0`-`sugarkube2`, tunnel `sugarkube-prod`, host `token.place`.
+
+Do not run production promotion from the staging cluster. That repoints the staging
+cluster's single `tokenplace` release to production host values and makes
+`staging.token.place` return 404 while `token.place` still routes to the separate
+production tunnel and cluster. Before every deploy, confirm the node and tunnel context:
+
+```bash
+hostname
+kubectl get nodes -o wide
+kubectl -n cloudflare get deploy,pod -l app.kubernetes.io/name=cloudflare-tunnel
+```
+
+### Cloudflare Browser Integrity Check skip rules
+
+Keep Browser Integrity Check enabled globally. Desktop compute nodes are non-browser
+API clients, and Cloudflare can return a pre-app `403` with `error code: 1010` when
+BIC blocks relay registration or polling. Use targeted custom WAF skip rules for
+`/api/v1/relay/` only:
+
+- Staging rule name: `Skip BIC for staging token.place relay API`
+  - Expression: `(http.host eq "staging.token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+  - Action: `Skip`
+  - WAF component skipped: `Browser Integrity Check`
+  - Log matching requests: enabled
+- Production rule name: `Skip BIC for prod token.place relay API`
+  - Expression: `(http.host eq "token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+  - Action: `Skip`
+  - WAF component skipped: `Browser Integrity Check`
+  - Log matching requests: enabled
+
+Validate the production rule with an intentionally invalid app request:
+
+```bash
+curl -i -X POST https://token.place/api/v1/relay/servers/register \
+  -H 'Content-Type: application/json' \
+  --data '{}'
+```
+
+Expected: not a Cloudflare `403 error code: 1010`. An app-level validation error is
+acceptable because `{}` is intentionally invalid.
+
 ## Local-development appendix
 
 Local image builds, root `docker-compose.yml`, and raw `k8s/` manifests are for

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -39,7 +39,7 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Release alignment: record the Git semver tag, chart `appVersion`, chart package version, and immutable relay image tag together for each promotion; the v0.1.0 launch record is in [releases/v0.1.0.md](releases/v0.1.0.md).
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and not staging sign-off or production promotion material
@@ -491,12 +491,12 @@ curl -fsS https://staging.token.place/metrics | head -n 40
 
 ### Image tag, chart version, and Git tag must be validated independently
 
-For final v0.1.0 release readiness, verify all four identifiers explicitly (separate from staging candidate validation):
+For release readiness, verify all identifiers explicitly (separate from staging candidate validation):
 
-- Git release tag: `v0.1.0`
-- Chart package version: `0.1.1` (with chart `appVersion: "0.1.0"`)
-- Chart appVersion: `"0.1.0"`
-- Relay image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Git release tag: `vX.Y.Z`
+- Desktop Git release tag when applicable, for example `desktop-vX.Y.Z`
+- Chart package version and chart `appVersion`
+- Immutable relay image tag, either `main-<shortsha>` for a promoted main artifact or `ghcr.io/futuroptimist/tokenplace-relay:vX.Y.Z` for a semver release
 
 Example image-tag existence checks:
 
@@ -506,7 +506,11 @@ IMAGE_TAG=main-REPLACE_SHORTSHA
 docker manifest inspect "ghcr.io/futuroptimist/tokenplace-relay:${IMAGE_TAG}" >/dev/null
 
 # Final release-tag validation.
-docker manifest inspect ghcr.io/futuroptimist/tokenplace-relay:v0.1.0 >/dev/null
+RELEASE_TAG=vX.Y.Z
+docker manifest inspect "ghcr.io/futuroptimist/tokenplace-relay:${RELEASE_TAG}" >/dev/null
+git fetch --tags origin
+git ls-remote --tags origin "${RELEASE_TAG}" "desktop-${RELEASE_TAG}"
+git rev-parse "${RELEASE_TAG}" "desktop-${RELEASE_TAG}"
 ~~~
 
 ### Relay-only health output expectations (staging and production)

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,83 @@
+# token.place v0.1.0 launch record
+
+The v0.1.0 production launch is complete. Keep this page as historical evidence; use
+[../PRODUCTION_PROMOTION.md](../PRODUCTION_PROMOTION.md) for the evergreen promotion checklist for
+future releases.
+
+## Artifacts promoted
+
+- Relay image/tag: `ghcr.io/futuroptimist/tokenplace-relay:main-d94c243`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Chart version: `0.1.0`
+- Chart digest observed during deploy: `sha256:52f55f9a3147194d092579a640382540da467dd2aa1f1cd416e30e970713cf1d`
+
+## Tag verification
+
+Both `v0.1.0` and `desktop-v0.1.0` were present at origin and pointed to the same commit:
+`d94c243a5600c1722c90aefc982ee0bdec05b1d0`.
+
+Maintainer verification commands:
+
+```bash
+git fetch --tags origin
+git ls-remote --tags origin v0.1.0 desktop-v0.1.0
+git rev-parse v0.1.0 desktop-v0.1.0
+```
+
+## Staging restoration evidence
+
+- Cluster: `sugarkube3`-`sugarkube5`
+- Cloudflare tunnel: `sugarkube-staging`
+- Hostname: `staging.token.place`
+- `just app-deploy app=tokenplace env=staging tag="main-d94c243"` succeeded.
+- `just app-verify app=tokenplace env=staging` passed 4/4.
+
+## Production promotion evidence
+
+- Cluster: `sugarkube0`-`sugarkube2`
+- Cloudflare tunnel: `sugarkube-prod`
+- Hostname: `token.place`
+- `just app-promote-prod app=tokenplace tag="main-d94c243"` succeeded.
+- `just app-verify app=tokenplace env=prod` passed 4/4.
+- Production JSON smoke passed:
+  - `/livez ok`
+  - `/healthz ok`
+  - `/relay/diagnostics ok`
+  - `/api/v1/models ok`
+- Production diagnostics showed `total_api_v1_registered_compute_nodes: 2`.
+- Windows and macOS desktop nodes both registered successfully to `https://token.place`.
+
+## Production browser smoke evidence
+
+- Page loads.
+- Live compute nodes shows 2.
+- Model dropdown has exactly `llama-3.1-8b-instruct`.
+- The page does not show `owned by token.place`.
+- Fresh browser clients round-robin between Windows/macOS server labels.
+- One client stays sticky across turns.
+- Stopping the sticky server fails over to the other node.
+- Chat history remains visible.
+- No full public key appears in the DOM.
+- No `/api/v2` calls from landing chat.
+- No `/api/v1/chat/completions` calls from landing chat.
+
+## Relay privacy sentinel evidence
+
+The production relay privacy sentinel passed:
+
+- Sentinel absent from relay logs.
+- Prompt phrase absent from relay logs.
+- Sensitive-looking grep showed health probes and relay request/response metadata only, not plaintext
+  prompts, messages, responses, model output, tool args, private keys, ciphertext bodies, cipherkeys,
+  or IVs.
+
+## Launch lesson
+
+Staging and production are separate Sugarkube clusters and separate Cloudflare Tunnel connectors:
+
+- Staging: `sugarkube3`-`sugarkube5` via `sugarkube-staging`.
+- Production: `sugarkube0`-`sugarkube2` via `sugarkube-prod`.
+
+Do not run production promotion from the staging cluster. Doing so repoints the staging cluster's
+single `tokenplace` release to production host values and makes `staging.token.place` return 404,
+while `token.place` still routes to the separate production tunnel and cluster.


### PR DESCRIPTION
### Motivation

- Record that the v0.1.0 production launch is complete and keep its evidence as a historical record so future promotions are not tied to v0.1.0 wording.  
- Convert the v0.1.0-specific staging-to-production checklist into an evergreen production promotion runbook that is reusable for future releases.  
- Capture important operational lessons (staging/prod Sugarkube cluster and Cloudflare tunnel separation) and document targeted Cloudflare BIC skip rules needed for relay API paths.

### Description

- Rewrote `docs/PRODUCTION_PROMOTION.md` into an evergreen `production promotion checklist` and added explicit environment-targeting guardrails and tag-verification guidance.  
- Added `docs/releases/v0.1.0.md` as the historical v0.1.0 launch record containing promoted artifact, chart/digest, staging/production evidence, browser smoke summary, and the launch lesson.  
- Documented targeted Cloudflare Browser Integrity Check (BIC) skip rules for `/api/v1/relay/` in `docs/ops/sugarkube-release.md` and included a quick `curl` validation example.  
- Updated README/docs indices and Sugarkube/relay onboarding and k3s runbooks to be version-agnostic while preserving the required artifact/tag/chart verification flow and reusable checks.

### Testing

- Verified tags and commits with `git fetch --tags https://github.com/futuroptimist/token.place.git && git rev-parse v0.1.0 desktop-v0.1.0`, which succeeded and showed both tags point to commit `d94c243a5600c1722c90aefc982ee0bdec05b1d0`.  
- Ran the repository search and sanity checks with `rg -n "v0\.1\.0.*pending|launch.*pending|TODO.*v0\.1\.0|error code: 1010|Browser Integrity|Skip BIC|sugarkube-prod|sugarkube-staging" docs README.md .github` and `git diff --check`, both of which completed without actionable findings.  
- Executed `python -m pytest tests/unit/test_api_v1_launch_contract.py -v`, which passed (11 tests passed).  
- Executed `python -m pytest tests/unit/test_promotion_smoke.py -v` and `pre-commit run --all-files`, both of which passed (35 promotion-smoke tests passed and pre-commit hooks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9763f3ec832fb46685abafa9e4c2)