### PR TITLE
Clarify relay-only upstream health reporting

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -536,6 +536,8 @@ After (explicit relay-only semantics):
   "relayOnly": true,
   "upstreamHealthRequired": false,
   "knownServers": 0,
+  "activeUpstreamServers": [],
+  "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
   "legacyConfiguredUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
@@ -546,8 +548,16 @@ After (explicit relay-only semantics):
 Interpretation:
 - `status: ok` reflects relay process readiness.
 - `knownServers: 0` means no registered external compute nodes yet (expected before node registration).
-- `configuredUpstreamServers` is retained as a stable compatibility key.
+- `activeUpstreamServers` is the explicit runtime upstream list; it is empty for relay-only
+  deployments that dispatch to registered compute nodes instead of an upstream fallback.
+- `requiredUpstreamServers` is the readiness dependency list; it is empty when
+  `upstreamHealthRequired: false`, so staging does not depend on prod `https://token.place`.
+- `configuredUpstreamServers` is retained as a stable compatibility key and may show legacy/default
+  fallback configuration.
 - `legacyConfiguredUpstreamServers` represents compatibility/default config, not a required staging dependency.
+- Operators should read `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`,
+  `requiredUpstreamServers`, and the registered compute-node counts before treating any
+  compatibility/default upstream field as operationally active.
 
 ## Guardrails
 

--- a/relay.py
+++ b/relay.py
@@ -808,6 +808,9 @@ def healthz():
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
     relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
+    legacy_configured_upstream_servers = [] if explicit_upstream_config else configured_servers
     status = {
         "status": "ok",
         "upstream": app.config.get("upstream_url"),
@@ -818,7 +821,9 @@ def healthz():
         "registeredServers": _live_server_diagnostics(),
     }
     status["configuredUpstreamServers"] = configured_servers
-    status["legacyConfiguredUpstreamServers"] = [] if explicit_upstream_config else configured_servers
+    status["legacyConfiguredUpstreamServers"] = legacy_configured_upstream_servers
+    status["activeUpstreamServers"] = active_upstream_servers
+    status["requiredUpstreamServers"] = required_upstream_servers
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -1068,15 +1073,21 @@ def relay_diagnostics():
     configured_servers = app.config.get("relay_configured_servers", [])
     require_upstream_health = _env_truthy(REQUIRE_UPSTREAM_HEALTH_ENV, default=False)
     explicit_upstream_config = _has_explicit_relay_upstream_config(configured_servers)
+    relay_only_mode = (not require_upstream_health) and (not explicit_upstream_config)
+    active_upstream_servers = [] if relay_only_mode else configured_servers
+    required_upstream_servers = configured_servers if require_upstream_health else []
+    legacy_configured_upstream_servers = [] if explicit_upstream_config else configured_servers
     diagnostics = {
-        "relay_only": (not require_upstream_health) and (not explicit_upstream_config),
+        "relay_only": relay_only_mode,
         "upstream_health_required": require_upstream_health,
         "registered_compute_nodes": live_nodes,
         "total_registered_compute_nodes": len(live_nodes),
         "api_v1_registered_compute_nodes": api_v1_live_nodes,
         "total_api_v1_registered_compute_nodes": len(api_v1_live_nodes),
         "configured_upstream_servers": configured_servers,
-        "legacy_configured_upstream_servers": [] if explicit_upstream_config else configured_servers,
+        "legacy_configured_upstream_servers": legacy_configured_upstream_servers,
+        "active_upstream_servers": active_upstream_servers,
+        "required_upstream_servers": required_upstream_servers,
     }
     response = jsonify(diagnostics)
     response.headers["Cache-Control"] = "no-store"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1042,6 +1042,8 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
 
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
+    assert payload["required_upstream_servers"] == []
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
     assert payload["total_registered_compute_nodes"] == 1
@@ -1049,6 +1051,29 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
     assert payload["api_v1_registered_compute_nodes"] == []
     assert payload["registered_compute_nodes"][0]["server_public_key"] == DUMMY_SERVER_PUB_KEY
     assert payload["registered_compute_nodes"][0]["queue_depth"] == 1
