### PR TITLE
v0.1.1: release metadata + landing badge, Helm env defaults, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable user-facing changes to token.place are tracked here. This file is
+lightweight and evergreen; detailed launch checklists and operational evidence
+remain in the release/runbook docs.
+
+## Unreleased / v0.1.1
+
+### Planned
+- Landing-page environment/version badge for public prod, staging, and local/dev relays.
+- Desktop multi-relay registration and polling from one operator runtime.
+- Production and staging simultaneous desktop compute-node operation with a shared warmed model.
+
+## v0.1.0 - Initial production release
+
+- Established the API v1 launch contract for non-streaming, relay-blind E2EE relay inference.
+- Shipped the landing chat demo against API v1 relay routes.
+- Added live compute-node count visibility on the relay landing page.
+- Added sticky server routing and failover for landing chat sessions.
+- Released Windows and macOS desktop compute-node flows.
+- Completed relay-blind E2EE smoke/signoff for launch readiness.
+
+Historical release evidence includes the `v0.1.0` relay release tag and the
+`desktop-v0.1.0` desktop release tag.

--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tokenplace
 description: Canonical Helm chart for deploying token.place relay
 version: 0.1.1
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 type: application

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -59,6 +59,16 @@ spec:
         - name: relay
           {{- $relayPort := printf "%v" .Values.containerPort }}
           {{- $selfDispatchURL := "http://127.0.0.1:$(RELAY_PORT)" }}
