### PR TITLE
desktop(tauri): add multi-relay UI/config, migrate & normalize legacy relay_base_url

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -27,6 +27,8 @@ use tokio::sync::Mutex;
 pub struct ComputeNodeRequest {
     pub model_path: String,
     pub relay_base_url: String,
+    #[serde(default)]
+    pub relay_base_urls: Vec<String>,
     pub mode: ComputeMode,
 }
 
@@ -1615,6 +1617,7 @@ mod tests {
         let request = ComputeNodeRequest {
             model_path: "model.gguf".into(),
             relay_base_url: "https://relay.example".into(),
+            relay_base_urls: vec!["https://relay.example".into()],
             mode: ComputeMode::Cpu,
         };
         let status = startup_failure_status(
@@ -1793,6 +1796,7 @@ mod tests {
         let request = ComputeNodeRequest {
             model_path: "model.gguf".into(),
             relay_base_url: "https://relay.example".into(),
+            relay_base_urls: vec!["https://relay.example".into()],
             mode: ComputeMode::Auto,
         };
 

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -1,32 +1,160 @@
 use crate::backend::ComputeMode;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+pub const DEFAULT_RELAY_BASE_URL: &str = "https://token.place";
+
+#[derive(Debug, Clone, Serialize)]
 pub struct DesktopConfig {
     pub model_path: String,
     pub relay_base_url: String,
+    pub relay_base_urls: Vec<String>,
     pub preferred_mode: ComputeMode,
+}
+
+#[derive(Debug, Deserialize)]
+struct DesktopConfigWire {
+    #[serde(default)]
+    model_path: String,
+    #[serde(default = "default_relay_base_url")]
+    relay_base_url: String,
+    #[serde(default)]
+    relay_base_urls: Vec<String>,
+    #[serde(default = "default_preferred_mode")]
+    preferred_mode: ComputeMode,
+}
+
+impl<'de> Deserialize<'de> for DesktopConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = DesktopConfigWire::deserialize(deserializer)?;
+        Ok(normalize_desktop_config(DesktopConfig {
+            model_path: wire.model_path,
+            relay_base_url: wire.relay_base_url,
+            relay_base_urls: wire.relay_base_urls,
+            preferred_mode: wire.preferred_mode,
+        }))
+    }
 }
 
 impl Default for DesktopConfig {
     fn default() -> Self {
         Self {
             model_path: String::new(),
-            relay_base_url: "https://token.place".into(),
+            relay_base_url: DEFAULT_RELAY_BASE_URL.into(),
+            relay_base_urls: vec![DEFAULT_RELAY_BASE_URL.into()],
             preferred_mode: ComputeMode::Auto,
         }
     }
 }
 
+fn default_relay_base_url() -> String {
+    DEFAULT_RELAY_BASE_URL.into()
+}
+
+fn default_preferred_mode() -> ComputeMode {
+    ComputeMode::Auto
+}
+
+pub fn normalize_relay_base_urls(relay_base_urls: &[String], relay_base_url: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for relay_url in relay_base_urls {
+        let trimmed = relay_url.trim();
+        if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
+            normalized.push(trimmed.to_string());
+        }
+    }
+
+    if normalized.is_empty() {
+        let trimmed_legacy = relay_base_url.trim();
+        if !trimmed_legacy.is_empty() {
+            normalized.push(trimmed_legacy.to_string());
+        }
+    }
+
+    if normalized.is_empty() {
+        normalized.push(DEFAULT_RELAY_BASE_URL.into());
+    }
+
+    normalized
+}
+
+pub fn normalize_desktop_config(config: DesktopConfig) -> DesktopConfig {
+    let relay_base_urls =
+        normalize_relay_base_urls(&config.relay_base_urls, &config.relay_base_url);
+    let relay_base_url = relay_base_urls
+        .first()
+        .cloned()
+        .unwrap_or_else(default_relay_base_url);
+
+    DesktopConfig {
+        model_path: config.model_path,
+        relay_base_url,
+        relay_base_urls,
+        preferred_mode: config.preferred_mode,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::DesktopConfig;
+    use super::{normalize_desktop_config, normalize_relay_base_urls, DesktopConfig};
+    use crate::backend::ComputeMode;
 
     #[test]
     fn desktop_config_defaults_to_token_place_relay() {
         let config = DesktopConfig::default();
         assert_eq!(config.relay_base_url, "https://token.place");
+        assert_eq!(config.relay_base_urls, vec!["https://token.place"]);
+    }
+
+    #[test]
+    fn desktop_config_migrates_legacy_relay_base_url() {
+        let config: DesktopConfig = serde_json::from_str(
+            r#"{
+                "model_path": "/tmp/model.gguf",
+                "relay_base_url": " https://legacy.example ",
+                "preferred_mode": "auto"
+            }"#,
+        )
+        .expect("legacy config should deserialize");
+
+        assert_eq!(config.model_path, "/tmp/model.gguf");
+        assert_eq!(config.relay_base_url, "https://legacy.example");
+        assert_eq!(config.relay_base_urls, vec!["https://legacy.example"]);
+    }
+
+    #[test]
+    fn desktop_config_normalizes_relay_base_urls() {
+        let config = normalize_desktop_config(DesktopConfig {
+            model_path: "/tmp/model.gguf".into(),
+            relay_base_url: "https://legacy.example".into(),
+            relay_base_urls: vec![
+                " https://one.example ".into(),
+                "https://two.example".into(),
+                "https://one.example".into(),
+                "  ".into(),
+            ],
+            preferred_mode: ComputeMode::Auto,
+        });
+
+        assert_eq!(config.relay_base_url, "https://one.example");
+        assert_eq!(
+            config.relay_base_urls,
+            vec!["https://one.example", "https://two.example"]
+        );
+    }
+
+    #[test]
+    fn normalize_relay_base_urls_falls_back_to_default() {
+        assert_eq!(
+            normalize_relay_base_urls(&[" ".into()], " "),
+            vec!["https://token.place"]
+        );
     }
 }
 

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ mod subprocess_logging;
 
 use backend::{detect_backend_for, BackendInfo};
 use compute_node::{ComputeNodeRequest, ComputeNodeState, ComputeNodeStatus};
