### PR TITLE
Landing chat: remove pre-hydration .message ghosts and add first-paint layout tests

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -518,9 +518,15 @@
                     Start a new chat
                 </button>
             </div>
-            <div v-for="message in chatHistory" :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}" class="message">
-                <span v-html="renderMarkdown(getDisplayContent(message))"></span>
-            </div>
+            <template v-for="(message, index) in chatHistory">
+                <div
+                    :key="message.id || `${message.role}-${index}`"
+                    :class="{'user-message': message.role === 'user', 'assistant-message': message.role === 'assistant'}"
+                    class="message"
+                >
+                    <span v-html="renderMarkdown(getDisplayContent(message))"></span>
+                </div>
+            </template>
             <div class="input-container">
                 <textarea
                     ref="messageInput"

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -285,6 +285,30 @@ def test_release_badge_renders_without_api_call(page: Page, base_url: str, setup
     assert metadata_api_calls == []
 
 
+def measure_landing_chat_layout(page: Page) -> dict:
+    """Return key landing chat geometry used to catch first-paint hydration shifts."""
+    return page.evaluate(
+        """
+        () => {
+            const chat = document.querySelector('.chat-container');
+            const select = document.querySelector('[data-testid=landing-model-select]');
+            const textarea = document.querySelector('textarea.message-input');
+            if (!chat || !select || !textarea) {
+                throw new Error('landing chat layout nodes are missing');
+            }
+            const chatRect = chat.getBoundingClientRect();
+            const selectRect = select.getBoundingClientRect();
+            const textareaRect = textarea.getBoundingClientRect();
+            return {
+                modelToTextareaGap: textareaRect.top - selectRect.bottom,
+                chatHeight: chatRect.height,
+                textareaTopRelativeToChat: textareaRect.top - chatRect.top,
+            };
+        }
+        """
+    )
+
+
 def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     page: Page, base_url: str, setup_servers
 ):
@@ -332,6 +356,10 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
     expect(send_button).to_be_disabled()
     expect(page.get_by_test_id("landing-model-select")).to_be_visible()
     expect(page.get_by_test_id("landing-selected-server-failure")).not_to_be_visible()
+    assert page.locator(".message").count() == 0
+
+    first_paint_layout = measure_landing_chat_layout(page)
+    assert 20 <= first_paint_layout["modelToTextareaGap"] <= 45
 
     status_text = status.inner_text().strip()
     assert "Updated" not in status_text
@@ -363,6 +391,14 @@ def test_landing_first_paint_hides_vue_variables_when_chat_js_is_delayed(
         """
     )
     page.wait_for_load_state("networkidle")
+    assert page.get_by_test_id("landing-model-select").input_value() == "llama-3.1-8b-instruct"
+    assert "Live compute nodes: 1" in status.inner_text()
+
+    hydrated_layout = measure_landing_chat_layout(page)
+    assert abs(hydrated_layout["modelToTextareaGap"] - first_paint_layout["modelToTextareaGap"]) <= 4
+    assert abs(hydrated_layout["textareaTopRelativeToChat"] - first_paint_layout["textareaTopRelativeToChat"]) <= 4
+    assert hydrated_layout["chatHeight"] >= 250
+    assert abs(hydrated_layout["chatHeight"] - first_paint_layout["chatHeight"]) <= 4
     assert_no_landing_console_regressions(errors)
 
 
@@ -756,8 +792,12 @@ def test_landing_chat_uses_api_v1_only_non_streaming(
     textarea.fill("hello")
     wait_for_landing_send_enabled(page).click()
 
+    user_message = page.locator(".user-message").last
+    user_message.wait_for(state="visible")
     assistant_message = page.locator(".assistant-message").last
     assistant_message.wait_for(state="visible")
+    assert user_message.evaluate("node => !node.hasAttribute('v-cloak')")
+    assert assistant_message.evaluate("node => !node.hasAttribute('v-cloak')")
     page.wait_for_function(
         """
         ({ selector, expectedText }) => {

--- a/tests/unit/test_relay_frontend_vue_mode.py
+++ b/tests/unit/test_relay_frontend_vue_mode.py
@@ -256,8 +256,13 @@ def test_dynamic_landing_nodes_are_not_cloaked_or_layout_conditional():
         r'<div[^>]*v-if="selectedServerTerminalFailure"[^>]*v-cloak',
         index_html,
     )
+    assert '<template v-for="(message, index) in chatHistory">' in index_html
     assert not re.search(
-        r'<div[^>]*v-for="message in chatHistory"[^>]*v-cloak',
+        r'<div[^>]*v-for="message in chatHistory"',
+        index_html,
+    )
+    assert not re.search(
+        r'<div[^>]*v-for="\(message, index\) in chatHistory"[^>]*v-cloak',
         index_html,
     )
 


### PR DESCRIPTION
### Motivation
- The landing chat rendered a raw `v-for` message element in `static/index.html` before Vue hydrated, creating a visible vertical gap between the model select and textarea on first paint.
- The goal is to make first-paint layout match hydrated layout pixel‑perfectly (within a small threshold) without reintroducing v‑cloak or hiding hydrated messages.

### Description
- Replace the visible `div v-for="message in chatHistory"` with an inert `<template v-for="(message, index) in chatHistory">` wrapper so no empty `.message` node occupies layout before hydration (`static/index.html`).
- Add a reusable layout measurement helper `measure_landing_chat_layout(page)` and extend the delayed-`chat.js` first-paint test to assert no visible `.message` before hydration and tight geometry parity after hydration (`tests/e2e/test_ui.py`).
- Strengthen the interaction test to assert generated `.user-message` and `.assistant-message` nodes are visible after sending and are not hidden by `v-cloak` (Playwright assertions in `tests/e2e/test_ui.py`).
- Update the unit-level HTML guard to require the inert `<template v-for>` pattern and to reject raw `v-for` or cloaked message nodes in `static/index.html` (`tests/unit/test_relay_frontend_vue_mode.py`).

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_relay_frontend_vue_mode.py -v` — PASSED.
- Ran JavaScript tests: `npm run test:js` — PASSED.
- Ran full repo checks: `pre-commit run --all-files` and `./run_all_tests.sh` — PASSED (note `./run_all_tests.sh` skips full E2E by default on this environment so E2E tests were not executed there).
- Attempted to run targeted browser E2E: `python -m pytest tests/e2e/test_ui.py -k "first_paint or layout or hydration or message or cloak or console or landing_chat" -v` and focused runs for the two new/changed E2E tests, but these errored in this container due to Playwright/browser environment issues; steps taken:
  - `python -m playwright install chromium` — succeeded and downloaded browsers.
  - Running the Playwright tests still failed to launch Chromium due to a missing system library (`libatk-1.0.so.0`) in the container, causing Playwright `BrowserType.launch` errors; therefore E2E assertions could not be fully exercised here.

Residual notes and follow-ups
- The change is intentionally minimal and restricted to the listed files; it preserves all API v1 E2EE and relay guardrails.
- Remaining action: run the new E2E layout/hydration tests in a CI or developer environment that has Playwright browsers and required system libraries installed (or run with `RUN_E2E=1` in an environment where Playwright can launch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ef890e20832fa8a26139cfc09cb8)