### PR TITLE
Add wildcard CORS for public API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,37 @@ All routes are served under `/api/v1` (preferred) and are also available at
 `/v1` for compatibility with standard OpenAI clients. Set the base URL to
 `https://token.place/api/v1`.
 
+#### Browser CORS for API v1
+
+API v1 is directly callable from browser applications on arbitrary origins.
+token.place owns this CORS contract in the application layer, so staging,
+production, and non-Sugarkube deployments return the same wildcard policy:
+`Access-Control-Allow-Origin: *`.
+
+Browser calls are non-credentialed: do not send cookies, token.place
+authorization headers, API keys, or bearer tokens. JSON `POST` clients should
+send `Content-Type: application/json`. API v2 remains outside the API v1 launch
+contract and does not inherit this browser CORS policy.
+
+Minimal browser example:
+
+```js
+const response = await fetch("https://token.place/api/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
+  body: JSON.stringify({
+    model: "llama-3.1-8b-instruct",
+    messages: [{ role: "user", content: "Hello from a browser app!" }],
+  }),
+});
+
+const completion = await response.json();
+console.log(completion);
+```
+
 #### List Models
 ```
 GET /api/v1/models

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -26,6 +26,14 @@ from config import get_config
 RATE_LIMIT_STORAGE_URI_ENV = "TOKENPLACE_RATE_LIMIT_STORAGE_URI"
 LOGGER = logging.getLogger("tokenplace.api")
 
+PUBLIC_API_V1_CORS_PREFIXES = ("/api/v1/", "/v1/")
+PUBLIC_API_V1_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Accept",
+    "Access-Control-Max-Age": "600",
+}
+
 CONTROL_PLANE_ROUTE_CLASS = "compute_node_control_plane"
 CONTROL_PLANE_DEFAULT_LIMIT_ENV = "API_RELAY_CONTROL_PLANE_RATE_LIMIT"
 CONTROL_PLANE_IP_LIMIT_ENV = "API_RELAY_CONTROL_PLANE_IP_RATE_LIMIT"
@@ -142,6 +150,8 @@ def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     """Return True when a route should not consume the public API quota."""
 
     normalized_path = _normalized_path(path)
+    if request.method == "OPTIONS" and _is_public_api_v1_cors_path(normalized_path):
+        return True
     if normalized_path in RATE_LIMIT_EXEMPT_PATHS:
         return True
     if normalized_path in CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS:
@@ -151,6 +161,38 @@ def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
         and normalized_path in RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS
         and _relay_server_token_is_valid()
     )
+
+
+def _is_public_api_v1_cors_path(path: str) -> bool:
+    """Return True when the fixed public API v1 browser CORS policy applies."""
+
+    return path.startswith(PUBLIC_API_V1_CORS_PREFIXES)
+
+
+def _install_public_api_v1_cors(app) -> None:
+    """Install application-owned wildcard CORS for public API v1 routes."""
+
+    @app.before_request
+    def _handle_public_api_v1_preflight():
+        if request.method != "OPTIONS" or not _is_public_api_v1_cors_path(request.path):
+            return None
+
+        response = app.response_class(status=204)
+        for header, value in PUBLIC_API_V1_CORS_HEADERS.items():
+            response.headers[header] = value
+        return response
+
+    @app.after_request
+    def _add_public_api_v1_cors_headers(response):
+        if not _is_public_api_v1_cors_path(request.path):
+            return response
+
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Expose-Headers"] = "Retry-After"
+        if request.method == "OPTIONS":
+            for header, value in PUBLIC_API_V1_CORS_HEADERS.items():
+                response.headers.setdefault(header, value)
+        return response
 
 
 def _resolve_rate_limit_storage_uri() -> str | None:
@@ -459,6 +501,8 @@ def _build_rate_limit_response(exc: RateLimitExceeded):
 
 def init_app(app):
     """Initialize the API with the Flask app."""
+
+    _install_public_api_v1_cors(app)
 
     limiter_storage_uri = _resolve_rate_limit_storage_uri()
     limiter_kwargs = {

--- a/tests/unit/test_api_v1_cors.py
+++ b/tests/unit/test_api_v1_cors.py
@@ -1,0 +1,150 @@
+"""Focused tests for public API v1 browser CORS behavior."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from flask import Flask, jsonify
+
+from api import init_app
+
+ORIGIN_ONE = "https://cors-smoke.invalid"
+ORIGIN_TWO = "https://another-browser.invalid"
+
+
+def _build_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        return "ok"
+
+    @app.route("/api/v1/meta")
+    def api_v1_meta():
+        return jsonify({"version": "test"})
+
+    init_app(app)
+    app.config["TESTING"] = True
+    return app
+
+
+def _preflight(client, path: str, origin: str = ORIGIN_ONE):
+    return client.options(
+        path,
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type, Accept",
+        },
+    )
+
+
+def _header_values(response, header_name: str) -> list[str]:
+    return [value.lower().strip() for value in response.headers.get(header_name, "").split(",")]
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "1/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_api_v1_chat_preflight_returns_literal_wildcard_without_credentials():
+    app = _build_app()
+
+    with app.test_client() as client:
+        response = _preflight(client, "/api/v1/chat/completions")
+
+    assert response.status_code == 204
+    assert response.data == b""
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert "post" in _header_values(response, "Access-Control-Allow-Methods")
+    assert "content-type" in _header_values(response, "Access-Control-Allow-Headers")
+    assert response.headers["Access-Control-Max-Age"] == "600"
+    assert "Access-Control-Allow-Credentials" not in response.headers
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "1/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_api_v1_cors_does_not_echo_or_allowlist_origins():
+    app = _build_app()
+
+    with app.test_client() as client:
+        first = _preflight(client, "/api/v1/chat/completions", ORIGIN_ONE)
+        second = _preflight(client, "/api/v1/chat/completions", ORIGIN_TWO)
+
+    assert first.headers["Access-Control-Allow-Origin"] == "*"
+    assert second.headers["Access-Control-Allow-Origin"] == "*"
+    assert first.headers["Access-Control-Allow-Origin"] != ORIGIN_ONE
+    assert second.headers["Access-Control-Allow-Origin"] != ORIGIN_TWO
+    assert "Access-Control-Allow-Credentials" not in first.headers
+    assert "Access-Control-Allow-Credentials" not in second.headers
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "10/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_api_v1_invalid_json_400_keeps_cors_and_exposes_retry_after():
+    app = _build_app()
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/v1/chat/completions",
+            data="{not-json",
+            content_type="application/json",
+            headers={"Origin": ORIGIN_ONE},
+        )
+
+    assert response.status_code == 400
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Expose-Headers"] == "Retry-After"
+    assert "Access-Control-Allow-Credentials" not in response.headers
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "10/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_api_v1_get_response_includes_cors():
+    app = _build_app()
+
+    with app.test_client() as client:
+        response = client.get("/api/v1/meta", headers={"Origin": ORIGIN_ONE})
+
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert "Access-Control-Allow-Credentials" not in response.headers
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "1/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_openai_v1_alias_has_same_cors_preflight_behavior():
+    app = _build_app()
+
+    with app.test_client() as client:
+        response = _preflight(client, "/v1/chat/completions")
+
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert "post" in _header_values(response, "Access-Control-Allow-Methods")
+    assert "content-type" in _header_values(response, "Access-Control-Allow-Headers")
+    assert "Access-Control-Allow-Credentials" not in response.headers
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "1/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_repeated_options_requests_do_not_consume_public_api_quota():
+    app = _build_app()
+
+    with app.test_client() as client:
+        preflights = [_preflight(client, "/api/v1/chat/completions") for _ in range(3)]
+        post_response = client.post("/api/v1/chat/completions", json={})
+
+    assert [response.status_code for response in preflights] == [204, 204, 204]
+    assert post_response.status_code != 429
+    assert post_response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+@patch.dict(os.environ, {"API_RATE_LIMIT": "10/hour", "API_DAILY_QUOTA": "1000/day"}, clear=True)
+def test_non_api_v1_paths_do_not_receive_public_api_v1_cors_policy():
+    app = _build_app()
+
+    with app.test_client() as client:
+        responses = [
+            client.options("/api/v2/chat/completions", headers={"Origin": ORIGIN_ONE}),
+            client.options("/v2/chat/completions", headers={"Origin": ORIGIN_ONE}),
+            client.options("/relay/api/v1/chat/completions", headers={"Origin": ORIGIN_ONE}),
+            client.get("/", headers={"Origin": ORIGIN_ONE}),
+        ]
+
+    for response in responses:
+        assert "Access-Control-Allow-Origin" not in response.headers
+        assert "Access-Control-Allow-Credentials" not in response.headers


### PR DESCRIPTION
### Motivation
- Allow browser clients on arbitrary origins to call API v1 and its OpenAI `/v1` aliases without credentials by owning the CORS contract in the application layer.
- Ensure preflight `OPTIONS` requests do not consume public API quota and that all API v1 responses (including errors and 429s) include the wildcard CORS headers.
- Preserve existing security invariants: no credentialed requests, no origin echoing, and no changes to API v2, streaming, or relay authentication.

### Description
- Added a small native Flask CORS implementation in `api/__init__.py` that applies only to `/api/v1/*` and `/v1/*`, using a literal `Access-Control-Allow-Origin: *`, allowed methods `GET, POST, OPTIONS`, allowed headers `Content-Type, Accept`, and `Access-Control-Max-Age: 600`.
- Installed early `OPTIONS` preflight handling (`before_request`) which returns a 204 empty response and an `after_request` hook that injects the wildcard CORS headers and `Access-Control-Expose-Headers: Retry-After` for actual responses.
- Exempted API v1 `OPTIONS` preflight paths from the public API rate limiter so repeated preflights do not consume quota while leaving all existing rate-limit behavior for real requests unchanged.
- Added focused tests at `tests/unit/test_api_v1_cors.py` covering preflight behavior, non-echo wildcard responses, invalid-JSON error responses retaining CORS, GET responses, `/v1` alias parity, quota-safety for repeated `OPTIONS`, and exclusions for `/api/v2`, `/v2`, `/relay/api/v1/*`, and `/`.
- Documented the API v1 browser CORS contract and added a minimal non-credentialed browser `fetch` example in `README.md`.

### Testing
- Ran focused CORS and contract tests with `pytest -q tests/unit/test_api_v1_cors.py tests/unit/test_api_v1_launch_contract.py` and observed: all tests passed (`18 passed`).
- Verified broader rate-limit coverage with `pytest -q tests/unit/test_rate_limit.py` and observed: all tests passed (`26 passed`).
- Ran repository checks and lint hooks with `pre-commit run --all-files` and observed the checks completed successfully (pre-commit hooks passed).
- Verified header occurrences with `rg -n "Access-Control-Allow-Origin|Access-Control-Allow-Credentials|Access-Control-Allow-Methods|Access-Control-Allow-Headers|OPTIONS" api tests README.md static` to ensure strings are present only where intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e7471ec8832f93ff8f6d7b9f4166)