### PR TITLE
docs: close out token.place v0.1.0 launch and make promotion checklist evergreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,27 +223,27 @@ See also:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
 
-## API v1 E2EE architecture baseline (v0.1.0)
+## API v1 E2EE architecture baseline
 
-- **This baseline applies to the active v0.1.0 relay/client-server runtime path** (including distributed relay and desktop integration paths being finalized for v0.1.0).
-- **API v1 is the active API for v0.1.0** and the only approved runtime integration target.
+- **This baseline applies to the active relay/client-server runtime path** (including distributed relay and desktop integration paths launched for v0.1.0).
+- **API v1 is the active runtime API** and the only approved runtime integration target.
 - **API v1 is non-streaming** for relay/client-server inference paths; return responses only after
   full model generation is complete.
 - **Do not add streaming to API v1** for active relay/client-server paths.
-- **API v2 exists but is incomplete**; do not route runtime traffic through API v2 until API v1 is
-  launched and v0.1.0 is finalized.
+- **API v2 exists but is incomplete**; do not route runtime traffic through API v2 for production
+  runtime paths until a future release explicitly promotes it.
 - **If later sections of this README show API v2 streaming or `/api/v2/chat/completions` examples,
-  treat them as experimental/reference-only** and not as approved runtime integration guidance for v0.1.0.
+  treat them as experimental/reference-only** and not as approved runtime integration guidance.
 - **Deprecated legacy relay endpoints**: `/sink`, `/faucet`, `/source`, `/retrieve`,
   `/next_server`. Do not use, extend, or reintroduce these as active production fallbacks.
 - Relay-blind E2EE remains mandatory: relay surfaces may see ciphertext + safe routing metadata
   only, and must never store or expose plaintext model payload content.
 
-Known migration gap: `relay.py`, desktop-tauri paths, and relay landing-page HTML chat flow are
-not fully aligned yet; some E2E pieces still hit legacy routes. This migration is tracked as
-follow-up implementation work.
+Known migration gaps after the v0.1.0 launch remain tracked as follow-up implementation work; do
+not preserve or expand legacy relay routes for new production behavior.
 
-See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md).
+See [docs/architecture/api_v1_e2ee_relay.md](docs/architecture/api_v1_e2ee_relay.md). The completed
+launch evidence is recorded in [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md).
 
 ## Canonical entrypoints
 
@@ -281,9 +281,9 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- v0.1.0 runtime/release alignment: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
 - Preferred staging/prod tag: immutable `main-<shortsha>` copied from the `ci-image.yml` workflow summary (`main-latest` is convenience-only)
-- Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `vX.Y.Z` -> `ghcr.io/futuroptimist/tokenplace-relay:vX.Y.Z`)
+- Completed v0.1.0 launch artifact record: image `ghcr.io/futuroptimist/tokenplace-relay:main-d94c243`, chart version `0.1.0`, and chart digest `sha256:52f55f9a3147194d092579a640382540da467dd2aa1f1cd416e30e970713cf1d`; see [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md)
 - Pre-publish gate: `ci-helm.yml` checks whether the current chart version already exists at `oci://ghcr.io/futuroptimist/charts/tokenplace`. It publishes only new chart versions when chart source files changed, skips unchanged already-published versions as a no-op, and fails changed chart source with an already-published version so maintainers bump `charts/tokenplace/Chart.yaml`.
 
 Sugarkube values, wrappers, and operator workflows are maintained in the Sugarkube repo. The current app-specific deploy command is:

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -34,23 +34,24 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - Keep `server/server_app.py` as compatibility-only shim behavior.
 - Keep sugarkube/k3s scope relay-only (`relay.py`) in short-to-medium-term planning.
 
-### API boundary for `v0.1.0` (must-follow)
+### API boundary for the active runtime (must-follow)
 
-- API v1 is the active API for `v0.1.0` and the only active runtime integration target.
+- API v1 is the active runtime API and the only active runtime integration target.
 - API v1 relay/client-server inference is **non-streaming by design**: return responses only
   after full model generation is complete. Do not add streaming to API v1.
