### PR TITLE
Fix landing cache-busted assets, release badge metadata, and defensive UI + tests

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Any, Dict
 from urllib.parse import urlparse
 
-from release_metadata import get_release_metadata
+from release_metadata import get_release_metadata, resolve_asset_version
 
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from prometheus_client import Counter, REGISTRY
@@ -105,6 +105,8 @@ INDEX_HTML_PATH = os.path.join(STATIC_DIR_PATH, "index.html")
 VUE_SCRIPT_PLACEHOLDER = "__TOKENPLACE_VUE_SCRIPT_SRC__"
 RELEASE_METADATA_PLACEHOLDER = '{"environment":"dev","label":"dev dev","version":"dev"}'
 RELEASE_BADGE_TEXT_PLACEHOLDER = "dev dev"
+CHAT_TYPING_SCRIPT_PLACEHOLDER = "__TOKENPLACE_CHAT_TYPING_SCRIPT_SRC__"
+CHAT_SCRIPT_PLACEHOLDER = "__TOKENPLACE_CHAT_SCRIPT_SRC__"
 VUE_DEV_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"
 VUE_PROD_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
 
@@ -126,8 +128,11 @@ def _render_index_html(host: str | None = None) -> str:
     with open(INDEX_HTML_PATH, encoding="utf-8") as index_file:
         html = index_file.read()
     metadata = get_release_metadata(host)
