### PR TITLE
Clarify relay-only upstream health reporting

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -550,11 +550,16 @@ Interpretation:
 - `knownServers: 0` means no registered external compute nodes yet (expected before node registration).
 - `activeUpstreamServers: []` means the relay-only process is not actively using the compatibility fallback pool for readiness.
 - `requiredUpstreamServers: []` plus `upstreamHealthRequired: false` means readiness does not depend on `https://token.place` or any other upstream.
+- If `TOKENPLACE_RELAY_UPSTREAM_URL` is set, that explicit runtime upstream is
+  reported in `activeUpstreamServers` even when compatibility/default config
+  still lists `https://token.place`.
 - When `upstreamHealthRequired: true`, `requiredUpstreamServers` reports the concrete
   `upstream` URL that `/healthz` actually checks, not every URL retained in the
   compatibility/configured upstream pool.
-- `configuredUpstreamServers` is retained as a stable compatibility key.
-- `legacyConfiguredUpstreamServers` represents compatibility/default config, not a required staging dependency.
+- `configuredUpstreamServers` is retained as a stable compatibility key and can
+  differ from the explicit runtime upstream.
+- `legacyConfiguredUpstreamServers` represents compatibility/default config, not
+  active runtime state or a required staging dependency.
 - Operators should rely on `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`, `requiredUpstreamServers`, and registered compute-node counts when judging relay-only readiness.
 
 ## Guardrails

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -550,6 +550,9 @@ Interpretation:
 - `knownServers: 0` means no registered external compute nodes yet (expected before node registration).
 - `activeUpstreamServers: []` means the relay-only process is not actively using the compatibility fallback pool for readiness.
 - `requiredUpstreamServers: []` plus `upstreamHealthRequired: false` means readiness does not depend on `https://token.place` or any other upstream.
+- When `upstreamHealthRequired: true`, `requiredUpstreamServers` reports the concrete
+  `upstream` URL that `/healthz` actually checks, not every URL retained in the
+  compatibility/configured upstream pool.
 - `configuredUpstreamServers` is retained as a stable compatibility key.
 - `legacyConfiguredUpstreamServers` represents compatibility/default config, not a required staging dependency.
 - Operators should rely on `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`, `requiredUpstreamServers`, and registered compute-node counts when judging relay-only readiness.

--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -536,6 +536,8 @@ After (explicit relay-only semantics):
   "relayOnly": true,
   "upstreamHealthRequired": false,
   "knownServers": 0,
+  "activeUpstreamServers": [],
+  "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
   "legacyConfiguredUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
@@ -546,8 +548,11 @@ After (explicit relay-only semantics):
 Interpretation:
 - `status: ok` reflects relay process readiness.
 - `knownServers: 0` means no registered external compute nodes yet (expected before node registration).
+- `activeUpstreamServers: []` means the relay-only process is not actively using the compatibility fallback pool for readiness.
+- `requiredUpstreamServers: []` plus `upstreamHealthRequired: false` means readiness does not depend on `https://token.place` or any other upstream.
 - `configuredUpstreamServers` is retained as a stable compatibility key.
 - `legacyConfiguredUpstreamServers` represents compatibility/default config, not a required staging dependency.
+- Operators should rely on `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`, `requiredUpstreamServers`, and registered compute-node counts when judging relay-only readiness.
 
 ## Guardrails
 