-- API v2 exists but is incomplete and is deferred until **after** API v1 is fully launched on
-  sugarkube and `v0.1.0` is finalized.
+- API v2 exists but is incomplete and remains deferred until a future release explicitly promotes it
+  for production runtime traffic.
 - Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, and
   `/next_server` are historical compatibility only. Do not use them in active production paths, do
   not extend them for new features, and do not reintroduce them as fallbacks.
-- Until that launch happens, the following traffic must be **API v1-only**:
+- The following traffic must remain **API v1-only** unless a future release explicitly changes the
+  production runtime target:
   - desktop-tauri network/API calls,
   - `relay.py`,
   - relay landing-page chat UI served by `relay.py` (`static/index.html` + `static/chat.js`),
   - `server.py` API traffic.
-- Relay-path traffic in `v0.1.0` is **non-streaming by design**. Do not add v2 or SSE paths for
-  the landing-page relay chat flow.
+- Relay-path traffic is **non-streaming by design**. Do not add v2 or SSE paths for the
+  landing-page relay chat flow.
 - Desktop prompt smoke tests may still use local `llama_cpp_python` streaming because that path is
   local-only and not relay/API traffic.
 - Architecture reference: [architecture/api_v1_e2ee_relay.md](architecture/api_v1_e2ee_relay.md).

--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,27 +1,87 @@
-# token.place 0.1.0 staging-to-production promotion checklist
+# token.place production promotion checklist
 
-Use this checklist for every `v0.1.0` relay promotion from staging to production. It is intentionally
+Use this checklist for every relay promotion from staging to production. It is intentionally
 repeatable and focused on the launch risks that have regressed before: API v1 model identity,
 landing-chat routing, relay-blind E2EE privacy, live compute-node diagnostics, production secrets,
-and rollback readiness.
+and rollback readiness. The historical `v0.1.0` launch evidence lives in
+[`docs/releases/v0.1.0.md`](releases/v0.1.0.md).
 
 ## Promotion rules
 
 - Promote only an already-verified staging artifact. Do not rebuild between staging sign-off and
   production unless the new artifact repeats this checklist from the beginning.
-- Keep API v1 as the only active runtime target for `v0.1.0`; it is non-streaming by design.
+- Keep API v1 as the active runtime target; it is non-streaming by design for relay/client-server inference.
 - Keep relay-owned state, logs, diagnostics, and payloads ciphertext-only plus safe routing metadata.
   Never capture or paste plaintext prompts, messages, responses, tool arguments, or model output.
 - Use synthetic smoke prompts only; do not send sensitive, customer, or private content.
 - Record exact artifact identifiers, environment URLs, command output summaries, and rollback steps
   in the release notes or promotion issue.
 
