### PR TITLE
v0.1.1: add release metadata, landing badge, chart & desktop version bumps, and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to token.place are tracked here. This project keeps the format lightweight and evergreen so release notes stay useful without duplicating launch checklists.
+
+## [Unreleased] / v0.1.1
+
+### Planned
+- Landing-page environment/version badge backed by public-safe release metadata.
+- Desktop multi-relay registration and polling from a single warmed compute-node runtime.
+- Production and staging simultaneous desktop node operation for release validation.
+
+## v0.1.0 - Initial production release
+
+Initial production release of the API v1 relay path and desktop compute-node foundation.
+
+### Included
+- API v1 launch contract for non-streaming relay/client-server inference.
+- Landing chat demo using API v1 relay E2EE routes.
+- Live compute-node count on the landing page.
+- Sticky server routing with failover for selected compute nodes.
+- Windows and macOS desktop compute-node support.
+- Relay-blind E2EE smoke/signoff coverage for ciphertext-only relay paths.
+
+Historical release evidence includes the `v0.1.0` and `desktop-v0.1.0` release tags.

--- a/README.md
+++ b/README.md
@@ -225,13 +225,13 @@ See also:
 
 ## API v1 E2EE architecture baseline (v0.1.0)
 
-- **This baseline applies to the active v0.1.0 relay/client-server runtime path** (including distributed relay and desktop integration paths being finalized for v0.1.0).
+- **This baseline applies to the active v0.1.0 relay/client-server runtime path** (including distributed relay and desktop integration paths maintained across v0.1.x).
 - **API v1 is the active API for v0.1.0** and the only approved runtime integration target.
 - **API v1 is non-streaming** for relay/client-server inference paths; return responses only after
   full model generation is complete.
 - **Do not add streaming to API v1** for active relay/client-server paths.
 - **API v2 exists but is incomplete**; do not route runtime traffic through API v2 until API v1 is
-  launched and v0.1.0 is finalized.
+  ready for a future runtime target.
 - **If later sections of this README show API v2 streaming or `/api/v2/chat/completions` examples,
   treat them as experimental/reference-only** and not as approved runtime integration guidance for v0.1.0.
 - **Deprecated legacy relay endpoints**: `/sink`, `/faucet`, `/source`, `/retrieve`,
@@ -281,7 +281,7 @@ Artifact references:
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- v0.1.0 runtime/release alignment: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Current runtime/release alignment: chart `appVersion: "0.1.1"`; historical v0.1.0 evidence includes Git tag `v0.1.0` and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
 - Preferred staging/prod tag: immutable `main-<shortsha>` copied from the `ci-image.yml` workflow summary (`main-latest` is convenience-only)
 - Canonical release tag after pushing a Git release tag is the matching semver image tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - Pre-publish gate: `ci-helm.yml` checks whether the current chart version already exists at `oci://ghcr.io/futuroptimist/charts/tokenplace`. It publishes only new chart versions when chart source files changed, skips unchanged already-published versions as a no-op, and fails changed chart source with an already-published version so maintainers bump `charts/tokenplace/Chart.yaml`.
@@ -1000,6 +1000,7 @@ Request body:
 #### Health Check
 ```
 GET /api/v1/health
+GET /api/v1/meta
 # or
 GET /v1/health
 ```
@@ -1007,6 +1008,9 @@ Returns the service's readiness metadata. The JSON payload includes `status`, `v
 `service`, and a Unix `timestamp`. Override the reported service identifier by setting the
 `SERVICE_NAME` environment variable; blank or whitespace-only overrides are ignored so the
 default `token.place` label is preserved.
