### PR TITLE
Prevent landing page Vue template pop-in

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -44,12 +44,24 @@ new Vue({
     computed: {
         computeNodeCountLabel() {
             if (this.computeNodeCountStatus === 'loading') {
-                return 'Live compute nodes: loading…';
+                return '';
             }
             if (this.computeNodeCountStatus === 'error') {
                 return 'Live compute nodes: unavailable';
             }
             return `Live compute nodes: ${this.computeNodeCount}`;
+        },
+        computeNodeCountLastUpdatedLabel() {
+            if (!this.computeNodeCountLastUpdated) {
+                return '';
+            }
+            return `Updated ${this.computeNodeCountLastUpdated}`;
+        },
+        selectedModelFallbackLabel() {
+            if (!this.selectedModelId) {
+                return '';
+            }
+            return `${this.selectedModelId} (emergency fallback)`;
         },
         selectedModel() {
             if (!Array.isArray(this.availableModels)) {

--- a/static/index.html
+++ b/static/index.html
@@ -470,8 +470,8 @@
             aria-live="polite"
             v-cloak
         >
-            <span><strong>{{ computeNodeCountLabel }}</strong></span>
-            <small v-if="computeNodeCountLastUpdated">Updated {{ computeNodeCountLastUpdated }}</small>
+            <span><strong v-if="computeNodeCountLabel" v-text="computeNodeCountLabel"></strong></span>
+            <small v-if="computeNodeCountLastUpdatedLabel" v-text="computeNodeCountLastUpdatedLabel"></small>
         </div>
         <div class="chat-container" v-cloak>
             <div class="model-selector-container">
@@ -484,21 +484,21 @@
                     data-testid="landing-model-select"
                     :disabled="modelsLoading || (!modelsError && availableModels.length === 0)"
                 >
-                    <option v-if="modelsError" :value="selectedModelId">{{ selectedModelId }} (emergency fallback)</option>
+                    <option v-if="modelsError" :value="selectedModelId" v-text="selectedModelFallbackLabel"></option>
                     <option v-else-if="availableModels.length === 0" value="">No API v1 models available</option>
-                    <option v-for="model in availableModels" :key="model.id" :value="model.id">{{ model.id }}</option>
+                    <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
                 </select>
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>
-                <p v-else-if="modelsError" class="model-status model-error">{{ modelsError }}</p>
+                <p v-else-if="modelsError" class="model-status model-error" v-text="modelsError"></p>
             </div>
-            <p v-if="selectedServerKeyLabel" class="server-key-label" data-testid="landing-server-key-label">{{ selectedServerKeyLabel }}</p>
+            <p v-if="selectedServerKeyLabel" class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div
                 v-if="selectedServerTerminalFailure"
                 class="selected-server-failure"
                 data-testid="landing-selected-server-failure"
                 role="alert"
             >
-                <div>{{ selectedServerTerminalFailure }}</div>
+                <div v-text="selectedServerTerminalFailure"></div>
                 <button
                     type="button"
                     class="retry-chat-button"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,7 @@ BROWSER_MATRIX_TARGETS = ("chromium", "firefox", "webkit")
 FOCUSED_RELAY_E2E_NODEIDS = {
     "tests/e2e/test_ui.py::test_root_page_loads",
     "tests/e2e/test_ui.py::test_release_badge_renders_without_api_call",
+    "tests/e2e/test_ui.py::test_landing_first_paint_hides_raw_vue_templates_when_chat_js_blocked",
     "tests/e2e/test_ui.py::test_landing_chat_uses_api_v1_only_non_streaming",
     "tests/e2e/test_ui.py::test_landing_chat_sticky_server_two_turns_and_key_label",
     "tests/e2e/test_ui.py::test_landing_chat_sticky_server_auto_failover_preserves_history",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -264,6 +264,31 @@ def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup
     assert metadata_api_calls == []
 
 
+def test_landing_first_paint_hides_raw_vue_templates_when_chat_js_blocked(page: Page, base_url: str, setup_servers):
+    """Landing HTML should not flash raw Vue template variables before hydration."""
+    page.route("**/static/chat.js", lambda route: route.abort())
+
+    page.goto(base_url, wait_until="domcontentloaded")
+
+    body_text = page.locator("body").inner_text()
+    forbidden_fragments = [
+        "{{",
+        "}}",
+        "computeNodeCountLabel",
+        "computeNodeCountLastUpdated",
+        "selectedModelId",
+        "model.id",
+        "selectedServerKeyLabel",
+        "selectedServerTerminalFailure",
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in body_text
+
+    status_text = page.locator(".compute-node-status").inner_text()
+    assert "Updated" not in status_text
+    assert "Live compute nodes: loading…" not in status_text
+
+
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):
     """Landing page should render and refresh the relay diagnostics compute-node count."""
     counts = iter([3, 5])

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -16,6 +16,13 @@ def test_chat_js_defines_touch_detection_hook():
     assert "detectTouchInput" in chat_js, "chat.js must implement touch detection helper"
 
 
+def test_landing_page_visible_html_avoids_raw_vue_mustache_interpolation():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    assert not re.search(r"{{\s*[A-Za-z_$][^}]*}}", index_html), (
+        "landing page must not ship user-visible raw Vue mustache text that can flash before hydration"
+    )
+
+
 def test_landing_chat_js_avoids_relay_v2_streaming_path():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "/api/v1/relay/servers/next" in chat_js, (


### PR DESCRIPTION
### Motivation
- Prevent raw Vue mustache expressions from flashing on the landing page before Vue hydrates and improve first-paint UX for dynamic landing fields.
- Ensure the compute-node status and other dynamic labels are blank/hidden on first paint until Vue can populate them or a real error state is known.

### Description
- Replaced visible mustache interpolation in `static/index.html` with safe Vue bindings (`v-if` / `v-text`) for compute-node status, compute-node timestamp, model dropdown entries, model-error text, selected-server label, and selected-server terminal failure text.
- Changed `static/chat.js` computed properties so the loading state returns an empty label instead of visible `loading…`, added `computeNodeCountLastUpdatedLabel` and `selectedModelFallbackLabel` computed properties, and preserved the existing `unavailable` failure state.
- Added a unit source-level regression test `tests/unit/test_touch_ui.py::test_landing_page_visible_html_avoids_raw_vue_mustache_interpolation` to assert `static/index.html` contains no raw `{{ ... }}` mustache tokens.
- Added a Playwright first-paint regression test `tests/e2e/test_ui.py::test_landing_first_paint_hides_raw_vue_templates_when_chat_js_blocked` that aborts `static/chat.js` and asserts no template fragments or loading compute-node text are visible, and added the test to the focused E2E allowlist in `tests/conftest.py`.

### Testing
- Ran the unit regression: `python -m pytest tests/unit -k "ui or static or landing or hydration or mustache" -v`, relevant unit tests passed (100% for selected set including new test).
- Ran focused e2e: `python -m pytest tests/e2e/test_ui.py -k "compute_node_count or landing or release or pop or cloak or hydration" -v`, the focused suite passed (24 passed, 2 skipped where runway guardrails applied).
- Ran the single Playwright first-paint test: `python -m pytest tests/e2e/test_ui.py::test_landing_first_paint_hides_raw_vue_templates_when_chat_js_blocked -v`, which passed.
- Ran JavaScript smoke: `npm run test:js`, which completed successfully.
- Ran the full project verification: `./run_all_tests.sh` and `pre-commit run --all-files`, both completed with no failures in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2da35c2800832f8b6ba4a2bce4f405)