### PR TITLE
desktop: Add multi-relay UI/config with migration and normalization (v0.1.1 prep)

### DIFF
--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -2,31 +2,132 @@ use crate::backend::ComputeMode;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+pub const DEFAULT_RELAY_BASE_URL: &str = "https://token.place";
+
+fn default_relay_base_url() -> String {
+    DEFAULT_RELAY_BASE_URL.into()
+}
+
+fn default_preferred_mode() -> ComputeMode {
+    ComputeMode::Auto
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DesktopConfig {
+    #[serde(default)]
     pub model_path: String,
+    #[serde(default = "default_relay_base_url")]
     pub relay_base_url: String,
+    #[serde(default)]
+    pub relay_base_urls: Vec<String>,
+    #[serde(default = "default_preferred_mode")]
     pub preferred_mode: ComputeMode,
+}
+
+impl DesktopConfig {
+    pub fn normalized(mut self) -> Self {
+        let relay_base_urls =
+            normalize_relay_base_urls(&self.relay_base_urls, &self.relay_base_url);
+        let relay_base_url = relay_base_urls
+            .first()
+            .cloned()
+            .unwrap_or_else(default_relay_base_url);
+        self.relay_base_urls = relay_base_urls;
+        self.relay_base_url = relay_base_url;
+        self
+    }
 }
 
 impl Default for DesktopConfig {
     fn default() -> Self {
         Self {
             model_path: String::new(),
-            relay_base_url: "https://token.place".into(),
+            relay_base_url: default_relay_base_url(),
+            relay_base_urls: vec![default_relay_base_url()],
             preferred_mode: ComputeMode::Auto,
         }
     }
 }
 
+pub fn normalize_relay_base_urls(relay_base_urls: &[String], relay_base_url: &str) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let has_configured_relay_urls = relay_base_urls
+        .iter()
+        .any(|candidate| !candidate.trim().is_empty());
+    let candidates: Vec<&str> = if has_configured_relay_urls {
+        relay_base_urls.iter().map(String::as_str).collect()
+    } else {
+        vec![relay_base_url]
+    };
+    for candidate in candidates {
+        let trimmed = candidate.trim();
+        if trimmed.is_empty() || normalized.iter().any(|existing| existing == trimmed) {
+            continue;
+        }
+        normalized.push(trimmed.to_string());
+    }
+    if normalized.is_empty() {
+        normalized.push(default_relay_base_url());
+    }
+    normalized
+}
+
 #[cfg(test)]
 mod tests {
-    use super::DesktopConfig;
+    use super::{normalize_relay_base_urls, DesktopConfig};
 
     #[test]
     fn desktop_config_defaults_to_token_place_relay() {
         let config = DesktopConfig::default();
         assert_eq!(config.relay_base_url, "https://token.place");
+        assert_eq!(config.relay_base_urls, vec!["https://token.place"]);
+    }
+
+    #[test]
+    fn desktop_config_migrates_legacy_single_relay_url() {
+        let config: DesktopConfig = serde_json::from_str::<DesktopConfig>(
+            r#"{
+                "model_path": "/tmp/model.gguf",
+                "relay_base_url": "https://legacy.example",
+                "preferred_mode": "auto"
+            }"#,
+        )
+        .expect("legacy config should deserialize")
+        .normalized();
+
+        assert_eq!(config.relay_base_url, "https://legacy.example");
+        assert_eq!(config.relay_base_urls, vec!["https://legacy.example"]);
+    }
+
+    #[test]
+    fn desktop_config_normalizes_trims_and_deduplicates_relay_urls() {
+        let config: DesktopConfig = serde_json::from_str::<DesktopConfig>(
+            r#"{
+                "model_path": "/tmp/model.gguf",
+                "relay_base_url": " https://relay-one.example ",
+                "relay_base_urls": [
+                    " https://relay-one.example ",
+                    "https://relay-two.example",
+                    "",
+                    "https://relay-two.example"
+                ],
+                "preferred_mode": "cpu"
+            }"#,
+        )
+        .expect("config should deserialize")
+        .normalized();
+
+        assert_eq!(config.relay_base_url, "https://relay-one.example");
+        assert_eq!(
+            config.relay_base_urls,
+            vec!["https://relay-one.example", "https://relay-two.example"]
+        );
+    }
+
+    #[test]
+    fn normalize_relay_base_urls_uses_default_when_all_urls_are_blank() {
+        let relay_urls = normalize_relay_base_urls(&[" ".to_string(), "".to_string()], " ");
+        assert_eq!(relay_urls, vec!["https://token.place"]);
     }
 }
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -277,7 +277,8 @@ fn load_config(
         return Ok(DesktopConfig::default());
     }
     let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&raw).map_err(|e| e.to_string())
