### PR TITLE
Clarify relay-only upstream diagnostics

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -536,8 +536,11 @@ After (explicit relay-only semantics):
   "relayOnly": true,
   "upstreamHealthRequired": false,
   "knownServers": 0,
+  "activeUpstreamServers": [],
+  "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
   "legacyConfiguredUpstreamServers": ["https://token.place"],
+  "fallbackUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
   "details": {"knownServers": "empty"}
 }
@@ -546,8 +549,16 @@ After (explicit relay-only semantics):
 Interpretation:
 - `status: ok` reflects relay process readiness.
 - `knownServers: 0` means no registered external compute nodes yet (expected before node registration).
+- `activeUpstreamServers: []` and `requiredUpstreamServers: []` are the explicit signal that
+  relay-only staging is not actively dispatching to, or requiring readiness from, prod
+  `https://token.place`.
 - `configuredUpstreamServers` is retained as a stable compatibility key.
-- `legacyConfiguredUpstreamServers` represents compatibility/default config, not a required staging dependency.
+- `legacyConfiguredUpstreamServers` and `fallbackUpstreamServers` represent compatibility/default
+  fallback config, not a required staging dependency.
+- In `/relay/diagnostics`, use the snake_case equivalents (`relay_only`,
+  `upstream_health_required`, `active_upstream_servers`, `required_upstream_servers`, and
+  `legacy_configured_upstream_servers`) together with the registered compute-node counts to decide
+  whether a relay-only deployment has capacity.
 
 ## Guardrails
 