+
+
+def test_relay_diagnostics_staging_relay_only_reports_no_active_or_required_upstream(client, monkeypatch):
+    """Staging-like relay-only diagnostics should not report prod as active or required."""
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+
+    response = client.get("/relay/diagnostics")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["relay_only"] is True
+    assert payload["upstream_health_required"] is False
+    assert payload["configured_upstream_servers"] == ["https://token.place"]
+    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
+    assert payload["active_upstream_servers"] == []
+    assert payload["required_upstream_servers"] == []
+    assert "https://token.place" not in payload["active_upstream_servers"]
+    assert "https://token.place" not in payload["required_upstream_servers"]
 
 
 def test_relay_diagnostics_counts_live_api_v1_compute_nodes(client):
@@ -1176,6 +1201,8 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
     assert payload["legacy_configured_upstream_servers"] == []
+    assert payload["active_upstream_servers"] == configured_servers
+    assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
     assert payload["upstream_health_required"] is False
 
@@ -1212,6 +1239,8 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
     assert payload["legacyConfiguredUpstreamServers"] == []
+    assert payload["activeUpstreamServers"] == configured_servers
+    assert payload["requiredUpstreamServers"] == []
     assert payload["registeredServers"][0]["server_public_key"] == live_server_key
     assert payload["registeredServers"][0]["age_seconds"] >= 0
     assert payload["registeredServers"][0]["queue_depth"] == 1
@@ -1269,6 +1298,8 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["relayOnly"] is True
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("gpuHostResolution") != "failed"
 
 
@@ -1285,6 +1316,7 @@ def test_healthz_requires_upstream_health_when_env_enabled(client, monkeypatch):
     assert payload["status"] == "degraded"
     assert payload["upstreamHealthRequired"] is True
     assert payload["relayOnly"] is False
+    assert payload["requiredUpstreamServers"] == app.config["relay_configured_servers"]
     assert payload["details"]["gpuHostResolution"] == "failed"
 
 
@@ -1309,6 +1341,10 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["upstreamHealthRequired"] is False
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
+    assert "https://token.place" not in payload["activeUpstreamServers"]
+    assert "https://token.place" not in payload["requiredUpstreamServers"]
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
@@ -1327,6 +1363,8 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
     assert payload["relayOnly"] is True
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert payload["activeUpstreamServers"] == []
+    assert payload["requiredUpstreamServers"] == []
 
 
 def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, monkeypatch):
@@ -1344,6 +1382,8 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
     assert payload["relayOnly"] is False
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
     assert payload["legacyConfiguredUpstreamServers"] == []
+    assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
+    assert payload["requiredUpstreamServers"] == []
 
 
 def test_relay_entrypoint_defaults_to_one_worker_and_multiple_threads():


### PR DESCRIPTION
### Motivation

- Relay-only staging health and diagnostics could be misread as depending on prod `https://token.place` because compatibility/default upstream fields were exposed without explicit active/required semantics.
- The intent is to make readiness and operator intent obvious while preserving backward-compatible keys for existing tooling.

### Description

- Add explicit `activeUpstreamServers` / `requiredUpstreamServers` to `/healthz` and `active_upstream_servers` / `required_upstream_servers` to `/relay/diagnostics`, computed so relay-only deployments report empty active/required lists while retaining `configuredUpstreamServers` and legacy compatibility fields.
- Preserve old compatibility keys (`configuredUpstreamServers`, `legacyConfiguredUpstreamServers`, `configured_upstream_servers`, `legacy_configured_upstream_servers`) and downstream behavior (`relayOnly`, `upstreamHealthRequired`, `publicBaseUrl`).
- Add focused tests in `tests/test_relay.py` that assert relay-only staging does not advertise active or required upstreams even when legacy/default configured upstreams include `https://token.place` and update existing assertions to lock the new fields.
- Update `docs/relay_sugarkube_onboarding.md` with examples and operator guidance to prefer `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers` / `requiredUpstreamServers`, and registered compute-node counts over compatibility fields.

### Testing

- Ran `pytest -q tests/test_relay.py` which completed successfully with `117 passed, 1673 warnings`.
- Ran `pytest -q tests/unit/test_api_v1_launch_contract.py` which completed successfully with `11 passed`.
- Ran repository checks `pre-commit run --all-files` which passed, and a targeted search `rg -n "configuredUpstreamServers|legacyConfiguredUpstreamServers|activeUpstream|requiredUpstream|relayOnly|upstreamHealthRequired" relay.py tests docs README.md` to verify updated occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ec54c5d4832f8a78b6d350b17115)