--- a/relay.py
+++ b/relay.py
@@ -309,6 +309,16 @@ def _has_explicit_relay_upstream_config(configured_servers: List[str] | None = N
     return False
 
 
+def _required_upstream_health_servers() -> List[str]:
+    """Return upstream resources actually checked when upstream health is required."""
+
+    upstream_url = app.config.get("upstream_url")
+    if not isinstance(upstream_url, str):
+        return []
+    upstream_url = upstream_url.strip()
+    return [upstream_url] if upstream_url else []
+
+
 def _load_upstream_config() -> Dict[str, Any]:
     upstream_override = os.environ.get(UPSTREAM_URL_ENV)
     parsed_host = None
@@ -809,7 +819,9 @@ def healthz():
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
     active_upstream_servers = [] if relay_only_mode else configured_servers
-    required_upstream_servers = configured_servers if require_upstream_health else []
+    required_upstream_servers = (
+        _required_upstream_health_servers() if require_upstream_health else []
+    )
     status = {
         "status": "ok",
         "upstream": app.config.get("upstream_url"),
@@ -1074,7 +1086,9 @@ def relay_diagnostics():
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
     active_upstream_servers = [] if relay_only_mode else configured_servers
-    required_upstream_servers = configured_servers if require_upstream_health else []
+    required_upstream_servers = (
+        _required_upstream_health_servers() if require_upstream_health else []
+    )
     diagnostics = {
         "relay_only": relay_only_mode,
         "upstream_health_required": require_upstream_health,

--- a/relay.py
+++ b/relay.py
@@ -319,6 +319,36 @@ def _required_upstream_health_servers() -> List[str]:
     return [upstream_url] if upstream_url else []
 
 
+def _active_upstream_reporting_servers(
+    configured_servers: List[str],
+    *,
+    relay_only_mode: bool,
+) -> List[str]:
+    """Return upstream resources that represent the active relay runtime path."""
+
+    if relay_only_mode:
+        return []
+    if os.environ.get(UPSTREAM_URL_ENV, "").strip():
+        return _required_upstream_health_servers()
+    return configured_servers
+
+
+def _legacy_configured_upstream_reporting_servers(
+    configured_servers: List[str],
+    *,
+    explicit_upstream_config: bool,
+) -> List[str]:
+    """Return compatibility/default upstream config without relabeling custom pools."""
+
+    if (
+        explicit_upstream_config
+        and _normalise_upstream_server_pool(configured_servers)
+        != _normalise_upstream_server_pool(["https://token.place"])
+    ):
+        return []
+    return configured_servers
+
+
 def _load_upstream_config() -> Dict[str, Any]:
     upstream_override = os.environ.get(UPSTREAM_URL_ENV)
     parsed_host = None
@@ -818,7 +848,10 @@ def healthz():
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
-    active_upstream_servers = [] if relay_only_mode else configured_servers
+    active_upstream_servers = _active_upstream_reporting_servers(
+        configured_servers,
+        relay_only_mode=relay_only_mode,
+    )
     required_upstream_servers = (
         _required_upstream_health_servers() if require_upstream_health else []
     )
@@ -834,7 +867,12 @@ def healthz():
         "registeredServers": _live_server_diagnostics(),
     }
     status["configuredUpstreamServers"] = configured_servers
-    status["legacyConfiguredUpstreamServers"] = [] if explicit_upstream_config else configured_servers
+    status["legacyConfiguredUpstreamServers"] = (
+        _legacy_configured_upstream_reporting_servers(
+            configured_servers,
+            explicit_upstream_config=explicit_upstream_config,
+        )
+    )
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -1085,7 +1123,10 @@ def relay_diagnostics():
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
-    active_upstream_servers = [] if relay_only_mode else configured_servers
+    active_upstream_servers = _active_upstream_reporting_servers(
+        configured_servers,
+        relay_only_mode=relay_only_mode,
+    )
     required_upstream_servers = (
         _required_upstream_health_servers() if require_upstream_health else []
     )
@@ -1099,7 +1140,12 @@ def relay_diagnostics():
         "api_v1_registered_compute_nodes": api_v1_live_nodes,
         "total_api_v1_registered_compute_nodes": len(api_v1_live_nodes),
         "configured_upstream_servers": configured_servers,
-        "legacy_configured_upstream_servers": [] if explicit_upstream_config else configured_servers,
+        "legacy_configured_upstream_servers": (
+            _legacy_configured_upstream_reporting_servers(
+                configured_servers,
+                explicit_upstream_config=explicit_upstream_config,
+            )
+        ),
     }
     response = jsonify(diagnostics)
     response.headers["Cache-Control"] = "no-store"

--- a/relay.py
+++ b/relay.py
@@ -808,11 +808,15 @@ def healthz():
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
     status = {
         "status": "ok",
         "upstream": app.config.get("upstream_url"),
         "upstreamHealthRequired": require_upstream_health,
         "relayOnly": relay_only_mode,
+        "activeUpstreamServers": active_upstream_servers,
+        "requiredUpstreamServers": required_upstream_servers,
         "gpuHost": gpu_host,
         "knownServers": len(known_servers),
         "registeredServers": _live_server_diagnostics(),
@@ -1068,9 +1072,14 @@ def relay_diagnostics():
     configured_servers = app.config.get("relay_configured_servers", [])
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
+    relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
     diagnostics = {
-        "relay_only": (not require_upstream_health) and (not explicit_upstream_config),
+        "relay_only": relay_only_mode,
         "upstream_health_required": require_upstream_health,
+        "active_upstream_servers": active_upstream_servers,
+        "required_upstream_servers": required_upstream_servers,
         "registered_compute_nodes": live_nodes,
         "total_registered_compute_nodes": len(live_nodes),
         "api_v1_registered_compute_nodes": api_v1_live_nodes,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1303,6 +1303,9 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
 def test_healthz_requires_upstream_health_when_env_enabled(client, monkeypatch):
     """healthz should degrade when upstream resolution is required and fails."""
     monkeypatch.setitem(app.config, "gpu_host", "definitely-not-resolvable.invalid")
+    monkeypatch.setitem(
+        app.config, "upstream_url", "http://definitely-not-resolvable.invalid:3000"
+    )
     monkeypatch.setattr(relay_module, "_can_resolve_gpu_host", lambda _host: False)
     monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "1")
     monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
@@ -1315,9 +1318,35 @@ def test_healthz_requires_upstream_health_when_env_enabled(client, monkeypatch):
     assert payload["upstreamHealthRequired"] is True
     assert payload["relayOnly"] is False
     assert payload["activeUpstreamServers"] == ["https://token.place"]
-    assert payload["requiredUpstreamServers"] == ["https://token.place"]
+    assert payload["requiredUpstreamServers"] == [
+        "http://definitely-not-resolvable.invalid:3000"
+    ]
     assert payload["details"]["gpuHostResolution"] == "failed"
 
+
+def test_healthz_required_upstreams_report_checked_upstream_url(client, monkeypatch):
+    """Required upstreams should name the checked URL, not the configured pool."""
+    monkeypatch.setitem(app.config, "gpu_host", "gpu-server")
+    monkeypatch.setitem(app.config, "upstream_url", "http://gpu-server:3000")
+    monkeypatch.setattr(relay_module, "_can_resolve_gpu_host", lambda _host: True)
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "1")
+    monkeypatch.setenv("TOKEN_PLACE_RELAY_UPSTREAMS", "https://node-a")
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://node-a"])
+
+    response = client.get("/healthz")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["status"] == "ok"
+    assert payload["activeUpstreamServers"] == ["https://node-a"]
+    assert payload["requiredUpstreamServers"] == ["http://gpu-server:3000"]
+
+    diagnostics_response = client.get("/relay/diagnostics")
+    diagnostics_payload = diagnostics_response.get_json()
+
+    assert diagnostics_response.status_code == 200
+    assert diagnostics_payload["active_upstream_servers"] == ["https://node-a"]
+    assert diagnostics_payload["required_upstream_servers"] == ["http://gpu-server:3000"]
 
 def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeypatch):
     """Staging relay-only health should be OK with zero registered external nodes."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1171,6 +1171,7 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
     configured_servers = ["https://configured-one.example.com:8000"]
     monkeypatch.setitem(app.config, "relay_configured_servers", configured_servers)
     monkeypatch.setenv("TOKENPLACE_RELAY_UPSTREAM_URL", "https://gpu.example.com:5015")
+    monkeypatch.setitem(app.config, "upstream_url", "https://gpu.example.com:5015")
 
     response = client.get("/relay/diagnostics")
     payload = response.get_json()
@@ -1178,7 +1179,7 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
     assert payload["legacy_configured_upstream_servers"] == []
-    assert payload["active_upstream_servers"] == configured_servers
+    assert payload["active_upstream_servers"] == ["https://gpu.example.com:5015"]
     assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
     assert payload["upstream_health_required"] is False
@@ -1347,6 +1348,87 @@ def test_healthz_required_upstreams_report_checked_upstream_url(client, monkeypa
     assert diagnostics_response.status_code == 200
     assert diagnostics_payload["active_upstream_servers"] == ["https://node-a"]
     assert diagnostics_payload["required_upstream_servers"] == ["http://gpu-server:3000"]
+
+
+def test_explicit_runtime_upstream_reports_active_without_required_dependency(
+    client, monkeypatch
+):
+    """Env runtime upstream should be active without making fallback config required."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_UPSTREAM_URL", "https://gpu.example.test:3000")
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.setitem(app.config, "upstream_url", "https://gpu.example.test:3000")
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+
+    response = client.get("/healthz")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["relayOnly"] is False
+    assert payload["upstreamHealthRequired"] is False
+    assert payload["activeUpstreamServers"] == ["https://gpu.example.test:3000"]
+    assert payload["requiredUpstreamServers"] == []
+    assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+
+    diagnostics_response = client.get("/relay/diagnostics")
+    diagnostics_payload = diagnostics_response.get_json()
+
+    assert diagnostics_response.status_code == 200
+    assert diagnostics_payload["relay_only"] is False
+    assert diagnostics_payload["upstream_health_required"] is False
+    assert diagnostics_payload["active_upstream_servers"] == [
+        "https://gpu.example.test:3000"
+    ]
+    assert diagnostics_payload["required_upstream_servers"] == []
+    assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
+    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
+        "https://token.place"
+    ]
+
+
+def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
+    client, monkeypatch
+):
+    """Required health should name only the env upstream URL that readiness checks."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_UPSTREAM_URL", "https://gpu.example.test:3000")
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "1")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.setitem(app.config, "gpu_host", "gpu.example.test")
+    monkeypatch.setitem(app.config, "upstream_url", "https://gpu.example.test:3000")
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+    monkeypatch.setattr(relay_module, "_can_resolve_gpu_host", lambda _host: True)
+
+    response = client.get("/healthz")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["relayOnly"] is False
+    assert payload["upstreamHealthRequired"] is True
+    assert payload["activeUpstreamServers"] == ["https://gpu.example.test:3000"]
+    assert payload["requiredUpstreamServers"] == ["https://gpu.example.test:3000"]
+    assert "https://token.place" not in payload["requiredUpstreamServers"]
+    assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+
+    diagnostics_response = client.get("/relay/diagnostics")
+    diagnostics_payload = diagnostics_response.get_json()
+
+    assert diagnostics_response.status_code == 200
+    assert diagnostics_payload["active_upstream_servers"] == [
+        "https://gpu.example.test:3000"
+    ]
+    assert diagnostics_payload["required_upstream_servers"] == [
+        "https://gpu.example.test:3000"
+    ]
+    assert "https://token.place" not in diagnostics_payload["required_upstream_servers"]
+    assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
+    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
+        "https://token.place"
+    ]
+
 
 def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeypatch):
     """Staging relay-only health should be OK with zero registered external nodes."""

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1041,6 +1041,8 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
     payload = response.get_json()
 
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
+    assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
+    assert payload["required_upstream_servers"] == []
     assert payload["legacy_configured_upstream_servers"] == []
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
@@ -1176,8 +1178,30 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == configured_servers
+    assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
     assert payload["upstream_health_required"] is False
+
+
+def test_relay_diagnostics_relay_only_reports_no_active_or_required_upstreams(client, monkeypatch):
+    """Relay-only diagnostics should separate legacy fallback config from readiness dependencies."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["relay_only"] is True
+    assert payload["upstream_health_required"] is False
+    assert payload["active_upstream_servers"] == []
+    assert payload["required_upstream_servers"] == []
+    assert payload["configured_upstream_servers"] == ["https://token.place"]
+    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
 
 
 def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