+## Cluster and tunnel guardrail
+
+Staging and production run on separate Sugarkube clusters and Cloudflare tunnel connectors:
+
+- Staging: `sugarkube3`-`sugarkube5` via `sugarkube-staging` for `staging.token.place`.
+- Production: `sugarkube0`-`sugarkube2` via `sugarkube-prod` for `token.place`.
+
+Do not run production promotion from the staging cluster. That repoints the staging cluster's single
+`tokenplace` release to production host values and makes `staging.token.place` 404, while
+`token.place` continues to route to the separate production tunnel/cluster. Before staging deploys,
+verify the hostname/node context is `sugarkube3`-`sugarkube5`; before production deploys, verify the
+hostname/node context is `sugarkube0`-`sugarkube2`:
+
+```bash
+hostname
+kubectl get nodes -o wide
+kubectl -n cloudflare get deploy,pod -l app.kubernetes.io/name=cloudflare-tunnel
+```
+
+## Cloudflare Browser Integrity Check skip rules
+
+token.place intentionally does not disable Cloudflare Browser Integrity Check globally. Desktop
+compute nodes are non-browser API clients, so Cloudflare can block registration or polling before
+requests reach the app with a pre-app `403` and `error code: 1010`. Add targeted custom WAF skip
+rules for the relay API paths only, preserving the normal browser security posture elsewhere.
+
+Staging rule:
+
+- Name: `Skip BIC for staging token.place relay API`
+- Expression: `(http.host eq "staging.token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+- Action: `Skip`
+- WAF component skipped: `Browser Integrity Check`
+- Log matching requests: enabled
+
+Production rule:
+
+- Name: `Skip BIC for prod token.place relay API`
+- Expression: `(http.host eq "token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+- Action: `Skip`
+- WAF component skipped: `Browser Integrity Check`
+- Log matching requests: enabled
+
+Quick validation after the Cloudflare skip is active:
+
+```bash
+curl -i -X POST https://token.place/api/v1/relay/servers/register \
+  -H 'Content-Type: application/json' \
+  --data '{}'
+```
+
+Expected result: not a Cloudflare `403 error code: 1010`. An app-level validation error is acceptable
+because `{}` is intentionally invalid.
+
 ## Pre-promotion gates
 
 - [ ] Confirm PR CI checks are green, including the Linux and macOS `run_all_tests.sh` PR checks.
 - [ ] Confirm the staging deployment image, chart, and release artifact are exactly the ones intended
       for production promotion; prefer immutable image tags and chart versions, plus a digest where
-      available.
+      available. For Git releases, verify tags with:
+
+      ```bash
+      git fetch --tags origin
+      git ls-remote --tags origin vX.Y.Z desktop-vX.Y.Z
+      git rev-parse vX.Y.Z desktop-vX.Y.Z
+      ```
 - [ ] Confirm desktop releases for Windows and macOS install successfully and register as compute
       nodes against staging.
 - [ ] Confirm production secrets and relay registration tokens are set for the production target.
@@ -111,3 +171,14 @@ Browser-only checklist items such as dropdown count, missing owner text, no full
 DOM, no landing-chat `/api/v2` calls, no landing-chat `/api/v1/chat/completions` calls, sticky
 routing, two-node round-robin, and automatic history-preserving failover still require the Playwright
 or manual browser evidence listed above.
+
+
+## Post-launch backlog template
+
+Carry forward follow-ups that should not block a promotion but are worth tracking after launch:
+
+- Shorten public keys in health, diagnostics, and log output to fingerprints.
+- Keep the Cloudflare Browser Integrity Check skip rules for staging/prod relay APIs documented and
+  verified during future promotions.
+- Consider making staging/prod release separation harder to misuse with clearer recipes, guardrails,
+  or separate release names.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -357,13 +357,14 @@ To add a new visual test:
 
 ## Promotion smoke checks
 
-The repeatable `v0.1.0` staging-to-production checklist lives in
-[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md). It covers the release-specific
-smoke risks for API v1 model identity (`llama-3.1-8b-instruct` as the only public
+The repeatable production promotion checklist lives in
+[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md). It covers the reusable smoke
+risks for API v1 model identity (`llama-3.1-8b-instruct` as the only public
 model), landing dropdown count, absence of `owned by token.place`, live
 compute-node diagnostics, two-node round-robin, sticky server routing, automatic
 history-preserving failover, relay-blind privacy invariants, production secrets,
-rate-limit storage, and rollback readiness.
+rate-limit storage, and rollback readiness. The completed `v0.1.0` launch record
+lives in [releases/v0.1.0.md](releases/v0.1.0.md).
 
 For endpoint-only external smoke checks, use the opt-in helper:
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -70,6 +70,25 @@ current token.place chart source is `0.1.1`; Sugarkube `docs/apps/tokenplace.ver
 should pin `0.1.1` unless an operator explicitly documents why a different
 package is being held back.
 
+## Cluster and tunnel guardrail
+
+Staging and production are separate Sugarkube clusters and separate Cloudflare tunnel connectors:
+
+- Staging: `sugarkube3`-`sugarkube5` via `sugarkube-staging` for `staging.token.place`.
+- Production: `sugarkube0`-`sugarkube2` via `sugarkube-prod` for `token.place`.
+
+Do not run production promotion from the staging cluster. Doing so repoints the staging cluster's
+single `tokenplace` release to production host values and makes `staging.token.place` 404, while
+`token.place` still routes to the separate production tunnel/cluster. Before staging deploys, verify
+the hostname/node context is `sugarkube3`-`sugarkube5`; before production deploys, verify the
+hostname/node context is `sugarkube0`-`sugarkube2`:
+
+```bash
+hostname
+kubectl get nodes -o wide
+kubectl -n cloudflare get deploy,pod -l app.kubernetes.io/name=cloudflare-tunnel
+```
+
 ## Staging deploy path
 
 Run these steps from the appropriate repositories and replace every placeholder
@@ -131,6 +150,31 @@ release gate because desktop/compute-node registration can be blocked before it
 reaches `relay.py`; validate HTTPS `/`, `/livez`, `/healthz`, and
 `/relay/diagnostics`, and check Cloudflare Security Events by `cf-ray` when a
 desktop/compute node sees a pre-app 403 before changing relay code.
+
+Do not disable Browser Integrity Check globally. Instead, configure targeted
+custom WAF skip rules for non-browser desktop compute-node relay API traffic:
+
+- Staging rule name: `Skip BIC for staging token.place relay API`
+  - Expression: `(http.host eq "staging.token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+  - Action: `Skip`
+  - WAF component skipped: `Browser Integrity Check`
+  - Log matching requests: enabled
+- Production rule name: `Skip BIC for prod token.place relay API`
+  - Expression: `(http.host eq "token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+  - Action: `Skip`
+  - WAF component skipped: `Browser Integrity Check`
+  - Log matching requests: enabled
+
+These narrow skips avoid Cloudflare pre-app `403` responses with `error code: 1010` on
+`/api/v1/relay/` registration/polling while preserving normal browser security posture elsewhere.
+After the production skip is active, this intentionally invalid request should return an app-level
+validation error rather than a Cloudflare 1010 page:
+
+```bash
+curl -i -X POST https://token.place/api/v1/relay/servers/register \
+  -H 'Content-Type: application/json' \
+  --data '{}'
+```
 
 ## Local-development appendix
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,103 @@
+# token.place v0.1.0 launch record
+
+The token.place `v0.1.0` production launch is complete. Keep this page as a
+historical record of the launch evidence; use
+[`../PRODUCTION_PROMOTION.md`](../PRODUCTION_PROMOTION.md) as the reusable
+production promotion checklist for future releases.
+
+## Tags
+
+Verify release tags with:
+
+```bash
+git fetch --tags origin
+git ls-remote --tags origin v0.1.0 desktop-v0.1.0
+git rev-parse v0.1.0 desktop-v0.1.0
+```
+
+Observed launch result: both `v0.1.0` and `desktop-v0.1.0` exist at origin and
+point to the same commit:
+
+```text
+d94c243a5600c1722c90aefc982ee0bdec05b1d0  refs/tags/desktop-v0.1.0
+d94c243a5600c1722c90aefc982ee0bdec05b1d0  refs/tags/v0.1.0
+```
+
+If a future verification shows the tags point to different commits, do not move
+published tags in a docs PR; record the actual result and ask maintainers to
+review the release provenance.
+
+## Promoted artifacts
+
+- Relay image/tag: `ghcr.io/futuroptimist/tokenplace-relay:main-d94c243`
+- OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Chart version: `0.1.0`
+- Chart digest observed during deploy:
+  `sha256:52f55f9a3147194d092579a640382540da467dd2aa1f1cd416e30e970713cf1d`
+
+## Staging restoration evidence
+
+- Cluster: `sugarkube3`-`sugarkube5`
+- Cloudflare tunnel: `sugarkube-staging`
+- Hostname: `staging.token.place`
+- `just app-deploy app=tokenplace env=staging tag="main-d94c243"` succeeded.
+- `just app-verify app=tokenplace env=staging` passed 4/4.
+
+## Production promotion evidence
+
+- Cluster: `sugarkube0`-`sugarkube2`
+- Cloudflare tunnel: `sugarkube-prod`
+- Hostname: `token.place`
+- `just app-promote-prod app=tokenplace tag="main-d94c243"` succeeded.
+- `just app-verify app=tokenplace env=prod` passed 4/4.
+- Production JSON smoke passed for `/livez`, `/healthz`, `/relay/diagnostics`,
+  and `/api/v1/models`.
+- Production diagnostics showed `total_api_v1_registered_compute_nodes: 2`.
+- Windows and macOS desktop nodes both registered successfully to
+  `https://token.place`.
+
+## Browser smoke evidence
+
+Production browser smoke passed:
+
+- Page loads.
+- Live compute nodes shows `2`.
+- The model dropdown has exactly `llama-3.1-8b-instruct`.
+- The landing UI does not show `owned by token.place`.
+- Fresh browser clients round-robin between Windows/macOS server labels.
+- One client stays sticky across turns.
+- Stopping the sticky server fails over to the other node.
+- Chat history remains visible.
+- No full public key appears in the DOM.
+- The landing chat makes no `/api/v2` calls.
+- The landing chat makes no `/api/v1/chat/completions` calls.
+
+## Privacy sentinel evidence
+
+The production relay privacy sentinel passed. The sentinel and prompt phrase were
+absent from relay logs. Sensitive-looking log searches showed health probes and
+relay request/response metadata only, not plaintext prompts, messages, responses,
+model output, tool arguments, private keys, ciphertext bodies, cipherkeys, or
+IVs.
+
+## Launch lesson: staging and prod are separate clusters
+
+Staging and production are separate Sugarkube clusters and separate Cloudflare
+tunnel connectors:
+
+- Staging: `sugarkube3`-`sugarkube5` via `sugarkube-staging` for
+  `staging.token.place`.
+- Production: `sugarkube0`-`sugarkube2` via `sugarkube-prod` for `token.place`.
+
+Do not run production promotion from the staging cluster. Doing so repoints the
+staging cluster's single `tokenplace` release to production host values and makes
+`staging.token.place` return 404, while `token.place` still routes to the
+separate production tunnel and cluster.
+
+## Post-launch backlog
+
+- Shorten public keys in health, diagnostics, and log output to fingerprints.
+- Keep the Cloudflare Browser Integrity Check skip rules for staging/prod relay
+  APIs documented and reviewed during future promotions.
+- Consider making staging/prod release separation harder to misuse with clearer
+  recipes, guardrails, or separate release names.


### PR DESCRIPTION
### Motivation

- Record the completed `v0.1.0` production launch as a historical release note and remove v0.1.0-specific "pending" framing from evergreen promotion guidance. 
- Capture an important operator lesson that staging and production run on separate Sugarkube clusters and separate Cloudflare tunnels to avoid accidental mis-promotions. 
- Document targeted Cloudflare Browser Integrity Check (BIC) skip rules for relay API paths so desktop compute-node registration is not blocked by Cloudflare while preserving normal browser security posture. 
- Provide maintainers with concise tag-verification commands so future promotions can be validated without guessing release provenance. 

### Description

- Converted `docs/PRODUCTION_PROMOTION.md` from a v0.1.0-specific checklist into an evergreen `production promotion checklist`, added a `Cluster and tunnel guardrail` section with suggested context-check commands, and added explicit `Cloudflare Browser Integrity Check skip rules` and a quick `curl` validation example. 
- Added `docs/releases/v0.1.0.md` containing the historical launch record (tag verification, promoted artifacts, staging/prod evidence, browser smoke evidence, privacy sentinel note, and a short post-launch backlog). 
- Mirrored the cluster/tunnel guardrail and BIC skip rule guidance into `docs/ops/sugarkube-release.md` and updated `docs/AGENTS.md`, `docs/TESTING.md`, and `README.md` to remove stale v0.1.0 wording and point maintainers to the reusable checklist and the release record. 
- Kept all changes docs-only, preserved existing test helpers and smoke-check references, and added tag-verification commands to the pre-promotion gates (example: `git fetch --tags origin` and `git ls-remote --tags origin v0.1.0 desktop-v0.1.0`). 

### Testing

- Verified tags at origin with `git ls-remote --tags https://github.com/futuroptimist/token.place.git v0.1.0 desktop-v0.1.0` and `git fetch --tags ... && git rev-parse v0.1.0 desktop-v0.1.0`, which both showed `v0.1.0` and `desktop-v0.1.0` resolving to commit `d94c243a5600c1722c90aefc982ee0bdec05b1d0` (pass). 
- Ran the focused unit suites: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` (11 passed) and `python -m pytest tests/unit/test_promotion_smoke.py -v` (35 passed), both passing. 
- Ran repository hygiene checks: `rg` searches for stale v0.1.0/promotion/BIC references and `git diff --check` (no blocking findings), and `pre-commit run --all-files` which completed successfully (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b974c639c832f96b40d2ef552b014)