-use config::{config_path, DesktopConfig};
+use config::{config_path, normalize_desktop_config, DesktopConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sidecar::{InferenceRequest, SidecarState};
@@ -277,7 +277,9 @@ fn load_config(
         return Ok(DesktopConfig::default());
     }
     let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&raw).map_err(|e| e.to_string())
+    serde_json::from_str(&raw)
+        .map(normalize_desktop_config)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -288,7 +290,8 @@ fn save_config(
 ) -> Result<(), String> {
     let dir = resolve_config_dir(&app, &state).map_err(|e| e.to_string())?;
     let path = config_path(&dir);
-    let raw = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
+    let normalized = normalize_desktop_config(config);
+    let raw = serde_json::to_string_pretty(&normalized).map_err(|e| e.to_string())?;
     fs::write(path, raw).map_err(|e| e.to_string())
 }
 

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1383,6 +1383,167 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
   });
 
+
+  it('renders one relay URL field from legacy config', async () => {
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    expect(relayInput.value).toBe('https://token.place');
+    expect(screen.getByText('Add new relay URL')).toBeTruthy();
+    expect((screen.getByText('Delete') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('loads and displays multiple persisted relay URLs', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://primary.example',
+          relay_base_urls: ['https://primary.example', 'https://staging.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+
+    expect(((await screen.findByLabelText('Relay URL 1')) as HTMLInputElement).value).toBe(
+      'https://primary.example'
+    );
+    expect((screen.getByLabelText('Relay URL 2') as HTMLInputElement).value).toBe(
+      'https://staging.example'
+    );
+    expect(screen.getByText(/Configured relay URLs:/).textContent).toContain(
+      'https://primary.example, https://staging.example'
+    );
+  });
+
+  it('adds relay URL fields up to the documented maximum', async () => {
+    render(<App />);
+    await screen.findByLabelText('Relay URL 1');
+
+    fireEvent.click(screen.getByText('Add new relay URL'));
+
+    expect(await screen.findByLabelText('Relay URL 2')).toBeTruthy();
+    for (let index = 2; index < 10; index += 1) {
+      fireEvent.click(screen.getByText('Add new relay URL'));
+    }
+    expect(screen.getByLabelText('Relay URL 10')).toBeTruthy();
+    expect((screen.getByText('Add new relay URL') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('deletes a non-final relay URL but does not delete the last field', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://primary.example',
+          relay_base_urls: ['https://primary.example', 'https://staging.example'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    await screen.findByLabelText('Relay URL 2');
+
+    const deleteButtons = screen.getAllByText('Delete') as HTMLButtonElement[];
+    expect(deleteButtons[0].disabled).toBe(false);
+    fireEvent.click(deleteButtons[1]);
+
+    await waitFor(() => expect(screen.queryByLabelText('Relay URL 2')).toBeNull());
+    expect((screen.getByLabelText('Relay URL 1') as HTMLInputElement).value).toBe(
+      'https://primary.example'
+    );
+    expect((screen.getByText('Delete') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables relay URL editing while the operator is running', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      warm_load_state: 'ready',
+      warm_load_enabled: true,
+    });
+
+    render(<App />);
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    await waitFor(() => expect(relayInput.disabled).toBe(true));
+    expect((screen.getByText('Add new relay URL') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('Stop the operator to edit relay URLs. Changes apply on next start.')).toBeTruthy();
+  });
+
+  it('disables relay URL editing while operator startup is pending', async () => {
+    let resolveStart: (() => void) | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'start_compute_node') {
+        return new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() => expect((screen.getByLabelText('Relay URL 1') as HTMLInputElement).disabled).toBe(true));
+    expect((screen.getByText('Add new relay URL') as HTMLButtonElement).disabled).toBe(true);
+    resolveStart?.();
+  });
+
+  it('saves relay_base_urls plus first-url relay_base_url compatibility', async () => {
+    render(<App />);
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+
+    fireEvent.change(relayInput, { target: { value: ' https://updated.example ' } });
+
+    await waitFor(() => {
+      const saveCall = invokeMock.mock.calls.find((call) => call[0] === 'save_config');
+      expect(saveCall?.[1]?.config?.relay_base_url).toBe('https://updated.example');
+      expect(saveCall?.[1]?.config?.relay_base_urls).toEqual(['https://updated.example']);
+    });
+  });
+
+  it('starts the operator with normalized relay URL list and primary relay URL', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: 'https://legacy.example',
+          relay_base_urls: [
+            ' https://primary.example ',
+            '',
+            'https://staging.example',
+            'https://primary.example',
+          ],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() => {
+      const startCall = invokeMock.mock.calls.find((call) => call[0] === 'start_compute_node');
+      expect(startCall?.[1]?.request?.relay_base_url).toBe('https://primary.example');
+      expect(startCall?.[1]?.request?.relay_base_urls).toEqual([
+        'https://primary.example',
+        'https://staging.example',
+      ]);
+    });
+  });
+
   it('marks local inference as failed on emitted error events after start invoke resolves', async () => {
     render(<App />);
     const promptArea = (await screen.findByText('Prompt'))

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -16,6 +16,7 @@ interface BackendInfo {
 interface DesktopConfig {
   model_path: string;
   relay_base_url: string;
+  relay_base_urls: string[];
   preferred_mode: BackendMode;
 }
 
@@ -59,6 +60,99 @@ interface SidecarEvent {
   text?: string;
   code?: string;
   message?: string;
+}
+
+const DEFAULT_RELAY_BASE_URL = 'https://token.place';
+export const MAX_RELAY_URLS = 10;
+
+function relayUrlInputFields(config: DesktopConfig): string[] {
+  if (Array.isArray(config.relay_base_urls) && config.relay_base_urls.length > 0) {
+    return config.relay_base_urls;
+  }
+  if (config.relay_base_url) {
+    return [config.relay_base_url];
+  }
+  return [DEFAULT_RELAY_BASE_URL];
+}
+
+export function normalizeRelayUrls(
+  relayUrls: readonly string[] | undefined,
+  legacyRelayUrl = DEFAULT_RELAY_BASE_URL
+): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  const candidates = Array.isArray(relayUrls) ? relayUrls : [];
+
+  for (const relayUrl of candidates) {
+    const trimmed = relayUrl.trim();
+    if (trimmed && !seen.has(trimmed)) {
+      normalized.push(trimmed);
+      seen.add(trimmed);
+    }
+  }
+
+  if (normalized.length === 0) {
+    const trimmedLegacy = legacyRelayUrl.trim();
+    if (trimmedLegacy) {
+      normalized.push(trimmedLegacy);
+    }
+  }
+
+  return normalized.length > 0 ? normalized : [DEFAULT_RELAY_BASE_URL];
+}
+
+export function primaryRelayUrl(config: DesktopConfig): string {
+  return normalizeRelayUrls(config.relay_base_urls, config.relay_base_url)[0];
+}
+
+function normalizeDesktopConfig(config: DesktopConfig): DesktopConfig {
+  const relay_base_urls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+  return {
+    ...config,
+    relay_base_url: relay_base_urls[0],
+    relay_base_urls,
+  };
+}
+
+export function updateRelayUrlAtIndex(
+  config: DesktopConfig,
+  index: number,
+  relayUrl: string
+): DesktopConfig {
+  const relay_base_urls = relayUrlInputFields(config).slice(0, MAX_RELAY_URLS);
+  if (index < 0 || index >= relay_base_urls.length) {
+    return config;
+  }
+  relay_base_urls[index] = relayUrl;
+  return {
+    ...config,
+    relay_base_url: relay_base_urls[0] ?? '',
+    relay_base_urls,
+  };
+}
+
+export function addRelayUrl(config: DesktopConfig): DesktopConfig {
+  const relay_base_urls = relayUrlInputFields(config).slice(0, MAX_RELAY_URLS);
+  if (relay_base_urls.length >= MAX_RELAY_URLS) {
+    return config;
+  }
+  return {
+    ...config,
+    relay_base_urls: [...relay_base_urls, ''],
+  };
+}
+
+export function removeRelayUrl(config: DesktopConfig, index: number): DesktopConfig {
+  const relay_base_urls = relayUrlInputFields(config).slice(0, MAX_RELAY_URLS);
+  if (relay_base_urls.length <= 1 || index < 0 || index >= relay_base_urls.length) {
+    return config;
+  }
+  const nextRelayUrls = relay_base_urls.filter((_, relayIndex) => relayIndex !== index);
+  return {
+    ...config,
+    relay_base_url: nextRelayUrls[0] ?? DEFAULT_RELAY_BASE_URL,
+    relay_base_urls: nextRelayUrls,
+  };
 }
 
 const defaultComputeStatus: ComputeNodeStatus = {
@@ -222,7 +316,8 @@ export function App() {
   const [backend, setBackend] = useState<BackendInfo | null>(null);
   const [config, setConfig] = useState<DesktopConfig>({
     model_path: '',
-    relay_base_url: 'https://token.place',
+    relay_base_url: DEFAULT_RELAY_BASE_URL,
+    relay_base_urls: [DEFAULT_RELAY_BASE_URL],
     preferred_mode: 'auto',
   });
   const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
@@ -255,7 +350,7 @@ export function App() {
     const initializeConfigAndArtifact = async () => {
       try {
         const loadedConfig = await invoke<DesktopConfig>('load_config');
-        setConfig(loadedConfig);
+        setConfig(normalizeDesktopConfig(loadedConfig));
         const nodeStatus = await invoke<ComputeNodeStatus>('get_compute_node_status');
         computeStatusRef.current = nodeStatus;
         setComputeStatus(nodeStatus);
@@ -346,8 +441,12 @@ export function App() {
   );
 
   const canStartComputeNode = useMemo(
-    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
-    [config.model_path, computeStatus.running, isStartingComputeNode]
+    () =>
+      Boolean(config.model_path.trim()) &&
+      normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).length > 0 &&
+      !computeStatus.running &&
+      !isStartingComputeNode,
+    [config.model_path, config.relay_base_url, config.relay_base_urls, computeStatus.running, isStartingComputeNode]
   );
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
@@ -357,7 +456,7 @@ export function App() {
       window.clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = window.setTimeout(() => {
-      invoke('save_config', { config: next }).catch((e) => setError(formatErrorMessage(e)));
+      invoke('save_config', { config: normalizeDesktopConfig(next) }).catch((e) => setError(formatErrorMessage(e)));
       saveTimerRef.current = null;
     }, 300);
   };
@@ -430,6 +529,11 @@ export function App() {
 
   const startComputeNode = async () => {
     try {
+      const relayBaseUrls = normalizeRelayUrls(config.relay_base_urls, config.relay_base_url);
+      const relayBaseUrl = relayBaseUrls[0];
+      const normalizedConfig = { ...config, relay_base_url: relayBaseUrl, relay_base_urls: relayBaseUrls };
+      setConfig(normalizedConfig);
+      scheduleConfigSave(normalizedConfig);
       setIsStartingComputeNode(true);
       setError('');
       const optimisticStatus = {
@@ -438,7 +542,7 @@ export function App() {
         registered: false,
         relay_runtime_state: 'starting',
         sequence: computeStatusRef.current.operator_session_id ? Number.MAX_SAFE_INTEGER : null,
-        active_relay_url: config.relay_base_url,
+        active_relay_url: relayBaseUrl,
         requested_mode: config.preferred_mode,
         effective_mode: null,
         backend_available: null,
@@ -454,7 +558,8 @@ export function App() {
       await invoke('start_compute_node', {
         request: {
           model_path: config.model_path,
-          relay_base_url: config.relay_base_url,
+          relay_base_url: relayBaseUrl,
+          relay_base_urls: relayBaseUrls,
           mode: config.preferred_mode,
         },
       });
@@ -529,7 +634,7 @@ export function App() {
       setIsForwarding(true);
       setError('');
       await invoke('encrypt_and_forward', {
-        relay_base_url: config.relay_base_url,
+        relay_base_url: primaryRelayUrl(config),
         final_output: output,
       });
     } catch (e) {
@@ -595,12 +700,46 @@ export function App() {
         partial offload. Unsupported platforms fall back to CPU with diagnostics.
       </p>
 
-      <label style={{ display: 'block', marginTop: 12 }}>Relay URL</label>
-      <input
-        value={config.relay_base_url}
-        style={{ width: '100%' }}
-        onChange={(e) => updateConfig({ ...config, relay_base_url: e.target.value })}
-      />
+      <section style={{ marginTop: 12 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>Relay URLs</h2>
+        <p style={{ marginTop: 0, fontSize: 12, color: '#555' }}>
+          Configure up to {MAX_RELAY_URLS} relay URLs. Blank and duplicate URLs are removed when saved or started.
+        </p>
+        {(computeStatus.running || isStartingComputeNode) && (
+          <p style={{ fontSize: 12, color: '#555' }}>
+            Stop the operator to edit relay URLs. Changes apply on next start.
+          </p>
+        )}
+        {relayUrlInputFields(config).map((relayUrl, index, relayUrls) => (
+          <div key={index} style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <label htmlFor={`relay-url-${index}`} style={{ minWidth: 86, alignSelf: 'center' }}>
+              Relay URL {index + 1}
+            </label>
+            <input
+              id={`relay-url-${index}`}
+              value={relayUrl}
+              disabled={computeStatus.running || isStartingComputeNode}
+              style={{ width: '100%' }}
+              onChange={(e) => updateConfig(updateRelayUrlAtIndex(config, index, e.target.value))}
+            />
+            <button
+              type="button"
+              disabled={computeStatus.running || isStartingComputeNode || relayUrls.length <= 1}
+              onClick={() => updateConfig(removeRelayUrl(config, index))}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          style={{ marginTop: 8 }}
+          disabled={computeStatus.running || isStartingComputeNode || relayUrlInputFields(config).length >= MAX_RELAY_URLS}
+          onClick={() => updateConfig(addRelayUrl(config))}
+        >
+          Add new relay URL
+        </button>
+      </section>
 
       <section style={{ marginTop: 14, border: '1px solid #ddd', padding: 12 }}>
         <h2 style={{ marginTop: 0 }}>Compute node operator</h2>
@@ -618,7 +757,8 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{displayStatusValue(computeStatus.runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{displayStatusValue(computeStatus.relay_runtime_path, 'pending')}</code></p>
-        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, config.relay_base_url)}</code></p>
+        <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, primaryRelayUrl(config))}</code></p>
+        <p style={{ marginBottom: 0 }}>Configured relay URLs: <code>{normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).join(', ')}</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{displayStatusValue(computeStatus.requested_mode, config.preferred_mode)}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{displayStatusValue(computeStatus.effective_mode, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Backend available: <code>{displayStatusValue(computeStatus.backend_available, 'pending')}</code></p>


### PR DESCRIPTION
### Motivation
- Prepare desktop v0.1.1 UI/config plumbing to support multiple relay endpoints while preserving backwards compatibility with the legacy `relay_base_url` field and safe migration semantics.
- Surface a normalized, persisted relay list in the Tauri UI so future runtime multi-relay polling can be implemented without changing the UX/config shape.

### Description
- Rust: replaced `DesktopConfig` deserialization with a wire type and added `relay_base_urls: Vec<String>` plus `normalize_desktop_config` and `normalize_relay_base_urls` helpers to migrate legacy `relay_base_url`, trim, dedupe, preserve order, and default to `https://token.place` when empty; saving now writes normalized `relay_base_urls` and compatible first-url `relay_base_url`.
- Rust: updated `ComputeNodeRequest` to accept an optional `relay_base_urls: Vec<String>` (kept `relay_base_url` for compatibility) so the normalized list can be passed through when low-risk.
- TypeScript (desktop-tauri/src/App.tsx): extended `DesktopConfig` type with `relay_base_urls: string[]` and added helper functions `normalizeRelayUrls`, `primaryRelayUrl`, `updateRelayUrlAtIndex`, `addRelayUrl`, `removeRelayUrl`, plus UI changes that replace the single Relay URL input with a Relay URLs section showing one input per URL, Add/Delete controls, a documented max (`MAX_RELAY_URLS = 10`), and the stop-only edit behavior (fields and controls disabled when operator is running or starting with helper text).
- App behavior: `load_config` normalizes migrated legacy configs on load, `save_config` saves normalized config, `start_compute_node` normalizes and saves the list before starting and sends both `relay_base_url` (primary) and `relay_base_urls` in the start request; `encrypt_and_forward` uses `primaryRelayUrl(config)` for compatibility.
- Tests: added/updated TS tests in `desktop-tauri/src/App.test.tsx` to cover legacy migration, multiple persisted URLs, add/delete behavior, disable-while-running behavior, save normalization, and start request shape assertions; added Rust unit tests for config defaults, migration, and normalization.

### Testing
- Ran the desktop unit tests (UI): `cd desktop-tauri && npm test` — result: passed (1 file, 36 tests, all passed).
- Ran focused Rust tests: attempted `cd desktop-tauri/src-tauri && cargo test config && cargo test compute_node` but system build failed due to a missing native system dependency for `glib-2.0` (pkg-config / `glib-2.0.pc`) in this environment, so full `cargo test` could not complete here; the config-level logic is covered by the included Rust unit tests and CI should run `cargo test` with required system packages.
- Ran targeted Rust/Python unit suites: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_runtime_setup.py -v` — result: passed (these desktop runtime tests passed in this environment; output showed the test suites succeeded).
- Ran full JS+Python unit integration: `./run_all_tests.sh` was started and ran many Python unit tests (numerous tests passed in the run logs shown); environment-level native Rust build steps requiring `glib-2.0` or other platform libs may still need host packages in CI to run `cargo test` end-to-end.

Residual risks & follow-ups
- Backend runtime multi-relay polling (parallel registration/polling) is not yet implemented here and will be addressed in the follow-up prompt; this change prepares the config shape and UI only.
- CI / developer machines must have native dependencies (e.g., `glib-2.0` / `pkg-config`) installed for `cargo test` to finish; add CI runner system packages or mock those crates in CI if needed.
- Consider small UX follow-ups: show clearer validation for malformed schemes/hosts, and add an e2e acceptance test exercising `start_compute_node` request propagation once backend multi-relay support is active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c42cb28d8832fb1f0f396c55dffdf)