### PR TITLE
docs: close out v0.1.0 launch and make production promotion checklist evergreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,17 +223,17 @@ See also:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
 
-## API v1 E2EE architecture baseline (v0.1.0)
+## API v1 E2EE architecture baseline
 
-- **This baseline applies to the active v0.1.0 relay/client-server runtime path** (including distributed relay and desktop integration paths being finalized for v0.1.0).
-- **API v1 is the active API for v0.1.0** and the only approved runtime integration target.
+- **This baseline applies to the active production relay/client-server runtime path** (including distributed relay and desktop integration paths launched for v0.1.0).
+- **API v1 is the active production API** and the only approved runtime integration target.
 - **API v1 is non-streaming** for relay/client-server inference paths; return responses only after
   full model generation is complete.
 - **Do not add streaming to API v1** for active relay/client-server paths.
-- **API v2 exists but is incomplete**; do not route runtime traffic through API v2 until API v1 is
-  launched and v0.1.0 is finalized.
+- **API v2 exists but is incomplete**; do not route runtime traffic through API v2 until a future
+  migration is explicitly approved after the API v1 production baseline.
 - **If later sections of this README show API v2 streaming or `/api/v2/chat/completions` examples,
-  treat them as experimental/reference-only** and not as approved runtime integration guidance for v0.1.0.
+  treat them as experimental/reference-only** and not as approved runtime integration guidance for production.
 - **Deprecated legacy relay endpoints**: `/sink`, `/faucet`, `/source`, `/retrieve`,
   `/next_server`. Do not use, extend, or reintroduce these as active production fallbacks.
 - Relay-blind E2EE remains mandatory: relay surfaces may see ciphertext + safe routing metadata
@@ -281,7 +281,7 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- v0.1.0 runtime/release alignment: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- v0.1.0 launch record: Git tags `v0.1.0` and `desktop-v0.1.0` were both pushed and resolved to the same commit; see [`docs/releases/v0.1.0.md`](docs/releases/v0.1.0.md) for the promoted artifact evidence.
 - Preferred staging/prod tag: immutable `main-<shortsha>` copied from the `ci-image.yml` workflow summary (`main-latest` is convenience-only)
 - Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - Pre-publish gate: `ci-helm.yml` checks whether the current chart version already exists at `oci://ghcr.io/futuroptimist/charts/tokenplace`. It publishes only new chart versions when chart source files changed, skips unchanged already-published versions as a no-op, and fails changed chart source with an already-published version so maintainers bump `charts/tokenplace/Chart.yaml`.