+
+`GET /api/v1/meta` returns public-safe deployment metadata for clients and status pages,
+including environment, release version, display label, and optional short Git/image reference.
 
 #### Image Generations
 ```

--- a/charts/tokenplace/Chart.yaml
+++ b/charts/tokenplace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tokenplace
 description: Canonical Helm chart for deploying token.place relay
 version: 0.1.1
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 type: application

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -59,6 +59,16 @@ spec:
         - name: relay
           {{- $relayPort := printf "%v" .Values.containerPort }}
           {{- $selfDispatchURL := "http://127.0.0.1:$(RELAY_PORT)" }}
+          {{- $ingressHost := lower (default "" .Values.ingress.host) }}
+          {{- $inferredDeployEnv := "dev" }}
+          {{- if eq $ingressHost "token.place" }}
+          {{- $inferredDeployEnv = "prod" }}
+          {{- else if eq $ingressHost "staging.token.place" }}
+          {{- $inferredDeployEnv = "staging" }}
+          {{- else if or (eq $ingressHost "localhost") (eq $ingressHost "127.0.0.1") }}
+          {{- $inferredDeployEnv = "dev" }}
+          {{- end }}
+          {{- $deployEnv := default $inferredDeployEnv .Values.deployEnv }}
           {{- $defaultEnv := dict
                 "RELAY_HOST" (dict "name" "RELAY_HOST" "value" "0.0.0.0")
                 "RELAY_PORT" (dict "name" "RELAY_PORT" "value" $relayPort)
@@ -66,6 +76,10 @@ spec:
                 "RELAY_THREADS" (dict "name" "RELAY_THREADS" "value" "4")
                 "TOKENPLACE_RELAY_INTERNAL_URL" (dict "name" "TOKENPLACE_RELAY_INTERNAL_URL" "value" $selfDispatchURL)
                 "TOKENPLACE_FRONTEND_MODE" (dict "name" "TOKENPLACE_FRONTEND_MODE" "value" "production")
+                "TOKENPLACE_RELEASE_VERSION" (dict "name" "TOKENPLACE_RELEASE_VERSION" "value" .Chart.AppVersion)
+                "TOKENPLACE_CHART_VERSION" (dict "name" "TOKENPLACE_CHART_VERSION" "value" .Chart.Version)
+                "TOKENPLACE_DEPLOY_ENV" (dict "name" "TOKENPLACE_DEPLOY_ENV" "value" $deployEnv)
+                "TOKENPLACE_IMAGE_TAG" (dict "name" "TOKENPLACE_IMAGE_TAG" "value" .Values.image.tag)
                 "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" (dict "name" "TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH" "value" "0")
                 "XDG_CONFIG_HOME" (dict "name" "XDG_CONFIG_HOME" "value" "/tmp/.config")
                 "XDG_DATA_HOME" (dict "name" "XDG_DATA_HOME" "value" "/tmp/.local/share")

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -24,6 +24,10 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# Optional public deploy-environment label for the landing badge (for example prod or staging).
+# When blank, the chart infers common environments from ingress.host.
+deployEnv: ""
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000

--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -4167,7 +4167,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-place-desktop-tauri"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-place-desktop-tauri"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1185,7 +1185,7 @@ def run(args: argparse.Namespace) -> int:
                         last_error = relay_error
                     else:
                         last_error = (
-                            "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
+                            "relay appears unreachable, old, or incompatible with desktop-v0.1.1 "
                             "operator; update relay.py to repo HEAD"
                         )
                 elif api_v1_payload:
@@ -1252,7 +1252,7 @@ def run(args: argparse.Namespace) -> int:
                         last_error = None
                     else:
                         last_error = (
-                            "relay appears unreachable, old, or incompatible with desktop-v0.1.0 "
+                            "relay appears unreachable, old, or incompatible with desktop-v0.1.1 "
                             "operator; update relay.py to repo HEAD"
                         )
 

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ testing, and deploying token.place. For an expanded overview of every directory,
 - **Security:** [SECURITY_PRIVACY_AUDIT.md](SECURITY_PRIVACY_AUDIT.md) contains the rolling
   hardening checklist and threat model; use
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
-- **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
+- **Release notes:** Track changes in [CHANGELOG.md](../CHANGELOG.md) and stepwise updates in
   [CHANGELOG_STEP.md](CHANGELOG_STEP.md).
 
 ## Prompt docs

--- a/docs/architecture/api_v1_e2ee_relay.md
+++ b/docs/architecture/api_v1_e2ee_relay.md
@@ -44,7 +44,7 @@ runtime fallback for API v1 desktop relay requests.
 - API v2 exists in the repository, but it is currently incomplete.
 - Do **not** route active runtime traffic through API v2 yet.
 - Do **not** migrate server, relay, client, desktop, or relay HTML chat UI runtime paths to API v2
-  until API v1 is launched and v0.1.0 is finalized.
+  until API v2 is explicitly approved as a future runtime target.
 
 ## Deprecated legacy relay endpoints
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -28,7 +28,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Current runtime alignment: chart `appVersion: "0.1.1"`; historical v0.1.0 evidence includes Git tag `v0.1.0` and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
 - Required sign-off tag style: immutable semver release tag `vX.Y.Z` (published from a signed-off main artifact)
 - Canonical release image tag after Git tagging is the matching semver tag (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and not production sign-off

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -29,7 +29,7 @@ stateful relay phase by rendering `replicaCount: 1` and `strategy.type: Recreate
 
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Current runtime alignment: chart `appVersion: "0.1.1"`; historical v0.1.0 evidence includes Git tag `v0.1.0` and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
 - Preferred tag for validation/sign-off: immutable `main-<shortsha>`
 - Final release Git tags publish matching image tags (example: `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and must not be used for staging sign-off or production promotion

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -39,7 +39,7 @@ operator workflow.
 
 - Relay image: `ghcr.io/futuroptimist/tokenplace-relay`
 - OCI Helm chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Launch runtime alignment for v0.1.0: Git tag `v0.1.0`, chart `appVersion: "0.1.0"`, release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`; updated chart defaults publish as chart package version `0.1.1`
+- Current runtime alignment: chart `appVersion: "0.1.1"`; historical v0.1.0 evidence includes Git tag `v0.1.0` and release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
 - Preferred deploy tag for staging/prod validation: immutable `main-<shortsha>`
 - Canonical release tag after pushing a Git tag (example): `v0.1.0` -> `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 - `main-latest`, `latest`, `staging`, `prod`, and `production` are mutable/convenience labels only and not staging sign-off or production promotion material
@@ -491,11 +491,11 @@ curl -fsS https://staging.token.place/metrics | head -n 40
 
 ### Image tag, chart version, and Git tag must be validated independently
 
-For final v0.1.0 release readiness, verify all four identifiers explicitly (separate from staging candidate validation):
+For final release readiness, verify all four identifiers explicitly (separate from staging candidate validation):
 
 - Git release tag: `v0.1.0`
-- Chart package version: `0.1.1` (with chart `appVersion: "0.1.0"`)
-- Chart appVersion: `"0.1.0"`
+- Chart package version: `0.1.1` (with chart `appVersion: "0.1.1"`)
+- Chart appVersion: `"0.1.1"`
 - Relay image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
 
 Example image-tag existence checks:

--- a/relay.py
+++ b/relay.py
@@ -16,6 +16,8 @@ from urllib.parse import urlparse
 
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
+
+from release_metadata import build_release_metadata
 from werkzeug.serving import make_server
 
 # Logging --------------------------------------------------------------------
@@ -101,6 +103,7 @@ _ORIGINAL_SIGNAL_HANDLERS: dict[int, Any] = {}
 STATIC_DIR_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
 INDEX_HTML_PATH = os.path.join(STATIC_DIR_PATH, "index.html")
 VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
+RELEASE_META_PLACEHOLDER = "__TOKENPLACE_RELEASE_META_JSON__"
 VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
 VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
 
@@ -118,10 +121,20 @@ def _vue_script_src_for_mode(mode: str) -> str:
     return VUE_DEV_SCRIPT_SRC if mode == "development" else VUE_PROD_SCRIPT_SRC
 
 
-def _render_index_html() -> str:
+def _json_for_script_tag(payload: dict[str, Any]) -> str:
+    """Serialize JSON so it is safe inside an application/json script tag."""
+
+    return json.dumps(payload, sort_keys=True).replace("</", "<\\/")
+
+
+def _render_index_html(host: str | None = None) -> str:
     with open(INDEX_HTML_PATH, encoding="utf-8") as index_file:
         html = index_file.read()
-    return html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+    metadata = build_release_metadata(host=host)
+    return (
+        html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+        .replace(RELEASE_META_PLACEHOLDER, _json_for_script_tag(metadata))
+    )
 
 
 def _handle_shutdown_signal(signum: int, frame: Any) -> None:
@@ -905,11 +918,19 @@ def _pop_stream_chunks_for_client(client_public_key):
 
 @app.route('/')
 def index():
-    response = Response(_render_index_html(), mimetype='text/html')
+    response = Response(_render_index_html(host=request.host), mimetype='text/html')
     response.last_modified = os.path.getmtime(INDEX_HTML_PATH)
     response.add_etag()
     response.make_conditional(request)
     return response
+
+
+@app.route('/api/v1/meta', methods=['GET'])
+def api_v1_meta():
+    """Return public-safe release metadata for deployed clients."""
+
+    return jsonify(build_release_metadata(host=request.host))
+
 
 # Generic route for serving static files
 @app.route('/static/<path:path>')

--- a/release_metadata.py
+++ b/release_metadata.py
@@ -1,0 +1,152 @@
+"""Public-safe release metadata helpers for relay-rendered pages."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parent
+_CHART_PATH = _REPO_ROOT / "charts" / "tokenplace" / "Chart.yaml"
+_DESKTOP_PACKAGE_PATH = _REPO_ROOT / "desktop-tauri" / "package.json"
+_SAFE_VALUE_RE = re.compile(r"[^A-Za-z0-9._+-]+")
+_IMAGE_TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
+
+def _clean_public_value(value: object, *, max_length: int = 128) -> str:
+    """Return a small public-safe token suitable for HTML/JSON metadata."""
+
+    if not isinstance(value, str):
+        return ""
+    cleaned = _SAFE_VALUE_RE.sub("-", value.strip())[:max_length].strip("-._+")
+    return cleaned
+
+
+def _env_value(environ: Mapping[str, str], *names: str) -> str:
+    for name in names:
+        value = _clean_public_value(environ.get(name, ""))
+        if value:
+            return value
+    return ""
+
+
+def _chart_app_version() -> str:
+    try:
+        text = _CHART_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    for line in text.splitlines():
+        if not line.strip().startswith("appVersion:"):
+            continue
+        _, raw_value = line.split(":", 1)
+        return _clean_public_value(raw_value.strip().strip("'\""))
+    return ""
+
+
+def _desktop_package_version() -> str:
+    try:
+        data = json.loads(_DESKTOP_PACKAGE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    return _clean_public_value(data.get("version", ""))
+
+
+def resolve_release_version(environ: Mapping[str, str] | None = None) -> str:
+    """Resolve the public release version, falling back to development metadata."""
+
+    env = environ or os.environ
+    return (
+        _env_value(env, "TOKENPLACE_RELEASE_VERSION", "TOKENPLACE_CHART_APP_VERSION")
+        or _chart_app_version()
+        or _desktop_package_version()
+        or "dev"
+    )
+
+
+def _host_without_port(host: str | None) -> str:
+    if not host:
+        return ""
+    candidate = host.strip().lower()
+    if candidate.startswith("[") and "]" in candidate:
+        return candidate[1 : candidate.index("]")]
+    if ":" in candidate:
+        candidate = candidate.split(":", 1)[0]
+    return candidate.strip(".")
+
+
+def resolve_release_environment(
+    host: str | None = None, environ: Mapping[str, str] | None = None
+) -> str:
+    """Resolve the public deploy environment from env, then request host."""
+
+    env = environ or os.environ
+    env_value = _env_value(env, "TOKENPLACE_DEPLOY_ENV", "TOKEN_PLACE_ENV")
+    normalized_env = env_value.lower()
+    if normalized_env:
+        if normalized_env in {"production", "prod"}:
+            return "prod"
+        if normalized_env in {"stage", "staging"}:
+            return "staging"
+        if normalized_env in {"development", "dev", "local", "localhost"}:
+            return "dev"
+        return normalized_env
+
+    normalized_host = _host_without_port(host)
+    if normalized_host == "token.place":
+        return "prod"
+    if normalized_host == "staging.token.place":
+        return "staging"
+    if normalized_host in {"localhost", "127.0.0.1", "::1"}:
+        return "dev"
+    return "dev"
+
+
+def resolve_release_ref(environ: Mapping[str, str] | None = None) -> str:
+    """Return an optional short git SHA or image tag safe for public display."""
+
+    env = environ or os.environ
+    git_sha = _clean_public_value(env.get("TOKENPLACE_GIT_SHA", ""), max_length=40)
+    if _GIT_SHA_RE.fullmatch(git_sha):
+        return git_sha[:12]
+
+    image_tag = _clean_public_value(env.get("TOKENPLACE_IMAGE_TAG", ""), max_length=128)
+    if image_tag and _IMAGE_TAG_RE.fullmatch(image_tag):
+        return image_tag
+    return ""
+
+
+def _display_version(version: str) -> str:
+    semantic_version_pattern = r"\d+(?:\.\d+){1,3}(?:[-+][A-Za-z0-9._-]+)?"
+    if (
+        version == "dev"
+        or version.startswith("v")
+        or not re.fullmatch(semantic_version_pattern, version)
+    ):
+        return version
+    return f"v{version}"
+
+
+def build_release_metadata(
+    host: str | None = None, environ: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """Build public-safe release metadata for the landing page and API."""
+
+    env = environ or os.environ
+    version = resolve_release_version(env)
+    deploy_env = resolve_release_environment(host, env)
+    ref = resolve_release_ref(env)
+    display_value = _display_version(version) if version != "dev" else (ref or "dev")
+    label = f"{deploy_env} {display_value}".strip()
+    metadata = {
+        "environment": deploy_env,
+        "version": version,
+        "display_version": display_value,
+        "label": label,
+    }
+    if ref:
+        metadata["ref"] = ref
+    return metadata

--- a/static/index.html
+++ b/static/index.html
@@ -76,6 +76,32 @@
         [v-cloak] {
             display: none;
         }
+        .release-badge {
+            position: fixed;
+            left: 12px;
+            bottom: 12px;
+            z-index: 50;
+            max-width: calc(100vw - 24px);
+            padding: 6px 10px;
+            border: 1px solid rgba(0, 255, 255, 0.42);
+            border-radius: 999px;
+            background: rgba(17, 17, 17, 0.78);
+            color: #ffffff;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+            backdrop-filter: blur(8px);
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            line-height: 1.2;
+            pointer-events: none;
+            text-transform: lowercase;
+        }
+        body.light-mode .release-badge {
+            border-color: rgba(0, 123, 255, 0.35);
+            background: rgba(255, 255, 255, 0.82);
+            color: #111111;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+        }
         .chat-container {
             background-color: rgba(255, 255, 255, 0.1);
             border-radius: 10px;
@@ -414,6 +440,10 @@
     </style>
 </head>
 <body class="dark-mode">
+    <script id="tokenplace-release-meta" type="application/json">__TOKENPLACE_RELEASE_META_JSON__</script>
+    <div class="release-badge" data-testid="release-badge" aria-label="token.place release metadata">
+        <span id="release-badge-label">dev dev</span>
+    </div>
     <div id="app" class="container">
         <h1>Welcome to token.place!</h1>
         <p>tokenplace is a peer-to-peer generative AI platform that pairs those in need of LLM compute with individuals donating spare resources, aiming to democratize AI access.</p>
@@ -597,6 +627,12 @@
             <p>Returns API health metadata: <code>status</code>, <code>version</code>, <code>service</code>, and a current <code>timestamp</code>.</p>
         </div>
 
+
+        <div class="api-endpoint">
+            <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/meta</span></h3>
+            <p>Returns public-safe release metadata for clients and status pages: deploy environment, release version, display label, and optional short Git/image reference. It never exposes secrets or private relay payload data.</p>
+        </div>
+
         <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/community/providers</span></h3>
             <p>Lists community-operated relay and server providers as <code>{"object":"list","data":[...]}</code>, with optional metadata.</p>
@@ -693,6 +729,35 @@
             <button id="toggleMode"></button>
         </div>
     </div>
+
+    <script>
+        (function renderReleaseBadge() {
+            const defaultMetadata = { environment: 'dev', display_version: 'dev', label: 'dev dev' };
+            const labelElement = document.getElementById('release-badge-label');
+            const metadataElement = document.getElementById('tokenplace-release-meta');
+            if (!labelElement || !metadataElement) {
+                return;
+            }
+
+            let metadata = defaultMetadata;
+            const rawMetadata = (metadataElement.textContent || '').trim();
+            if (rawMetadata && !rawMetadata.includes('__TOKENPLACE_RELEASE_META_JSON__')) {
+                try {
+                    const parsed = JSON.parse(rawMetadata);
+                    if (parsed && typeof parsed === 'object') {
+                        metadata = parsed;
+                    }
+                } catch (error) {
+                    console.warn('Unable to parse release metadata:', error);
+                }
+            }
+
+            const safeLabel = typeof metadata.label === 'string' && metadata.label.trim()
+                ? metadata.label.trim()
+                : `${metadata.environment || 'dev'} ${metadata.display_version || metadata.version || 'dev'}`.trim();
+            labelElement.textContent = safeLabel || defaultMetadata.label;
+        })();
+    </script>
 
     <!-- Vue.js -->
     <script src="__TOKENPLACE_VUE_SCRIPT_SRC__"></script>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_compute_node_count_failure_is_graceful",
     "tests/e2e/test_ui.py::test_compute_node_count_rejects_null_diagnostics",
     "tests/e2e/test_ui.py::test_compute_node_count_ignores_stale_refresh",
+    "tests/e2e/test_ui.py::test_release_badge_renders_public_metadata",
     "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1",
 }
 REAL_DESKTOP_BRIDGE_E2E_NODEID = "tests/e2e/test_ui.py::test_landing_chat_real_inference_with_desktop_bridge_api_v1"
@@ -198,6 +199,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
         "failover",
         "sticky",
         "server_key",
+        "model",
+        "landing_chat",
         "landing_chat_model_dropdown_uses_api_v1_models",
         "landing_chat_model_catalog_failure_uses_api_v1_fallback",
         "landing_chat_shows_no_servers_available_message",
@@ -212,6 +215,10 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
         "compute_node_count_rejects_null_diagnostics",
         "compute_node_count_ignores_stale_refresh",
         "landing_chat_real_inference_with_desktop_bridge_api_v1",
+        "release_badge_renders_public_metadata",
+        "release",
+        "version",
+        "env",
     }
     target_path = "tests/e2e/test_ui.py"
 

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -239,6 +239,21 @@ def test_root_page_loads(page: Page, base_url: str, setup_servers):
     print(f"✓ Found {len(headings)} headings on the page")
 
 
+
+
+def test_release_badge_renders_public_metadata(page: Page, base_url: str, setup_servers):
+    """Landing page should render the release/environment badge without API calls."""
+
+    page.goto(base_url, wait_until="domcontentloaded")
+
+    badge = page.get_by_test_id("release-badge")
+    badge.wait_for(state="visible")
+    badge_text = badge.inner_text().strip()
+
+    assert re.fullmatch(r"(dev|prod|staging) (dev|v?\d+\.\d+\.\d+(?:[-+][A-Za-z0-9._-]+)?|[A-Za-z0-9][A-Za-z0-9._-]{0,127})", badge_text)
+    assert "secret" not in badge_text.lower()
+    assert "TOKENPLACE" not in badge_text
+
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):
     """Landing page should render and refresh the relay diagnostics compute-node count."""
     counts = iter([3, 5])

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -20,6 +20,7 @@ PUBLIC_CLIENT_ROUTES = {
     ("POST", "/api/v1/completions"),
     ("POST", "/api/v1/images/generations"),
     ("GET", "/api/v1/health"),
+    ("GET", "/api/v1/meta"),
     ("GET", "/api/v1/community/providers"),
     ("GET", "/api/v1/community/leaderboard"),
     ("POST", "/api/v1/community/contributions"),

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -40,6 +40,7 @@ def test_static_index_uses_runtime_vue_placeholder() -> None:
     html = INDEX_HTML_PATH.read_text(encoding="utf-8")
 
     assert relay.VUE_SCRIPT_PLACEHOLDER in html
+    assert relay.RELEASE_META_PLACEHOLDER in html
     assert "dist/vue.js" not in html
 
 

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+
+import release_metadata
+import relay
+
+
+SECRET_ENV = {
+    "TOKENPLACE_RELEASE_VERSION": "0.1.1",
+    "TOKENPLACE_DEPLOY_ENV": "prod",
+    "TOKENPLACE_GIT_SHA": "abcdef1234567890abcdef",
+    "TOKEN_PLACE_RELAY_SERVER_TOKEN": "super-secret-registration-token",
+    "OPENAI_API_KEY": "sk-secret-token",
+}
+
+
+def test_release_metadata_prefers_public_env_values():
+    metadata = release_metadata.build_release_metadata(
+        host="localhost:5010",
+        environ=SECRET_ENV,
+    )
+
+    assert metadata == {
+        "environment": "prod",
+        "version": "0.1.1",
+        "display_version": "v0.1.1",
+        "label": "prod v0.1.1",
+        "ref": "abcdef123456",
+    }
+
+
+def test_release_metadata_infers_prod_and_staging_hosts(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_RELEASE_VERSION", raising=False)
+    monkeypatch.delenv("TOKENPLACE_DEPLOY_ENV", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_ENV", raising=False)
+    monkeypatch.delenv("TOKENPLACE_GIT_SHA", raising=False)
+    monkeypatch.delenv("TOKENPLACE_IMAGE_TAG", raising=False)
+
+    prod_metadata = release_metadata.build_release_metadata(host="token.place")
+    staging_metadata = release_metadata.build_release_metadata(host="staging.token.place")
+
+    assert prod_metadata["environment"] == "prod"
+    assert prod_metadata["label"] == "prod v0.1.1"
+    assert staging_metadata["environment"] == "staging"
+    assert staging_metadata["label"] == "staging v0.1.1"
+
+
+def test_release_metadata_uses_image_tag_when_version_is_dev():
+    metadata = release_metadata.build_release_metadata(
+        host="unknown.example",
+        environ={"TOKENPLACE_RELEASE_VERSION": "dev", "TOKENPLACE_IMAGE_TAG": "main-abc123"},
+    )
+
+    assert metadata["environment"] == "dev"
+    assert metadata["version"] == "dev"
+    assert metadata["ref"] == "main-abc123"
+    assert metadata["label"] == "dev main-abc123"
+
+
+def test_release_metadata_does_not_expose_secret_env_values():
+    metadata = release_metadata.build_release_metadata(host="token.place", environ=SECRET_ENV)
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert "super-secret" not in serialized
+    assert "sk-secret" not in serialized
+    assert set(metadata) <= {"environment", "version", "display_version", "label", "ref"}
+
+
+def test_rendered_landing_page_injects_release_metadata(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.delenv("TOKENPLACE_DEPLOY_ENV", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_ENV", raising=False)
+    monkeypatch.setenv("TOKENPLACE_GIT_SHA", "abcdef1234567890")
+
+    html = relay._render_index_html(host="token.place")
+
+    assert relay.RELEASE_META_PLACEHOLDER not in html
+    assert 'data-testid="release-badge"' in html
+    assert '"environment": "prod"' in html
+    assert '"version": "0.1.1"' in html
+    assert "abcdef123456" in html
+    assert "TOKENPLACE_GIT_SHA" not in html
+
+
+def test_meta_endpoint_returns_public_safe_metadata(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.delenv("TOKENPLACE_DEPLOY_ENV", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_ENV", raising=False)
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-abc123")
+
+    with relay.app.test_client() as client:
+        response = client.get("/api/v1/meta", headers={"Host": "staging.token.place"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "environment": "staging",
+        "version": "0.1.1",
+        "display_version": "v0.1.1",
+        "label": "staging v0.1.1",
+        "ref": "main-abc123",
+    }

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -464,3 +464,17 @@ def test_run_all_tests_pr_tiny_gguf_path_is_absolute_workspace_path() -> None:
         assert "scripts/provision-ci-tiny-gguf.sh" in _step_runs(
             job
         ), f"{job_name} must provision the tiny real GGUF before run_all_tests.sh."
+
+
+def test_chart_app_version_and_release_env_metadata_defaults_are_current() -> None:
+    chart = yaml.safe_load(Path("charts/tokenplace/Chart.yaml").read_text(encoding="utf-8"))
+    values = yaml.safe_load(Path("charts/tokenplace/values.yaml").read_text(encoding="utf-8"))
+    deployment = Path("charts/tokenplace/templates/deployment.yaml").read_text(encoding="utf-8")
+
+    assert chart["appVersion"] == "0.1.1"
+    assert values["deployEnv"] == ""
+    assert '"TOKENPLACE_RELEASE_VERSION" (dict "name" "TOKENPLACE_RELEASE_VERSION" "value" .Chart.AppVersion)' in deployment
+    assert '"TOKENPLACE_CHART_VERSION" (dict "name" "TOKENPLACE_CHART_VERSION" "value" .Chart.Version)' in deployment
+    assert '"TOKENPLACE_DEPLOY_ENV" (dict "name" "TOKENPLACE_DEPLOY_ENV" "value" $deployEnv)' in deployment
+    assert 'else if eq $ingressHost "staging.token.place"' in deployment
+    assert 'eq $ingressHost "token.place"' in deployment


### PR DESCRIPTION
### Motivation
- Provide public-safe, runtime-driven release metadata for the landing page so deployed sites can show environment and version without hardcoding HTML.
- Surface a small bottom-left release badge on the landing page for easier prod/staging identification and developer debugging.
- Propagate release metadata into Helm defaults and desktop packaging metadata to align `v0.1.1` as the current development target.
- Create a lightweight evergreen `CHANGELOG.md` and add tests so the new metadata surface is verifiable by CI and local runs.

### Description
- Added `release_metadata.py` which resolves `version`, `environment`, and a short `ref` from env vars (`TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_DEPLOY_ENV`, `TOKENPLACE_GIT_SHA`, `TOKENPLACE_IMAGE_TAG`) and safe fallbacks, and exposes `build_release_metadata()` for public-safe output.
- Injected release metadata into the served landing HTML by updating `relay.py` to render a `__TOKENPLACE_RELEASE_META_JSON__` placeholder and added a public endpoint `GET /api/v1/meta` that returns `build_release_metadata()` JSON.
- Updated `static/index.html` to include an `application/json` script tag with the metadata placeholder and added a fixed bottom-left release badge (CSS + small JS) that reads the injected JSON and renders immediately without API calls; added `data-testid="release-badge"` for tests.
- Bumped release/version metadata to `0.1.1` by updating `charts/tokenplace/Chart.yaml` `appVersion` and desktop artifacts in `desktop-tauri` (`package.json`, `tauri.conf.json`, `package-lock.json`, `Cargo.toml`/`Cargo.lock`), and updated `charts/tokenplace/templates/deployment.yaml` and `values.yaml` to export safe env defaults (`TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, `TOKENPLACE_DEPLOY_ENV`, `TOKENPLACE_IMAGE_TAG`) with simple ingress.host-based deploy-env inference.
- Added `CHANGELOG.md` with `Unreleased / v0.1.1` and `v0.1.0` entries and made small docs updates to remove stale wording referencing `v0.1.0` finalization.
- Tests and test tweaks: added `tests/unit/test_release_metadata.py`, updated `tests/e2e/test_ui.py` to include `test_release_badge_renders_public_metadata`, and adjusted `relay`-frontend unit expectations to include the release-placeholder; CI workflow sentinel tests updated to assert chart/appVersion defaults.

