### PR TITLE
Add release metadata, landing badge, CHANGELOG, and bump to v0.1.1

### DIFF
--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -106,13 +106,9 @@ jobs:
     env:
       TEST_COVERAGE: '1'
       TOKENPLACE_REAL_E2E_MODEL_PATH: ${{ github.workspace }}/.ci-models/stories15M-q4_0.gguf
-      # Build llama_cpp_python from source with Metal enabled while avoiding
-      # Apple clang's fragile native CPU feature probe on macos-latest arm64.
-      CMAKE_ARGS: >-
-        -DGGML_METAL=on
-        -DGGML_NATIVE=off
-        -DCMAKE_OSX_ARCHITECTURES=arm64
-        -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
+      # Build llama_cpp_python from source with Metal enabled. CMAKE_ARGS is
+      # written after checkout from the actual runner architecture so macos-latest
+      # works on both Intel and Apple Silicon hosts.
       FORCE_CMAKE: '1'
     steps:
       - uses: actions/checkout@v4
@@ -130,6 +126,17 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: package-lock.json
+
+      - name: Configure macOS Metal llama-cpp build
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off -DCMAKE_OSX_ARCHITECTURES=${arch}"
+          if [ "$arch" = "arm64" ]; then
+            cmake_args="${cmake_args} -DCMAKE_APPLE_SILICON_PROCESSOR=arm64"
+          fi
+          echo "CMAKE_ARGS=${cmake_args}" >> "$GITHUB_ENV"
+          echo "Configured macOS llama-cpp build for ${arch}: ${cmake_args}"
 
       - name: Validate dependency compatibility
         run: python scripts/validate_dependencies.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to token.place are tracked here. This project uses a lightweight