@@ -1209,6 +1233,8 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     payload = response.get_json()
 
     assert payload["configuredUpstreamServers"] == configured_servers
+    assert payload["activeUpstreamServers"] == configured_servers
+    assert payload["requiredUpstreamServers"] == []
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
     assert payload["legacyConfiguredUpstreamServers"] == []
@@ -1269,6 +1295,8 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["relayOnly"] is True
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("gpuHostResolution") != "failed"
 
 
@@ -1277,6 +1305,7 @@ def test_healthz_requires_upstream_health_when_env_enabled(client, monkeypatch):
     monkeypatch.setitem(app.config, "gpu_host", "definitely-not-resolvable.invalid")
     monkeypatch.setattr(relay_module, "_can_resolve_gpu_host", lambda _host: False)
     monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "1")
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
 
     response = client.get("/healthz")
     payload = response.get_json()
@@ -1285,6 +1314,8 @@ def test_healthz_requires_upstream_health_when_env_enabled(client, monkeypatch):
     assert payload["status"] == "degraded"
     assert payload["upstreamHealthRequired"] is True
     assert payload["relayOnly"] is False
+    assert payload["activeUpstreamServers"] == ["https://token.place"]
+    assert payload["requiredUpstreamServers"] == ["https://token.place"]
     assert payload["details"]["gpuHostResolution"] == "failed"
 
 
