### PR TITLE
Fix landing chat first-paint message layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -518,9 +518,15 @@
                     Start a new chat
                 </button>
             </div>
-            <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
-                <span v-html="renderMarkdown(getDisplayContent(message))"></span>
-            </div>
+            <template v-for="(message, index) in chatHistory">
+                <div
+                    :key="message.id || `${message.role}-${index}`"
+                    :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}"
+                    class="message"
+                >
+                    <span v-html="renderMarkdown(getDisplayContent(message))"></span>
+                </div>
+            </template>
             <div class="input-container">
                 <textarea
                     ref="messageInput"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -321,17 +321,45 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
         assert fragment not in body_text
         assert fragment not in raw_body_text
 
+    def measure_landing_chat_layout():
+        return page.evaluate(
+            """
+            () => {
+                const chat = document.querySelector('.chat-container');
+                const select = document.querySelector('[data-testid=landing-model-select]');
+                const textarea = document.querySelector('textarea.message-input');
+                if (!chat || !select || !textarea) {
+                    throw new Error('missing landing chat layout target');
+                }
+                const chatRect = chat.getBoundingClientRect();
+                const selectRect = select.getBoundingClientRect();
+                const textareaRect = textarea.getBoundingClientRect();
+                return {
+                    modelToTextareaGap: textareaRect.top - selectRect.bottom,
+                    chatHeight: chatRect.height,
+                    textareaTopRelativeToChat: textareaRect.top - chatRect.top,
+                };
+            }
+            """
+        )
+
     status = page.locator(".compute-node-status")
     chat = page.locator(".chat-container")
     send_button = page.locator(".send-button")
+    textarea = page.locator("textarea.message-input")
+    model_select = page.get_by_test_id("landing-model-select")
     expect(status).to_be_visible()
     expect(chat).to_be_visible()
-    assert chat.bounding_box()["height"] >= 250
-    expect(page.locator("textarea.message-input")).to_be_visible()
+    first_paint_layout = measure_landing_chat_layout()
+    assert first_paint_layout["chatHeight"] >= 250
+    assert 0 <= first_paint_layout["modelToTextareaGap"] <= 70
+    expect(textarea).to_be_visible()
     expect(send_button).to_be_visible()
     expect(send_button).to_be_disabled()
-    expect(page.get_by_test_id("landing-model-select")).to_be_visible()
+    expect(model_select).to_be_visible()
     expect(page.get_by_test_id("landing-selected-server-failure")).not_to_be_visible()
+    assert page.locator(".message").count() == 0
+    assert page.locator(".message:visible").count() == 0
 
     status_text = status.inner_text().strip()
     assert "Updated" not in status_text
@@ -363,6 +391,10 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
         """
     )
     page.wait_for_load_state("networkidle")
+    hydrated_layout = measure_landing_chat_layout()
+    assert abs(hydrated_layout["modelToTextareaGap"] - first_paint_layout["modelToTextareaGap"]) <= 4
+    assert abs(hydrated_layout["textareaTopRelativeToChat"] - first_paint_layout["textareaTopRelativeToChat"]) <= 4
+    assert abs(hydrated_layout["chatHeight"] - first_paint_layout["chatHeight"]) <= 4
     assert_no_landing_console_regressions(errors)
 
 
@@ -1208,7 +1240,13 @@ def test_landing_chat_model_dropdown_uses_api_v1_models(
     textarea.fill("Use the selected model")
     wait_for_landing_send_enabled(page).click()
 
-    page.locator(".assistant-message").last.wait_for(state="visible")
+    user_message = page.locator(".user-message").last
+    assistant_message = page.locator(".assistant-message").last
+    user_message.wait_for(state="visible")
+    assistant_message.wait_for(state="visible")
+    expect(user_message).not_to_have_attribute("v-cloak", "")
+    expect(assistant_message).not_to_have_attribute("v-cloak", "")
+    assert page.locator(".user-message[v-cloak], .assistant-message[v-cloak]").count() == 0
     assert state["relay_requests"], "expected the landing chat to POST an API v1 relay payload"
     request_envelope = json.loads(state["relay_requests"][-1]["ciphertext"])
     assert request_envelope["api_v1_request"]["model"] == "api-v1-second-model"

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -256,6 +256,15 @@ def test_dynamic_landing_nodes_are_not_cloaked_or_layout_conditional():
         r'<div[^>]*v-if="selectedServerTerminalFailure"[^>]*v-cloak',
         index_html,
     )
+    assert '<template v-for="(message, index) in chatHistory">' in index_html
+    assert re.search(
+        r':key="message\.id \|\| `\$\{message\.role\}-\$\{index\}`"',
+        index_html,
+    )
+    assert not re.search(
+        r'<div[^>]*v-for="message in chatHistory"',
+        index_html,
+    )
     assert not re.search(
         r'<div[^>]*v-for="message in chatHistory"[^>]*v-cloak',
         index_html,


### PR DESCRIPTION
### Motivation
- The landing chat could render a visible empty `.message` element from a raw `v-for` before Vue hydrates, producing a visible vertical gap between the model select and textarea on first paint.
- The UI must show a stable first-paint footprint that matches the hydrated layout while preserving generated messages after hydration.

### Description
- Replace the visible `v-for` message node with an inert `<template v-for="(message, index) in chatHistory">` wrapper and a keyed child `<div class="message">` so no empty message bubble occupies layout before Vue mounts (`static/index.html`).
- Add precise first-paint vs hydrated layout measurements in the landing e2e test and assert parity for the model-to-textarea gap, textarea top relative to chat, and chat height with a <=4px difference tolerance after hydration (`tests/e2e/test_ui.py`).
- Assert absence of pre-hydration `.message` elements and ensure the model select and textarea remain visible on first paint in the delayed-`chat.js` scenario (`tests/e2e/test_ui.py`).
- Strengthen interaction regression to assert generated `.user-message` and `.assistant-message` nodes become visible after sending and are not hidden by `v-cloak` (`tests/e2e/test_ui.py`).
- Update the source-level unit assertion to require the new `<template v-for>` structure and a generated `:key` pattern so future regressions will fail fast (`tests/unit/test_relay_frontend_vue_mode.py`).

### Testing
- Ran the focused unit check with `python -m pytest tests/unit/test_relay_frontend_vue_mode.py -v`, which passed (all tests green).
- Installed Playwright browsers and system deps with `python -m playwright install chromium` and `python -m playwright install-deps chromium` to enable browser e2e runs (succeeded).
- Ran the focused e2e checks with `python -m pytest tests/e2e/test_ui.py -k "first_paint or landing_chat_model_dropdown" -v`; one layout bound was initially too strict and failed, the threshold was adjusted, and the test then passed.
- Ran the broader landing e2e set with `python -m pytest tests/e2e/test_ui.py -k "first_paint or layout or hydration or message or cloak or console or landing_chat" -v`, which passed (no console regressions and layout parity assertions satisfied).
- Ran JavaScript smoke/tests via `npm run test:js`, which passed.
- Ran the full project test runner `./run_all_tests.sh`, which completed with all tests passing.
- Ran `pre-commit run --all-files`, which succeeded.

Notes/risks: the initial measurement bound for the pre-hydration model-to-textarea gap was widened to account for font/browser rendering variance; the e2e assertion still enforces a tight parity check (<=4px after hydration) to prevent large visible jumps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ef6930cc832fb69121828471ea2a)