### PR TITLE
Fix landing asset cache-busting, release badge metadata, and add defensive UI + regression tests

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Any, Dict
 from urllib.parse import urlparse
 
-from release_metadata import get_release_metadata
+from release_metadata import get_release_metadata, resolve_deploy_ref, resolve_release_version, _clean_public_token
 
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
@@ -105,6 +105,7 @@ INDEX_HTML_PATH = os.path.join(STATIC_DIR_PATH, "index.html")
 VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
 RELEASE_METADATA_PLACEHOLDER = '{"environment":"dev","label":"dev dev","version":"dev"}'
 RELEASE_BADGE_TEXT_PLACEHOLDER = "dev dev"
+ASSET_VERSION_PLACEHOLDER = "__TOKENPLACE_ASSET_VERSION__"
 VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
 VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
 
@@ -122,12 +123,34 @@ def _vue_script_src_for_mode(mode: str) -> str:
     return VUE_DEV_SCRIPT_SRC if mode == "development" else VUE_PROD_SCRIPT_SRC
 
 
+def _asset_version() -> str:
+    """Resolve a short public cache-busting token for landing JS assets."""
+
+    version = (
+        resolve_deploy_ref()
+        or _clean_public_token(os.environ.get("TOKENPLACE_IMAGE_TAG"), max_length=80)
+        or _clean_public_token(os.environ.get("TOKENPLACE_GIT_SHA"), max_length=64)[:12]
+        or resolve_release_version()
+        or "dev"
+    )
+    return _clean_public_token(version, max_length=32) or "dev"
+
+
+def _no_store_response(body: str, *, mimetype: str) -> Response:
+    response = Response(body, mimetype=mimetype)
+    response.headers["Cache-Control"] = "no-store"
+    response.headers.pop("ETag", None)
+    response.headers.pop("Last-Modified", None)
+    return response
+
+
 def _render_index_html(host: str | None = None) -> str:
     with open(INDEX_HTML_PATH, encoding="utf-8") as index_file:
         html = index_file.read()
     metadata = get_release_metadata(host)
     return (
         html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+        .replace(ASSET_VERSION_PLACEHOLDER, _asset_version())
         .replace(
             RELEASE_METADATA_PLACEHOLDER,
             json.dumps(metadata, sort_keys=True, separators=(",", ":")),
@@ -917,15 +940,13 @@ def _pop_stream_chunks_for_client(client_public_key):
 
 @app.route('/')
 def index():
-    response = Response(_render_index_html(request.host), mimetype='text/html')
-    response.last_modified = os.path.getmtime(INDEX_HTML_PATH)
-    response.add_etag()
-    response.make_conditional(request)
-    return response
+    return _no_store_response(_render_index_html(request.host), mimetype='text/html')
 
 
 def _release_metadata_response():
-    return jsonify(get_release_metadata(request.host))
+    response = jsonify(get_release_metadata(request.host))
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.route('/api/v1/meta', methods=['GET'])
@@ -943,7 +964,10 @@ def api_v1_version():
 def serve_static(path):
     if path == 'index.html':
         return index()
-    return send_from_directory(STATIC_DIR_PATH, path)
+    response = send_from_directory(STATIC_DIR_PATH, path)
+    if path in {'chat.js', 'chat_typing.js'}:
+        response.headers['Cache-Control'] = 'no-cache'
+    return response
 
 
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -1118,7 +1118,13 @@ new Vue({
     },
     updated() {
         this.$nextTick(() => {
+            if (!this.$el || typeof this.$el.querySelector !== "function") {
+                return;
+            }
             const container = this.$el.querySelector(".chat-container");
+            if (!container) {
+                return;
+            }
             container.scrollTop = container.scrollHeight;
         });
     }

--- a/static/index.html
+++ b/static/index.html
@@ -764,14 +764,17 @@
         crossorigin="anonymous"
         referrerpolicy="no-referrer"
     ></script>
-    <script src="/static/chat_typing.js"></script>
-    <script src="/static/chat.js"></script>
+    <script src="/static/chat_typing.js?v=__TOKENPLACE_ASSET_VERSION__"></script>
+    <script src="/static/chat.js?v=__TOKENPLACE_ASSET_VERSION__"></script>
 
     <script>
         // Wait for the DOM to load
         document.addEventListener('DOMContentLoaded', function() {
             const toggleModeButton = document.getElementById('toggleMode');
             const body = document.body;
+            if (!toggleModeButton || !body) {
+                return;
+            }
 
             const switchTheme = () => {
                 if (body.classList.contains('dark-mode')) {

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -28,6 +28,32 @@ alt-test-public-key
 ALT_SERVER_PUBLIC_KEY_B64 = base64.b64encode(ALT_SERVER_PUBLIC_KEY_PEM.encode("utf-8")).decode("ascii")
 
 
+def attach_landing_console_error_collector(page: Page):
+    errors = []
+    page.on("pageerror", lambda exc: errors.append(f"pageerror: {exc}"))
+    page.on(
+        "console",
+        lambda msg: errors.append(f"console {msg.type}: {msg.text}")
+        if msg.type in {"error"}
+        else None,
+    )
+    return errors
+
+
+def assert_no_landing_console_regressions(errors):
+    forbidden = (
+        "ReferenceError",
+        "TypeError",
+        "computeNodeCountLastUpdatedLabel",
+        "addEventListener",
+        "querySelector",
+        "Vue warn",
+        "Error in render",
+    )
+    matches = [error for error in errors if any(fragment in error for fragment in forbidden)]
+    assert matches == []
+
+
 def patch_landing_crypto_for_visible_envelopes(page: Page):
     """Make landing-chat E2EE envelopes inspectable without weakening production code."""
     page.evaluate(
@@ -278,7 +304,7 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
             body="// chat.js intentionally blocked before Vue initializes",
         )
 
-    page.route("**/static/chat.js", block_chat_js)
+    page.route("**/static/chat.js**", block_chat_js)
     page.goto(base_url, wait_until="domcontentloaded")
 
     body_text = page.locator("body").inner_text()
@@ -297,6 +323,39 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     assert "Live compute nodes:" not in status_text
 
     assert blocked_chat_js["called"], "expected chat.js to be blocked"
+
+
+def test_landing_hydrates_without_console_or_page_errors(page: Page, base_url: str, setup_servers):
+    errors = attach_landing_console_error_collector(page)
+
+    page.goto(base_url, wait_until="domcontentloaded")
+    page.wait_for_function("document.querySelector('#app') && document.querySelector('#app').__vue__")
+    page.wait_for_load_state("networkidle")
+
+    assert_no_landing_console_regressions(errors)
+
+
+def test_landing_requests_cache_busted_chat_assets(page: Page, base_url: str, setup_servers):
+    errors = attach_landing_console_error_collector(page)
+    script_requests = {}
+
+    def record_script(route):
+        url = route.request.url
+        if "/static/chat.js" in url:
+            script_requests["chat.js"] = url
+        if "/static/chat_typing.js" in url:
+            script_requests["chat_typing.js"] = url
+        route.continue_()
+
+    page.route("**/static/chat*.js**", record_script)
+    page.goto(base_url, wait_until="domcontentloaded")
+    page.wait_for_function("document.querySelector('#app') && document.querySelector('#app').__vue__")
+    page.wait_for_load_state("networkidle")
+
+    assert set(script_requests) == {"chat.js", "chat_typing.js"}
+    assert "?v=" in script_requests["chat.js"] or "&v=" in script_requests["chat.js"]
+    assert "?v=" in script_requests["chat_typing.js"] or "&v=" in script_requests["chat_typing.js"]
+    assert_no_landing_console_regressions(errors)
 
 
 def test_compute_node_status_hidden_when_loading_label_is_blank(

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -75,17 +75,15 @@ def test_static_index_route_uses_runtime_rendering(monkeypatch):
     assert relay.VUE_SCRIPT_PLACEHOLDER not in body
 
 
-def test_index_route_supports_conditional_get(monkeypatch):
+def test_index_route_ignores_conditional_get_for_dynamic_html(monkeypatch):
     monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
 
     with relay.app.test_client() as client:
-        first_response = client.get("/")
-        etag = first_response.headers.get("ETag")
-        assert etag
+        response = client.get("/", headers={"If-None-Match": "stale"})
 
-        second_response = client.get("/", headers={"If-None-Match": etag})
-
-    assert second_response.status_code == 304
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert "ETag" not in response.headers
 
 
 def test_root_route_uses_development_vue_when_requested(monkeypatch):
@@ -192,3 +190,88 @@ def test_release_badge_and_embedded_metadata_agree_for_prod_release(monkeypatch)
     assert version_response.get_json() == expected
     assert _embedded_release_metadata(html) == expected
     assert '<span class="release-badge-label" data-testid="release-badge-label">prod 0.1.1</span>' in html
+
+
+def test_dynamic_index_and_metadata_are_no_store(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-d35648d")
+
+    with relay.app.test_client() as client:
+        first_response = client.get("/", headers={"Host": "staging.token.place"})
+        static_index_response = client.get(
+            "/static/index.html", headers={"Host": "staging.token.place"}
+        )
+        conditional_response = client.get(
+            "/", headers={"If-None-Match": "anything", "Host": "staging.token.place"}
+        )
+        meta_response = client.get(
+            "/api/v1/meta", headers={"Host": "staging.token.place"}
+        )
+        version_response = client.get(
+            "/api/v1/version", headers={"Host": "staging.token.place"}
+        )
+
+    for response in (
+        first_response,
+        static_index_response,
+        conditional_response,
+        meta_response,
+        version_response,
+    ):
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "no-store"
+        assert "ETag" not in response.headers
+        assert "Last-Modified" not in response.headers
+
+
+def test_rendered_index_uses_deploy_ref_cache_busted_js_assets(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-d35648d")
+    monkeypatch.delenv("TOKENPLACE_GIT_SHA", raising=False)
+
+    html = relay._render_index_html("staging.token.place")
+
+    assert '/static/chat_typing.js?v=main-d35648d' in html
+    assert '/static/chat.js?v=main-d35648d' in html
+    assert '/static/chat.js"></script>' not in html
+    assert relay.ASSET_VERSION_PLACEHOLDER not in html
+
+
+def test_chat_js_assets_are_revalidated_when_requested_unversioned():
+    with relay.app.test_client() as client:
+        chat_response = client.get("/static/chat.js")
+        typing_response = client.get("/static/chat_typing.js")
+
+    assert chat_response.status_code == 200
+    assert typing_response.status_code == 200
+    assert chat_response.headers["Cache-Control"] == "no-cache"
+    assert typing_response.headers["Cache-Control"] == "no-cache"
+
+
+def test_static_template_runtime_bindings_are_consistent():
+    html = INDEX_HTML_PATH.read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "{{" not in html
+    assert "}}" not in html
+    if "computeNodeCountLastUpdatedLabel" in html:
+        assert "computeNodeCountLastUpdatedLabel()" in chat_js
+    for binding in (
+        "computeNodeCountLabel",
+        "computeNodeCountLastUpdatedLabel",
+        "selectedModelId",
+        "selectedServerKeyLabel",
+        "selectedServerTerminalFailure",
+    ):
+        assert binding in chat_js
+
+
+def test_dark_mode_script_and_vue_updated_have_defensive_guards():
+    html = INDEX_HTML_PATH.read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "if (!toggleModeButton || !body)" in html
+    assert 'typeof this.$el.querySelector !== "function"' in chat_js
+    assert "if (!container)" in chat_js


### PR DESCRIPTION
### Motivation
- Prevent staging breakage caused by stale/mismatched frontend assets and incorrect release badge text that led to browser console errors like `ReferenceError: computeNodeCountLastUpdatedLabel is not defined`, `addEventListener` and `querySelector` TypeErrors.
- Ensure the root HTML and embedded release metadata never present stale deploy-specific content to browsers or CDNs.
- Harden non-critical UI code so missing DOM elements or temporarily non-element Vue roots do not throw and break page hydration.

### Description
- Rendered index and embedded release metadata now use `Cache-Control: no-store` and the root HTML no longer relies on conditional ETag/Last-Modified behavior to avoid serving stale dynamic content. (`relay.py`)
- Introduced a short, public asset version token derived from deploy-safe metadata and expanded `static/index.html` to load `/static/chat_typing.js?v=<asset-version>` and `/static/chat.js?v=<asset-version>` so new deployments cannot reuse stale JS. (`relay.py`, `static/index.html`)
- For unversioned requests to `/static/chat.js` and `/static/chat_typing.js` the server sets `Cache-Control: no-cache` to force revalidation when the version query is absent. (`relay.py`)
- Added defensive guards in the DOMContentLoaded dark/light toggle (no-op if `#toggleMode` or `document.body` are missing) and in the Vue `updated()` hook to tolerate missing/non-element `this.$el` and absent `.chat-container`. (`static/index.html`, `static/chat.js`)
- Kept `computeNodeCountLastUpdatedLabel` as a computed property that returns `''` until a timestamp exists and `Updated <time>` afterwards. (`static/chat.js`)
- Added unit and Playwright regression tests that assert: dynamic index/meta endpoints are `no-store`, index injects versioned asset URLs, unversioned chat assets are revalidated, template/runtime Vue binding consistency, defensive UI guards, page has no console/page errors on load, and the landing page never requests unversioned `chat.js`/`chat_typing.js`. (`tests/unit/test_relay_frontend_vue_mode.py`, `tests/e2e/test_ui.py`)

### Testing
- Ran focused unit tests: `python -m pytest tests/unit/test_release_metadata.py -v` and `python -m pytest tests/unit/test_relay_frontend_vue_mode.py -v` and all tests in those modules passed.
- Executed Playwright-backed e2e subset: `python -m pytest tests/e2e/test_ui.py -k "release or badge or metadata or pop or cloak or hydration or compute_node_count or console or cache_busted" -v` and the selected tests passed (5 passed, 2 skipped due to repo opt-in settings for relay registration tests).
- Ran `pre-commit run --all-files` which completed cleanly and then executed `./run_all_tests.sh` which ran the full test matrix and completed successfully (all automated checks passed in this environment).
- `helm lint`/`helm template` were not run in this environment because `helm` is not installed, so chart packaging validation remains a follow-up if required in CI.

Residual risks / follow-ups: CDN/Cloudflare caches that ignore origin Cache-Control might still serve stale content until invalidated, so a deployment step that invalidates caches (or ensures the asset-version token is updated by the image tag) is recommended; if chart changes are later required, follow OCI immutability rules for `charts/tokenplace` as noted in the repo policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5473d1dc832f817b7eca2497a0ef)