@@ -298,6 +298,7 @@ Once Sugarkube P5 lands, the equivalent generic command is:
 just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
 ```
 
+- Production promotion checklist: [`docs/PRODUCTION_PROMOTION.md`](docs/PRODUCTION_PROMOTION.md)
 - GHCR-first release workflow: [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md)
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -34,22 +34,22 @@ Important: Always stylize the project name as lowercase `token.place` (not Title
 - Keep `server/server_app.py` as compatibility-only shim behavior.
 - Keep sugarkube/k3s scope relay-only (`relay.py`) in short-to-medium-term planning.
 
-### API boundary for `v0.1.0` (must-follow)
+### API boundary for production relay paths (must-follow)
 
-- API v1 is the active API for `v0.1.0` and the only active runtime integration target.
+- API v1 is the active production API and the only active runtime integration target.
 - API v1 relay/client-server inference is **non-streaming by design**: return responses only
   after full model generation is complete. Do not add streaming to API v1.
-- API v2 exists but is incomplete and is deferred until **after** API v1 is fully launched on
-  sugarkube and `v0.1.0` is finalized.
+- API v2 exists but is incomplete and is deferred until a future API v2 migration is explicitly
+  approved after the API v1 production baseline.
 - Deprecated legacy relay endpoints `/sink`, `/faucet`, `/source`, `/retrieve`, and
   `/next_server` are historical compatibility only. Do not use them in active production paths, do
   not extend them for new features, and do not reintroduce them as fallbacks.
-- Until that launch happens, the following traffic must be **API v1-only**:
+- The following active runtime traffic must remain **API v1-only**:
   - desktop-tauri network/API calls,
   - `relay.py`,
   - relay landing-page chat UI served by `relay.py` (`static/index.html` + `static/chat.js`),
   - `server.py` API traffic.
-- Relay-path traffic in `v0.1.0` is **non-streaming by design**. Do not add v2 or SSE paths for
+- Relay-path traffic in production is **non-streaming by design**. Do not add v2 or SSE paths for
   the landing-page relay chat flow.
 - Desktop prompt smoke tests may still use local `llama_cpp_python` streaming because that path is
   local-only and not relay/API traffic.

--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,20 +1,58 @@
-# token.place 0.1.0 staging-to-production promotion checklist
+# token.place production promotion checklist
 
-Use this checklist for every `v0.1.0` relay promotion from staging to production. It is intentionally
+Use this checklist for every relay promotion from staging to production. It is intentionally
 repeatable and focused on the launch risks that have regressed before: API v1 model identity,
 landing-chat routing, relay-blind E2EE privacy, live compute-node diagnostics, production secrets,
-and rollback readiness.
+and rollback readiness. Historical evidence for the completed v0.1.0 launch lives in
+[releases/v0.1.0.md](releases/v0.1.0.md).
 
 ## Promotion rules
 
 - Promote only an already-verified staging artifact. Do not rebuild between staging sign-off and
   production unless the new artifact repeats this checklist from the beginning.
-- Keep API v1 as the only active runtime target for `v0.1.0`; it is non-streaming by design.
+- Keep API v1 as the only active runtime target for the current production relay; it is
+  non-streaming by design.
 - Keep relay-owned state, logs, diagnostics, and payloads ciphertext-only plus safe routing metadata.
   Never capture or paste plaintext prompts, messages, responses, tool arguments, or model output.
 - Use synthetic smoke prompts only; do not send sensitive, customer, or private content.
 - Record exact artifact identifiers, environment URLs, command output summaries, and rollback steps
   in the release notes or promotion issue.
+
+## Environment context guardrail
+
+Staging and production are separate Sugarkube clusters with separate Cloudflare Tunnel connectors:
+
+- Staging: `sugarkube3-sugarkube5`, Cloudflare Tunnel `sugarkube-staging`, hostname
+  `staging.token.place`.
+- Production: `sugarkube0-sugarkube2`, Cloudflare Tunnel `sugarkube-prod`, hostname `token.place`.
+
+Do not run production promotion from the staging cluster. Doing so repoints the staging cluster's
+single `tokenplace` release to production host values and makes `staging.token.place` return 404,
+while `token.place` continues routing to the separate production tunnel and cluster.
+
+Before staging deploys, verify the hostname/node context is `sugarkube3-sugarkube5`. Before
+production deploys, verify the hostname/node context is `sugarkube0-sugarkube2`:
+
+```bash
+hostname
+kubectl get nodes -o wide
+kubectl -n cloudflare get deploy,pod -l app.kubernetes.io/name=cloudflare-tunnel
+```
+
+## Tag verification
+
+Verify release tags before cutting or announcing a production promotion:
+
+```bash
+git fetch --tags origin
+git ls-remote --tags origin vX.Y.Z desktop-vX.Y.Z
+git rev-parse vX.Y.Z desktop-vX.Y.Z
+```
+
+For the v0.1.0 launch, both `v0.1.0` and `desktop-v0.1.0` existed on the upstream GitHub remote and
+resolved to the same commit. See [releases/v0.1.0.md](releases/v0.1.0.md) for the exact evidence.
+If future relay and desktop tags resolve to different commits, do not retag in place from this
+checklist; record the actual result and route it for maintainer review.
 
 ## Pre-promotion gates
 
@@ -75,6 +113,40 @@ promotion complete:
       are still present after rollout.
 - [ ] Rollback remains available until the production smoke window is complete.
 
+## Cloudflare Browser Integrity Check skip rules
+
+Do not disable Browser Integrity Check globally. Desktop compute nodes are non-browser API clients,
+and Cloudflare can return a pre-app `403` with `error code: 1010` when Browser Integrity Check blocks
+relay registration or polling. Instead, keep normal browser security posture elsewhere and add targeted
+custom WAF skip rules for API v1 relay paths only.
+
+Staging rule:
+
+- Name: `Skip BIC for staging token.place relay API`
+- Expression: `(http.host eq "staging.token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+- Action: `Skip`
+- WAF component skipped: `Browser Integrity Check`
+- Log matching requests: enabled
+
+Production rule:
+
+- Name: `Skip BIC for prod token.place relay API`
+- Expression: `(http.host eq "token.place" and starts_with(http.request.uri.path, "/api/v1/relay/"))`
+- Action: `Skip`
+- WAF component skipped: `Browser Integrity Check`
+- Log matching requests: enabled
+
+Quick validation after the Cloudflare skip is in place:
+
+```bash
+curl -i -X POST https://token.place/api/v1/relay/servers/register \
+  -H 'Content-Type: application/json' \
+  --data '{}'
+```
+
+Expected result: not a Cloudflare `403 error code: 1010`. An app-level validation error is acceptable
+because `{}` is intentionally invalid.
+
 ## Optional JSON endpoint smoke helper
 
 `scripts/promotion_smoke.py` provides a small offline-testable harness for the JSON endpoint portion
@@ -111,3 +183,11 @@ Browser-only checklist items such as dropdown count, missing owner text, no full
 DOM, no landing-chat `/api/v2` calls, no landing-chat `/api/v1/chat/completions` calls, sticky
 routing, two-node round-robin, and automatic history-preserving failover still require the Playwright
 or manual browser evidence listed above.
+
+## Post-launch backlog
+
+- Shorten public keys in health, diagnostics, and log output to fingerprints.
+- Keep the staging and production Cloudflare BIC skip rules documented and reviewed as relay paths
+  evolve.
+- Consider making staging/prod release separation harder to misuse with clearer recipes, guardrails,
+  or separate release names.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,11 @@ testing, and deploying token.place. For an expanded overview of every directory,
 - **Security:** [SECURITY_PRIVACY_AUDIT.md](SECURITY_PRIVACY_AUDIT.md) contains the rolling
   hardening checklist and threat model; use
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
-- **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
-  [CHANGELOG_STEP.md](CHANGELOG_STEP.md).
+- **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md), stepwise updates in
+  [CHANGELOG_STEP.md](CHANGELOG_STEP.md), and historical launch records such as
+  [releases/v0.1.0.md](releases/v0.1.0.md).
+- **Promotion:** Use the evergreen [PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md) checklist for
+  staging-to-production relay promotions.
 
 ## Prompt docs
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -357,8 +357,8 @@ To add a new visual test:
 
 ## Promotion smoke checks
 
