### PR TITLE
desktop: Add persisted multi-relay config & stopped-only UI for Relay URLs

### DIFF
--- a/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
+++ b/desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
@@ -223,7 +223,7 @@ def wait_for_ui_ready(driver: webdriver.Remote, timeout_seconds: float = 45.0) -
             relay_input_ready = bool(
                 d.find_elements(
                     By.XPATH,
-                    "(//label[normalize-space()='Relay URL']/following::input[1])[1]",
+                    "(//label[normalize-space()='Relay URL 1']/following::input[1])[1]",
                 )
             )
             runtime_path_ready = bool(
@@ -319,7 +319,7 @@ def wait_for_start_operator_enabled(
         with contextlib.suppress(Exception):
             relay_value = driver.find_element(
                 By.XPATH,
-                "(//label[normalize-space()='Relay URL']/following::input[1])[1]",
+                "(//label[normalize-space()='Relay URL 1']/following::input[1])[1]",
             ).get_attribute("value")
         with contextlib.suppress(Exception):
             status_snippet = " | ".join(
@@ -548,7 +548,7 @@ def main() -> int:
         )
         assert model_input.get_attribute("value") == model_path
         assert_model_path_exists(model_path)
-        fill_input_by_label(driver, "Relay URL", relay_url)
+        fill_input_by_label(driver, "Relay URL 1", relay_url)
 
         wait_for_start_operator_enabled(driver, relay_log, driver_log)
         driver.find_element(By.XPATH, "//button[.='Start operator']").click()

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import time
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 if __package__ in (None, ""):
@@ -503,7 +503,9 @@ def _structured_startup_error_payload(
         "running": False,
         "registered": False,
         "relay_runtime_state": "failed",
-        "active_relay_url": getattr(args, "relay_url", "https://token.place"),
+        "active_relay_url": _normalize_relay_urls(
+            getattr(args, "relay_url", "https://token.place")
+        )[0],
         "requested_mode": _normalize_compute_mode_local(getattr(args, "mode", "auto")),
         "effective_mode": "pending",
         "backend_available": "pending",
@@ -536,6 +538,27 @@ def _sleep_with_cancel(seconds: float) -> bool:
         time.sleep(0.1)
     return stop_requested()
 
+
+
+def _normalize_relay_urls(raw_relay_urls: Any) -> List[str]:
+    """Return a trimmed, de-duplicated relay list from argparse or tests."""
+
+    if isinstance(raw_relay_urls, str):
+        candidates = [raw_relay_urls]
+    elif isinstance(raw_relay_urls, (list, tuple)):
+        candidates = list(raw_relay_urls)
+    else:
+        candidates = []
+
+    normalized: List[str] = []
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        trimmed = candidate.strip()
+        if trimmed and trimmed not in normalized:
+            normalized.append(trimmed)
+
+    return normalized or ["https://token.place"]
 
 def run(args: argparse.Namespace) -> int:
     bridge_session_id = _bridge_session_id_from_env()
@@ -616,7 +639,9 @@ def run(args: argparse.Namespace) -> int:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
 
-    relay_url = resolve_relay_url(args.relay_url, prefer_cli=True)
+    relay_urls = _normalize_relay_urls(args.relay_url)
+    relay_url = resolve_relay_url(relay_urls[0], prefer_cli=True)
+    relay_urls = [relay_url, *relay_urls[1:]]
     relay_port = resolve_relay_port(args.relay_port, relay_url)
     print(
         "desktop.compute_node_bridge.start "
@@ -637,6 +662,7 @@ def run(args: argparse.Namespace) -> int:
             relay_url=relay_url,
             relay_port=relay_port,
             use_configured_relay_fallbacks=False,
+            relay_urls=tuple(relay_urls),
         )
     )
     start_relay_session = getattr(runtime, "start_relay_session", None)
@@ -1322,7 +1348,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--model", required=True)
     parser.add_argument("--mode", default="auto")
-    parser.add_argument("--relay-url", default="https://token.place")
+    parser.add_argument("--relay-url", action="append", default=None)
     parser.add_argument("--relay-port", type=int, default=None)
     args = parser.parse_args()
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::config::normalize_relay_base_urls;
 use crate::operator_logs::{
     append_line_to_path, sanitize_operator_diagnostic_line, sanitize_operator_path_display,
     OperatorLogSink,
@@ -27,6 +28,8 @@ use tokio::sync::Mutex;
 pub struct ComputeNodeRequest {
     pub model_path: String,
     pub relay_base_url: String,
+    #[serde(default)]
+    pub relay_base_urls: Vec<String>,
     pub mode: ComputeMode,
 }
 
@@ -196,6 +199,10 @@ fn sanitize_relay_target(relay_url: &str) -> String {
     "unknown".into()
 }
 
+fn normalized_request_relay_urls(request: &ComputeNodeRequest) -> Vec<String> {
+    normalize_relay_base_urls(&request.relay_base_urls, &request.relay_base_url)
+}
+
 fn current_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -216,7 +223,10 @@ fn startup_failure_status(
     ComputeNodeStatus {
         running: false,
         registered: false,
-        active_relay_url: request.relay_base_url.clone(),
+        active_relay_url: normalized_request_relay_urls(request)
+            .first()
+            .cloned()
+            .unwrap_or_else(|| request.relay_base_url.clone()),
         requested_mode: format!("{:?}", request.mode).to_lowercase(),
         effective_mode: "cpu".into(),
         backend_available: "unknown".into(),
@@ -575,6 +585,11 @@ pub async fn start_compute_node(
     request: ComputeNodeRequest,
 ) -> anyhow::Result<()> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let relay_base_urls = normalized_request_relay_urls(&request);
+    let primary_relay_url = relay_base_urls
+        .first()
+        .cloned()
+        .unwrap_or_else(|| request.relay_base_url.clone());
 
     {
         let _lifecycle_lock = state.lifecycle_lock.lock().await;
@@ -723,7 +738,7 @@ pub async fn start_compute_node(
     eprintln!(
         "desktop.compute_node.session.start operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={} cancellation_token_reset=true",
         session_id,
-        sanitize_relay_target(&request.relay_base_url),
+        sanitize_relay_target(&primary_relay_url),
         bridge_script,
         interpreter,
         selected_resource_root.display(),
@@ -736,7 +751,7 @@ pub async fn start_compute_node(
         &format!(
             "operator_session_id={} relay={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
             session_id,
-            sanitize_relay_target(&request.relay_base_url),
+            sanitize_relay_target(&primary_relay_url),
             sanitize_path_for_operator_log(Path::new(&bridge_script)),
             sanitize_freeform_bridge_log_line(&interpreter),
             sanitize_path_for_operator_log(&selected_resource_root),
@@ -755,8 +770,11 @@ pub async fn start_compute_node(
         .arg(&request.model_path)
         .arg("--mode")
         .arg(format!("{:?}", request.mode).to_lowercase())
-        .arg("--relay-url")
-        .arg(&request.relay_base_url)
+        .args(
+            relay_base_urls
+                .iter()
+                .flat_map(|relay_url| ["--relay-url", relay_url.as_str()]),
+        )
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -808,7 +826,7 @@ pub async fn start_compute_node(
             eprintln!(
                 "desktop.compute_node.bridge_process.spawned operator_session_id={} relay={}",
                 session_id,
-                sanitize_relay_target(&request.relay_base_url)
+                sanitize_relay_target(&primary_relay_url)
             );
             *child_slot = pending_child.take();
             let mut stdin_slot = state.stdin.lock().await;
@@ -817,7 +835,7 @@ pub async fn start_compute_node(
             *status = ComputeNodeStatus {
                 running: true,
                 registered: false,
-                active_relay_url: request.relay_base_url.clone(),
+                active_relay_url: primary_relay_url.clone(),
                 requested_mode: format!("{:?}", request.mode).to_lowercase(),
                 effective_mode: "cpu".into(),
                 backend_available: "unknown".into(),
@@ -1615,6 +1633,7 @@ mod tests {
         let request = ComputeNodeRequest {
             model_path: "model.gguf".into(),
             relay_base_url: "https://relay.example".into(),
+            relay_base_urls: vec![],
             mode: ComputeMode::Cpu,
         };
         let status = startup_failure_status(
@@ -1793,6 +1812,7 @@ mod tests {
         let request = ComputeNodeRequest {
             model_path: "model.gguf".into(),
             relay_base_url: "https://relay.example".into(),
+            relay_base_urls: vec![],
             mode: ComputeMode::Auto,
         };
 

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -80,7 +80,9 @@ impl Default for DesktopConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_relay_base_urls, DesktopConfig, DEFAULT_RELAY_BASE_URL};
+    use super::{
+        normalize_relay_base_urls, DesktopConfig, DEFAULT_RELAY_BASE_URL, MAX_RELAY_BASE_URLS,
+    };
 
     #[test]
     fn desktop_config_defaults_to_token_place_relay() {
@@ -118,6 +120,46 @@ mod tests {
         assert_eq!(
             normalize_relay_base_urls(&urls, "https://fallback.example"),
             vec!["https://token.place", "https://staging.token.place"]
+        );
+    }
+
+    #[test]
+    fn relay_base_url_normalization_caps_at_max_while_preserving_order_and_deduping() {
+        let urls = vec![
+            "https://relay-01.example",
+            " https://relay-02.example ",
+            "https://relay-03.example",
+            "https://relay-04.example",
+            "https://relay-05.example",
+            "https://relay-03.example",
+            "https://relay-06.example",
+            "https://relay-07.example",
+            "https://relay-08.example",
+            "https://relay-09.example",
+            "https://relay-10.example",
+            "https://relay-11.example",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<_>>();
+
+        let normalized = normalize_relay_base_urls(&urls, "https://fallback.example");
+
+        assert_eq!(normalized.len(), MAX_RELAY_BASE_URLS);
+        assert_eq!(
+            normalized,
+            vec![
+                "https://relay-01.example",
+                "https://relay-02.example",
+                "https://relay-03.example",
+                "https://relay-04.example",
+                "https://relay-05.example",
+                "https://relay-06.example",
+                "https://relay-07.example",
+                "https://relay-08.example",
+                "https://relay-09.example",
+                "https://relay-10.example",
+            ]
         );
     }
 

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -2,18 +2,77 @@ use crate::backend::ComputeMode;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+pub const DEFAULT_RELAY_BASE_URL: &str = "https://token.place";
+pub const MAX_RELAY_BASE_URLS: usize = 10;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DesktopConfig {
+    #[serde(default)]
     pub model_path: String,
+    #[serde(default = "default_relay_base_url")]
     pub relay_base_url: String,
+    #[serde(default)]
+    pub relay_base_urls: Vec<String>,
+    #[serde(default = "default_compute_mode")]
     pub preferred_mode: ComputeMode,
+}
+
+fn default_relay_base_url() -> String {
+    DEFAULT_RELAY_BASE_URL.into()
+}
+
+fn default_compute_mode() -> ComputeMode {
+    ComputeMode::Auto
+}
+
+pub fn normalize_relay_base_urls(
+    relay_base_urls: &[String],
+    legacy_relay_base_url: &str,
+) -> Vec<String> {
+    let mut normalized = Vec::new();
+
+    for relay_url in relay_base_urls {
+        let trimmed = relay_url.trim();
+        if trimmed.is_empty() || normalized.iter().any(|existing| existing == trimmed) {
+            continue;
+        }
+        normalized.push(trimmed.to_string());
+        if normalized.len() >= MAX_RELAY_BASE_URLS {
+            break;
+        }
+    }
+
+    if normalized.is_empty() {
+        let legacy = legacy_relay_base_url.trim();
+        normalized.push(if legacy.is_empty() {
+            DEFAULT_RELAY_BASE_URL.into()
+        } else {
+            legacy.to_string()
+        });
+    }
+
+    normalized
+}
+
+impl DesktopConfig {
+    pub fn normalized(mut self) -> Self {
+        self.relay_base_urls =
+            normalize_relay_base_urls(&self.relay_base_urls, &self.relay_base_url);
+        self.relay_base_url = self
+            .relay_base_urls
+            .first()
+            .cloned()
+            .unwrap_or_else(default_relay_base_url);
+        self
+    }
 }
 
 impl Default for DesktopConfig {
     fn default() -> Self {
         Self {
             model_path: String::new(),
-            relay_base_url: "https://token.place".into(),
+            relay_base_url: DEFAULT_RELAY_BASE_URL.into(),
+            relay_base_urls: vec![DEFAULT_RELAY_BASE_URL.into()],
             preferred_mode: ComputeMode::Auto,
         }
     }
@@ -21,12 +80,53 @@ impl Default for DesktopConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::DesktopConfig;
+    use super::{normalize_relay_base_urls, DesktopConfig, DEFAULT_RELAY_BASE_URL};
 
     #[test]
     fn desktop_config_defaults_to_token_place_relay() {
         let config = DesktopConfig::default();
-        assert_eq!(config.relay_base_url, "https://token.place");
+        assert_eq!(config.relay_base_url, DEFAULT_RELAY_BASE_URL);
+        assert_eq!(config.relay_base_urls, vec![DEFAULT_RELAY_BASE_URL]);
+    }
+
+    #[test]
+    fn legacy_desktop_config_migrates_to_single_relay_list() {
+        let config: DesktopConfig = serde_json::from_str::<DesktopConfig>(
+            r#"{
+                "model_path": "/tmp/model.gguf",
+                "relay_base_url": " https://staging.token.place ",
+                "preferred_mode": "auto"
+            }"#,
+        )
+        .expect("legacy config should deserialize")
+        .normalized();
+
+        assert_eq!(config.relay_base_url, "https://staging.token.place");
+        assert_eq!(config.relay_base_urls, vec!["https://staging.token.place"]);
+        assert_eq!(config.model_path, "/tmp/model.gguf");
+    }
+
+    #[test]
+    fn relay_base_url_normalization_trims_dedupes_and_preserves_order() {
+        let urls = vec![
+            " https://token.place ".to_string(),
+            "".to_string(),
+            "https://staging.token.place".to_string(),
+            "https://token.place".to_string(),
+        ];
+
+        assert_eq!(
+            normalize_relay_base_urls(&urls, "https://fallback.example"),
+            vec!["https://token.place", "https://staging.token.place"]
+        );
+    }
+
+    #[test]
+    fn relay_base_url_normalization_uses_default_when_empty() {
+        assert_eq!(
+            normalize_relay_base_urls(&[], "   "),
+            vec![DEFAULT_RELAY_BASE_URL]
+        );
     }
 }
 

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 pub const DEFAULT_RELAY_BASE_URL: &str = "https://token.place";
 pub const MAX_RELAY_BASE_URLS: usize = 10;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DesktopConfig {
     #[serde(default)]
     pub model_path: String,

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -277,7 +277,9 @@ fn load_config(
         return Ok(DesktopConfig::default());
     }
     let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&raw).map_err(|e| e.to_string())
+    serde_json::from_str::<DesktopConfig>(&raw)
+        .map(DesktopConfig::normalized)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -288,7 +290,7 @@ fn save_config(
 ) -> Result<(), String> {
     let dir = resolve_config_dir(&app, &state).map_err(|e| e.to_string())?;
     let path = config_path(&dir);
-    let raw = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
+    let raw = serde_json::to_string_pretty(&config.normalized()).map_err(|e| e.to_string())?;
     fs::write(path, raw).map_err(|e| e.to_string())
 }
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -266,20 +266,30 @@ fn detect_backend() -> BackendInfo {
     detect_backend_for(std::env::consts::OS, std::env::consts::ARCH)
 }
 
+fn load_config_from_path(path: &std::path::Path) -> Result<DesktopConfig, String> {
+    if !path.exists() {
+        return Ok(DesktopConfig::default());
+    }
+
+    let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let parsed = serde_json::from_str::<DesktopConfig>(&raw).map_err(|e| e.to_string())?;
+    let normalized = parsed.clone().normalized();
+
+    if parsed != normalized {
+        let migrated = serde_json::to_string_pretty(&normalized).map_err(|e| e.to_string())?;
+        fs::write(path, migrated).map_err(|e| e.to_string())?;
+    }
+
+    Ok(normalized)
+}
+
 #[tauri::command]
 fn load_config(
     app: tauri::AppHandle,
     state: tauri::State<AppState>,
 ) -> Result<DesktopConfig, String> {
     let dir = resolve_config_dir(&app, &state).map_err(|e| e.to_string())?;
-    let path = config_path(&dir);
-    if !path.exists() {
-        return Ok(DesktopConfig::default());
-    }
-    let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    serde_json::from_str::<DesktopConfig>(&raw)
-        .map(DesktopConfig::normalized)
-        .map_err(|e| e.to_string())
+    load_config_from_path(&config_path(&dir))
 }
 
 #[tauri::command]
@@ -490,6 +500,30 @@ mod tests {
             .find_map(|(env_key, value)| (env_key == key).then_some(value))
             .flatten()
             .map(|value| value.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn load_config_from_path_persists_normalized_legacy_config() {
+        let temp = TempDir::new().expect("tempdir");
+        let path = config_path(temp.path());
+        std::fs::write(
+            &path,
+            r#"{
+                "model_path": "/tmp/model.gguf",
+                "relay_base_url": " https://staging.token.place ",
+                "preferred_mode": "auto"
+            }"#,
+        )
+        .expect("write legacy config");
+
+        let loaded = load_config_from_path(&path).expect("load config");
+        let persisted: DesktopConfig =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read migrated config"))
+                .expect("parse migrated config");
+
+        assert_eq!(loaded.relay_base_url, "https://staging.token.place");
+        assert_eq!(loaded.relay_base_urls, vec!["https://staging.token.place"]);
+        assert_eq!(persisted, loaded);
     }
 
     #[test]

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
+import { App, normalizeDesktopConfig } from './App';
 
 const invokeMock = vi.fn();
 const listenMock = vi.fn();
@@ -75,6 +75,22 @@ describe('desktop app start failure handling', () => {
         });
       }
       return Promise.resolve(undefined);
+    });
+  });
+
+  it('normalizes untrusted relay URLs and preferred mode from persisted config', () => {
+    expect(
+      normalizeDesktopConfig({
+        model_path: 123,
+        relay_base_url: 42,
+        relay_base_urls: [' https://token.place ', 123, 'https://staging.token.place'],
+        preferred_mode: 'bogus',
+      })
+    ).toEqual({
+      model_path: '',
+      relay_base_url: 'https://token.place',
+      relay_base_urls: ['https://token.place', 'https://staging.token.place'],
+      preferred_mode: 'auto',
     });
   });
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1504,6 +1504,22 @@ describe('desktop app start failure handling', () => {
     expect(screen.queryByText('Delete')).toBeNull();
   });
 
+  it('enforces the documented maximum of 10 relay URL fields', async () => {
+    render(<App />);
+
+    const addButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    expect(await screen.findByLabelText('Relay URL 1')).toBeTruthy();
+
+    for (let relayNumber = 2; relayNumber <= 10; relayNumber += 1) {
+      expect(addButton.disabled).toBe(false);
+      fireEvent.click(addButton);
+      expect(await screen.findByLabelText(`Relay URL ${relayNumber}`)).toBeTruthy();
+    }
+
+    expect(screen.queryByLabelText('Relay URL 11')).toBeNull();
+    expect(addButton.disabled).toBe(true);
+  });
+
   it('disables relay URL editing while the operator is running', async () => {
     mockInitialComputeStatus({ running: true, registered: true, relay_runtime_state: 'ready' });
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1428,4 +1428,154 @@ describe('desktop app start failure handling', () => {
     );
     expect(screen.getByText(/Error:/).textContent).toContain('event failure path');
   });
+
+  it('renders one relay URL field from legacy config and migrates it on save', async () => {
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    await waitFor(() => expect(relayInput.value).toBe('https://token.place'));
+    expect(screen.getByText(/Configured relay URLs:/).textContent).toContain('https://token.place');
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'save_config' &&
+            args?.config?.relay_base_url === 'https://token.place' &&
+            Array.isArray(args?.config?.relay_base_urls) &&
+            args.config.relay_base_urls.length === 1 &&
+            args.config.relay_base_urls[0] === 'https://token.place'
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('loads and displays multiple persisted relay URLs', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          relay_base_urls: ['https://token.place', 'https://staging.token.place'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+
+    expect((await screen.findByLabelText('Relay URL 1') as HTMLInputElement).value).toBe('https://token.place');
+    expect((await screen.findByLabelText('Relay URL 2') as HTMLInputElement).value).toBe('https://staging.token.place');
+    expect(screen.getByText(/Configured relay URLs:/).textContent).toContain('https://token.place, https://staging.token.place');
+  });
+
+  it('adds and removes relay URL fields while keeping one field', async () => {
+    render(<App />);
+
+    const addButton = await screen.findByText('Add new relay URL');
+    fireEvent.click(addButton);
+
+    const secondRelayInput = (await screen.findByLabelText('Relay URL 2')) as HTMLInputElement;
+    expect(secondRelayInput.value).toBe('');
+    fireEvent.change(secondRelayInput, { target: { value: ' https://staging.token.place ' } });
+
+    const deleteSecondRelayButton = await screen.findByLabelText('Delete relay URL 2');
+    fireEvent.click(deleteSecondRelayButton);
+
+    await waitFor(() => expect(screen.queryByLabelText('Relay URL 2')).toBeNull());
+    expect(screen.getByLabelText('Relay URL 1')).toBeTruthy();
+    expect(screen.queryByText('Delete')).toBeNull();
+  });
+
+  it('disables relay URL editing while the operator is running', async () => {
+    mockInitialComputeStatus({ running: true, registered: true, relay_runtime_state: 'ready' });
+
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const addButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+
+    await waitFor(() => expect(relayInput.disabled).toBe(true));
+    expect(addButton.disabled).toBe(true);
+    expect(screen.getByText('Stop the operator to edit relay URLs. Changes apply on next start.')).toBeTruthy();
+  });
+
+  it('disables relay URL editing while the operator is starting', async () => {
+    let resolveStart: (() => void) | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'start_compute_node') {
+        return new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const addButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    await waitFor(() => expect(relayInput.disabled).toBe(true));
+    expect(addButton.disabled).toBe(true);
+
+    resolveStart?.();
+  });
+
+  it('saves normalized relay_base_urls and first-url relay_base_url compatibility', async () => {
+    render(<App />);
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    fireEvent.change(relayInput, { target: { value: ' https://staging.token.place ' } });
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'save_config' &&
+            args?.config?.relay_base_url === 'https://staging.token.place' &&
+            args?.config?.relay_base_urls?.[0] === 'https://staging.token.place'
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('starts the operator with the normalized configured relay list and primary relay URL', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://legacy.example',
+          relay_base_urls: [
+            ' https://token.place ',
+            'https://staging.token.place',
+            'https://token.place',
+            '',
+          ],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'start_compute_node' &&
+            args?.request?.relay_base_url === 'https://token.place' &&
+            JSON.stringify(args?.request?.relay_base_urls) ===
+              JSON.stringify(['https://token.place', 'https://staging.token.place'])
+        )
+      ).toBe(true)
+    );
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -23,11 +23,11 @@ interface DesktopConfig {
 const DEFAULT_RELAY_BASE_URL = 'https://token.place';
 export const MAX_RELAY_BASE_URLS = 10;
 
-type PartialDesktopConfig = Partial<DesktopConfig> & {
-  model_path?: string;
-  relay_base_url?: string;
+type PartialDesktopConfig = Omit<Partial<DesktopConfig>, 'relay_base_url' | 'relay_base_urls' | 'preferred_mode'> & {
+  model_path?: unknown;
+  relay_base_url?: unknown;
   relay_base_urls?: unknown;
-  preferred_mode?: BackendMode;
+  preferred_mode?: unknown;
 };
 
 interface ComputeNodeStatus {
@@ -134,13 +134,23 @@ export function normalizeRelayUrls(
   return normalized;
 }
 
+function normalizeBackendMode(preferredMode: unknown): BackendMode {
+  return preferredMode === 'cpu' ||
+    preferredMode === 'gpu' ||
+    preferredMode === 'hybrid' ||
+    preferredMode === 'auto'
+    ? preferredMode
+    : 'auto';
+}
+
 export function normalizeDesktopConfig(config: PartialDesktopConfig): DesktopConfig {
-  const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+  const legacyRelayBaseUrl = typeof config.relay_base_url === 'string' ? config.relay_base_url : '';
+  const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, legacyRelayBaseUrl);
   return {
     model_path: typeof config.model_path === 'string' ? config.model_path : '',
     relay_base_url: relayBaseUrls[0] || DEFAULT_RELAY_BASE_URL,
     relay_base_urls: relayBaseUrls,
-    preferred_mode: config.preferred_mode ?? 'auto',
+    preferred_mode: normalizeBackendMode(config.preferred_mode),
   };
 }
 

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -16,8 +16,19 @@ interface BackendInfo {
 interface DesktopConfig {
   model_path: string;
   relay_base_url: string;
+  relay_base_urls: string[];
   preferred_mode: BackendMode;
 }
+
+const DEFAULT_RELAY_BASE_URL = 'https://token.place';
+export const MAX_RELAY_BASE_URLS = 10;
+
+type PartialDesktopConfig = Partial<DesktopConfig> & {
+  model_path?: string;
+  relay_base_url?: string;
+  relay_base_urls?: unknown;
+  preferred_mode?: BackendMode;
+};
 
 interface ComputeNodeStatus {
   running: boolean;
@@ -91,6 +102,90 @@ function formatErrorMessage(error: unknown): string {
 
 function displayStatusValue(value: string | null | undefined, fallback: string): string {
   return value && value.trim() ? value : fallback;
+}
+
+export function normalizeRelayUrls(
+  relayBaseUrls: unknown,
+  legacyRelayBaseUrl = '',
+  fallback = DEFAULT_RELAY_BASE_URL
+): string[] {
+  const rawUrls = Array.isArray(relayBaseUrls) ? relayBaseUrls : [];
+  const normalized: string[] = [];
+
+  for (const rawUrl of rawUrls) {
+    if (typeof rawUrl !== 'string') {
+      continue;
+    }
+    const trimmed = rawUrl.trim();
+    if (!trimmed || normalized.includes(trimmed)) {
+      continue;
+    }
+    normalized.push(trimmed);
+    if (normalized.length >= MAX_RELAY_BASE_URLS) {
+      break;
+    }
+  }
+
+  if (normalized.length === 0) {
+    const legacy = legacyRelayBaseUrl.trim();
+    normalized.push(legacy || fallback);
+  }
+
+  return normalized;
+}
+
+export function normalizeDesktopConfig(config: PartialDesktopConfig): DesktopConfig {
+  const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+  return {
+    model_path: typeof config.model_path === 'string' ? config.model_path : '',
+    relay_base_url: relayBaseUrls[0] || DEFAULT_RELAY_BASE_URL,
+    relay_base_urls: relayBaseUrls,
+    preferred_mode: config.preferred_mode ?? 'auto',
+  };
+}
+
+function configForSave(config: DesktopConfig): DesktopConfig {
+  return normalizeDesktopConfig(config);
+}
+
+export function primaryRelayUrl(config: DesktopConfig): string {
+  return normalizeRelayUrls(config.relay_base_urls, config.relay_base_url)[0] || DEFAULT_RELAY_BASE_URL;
+}
+
+export function updateRelayUrlAtIndex(
+  config: DesktopConfig,
+  index: number,
+  value: string
+): DesktopConfig {
+  const relayBaseUrls = [...config.relay_base_urls];
+  relayBaseUrls[index] = value;
+  return {
+    ...config,
+    relay_base_url: primaryRelayUrl({ ...config, relay_base_urls: relayBaseUrls }),
+    relay_base_urls: relayBaseUrls,
+  };
+}
+
+export function addRelayUrl(config: DesktopConfig): DesktopConfig {
+  if (config.relay_base_urls.length >= MAX_RELAY_BASE_URLS) {
+    return config;
+  }
+  return { ...config, relay_base_urls: [...config.relay_base_urls, ''] };
+}
+
+export function removeRelayUrl(config: DesktopConfig, index: number): DesktopConfig {
+  if (config.relay_base_urls.length <= 1) {
+    return config;
+  }
+  const relayBaseUrls = config.relay_base_urls.filter((_, currentIndex) => currentIndex !== index);
+  if (relayBaseUrls.length === 0) {
+    relayBaseUrls.push(DEFAULT_RELAY_BASE_URL);
+  }
+  return {
+    ...config,
+    relay_base_url: primaryRelayUrl({ ...config, relay_base_urls: relayBaseUrls }),
+    relay_base_urls: relayBaseUrls,
+  };
 }
 
 function mergeComputeStatusEvent(
@@ -222,7 +317,8 @@ export function App() {
   const [backend, setBackend] = useState<BackendInfo | null>(null);
   const [config, setConfig] = useState<DesktopConfig>({
     model_path: '',
-    relay_base_url: 'https://token.place',
+    relay_base_url: DEFAULT_RELAY_BASE_URL,
+    relay_base_urls: [DEFAULT_RELAY_BASE_URL],
     preferred_mode: 'auto',
   });
   const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
@@ -254,8 +350,12 @@ export function App() {
 
     const initializeConfigAndArtifact = async () => {
       try {
-        const loadedConfig = await invoke<DesktopConfig>('load_config');
-        setConfig(loadedConfig);
+        const loadedConfig = await invoke<PartialDesktopConfig>('load_config');
+        const normalizedConfig = normalizeDesktopConfig(loadedConfig);
+        setConfig(normalizedConfig);
+        if (JSON.stringify(loadedConfig) !== JSON.stringify(normalizedConfig)) {
+          invoke('save_config', { config: normalizedConfig }).catch((e) => setError(formatErrorMessage(e)));
+        }
         const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
         computeStatusRef.current = nodeStatus;
         setComputeStatus(nodeStatus);
@@ -357,7 +457,7 @@ export function App() {
       window.clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = window.setTimeout(() => {
-      invoke('save_config', { config: next }).catch((e) => setError(formatErrorMessage(e)));
+      invoke('save_config', { config: configForSave(next) }).catch((e) => setError(formatErrorMessage(e)));
       saveTimerRef.current = null;
     }, 300);
   };
@@ -438,7 +538,7 @@ export function App() {
         registered: false,
         relay_runtime_state: 'starting',
         sequence: computeStatusRef.current.operator_session_id ? Number.MAX_SAFE_INTEGER : null,
-        active_relay_url: config.relay_base_url,
+        active_relay_url: primaryRelayUrl(config),
         requested_mode: config.preferred_mode,
         effective_mode: null,
         backend_available: null,
@@ -454,7 +554,8 @@ export function App() {
       await invoke('start_compute_node', {
         request: {
           model_path: config.model_path,
-          relay_base_url: config.relay_base_url,
+          relay_base_url: primaryRelayUrl(config),
+          relay_base_urls: normalizeRelayUrls(config.relay_base_urls, config.relay_base_url),
           mode: config.preferred_mode,
         },
       });
@@ -529,7 +630,7 @@ export function App() {
       setIsForwarding(true);
       setError('');
       await invoke('encrypt_and_forward', {
-        relay_base_url: config.relay_base_url,
+        relay_base_url: primaryRelayUrl(config),
         final_output: output,
       });
     } catch (e) {
@@ -595,12 +696,51 @@ export function App() {
         partial offload. Unsupported platforms fall back to CPU with diagnostics.
       </p>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
-      <input
-        value={config.relay_base_url}
-        style={{ width: '100%' }}
-        onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })}
-      />
+      <section aria-labelledby="relay-urls-heading" style={{ marginTop: 12 }}>
+        <h2 id="relay-urls-heading" style={{ fontSize: 16, marginBottom: 8 }}>Relay URLs</h2>
+        {(computeStatus.running || isStartingComputeNode) && (
+          <p style={{ marginTop: 0, fontSize: 12, color: '#555' }}>
+            Stop the operator to edit relay URLs. Changes apply on next start.
+          </p>
+        )}
+        {config.relay_base_urls.map((relayUrl, index) => {
+          const inputId = `relay-url-${index}`;
+          const relayControlsDisabled = computeStatus.running || isStartingComputeNode;
+          return (
+            <div key={index} style={{ display: 'flex', gap: 8, marginTop: 6, alignItems: 'center' }}>
+              <label htmlFor={inputId} style={{ minWidth: 92 }}>Relay URL {index + 1}</label>
+              <input
+                id={inputId}
+                value={relayUrl}
+                disabled={relayControlsDisabled}
+                style={{ width: '100%' }}
+                onChange={(e) => updateConfig(updateRelayUrlAtIndex(config, index, e.target.value))}
+              />
+              {index > 0 && (
+                <button
+                  type="button"
+                  disabled={relayControlsDisabled}
+                  onClick={() => updateConfig(removeRelayUrl(config, index))}
+                  aria-label={`Delete relay URL ${index + 1}`}
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => updateConfig(addRelayUrl(config))}
+          disabled={computeStatus.running || isStartingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
+          style={{ marginTop: 8 }}
+        >
+          Add new relay URL
+        </button>
+        <p style={{ marginTop: 6, fontSize: 12, color: '#555' }}>
+          Up to {MAX_RELAY_BASE_URLS} relay URLs are supported. Blank entries are ignored when saved or started.
+        </p>
+      </section>
 
       <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
@@ -618,7 +758,8 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{displayStatusValue(computeStatus.runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{displayStatusValue(computeStatus.relay_runtime_path, 'pending')}</code></p>
-        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, config.relay_base_url)}</code></p>
+        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, primaryRelayUrl(config))}</code></p>
+        <p style={{ marginBottom: 0 }}>Configured relay URLs: <code>{normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).join(', ')}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{displayStatusValue(computeStatus.requested_mode, config.preferred_mode)}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{displayStatusValue(computeStatus.effective_mode, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Backend available: <code>{displayStatusValue(computeStatus.backend_available, 'pending')}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1376,6 +1376,71 @@ def test_run_prefers_explicit_desktop_relay_url_and_disables_configured_fallback
     assert status == 0
     assert captured['config'].relay_url == 'http://127.0.0.1:5010'
     assert captured['config'].use_configured_relay_fallbacks is False
+    assert captured['config'].relay_urls == ('http://127.0.0.1:5010',)
+
+
+def test_run_passes_desktop_relay_list_to_runtime(monkeypatch):
+    _reset_cancel_queue()
+    captured = {}
+
+    class CapturingRuntime:
+        def __init__(self, config):
+            captured['config'] = config
+            self.model_manager = FakeModelManager()
+            self.relay_client = SimpleNamespace(relay_url=config.relay_url)
+
+        def ensure_model_ready(self):
+            return True
+
+        def ensure_api_v1_runtime_ready(self):
+            return self.ensure_model_ready()
+
+        def register_and_poll_once(self):
+            return {'next_ping_in_x_seconds': 0}
+
+        def process_relay_request(self, _payload):
+            return True
+
+        def stop(self):
+            return None
+
+    module = ModuleType('utils.compute_node_runtime')
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port, **kwargs: SimpleNamespace(
+        relay_url=relay_url,
+        relay_port=relay_port,
+        **kwargs,
+    )
+    module.ComputeNodeRuntime = CapturingRuntime
+    module.is_api_v1_relay_payload = lambda _payload: False
+    module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    module.resolve_relay_url = lambda relay_url, **_kwargs: relay_url.strip()
+    module.normalize_compute_mode = lambda mode: mode
+    module.apply_compute_mode = lambda _model_manager, mode: mode
+    module.SUPPORTED_COMPUTE_MODES = {'auto', 'cpu', 'cuda', 'metal'}
+    module.compute_mode_diagnostics = lambda _model_manager: {}
+    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url=[
+            ' http://127.0.0.1:5010 ',
+            'https://staging.token.place',
+            'https://staging.token.place',
+        ],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert captured['config'].relay_url == 'http://127.0.0.1:5010'
+    assert captured['config'].use_configured_relay_fallbacks is False
+    assert captured['config'].relay_urls == (
+        'http://127.0.0.1:5010',
+        'https://staging.token.place',
+    )
 
 
 def test_main_emits_structured_error_when_compute_runtime_missing(capsys, monkeypatch):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -48,6 +48,7 @@ class ComputeNodeRuntimeConfig:
     relay_url: str
     relay_port: Optional[int]
     use_configured_relay_fallbacks: bool = True
+    relay_urls: Tuple[str, ...] = ()
 
 
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
@@ -280,6 +281,7 @@ class ComputeNodeRuntime:
             crypto_manager=self.crypto_manager,
             model_manager=self.model_manager,
             include_configured_servers=runtime_config.use_configured_relay_fallbacks,
+            explicit_relay_urls=runtime_config.relay_urls[1:],
         )
         if request_adapters is None:
             self.request_adapters = [

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -12,7 +12,7 @@ import os
 import hashlib
 import re
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
 from utils.networking.http_requests_compat import requests
@@ -502,6 +502,7 @@ class RelayClient:
         model_manager,
         *,
         include_configured_servers: bool = True,
+        explicit_relay_urls: Optional[Sequence[str]] = None,
     ):
         """
         Initialize the RelayClient.
@@ -514,6 +515,8 @@ class RelayClient:
             model_manager: Instance of ModelManager for LLM interaction
             include_configured_servers: When True, include configured/env relay fallbacks
                 and relay cluster-only mode. When False, use only the explicit base relay.
+            explicit_relay_urls: Additional explicit relay URLs supplied by the desktop
+                start request. These are included even when configured fallbacks are disabled.
         """
         self.base_url = base_url
         self.port = port
@@ -603,6 +606,11 @@ class RelayClient:
             self._registration_token = _normalise_registration_token(
                 os.environ.get('TOKEN_PLACE_RELAY_SERVER_TOKEN')
             )
+
+        if explicit_relay_urls:
+            for entry in explicit_relay_urls:
+                if isinstance(entry, str) and entry.strip() and entry not in configured_servers:
+                    configured_servers.append(entry)
 
         self._relay_urls = self._build_relay_targets(
             base_url,


### PR DESCRIPTION
### Motivation
- Prepare the desktop Tauri UI/config for v0.1.1 multi-relay operation while preserving legacy `relay_base_url` compatibility and enabling future multi-relay runtime behavior. 
- Ensure existing single-URL configs migrate automatically and that the UI only allows editing relay list when the operator is stopped.

### Description
- Add `relay_base_urls: Vec<String>` to the Rust `DesktopConfig`, introduce `DEFAULT_RELAY_BASE_URL` and `MAX_RELAY_BASE_URLS`, and implement `normalize_relay_base_urls` plus a `DesktopConfig::normalized()` migration/normalization helper in `desktop-tauri/src-tauri/src/config.rs`.
- Update `load_config` and `save_config` in `desktop-tauri/src-tauri/src/main.rs` to apply normalization on load and save, preserving `relay_base_url` as the first-entry compatibility field.
- Extend the React `DesktopConfig` shape and add helper functions `normalizeRelayUrls`, `normalizeDesktopConfig`, `primaryRelayUrl`, `updateRelayUrlAtIndex`, `addRelayUrl`, and `removeRelayUrl` in `desktop-tauri/src/App.tsx`, and wire config load/save to normalize/migrate legacy shape.
- Replace the single Relay URL input with a stopped-only “Relay URLs” section in `App.tsx` that renders one field per relay, supports add/delete (keeps at least one), disables editing while the operator is running/starting, shows helper text, and limits entries to `MAX_RELAY_BASE_URLS`.
- Add UI/tests: Vitest updates in `desktop-tauri/src/App.test.tsx` covering legacy migration, multi-URL load/save, add/delete behavior, stopped-only disabling, and start-time normalized start payload; and Rust unit tests for defaults and normalization in `desktop-tauri/src-tauri/src/config.rs`.

### Testing
- Ran frontend unit tests with `cd desktop-tauri && npm test` and all Vitest tests passed.
- Ran Rust unit tests with `cd desktop-tauri/src-tauri && cargo test config && cargo test compute_node` and all requested Rust tests passed.
- Ran focused desktop unit tests with `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_runtime_setup.py -v` and they passed.
- Ran the full project verification `./run_all_tests.sh` and `pre-commit run --all-files`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c42abe124832f8393e9775919b716)