### Testing
- Unit smoke for new metadata and frontend rendering: `python -m pytest tests/unit/test_release_metadata.py tests/unit/test_relay_frontend_vue_mode.py tests/unit/test_workflow_ci_sentinel.py -v` — all selected tests passed (17 passed / 0 failed).
- E2E landing UI subset: `python -m pytest tests/e2e/test_ui.py -k "landing_chat or model or compute_node_count or release or version or env" -v` — end-to-end suite exercising landing chat, compute-node count, and the release badge passed (24 passed, 1 skipped for desktop-bridge guardrail in this environment).
- JavaScript tests: `npm run test:js` — JS tests passed (all JS smoke tests passed).  
- Desktop tests: `cd desktop-tauri && npm test` — desktop unit tests passed (Vitest run passed).
- Full unit suite during pre-commit: `pre-commit run --all-files` invoked the project test runner which ran the Python unit test suite; the run exposed a single failing unit assertion: `tests/unit/test_api_v1_launch_contract.py::test_no_unclassified_api_v1_routes_leak_into_launch_contract` failed because the new public route `/api/v1/meta` must be added to the test's expected set (test currently treats any extra API v1 route as a leak).  All other unit tests ran and the large majority passed (1 failed, many passed as shown in logs).

Notes and follow-ups: update `tests/unit/test_api_v1_launch_contract.py` to include the new `GET /api/v1/meta` route (or adjust the test's expected list) so the full unit suite is green under pre-commit; this PR intentionally leaves the metadata endpoint public-safe and small, and the failing assertion is an expected test update needed to accept the new documented metadata surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9d04f97c832fa5ce139cbf8c54b7)