-The repeatable `v0.1.0` staging-to-production checklist lives in
-[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md). It covers the release-specific
+The repeatable production promotion checklist lives in
+[PRODUCTION_PROMOTION.md](PRODUCTION_PROMOTION.md). It covers the reusable
 smoke risks for API v1 model identity (`llama-3.1-8b-instruct` as the only public
 model), landing dropdown count, absence of `owned by token.place`, live
 compute-node diagnostics, two-node round-robin, sticky server routing, automatic

--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -44,7 +44,7 @@ runtime fallback for API v1 desktop relay requests.
 - API v2 exists in the repository, but it is currently incomplete.
 - Do **not** route active runtime traffic through API v2 yet.
 - Do **not** migrate server, relay, client, desktop, or relay HTML chat UI runtime paths to API v2
-  until API v1 is launched and v0.1.0 is finalized.
+  until a future API v2 migration is explicitly approved after the API v1 production baseline.
 
 ## Deprecated legacy relay endpoints
 

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -114,7 +114,10 @@ specific, so record the command actually used rather than inventing one here.
 
 Production uses the same GHCR image and OCI Helm chart path, with release and
 namespace `tokenplace/tokenplace`, host `token.place`, and an explicit immutable
-image tag. After promotion, repeat the real external proof against production:
+image tag. The reusable promotion checklist lives in
+[`docs/PRODUCTION_PROMOTION.md`](../PRODUCTION_PROMOTION.md), with historical v0.1.0 evidence in
+[`docs/releases/v0.1.0.md`](../releases/v0.1.0.md). After promotion, repeat the real external proof
+against production:
 
 - A separate production desktop/compute node registers to `https://token.place`
   and appears in `/healthz` and `/relay/diagnostics`.
