### PR TITLE
Clarify relay-only upstream diagnostics

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -536,6 +536,8 @@ After (explicit relay-only semantics):
   "relayOnly": true,
   "upstreamHealthRequired": false,
   "knownServers": 0,
+  "activeUpstreamServers": [],
+  "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
   "legacyConfiguredUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
@@ -546,8 +548,13 @@ After (explicit relay-only semantics):
 Interpretation:
 - `status: ok` reflects relay process readiness.
 - `knownServers: 0` means no registered external compute nodes yet (expected before node registration).
-- `configuredUpstreamServers` is retained as a stable compatibility key.
+- `activeUpstreamServers: []` and `requiredUpstreamServers: []` are the authoritative signal that
+  relay-only readiness is not actively using or requiring the compatibility/default upstream list.
+- `configuredUpstreamServers` is retained as a stable compatibility key and may show the historical
+  default fallback (`https://token.place`) in relay-only deployments.
 - `legacyConfiguredUpstreamServers` represents compatibility/default config, not a required staging dependency.
+- Operators should read `relayOnly`, `upstreamHealthRequired`, the active/required upstream fields,
+  and registered compute-node status together before concluding that staging depends on production.
 
 ## Guardrails
 

--- a/relay.py
+++ b/relay.py
@@ -808,11 +808,15 @@ def healthz():
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
     status = {
         "status": "ok",
         "upstream": app.config.get("upstream_url"),
         "upstreamHealthRequired": require_upstream_health,
         "relayOnly": relay_only_mode,
+        "activeUpstreamServers": active_upstream_servers,
+        "requiredUpstreamServers": required_upstream_servers,
         "gpuHost": gpu_host,
         "knownServers": len(known_servers),
         "registeredServers": _live_server_diagnostics(),
@@ -1068,9 +1072,14 @@ def relay_diagnostics():
     configured_servers = app.config.get("relay_configured_servers", [])
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
+    relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
     diagnostics = {
-        "relay_only": (not require_upstream_health) and (not explicit_upstream_config),
+        "relay_only": relay_only_mode,
         "upstream_health_required": require_upstream_health,
+        "active_upstream_servers": active_upstream_servers,
+        "required_upstream_servers": required_upstream_servers,
         "registered_compute_nodes": live_nodes,
         "total_registered_compute_nodes": len(live_nodes),
         "api_v1_registered_compute_nodes": api_v1_live_nodes,

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1042,6 +1042,8 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
 
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
+    assert payload["required_upstream_servers"] == []
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
     assert payload["total_registered_compute_nodes"] == 1
@@ -1176,8 +1178,31 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == configured_servers
+    assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
     assert payload["upstream_health_required"] is False
+
+
+def test_relay_diagnostics_staging_relay_only_reports_no_active_or_required_upstream(client, monkeypatch):
+    """Diagnostics should not make relay-only staging look dependent on prod."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["relay_only"] is True
+    assert payload["upstream_health_required"] is False
+    assert payload["active_upstream_servers"] == []
+    assert payload["required_upstream_servers"] == []
+    assert payload["configured_upstream_servers"] == ["https://token.place"]
+    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
 
 
 def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
@@ -1209,6 +1234,8 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     payload = response.get_json()
 
     assert payload["configuredUpstreamServers"] == configured_servers
+    assert payload["activeUpstreamServers"] == configured_servers
+    assert payload["requiredUpstreamServers"] == []
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
     assert payload["legacyConfiguredUpstreamServers"] == []
@@ -1269,6 +1296,8 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["relayOnly"] is True
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("gpuHostResolution") != "failed"
 
 
@@ -1285,6 +1314,7 @@ def test_healthz_requires_upstream_health_when_env_enabled(client, monkeypatch):
     assert payload["status"] == "degraded"
     assert payload["upstreamHealthRequired"] is True
     assert payload["relayOnly"] is False
+    assert payload["requiredUpstreamServers"] == app.config["relay_configured_servers"]
     assert payload["details"]["gpuHostResolution"] == "failed"
 
 
@@ -1309,6 +1339,8 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["upstreamHealthRequired"] is False
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
@@ -1327,6 +1359,8 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
     assert payload["relayOnly"] is True
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
 
 
 def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, monkeypatch):
@@ -1343,6 +1377,8 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
     assert response.status_code == 200
     assert payload["relayOnly"] is False
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
+    assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
+    assert payload["requiredUpstreamServers"] == []
     assert payload["legacyConfiguredUpstreamServers"] == []
 
 


### PR DESCRIPTION
### Motivation

- Relay-only relay health/diagnostics output could be misread as depending on the production fallback upstream because compatibility fields still showed `https://token.place` as configured.
- Operators need an explicit, unambiguous signal that relay-only staging does not require upstream health or actively use the legacy fallback list.

### Description

- Add explicit active/required upstream fields to `/healthz` as `activeUpstreamServers` and `requiredUpstreamServers`, computed from `relay_only` and `require_upstream_health` logic while preserving `configuredUpstreamServers` and `legacyConfiguredUpstreamServers` for compatibility (`relay.py`).
- Add snake_case equivalents `active_upstream_servers` and `required_upstream_servers` to `/relay/diagnostics` and expose the `relay_only` boolean consistently without changing routing or compute-node registration behavior (`relay.py`).
- Add focused tests to assert relay-only staging reports empty active/required upstream lists and retain compatibility fields, and update existing health/diagnostics tests to lock the new fields (`tests/test_relay.py`).
- Update Sugarkube relay onboarding docs to explain how to interpret compatibility vs active/required upstream fields (`docs/relay_sugarkube_onboarding.md`).

### Testing

- Ran `pytest -q tests/test_relay.py` and all relay tests passed (`117 passed, 0 failed`).
- Ran `pytest -q tests/unit/test_api_v1_launch_contract.py` and the unit launch-contract suite passed (`11 passed, 0 failed`).
- Searched code/docs for new/compatible keys with `rg -n "configuredUpstreamServers|legacyConfiguredUpstreamServers|activeUpstream|requiredUpstream|fallbackUpstream|relayOnly|upstreamHealthRequired" relay.py tests docs README.md` to verify coverage (matches updated files).
- Ran `pre-commit run --all-files` and hooks passed.

Files changed: `relay.py`, `tests/test_relay.py`, `docs/relay_sugarkube_onboarding.md`.

Residual risk/follow-ups: None to runtime semantics; changes are diagnostic-only and preserve compatibility fields, but operators should be informed about the new active/required flags in monitoring dashboards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ec6f76b8832fa313ee33cbe5e7c6)