+    let config: DesktopConfig = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
+    Ok(config.normalized())
 }
 
 #[tauri::command]
@@ -288,7 +289,7 @@ fn save_config(
 ) -> Result<(), String> {
     let dir = resolve_config_dir(&app, &state).map_err(|e| e.to_string())?;
     let path = config_path(&dir);
-    let raw = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
+    let raw = serde_json::to_string_pretty(&config.normalized()).map_err(|e| e.to_string())?;
     fs::write(path, raw).map_err(|e| e.to_string())
 }
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -424,6 +424,169 @@ describe('desktop app start failure handling', () => {
     await waitFor(() => expect((modelInput as HTMLInputElement).value).toBe('/tmp/model.gguf'));
   });
 
+  it('renders one relay URL field from legacy single-url config', async () => {
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    await waitFor(() => expect(relayInput.value).toBe('https://token.place'));
+    expect(screen.queryByLabelText('Relay URL 2')).toBeNull();
+  });
+
+  it('loads and displays multiple persisted relay URLs', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://primary.example',
+          relay_base_urls: ['https://primary.example', 'https://staging.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+
+    const primaryInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const stagingInput = (await screen.findByLabelText('Relay URL 2')) as HTMLInputElement;
+    expect(primaryInput.value).toBe('https://primary.example');
+    expect(stagingInput.value).toBe('https://staging.example');
+    expect(screen.getByText(/Configured relay URLs:/).textContent).toContain(
+      'https://primary.example, https://staging.example'
+    );
+  });
+
+  it('adds and deletes relay URL fields while keeping one field minimum', async () => {
+    render(<App />);
+
+    const addButton = await screen.findByText('Add new relay URL');
+    fireEvent.click(addButton);
+
+    const secondInput = (await screen.findByLabelText('Relay URL 2')) as HTMLInputElement;
+    fireEvent.change(secondInput, { target: { value: 'https://staging.example' } });
+    expect(secondInput.value).toBe('https://staging.example');
+
+    const deleteButton = screen.getByText('Delete');
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(screen.queryByLabelText('Relay URL 2')).toBeNull());
+    expect(screen.getByLabelText('Relay URL 1')).toBeTruthy();
+    expect(screen.queryByText('Delete')).toBeNull();
+  });
+
+  it('disables relay URL editing while the operator is running', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+    });
+
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    expect(relayInput.disabled).toBe(true);
+    const addButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+    expect(
+      screen.getByText('Stop the operator to edit relay URLs. Changes apply on next start.')
+    ).toBeTruthy();
+  });
+
+  it('disables relay URL editing while the operator is starting', async () => {
+    let resolveStart: (() => void) | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'start_compute_node') {
+        return new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Relay URL 1') as HTMLInputElement).disabled).toBe(true)
+    );
+    expect((screen.getByText('Add new relay URL') as HTMLButtonElement).disabled).toBe(true);
+    resolveStart?.();
+  });
+
+  it('caps relay URL fields at the documented maximum of 10', async () => {
+    render(<App />);
+
+    const addButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    for (let index = 1; index < 10; index += 1) {
+      fireEvent.click(addButton);
+    }
+
+    expect(screen.getByLabelText('Relay URL 10')).toBeTruthy();
+    expect(screen.queryByLabelText('Relay URL 11')).toBeNull();
+    expect(addButton.disabled).toBe(true);
+  });
+
+  it('saves normalized relay URL list and legacy first-url compatibility field', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          relay_base_urls: [' https://primary.example ', '', 'https://primary.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'save_config' &&
+            args?.config?.relay_base_url === 'https://primary.example' &&
+            JSON.stringify(args.config.relay_base_urls) === '["https://primary.example"]'
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('starts the operator with the normalized primary relay URL and configured list', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://token.place',
+          relay_base_urls: [' https://primary.example ', 'https://staging.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'start_compute_node' &&
+            args?.request?.relay_base_url === 'https://primary.example' &&
+            JSON.stringify(args.request.relay_base_urls) ===
+              '["https://primary.example","https://staging.example"]'
+        )
+      ).toBe(true)
+    );
+  });
+
   it('surfaces bridge startup exits through compute_node_event errors', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'start_compute_node') {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -16,6 +16,7 @@ interface BackendInfo {
 interface DesktopConfig {
   model_path: string;
   relay_base_url: string;
+  relay_base_urls: string[];
   preferred_mode: BackendMode;
 }
 
@@ -61,6 +62,9 @@ interface SidecarEvent {
   message?: string;
 }
 
+const DEFAULT_RELAY_BASE_URL = 'https://token.place';
+export const MAX_RELAY_URLS = 10;
+
 const defaultComputeStatus: ComputeNodeStatus = {
   running: false,
   registered: false,
@@ -91,6 +95,77 @@ function formatErrorMessage(error: unknown): string {
 
 function displayStatusValue(value: string | null | undefined, fallback: string): string {
   return value && value.trim() ? value : fallback;
+}
+
+export function normalizeRelayUrls(
+  relayBaseUrls: string[] | null | undefined,
+  relayBaseUrl = DEFAULT_RELAY_BASE_URL
+): string[] {
+  const normalized: string[] = [];
+  const configuredCandidates = relayBaseUrls ?? [];
+  const candidates = configuredCandidates.some((candidate) => candidate.trim())
+    ? configuredCandidates
+    : [relayBaseUrl];
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed || normalized.includes(trimmed)) {
+      continue;
+    }
+    normalized.push(trimmed);
+    if (normalized.length >= MAX_RELAY_URLS) {
+      break;
+    }
+  }
+  return normalized.length > 0 ? normalized : [DEFAULT_RELAY_BASE_URL];
+}
+
+function normalizeDesktopConfig(config: DesktopConfig): DesktopConfig {
+  const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+  return {
+    ...config,
+    relay_base_url: relayBaseUrls[0],
+    relay_base_urls: relayBaseUrls,
+  };
+}
+
+export function primaryRelayUrl(config: DesktopConfig): string {
+  return normalizeRelayUrls(config.relay_base_urls, config.relay_base_url)[0];
+}
+
+export function updateRelayUrlAtIndex(
+  config: DesktopConfig,
+  index: number,
+  relayUrl: string
+): DesktopConfig {
+  const relayBaseUrls = [...config.relay_base_urls];
+  relayBaseUrls[index] = relayUrl;
+  return {
+    ...config,
+    relay_base_url: normalizeRelayUrls(relayBaseUrls, config.relay_base_url)[0],
+    relay_base_urls: relayBaseUrls.slice(0, MAX_RELAY_URLS),
+  };
+}
+
+export function addRelayUrl(config: DesktopConfig): DesktopConfig {
+  if (config.relay_base_urls.length >= MAX_RELAY_URLS) {
+    return config;
+  }
+  return {
+    ...config,
+    relay_base_urls: [...config.relay_base_urls, ''],
+  };
+}
+
+export function removeRelayUrl(config: DesktopConfig, index: number): DesktopConfig {
+  if (config.relay_base_urls.length <= 1) {
+    return config;
+  }
+  const relayBaseUrls = config.relay_base_urls.filter((_, currentIndex) => currentIndex !== index);
+  return {
+    ...config,
+    relay_base_url: normalizeRelayUrls(relayBaseUrls, config.relay_base_url)[0],
+    relay_base_urls: relayBaseUrls.length > 0 ? relayBaseUrls : [DEFAULT_RELAY_BASE_URL],
+  };
 }
 
 function mergeComputeStatusEvent(
@@ -222,7 +297,8 @@ export function App() {
   const [backend, setBackend] = useState<BackendInfo | null>(null);
   const [config, setConfig] = useState<DesktopConfig>({
     model_path: '',
-    relay_base_url: 'https://token.place',
+    relay_base_url: DEFAULT_RELAY_BASE_URL,
+    relay_base_urls: [DEFAULT_RELAY_BASE_URL],
     preferred_mode: 'auto',
   });
   const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
@@ -255,7 +331,14 @@ export function App() {
     const initializeConfigAndArtifact = async () => {
       try {
         const loadedConfig = await invoke<DesktopConfig>('load_config');
-        setConfig(loadedConfig);
+        const normalizedConfig = normalizeDesktopConfig({
+          ...loadedConfig,
+          relay_base_urls: loadedConfig.relay_base_urls ?? [],
+        });
+        setConfig(normalizedConfig);
+        if (JSON.stringify(normalizedConfig) !== JSON.stringify(loadedConfig)) {
+          scheduleConfigSave(normalizedConfig);
+        }
         const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
         computeStatusRef.current = nodeStatus;
         setComputeStatus(nodeStatus);
@@ -349,15 +432,18 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
     [config.model_path, computeStatus.running, isStartingComputeNode]
   );
+  const relayUrlEditingDisabled = computeStatus.running || isStartingComputeNode;
+  const normalizedRelayUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
 
   const scheduleConfigSave = (next: DesktopConfig) => {
+    const configToSave = normalizeDesktopConfig(next);
     if (saveTimerRef.current !== null) {
       window.clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = window.setTimeout(() => {
-      invoke('save_config', { config: next }).catch((e) => setError(formatErrorMessage(e)));
+      invoke('save_config', { config: configToSave }).catch((e) => setError(formatErrorMessage(e)));
       saveTimerRef.current = null;
     }, 300);
   };
@@ -432,20 +518,29 @@ export function App() {
     try {
       setIsStartingComputeNode(true);
       setError('');
+      const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+      const relayBaseUrl = relayBaseUrls[0];
+      const runtimeConfig = {
+        ...config,
+        relay_base_url: relayBaseUrl,
+        relay_base_urls: relayBaseUrls,
+      };
+      setConfig(runtimeConfig);
+      scheduleConfigSave(runtimeConfig);
       const optimisticStatus = {
         ...computeStatusRef.current,
         running: false,
         registered: false,
         relay_runtime_state: 'starting',
         sequence: computeStatusRef.current.operator_session_id ? Number.MAX_SAFE_INTEGER : null,
-        active_relay_url: config.relay_base_url,
-        requested_mode: config.preferred_mode,
+        active_relay_url: relayBaseUrl,
+        requested_mode: runtimeConfig.preferred_mode,
         effective_mode: null,
         backend_available: null,
         backend_selected: null,
         backend_used: null,
         fallback_reason: null,
-        model_path: config.model_path,
+        model_path: runtimeConfig.model_path,
         last_error: null,
         log_file_path: null,
       };
@@ -453,9 +548,10 @@ export function App() {
       setComputeStatus(optimisticStatus);
       await invoke('start_compute_node', {
         request: {
-          model_path: config.model_path,
-          relay_base_url: config.relay_base_url,
-          mode: config.preferred_mode,
+          model_path: runtimeConfig.model_path,
+          relay_base_url: relayBaseUrl,
+          relay_base_urls: relayBaseUrls,
+          mode: runtimeConfig.preferred_mode,
         },
       });
     } catch (e) {
@@ -529,7 +625,7 @@ export function App() {
       setIsForwarding(true);
       setError('');
       await invoke('encrypt_and_forward', {
-        relay_base_url: config.relay_base_url,
+        relay_base_url: primaryRelayUrl(config),
         final_output: output,
       });
     } catch (e) {
@@ -595,12 +691,49 @@ export function App() {
         partial offload. Unsupported platforms fall back to CPU with diagnostics.
       </p>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
-      <input
-        value={config.relay_base_url}
-        style={{ width: '100%' }}
-        onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })}
-      />
+      <section aria-labelledby="relay-urls-heading" style={{ marginTop: 12 }}>
+        <h2 id="relay-urls-heading" style={{ marginBottom: 8 }}>Relay URLs</h2>
+        <p style={{ marginTop: 0, fontSize: 12, color: '#555' }}>
+          Configure up to {MAX_RELAY_URLS} relay URLs. Blank URLs are dropped on save/start,
+          duplicates are removed, and the first URL is saved as the legacy Relay URL.
+        </p>
+        {relayUrlEditingDisabled && (
+          <p style={{ marginTop: 0, fontSize: 12, color: '#8a5a00' }}>
+            Stop the operator to edit relay URLs. Changes apply on next start.
+          </p>
+        )}
+        {config.relay_base_urls.map((relayUrl, index) => (
+          <div key={index} style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <label htmlFor={`relay-url-${index}`} style={{ minWidth: 92 }}>
+              Relay URL {index + 1}
+            </label>
+            <input
+              id={`relay-url-${index}`}
+              value={relayUrl}
+              disabled={relayUrlEditingDisabled}
+              style={{ width: '100%' }}
+              onChange={(e) => updateConfig(updateRelayUrlAtIndex(config, index, e.target.value))}
+            />
+            {index > 0 && (
+              <button
+                type="button"
+                disabled={relayUrlEditingDisabled}
+                onClick={() => updateConfig(removeRelayUrl(config, index))}
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        ))}
+        <button
+          type="button"
+          disabled={relayUrlEditingDisabled || config.relay_base_urls.length >= MAX_RELAY_URLS}
+          onClick={() => updateConfig(addRelayUrl(config))}
+          style={{ marginTop: 8 }}
+        >
+          Add new relay URL
+        </button>
+      </section>
 
       <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
@@ -618,7 +751,8 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{displayStatusValue(computeStatus.runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{displayStatusValue(computeStatus.relay_runtime_path, 'pending')}</code></p>
-        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, config.relay_base_url)}</code></p>
+        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, primaryRelayUrl(config))}</code></p>
+        <p style={{ marginBottom: 0 }}>Configured relay URLs: <code>{normalizedRelayUrls.join(', ')}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{displayStatusValue(computeStatus.requested_mode, config.preferred_mode)}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{displayStatusValue(computeStatus.effective_mode, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Backend available: <code>{displayStatusValue(computeStatus.backend_available, 'pending')}</code></p>


### PR DESCRIPTION
### Motivation

- Prepare desktop v0.1.1 UX and persisted config for true multi-relay operation while preserving legacy single `relay_base_url` compatibility.
- Ensure desktop UI allows editing an ordered list of relay URLs, persists them, and safely migrates legacy configs.

### Description

- Add `relay_base_urls: Vec<String>` to Rust `DesktopConfig` and provide `normalized()` + `normalize_relay_base_urls` helpers to migrate legacy `relay_base_url`, trim, dedupe, drop blanks, and default to `https://token.place` when needed.
- Update Rust load/save to apply normalization so persisted config contains both the canonical list and the legacy first-url for compatibility.
- Update React desktop UI (`desktop-tauri/src/App.tsx`) to expose a Relay URLs section with one input per URL, `Add new relay URL` and per-item `Delete` controls, and enforce a maximum of 10 entries; fields and controls are disabled while the compute operator is running or starting and show helper text explaining edits apply on next start.
- Add TypeScript helpers: `normalizeRelayUrls`, `normalizeDesktopConfig`, `primaryRelayUrl`, `updateRelayUrlAtIndex`, `addRelayUrl`, and `removeRelayUrl`; update start/save flows to normalize and persist `relay_base_urls` while keeping `relay_base_url` for compatibility and to send the primary URL to `start_compute_node` (also include `relay_base_urls` in the request when available).
- Add unit tests and adjust existing tests (`desktop-tauri/src/App.test.tsx`) to cover: legacy single-url migration, loading multiple URLs, add/delete behavior, disabled editing when operator running/starting, max-URLs cap, saving normalized list and legacy first-url, and start request includes normalized list.
- Add Rust config unit tests in `desktop-tauri/src-tauri/src/config.rs` for defaults, migration, trimming and dedupe behavior.

### Testing

- Ran desktop UI unit tests: `cd desktop-tauri && npm test` (vitest) — 36 tests passed (including the new relay UI tests). — PASSED.
- Ran full repository test sweep: `./run_all_tests.sh` (Python unit/integration suites, JS tests, crypto compatibility tests, playright crypto smoke, bandit) — all included tests passed and the script reported "All tests passed!" — PASSED.
- Ran Python unit + integration tests specifically: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_runtime_setup.py -v` and broader pytest runs invoked by `./run_all_tests.sh` — 1468 unit + 20 integration tests passed where executed — PASSED.
- Attempted Rust desktop-tauri tests: `cd desktop-tauri/src-tauri && cargo test config compute_node`; `cargo test` for the `compute_node` suite could not complete in this environment due to missing system-level GTK/GLIB native build dependencies (`glib-2.0.pc`), which causes the Cargo build to fail for some crates; the `config`-scoped logic was added and formatted (`cargo fmt`) and unit tests are present, but running the full `compute_node` integration on this runner requires the native GTK/GLIB dev packages be available in the environment — PARTIAL (Rust compute_node tests could not be run here due to missing system libs).

Residual risks / follow-ups:

- The Rust `compute_node` test matrix requires system GTK/GLIB and related native dev packages; CI should run the full `cargo test` job on an environment that includes those packages (or use the repository CI which provisions them). I attempted to install them locally in the container, but this step is heavy; please verify `cargo test` for `compute_node` in CI.
- The UI changes are constrained to editing/persistence and do not implement multi-relay polling/compute-node runtime behavior beyond passing the normalized list through to `start_compute_node`; a follow-up will implement the multi-relay runtime behavior and any compute-node request schema expansions on the Rust side if desired.

Commands run (high level):

- `cd desktop-tauri && npm test` — vitest UI tests — PASSED.
- `./run_all_tests.sh` — repository test sweep (pytest, JS tests, crypto tests, bandit) — PASSED.
- `cd desktop-tauri/src-tauri && cargo fmt` — formatted Rust code — PASSED.
- `cd desktop-tauri/src-tauri && cargo test config compute_node` — attempted; `compute_node` tests could not finish due to missing system `glib-2.0` pkg-config file (native dev libs missing); see logs for details — NOT RUN / ENV LIMITATION.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c42c5040c832fb236af2f20e2585a)