+          {{- $deployEnv := default "" .Values.deployEnv }}
+          {{- if not $deployEnv }}
+          {{- if eq .Values.ingress.host "token.place" }}
+          {{- $deployEnv = "prod" }}
+          {{- else if eq .Values.ingress.host "staging.token.place" }}
+          {{- $deployEnv = "staging" }}
+          {{- else }}
+          {{- $deployEnv = "dev" }}
+          {{- end }}
+          {{- end }}
           {{- $defaultEnv := dict
                 "RELAY_HOST" (dict "name" "RELAY_HOST" "value" "0.0.0.0")
                 "RELAY_PORT" (dict "name" "RELAY_PORT" "value" $relayPort)
@@ -66,6 +76,9 @@ spec:
                 "RELAY_THREADS" (dict "name" "RELAY_THREADS" "value" "4")
                 "TOKENPLACE_RELAY_INTERNAL_URL" (dict "name" "TOKENPLACE_RELAY_INTERNAL_URL" "value" $selfDispatchURL)
                 "TOKENPLACE_FRONTEND_MODE" (dict "name" "TOKENPLACE_FRONTEND_MODE" "value" "production")
+                "TOKENPLACE_RELEASE_VERSION" (dict "name" "TOKENPLACE_RELEASE_VERSION" "value" .Chart.AppVersion)
+                "TOKENPLACE_CHART_VERSION" (dict "name" "TOKENPLACE_CHART_VERSION" "value" .Chart.Version)
+                "TOKENPLACE_DEPLOY_ENV" (dict "name" "TOKENPLACE_DEPLOY_ENV" "value" $deployEnv)
                 "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" (dict "name" "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "value" "0")
                 "XDG_CONFIG_HOME" (dict "name" "XDG_CONFIG_HOME" "value" "/tmp/.config")
                 "XDG_DATA_HOME" (dict "name" "XDG_DATA_HOME" "value" "/tmp/.local/share")

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -16,6 +16,10 @@ fullnameOverride: ""
 
 containerPort: 5010
 
+# Public deployment environment shown in release metadata. Leave empty to infer
+# prod/staging from ingress.host or fall back to dev.
+deployEnv: ""
+
 serviceAccount:
   create: false
   annotations: {}

--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,6 +1,6 @@
-# token.place 0.1.0 staging-to-production promotion checklist
+# token.place staging-to-production promotion checklist
 
-Use this checklist for every `v0.1.0` relay promotion from staging to production. It is intentionally
+Use this checklist for every relay promotion from staging to production. It is intentionally
 repeatable and focused on the launch risks that have regressed before: API v1 model identity,
 landing-chat routing, relay-blind E2EE privacy, live compute-node diagnostics, production secrets,
 and rollback readiness.
@@ -9,7 +9,7 @@ and rollback readiness.
 
 - Promote only an already-verified staging artifact. Do not rebuild between staging sign-off and
   production unless the new artifact repeats this checklist from the beginning.
-- Keep API v1 as the only active runtime target for `v0.1.0`; it is non-streaming by design.
+- Keep API v1 as the only active runtime target until a future documented migration; it is non-streaming by design.
 - Keep relay-owned state, logs, diagnostics, and payloads ciphertext-only plus safe routing metadata.
   Never capture or paste plaintext prompts, messages, responses, tool arguments, or model output.
 - Use synthetic smoke prompts only; do not send sensitive, customer, or private content.

--- a/relay.py
+++ b/relay.py
@@ -18,6 +18,8 @@ from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
 from werkzeug.serving import make_server
 
+from release_metadata import release_metadata, release_metadata_json
+
 # Logging --------------------------------------------------------------------
 
 def _json_default(value: Any) -> Any:
@@ -101,6 +103,7 @@ _ORIGINAL_SIGNAL_HANDLERS: dict[int, Any] = {}
 STATIC_DIR_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
 INDEX_HTML_PATH = os.path.join(STATIC_DIR_PATH, "index.html")
 VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
+RELEASE_METADATA_PLACEHOLDER = '{"environment":"dev","version":"dev","ref":"","placeholder":true}'
 VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
 VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
 
@@ -118,10 +121,13 @@ def _vue_script_src_for_mode(mode: str) -> str:
     return VUE_DEV_SCRIPT_SRC if mode == "development" else VUE_PROD_SCRIPT_SRC
 
 
-def _render_index_html() -> str:
+def _render_index_html(host: str | None = None) -> str:
     with open(INDEX_HTML_PATH, encoding="utf-8") as index_file:
         html = index_file.read()
-    return html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+    return (
+        html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+        .replace(RELEASE_METADATA_PLACEHOLDER, release_metadata_json(host))
+    )
 
 
 def _handle_shutdown_signal(signum: int, frame: Any) -> None:
@@ -905,11 +911,17 @@ def _pop_stream_chunks_for_client(client_public_key):
 
 @app.route('/')
 def index():
-    response = Response(_render_index_html(), mimetype='text/html')
+    response = Response(_render_index_html(request.host), mimetype='text/html')
     response.last_modified = os.path.getmtime(INDEX_HTML_PATH)
     response.add_etag()
     response.make_conditional(request)
     return response
+
+@app.route('/api/v1/meta', methods=['GET'])
+def api_v1_meta():
+    """Return public-safe deployment metadata for diagnostics/UI display."""
+
+    return jsonify(release_metadata(request.host))
 
 # Generic route for serving static files
 @app.route('/static/<path:path>')

--- a/release_metadata.py
+++ b/release_metadata.py
@@ -1,0 +1,126 @@
+"""Public-safe release metadata helpers for token.place deployments."""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_RELEASE_VERSION = "dev"
+DEFAULT_DEPLOY_ENV = "dev"
+_PUBLIC_REF_RE = re.compile(r"[^A-Za-z0-9._:-]+")
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped or None
+
+
+def _read_chart_app_version() -> str | None:
+    chart_path = REPO_ROOT / "charts" / "tokenplace" / "Chart.yaml"
+    try:
+        for line in chart_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip().startswith("appVersion:"):
+                continue
+            _, value = line.split(":", 1)
+            return _clean(value.strip().strip('"\''))
+    except OSError:
+        return None
+    return None
+
+
+def _read_desktop_package_version() -> str | None:
+    package_path = REPO_ROOT / "desktop-tauri" / "package.json"
+    try:
+        package = json.loads(package_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _clean(package.get("version"))
+
+
+def release_version() -> str:
+    """Resolve the public release version with environment overrides first."""
+
+    return (
+        _clean(os.environ.get("TOKENPLACE_RELEASE_VERSION"))
+        or _read_chart_app_version()
+        or _read_desktop_package_version()
+        or DEFAULT_RELEASE_VERSION
+    )
+
+
+def _hostname_from_host(host: str | None) -> str | None:
+    host_value = _clean(host)
+    if not host_value:
+        return None
+    # Flask request.host may include a port; IPv6 localhost is not expected for
+    # production inference but handle bracketed values safely for dev launches.
+    if host_value.startswith("[") and "]" in host_value:
+        return host_value[1:host_value.index("]")].lower()
+    return host_value.split(":", 1)[0].lower()
+
+
+def infer_deploy_env_from_host(host: str | None) -> str | None:
+    """Infer a public deployment environment from a request host."""
+
+    hostname = _hostname_from_host(host)
+    if hostname == "token.place":
+        return "prod"
+    if hostname == "staging.token.place":
+        return "staging"
+    if hostname in {"localhost", "127.0.0.1", "::1"}:
+        return "dev"
+    return None
+
+
+def deploy_environment(host: str | None = None) -> str:
+    """Resolve the public deployment environment with host inference fallback."""
+
+    return (
+        _clean(os.environ.get("TOKENPLACE_DEPLOY_ENV"))
+        or _clean(os.environ.get("TOKEN_PLACE_ENV"))
+        or infer_deploy_env_from_host(host)
+        or DEFAULT_DEPLOY_ENV
+    )
+
+
+def short_release_ref() -> str | None:
+    """Return an optional public-safe short git SHA or image tag."""
+
+    git_sha = _clean(os.environ.get("TOKENPLACE_GIT_SHA"))
+    if git_sha:
+        return _PUBLIC_REF_RE.sub("-", git_sha)[:12]
+
+    image_tag = _clean(os.environ.get("TOKENPLACE_IMAGE_TAG"))
+    if image_tag:
+        return _PUBLIC_REF_RE.sub("-", image_tag)[:40]
+
+    return None
+
+
+def release_metadata(host: str | None = None) -> dict[str, Any]:
+    """Build the public-safe release metadata payload for web/UI consumers."""
+
+    version = release_version()
+    environment = deploy_environment(host)
+    ref = short_release_ref()
+    display_version = ref if environment == "staging" and ref else version
+    metadata: dict[str, Any] = {
+        "environment": environment,
+        "version": version,
+        "display_version": display_version,
+        "badge_label": f"{environment} {display_version}",
+    }
+    if ref:
+        metadata["ref"] = ref
+    return metadata
+
+
+def release_metadata_json(host: str | None = None) -> str:
+    """Serialize public release metadata for safe inline HTML injection."""
+
+    return json.dumps(release_metadata(host), sort_keys=True, separators=(",", ":"))

--- a/static/index.html
+++ b/static/index.html
@@ -224,6 +224,53 @@
             cursor: not-allowed;
             opacity: 0.55;
         }
+        .release-badge {
+            position: fixed;
+            left: 12px;
+            bottom: 12px;
+            z-index: 1000;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            max-width: min(260px, calc(100vw - 24px));
+            padding: 5px 9px;
+            border: 1px solid rgba(0, 255, 255, 0.45);
+            border-radius: 999px;
+            background: rgba(17, 17, 17, 0.82);
+            color: #ffffff;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+            font-size: 12px;
+            line-height: 1.2;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            pointer-events: none;
+            backdrop-filter: blur(8px);
+        }
+        .release-badge__env {
+            color: #00ffff;
+            font-weight: 700;
+        }
+        .release-badge__version {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        body.light-mode .release-badge {
+            background: rgba(255, 255, 255, 0.88);
+            border-color: rgba(0, 120, 140, 0.4);
+            color: #111111;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.16);
+        }
+        body.light-mode .release-badge__env {
+            color: #007c89;
+        }
+        @media (max-width: 768px) {
+            .release-badge {
+                bottom: 8px;
+                left: 8px;
+                font-size: 11px;
+            }
+        }
         .mode-toggle-container {
             display: flex;
             justify-content: center;
@@ -414,6 +461,11 @@
     </style>
 </head>
 <body class="dark-mode">
+    <script id="tokenplace-release-metadata" type="application/json">{"environment":"dev","version":"dev","ref":"","placeholder":true}</script>
+    <div class="release-badge" data-testid="release-badge" aria-label="token.place release metadata">
+        <span class="release-badge__env" data-testid="release-badge-env">dev</span>
+        <span class="release-badge__version" data-testid="release-badge-version">dev</span>
+    </div>
     <div id="app" class="container">
         <h1>Welcome to token.place!</h1>
         <p>tokenplace is a peer-to-peer generative AI platform that pairs those in need of LLM compute with individuals donating spare resources, aiming to democratize AI access.</p>
@@ -598,6 +650,11 @@
         </div>
 
         <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/meta</span></h3>
+            <p>Returns public-safe release metadata for UI and diagnostics display: deployment environment, release version, and optional short public image/git reference. Secrets and plaintext model payload content are never included.</p>
+        </div>
+
+        <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/providers</span></h3>
             <p>Lists community-operated relay and server providers as <code>{"object":"list","data":[...]}</code>, with optional metadata.</p>
         </div>
@@ -710,6 +767,27 @@
         crossorigin="anonymous"
         referrerpolicy="no-referrer"
     ></script>
+    <script>
+        (function renderReleaseBadge() {
+            var metadataElement = document.getElementById('tokenplace-release-metadata');
+            var envElement = document.querySelector('[data-testid="release-badge-env"]');
+            var versionElement = document.querySelector('[data-testid="release-badge-version"]');
+            if (!metadataElement || !envElement || !versionElement) {
+                return;
+            }
+            try {
+                var metadata = JSON.parse(metadataElement.textContent || '{}');
+                var environment = metadata.environment || 'dev';
+                var displayVersion = metadata.display_version || metadata.version || 'dev';
+                envElement.textContent = environment;
+                versionElement.textContent = displayVersion;
+                versionElement.title = metadata.badge_label || (environment + ' ' + displayVersion);
+            } catch (error) {
+                envElement.textContent = 'dev';
+                versionElement.textContent = 'dev';
+            }
+        })();
+    </script>
     <script src="/static/chat_typing.js"></script>
     <script src="/static/chat.js"></script>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,9 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "root_page_loads",
+        "release",
+        "version",
+        "env",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_sticky_server_two_turns_and_key_label",
         "landing_chat_sticky_server_auto_failover_preserves_history",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -238,6 +238,11 @@ def test_root_page_loads(page: Page, base_url: str, setup_servers):
     assert len(headings) > 0, "Page should contain at least one heading"
     print(f"✓ Found {len(headings)} headings on the page")
 
+    badge = page.get_by_test_id("release-badge")
+    badge.wait_for(state="visible")
+    assert "testing" in badge.inner_text().lower()
+    assert "0.1.1" in badge.inner_text()
+
 
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):
     """Landing page should render and refresh the relay diagnostics compute-node count."""

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -20,6 +20,7 @@ PUBLIC_CLIENT_ROUTES = {
     ("POST", "/api/v1/completions"),
     ("POST", "/api/v1/images/generations"),
     ("GET", "/api/v1/health"),
+    ("GET", "/api/v1/meta"),
     ("GET", "/api/v1/community/providers"),
     ("GET", "/api/v1/community/leaderboard"),
     ("POST", "/api/v1/community/contributions"),

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -1,0 +1,142 @@
+import json
+
+import pytest
+
+import release_metadata
+from relay import app
+
+
+PUBLIC_METADATA_KEYS = {"environment", "version", "display_version", "badge_label", "ref"}
+
+
+@pytest.fixture(autouse=True)
+def clear_release_metadata_env(monkeypatch):
+    for name in (
+        "TOKENPLACE_RELEASE_VERSION",
+        "TOKENPLACE_DEPLOY_ENV",
+        "TOKEN_PLACE_ENV",
+        "TOKENPLACE_GIT_SHA",
+        "TOKENPLACE_IMAGE_TAG",
+        "TOKENPLACE_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_release_version_prefers_env_then_chart_app_version(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "9.9.9")
+    assert release_metadata.release_version() == "9.9.9"
+
+    monkeypatch.delenv("TOKENPLACE_RELEASE_VERSION")
+    assert release_metadata.release_version() == "0.1.1"
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("token.place", "prod"),
+        ("token.place:443", "prod"),
+        ("staging.token.place", "staging"),
+        ("staging.token.place:443", "staging"),
+        ("localhost:5010", "dev"),
+        ("127.0.0.1:5010", "dev"),
+        ("preview.example.com", "dev"),
+    ],
+)
+def test_deploy_environment_infers_public_hosts(host, expected):
+    assert release_metadata.deploy_environment(host) == expected
+
+
+def test_deploy_environment_prefers_explicit_env(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "testing")
+    assert release_metadata.deploy_environment("token.place") == "staging"
+
+    monkeypatch.delenv("TOKENPLACE_DEPLOY_ENV")
+    assert release_metadata.deploy_environment("token.place") == "testing"
+
+
+def test_short_release_ref_uses_public_safe_short_git_sha(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_GIT_SHA", "abcdef1234567890SECRET")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-ignored")
+    assert release_metadata.short_release_ref() == "abcdef123456"
+
+
+def test_short_release_ref_falls_back_to_image_tag(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-abc123")
+    assert release_metadata.short_release_ref() == "main-abc123"
+
+
+def test_release_metadata_is_public_safe_and_omits_secrets(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "prod")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
+    monkeypatch.setenv("TOKENPLACE_API_KEY", "tokenplace-secret-value")
+
+    metadata = release_metadata.release_metadata("token.place")
+    serialized = json.dumps(metadata)
+
+    assert set(metadata).issubset(PUBLIC_METADATA_KEYS)
+    assert metadata["badge_label"] == "prod 0.1.1"
+    assert "secret" not in serialized.lower()
+    assert "sk-" not in serialized
+    assert "OPENAI" not in serialized
+    assert "TOKENPLACE_API_KEY" not in serialized
+
+
+def test_staging_badge_prefers_ref_when_available(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-abc123")
+
+    metadata = release_metadata.release_metadata("staging.token.place")
+
+    assert metadata["environment"] == "staging"
+    assert metadata["version"] == "0.1.1"
+    assert metadata["display_version"] == "main-abc123"
+    assert metadata["badge_label"] == "staging main-abc123"
+
+
+def test_api_v1_meta_endpoint_returns_public_safe_metadata(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-abc123")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
+
+    with app.test_client() as client:
+        response = client.get("/api/v1/meta", headers={"Host": "staging.token.place"})
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["environment"] == "staging"
+    assert payload["version"] == "0.1.1"
+    assert payload["display_version"] == "main-abc123"
+    assert set(payload).issubset(PUBLIC_METADATA_KEYS)
+    assert "secret" not in response.get_data(as_text=True).lower()
+
+
+def test_rendered_index_injects_prod_badge_metadata(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+
+    with app.test_client() as client:
+        response = client.get("/", headers={"Host": "token.place"})
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'data-testid="release-badge"' in html
+    assert '"badge_label":"prod 0.1.1"' in html
+    assert "__TOKENPLACE_VUE_SCRIPT_SRC__" not in html
+
+
+def test_chart_defaults_wire_release_metadata_env():
+    chart = (release_metadata.REPO_ROOT / "charts" / "tokenplace" / "Chart.yaml").read_text(encoding="utf-8")
+    deployment = (
+        release_metadata.REPO_ROOT / "charts" / "tokenplace" / "templates" / "deployment.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert 'appVersion: "0.1.1"' in chart
+    assert '"TOKENPLACE_RELEASE_VERSION"' in deployment
+    assert '.Chart.AppVersion' in deployment
+    assert '"TOKENPLACE_CHART_VERSION"' in deployment
+    assert '.Chart.Version' in deployment
+    assert '"TOKENPLACE_DEPLOY_ENV"' in deployment
+    assert 'eq .Values.ingress.host "token.place"' in deployment
+    assert 'eq .Values.ingress.host "staging.token.place"' in deployment


### PR DESCRIPTION
### Motivation

- Make deployed relay/landing UI visibly identify its public environment and release version and provide a small, public-safe JSON metadata surface for diagnostics and tooling. 
- Wire chart/deployment defaults so Kubernetes pods expose safe release metadata via environment variables while still allowing overrides. 
- Establish a lightweight evergreen CHANGELOG and bump desktop/chart appVersion to target `v0.1.1` for the upcoming release.

### Description

- Added `release_metadata.py` helper to resolve public-safe `version`, `environment`, and optional short `ref` from env, chart/package sources, and host inference. 
- Injected release metadata into the landing page rendering in `relay.py` by updating `_render_index_html()` to accept request host and replacing an inline JSON placeholder, and added a public endpoint `GET /api/v1/meta` returning the same metadata. 
- Updated `static/index.html` to include an inline `tokenplace-release-metadata` JSON script, a small fixed bottom-left release badge (`data-testid="release-badge"`) and a tiny client-side initializer that reads the inline JSON and populates the badge (renders without external API calls). 
- Helm/chart changes: bumped `charts/tokenplace/Chart.yaml` appVersion to `0.1.1`, added `deployEnv` value to `charts/tokenplace/values.yaml` and added logic in `charts/tokenplace/templates/deployment.yaml` to set `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, and `TOKENPLACE_DEPLOY_ENV` and infer a safe deploy env from `ingress.host` when not explicitly provided. 
- Desktop metadata bumps: set `desktop-tauri/package.json` and `desktop-tauri/src-tauri/tauri.conf.json` `version` to `0.1.1` (and updated lock/package-lock entries where present). 
- Added `CHANGELOG.md` with Unreleased / v0.1.1 planned bullets and a concise v0.1.0 history entry. 
- Minor docs tweak in `docs/PRODUCTION_PROMOTION.md` to keep promotion guidance evergreen. 
- Tests and test-support updates: added `tests/unit/test_release_metadata.py` asserting env/host inference, API endpoint, and index injection; updated `tests/e2e/test_ui.py` to assert the badge is visible in the browser run and refreshed a small focused expectation; small `tests/conftest.py` focus-list update. 

### Testing

- Unit: ran the new unit tests `python -m pytest tests/unit/test_release_metadata.py -v` which passed (16 passed). 
- Unit (larger selection): executed `python -m pytest tests/unit -k "release or metadata or workflow or promotion" -v` and observed the added metadata/unit checks passing in the broader unit selection (111 passed for the selected run). 
- E2E (focused): ran Playwright-backed e2e landing-chat-focused tests `python -m pytest tests/e2e/test_ui.py -k "landing_chat or model or compute_node_count or release or version or env" -v`; this required installing Playwright browsers and OS deps during the run (`playwright install` / `playwright install-deps chromium`) and then completed with the focused UI suite passing (23 passed, 1 skipped). 
- JavaScript: ran `npm run test:js` with the repository JS tests which completed successfully. 
- Desktop: ran `cd desktop-tauri && npm test` which ran the Tauri UI unit tests and passed (`28 tests passed`). 
- Full runner: executed the repository runner `./run_all_tests.sh` and the selected/filtered suites above ran to completion after installing Playwright browsers/deps; test failures encountered during an initial run were fixed (insertion order for the inline metadata/badge) and re-run until the focused unit and e2e expectations passed. 

If you want, I can split this into smaller PRs (metadata + badge, Helm wiring, desktop version bumps, and CHANGELOG) for easier review; follow-ups could include Server-side endpoint caching policy, adding badge styling variants for compact placements, and publishing a release note in CI that consumes `release_metadata` values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9ce3c7e4832fafff7192bc98bdec)