@@ -1309,6 +1340,8 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["upstreamHealthRequired"] is False
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
@@ -1325,6 +1358,8 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
 
     assert response.status_code == 200
     assert payload["relayOnly"] is True
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
@@ -1342,6 +1377,8 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
 
     assert response.status_code == 200
     assert payload["relayOnly"] is False
+    assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
+    assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
     assert payload["legacyConfiguredUpstreamServers"] == []
 


### PR DESCRIPTION
### Motivation
- Relay-only relay health output could be misinterpreted as actively depending on production `https://token.place` because legacy/config fields were present in `/healthz` and `/relay/diagnostics` without an explicit separation of active/required upstreams.
- The change makes relay-only semantics explicit so staging readiness is not mistaken for a prod upstream dependency while preserving backward-compatible fields.

### Description
- Add explicit `activeUpstreamServers` and `requiredUpstreamServers` to `/healthz` (camelCase) and `active_upstream_servers` and `required_upstream_servers` to `/relay/diagnostics` (snake_case) and compute them from existing `relayOnly`/`upstreamHealthRequired` logic.
- Preserve existing compatibility keys `configuredUpstreamServers`/`configured_upstream_servers` and `legacyConfiguredUpstreamServers`/`legacy_configured_upstream_servers` and leave `publicBaseUrl`, `relayOnly`, and `upstreamHealthRequired` behavior unchanged.
- Add focused tests in `tests/test_relay.py` to assert relay-only diagnostics report empty active/required upstreams while legacy/config fields remain present and to assert explicit upstream-required behavior when enabled.
- Update `docs/relay_sugarkube_onboarding.md` to document the new fields and to explain that compatibility/default upstreams may still list `https://token.place` without implying a readiness dependency.

### Testing
- Ran `pytest -q tests/test_relay.py` which completed successfully: `117 passed` (all relay tests passed). 
- Ran `pytest -q tests/unit/test_api_v1_launch_contract.py` which completed successfully: `11 passed`.
- Searched the code/docs for the new/related keys with `rg` to verify coverage of changes and documentation, which returned the updated occurrences.
- Ran `pre-commit run --all-files` which completed with all hooks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ec975eb4832fa63175974c1bb8e6)