### PR TITLE
Preserve landing chat layout before hydration

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -19,6 +19,7 @@ new Vue({
         availableModels: [],
         selectedModelId: '',
         modelsLoading: false,
+        modelsLoaded: false,
         modelsError: '',
         isGeneratingResponse: false,
         isTouchInput: false,
@@ -162,6 +163,7 @@ new Vue({
         },
         fetchModels() {
             this.modelsLoading = true;
+            this.modelsLoaded = false;
             this.modelsError = '';
 
             return fetch('/api/v1/models')
@@ -187,6 +189,7 @@ new Vue({
                     this.selectedModelId = EMERGENCY_MODEL_FALLBACK_ID;
                 })
                 .finally(() => {
+                    this.modelsLoaded = true;
                     this.modelsLoading = false;
                 });
         },

--- a/static/index.html
+++ b/static/index.html
@@ -81,6 +81,7 @@
             border-radius: 10px;
             padding: 20px;
             margin-top: 30px;
+            min-height: 260px;
         }
         .compute-node-status {
             display: flex;
@@ -94,6 +95,18 @@
             border-radius: 10px;
             background-color: rgba(0, 255, 255, 0.08);
             color: #ffffff;
+            min-height: 44px;
+        }
+        .compute-node-status-label,
+        .compute-node-status-updated {
+            display: inline-block;
+            min-height: 1em;
+        }
+        .compute-node-status-label {
+            min-width: 14em;
+        }
+        .compute-node-status-updated {
+            min-width: 7em;
         }
         .compute-node-status strong {
             color: #00ffff;
@@ -465,16 +478,14 @@
 
         <h2>Try it out:</h2>
         <div
-            v-show="computeNodeCountLabel || computeNodeCountLastUpdatedLabel"
             class="compute-node-status"
             :class="{'status-error': computeNodeCountStatus === 'error'}"
             aria-live="polite"
-            v-cloak
         >
-            <span><strong v-text="computeNodeCountLabel"></strong></span>
-            <small v-if="computeNodeCountLastUpdatedLabel" v-text="computeNodeCountLastUpdatedLabel"></small>
+            <span class="compute-node-status-label"><strong v-text="computeNodeCountLabel"></strong></span>
+            <small class="compute-node-status-updated" v-text="computeNodeCountLastUpdatedLabel"></small>
         </div>
-        <div class="chat-container" v-cloak>
+        <div class="chat-container">
             <div class="model-selector-container">
                 <label for="model-select">Model</label>
                 <select
@@ -486,7 +497,8 @@
                     :disabled="modelsLoading || (!modelsError && availableModels.length === 0)"
                 >
                     <option v-if="modelsError" :value="selectedModelId" v-text="`${selectedModelId} (emergency fallback)`"></option>
-                    <option v-else-if="availableModels.length === 0" value="">No API v1 models available</option>
+                    <option v-else-if="modelsLoading || !modelsLoaded" value="" disabled></option>
+                    <option v-else-if="availableModels.length === 0" value="" disabled v-text="'No API v1 models available'"></option>
                     <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
                 </select>
                 <p v-if="modelsLoading" class="model-status">Loading API v1 models…</p>

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -312,6 +312,7 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
         "computeNodeCountLastUpdated",
         "computeNodeCountLastUpdatedLabel",
         "selectedModelId",
+        "model.id",
         "selectedServerKeyLabel",
         "selectedServerTerminalFailure",
     ]
@@ -319,14 +320,61 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
         assert fragment not in body_text
         assert fragment not in raw_body_text
 
-    status_text = page.locator(".compute-node-status").inner_text().strip()
+    status = page.locator(".compute-node-status")
+    expect(status).to_be_visible()
+    status_text = status.inner_text().strip()
     assert "Updated" not in status_text
     assert "Live compute nodes: loading…" not in status_text
     assert "Live compute nodes:" not in status_text
 
+    chat_container = page.locator(".chat-container")
+    expect(chat_container).to_be_visible()
+    assert chat_container.bounding_box()["height"] >= 250
+    expect(page.locator("textarea").first).to_be_visible()
+    expect(page.locator(".send-button").first).to_be_visible()
+    expect(page.get_by_test_id("landing-model-select")).to_be_visible()
+
     assert blocked_chat_js["called"], "expected chat.js to be blocked"
     assert_no_landing_console_regressions(errors)
 
+
+def test_landing_hydrates_compute_status_and_models_without_layout_collapse(
+    page: Page, base_url: str, setup_servers
+):
+    errors = attach_landing_console_error_collector(page)
+    route_landing_relay_chat(page, diagnostics_count=1)
+
+    page.goto(base_url, wait_until="domcontentloaded")
+    chat_container = page.locator(".chat-container")
+    expect(chat_container).to_be_visible()
+    first_height = chat_container.bounding_box()["height"]
+
+    page.wait_for_function("document.querySelector('#app') && document.querySelector('#app').__vue__")
+    page.wait_for_function(
+        """
+        () => {
+            const status = document.querySelector('.compute-node-status');
+            const select = document.querySelector('[data-testid=landing-model-select]');
+            return Boolean(
+                status &&
+                status.textContent.includes('Live compute nodes: 1') &&
+                status.textContent.includes('Updated') &&
+                select &&
+                Array.from(select.options).map((option) => option.textContent.trim()).includes('llama-3.1-8b-instruct')
+            );
+        }
+        """
+    )
+
+    status = page.locator(".compute-node-status")
+    assert "Live compute nodes: 1" in status.inner_text()
+    assert re.search(r"Updated \d{2}:\d{2}", status.inner_text())
+    assert page.get_by_test_id("landing-model-select").locator("option").all_inner_texts() == ["llama-3.1-8b-instruct"]
+    hydrated_height = chat_container.bounding_box()["height"]
+    assert first_height >= 250
+    assert hydrated_height >= 250
+    assert abs(hydrated_height - first_height) < 80
+    assert_no_landing_console_regressions(errors)
 
 
 def test_landing_loads_without_observed_console_regressions(page: Page, base_url: str, setup_servers):
@@ -381,10 +429,10 @@ def test_landing_badge_metadata_and_no_store_headers(page: Page, base_url: str, 
     assert version_metadata == metadata
     assert_no_landing_console_regressions(errors)
 
-def test_compute_node_status_hidden_when_loading_label_is_blank(
+def test_compute_node_status_reserves_space_when_loading_label_is_blank(
     page: Page, base_url: str, setup_servers
 ):
-    """The compute-node status bar should stay hidden when loading has no content."""
+    """The compute-node status bar should stay visible but blank while loading."""
     page.goto(base_url)
     page.wait_for_function(
         """
@@ -410,7 +458,10 @@ def test_compute_node_status_hidden_when_loading_label_is_blank(
         """
     )
 
-    expect(page.locator(".compute-node-status")).to_be_hidden()
+    status = page.locator(".compute-node-status")
+    expect(status).to_be_visible()
+    assert status.inner_text().strip() == ""
+    assert status.bounding_box()["height"] >= 40
 
 
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):


### PR DESCRIPTION
### Motivation
- Prevent the landing chat UI from collapsing to a tiny bar on first paint while keeping dynamic text blank until Vue hydrates. 
- Avoid showing any raw Vue template tokens or premature fallback messages before real diagnostic/model data arrives. 
- Preserve existing accessibility/relay invariants and no-console-error guards while making the first-paint layout stable.

### Description
- Reserve visible footprint for the chat card and compute-node status by adding stable CSS min-heights and inline placeholders and removing layout-cloaking from the outer containers in `static/index.html`. 
- Render only inner dynamic text nodes as blank/placeholders (keep `v-text` bindings) and stop hiding the whole `.chat-container` or `.compute-node-status` so the layout remains stable on first paint. 
- Add a `modelsLoaded` state to `static/chat.js` and change the model `<select>` to show a blank disabled option while loading and only surface empty/failure text after loading completes or errors. 
- Extend landing browser coverage in `tests/e2e/test_ui.py` to assert first-paint visibility and footprint, absence of raw Vue tokens, stable heights before/after hydration, and compute/model hydration without large layout jumps.

### Testing
- Ran unit checks `python -m pytest tests/unit/test_relay_frontend_vue_mode.py -v` which passed. 
- Ran JavaScript tests with `npm run test:js`, which passed. 
- Attempted the focused landing e2e subset with `python -m pytest tests/e2e/test_ui.py -k "first_paint or layout or release or badge or metadata or pop or cloak or hydration or compute_node_count or console" -v` but encountered Playwright/browser environment issues (headless Chromium failed to launch due to missing system library `libatk-1.0.so.0`), so that run errored in this environment; the test assertions themselves were added/updated as required. 
- Ran the full project test runner `./run_all_tests.sh` and standard JS/unit/integration/API test suites which completed successfully in this environment. 

Residual risk / follow-up: the Playwright-first-paint e2e assertions require a CI environment with Playwright browsers and needed system libraries present (e.g., `libatk`); ensure the CI runners have Playwright installed (`playwright install chromium`) and required OS packages so the new e2e coverage runs in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31972b90e4832fb90b5ae2c679e1a3)