### PR TITLE
Fix landing chat first-paint message layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -518,9 +518,15 @@
                     Start a new chat
                 </button>
             </div>
-            <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
-                <span v-html="renderMarkdown(getDisplayContent(message))"></span>
-            </div>
+            <template v-for="(message, index) in chatHistory">
+                <div
+                    :key="message.id || `${message.role}-${index}`"
+                    :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}"
+                    class="message"
+                >
+                    <span v-html="renderMarkdown(getDisplayContent(message))"></span>
+                </div>
+            </template>
             <div class="input-container">
                 <textarea
                     ref="messageInput"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -285,6 +285,29 @@ def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup
     assert metadata_api_calls == []
 
 
+def measure_landing_chat_layout(page: Page):
+    """Return layout metrics that should remain stable across Vue hydration."""
+    return page.evaluate(
+        """
+        () => {
+            const chat = document.querySelector('.chat-container');
+            const select = document.querySelector('[data-testid=landing-model-select]');
+            const textarea = document.querySelector('textarea.message-input');
+            if (!chat || !select || !textarea) {
+                throw new Error('missing landing chat layout node');
+            }
+            const chatRect = chat.getBoundingClientRect();
+            const selectRect = select.getBoundingClientRect();
+            const textareaRect = textarea.getBoundingClientRect();
+            return {
+                modelToTextareaGap: textareaRect.top - selectRect.bottom,
+                chatHeight: chatRect.height,
+                textareaTopRelativeToChat: textareaRect.top - chatRect.top,
+            };
+        }
+        """
+    )
+
 def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     page: Page, base_url: str, setup_servers
 ):
@@ -327,7 +350,12 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     expect(status).to_be_visible()
     expect(chat).to_be_visible()
     assert chat.bounding_box()["height"] >= 250
-    expect(page.locator("textarea.message-input")).to_be_visible()
+    message_nodes = page.locator(".message")
+    textarea = page.locator("textarea.message-input")
+    expect(textarea).to_be_visible()
+    assert message_nodes.count() == 0
+    first_paint_layout = measure_landing_chat_layout(page)
+    assert 20 <= first_paint_layout["modelToTextareaGap"] <= 70
     expect(send_button).to_be_visible()
     expect(send_button).to_be_disabled()
     expect(page.get_by_test_id("landing-model-select")).to_be_visible()
@@ -363,6 +391,11 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
         """
     )
     page.wait_for_load_state("networkidle")
+    hydrated_layout = measure_landing_chat_layout(page)
+    assert abs(hydrated_layout["modelToTextareaGap"] - first_paint_layout["modelToTextareaGap"]) <= 4
+    assert abs(hydrated_layout["textareaTopRelativeToChat"] - first_paint_layout["textareaTopRelativeToChat"]) <= 4
+    assert abs(hydrated_layout["chatHeight"] - first_paint_layout["chatHeight"]) <= 4
+    assert page.get_by_test_id("landing-model-select").input_value() == "llama-3.1-8b-instruct"
     assert_no_landing_console_regressions(errors)
 
 
@@ -715,8 +748,12 @@ def test_markdown_rendering_stream_updates(page: Page, base_url: str, setup_serv
     textarea.fill("Show markdown please")
     wait_for_landing_send_enabled(page).click()
 
+    user_message = page.locator(".user-message").last
+    user_message.wait_for(state="visible")
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
+    expect(user_message).not_to_have_attribute("v-cloak", "")
+    expect(assistant_message).not_to_have_attribute("v-cloak", "")
 
     assert assistant_message.locator("strong").inner_text() == "Bold"
 

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -256,8 +256,14 @@ def test_dynamic_landing_nodes_are_not_cloaked_or_layout_conditional():
         r'<div[^>]*v-if="selectedServerTerminalFailure"[^>]*v-cloak',
         index_html,
     )
+    assert '<template v-for="(message, index) in chatHistory">' in index_html
+    assert ':key="message.id || `${message.role}-${index}`"' in index_html
     assert not re.search(
-        r'<div[^>]*v-for="message in chatHistory"[^>]*v-cloak',
+        r'<div[^>]*v-for="message in chatHistory"',
+        index_html,
+    )
+    assert not re.search(
+        r'<div[^>]*class="message"[^>]*v-cloak|<div[^>]*v-cloak[^>]*class="message"',
         index_html,
     )
 

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -259,7 +259,7 @@ def test_dynamic_landing_nodes_are_not_cloaked_or_layout_conditional():
     assert '<template v-for="(message, index) in chatHistory">' in index_html
     assert ':key="message.id || `${message.role}-${index}`"' in index_html
     assert not re.search(
-        r'<div[^>]*v-for="message in chatHistory"',
+        r'<div\b(?=[^>]*\bv-for="[^"]*chatHistory[^"]*")[^>]*>',
         index_html,
     )
     assert not re.search(


### PR DESCRIPTION
### Motivation
- Prevent an empty pre-hydration `.message` bubble (Vue structural ghost) from affecting the landing chat first paint and causing a visible vertical gap between the model select and the textarea. 
- Add deterministic regression coverage that measures layout before and after Vue hydration so future changes cannot reintroduce the spacing jump.

### Description
- Replace the visible `div v-for=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ef79576c832fb1df58056c72e4d6)