--- a/relay.py
+++ b/relay.py
@@ -309,6 +309,26 @@ def _has_explicit_relay_upstream_config(configured_servers: List[str] | None = N
     return False
 
 
+def _upstream_reporting_state(configured_servers: List[str]) -> Dict[str, Any]:
+    """Return explicit upstream dependency fields for health and diagnostics output."""
+
+    require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
+    explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
+    relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
+    legacy_configured_upstream_servers = [] if explicit_upstream_config else configured_servers
+    fallback_upstream_servers = legacy_configured_upstream_servers
+    return {
+        "relay_only": relay_only_mode,
+        "upstream_health_required": require_upstream_health,
+        "active_upstream_servers": active_upstream_servers,
+        "required_upstream_servers": required_upstream_servers,
+        "legacy_configured_upstream_servers": legacy_configured_upstream_servers,
+        "fallback_upstream_servers": fallback_upstream_servers,
+    }
+
+
 def _load_upstream_config() -> Dict[str, Any]:
     upstream_override = os.environ.get(UPSTREAM_URL_ENV)
     parsed_host = None
@@ -805,20 +825,22 @@ def healthz():
     _evict_stale_servers()
     gpu_host = app.config.get("gpu_host")
     configured_servers = app.config.get("relay_configured_servers", [])
-    require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
-    explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
-    relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    upstream_reporting = _upstream_reporting_state(configured_servers)
+    require_upstream_health = upstream_reporting["upstream_health_required"]
     status = {
         "status": "ok",
         "upstream": app.config.get("upstream_url"),
         "upstreamHealthRequired": require_upstream_health,
-        "relayOnly": relay_only_mode,
+        "relayOnly": upstream_reporting["relay_only"],
+        "activeUpstreamServers": upstream_reporting["active_upstream_servers"],
+        "requiredUpstreamServers": upstream_reporting["required_upstream_servers"],
+        "fallbackUpstreamServers": upstream_reporting["fallback_upstream_servers"],
         "gpuHost": gpu_host,
         "knownServers": len(known_servers),
         "registeredServers": _live_server_diagnostics(),
     }
     status["configuredUpstreamServers"] = configured_servers
-    status["legacyConfiguredUpstreamServers"] = [] if explicit_upstream_config else configured_servers
+    status["legacyConfiguredUpstreamServers"] = upstream_reporting["legacy_configured_upstream_servers"]
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -1066,17 +1088,19 @@ def relay_diagnostics():
     live_nodes = _live_server_diagnostics()
     api_v1_live_nodes = _live_server_diagnostics(api_v1_only=True)
     configured_servers = app.config.get("relay_configured_servers", [])
-    require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
-    explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
+    upstream_reporting = _upstream_reporting_state(configured_servers)
     diagnostics = {
-        "relay_only": (not require_upstream_health) and (not explicit_upstream_config),
-        "upstream_health_required": require_upstream_health,
+        "relay_only": upstream_reporting["relay_only"],
+        "upstream_health_required": upstream_reporting["upstream_health_required"],
+        "active_upstream_servers": upstream_reporting["active_upstream_servers"],
+        "required_upstream_servers": upstream_reporting["required_upstream_servers"],
+        "fallback_upstream_servers": upstream_reporting["fallback_upstream_servers"],
         "registered_compute_nodes": live_nodes,
         "total_registered_compute_nodes": len(live_nodes),
         "api_v1_registered_compute_nodes": api_v1_live_nodes,
         "total_api_v1_registered_compute_nodes": len(api_v1_live_nodes),
         "configured_upstream_servers": configured_servers,
-        "legacy_configured_upstream_servers": [] if explicit_upstream_config else configured_servers,
+        "legacy_configured_upstream_servers": upstream_reporting["legacy_configured_upstream_servers"],
     }
     response = jsonify(diagnostics)
     response.headers["Cache-Control"] = "no-store"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1042,6 +1042,9 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
 
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
+    assert payload["required_upstream_servers"] == []
+    assert payload["fallback_upstream_servers"] == []
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
     assert payload["total_registered_compute_nodes"] == 1
@@ -1176,8 +1179,32 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == configured_servers
+    assert payload["required_upstream_servers"] == []
+    assert payload["fallback_upstream_servers"] == []
     assert payload["relay_only"] is False
     assert payload["upstream_health_required"] is False
+
+
+def test_relay_diagnostics_staging_relay_only_reports_no_active_or_required_prod_upstream(client, monkeypatch):
+    """Relay-only diagnostics should separate default fallback config from active dependencies."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["relay_only"] is True
+    assert payload["upstream_health_required"] is False
+    assert payload["active_upstream_servers"] == []
+    assert payload["required_upstream_servers"] == []
+    assert payload["configured_upstream_servers"] == ["https://token.place"]
+    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
+    assert payload["fallback_upstream_servers"] == ["https://token.place"]
 
 
 def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
@@ -1212,6 +1239,9 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
     assert payload["legacyConfiguredUpstreamServers"] == []
+    assert payload["activeUpstreamServers"] == configured_servers
+    assert payload["requiredUpstreamServers"] == []
+    assert payload["fallbackUpstreamServers"] == []
     assert payload["registeredServers"][0]["server_public_key"] == live_server_key
     assert payload["registeredServers"][0]["age_seconds"] >= 0
     assert payload["registeredServers"][0]["queue_depth"] == 1
@@ -1269,6 +1299,9 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["relayOnly"] is True
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
+    assert payload["fallbackUpstreamServers"] == ["https://token.place"]
     assert payload.get("details", {}).get("gpuHostResolution") != "failed"
 
 
@@ -1309,6 +1342,9 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["upstreamHealthRequired"] is False
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
+    assert payload["fallbackUpstreamServers"] == ["https://token.place"]
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
@@ -1327,6 +1363,9 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
     assert payload["relayOnly"] is True
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
+    assert payload["fallbackUpstreamServers"] == ["https://token.place"]
 
 
 def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, monkeypatch):
@@ -1344,6 +1383,9 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
     assert payload["relayOnly"] is False
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
     assert payload["legacyConfiguredUpstreamServers"] == []
+    assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
+    assert payload["requiredUpstreamServers"] == []
+    assert payload["fallbackUpstreamServers"] == []
 
 
 def test_relay_entrypoint_defaults_to_one_worker_and_multiple_threads():


### PR DESCRIPTION
### Motivation
- Relay-only readiness output could be mistaken for an active dependency on the production upstream because compatibility/default upstream fields were present without explicit active/required semantics.

### Description
- Add a shared helper `_upstream_reporting_state` that computes relay-only, active, required, legacy and fallback upstream sets based on env/config and the existing `_has_explicit_relay_upstream_config` check.
- Surface explicit fields in `/healthz`: `activeUpstreamServers`, `requiredUpstreamServers`, and `fallbackUpstreamServers` while preserving `configuredUpstreamServers` and `legacyConfiguredUpstreamServers` for compatibility.
- Surface snake_case equivalents in `/relay/diagnostics`: `active_upstream_servers`, `required_upstream_servers`, and `fallback_upstream_servers`, plus `relay_only` and `upstream_health_required` to make dependency intent obvious.
- Update focused tests in `tests/test_relay.py` and add a staging-focused diagnostics test to assert relay-only mode reports no active/required upstreams even when legacy/default config contains `https://token.place`.
- Update onboarding docs (`docs/relay_sugarkube_onboarding.md`) to explain how to interpret compatibility vs active/required upstream fields.

### Testing
- Ran `pytest -q tests/test_relay.py` which passed: `117 passed`.
- Ran `pytest -q tests/unit/test_api_v1_launch_contract.py` which passed: `11 passed`.
- Grepped for the new/updated fields with `rg -n "configuredUpstreamServers|legacyConfiguredUpstreamServers|configured_upstream_servers|legacy_configured_upstream_servers|activeUpstream|requiredUpstream|fallbackUpstream|active_upstream|required_upstream|fallback_upstream|relayOnly|upstreamHealthRequired" relay.py tests docs README.md` to validate coverage of changes.
- Ran `pre-commit run --all-files`, which completed successfully.

Files changed: `relay.py`, `tests/test_relay.py`, `docs/relay_sugarkube_onboarding.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ecd546a4832f8c50a2fe4c1ff5c9)