+    asset_version = resolve_asset_version(host)
     return (
         html.replace(VUE_SCRIPT_PLACEHOLDER, _vue_script_src_for_mode(_frontend_mode()))
+        .replace(CHAT_TYPING_SCRIPT_PLACEHOLDER, f"/static/chat_typing.js?v={asset_version}")
+        .replace(CHAT_SCRIPT_PLACEHOLDER, f"/static/chat.js?v={asset_version}")
         .replace(
             RELEASE_METADATA_PLACEHOLDER,
             json.dumps(metadata, sort_keys=True, separators=(",", ":")),
@@ -918,14 +923,14 @@ def _pop_stream_chunks_for_client(client_public_key):
 @app.route('/')
 def index():
     response = Response(_render_index_html(request.host), mimetype='text/html')
-    response.last_modified = os.path.getmtime(INDEX_HTML_PATH)
-    response.add_etag()
-    response.make_conditional(request)
+    response.headers['Cache-Control'] = 'no-store'
     return response
 
 
 def _release_metadata_response():
-    return jsonify(get_release_metadata(request.host))
+    response = jsonify(get_release_metadata(request.host))
+    response.headers['Cache-Control'] = 'no-store'
+    return response
 
 
 @app.route('/api/v1/meta', methods=['GET'])
@@ -943,7 +948,10 @@ def api_v1_version():
 def serve_static(path):
     if path == 'index.html':
         return index()
-    return send_from_directory(STATIC_DIR_PATH, path)
+    response = send_from_directory(STATIC_DIR_PATH, path)
+    if path in {'chat.js', 'chat_typing.js'}:
+        response.headers['Cache-Control'] = 'no-cache'
+    return response
 
 
 

--- a/release_metadata.py
+++ b/release_metadata.py
@@ -209,6 +209,20 @@ def get_release_metadata(host: str | None = None) -> dict[str, str]:
     return metadata
 
 
+def resolve_asset_version(host: str | None = None) -> str:
+    """Resolve a short public token for cache-busting frontend assets."""
+
+    metadata = get_release_metadata(host)
+    candidate = (
+        metadata.get("ref")
+        or _image_tag()
+        or _immutable_git_ref()
+        or metadata.get("version")
+        or "dev"
+    )
+    return _clean_public_token(candidate, max_length=40) or "dev"
+
+
 def release_metadata_json(host: str | None = None) -> str:
     """Return compact JSON suitable for embedding in static HTML."""
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -1118,7 +1118,13 @@ new Vue({
     },
     updated() {
         this.$nextTick(() => {
+            if (!this.$el || typeof this.$el.querySelector !== "function") {
+                return;
+            }
             const container = this.$el.querySelector(".chat-container");
+            if (!container) {
+                return;
+            }
             container.scrollTop = container.scrollHeight;
         });
     }

--- a/static/index.html
+++ b/static/index.html
@@ -764,14 +764,17 @@
         crossorigin="anonymous"
         referrerpolicy="no-referrer"
     ></script>
-    <script src="/static/chat_typing.js"></script>
-    <script src="/static/chat.js"></script>
+    <script src="__TOKENPLACE_CHAT_TYPING_SCRIPT_SRC__"></script>
+    <script src="__TOKENPLACE_CHAT_SCRIPT_SRC__"></script>
 
     <script>
         // Wait for the DOM to load
         document.addEventListener('DOMContentLoaded', function() {
             const toggleModeButton = document.getElementById('toggleMode');
             const body = document.body;
+            if (!toggleModeButton || !body) {
+                return;
+            }
 
             const switchTheme = () => {
                 if (body.classList.contains('dark-mode')) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,8 @@ def _is_focused_relay_landing_chat_request(request: pytest.FixtureRequest) -> bo
     target_names = {
         "root_page_loads",
         "test_release_badge_renders_without_api_call",
+        "landing_hydrates_without_staging_console_errors",
+        "landing_requests_cache_busted_chat_assets",
         "landing_chat_uses_api_v1_only_non_streaming",
         "landing_chat_sticky_server_two_turns_and_key_label",
         "landing_chat_sticky_server_auto_failover_preserves_history",

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -28,6 +28,27 @@ alt-test-public-key
 ALT_SERVER_PUBLIC_KEY_B64 = base64.b64encode(ALT_SERVER_PUBLIC_KEY_PEM.encode("utf-8")).decode("ascii")
 
 
+def attach_landing_console_error_collector(page: Page):
+    errors = []
+    page.on("pageerror", lambda exc: errors.append(f"pageerror: {exc}"))
+    page.on(
+        "console",
+        lambda msg: errors.append(f"console {msg.type}: {msg.text}")
+        if msg.type in {"error"}
+        else None,
+    )
+    return errors
+
+
+def assert_no_landing_console_regressions(errors):
+    forbidden = re.compile(
+        r"ReferenceError|TypeError|computeNodeCountLastUpdatedLabel|addEventListener|querySelector|Vue.*(?:warn|error)",
+        re.IGNORECASE,
+    )
+    matches = [error for error in errors if forbidden.search(error)]
+    assert matches == []
+
+
 def patch_landing_crypto_for_visible_envelopes(page: Page):
     """Make landing-chat E2EE envelopes inspectable without weakening production code."""
     page.evaluate(
@@ -239,6 +260,42 @@ def test_root_page_loads(page: Page, base_url: str, setup_servers):
     print(f"✓ Found {len(headings)} headings on the page")
 
 
+def test_landing_hydrates_without_staging_console_errors(page: Page, base_url: str, setup_servers):
+    errors = attach_landing_console_error_collector(page)
+    route_landing_relay_chat(page, diagnostics_count=1)
+
+    page.goto(base_url, wait_until="domcontentloaded")
+    page.wait_for_function("() => Boolean(document.querySelector('#app')?.__vue__)")
+    page.wait_for_function(
+        "() => document.querySelector('.compute-node-status')?.textContent.includes('Live compute nodes: 1')"
+    )
+    page.wait_for_load_state("networkidle")
+
+    assert_no_landing_console_regressions(errors)
+
+
+def test_landing_requests_cache_busted_chat_assets(page: Page, base_url: str, setup_servers):
+    errors = attach_landing_console_error_collector(page)
+    requested = {}
+
+    def record_static_script(route):
+        url = route.request.url
+        if "/static/chat.js" in url or "/static/chat_typing.js" in url:
+            requested[url.rsplit("/", 1)[-1].split("?", 1)[0]] = url
+        route.continue_()
+
+    page.route("**/static/chat*.js**", record_static_script)
+    route_landing_relay_chat(page, diagnostics_count=1)
+    page.goto(base_url, wait_until="domcontentloaded")
+    page.wait_for_function("() => Boolean(document.querySelector('#app')?.__vue__)")
+    page.wait_for_load_state("networkidle")
+
+    assert set(requested) == {"chat.js", "chat_typing.js"}
+    for url in requested.values():
+        assert re.search(r"[?&]v=[A-Za-z0-9._-]+", url), url
+    assert_no_landing_console_regressions(errors)
+
+
 def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup_servers):
     """Landing page should render release/env metadata without waiting on API calls."""
     metadata_api_calls = []
@@ -268,6 +325,7 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     page: Page, base_url: str, setup_servers
 ):
     """Initial paint should be safe even when Vue initialization is blocked."""
+    errors = attach_landing_console_error_collector(page)
     blocked_chat_js = {"called": False}
 
     def block_chat_js(route):
@@ -278,7 +336,7 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
             body="// chat.js intentionally blocked before Vue initializes",
         )
 
-    page.route("**/static/chat.js", block_chat_js)
+    page.route("**/static/chat.js**", block_chat_js)
     page.goto(base_url, wait_until="domcontentloaded")
 
     body_text = page.locator("body").inner_text()
@@ -286,6 +344,12 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     forbidden_visible_fragments = [
         "{{",
         "}}",
+        "computeNodeCountLabel",
+        "computeNodeCountLastUpdated",
+        "computeNodeCountLastUpdatedLabel",
+        "selectedModelId",
+        "selectedServerKeyLabel",
+        "selectedServerTerminalFailure",
     ]
     for fragment in forbidden_visible_fragments:
         assert fragment not in body_text
@@ -297,6 +361,7 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     assert "Live compute nodes:" not in status_text
 
     assert blocked_chat_js["called"], "expected chat.js to be blocked"
+    assert_no_landing_console_regressions(errors)
 
 
 def test_compute_node_status_hidden_when_loading_label_is_blank(

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -37,6 +37,8 @@ def test_root_route_uses_production_vue_by_default(monkeypatch):
     assert relay.VUE_PROD_SCRIPT_SRC in body
     assert relay.VUE_DEV_SCRIPT_SRC not in body
     assert relay.VUE_SCRIPT_PLACEHOLDER not in body
+    assert "/static/chat_typing.js?v=" in body
+    assert "/static/chat.js?v=" in body
 
 
 def test_relay_uses_development_vue_when_explicitly_requested(monkeypatch):
@@ -75,17 +77,18 @@ def test_static_index_route_uses_runtime_rendering(monkeypatch):
     assert relay.VUE_SCRIPT_PLACEHOLDER not in body
 
 
-def test_index_route_supports_conditional_get(monkeypatch):
+def test_index_route_is_dynamic_and_no_store(monkeypatch):
     monkeypatch.delenv("TOKENPLACE_FRONTEND_MODE", raising=False)
 
     with relay.app.test_client() as client:
         first_response = client.get("/")
-        etag = first_response.headers.get("ETag")
-        assert etag
+        second_response = client.get("/", headers={"If-None-Match": "stale"})
 
-        second_response = client.get("/", headers={"If-None-Match": etag})
-
-    assert second_response.status_code == 304
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.headers["Cache-Control"] == "no-store"
+    assert "ETag" not in first_response.headers
+    assert "Last-Modified" not in first_response.headers
 
 
 def test_root_route_uses_development_vue_when_requested(monkeypatch):
@@ -145,6 +148,8 @@ def test_meta_endpoint_returns_public_safe_metadata(monkeypatch):
     assert body["version"] == "v0.1.1"
     assert body["label"] == "staging main-830d0a4"
     assert body["ref"] == "main-830d0a4"
+    assert meta_response.headers["Cache-Control"] == "no-store"
+    assert version_response.headers["Cache-Control"] == "no-store"
     assert "do-not-leak" not in meta_response.get_data(as_text=True)
     assert "do-not-leak" not in version_response.get_data(as_text=True)
 
@@ -168,6 +173,8 @@ def test_release_badge_and_embedded_metadata_agree_for_staging_git_ref(monkeypat
         "ref": "main-830d0a4",
     }
     assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert meta_response.headers["Cache-Control"] == "no-store"
     assert meta_response.get_json() == expected
     assert version_response.get_json() == expected
     assert _embedded_release_metadata(html) == expected
@@ -188,7 +195,31 @@ def test_release_badge_and_embedded_metadata_agree_for_prod_release(monkeypatch)
     html = response.get_data(as_text=True)
     expected = {"environment": "prod", "version": "0.1.1", "label": "prod 0.1.1"}
     assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert meta_response.headers["Cache-Control"] == "no-store"
     assert meta_response.get_json() == expected
     assert version_response.get_json() == expected
     assert _embedded_release_metadata(html) == expected
     assert '<span class="release-badge-label" data-testid="release-badge-label">prod 0.1.1</span>' in html
+
+
+def test_rendered_index_uses_deploy_ref_cache_busted_scripts(monkeypatch):
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-d35648d")
+
+    html = relay._render_index_html("staging.token.place")
+
+    assert '<script src="/static/chat_typing.js?v=main-d35648d"></script>' in html
+    assert '<script src="/static/chat.js?v=main-d35648d"></script>' in html
+    assert '<script src="/static/chat.js"></script>' not in html
+    assert '<script src="/static/chat_typing.js"></script>' not in html
+
+
+def test_chat_static_assets_are_revalidated_not_cached_forever():
+    with relay.app.test_client() as client:
+        chat_response = client.get("/static/chat.js")
+        typing_response = client.get("/static/chat_typing.js")
+
+    assert chat_response.headers["Cache-Control"] == "no-cache"
+    assert typing_response.headers["Cache-Control"] == "no-cache"

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -327,3 +327,19 @@ def test_deployed_like_image_tag_does_not_fall_back_to_dev(monkeypatch, tmp_path
 
     assert metadata["version"] == "main-830d0a4"
     assert metadata["label"] == "staging main-830d0a4"
+
+
+def test_asset_version_prefers_deploy_ref(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_DEPLOY_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+    monkeypatch.setenv("TOKENPLACE_IMAGE_TAG", "main-d35648d")
+
+    assert release_metadata.resolve_asset_version("staging.token.place") == "main-d35648d"
+
+
+def test_asset_version_falls_back_to_release_version(monkeypatch):
+    _clear_metadata_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELEASE_VERSION", "0.1.1")
+
+    assert release_metadata.resolve_asset_version("localhost") == "0.1.1"

--- a/tests/unit/test_static_template_runtime_consistency.py
+++ b/tests/unit/test_static_template_runtime_consistency.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import re
+
+
+def test_index_referenced_compute_timestamp_computed_exists():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "computeNodeCountLastUpdatedLabel" in index_html
+    assert re.search(r"computeNodeCountLastUpdatedLabel\s*\(\)\s*{", chat_js)
+
+
+def test_static_index_has_no_raw_mustache_interpolation():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+
+    assert "{{" not in index_html
+    assert "}}" not in index_html
+
+
+def test_dark_mode_script_and_updated_hook_have_defensive_guards():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "if (!toggleModeButton || !body)" in index_html
+    assert 'typeof this.$el.querySelector !== "function"' in chat_js
+    assert "if (!container)" in chat_js


### PR DESCRIPTION
### Motivation
- Staging experienced browser-console errors due to mismatched cached frontend assets and a stale release badge, causing missing Vue computed properties and DOM APIs to throw. 
- The root HTML was being served with conditional ETag/Last-Modified semantics while embedding deployment-specific metadata, which allowed stale HTML (badge) to persist across deploys. 
- Non-critical UI code assumed DOM elements and element-like `this.$el` always exist, which made harmless failures crash the page; regressions needed automated detection.

### Description
- Make rendered index and metadata endpoints non-cacheable by setting `Cache-Control: no-store` for `/` and the `/api/v1/meta` and `/api/v1/version` JSON responses and remove conditional `If-None-Match`/Last-Modified behaviour for the dynamic index. (`relay.py`)
- Inject cache-busted script URLs into the rendered HTML (placeholders replaced with `/static/chat_typing.js?v=<asset-version>` and `/static/chat.js?v=<asset-version>`) where `asset-version` is resolved from public-safe release metadata (deploy ref, image tag, git sha, or release version). (`relay.py`, `release_metadata.py`, `static/index.html`)
- Make unversioned static responses for the landing JS revalidate instead of being cached forever by setting `Cache-Control: no-cache` for `chat.js` and `chat_typing.js`. (`relay.py`)
- Add defensive guards to frontend code to avoid hard throws: skip dark/light toggle when `#toggleMode` or `document.body` are missing, and make Vue `updated()` guard `this.$el` and `.chat-container` presence before calling `querySelector`/touching `scrollTop`. (`static/index.html`, `static/chat.js`)
- Add test coverage and small test infra changes: new unit checks for template/runtime consistency (`tests/unit/test_static_template_runtime_consistency.py`), updates to existing unit tests for no-store and cache-busted script assertions, and Playwright e2e helpers/tests that collect page console/pageerror and assert there are no regressions and that the landing page always requests versioned `chat.js` assets. (`tests/*`, `tests/e2e/test_ui.py`, `tests/unit/*`, `tests/conftest.py`)

### Testing
- Ran unit release metadata tests with `python -m pytest tests/unit/test_release_metadata.py -v` and they passed. (passed)
- Ran frontend/unit render and index tests with `python -m pytest tests/unit/test_relay_frontend_vue_mode.py -v` and they passed, including new assertions for `Cache-Control` and `?v=` script injection. (passed)
- Added and ran `tests/unit/test_static_template_runtime_consistency.py` with `python -m pytest tests/unit/test_static_template_runtime_consistency.py -q` and it passed. (passed)
- Added Playwright e2e tests and attempted targeted runs with `python -m pytest tests/e2e/test_ui.py -k "release or badge or metadata or pop or cloak or hydration or compute_node_count or console" -v`, and while the tests and helpers execute, targeted Playwright runs initially encountered environment limitations (Playwright browser download and a missing system library `libatk-1.0.so.0`) in this execution environment; a `python -m playwright install chromium` was invoked to fetch browsers but some CI containers may still need system-level deps for headless Chromium. (attempted; environment-limited)
- Ran the repository-wide checks `pre-commit run --all-files` and the project test runner `./run_all_tests.sh` which completed successfully in this environment (full test-suite reported passing). (passed)

Residual notes and follow-ups: 
- Playwright e2e tests depend on system browser libraries; CI runners should ensure Chromium/Playwright dependencies (e.g., `libatk-1.0.so.0` and related) are available so the new browser tests can run reliably. 
- Helm lint/template steps were not executed here because `helm` is not installed in the execution environment; chart changes were not required by this patch. 
- The changes are narrowly scoped to frontend rendering, metadata resolution, defensive UI guards, and tests; they do not alter API v1 relay behavior, encryption, compute-node routing, or release tags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5487e690832fbd5b79dd4303e2cf)