### PR TITLE
Prevent desktop relay registration token fanout

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -714,6 +714,13 @@ def run(args: argparse.Namespace) -> int:
 
     runtime = make_runtime(relay_url)
     runtimes = [runtime] + [make_runtime(url, shared_runtime=runtime) for url in relay_urls[1:]]
+    for relay_runtime in runtimes[1:]:
+        relay_client = getattr(relay_runtime, "relay_client", None)
+        if relay_client is not None and hasattr(relay_client, "_registration_token"):
+            # The process-wide registration token belongs to the trusted primary relay.
+            # Secondary desktop relay pollers may include public, staging, or fallback
+            # relays, so fail closed by never forwarding that secret to them.
+            relay_client._registration_token = None
     for relay_runtime in runtimes:
         start_relay_session = getattr(relay_runtime, "start_relay_session", None)
         if callable(start_relay_session):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1447,6 +1447,69 @@ def test_run_passes_desktop_relay_list_to_runtime(monkeypatch):
     ]
 
 
+def test_run_clears_registration_token_for_secondary_desktop_relays(monkeypatch):
+    _reset_cancel_queue()
+    captured = []
+
+    class TokenRelayClient:
+        def __init__(self, relay_url):
+            self.relay_url = relay_url
+            self._registration_token = 'private-registration-token'
+
+    class CapturingRuntime:
+        def __init__(self, config, **_kwargs):
+            captured.append(self)
+            self.model_manager = FakeModelManager()
+            self.relay_client = TokenRelayClient(config.relay_url)
+
+        def ensure_model_ready(self):
+            return True
+
+        def ensure_api_v1_runtime_ready(self):
+            return self.ensure_model_ready()
+
+        def register_and_poll_once(self):
+            return {'next_ping_in_x_seconds': 0}
+
+        def process_relay_request(self, _payload):
+            return True
+
+        def stop(self):
+            return None
+
+    module = ModuleType('utils.compute_node_runtime')
+    module.ComputeNodeRuntimeConfig = lambda relay_url, relay_port, **kwargs: SimpleNamespace(
+        relay_url=relay_url,
+        relay_port=relay_port,
+        **kwargs,
+    )
+    module.ComputeNodeRuntime = CapturingRuntime
+    module.is_api_v1_relay_payload = lambda _payload: False
+    module.resolve_relay_port = lambda relay_port, _relay_url: relay_port
+    module.resolve_relay_url = lambda relay_url, **_kwargs: relay_url.strip()
+    module.normalize_compute_mode = lambda mode: mode
+    module.apply_compute_mode = lambda _model_manager, mode: mode
+    module.SUPPORTED_COMPUTE_MODES = {'auto', 'cpu', 'cuda', 'metal'}
+    module.compute_mode_diagnostics = lambda _model_manager: {}
+    monkeypatch.setitem(sys.modules, 'utils.compute_node_runtime', module)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url=['https://trusted.example', 'https://public.example'],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    assert [runtime.relay_client.relay_url for runtime in captured] == [
+        'https://trusted.example',
+        'https://public.example',
+    ]
+    assert captured[0].relay_client._registration_token == 'private-registration-token'
+    assert captured[1].relay_client._registration_token is None
 
 def test_normalize_relay_urls_accepts_repeated_json_and_comma_values():
     assert compute_node_bridge._normalize_relay_urls(


### PR DESCRIPTION
### Motivation
- Desktop multi-relay polling constructs a runtime per configured relay and inherited a single process-wide registration token, which could be sent to every configured relay and leak a private registration token to untrusted relays.
- The registration token must be scoped to the trusted primary relay to preserve the relay-blind E2EE registration trust boundary.

### Description
- Clear any inherited `_registration_token` on secondary relay runtimes before starting poller threads in `desktop-tauri/src-tauri/python/compute_node_bridge.py` so the global token is not forwarded to non-primary relays. 
- Add a unit test `test_run_clears_registration_token_for_secondary_desktop_relays` to `tests/unit/test_desktop_compute_node_bridge.py` that asserts the primary runtime keeps the private token while secondary runtimes have it cleared.
- The change is intentionally minimal and only affects desktop bridge runtime setup prior to poller startup.

### Testing
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py::test_run_clears_registration_token_for_secondary_desktop_relays` and it passed. 
- Ran `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py::test_run_passes_desktop_relay_list_to_runtime tests/unit/test_desktop_compute_node_bridge.py::test_run_clears_registration_token_for_secondary_desktop_relays` and both tests passed. 
- Ran `pre-commit run --all-files` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d29102c10832fb5f22750d7cb4498)