### PR TITLE
Add wildcard CORS for public API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,30 @@ RTX 4090-class hardware, is documented in [docs/api_v2_model_catalog.md](docs/ap
 
 All routes are served under `/api/v1` (preferred) and are also available at
 `/v1` for compatibility with standard OpenAI clients. Set the base URL to
-`https://token.place/api/v1`.
+`https://token.place/api/v1`. API v1 is directly callable from browser
+applications on arbitrary origins: token.place returns
+`Access-Control-Allow-Origin: *` for public API v1 and `/v1` alias responses.
+Browser calls are non-credentialed and must not use cookies or token.place
+Authorization headers; JSON POST clients should send
+`Content-Type: application/json`. API v2 remains outside this API v1 browser
+launch contract.
+
+Minimal browser example:
+
+```js
+const response = await fetch("https://token.place/api/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
+  body: JSON.stringify({
+    model: "llama-3-8b-instruct",
+    messages: [{ role: "user", content: "Hello from a browser app!" }],
+  }),
+});
+const completion = await response.json();
+```
 
 #### List Models
 ```

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,7 +10,7 @@ import sys
 import time
 from typing import Any
 
-from flask import jsonify, request
+from flask import Response, jsonify, request
 from flask_limiter import Limiter
 from flask_limiter.errors import RateLimitExceeded
 from flask_limiter.util import get_remote_address
@@ -42,6 +42,36 @@ CONTROL_PLANE_ROUTE_DEFAULT_LIMITS = {
     "/api/v1/relay/responses": "1200/hour",
 }
 CONTROL_PLANE_IP_DEFAULT_LIMIT = "10000/hour"
+
+API_V1_CORS_ALLOWED_METHODS = "GET, POST, OPTIONS"
+API_V1_CORS_ALLOWED_HEADERS = "Content-Type, Accept"
+API_V1_CORS_MAX_AGE = "600"
+API_V1_CORS_EXPOSE_HEADERS = "Retry-After"
+
+
+def _is_public_api_v1_cors_path(path: str) -> bool:
+    """Return True for browser-callable public API v1 paths."""
+
+    return path.startswith("/api/v1/") or path.startswith("/v1/")
+
+
+def _apply_public_api_v1_cors_headers(response):
+    """Attach the fixed wildcard CORS contract to public API v1 responses."""
+
+    if _is_public_api_v1_cors_path(request.path):
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Expose-Headers"] = API_V1_CORS_EXPOSE_HEADERS
+    return response
+
+
+def _build_public_api_v1_preflight_response():
+    response = Response(status=204)
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = API_V1_CORS_ALLOWED_METHODS
+    response.headers["Access-Control-Allow-Headers"] = API_V1_CORS_ALLOWED_HEADERS
+    response.headers["Access-Control-Max-Age"] = API_V1_CORS_MAX_AGE
+    response.headers["Access-Control-Expose-Headers"] = API_V1_CORS_EXPOSE_HEADERS
+    return response
 
 # Paths that support operations, health checking, metrics scraping, and
 # diagnostics must not consume the public user API quota. Kubernetes readiness
@@ -140,6 +170,9 @@ def _relay_server_token_boundary_has_configured_token() -> bool:
 
 def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     """Return True when a route should not consume the public API quota."""
+
+    if request.method == "OPTIONS" and _is_public_api_v1_cors_path(path):
+        return True
 
     normalized_path = _normalized_path(path)
     if normalized_path in RATE_LIMIT_EXEMPT_PATHS:
@@ -459,6 +492,16 @@ def _build_rate_limit_response(exc: RateLimitExceeded):
 
 def init_app(app):
     """Initialize the API with the Flask app."""
+
+    @app.before_request
+    def _handle_public_api_v1_cors_preflight():
+        if request.method == "OPTIONS" and _is_public_api_v1_cors_path(request.path):
+            return _build_public_api_v1_preflight_response()
+        return None
+
+    @app.after_request
+    def _add_public_api_v1_cors_headers(response):
+        return _apply_public_api_v1_cors_headers(response)
 
     limiter_storage_uri = _resolve_rate_limit_storage_uri()
     limiter_kwargs = {

--- a/tests/unit/test_api_v1_cors.py
+++ b/tests/unit/test_api_v1_cors.py
@@ -1,0 +1,191 @@
+"""CORS contract tests for public browser-callable API v1 routes."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from flask import Flask
+
+from api import init_app
+
+
+def _fresh_client(*, rate_limit: str = "1000/hour"):
+    env = {
+        "API_RATE_LIMIT": rate_limit,
+        "API_DAILY_QUOTA": "10000/day",
+        "TOKENPLACE_RATE_LIMIT_STORAGE_URI": "memory://",
+    }
+    patcher = patch.dict(os.environ, env, clear=True)
+    patcher.start()
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    @app.route("/")
+    def index():
+        return "landing"
+
+    init_app(app)
+    client = app.test_client()
+    return client, patcher
+
+
+def _preflight(client, path: str, origin: str = "https://cors-smoke.invalid"):
+    return client.options(
+        path,
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type, accept",
+        },
+    )
+
+
+def _lower_header_tokens(value: str) -> set[str]:
+    return {token.strip().lower() for token in value.split(",") if token.strip()}
+
+
+def test_api_v1_preflight_returns_literal_wildcard_without_credentials():
+    client, patcher = _fresh_client()
+    try:
+        response = _preflight(client, "/api/v1/chat/completions")
+    finally:
+        patcher.stop()
+
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert "POST" in response.headers["Access-Control-Allow-Methods"]
+    allowed_headers = _lower_header_tokens(
+        response.headers["Access-Control-Allow-Headers"]
+    )
+    assert "content-type" in allowed_headers
+    assert "accept" in allowed_headers
+    assert "authorization" not in allowed_headers
+    assert "x-relay-server-token" not in allowed_headers
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+    assert response.headers["Access-Control-Max-Age"] == "600"
+
+
+def test_api_v1_preflight_does_not_echo_unrelated_origins():
+    client, patcher = _fresh_client()
+    try:
+        first = _preflight(
+            client, "/api/v1/chat/completions", "https://first.invalid"
+        )
+        second = _preflight(
+            client, "/api/v1/chat/completions", "https://second.invalid"
+        )
+    finally:
+        patcher.stop()
+
+    assert first.headers["Access-Control-Allow-Origin"] == "*"
+    assert second.headers["Access-Control-Allow-Origin"] == "*"
+
+
+def test_invalid_json_api_v1_post_keeps_wildcard_cors_on_api_owned_400():
+    client, patcher = _fresh_client()
+    try:
+        response = client.post(
+            "/api/v1/chat/completions",
+            data="{",
+            content_type="application/json",
+            headers={"Origin": "https://cors-smoke.invalid"},
+        )
+    finally:
+        patcher.stop()
+
+    assert response.status_code == 400
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+
+
+def test_get_api_v1_meta_includes_wildcard_cors():
+    import relay
+
+    relay.app.config["TESTING"] = True
+    with relay.app.test_client() as client:
+        response = client.get(
+            "/api/v1/meta", headers={"Origin": "https://cors-smoke.invalid"}
+        )
+
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+
+
+def test_openai_v1_alias_has_same_cors_behavior():
+    client, patcher = _fresh_client()
+    try:
+        preflight = _preflight(client, "/v1/chat/completions")
+        response = client.post(
+            "/v1/chat/completions",
+            data="{",
+            content_type="application/json",
+            headers={"Origin": "https://cors-smoke.invalid"},
+        )
+    finally:
+        patcher.stop()
+
+    assert preflight.status_code == 204
+    assert preflight.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.status_code == 400
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+
+
+def test_api_v1_rate_limit_429_keeps_wildcard_cors_and_exposes_retry_after():
+    client, patcher = _fresh_client(rate_limit="1/minute")
+    try:
+        assert client.get(
+            "/api/v1/models", headers={"Origin": "https://cors-smoke.invalid"}
+        ).status_code == 200
+        response = client.get(
+            "/api/v1/models", headers={"Origin": "https://cors-smoke.invalid"}
+        )
+    finally:
+        patcher.stop()
+
+    assert response.status_code == 429
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Expose-Headers"] == "Retry-After"
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+    assert response.headers.get("Retry-After") is not None
+
+
+def test_repeated_api_v1_options_do_not_consume_public_quota():
+    client, patcher = _fresh_client(rate_limit="1/minute")
+    try:
+        for _ in range(5):
+            assert _preflight(client, "/api/v1/chat/completions").status_code == 204
+        response = client.get("/api/v1/models")
+    finally:
+        patcher.stop()
+
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+def test_non_api_v1_routes_do_not_gain_public_api_v1_cors_policy():
+    client, patcher = _fresh_client()
+    try:
+        responses = [
+            client.options(
+                "/api/v2/chat/completions",
+                headers={"Origin": "https://cors-smoke.invalid"},
+            ),
+            client.options(
+                "/v2/chat/completions",
+                headers={"Origin": "https://cors-smoke.invalid"},
+            ),
+            client.options(
+                "/relay/api/v1/chat/completions",
+                headers={"Origin": "https://cors-smoke.invalid"},
+            ),
+            client.get("/", headers={"Origin": "https://cors-smoke.invalid"}),
+        ]
+    finally:
+        patcher.stop()
+
+    for response in responses:
+        assert response.headers.get("Access-Control-Allow-Origin") is None
+        assert response.headers.get("Access-Control-Allow-Credentials") is None


### PR DESCRIPTION
### Motivation
- Browser clients from arbitrary origins must be able to call the token.place public API v1 and OpenAI-compatible `/v1` aliases without relying on ingress or environment-specific CORS headers.
- CORS must be application-owned, not credentialed, and must not change API v1 authentication, rate-limits, streaming, or relay E2EE invariants.

### Description
- Implemented a small native Flask CORS helper in `api/__init__.py` that adds a literal `Access-Control-Allow-Origin: *` and exposes `Retry-After` for responses under `/api/v1/*` and `/v1/*` only.
- Added an early `OPTIONS` preflight handler registered in `init_app(app)` that returns a 204 with `Access-Control-Allow-Methods: GET, POST, OPTIONS`, `Access-Control-Allow-Headers: Content-Type, Accept`, and `Access-Control-Max-Age: 600` without invoking request quotas or route handlers.
- Ensured ordinary responses (successes and errors including 4xx/5xx/429) are augmented with the wildcard CORS header via an `after_request` hook and did not enable `Access-Control-Allow-Credentials`.
- Updated public docs in `README.md` with browser usage guidance and added focused tests in `tests/unit/test_api_v1_cors.py` that cover preflight, literal wildcard behavior, no credentials, alias `/v1` parity, 429 `Retry-After` exposure, quota-exempt OPTIONS, and exclusions for `/api/v2`, `/v2`, `/relay/api/v1`, and `/`.

### Testing
- Ran `pytest -q tests/unit/test_api_v1_cors.py tests/unit/test_api_v1_launch_contract.py` and the suite completed successfully (all tests passed).
- Ran `pytest -q tests/unit/test_rate_limit.py` and the rate-limit tests completed successfully (all tests passed).
- Verified code search with `rg -n "Access-Control-Allow-Origin|Access-Control-Allow-Credentials|Access-Control-Allow-Methods|Access-Control-Allow-Headers|OPTIONS" api tests README.md static` to confirm intended surface changes.
- Ran `pre-commit run --all-files` and project checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e72030a0832fa1d47c7931170b55)