@@ -130,7 +133,10 @@ Cloudflare Tunnel/DNS/WAF routing is external to Helm and remains an external
 release gate because desktop/compute-node registration can be blocked before it
 reaches `relay.py`; validate HTTPS `/`, `/livez`, `/healthz`, and
 `/relay/diagnostics`, and check Cloudflare Security Events by `cf-ray` when a
-desktop/compute node sees a pre-app 403 before changing relay code.
+desktop/compute node sees a pre-app 403 before changing relay code. Browser
+Integrity Check stays enabled globally; targeted Cloudflare custom WAF skip
+rules for `/api/v1/relay/` on `staging.token.place` and `token.place` are
+documented in the production promotion checklist.
 
 ## Local-development appendix
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,84 @@
+# token.place v0.1.0 launch record
+
+The token.place v0.1.0 production launch is complete. This page preserves the immutable launch
+evidence so the main [production promotion checklist](../PRODUCTION_PROMOTION.md) can stay reusable
+for future releases.
+
+## Release tags
+
+Verification commands used for this closeout:
+
+```bash
+git ls-remote --tags https://github.com/futuroptimist/token.place.git v0.1.0 desktop-v0.1.0
+git fetch --tags https://github.com/futuroptimist/token.place.git \
+  'refs/tags/v0.1.0:refs/tags/v0.1.0' \
+  'refs/tags/desktop-v0.1.0:refs/tags/desktop-v0.1.0'
+git rev-parse v0.1.0 desktop-v0.1.0
+```
+
+Observed result: both `v0.1.0` and `desktop-v0.1.0` were present on the upstream GitHub remote and
+resolved to `d94c243a5600c1722c90aefc982ee0bdec05b1d0`.
+
+## Promoted artifacts
+
+- Relay image/tag: `ghcr.io/futuroptimist/tokenplace-relay:main-d94c243`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Chart version: `0.1.0`
+- Chart digest observed during deploy: `sha256:52f55f9a3147194d092579a640382540da467dd2aa1f1cd416e30e970713cf1d`
+
+## Environment outcomes
+
+### Staging restored
+
+- Cluster: `sugarkube3-sugarkube5`
+- Cloudflare Tunnel: `sugarkube-staging`
+- Hostname: `staging.token.place`
+- `just app-deploy app=tokenplace env=staging tag="main-d94c243"` succeeded.
+- `just app-verify app=tokenplace env=staging` passed 4/4.
+
+### Production live
+
+- Cluster: `sugarkube0-sugarkube2`
+- Cloudflare Tunnel: `sugarkube-prod`
+- Hostname: `token.place`
+- `just app-promote-prod app=tokenplace tag="main-d94c243"` succeeded.
+- `just app-verify app=tokenplace env=prod` passed 4/4.
+- Production JSON smoke passed for `/livez`, `/healthz`, `/relay/diagnostics`, and
+  `/api/v1/models`.
+- Production diagnostics showed `total_api_v1_registered_compute_nodes: 2`.
+- Windows and macOS desktop nodes both registered successfully to `https://token.place`.
+
+## Browser smoke evidence
+
+Production browser smoke passed with this concise evidence:
+
+- Page loads.
+- Live compute nodes shows 2.
+- Model dropdown has exactly `llama-3.1-8b-instruct`.
+- The landing UI does not show `owned by token.place`.
+- Fresh browser clients round-robin between Windows/macOS server labels.
+- One client stays sticky across turns.
+- Stopping the sticky server fails over to the other node.
+- Chat history remains visible.
+- No full public key appears in the DOM.
+- The landing chat makes no `/api/v2` calls.
+- The landing chat makes no `/api/v1/chat/completions` calls.
+
+## Relay privacy sentinel
+
+Production relay privacy sentinel checks passed:
+
+- Sentinel absent from relay logs.
+- Prompt phrase absent from relay logs.
+- Sensitive-looking grep showed health probes and relay request/response metadata only, not plaintext
+  prompts, messages, responses, model output, tool arguments, private keys, ciphertext bodies,
+  cipherkeys, or IVs.
+
+## Launch lesson
+
+Staging and production are separate Sugarkube clusters with separate Cloudflare Tunnel connectors:
+staging is `sugarkube3-sugarkube5` via `sugarkube-staging`, while production is
+`sugarkube0-sugarkube2` via `sugarkube-prod`. Do not run production promotion from the staging
+cluster. Doing so repoints the staging cluster's single `tokenplace` release to production host
+values and makes `staging.token.place` 404 while `token.place` still routes to the separate
+production tunnel and cluster.