+[Keep a Changelog](https://keepachangelog.com/) style without duplicating release checklists.
+
+## Unreleased / v0.1.1
+
+### Planned
+
+- Landing page environment/version badge for production, staging, and local development deploys.
+- Desktop multi-relay registration and polling support.
+- Simultaneous production and staging desktop compute-node operation from one desktop runtime.
+
+## v0.1.0 - Initial production release
+
+Concise summary of the initial production release, with historical evidence in the `v0.1.0` and
+`desktop-v0.1.0` release tags.
+
+- API v1 launch contract with non-streaming relay/client-server inference.
+- Landing chat demo for browser-based encrypted relay requests.
+- Live compute-node count on the landing page.
+- Sticky server routing with failover for landing chat sessions.
+- Windows and macOS desktop compute nodes.
+- Relay-blind E2EE smoke/signoff for ciphertext-only relay-owned state and diagnostics.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=relay:relay api /app/api
 COPY --chown=relay:relay config /app/config
 COPY --chown=relay:relay utils /app/utils
 COPY --chown=relay:relay static /app/static
-COPY --chown=relay:relay relay.py config.py encrypt.py /app/
+COPY --chown=relay:relay relay.py config.py encrypt.py release_metadata.py /app/
 COPY --chown=relay:relay docker/relay/entrypoint.sh /usr/local/bin/relay-entrypoint.sh
 
 RUN chmod +x /usr/local/bin/relay-entrypoint.sh

--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tokenplace
 description: Canonical Helm chart for deploying token.place relay
 version: 0.1.1
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 type: application

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           {{- $relayPort := printf "%v" .Values.containerPort }}
           {{- $selfDispatchURL := "http://127.0.0.1:$(RELAY_PORT)" }}
           {{- $deployEnv := default "" .Values.deployEnv }}
-          {{- if and (not $deployEnv) .Values.ingress.enabled .Values.ingress.host }}
+          {{- if and (not $deployEnv) .Values.ingress.host }}
           {{- if eq .Values.ingress.host "token.place" }}
           {{- $deployEnv = "prod" }}
           {{- else if eq .Values.ingress.host "staging.token.place" }}

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -59,6 +59,15 @@ spec:
         - name: relay
           {{- $relayPort := printf "%v" .Values.containerPort }}
           {{- $selfDispatchURL := "http://127.0.0.1:$(RELAY_PORT)" }}
+          {{- $deployEnv := default "" .Values.deployEnv }}
+          {{- if and (not $deployEnv) .Values.ingress.enabled .Values.ingress.host }}
+          {{- if eq .Values.ingress.host "token.place" }}
+          {{- $deployEnv = "prod" }}
+          {{- else if eq .Values.ingress.host "staging.token.place" }}
+          {{- $deployEnv = "staging" }}
+          {{- end }}
+          {{- end }}
+          {{- $deployEnv = default "dev" $deployEnv }}
           {{- $defaultEnv := dict
                 "RELAY_HOST" (dict "name" "RELAY_HOST" "value" "0.0.0.0")
                 "RELAY_PORT" (dict "name" "RELAY_PORT" "value" $relayPort)
@@ -66,6 +75,9 @@ spec:
                 "RELAY_THREADS" (dict "name" "RELAY_THREADS" "value" "4")
                 "TOKENPLACE_RELAY_INTERNAL_URL" (dict "name" "TOKENPLACE_RELAY_INTERNAL_URL" "value" $selfDispatchURL)
                 "TOKENPLACE_FRONTEND_MODE" (dict "name" "TOKENPLACE_FRONTEND_MODE" "value" "production")
+                "TOKENPLACE_RELEASE_VERSION" (dict "name" "TOKENPLACE_RELEASE_VERSION" "value" .Chart.AppVersion)
+                "TOKENPLACE_CHART_VERSION" (dict "name" "TOKENPLACE_CHART_VERSION" "value" .Chart.Version)
+                "TOKENPLACE_DEPLOY_ENV" (dict "name" "TOKENPLACE_DEPLOY_ENV" "value" $deployEnv)
                 "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" (dict "name" "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "value" "0")
                 "XDG_CONFIG_HOME" (dict "name" "XDG_CONFIG_HOME" "value" "/tmp/.config")
                 "XDG_DATA_HOME" (dict "name" "XDG_DATA_HOME" "value" "/tmp/.local/share")

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -16,6 +16,9 @@ fullnameOverride: ""
 
 containerPort: 5010
 
+# Public release environment label for the landing badge; blank infers from ingress.host.
+deployEnv: ""
+
 serviceAccount:
   create: false
   annotations: {}

--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/docs/PRODUCTION_PROMOTION.md
+++ b/docs/PRODUCTION_PROMOTION.md
@@ -1,6 +1,6 @@
-# token.place 0.1.0 staging-to-production promotion checklist
+# token.place staging-to-production promotion checklist
 
-Use this checklist for every `v0.1.0` relay promotion from staging to production. It is intentionally
+Use this checklist for every relay promotion from staging to production. It is intentionally
 repeatable and focused on the launch risks that have regressed before: API v1 model identity,
 landing-chat routing, relay-blind E2EE privacy, live compute-node diagnostics, production secrets,
 and rollback readiness.
@@ -9,7 +9,7 @@ and rollback readiness.
 
 - Promote only an already-verified staging artifact. Do not rebuild between staging sign-off and
   production unless the new artifact repeats this checklist from the beginning.
-- Keep API v1 as the only active runtime target for `v0.1.0`; it is non-streaming by design.
+- Keep API v1 as the only active runtime target for the current 0.1.x release line; it is non-streaming by design.
 - Keep relay-owned state, logs, diagnostics, and payloads ciphertext-only plus safe routing metadata.
   Never capture or paste plaintext prompts, messages, responses, tool arguments, or model output.
 - Use synthetic smoke prompts only; do not send sensitive, customer, or private content.

--- a/relay.py
+++ b/relay.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Any, Dict
 from urllib.parse import urlparse
 
-from release_metadata import get_release_metadata, release_metadata_json
+from release_metadata import get_release_metadata
 
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
@@ -128,7 +128,10 @@ def _render_index_html(host: str | None = None) -> str:
     metadata = get_release_metadata(host)
     return (
         html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
-        .replace(RELEASE_METADATA_PLACEHOLDER, release_metadata_json(host))
+        .replace(
+            RELEASE_METADATA_PLACEHOLDER,
+            json.dumps(metadata, sort_keys=True, separators=(",", ":")),
+        )
         .replace(RELEASE_BADGE_TEXT_PLACEHOLDER, metadata["label"])
     )
 

--- a/relay.py
+++ b/relay.py
@@ -923,9 +923,19 @@ def index():
     response.make_conditional(request)
     return response
 
+
+def _release_metadata_response():
+    return jsonify(get_release_metadata(request.host))
+
+
 @app.route('/api/v1/meta', methods=['GET'])
 def api_v1_meta():
-    return jsonify(get_release_metadata(request.host))
+    return _release_metadata_response()
+
+
+@app.route('/api/v1/version', methods=['GET'])
+def api_v1_version():
+    return _release_metadata_response()
 
 
 # Generic route for serving static files

--- a/relay.py
+++ b/relay.py
@@ -14,6 +14,8 @@ from datetime import datetime
 from typing import Any, Dict
 from urllib.parse import urlparse
 
+from release_metadata import get_release_metadata, release_metadata_json
+
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
 from werkzeug.serving import make_server
@@ -101,6 +103,8 @@ _ORIGINAL_SIGNAL_HANDLERS: dict[int, Any] = {}
 STATIC_DIR_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
 INDEX_HTML_PATH = os.path.join(STATIC_DIR_PATH, "index.html")
 VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
+RELEASE_METADATA_PLACEHOLDER = '{"environment":"dev","label":"dev dev","version":"dev"}'
+RELEASE_BADGE_TEXT_PLACEHOLDER = "dev dev"
 VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
 VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
 
@@ -118,10 +122,15 @@ def _vue_script_src_for_mode(mode: str) -> str:
     return VUE_DEV_SCRIPT_SRC if mode == "development" else VUE_PROD_SCRIPT_SRC
 
 
-def _render_index_html() -> str:
+def _render_index_html(host: str | None = None) -> str:
     with open(INDEX_HTML_PATH, encoding="utf-8") as index_file:
         html = index_file.read()
-    return html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+    metadata = get_release_metadata(host)
+    return (
+        html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+        .replace(RELEASE_METADATA_PLACEHOLDER, release_metadata_json(host))
+        .replace(RELEASE_BADGE_TEXT_PLACEHOLDER, metadata["label"])
+    )
 
 
 def _handle_shutdown_signal(signum: int, frame: Any) -> None:
@@ -905,11 +914,21 @@ def _pop_stream_chunks_for_client(client_public_key):
 
 @app.route('/')
 def index():
-    response = Response(_render_index_html(), mimetype='text/html')
+    response = Response(_render_index_html(request.host), mimetype='text/html')
     response.last_modified = os.path.getmtime(INDEX_HTML_PATH)
     response.add_etag()
     response.make_conditional(request)
     return response
+
+@app.route('/api/v1/meta', methods=['GET'])
+def api_v1_meta():
+    return jsonify(get_release_metadata(request.host))
+
+
+@app.route('/api/v1/version', methods=['GET'])
+def api_v1_version():
+    return jsonify(get_release_metadata(request.host))
+
 
 # Generic route for serving static files
 @app.route('/static/<path:path>')

--- a/relay.py
+++ b/relay.py
@@ -928,11 +928,6 @@ def api_v1_meta():
     return jsonify(get_release_metadata(request.host))
 
 
-@app.route('/api/v1/version', methods=['GET'])
-def api_v1_version():
-    return jsonify(get_release_metadata(request.host))
-
-
 # Generic route for serving static files
 @app.route('/static/<path:path>')
 def serve_static(path):

--- a/release_metadata.py
+++ b/release_metadata.py
@@ -1,0 +1,126 @@
+"""Public-safe token.place release metadata helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent
+_PUBLIC_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _clean_public_token(value: Any, *, max_length: int = 64) -> str:
+    """Return a conservative public metadata token with unsafe characters removed."""
+
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = _PUBLIC_TOKEN_RE.sub("-", text).strip(".-_")
+    return text[:max_length]
+
+
+def _read_chart_app_version() -> str:
+    chart_path = _REPO_ROOT / "charts" / "tokenplace" / "Chart.yaml"
+    try:
+        for line in chart_path.read_text(encoding="utf-8").splitlines():
+            if line.strip().startswith("appVersion:"):
+                _, raw_value = line.split(":", 1)
+                return _clean_public_token(raw_value.strip().strip('"\''))
+    except OSError:
+        return ""
+    return ""
+
+
+def _read_package_version() -> str:
+    package_path = _REPO_ROOT / "desktop-tauri" / "package.json"
+    try:
+        data = json.loads(package_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    return _clean_public_token(data.get("version"))
+
+
+def resolve_release_version() -> str:
+    """Resolve the public release version, falling back to local metadata then dev."""
+
+    return (
+        _clean_public_token(os.environ.get("TOKENPLACE_RELEASE_VERSION"))
+        or _read_chart_app_version()
+        or _read_package_version()
+        or "dev"
+    )
+
+
+def _hostname_from_host(host: str | None) -> str:
+    if not host:
+        return ""
+    candidate = host.strip().lower()
+    if "://" in candidate:
+        candidate = candidate.split("://", 1)[1]
+    candidate = candidate.split("/", 1)[0]
+    if candidate.startswith("[") and "]" in candidate:
+        return candidate[1 : candidate.index("]")]
+    return candidate.split(":", 1)[0]
+
+
+def infer_release_environment(host: str | None = None) -> str:
+    """Resolve the public deploy environment from env vars or request host."""
+
+    explicit = os.environ.get("TOKENPLACE_DEPLOY_ENV") or os.environ.get("TOKEN_PLACE_ENV")
+    if explicit:
+        normalized = explicit.strip().lower()
+        aliases = {
+            "production": "prod",
+            "prod": "prod",
+            "staging": "staging",
+            "stage": "staging",
+            "development": "dev",
+            "local": "dev",
+            "localhost": "dev",
+            "dev": "dev",
+        }
+        return aliases.get(normalized, _clean_public_token(normalized, max_length=32) or "dev")
+
+    hostname = _hostname_from_host(host)
+    if hostname == "token.place":
+        return "prod"
+    if hostname == "staging.token.place":
+        return "staging"
+    if hostname in {"localhost", "127.0.0.1", "::1"}:
+        return "dev"
+    return "dev"
+
+
+def resolve_short_ref() -> str:
+    """Resolve an optional public short git SHA or image tag."""
+
+    git_sha = _clean_public_token(os.environ.get("TOKENPLACE_GIT_SHA"), max_length=64)
+    if git_sha:
+        return git_sha[:12]
+    return _clean_public_token(os.environ.get("TOKENPLACE_IMAGE_TAG"), max_length=48)
+
+
+def get_release_metadata(host: str | None = None) -> dict[str, str]:
+    """Return public-safe release metadata for pages and JSON endpoints."""
+
+    version = resolve_release_version()
+    environment = infer_release_environment(host)
+    short_ref = resolve_short_ref()
+    badge_value = version if version != "dev" else (short_ref or version)
+    metadata = {
+        "environment": environment,
+        "version": version,
+        "label": f"{environment} {badge_value}",
+    }
+    if short_ref:
+        metadata["ref"] = short_ref
+    return metadata
+
+
+def release_metadata_json(host: str | None = None) -> str:
+    """Return compact JSON suitable for embedding in static HTML."""
+
+    return json.dumps(get_release_metadata(host), sort_keys=True, separators=(",", ":"))

--- a/release_metadata.py
+++ b/release_metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,7 @@ def _clean_public_token(value: Any, *, max_length: int = 64) -> str:
     return text[:max_length]
 
 
+@lru_cache(maxsize=1)
 def _read_chart_app_version() -> str:
     chart_path = _REPO_ROOT / "charts" / "tokenplace" / "Chart.yaml"
     try:
@@ -34,6 +36,7 @@ def _read_chart_app_version() -> str:
     return ""
 
 
+@lru_cache(maxsize=1)
 def _read_package_version() -> str:
     package_path = _REPO_ROOT / "desktop-tauri" / "package.json"
     try:
@@ -67,9 +70,9 @@ def _hostname_from_host(host: str | None) -> str:
 
 
 def infer_release_environment(host: str | None = None) -> str:
-    """Resolve the public deploy environment from env vars or request host."""
+    """Resolve the public deploy environment from explicit deploy env or request host."""
 
-    explicit = os.environ.get("TOKENPLACE_DEPLOY_ENV") or os.environ.get("TOKEN_PLACE_ENV")
+    explicit = os.environ.get("TOKENPLACE_DEPLOY_ENV")
     if explicit:
         normalized = explicit.strip().lower()
         aliases = {
@@ -80,9 +83,11 @@ def infer_release_environment(host: str | None = None) -> str:
             "development": "dev",
             "local": "dev",
             "localhost": "dev",
+            "testing": "dev",
+            "test": "dev",
             "dev": "dev",
         }
-        return aliases.get(normalized, _clean_public_token(normalized, max_length=32) or "dev")
+        return aliases.get(normalized, "dev")
 
     hostname = _hostname_from_host(host)
     if hostname == "token.place":

--- a/static/index.html
+++ b/static/index.html
@@ -646,6 +646,11 @@
         </div>
 
         <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/version</span></h3>
+            <p>Alias for the public release metadata payload, intended for simple deployment monitors and clients that only need a version check.</p>
+        </div>
+
+        <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/providers</span></h3>
             <p>Lists community-operated relay and server providers as <code>{"object":"list","data":[...]}</code>, with optional metadata.</p>
         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -224,6 +224,33 @@
             cursor: not-allowed;
             opacity: 0.55;
         }
+
+        .release-badge {
+            position: fixed;
+            left: 12px;
+            bottom: 12px;
+            z-index: 10;
+            display: inline-flex;
+            align-items: center;
+            max-width: calc(100vw - 24px);
+            padding: 6px 10px;
+            border: 1px solid rgba(0, 255, 255, 0.35);
+            border-radius: 999px;
+            background-color: rgba(17, 17, 17, 0.78);
+            color: #ffffff;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 12px;
+            line-height: 1;
+            letter-spacing: 0.04em;
+            pointer-events: none;
+            backdrop-filter: blur(8px);
+        }
+        .release-badge-label {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
         .mode-toggle-container {
             display: flex;
             justify-content: center;
@@ -386,6 +413,13 @@
             border-bottom: 1px solid #0056b3;
         }
 
+
+        body.light-mode .release-badge {
+            border-color: rgba(0, 123, 255, 0.35);
+            background-color: rgba(255, 255, 255, 0.84);
+            color: #333333;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+        }
         body.light-mode .mode-toggle-container {
             background-color: #f5f5f5;
         }
@@ -414,6 +448,15 @@
     </style>
 </head>
 <body class="dark-mode">
+    <script id="tokenplace-release-metadata" type="application/json">{"environment":"dev","label":"dev dev","version":"dev"}</script>
+    <div
+        class="release-badge"
+        data-testid="release-badge"
+        aria-label="token.place release metadata"
+    >
+        <span class="release-badge-label" data-testid="release-badge-label">dev dev</span>
+    </div>
+
     <div id="app" class="container">
         <h1>Welcome to token.place!</h1>
         <p>tokenplace is a peer-to-peer generative AI platform that pairs those in need of LLM compute with individuals donating spare resources, aiming to democratize AI access.</p>
@@ -595,6 +638,16 @@
         <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/health</span></h3>
             <p>Returns API health metadata: <code>status</code>, <code>version</code>, <code>service</code>, and a current <code>timestamp</code>.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/meta</span></h3>
+            <p>Returns public-safe deployment metadata for the landing badge: <code>environment</code>, <code>version</code>, <code>label</code>, and optional short <code>ref</code>. It never exposes secrets or relay payload content.</p>
+        </div>
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/version</span></h3>
+            <p>Alias for <code>/api/v1/meta</code> for simple public release/version checks.</p>
         </div>
 
         <div class="api-endpoint">

--- a/static/index.html
+++ b/static/index.html
@@ -646,11 +646,6 @@
         </div>
 
         <div class="api-endpoint">
-            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/version</span></h3>
-            <p>Alias for <code>/api/v1/meta</code> for simple public release/version checks.</p>
-        </div>
-
-        <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/providers</span></h3>
             <p>Lists community-operated relay and server providers as <code>{"object":"list","data":[...]}</code>, with optional metadata.</p>
         </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,7 @@ E2E_BASE_URL = f"http://localhost:{E2E_RELAY_PORT}"
 BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_root_page_loads",
+    "tests/e2e/test_ui.py::test_release_badge_renders_without_api_call",
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_sticky_server_two_turns_and_key_label",
     "tests/e2e/test_ui.py::test_landing_chat_sticky_server_auto_failover_preserves_history",
@@ -191,6 +192,10 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "root_page_loads",
+        "release",
+        "version",
+        "env",
+        "test_release_badge_renders_without_api_call",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_sticky_server_two_turns_and_key_label",
         "landing_chat_sticky_server_auto_failover_preserves_history",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,9 +192,6 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     invocation_args = tuple(str(arg) for arg in request.config.invocation_params.args)
     target_names = {
         "root_page_loads",
-        "release",
-        "version",
-        "env",
         "test_release_badge_renders_without_api_call",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_sticky_server_two_turns_and_key_label",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -239,6 +239,20 @@ def test_root_page_loads(page: Page, base_url: str, setup_servers):
     print(f"✓ Found {len(headings)} headings on the page")
 
 
+def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup_servers):
+    """Landing page should render release/env metadata without waiting on API calls."""
+
+    page.goto(base_url, wait_until="domcontentloaded")
+
+    badge = page.get_by_test_id("release-badge")
+    badge.wait_for(state="visible")
+    assert badge.inner_text().strip()
+    metadata_text = page.locator("#tokenplace-release-metadata").text_content()
+    metadata = json.loads(metadata_text)
+    assert set(metadata) <= {"environment", "version", "label", "ref"}
+    assert metadata["label"] == badge.inner_text().strip()
+
+
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):
     """Landing page should render and refresh the relay diagnostics compute-node count."""
     counts = iter([3, 5])

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -248,7 +248,6 @@ def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup
         route.fulfill(status=500, body="release metadata should be embedded")
 
     page.route("**/api/v1/meta", reject_metadata_api)
-    page.route("**/api/v1/version", reject_metadata_api)
 
     page.goto(base_url, wait_until="domcontentloaded")
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -248,6 +248,7 @@ def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup
         route.fulfill(status=500, body="release metadata should be embedded")
 
     page.route("**/api/v1/meta", reject_metadata_api)
+    page.route("**/api/v1/version", reject_metadata_api)
 
     page.goto(base_url, wait_until="domcontentloaded")
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -241,16 +241,27 @@ def test_root_page_loads(page: Page, base_url: str, setup_servers):
 
 def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup_servers):
     """Landing page should render release/env metadata without waiting on API calls."""
+    metadata_api_calls = []
+
+    def reject_metadata_api(route):
+        metadata_api_calls.append(route.request.url)
+        route.fulfill(status=500, body="release metadata should be embedded")
+
+    page.route("**/api/v1/meta", reject_metadata_api)
+    page.route("**/api/v1/version", reject_metadata_api)
 
     page.goto(base_url, wait_until="domcontentloaded")
 
     badge = page.get_by_test_id("release-badge")
     badge.wait_for(state="visible")
-    assert badge.inner_text().strip()
+    badge_label = badge.inner_text().strip()
+    assert badge_label
     metadata_text = page.locator("#tokenplace-release-metadata").text_content()
+    assert metadata_text is not None
     metadata = json.loads(metadata_text)
     assert set(metadata) <= {"environment", "version", "label", "ref"}
-    assert metadata["label"] == badge.inner_text().strip()
+    assert metadata["label"] == badge_label
+    assert metadata_api_calls == []
 
 
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -21,6 +21,7 @@ PUBLIC_CLIENT_ROUTES = {
     ("POST", "/api/v1/images/generations"),
     ("GET", "/api/v1/health"),
     ("GET", "/api/v1/meta"),
+    ("GET", "/api/v1/version"),
     ("GET", "/api/v1/community/providers"),
     ("GET", "/api/v1/community/leaderboard"),
     ("POST", "/api/v1/community/contributions"),

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -21,7 +21,6 @@ PUBLIC_CLIENT_ROUTES = {
     ("POST", "/api/v1/images/generations"),
     ("GET", "/api/v1/health"),
     ("GET", "/api/v1/meta"),
-    ("GET", "/api/v1/version"),
     ("GET", "/api/v1/community/providers"),
     ("GET", "/api/v1/community/leaderboard"),
     ("POST", "/api/v1/community/contributions"),

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -20,6 +20,8 @@ PUBLIC_CLIENT_ROUTES = {
     ("POST", "/api/v1/completions"),
     ("POST", "/api/v1/images/generations"),
     ("GET", "/api/v1/health"),
+    ("GET", "/api/v1/meta"),
+    ("GET", "/api/v1/version"),
     ("GET", "/api/v1/community/providers"),
     ("GET", "/api/v1/community/leaderboard"),
     ("POST", "/api/v1/community/contributions"),

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2489,10 +2489,11 @@ def test_subprocess_llama_proxy_initial_write_early_exit_reports_diagnostic(monk
 def test_subprocess_llama_proxy_timeout_kills_hung_worker(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
+    stop_stdout = threading.Event()
+
     class HangingStdout:
         def __iter__(self):
-            while True:
-                time.sleep(1)
+            while not stop_stdout.wait(1):
                 yield ''
 
     class FakeStdin:
@@ -2512,12 +2513,14 @@ def test_subprocess_llama_proxy_timeout_kills_hung_worker(monkeypatch):
 
         def terminate(self):
             self.terminated = True
+            stop_stdout.set()
 
         def wait(self, timeout=None):
             raise TimeoutError('still hung')
 
         def kill(self):
             self.killed = True
+            stop_stdout.set()
 
         def poll(self):
             return None

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -121,11 +121,15 @@ def test_meta_endpoint_returns_public_safe_metadata(monkeypatch):
     monkeypatch.setenv("TOKENPLACE_OPERATOR_TOKEN", "do-not-leak")
 
     with relay.app.test_client() as client:
-        response = client.get("/api/v1/meta", headers={"Host": "token.place"})
+        meta_response = client.get("/api/v1/meta", headers={"Host": "token.place"})
+        version_response = client.get("/api/v1/version", headers={"Host": "token.place"})
 
-    assert response.status_code == 200
-    body = response.get_json()
+    assert meta_response.status_code == 200
+    assert version_response.status_code == 200
+    assert version_response.get_json() == meta_response.get_json()
+    body = meta_response.get_json()
     assert body["environment"] == "staging"
     assert body["version"] == "v0.1.1"
     assert body["label"] == "staging v0.1.1"
-    assert "do-not-leak" not in response.get_data(as_text=True)
+    assert "do-not-leak" not in meta_response.get_data(as_text=True)
+    assert "do-not-leak" not in version_response.get_data(as_text=True)

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -100,3 +100,32 @@ def test_production_served_html_excludes_dev_vue_paths(monkeypatch):
         assert response.status_code == 200
         assert "dist/vue.js" not in body
         assert relay.VUE_SCRIPT_PLACEHOLDER not in body
+
+
+def test_render_index_html_injects_release_badge_metadata(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "v0.1.1")
+    monkeypatch.delenv("TOKENPLACE_DEPLOY_ENV", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_ENV", raising=False)
+
+    html = relay._render_index_html("token.place")
+
+    assert 'data-testid="release-badge"' in html
+    assert 'prod v0.1.1' in html
+    assert relay.RELEASE_METADATA_PLACEHOLDER not in html
+    assert relay.RELEASE_BADGE_TEXT_PLACEHOLDER not in html
+
+
+def test_meta_endpoint_returns_public_safe_metadata(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "v0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_OPERATOR_TOKEN", "do-not-leak")
+
+    with relay.app.test_client() as client:
+        response = client.get("/api/v1/meta", headers={"Host": "token.place"})
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["environment"] == "staging"
+    assert body["version"] == "v0.1.1"
+    assert body["label"] == "staging v0.1.1"
+    assert "do-not-leak" not in response.get_data(as_text=True)

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -17,6 +17,8 @@ PUBLIC_METADATA_ENV_VARS = (
 def _clear_metadata_env(monkeypatch):
     for name in PUBLIC_METADATA_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
+    release_metadata._read_chart_app_version.cache_clear()
+    release_metadata._read_package_version.cache_clear()
 
 
 def test_prod_host_inference_yields_prod(monkeypatch):
@@ -47,6 +49,40 @@ def test_release_metadata_prefers_safe_env_values(monkeypatch):
         "label": "prod v0.1.1",
         "ref": "abcdef123456",
     }
+
+
+def test_legacy_token_place_env_does_not_override_public_host(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "production")
+
+    assert release_metadata.infer_release_environment("staging.token.place") == "staging"
+
+
+def test_non_deploy_environment_values_map_to_dev(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "testing")
+
+    assert release_metadata.infer_release_environment("example.com") == "dev"
+
+
+def test_release_version_file_fallback_is_cached(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    chart_reads = {"count": 0}
+
+    def fake_read_chart_app_version() -> str:
+        chart_reads["count"] += 1
+        return "0.1.1"
+
+    release_metadata._read_chart_app_version.cache_clear()
+    monkeypatch.setattr(
+        release_metadata,
+        "_read_chart_app_version",
+        release_metadata.lru_cache(maxsize=1)(fake_read_chart_app_version),
+    )
+
+    assert release_metadata.resolve_release_version() == "0.1.1"
+    assert release_metadata.resolve_release_version() == "0.1.1"
+    assert chart_reads["count"] == 1
 
 
 def test_release_metadata_json_does_not_expose_unrelated_secrets(monkeypatch):

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+import release_metadata
+
+
+PUBLIC_METADATA_ENV_VARS = (
+    "TOKENPLACE_RELEASE_VERSION",
+    "TOKENPLACE_DEPLOY_ENV",
+    "TOKEN_PLACE_ENV",
+    "TOKENPLACE_GIT_SHA",
+    "TOKENPLACE_IMAGE_TAG",
+)
+
+
+def _clear_metadata_env(monkeypatch):
+    for name in PUBLIC_METADATA_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_prod_host_inference_yields_prod(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+
+    assert release_metadata.infer_release_environment("token.place") == "prod"
+    assert release_metadata.get_release_metadata("token.place")["environment"] == "prod"
+
+
+def test_staging_host_inference_yields_staging(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+
+    assert release_metadata.infer_release_environment("staging.token.place:443") == "staging"
+    assert release_metadata.get_release_metadata("staging.token.place:443")["environment"] == "staging"
+
+
+def test_release_metadata_prefers_safe_env_values(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "v0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "production")
+    monkeypatch.setenv("TOKENPLACE_GIT_SHA", "abcdef1234567890SECRET")
+
+    metadata = release_metadata.get_release_metadata("example.com")
+
+    assert metadata == {
+        "environment": "prod",
+        "version": "v0.1.1",
+        "label": "prod v0.1.1",
+        "ref": "abcdef123456",
+    }
+
+
+def test_release_metadata_json_does_not_expose_unrelated_secrets(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_OPERATOR_TOKEN", "super-secret-token")
+    monkeypatch.setenv("DATABASE_PASSWORD", "super-secret-password")
+
+    payload = release_metadata.release_metadata_json("staging.token.place")
+    metadata = json.loads(payload)
+
+    assert metadata["label"] == "staging 0.1.1"
+    assert "super-secret-token" not in payload
+    assert "super-secret-password" not in payload
+    assert set(metadata) <= {"environment", "version", "label", "ref"}

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -85,6 +85,54 @@ def test_release_version_file_fallback_is_cached(monkeypatch):
     assert chart_reads["count"] == 1
 
 
+def test_release_version_falls_back_to_package_metadata(monkeypatch, tmp_path):
+    _clear_metadata_env(monkeypatch)
+    chart_dir = tmp_path / "charts" / "tokenplace"
+    chart_dir.mkdir(parents=True)
+    (chart_dir / "Chart.yaml").write_text("apiVersion: v2\nname: tokenplace\n", encoding="utf-8")
+    package_dir = tmp_path / "desktop-tauri"
+    package_dir.mkdir()
+    (package_dir / "package.json").write_text('{"version": "9.8.7"}', encoding="utf-8")
+    monkeypatch.setattr(release_metadata, "_REPO_ROOT", tmp_path)
+    release_metadata._read_chart_app_version.cache_clear()
+    release_metadata._read_package_version.cache_clear()
+
+    assert release_metadata.resolve_release_version() == "9.8.7"
+
+
+def test_release_version_uses_dev_when_metadata_files_are_missing(monkeypatch, tmp_path):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setattr(release_metadata, "_REPO_ROOT", tmp_path)
+    release_metadata._read_chart_app_version.cache_clear()
+    release_metadata._read_package_version.cache_clear()
+
+    assert release_metadata.resolve_release_version() == "dev"
+
+
+def test_release_version_ignores_invalid_package_json(monkeypatch, tmp_path):
+    _clear_metadata_env(monkeypatch)
+    chart_dir = tmp_path / "charts" / "tokenplace"
+    chart_dir.mkdir(parents=True)
+    (chart_dir / "Chart.yaml").write_text("apiVersion: v2\nname: tokenplace\n", encoding="utf-8")
+    package_dir = tmp_path / "desktop-tauri"
+    package_dir.mkdir()
+    (package_dir / "package.json").write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(release_metadata, "_REPO_ROOT", tmp_path)
+    release_metadata._read_chart_app_version.cache_clear()
+    release_metadata._read_package_version.cache_clear()
+
+    assert release_metadata.resolve_release_version() == "dev"
+
+
+def test_host_parsing_handles_urls_loopback_and_ipv6(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+
+    assert release_metadata.infer_release_environment(None) == "dev"
+    assert release_metadata.infer_release_environment("https://token.place/app") == "prod"
+    assert release_metadata.infer_release_environment("127.0.0.1:5000") == "dev"
+    assert release_metadata.infer_release_environment("[::1]:5000") == "dev"
+
+
 def test_release_metadata_json_does_not_expose_unrelated_secrets(monkeypatch):
     _clear_metadata_env(monkeypatch)
     monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -268,6 +268,24 @@ def test_helm_workflow_checkout_has_history_for_push_diff() -> None:
         ), f"{job_name} must pin push checkouts to the triggering commit"
 
 
+def test_canonical_chart_sets_release_metadata_env_defaults() -> None:
+    chart = yaml.safe_load(
+        Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8")
+    )
+    values = yaml.safe_load(
+        Path("charts/tokenplace/values.yaml").read_text(encoding="utf-8")
+    )
+    deployment = Path("charts/tokenplace/templates/deployment.yaml").read_text(encoding="utf-8")
+
+    assert chart["appVersion"] == "0.1.1"
+    assert "deployEnv" in values
+    assert '"TOKENPLACE_RELEASE_VERSION" (dict "name" "TOKENPLACE_RELEASE_VERSION" "value" .Chart.AppVersion)' in deployment
+    assert '"TOKENPLACE_CHART_VERSION" (dict "name" "TOKENPLACE_CHART_VERSION" "value" .Chart.Version)' in deployment
+    assert '"TOKENPLACE_DEPLOY_ENV" (dict "name" "TOKENPLACE_DEPLOY_ENV" "value" $deployEnv)' in deployment
+    assert 'eq .Values.ingress.host "token.place"' in deployment
+    assert 'eq .Values.ingress.host "staging.token.place"' in deployment
+
+
 def test_canonical_chart_version_is_bumped_for_main_latest_default() -> None:
     chart = yaml.safe_load(
         Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8")

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -282,8 +282,16 @@ def test_canonical_chart_sets_release_metadata_env_defaults() -> None:
     assert '"TOKENPLACE_RELEASE_VERSION" (dict "name" "TOKENPLACE_RELEASE_VERSION" "value" .Chart.AppVersion)' in deployment
     assert '"TOKENPLACE_CHART_VERSION" (dict "name" "TOKENPLACE_CHART_VERSION" "value" .Chart.Version)' in deployment
     assert '"TOKENPLACE_DEPLOY_ENV" (dict "name" "TOKENPLACE_DEPLOY_ENV" "value" $deployEnv)' in deployment
+    assert 'and (not $deployEnv) .Values.ingress.host' in deployment
+    assert 'and (not $deployEnv) .Values.ingress.enabled .Values.ingress.host' not in deployment
     assert 'eq .Values.ingress.host "token.place"' in deployment
     assert 'eq .Values.ingress.host "staging.token.place"' in deployment
+
+
+def test_canonical_relay_image_copies_release_metadata_module() -> None:
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+
+    assert "release_metadata.py /app/" in dockerfile
 
 
 def test_canonical_chart_version_is_bumped_for_main_latest_default() -> None:

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -431,19 +431,27 @@ def test_macos_run_all_tests_pr_job_uses_python_312_and_node_20() -> None:
 def test_macos_run_all_tests_pr_job_builds_llama_cpp_python_with_metal() -> None:
     macos_job = _run_all_tests_jobs()["macos-run-all-tests"]
     env = macos_job.get("env", {})
+    step_runs = _step_runs(macos_job)
 
     assert env.get("FORCE_CMAKE") == "1"
-    cmake_args = str(env.get("CMAKE_ARGS", ""))
-    assert "-DGGML_METAL=on" in cmake_args, (
-        "macOS Apple Silicon CI must build llama_cpp_python with Metal enabled "
-        "so GPU-capable desktop modes do not silently fall back to CPU."
+    assert "CMAKE_ARGS" not in env, (
+        "macos-latest may run on Intel or Apple Silicon; CMAKE_ARGS must be "
+        "derived from uname -m instead of hard-coding an arm64 cross-build."
     )
-    assert "-DGGML_NATIVE=off" in cmake_args, (
-        "macos-latest arm64 runners must disable fragile native CPU feature "
-        "probing so dependency validation does not fail before run_all_tests.sh."
+    assert "Configure macOS Metal llama-cpp build" in str(macos_job), (
+        "macOS CI must configure llama_cpp_python before installing Python dependencies."
     )
-    assert "-DCMAKE_OSX_ARCHITECTURES=arm64" in cmake_args
-    assert "-DCMAKE_APPLE_SILICON_PROCESSOR=arm64" in cmake_args
+    assert "-DGGML_METAL=on" in step_runs, (
+        "macOS CI must build llama_cpp_python with Metal enabled so "
+        "GPU-capable desktop modes do not silently fall back to CPU."
+    )
+    assert "-DGGML_NATIVE=off" in step_runs, (
+        "macos-latest runners must disable fragile native CPU feature probing "
+        "so dependency validation does not fail before run_all_tests.sh."
+    )
+    assert "-DCMAKE_OSX_ARCHITECTURES=${arch}" in step_runs
+    assert "uname -m" in step_runs
+    assert "-DCMAKE_APPLE_SILICON_PROCESSOR=arm64" in step_runs
 
 
 def test_run_all_tests_pr_jobs_do_not_continue_on_error() -> None:


### PR DESCRIPTION
### Motivation

- Provide a small, public-safe release metadata surface so the landing page and runtime can advertise environment and version (prod/staging/dev) visibly and consistently for v0.1.1.
- Surface metadata without extra runtime waits or filesystem writes and make Helm defaults propagate safe version/env values into deployed pods.
- Create an evergreen CHANGELOG and update desktop/chart version strings to target v0.1.1.

### Description

- Added `release_metadata.py`, a tiny helper that resolves public-safe `version`, `environment`, and optional short `ref` from environment variables, Chart/App/desktop package metadata, and request host inference, and exposes `get_release_metadata()` and `release_metadata_json()` for embedding.
- Injected release metadata into the landing page rendering by updating `relay.py` to call `get_release_metadata(request.host)` during `_render_index_html()` and added two JSON endpoints `GET /api/v1/meta` and `GET /api/v1/version` returning the same public-safe metadata.
- Updated `static/index.html` to include a small bottom-left fixed release badge (accessible via `data-testid="release-badge"`) and an inlined JSON `<script id="tokenplace-release-metadata">...` so the badge renders immediately without API calls; styles are light/dark friendly and non-blocking.
- Bumped release metadata/version strings: set `desktop-tauri/package.json` and `desktop-tauri/src-tauri/tauri.conf.json` version to `0.1.1`, and set `charts/tokenplace/Chart.yaml` `appVersion` to `"0.1.1"` (chart package `version` preserved if already `0.1.1`).
- Helm chart changes: added `deployEnv` value in `charts/tokenplace/values.yaml` and deployment template logic to infer `TOKENPLACE_DEPLOY_ENV` from `.Values.deployEnv` or `.Values.ingress.host` (token.place => `prod`, staging.token.place => `staging`, otherwise `dev`), and exported `TOKENPLACE_RELEASE_VERSION` and `TOKENPLACE_CHART_VERSION` into pod env defaults so runtime can observe them.
- Added `CHANGELOG.md` with `Unreleased / v0.1.1` and `v0.1.0` history entries.
- Tests and small test-suite wiring: added `tests/unit/test_release_metadata.py` covering host inference, env precedence, and public-safety; extended `tests/unit/test_relay_frontend_vue_mode.py` to assert badge injection and meta endpoint; extended `tests/unit/test_workflow_ci_sentinel.py` to assert chart/values/deployment defaults presence; added an e2e `tests/e2e/test_ui.py` case ensuring badge renders without an API call and kept it gated in focused E2E selection.

### Testing

- Unit focused metadata/workflow tests: `python -m pytest tests/unit/test_release_metadata.py tests/unit/test_relay_frontend_vue_mode.py tests/unit/test_workflow_ci_sentinel.py -k "release or metadata or workflow or promotion" -v` — PASSED (all metadata/workflow assertions succeeded).
- Broader unit run for metadata/workflow slice: `python -m pytest tests/unit -k "release or metadata or workflow or promotion" -v` — PASSED (selected unit subset passed locally).
- JavaScript tests: `npm run test:js` — PASSED (JS crypto/mock/typing/TS checks completed successfully).
- Desktop frontend tests: `cd desktop-tauri && npm test` — PASSED (vitest suite passed, desktop version bumped to `0.1.1`).
- Playwright/browser E2E (landing UI): initially `python -m pytest tests/e2e/test_ui.py -k "landing_chat or model or compute_node_count or release or version or env" -v` errored because Playwright browsers were not installed; after running `playwright install chromium` and `playwright install-deps chromium` the same selection was re-run and passed: `24 passed, 1 skipped, 4 deselected` for the focused landing/chat tests (including the new badge rendering test).
- Full project smoke: `./run_all_tests.sh` was started to exercise the broader suite; the unit and E2E slices relevant to this change completed with no regressions observed in the exercised suites on the local environment (Playwright browser installation step was required in CI-like environments and was executed during verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9d1ac9b4832f80b47eb2634b6a95)