### PR TITLE
Add wildcard CORS for API v1 browser clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,7 +967,24 @@ POST /api/v1/chat/completions
 # or
 POST /v1/chat/completions
 ```
-Creates a completion for chat messages.
+Creates a non-streaming completion for chat messages. API v1 can be called directly by browser applications from arbitrary origins: token.place returns `Access-Control-Allow-Origin: *` on public `/api/v1/*` and `/v1/*` responses. Browser calls are non-credentialed and must not use cookies or token.place authorization headers; JSON POST clients should send `Content-Type: application/json`. API v2 remains outside this API v1 browser launch contract.
+
+Minimal browser example:
+```js
+const response = await fetch("https://token.place/api/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
+  body: JSON.stringify({
+    model: "llama-3-8b-instruct",
+    messages: [{ role: "user", content: "Hello from a browser app!" }],
+  }),
+});
+
+const completion = await response.json();
+```
 
 Request body:
 ```json

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -72,6 +72,62 @@ CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS = frozenset(
 # preserving abuse limits.
 RELAY_CONTROL_PLANE_RATE_LIMIT_PATHS = frozenset(CONTROL_PLANE_ROUTE_LIMIT_ENVS)
 
+PUBLIC_API_V1_CORS_PREFIXES = ("/api/v1/", "/v1/")
+PUBLIC_API_V1_CORS_EXCLUDED_PREFIXES = ("/relay/api/v1/",)
+PUBLIC_API_V1_CORS_ALLOW_METHODS = "GET, POST, OPTIONS"
+PUBLIC_API_V1_CORS_ALLOW_HEADERS = "Content-Type, Accept"
+PUBLIC_API_V1_CORS_MAX_AGE = "600"
+
+
+def _is_public_api_v1_cors_path(path: str) -> bool:
+    """Return True when the public browser API v1 CORS policy applies."""
+
+    normalized_path = _normalized_path(path)
+    excluded = any(
+        normalized_path == prefix.rstrip("/") or normalized_path.startswith(prefix)
+        for prefix in PUBLIC_API_V1_CORS_EXCLUDED_PREFIXES
+    )
+    return not excluded and any(
+        normalized_path == prefix.rstrip("/") or normalized_path.startswith(prefix)
+        for prefix in PUBLIC_API_V1_CORS_PREFIXES
+    )
+
+
+def _add_public_api_v1_cors_headers(response):
+    """Attach non-credentialed wildcard CORS headers for public API v1."""
+
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Expose-Headers"] = "Retry-After"
+    return response
+
+
+def _build_public_api_v1_preflight_response():
+    response = jsonify()
+    response.set_data(b"")
+    response.status_code = 204
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = PUBLIC_API_V1_CORS_ALLOW_METHODS
+    response.headers["Access-Control-Allow-Headers"] = PUBLIC_API_V1_CORS_ALLOW_HEADERS
+    response.headers["Access-Control-Max-Age"] = PUBLIC_API_V1_CORS_MAX_AGE
+    response.headers["Access-Control-Expose-Headers"] = "Retry-After"
+    return response
+
+
+def _install_public_api_v1_cors(app) -> None:
+    """Install application-owned wildcard CORS for public API v1 routes."""
+
+    @app.before_request
+    def _handle_public_api_v1_cors_preflight():
+        if request.method == "OPTIONS" and _is_public_api_v1_cors_path(request.path):
+            return _build_public_api_v1_preflight_response()
+        return None
+
+    @app.after_request
+    def _apply_public_api_v1_cors(response):
+        if _is_public_api_v1_cors_path(request.path):
+            return _add_public_api_v1_cors_headers(response)
+        return response
+
 
 def _normalized_path(path: str) -> str:
     return path.rstrip("/") or "/"
@@ -135,7 +191,10 @@ def _relay_server_token_is_valid() -> bool:
 def _relay_server_token_boundary_has_configured_token() -> bool:
     """Return True only when this request matched an explicit relay token."""
 
-    return bool(_load_relay_server_registration_tokens()) and _relay_server_token_is_valid()
+    return (
+        bool(_load_relay_server_registration_tokens())
+        and _relay_server_token_is_valid()
+    )
 
 
 def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
@@ -145,6 +204,8 @@ def _is_public_api_rate_limit_exempt_path(path: str) -> bool:
     if normalized_path in RATE_LIMIT_EXEMPT_PATHS:
         return True
     if normalized_path in CLIENT_RELAY_READ_RATE_LIMIT_EXEMPT_PATHS:
+        return True
+    if request.method == "OPTIONS" and _is_public_api_v1_cors_path(normalized_path):
         return True
     return (
         request.method == "POST"
@@ -459,6 +520,8 @@ def _build_rate_limit_response(exc: RateLimitExceeded):
 
 def init_app(app):
     """Initialize the API with the Flask app."""
+
+    _install_public_api_v1_cors(app)
 
     limiter_storage_uri = _resolve_rate_limit_storage_uri()
     limiter_kwargs = {

--- a/static/index.html
+++ b/static/index.html
@@ -561,6 +561,20 @@
         <p>OpenAI-compatible aliases are also registered at <code>/v1/models</code>, <code>/v1/models/{model_id}</code>, <code>/v1/public-key</code>, <code>/v1/public-key/rotate</code>, <code>/v1/chat/completions</code>, <code>/v1/completions</code>, <code>/v1/images/generations</code>, <code>/v1/health</code>, and <code>/v1/relay/unregister</code>.</p>
 
         <h3>Public/client API v1 launch contract</h3>
+        <p>Public API v1 routes under <code>/api/v1/*</code> and OpenAI-compatible <code>/v1/*</code> aliases are directly callable by browser applications from arbitrary origins. token.place owns this CORS contract in the application and returns <code>Access-Control-Allow-Origin: *</code>; calls are non-credentialed and must not use cookies or token.place authorization headers. JSON POST clients should send <code>Content-Type: application/json</code>. API v2 remains outside this launch contract.</p>
+        <p><strong>Minimal browser fetch:</strong></p>
+        <pre>const response = await fetch("https://token.place/api/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json"
+  },
+  body: JSON.stringify({
+    model: "llama-3-8b-instruct",
+    messages: [{ role: "user", content: "Hello from a browser app!" }]
+  })
+});
+const completion = await response.json();</pre>
 
         <div class="api-endpoint">
             <h3><span class="api-method method-get">GET</span> <span class="api-path">/api/v1/models</span></h3>

--- a/tests/unit/test_api_v1_cors.py
+++ b/tests/unit/test_api_v1_cors.py
@@ -1,0 +1,154 @@
+"""Focused CORS contract tests for public API v1 browser clients."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from api import init_app
+
+UNRELATED_ORIGIN = "https://cors-smoke.invalid"
+SECOND_ORIGIN = "https://second-cors-smoke.invalid"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("API_RATE_LIMIT", "2/hour")
+    monkeypatch.setenv("API_DAILY_QUOTA", "100/day")
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    init_app(app)
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def _preflight(client, path: str, origin: str = UNRELATED_ORIGIN):
+    return client.open(
+        path,
+        method="OPTIONS",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type, Accept",
+        },
+    )
+
+
+def _assert_no_credentials(response):
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+
+
+def test_api_v1_chat_preflight_returns_literal_wildcard(client):
+    response = _preflight(client, "/api/v1/chat/completions")
+
+    assert response.status_code == 204
+    assert response.data == b""
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert "POST" in response.headers["Access-Control-Allow-Methods"]
+    assert "content-type" in response.headers["Access-Control-Allow-Headers"].lower()
+    assert response.headers["Access-Control-Max-Age"] == "600"
+    _assert_no_credentials(response)
+
+
+def test_api_v1_preflight_does_not_echo_or_allowlist_origin(client):
+    first = _preflight(client, "/api/v1/chat/completions", UNRELATED_ORIGIN)
+    second = _preflight(client, "/api/v1/chat/completions", SECOND_ORIGIN)
+
+    assert first.headers["Access-Control-Allow-Origin"] == "*"
+    assert second.headers["Access-Control-Allow-Origin"] == "*"
+    assert (
+        first.headers["Access-Control-Allow-Origin"]
+        == second.headers["Access-Control-Allow-Origin"]
+    )
+    _assert_no_credentials(first)
+    _assert_no_credentials(second)
+
+
+def test_api_v1_validation_error_includes_wildcard_cors(client):
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={},
+        headers={"Origin": UNRELATED_ORIGIN},
+    )
+
+    assert response.status_code == 400
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Expose-Headers"] == "Retry-After"
+    _assert_no_credentials(response)
+
+
+def test_api_v1_get_response_includes_wildcard_cors(client):
+    response = client.get("/api/v1/models", headers={"Origin": UNRELATED_ORIGIN})
+
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    _assert_no_credentials(response)
+
+
+def test_openai_v1_alias_has_same_cors_behavior(client):
+    preflight = _preflight(client, "/v1/chat/completions", SECOND_ORIGIN)
+    post = client.post(
+        "/v1/chat/completions",
+        json={},
+        headers={"Origin": SECOND_ORIGIN},
+    )
+
+    assert preflight.status_code == 204
+    assert preflight.headers["Access-Control-Allow-Origin"] == "*"
+    assert post.status_code == 400
+    assert post.headers["Access-Control-Allow-Origin"] == "*"
+    _assert_no_credentials(preflight)
+    _assert_no_credentials(post)
+
+
+def test_repeated_options_requests_do_not_consume_public_quota(client):
+    for _ in range(8):
+        response = _preflight(client, "/api/v1/chat/completions")
+        assert response.status_code == 204
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    first_post = client.post(
+        "/api/v1/chat/completions",
+        json={},
+        headers={"Origin": UNRELATED_ORIGIN},
+    )
+    second_post = client.post(
+        "/api/v1/chat/completions",
+        json={},
+        headers={"Origin": UNRELATED_ORIGIN},
+    )
+    limited_post = client.post(
+        "/api/v1/chat/completions",
+        json={},
+        headers={"Origin": UNRELATED_ORIGIN},
+    )
+
+    assert first_post.status_code == 400
+    assert second_post.status_code == 400
+    assert limited_post.status_code == 429
+    assert limited_post.headers["Access-Control-Allow-Origin"] == "*"
+    assert limited_post.headers["Access-Control-Expose-Headers"] == "Retry-After"
+    _assert_no_credentials(limited_post)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v2/chat/completions",
+        "/v2/chat/completions",
+        "/relay/api/v1/chat/completions",
+        "/",
+    ],
+)
+def test_non_public_api_v1_paths_do_not_gain_wildcard_policy(client, path):
+    with patch("api.v2.routes.get_model_instance", return_value=object()), patch(
+        "api.v2.routes.generate_response", return_value="hello"
+    ):
+        response = client.open(
+            path, method="OPTIONS", headers={"Origin": UNRELATED_ORIGIN}
+        )
+
+    assert "Access-Control-Allow-Origin" not in response.headers
+    assert "Access-Control-Allow-Credentials" not in response.headers


### PR DESCRIPTION
### Motivation
- Make token.place public API v1 and OpenAI-compatible `/v1/*` aliases directly callable from browser applications on arbitrary origins by owning the CORS contract in the application rather than relying on ingress.
- Preserve existing security and rate-limit invariants by keeping API v2, relay lifecycle routes, credentialed requests, and relay E2EE semantics unchanged while ensuring preflight OPTIONS do not consume public API quota.

### Description
- Add a small native Flask CORS helper in `api/__init__.py` that registers an early `OPTIONS` preflight handler and an `after_request` hook that attaches `Access-Control-Allow-Origin: *` and `Access-Control-Expose-Headers: Retry-After` to `/api/v1/*` and `/v1/*` responses while excluding `/relay/api/v1/*` and API v2 routes.
- The preflight response supports `GET, POST, OPTIONS`, allows `Content-Type` and `Accept` headers, sets `Access-Control-Max-Age: 600`, returns a 204 with an empty body, and deliberately does not enable credentials.
- OPTIONS matching the public API v1 prefixes are exempted from the public user rate quota so preflights do not consume API quota and do not trigger 429s; normal rate limiting and Retry-After exposure remain unchanged for actual requests.
- Add focused unit tests `tests/unit/test_api_v1_cors.py` covering literal wildcard preflight behavior, non-echoing wildcard responses for multiple origins, validation/error responses including wildcard CORS, GET responses, `/v1` aliases, repeated OPTIONS not consuming quota, and ensuring API v2/relay/root paths are unaffected; update `README.md` and `static/index.html` with a minimal non-credentialed browser `fetch` example.

### Testing
- Ran the focused CORS and launch contract tests: `pytest -q tests/unit/test_api_v1_cors.py tests/unit/test_api_v1_launch_contract.py` and they passed (all tests green). ✅
- Ran the rate-limit suite: `pytest -q tests/unit/test_rate_limit.py` and it passed (all tests green). ✅
- Searched for CORS headers and related tokens: `rg -n "Access-Control-Allow-Origin|Access-Control-Allow-Credentials|Access-Control-Allow-Methods|Access-Control-Allow-Headers|OPTIONS" api tests README.md static` and verified the expected additions are present. ✅
- Ran repository checks: `pre-commit run --all-files` and it completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e74078cc832fbb75957838017c12)