### PR TITLE
Prevent landing Vue template pop-in

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -44,12 +44,18 @@ new Vue({
     computed: {
         computeNodeCountLabel() {
             if (this.computeNodeCountStatus === 'loading') {
-                return 'Live compute nodes: loading…';
+                return '';
             }
             if (this.computeNodeCountStatus === 'error') {
                 return 'Live compute nodes: unavailable';
             }
             return `Live compute nodes: ${this.computeNodeCount}`;
+        },
+        computeNodeCountLastUpdatedLabel() {
+            if (!this.computeNodeCountLastUpdated) {
+                return '';
+            }
+            return `Updated ${this.computeNodeCountLastUpdated}`;
         },
         selectedModel() {
             if (!Array.isArray(this.availableModels)) {

--- a/static/index.html
+++ b/static/index.html
@@ -470,8 +470,8 @@
             aria-live="polite"
             v-cloak
         >
-            <span><strong>{{ computeNodeCountLabel }}</strong></span>
-            <small v-if="computeNodeCountLastUpdated">Updated {{ computeNodeCountLastUpdated }}</small>
+            <span><strong v-if="computeNodeCountLabel" v-text="computeNodeCountLabel"></strong></span>
+            <small v-if="computeNodeCountLastUpdatedLabel" v-text="computeNodeCountLastUpdatedLabel"></small>
         </div>
         <div class="chat-container" v-cloak>
             <div class="model-selector-container">
@@ -484,21 +484,21 @@
                     data-testid="landing-model-select"
                     :disabled="modelsLoading || (!modelsError && availableModels.length === 0)"
                 >
-                    <option v-if="modelsError" :value="selectedModelId">{{ selectedModelId }} (emergency fallback)</option>
+                    <option v-if="modelsError" :value="selectedModelId" v-text="`${selectedModelId} (emergency fallback)`"></option>
                     <option v-else-if="availableModels.length === 0" value="">No API v1 models available</option>
-                    <option v-for="model in availableModels" :key="model.id" :value="model.id">{{ model.id }}</option>
+                    <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
                 </select>
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>
-                <p v-else-if="modelsError" class="model-status model-error">{{ modelsError }}</p>
+                <p v-else-if="modelsError" class="model-status model-error" v-text="modelsError"></p>
             </div>
-            <p v-if="selectedServerKeyLabel" class="server-key-label" data-testid="landing-server-key-label">{{ selectedServerKeyLabel }}</p>
+            <p v-if="selectedServerKeyLabel" class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div
                 v-if="selectedServerTerminalFailure"
                 class="selected-server-failure"
                 data-testid="landing-selected-server-failure"
                 role="alert"
             >
-                <div>{{ selectedServerTerminalFailure }}</div>
+                <div v-text="selectedServerTerminalFailure"></div>
                 <button
                     type="button"
                     class="retry-chat-button"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+from pathlib import Path
 import pytest
 import queue
 import re
@@ -262,6 +263,49 @@ def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup
     assert set(metadata) <= {"environment", "version", "label", "ref"}
     assert metadata["label"] == badge_label
     assert metadata_api_calls == []
+
+
+def test_landing_page_source_has_no_raw_vue_mustache_interpolation():
+    """Visible landing HTML should not ship raw Vue mustache text nodes."""
+    html = Path("static/index.html").read_text(encoding="utf-8")
+
+    assert re.search(r"{{\s*[A-Za-z_$][^}]*}}", html) is None
+
+
+def test_landing_first_paint_hides_vue_variables_before_chat_js(
+    page: Page, base_url: str, setup_servers
+):
+    """Raw Vue bindings must not be visible while the landing app is still hydrating."""
+    held_chat_js_route = {}
+    chat_js_seen = threading.Event()
+
+    def hold_chat_js(route):
+        held_chat_js_route["route"] = route
+        chat_js_seen.set()
+
+    page.route("**/static/chat.js", hold_chat_js)
+    page.goto(base_url, wait_until="domcontentloaded")
+    assert chat_js_seen.wait(timeout=5), "chat.js request was not intercepted"
+
+    body_text = page.locator("body").inner_text()
+    forbidden_fragments = [
+        "{{",
+        "}}",
+        "computeNodeCountLabel",
+        "computeNodeCountLastUpdated",
+        "selectedModelId",
+        "model.id",
+        "selectedServerKeyLabel",
+        "selectedServerTerminalFailure",
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in body_text
+
+    status_text = page.locator(".compute-node-status").inner_text()
+    assert "Updated" not in status_text
+    assert "Live compute nodes: loading…" not in status_text
+
+    held_chat_js_route["route"].abort()
 
 
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):


### PR DESCRIPTION
### Motivation
- Prevent raw Vue mustache variables from flashing on the landing page before Vue hydrates, which exposed bindings like `{{ computeNodeCountLabel }}` and `Updated {{ computeNodeCountLastUpdated }}` on first paint.
- Ensure compute-node status and other dynamic landing fields are blank/hidden until Vue can populate them, while preserving the existing post-hydration behavior and accessibility (`aria-live`).

### Description
- Replaced user-visible mustache interpolations in `static/index.html` with declarative bindings (`v-text`, `v-if`) so no `{{ ... }}` text nodes appear in the shipped HTML (compute status, model options, server label, terminal-failure block, and model error text).
- Updated `static/chat.js` computed properties so `computeNodeCountLabel` returns `''` while loading and added `computeNodeCountLastUpdatedLabel` which returns `''` until a real timestamp exists, avoiding initial loading copy in the DOM.
- Added two e2e regression tests in `tests/e2e/test_ui.py`: a source-level assertion that `static/index.html` contains no raw mustache interpolation, and a Playwright-first-paint test that intercepts/delays `/static/chat.js` and asserts forbidden fragments are not visible before hydration.

### Testing
- Ran the unit test subset with `python -m pytest tests/unit -k "ui or static or landing or hydration or mustache" -v` and observed `99 passed` (unit UI/static/hydration tests passed).
- Verified the new static-source test with `python -m pytest tests/e2e/test_ui.py::test_landing_page_source_has_no_raw_vue_mustache_interpolation -v` and it passed; `npm run test:js` also passed.
- Ran repository checks with `pre-commit run --all-files` which passed.
- Attempted full e2e Playwright runs `python -m pytest tests/e2e/test_ui.py -k "compute_node_count or landing or release or pop or cloak or hydration" -v`, but the environment blocked full Playwright execution: initial failures were due to missing Playwright browsers and later Chromium system library (`libatk-1.0.so.0`) and Playwright sync/async loop issues in this container; `python -m playwright install chromium` did download browsers successfully but the CI container lacks required system libs so some e2e tests remain not runnable here.

Residual risk / follow-up: run the full Playwright e2e suite on CI or a local machine with Playwright browsers installed and the needed system libraries (e.g. `libatk-1.0.so.0`) to validate the Playwright-first-paint test and the compute-node flows end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2da36d33e8832f97d4acbf5e5ecd87)