### PR DESCRIPTION
### Motivation
- Record that the token.place `v0.1.0` production launch is complete and preserve immutable launch evidence separately so the main promotion checklist stays reusable. 
- Capture the operator lesson that staging and production are separate Sugarkube clusters and must not be conflated during promotions. 
- Document targeted Cloudflare Browser Integrity Check (BIC) skip rules for API v1 relay paths so desktop compute-node registration is not blocked while preserving global browser security. 
- Make minimal, durable docs changes (checklist, release record, cross-references) so future promotions can re-use the process.

### Description
- Rewrote `docs/PRODUCTION_PROMOTION.md` into an evergreen `production promotion checklist` and added an operator guardrail section with commands to verify cluster/tunnel context (`hostname`, `kubectl get nodes -o wide`, `kubectl -n cloudflare get deploy,pod -l app.kubernetes.io/name=cloudflare-tunnel`).
- Added a historical launch record at `docs/releases/v0.1.0.md` that contains the promoted artifact evidence (image tag, chart, chart digest), staging/production outcomes, browser smoke summary, and tag verification notes.
- Documented exact Cloudflare WAF skip rules for staging and production relay API paths and a quick validation `curl` check in the promotion checklist.
- Updated surrounding docs and indexes to remove v0.1.0-specific pending wording and point maintainers to the evergreen checklist (`README.md`, `docs/README.md`, `docs/AGENTS.md`, `docs/TESTING.md`, `docs/architecture/api_v1_e2ee_relay.md`, and `docs/ops/sugarkube-release.md`).

### Testing
- Verified release tags: ran the tag verification sequence against upstream and observed both tags resolved to the same commit: `d94c243a5600c1722c90aefc982ee0bdec05b1d0` (commands used: `git ls-remote --tags https://github.com/futuroptimist/token.place.git v0.1.0 desktop-v0.1.0` and fetch+`git rev-parse`).
- Ran focused docs-related unit checks: `python -m pytest tests/unit/test_api_v1_launch_contract.py -v` (passed) and `python -m pytest tests/unit/test_promotion_smoke.py -v` (passed).
- Ran repository checks: `pre-commit run --all-files` and `python -m pytest tests/unit/ -q` reproduced an unrelated/non-doc regression in the unit suite: `tests/unit/test_relay_client.py::TestRelayClient::test_poll_api_v1_encrypted_work_continuously_stops_after_invalid_responses` failed with an assertion mismatch (`mock_sleep.call_count == 1406` vs expected `1`), causing the pre-commit step to fail; this is not a docs change and has been reported for maintainer follow-up.
- Per repo guidance, all modified files were linted/checked via `pre-commit` during the run; the only failing test was the single unit test noted above and is outside the scope of these docs changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b97383010832fbd51003fbc6ceecf)