### PR TITLE
Desktop: support list of Relay URLs (UI + config + migration)

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -27,6 +27,8 @@ use tokio::sync::Mutex;
 pub struct ComputeNodeRequest {
     pub model_path: String,
     pub relay_base_url: String,
+    #[serde(default)]
+    pub relay_base_urls: Vec<String>,
     pub mode: ComputeMode,
 }
 
@@ -1615,6 +1617,7 @@ mod tests {
         let request = ComputeNodeRequest {
             model_path: "model.gguf".into(),
             relay_base_url: "https://relay.example".into(),
+            relay_base_urls: vec!["https://relay.example".into()],
             mode: ComputeMode::Cpu,
         };
         let status = startup_failure_status(
@@ -1793,6 +1796,7 @@ mod tests {
         let request = ComputeNodeRequest {
             model_path: "model.gguf".into(),
             relay_base_url: "https://relay.example".into(),
+            relay_base_urls: vec!["https://relay.example".into()],
             mode: ComputeMode::Auto,
         };
 

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -1,11 +1,22 @@
 use crate::backend::ComputeMode;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+
+pub const DEFAULT_RELAY_BASE_URL: &str = "https://token.place";
+pub const MAX_RELAY_BASE_URLS: usize = 10;
+
+fn default_relay_base_url() -> String {
+    DEFAULT_RELAY_BASE_URL.into()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DesktopConfig {
     pub model_path: String,
+    #[serde(default = "default_relay_base_url")]
     pub relay_base_url: String,
+    #[serde(default)]
+    pub relay_base_urls: Vec<String>,
     pub preferred_mode: ComputeMode,
 }
 
@@ -13,20 +24,107 @@ impl Default for DesktopConfig {
     fn default() -> Self {
         Self {
             model_path: String::new(),
-            relay_base_url: "https://token.place".into(),
+            relay_base_url: DEFAULT_RELAY_BASE_URL.into(),
+            relay_base_urls: vec![DEFAULT_RELAY_BASE_URL.into()],
             preferred_mode: ComputeMode::Auto,
         }
     }
 }
 
+pub fn normalize_relay_base_urls(
+    relay_base_urls: &[String],
+    legacy_relay_base_url: &str,
+) -> Vec<String> {
+    let candidates: Vec<&str> = if relay_base_urls.is_empty() {
+        vec![legacy_relay_base_url]
+    } else {
+        relay_base_urls.iter().map(String::as_str).collect()
+    };
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for candidate in candidates {
+        let trimmed = candidate.trim();
+        if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
+            continue;
+        }
+        normalized.push(trimmed.to_string());
+        if normalized.len() >= MAX_RELAY_BASE_URLS {
+            break;
+        }
+    }
+    if normalized.is_empty() {
+        normalized.push(DEFAULT_RELAY_BASE_URL.into());
+    }
+    normalized
+}
+
+pub fn normalize_desktop_config(mut config: DesktopConfig) -> DesktopConfig {
+    config.relay_base_urls =
+        normalize_relay_base_urls(&config.relay_base_urls, &config.relay_base_url);
+    config.relay_base_url = config
+        .relay_base_urls
+        .first()
+        .cloned()
+        .unwrap_or_else(default_relay_base_url);
+    config
+}
+
 #[cfg(test)]
 mod tests {
-    use super::DesktopConfig;
+    use super::{
+        normalize_desktop_config, normalize_relay_base_urls, DesktopConfig, DEFAULT_RELAY_BASE_URL,
+    };
 
     #[test]
     fn desktop_config_defaults_to_token_place_relay() {
         let config = DesktopConfig::default();
-        assert_eq!(config.relay_base_url, "https://token.place");
+        assert_eq!(config.relay_base_url, DEFAULT_RELAY_BASE_URL);
+        assert_eq!(
+            config.relay_base_urls,
+            vec![DEFAULT_RELAY_BASE_URL.to_string()]
+        );
+    }
+
+    #[test]
+    fn legacy_config_migrates_from_single_relay_base_url() {
+        let raw = r#"{
+            "model_path": "/tmp/model.gguf",
+            "relay_base_url": " https://legacy.example ",
+            "preferred_mode": "auto"
+        }"#;
+        let config: DesktopConfig = serde_json::from_str(raw).expect("legacy config deserializes");
+        let normalized = normalize_desktop_config(config);
+        assert_eq!(
+            normalized.relay_base_urls,
+            vec!["https://legacy.example".to_string()]
+        );
+        assert_eq!(normalized.relay_base_url, "https://legacy.example");
+        assert_eq!(normalized.model_path, "/tmp/model.gguf");
+    }
+
+    #[test]
+    fn relay_list_normalization_trims_dedupes_and_preserves_order() {
+        let relays = vec![
+            " https://one.example ".to_string(),
+            "".to_string(),
+            "https://two.example".to_string(),
+            "https://one.example".to_string(),
+        ];
+        assert_eq!(
+            normalize_relay_base_urls(&relays, "https://legacy.example"),
+            vec![
+                "https://one.example".to_string(),
+                "https://two.example".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_relay_list_falls_back_to_default() {
+        assert_eq!(
+            normalize_relay_base_urls(&[], "   "),
+            vec![DEFAULT_RELAY_BASE_URL.to_string()]
+        );
     }
 }
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ mod subprocess_logging;
 
 use backend::{detect_backend_for, BackendInfo};
 use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
-use config::{config_path, DesktopConfig};
+use config::{config_path, normalize_desktop_config, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sidecar::{InferenceRequest, SidecarState};
@@ -277,7 +277,8 @@ fn load_config(
         return Ok(DesktopConfig::default());
     }
     let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&raw).map_err(|e| e.to_string())
+    let config: DesktopConfig = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
+    Ok(normalize_desktop_config(config))
 }
 
 #[tauri::command]
@@ -288,6 +289,7 @@ fn save_config(
 ) -> Result<(), String> {
     let dir = resolve_config_dir(&app, &state).map_err(|e| e.to_string())?;
     let path = config_path(&dir);
+    let config = normalize_desktop_config(config);
     let raw = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
     fs::write(path, raw).map_err(|e| e.to_string())
 }

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1383,6 +1383,152 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
   });
 
+
+  it('renders one relay URL field from a legacy single-relay config', async () => {
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    await waitFor(() => expect(relayInput.value).toBe('https://token.place'));
+    expect(screen.queryByLabelText('Relay URL 2')).toBeNull();
+  });
+
+  it('loads and displays multiple persisted relay URLs', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://primary.example',
+          relay_base_urls: ['https://primary.example', 'https://staging.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Relay URL 1') as HTMLInputElement).value).toBe(
+        'https://primary.example'
+      )
+    );
+    expect((screen.getByLabelText('Relay URL 2') as HTMLInputElement).value).toBe(
+      'https://staging.example'
+    );
+    expect(screen.getByText(/Configured relay URLs:/).textContent).toContain('https://staging.example');
+  });
+
+  it('adds and removes relay URL fields while preserving a final field', async () => {
+    render(<App />);
+    await screen.findByLabelText('Relay URL 1');
+
+    fireEvent.click(screen.getByText('Add new relay URL'));
+    const relay2 = (await screen.findByLabelText('Relay URL 2')) as HTMLInputElement;
+    fireEvent.change(relay2, { target: { value: 'https://staging.example' } });
+    expect(relay2.value).toBe('https://staging.example');
+
+    const deleteButtons = screen.getAllByText('Delete') as HTMLButtonElement[];
+    fireEvent.click(deleteButtons[1]);
+    await waitFor(() => expect(screen.queryByLabelText('Relay URL 2')).toBeNull());
+    expect((screen.getByText('Delete') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables relay URL controls when the operator is running', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      relay_runtime_state: 'ready',
+      active_relay_url: 'https://token.place',
+    });
+
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    expect(relayInput.disabled).toBe(true);
+    expect((screen.getByText('Add new relay URL') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByText('Delete') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('Stop the operator to edit relay URLs. Changes apply on next start.')).toBeTruthy();
+  });
+
+  it('disables relay URL controls while the operator is starting', async () => {
+    let resolveStart: (() => void) | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'start_compute_node') {
+        return new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() => expect((screen.getByLabelText('Relay URL 1') as HTMLInputElement).disabled).toBe(true));
+    expect((screen.getByText('Add new relay URL') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('Stop the operator to edit relay URLs. Changes apply on next start.')).toBeTruthy();
+    resolveStart?.();
+  });
+
+  it('saves relay_base_urls and first-url relay_base_url compatibility fields', async () => {
+    render(<App />);
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    fireEvent.change(relayInput, { target: { value: ' https://primary.example ' } });
+    fireEvent.click(screen.getByText('Add new relay URL'));
+    fireEvent.change((await screen.findByLabelText('Relay URL 2')) as HTMLInputElement, {
+      target: { value: 'https://primary.example' },
+    });
+    fireEvent.click(screen.getByText('Add new relay URL'));
+    fireEvent.change((await screen.findByLabelText('Relay URL 3')) as HTMLInputElement, {
+      target: { value: 'https://secondary.example' },
+    });
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'save_config' &&
+            args?.config?.relay_base_url === 'https://primary.example' &&
+            JSON.stringify(args.config.relay_base_urls) ===
+              JSON.stringify(['https://primary.example', 'https://secondary.example'])
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('starts the operator with the normalized relay list and primary relay URL', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://legacy.example',
+          relay_base_urls: [' https://primary.example ', '', 'https://primary.example', 'https://secondary.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'start_compute_node' &&
+            args?.request?.relay_base_url === 'https://primary.example' &&
+            JSON.stringify(args.request.relay_base_urls) ===
+              JSON.stringify(['https://primary.example', 'https://secondary.example'])
+        )
+      ).toBe(true)
+    );
+  });
+
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -16,6 +16,7 @@ interface BackendInfo {
 interface DesktopConfig {
   model_path: string;
   relay_base_url: string;
+  relay_base_urls: string[];
   preferred_mode: BackendMode;
 }
 
@@ -60,6 +61,16 @@ interface SidecarEvent {
   code?: string;
   message?: string;
 }
+
+const DEFAULT_RELAY_BASE_URL = 'https://token.place';
+const MAX_RELAY_BASE_URLS = 10;
+
+const defaultDesktopConfig: DesktopConfig = {
+  model_path: '',
+  relay_base_url: DEFAULT_RELAY_BASE_URL,
+  relay_base_urls: [DEFAULT_RELAY_BASE_URL],
+  preferred_mode: 'auto',
+};
 
 const defaultComputeStatus: ComputeNodeStatus = {
   running: false,
@@ -208,6 +219,68 @@ function mergeComputeStatusEvent(
   };
 }
 
+
+export function normalizeRelayUrls(relayBaseUrls: string[] | undefined, legacyRelayBaseUrl = ''): string[] {
+  const source = relayBaseUrls && relayBaseUrls.length > 0 ? relayBaseUrls : [legacyRelayBaseUrl];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const relayUrl of source) {
+    const trimmed = relayUrl.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+    if (normalized.length >= MAX_RELAY_BASE_URLS) {
+      break;
+    }
+  }
+  return normalized.length > 0 ? normalized : [DEFAULT_RELAY_BASE_URL];
+}
+
+export function primaryRelayUrl(config: Pick<DesktopConfig, 'relay_base_url' | 'relay_base_urls'>): string {
+  return normalizeRelayUrls(config.relay_base_urls, config.relay_base_url)[0];
+}
+
+function normalizeConfigForPersistence(config: DesktopConfig): DesktopConfig {
+  const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+  return {
+    ...config,
+    relay_base_url: relayBaseUrls[0],
+    relay_base_urls: relayBaseUrls,
+  };
+}
+
+function normalizeConfigForDisplay(config: Partial<DesktopConfig>): DesktopConfig {
+  return {
+    ...defaultDesktopConfig,
+    ...config,
+    ...normalizeConfigForPersistence({ ...defaultDesktopConfig, ...config }),
+  };
+}
+
+export function updateRelayUrlAtIndex(config: DesktopConfig, index: number, value: string): DesktopConfig {
+  const relayBaseUrls = [...config.relay_base_urls];
+  relayBaseUrls[index] = value;
+  return { ...config, relay_base_urls: relayBaseUrls, relay_base_url: index === 0 ? value : config.relay_base_url };
+}
+
+export function addRelayUrl(config: DesktopConfig): DesktopConfig {
+  if (config.relay_base_urls.length >= MAX_RELAY_BASE_URLS) {
+    return config;
+  }
+  return { ...config, relay_base_urls: [...config.relay_base_urls, ''] };
+}
+
+export function removeRelayUrl(config: DesktopConfig, index: number): DesktopConfig {
+  if (config.relay_base_urls.length <= 1) {
+    return config;
+  }
+  const relayBaseUrls = config.relay_base_urls.filter((_, i) => i !== index);
+  const next = { ...config, relay_base_urls: relayBaseUrls.length > 0 ? relayBaseUrls : [DEFAULT_RELAY_BASE_URL] };
+  return { ...next, relay_base_url: next.relay_base_urls[0] };
+}
+
 export function selectedModelPath(selection: string | string[] | null): string {
   if (typeof selection === 'string') {
     return selection;
@@ -220,11 +293,7 @@ export function selectedModelPath(selection: string | string[] | null): string {
 
 export function App() {
   const [backend, setBackend] = useState<BackendInfo | null>(null);
-  const [config, setConfig] = useState<DesktopConfig>({
-    model_path: '',
-    relay_base_url: 'https://token.place',
-    preferred_mode: 'auto',
-  });
+  const [config, setConfig] = useState<DesktopConfig>(defaultDesktopConfig);
   const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
   const [prompt, setPrompt] = useState('');
   const [output, setOutput] = useState('');
@@ -254,8 +323,8 @@ export function App() {
 
     const initializeConfigAndArtifact = async () => {
       try {
-        const loadedConfig = await invoke<DesktopConfig>('load_config');
-        setConfig(loadedConfig);
+        const loadedConfig = await invoke<Partial<DesktopConfig>>('load_config');
+        setConfig(normalizeConfigForDisplay(loadedConfig));
         const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
         computeStatusRef.current = nodeStatus;
         setComputeStatus(nodeStatus);
@@ -357,7 +426,7 @@ export function App() {
       window.clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = window.setTimeout(() => {
-      invoke('save_config', { config: next }).catch((e) => setError(formatErrorMessage(e)));
+      invoke('save_config', { config: normalizeConfigForPersistence(next) }).catch((e) => setError(formatErrorMessage(e)));
       saveTimerRef.current = null;
     }, 300);
   };
@@ -438,7 +507,7 @@ export function App() {
         registered: false,
         relay_runtime_state: 'starting',
         sequence: computeStatusRef.current.operator_session_id ? Number.MAX_SAFE_INTEGER : null,
-        active_relay_url: config.relay_base_url,
+        active_relay_url: primaryRelayUrl(config),
         requested_mode: config.preferred_mode,
         effective_mode: null,
         backend_available: null,
@@ -454,7 +523,8 @@ export function App() {
       await invoke('start_compute_node', {
         request: {
           model_path: config.model_path,
-          relay_base_url: config.relay_base_url,
+          relay_base_url: primaryRelayUrl(config),
+          relay_base_urls: normalizeRelayUrls(config.relay_base_urls, config.relay_base_url),
           mode: config.preferred_mode,
         },
       });
@@ -529,7 +599,7 @@ export function App() {
       setIsForwarding(true);
       setError('');
       await invoke('encrypt_and_forward', {
-        relay_base_url: config.relay_base_url,
+        relay_base_url: primaryRelayUrl(config),
         final_output: output,
       });
     } catch (e) {
@@ -595,12 +665,46 @@ export function App() {
         partial offload. Unsupported platforms fall back to CPU with diagnostics.
       </p>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
-      <input
-        value={config.relay_base_url}
-        style={{ width: '100%' }}
-        onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })}
-      />
+      <section style={{ marginTop: 12 }}>
+        <label style={{ display: 'block' }}>Relay URLs</label>
+        <p style={{ marginTop: 4, fontSize: 12, color: '#555' }}>
+          Configure up to {MAX_RELAY_BASE_URLS} relay URLs. Duplicate and blank entries are removed on save/start.
+        </p>
+        {(computeStatus.running || isStartingComputeNode) && (
+          <p style={{ marginTop: 4, fontSize: 12, color: '#555' }}>
+            Stop the operator to edit relay URLs. Changes apply on next start.
+          </p>
+        )}
+        {config.relay_base_urls.map((relayUrl, index) => {
+          const isRelayEditingDisabled = computeStatus.running || isStartingComputeNode;
+          return (
+            <div key={index} style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+              <input
+                aria-label={`Relay URL ${index + 1}`}
+                value={relayUrl}
+                disabled={isRelayEditingDisabled}
+                style={{ width: '100%' }}
+                onChange={(e) => updateConfig(updateRelayUrlAtIndex(config, index, e.target.value))}
+              />
+              <button
+                type="button"
+                disabled={isRelayEditingDisabled || config.relay_base_urls.length <= 1}
+                onClick={() => updateConfig(removeRelayUrl(config, index))}
+              >
+                Delete
+              </button>
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          style={{ marginTop: 8 }}
+          disabled={computeStatus.running || isStartingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
+          onClick={() => updateConfig(addRelayUrl(config))}
+        >
+          Add new relay URL
+        </button>
+      </section>
 
       <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
@@ -618,7 +722,8 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{displayStatusValue(computeStatus.runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{displayStatusValue(computeStatus.relay_runtime_path, 'pending')}</code></p>
-        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, config.relay_base_url)}</code></p>
+        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, primaryRelayUrl(config))}</code></p>
+        <p style={{ marginBottom: 0 }}>Configured relay URLs: <code>{normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).join(', ')}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{displayStatusValue(computeStatus.requested_mode, config.preferred_mode)}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{displayStatusValue(computeStatus.effective_mode, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Backend available: <code>{displayStatusValue(computeStatus.backend_available, 'pending')}</code></p>


### PR DESCRIPTION
### Motivation
- Prepare the desktop Tauri UI/config for v0.1.1 multi-relay operation while preserving the legacy single `relay_base_url` field and avoiding user-visible migration steps.
- Ensure the runtime can be given a normalized, de-duplicated, bounded list of relays (ready for multi-relay compute-node behavior) without breaking existing flows.

### Description
- Rust config: added `relay_base_urls: Vec<String>` to `DesktopConfig`, introduced `DEFAULT_RELAY_BASE_URL`, `MAX_RELAY_BASE_URLS`, `normalize_relay_base_urls`, and `normalize_desktop_config` to migrate legacy single `relay_base_url` and enforce trim/dedupe/limit on relay lists, and updated `load_config`/`save_config` to normalize on read/write.
- Tauri compute bridge: `ComputeNodeRequest` now accepts `relay_base_urls` (kept `relay_base_url` for compatibility) and `start_compute_node`/calls were updated to send both the primary relay and the normalized relay list.
- Frontend (React TS): extended `DesktopConfig` to include `relay_base_urls`, added helper functions `normalizeRelayUrls`, `primaryRelayUrl`, `normalizeConfigForPersistence`, `updateRelayUrlAtIndex`, `addRelayUrl`, and `removeRelayUrl`, replaced the single Relay URL input with a stopped-only Relay URLs list UI that supports add/delete, keeps at least one entry, disables editing when operator is running/starting, and preserves backwards-compatible primary URL behavior.
- Tests: added Rust unit tests for defaults, legacy migration, and normalization, and extended `desktop-tauri/src/App.test.tsx` with coverage for legacy single-field display, multi-relay load/save display, add/delete behavior, disabled controls while running/starting, and normalized `start_compute_node` request payload assertions.

### Testing
- Ran frontend unit tests with Vitest using `cd desktop-tauri && npm test -- --run`, which passed (`src/App.test.tsx` and suite passed). 
- Ran Rust unit tests with `cd desktop-tauri/src-tauri && cargo test config && cargo test compute_node`, which passed (config and compute_node tests passed).
- Ran focused Python tests with `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_runtime_setup.py -v`, which passed. 
- Executed the full project sweep `./run_all_tests.sh` and `pre-commit run --all-files`, and all automated tests and pre-commit hooks passed (final test summary: all tests passed, pre-commit passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c42d1a630832face8d844b72e87c6)