### PR TITLE
docs: add v0.1.2 observability release plan and link from docs/README and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
 ```
 
 - GHCR-first release workflow: [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md)
+- v0.1.2 observability release gate: [`docs/releases/v0.1.2.md`](docs/releases/v0.1.2.md)
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:
   - [`docs/k3s-sugarkube-dev.md`](docs/k3s-sugarkube-dev.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,8 @@ testing, and deploying token.place. For an expanded overview of every directory,
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
 - **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
   [CHANGELOG_STEP.md](CHANGELOG_STEP.md). Historical launch evidence lives in
-  [releases/v0.1.0.md](releases/v0.1.0.md).
+  [releases/v0.1.0.md](releases/v0.1.0.md), with current release planning in
+  [releases/v0.1.2.md](releases/v0.1.2.md).
 
 ## Prompt docs
 

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,269 @@
+# token.place v0.1.2 observability release plan
+
+This page is the unchecked release plan and QA gate for making production-grade,
+privacy-preserving observability an explicit token.place `v0.1.2` requirement. It is planning and
+validation documentation only: do not implement metrics, alerts, dashboards, chart templates, or
+application/chart version bumps in this release-plan change.
+
+The plan follows the canonical Sugarkube observability design at
+<https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-design.md>, which assigns
+application repositories ownership of safe `/metrics` endpoints, bounded labels, health semantics,
+release/build identity, chart scrape hooks, and app-specific release evidence while Sugarkube owns
+Prometheus, Grafana, Alertmanager, blackbox exporter, discovery policy, retention, alert routing,
+and platform runbooks.
+
+## Current implementation and deployment baseline
+
+- [ ] Treat `charts/tokenplace` as the canonical token.place Helm chart source for Sugarkube,
+      published as `oci://ghcr.io/futuroptimist/charts/tokenplace` and deployed with immutable
+      `ghcr.io/futuroptimist/tokenplace-relay` image tags.
+- [ ] Treat `k8s/`, `k8s/charts/tokenplace-relay`, and `k8s/sugarkube/*` as legacy or local
+      compatibility paths, not the staging or production Sugarkube chart path.
+- [ ] Record the chart package version, chart `appVersion`, immutable image tag, and image digest
+      used for staging and production evidence without bumping versions solely for this plan.
+- [ ] Record that the current relay `/metrics` implementation is Flask-Limiter's exported endpoint
+      from `relay.py`, currently exempt from request logging and public API rate-limit quota, and not
+      yet evidence that Sugarkube Prometheus scrapes staging or production.
+- [ ] Record that repository-root `server.py` exposes `/metrics/resource` JSON for compute-node CPU,
+      memory, and GPU resource monitoring, while Sugarkube k3s scope remains relay-only in the
+      short-to-medium term.
+- [ ] Audit the active API v1 relay routes in `relay.py` and `api/v1/*` before implementation so no
+      observability work routes runtime traffic through API v2, legacy relay endpoints, or API v1
+      streaming.
+- [ ] Audit existing structured logging tests, especially
+      `tests/unit/test_relay_logging_and_metrics.py`, before changing any logging or metric behavior.
+- [ ] Audit existing diagnostics endpoints (`/healthz`, `/livez`, `/relay/diagnostics`,
+      `/api/v1/meta`, and `/api/v1/version`) and preserve relay-blind output.
+- [ ] Audit the canonical chart's current lack of ServiceMonitor and PrometheusRule templates before
+      defining implementation gaps; do not describe those resources as deployed until a later PR
+      renders and verifies them.
+
+## Non-negotiable E2EE and privacy observability invariants
+
+- [ ] Metrics, labels, logs, dashboards, annotations, alert labels, alert descriptions, and release
+      evidence never include plaintext prompts, responses, tool arguments, model output, API keys,
+      private keys, cryptographic keys, ciphertext payloads, public-key material, raw request IDs,
+      client identifiers, IP addresses, authorization headers, cookies, or arbitrary exception text.
+- [ ] Relay-owned diagnostics remain ciphertext-blind and fail closed when an unsafe diagnostic path
+      would be required.
+- [ ] Metrics use fixed outcome enums and normalized route names instead of raw URLs, raw Flask
+      endpoint names that include user input, request IDs, exception strings, or other
+      high-cardinality values.
+- [ ] Prompt length, response length, model names, URLs, user-agent strings, public keys,
+      client-provided metadata, and user-controlled provider strings are not metric labels unless a
+      future design explicitly approves a bounded representation.
+- [ ] API v1 remains non-streaming on relay/client-server paths; observability work must not revive
+      `/sink`, `/faucet`, `/source`, `/retrieve`, or `/next_server` as active production fallbacks.
+- [ ] Privacy review includes generated `/metrics` samples, PromQL label inspections, dashboard JSON
+      or screenshots, alert rule YAML, Alertmanager payloads, and representative structured logs.
+
+## Required metrics contract
+
+Every token.place application metric exposed to Sugarkube must have low-cardinality common labels
+provided directly or by Prometheus relabeling: `app="tokenplace"`, `environment` (`dev`, `staging`,
+`prod`), `cluster`, `namespace`, and release identity. Route labels must be normalized route groups
+such as `/`, `/livez`, `/healthz`, `/metrics`, `/relay/diagnostics`, `/api/v1/meta`,
+`/api/v1/models`, `/api/v1/relay/servers/register`, `/api/v1/relay/servers/poll`,
+`/api/v1/relay/requests`, `/api/v1/relay/responses`, `static`, and `unknown`. Status labels should
+use `status_class` (`2xx`, `3xx`, `4xx`, `5xx`) unless a bounded status-code label is explicitly
+justified. Outcome labels must be fixed enums such as `success`, `validation_error`, `rate_limited`,
+`quota_rejected`, `no_compute_node`, `timeout`, `cancelled`, `expired`, `dependency_failure`,
+`unavailable`, and `unknown_error`.
+
+- [ ] API v1 request totals: count demand and failures by bounded `route`, `status_class`,
+      `provider_mode` (`relay_e2ee`, `self_dispatch`, `upstream`, `none`, or another reviewed enum),
+      and `outcome`; purpose: API availability, error ratio, and demand detection.
+- [ ] API v1 request duration histograms: measure end-to-end handler latency by bounded `route`,
+      `status_class`, `provider_mode`, and `outcome`; purpose: latency SLI and timeout regression
+      detection with coarse seconds buckets.
+- [ ] Relay queue depth gauge: expose total queued API v1 E2EE work, optionally split only by a
+      bounded route/class; purpose: backlog and no-compute-node detection.
+- [ ] Oldest queued request age gauge: expose age in seconds of the oldest queued item without
+      request or client identifiers; purpose: stale work and user-impact detection.
+- [ ] Registered compute-node count gauge: aggregate live API v1 compute nodes; purpose: capacity and
+      registration health.
+- [ ] Healthy compute-node count gauge: aggregate nodes considered eligible for API v1 relay work;
+      purpose: demand-without-capacity alerting.
+- [ ] Compute-node lease age histogram or gauges: aggregate lease/last-success ages without node IDs
+      or public-key labels; purpose: heartbeat freshness and stale lease detection.
+- [ ] Stale-node eviction counter: count evictions by bounded reason; purpose: catch lease expiry or
+      cleanup spikes.
+- [ ] Registration failure counter: count register/refresh failures by bounded outcome/status class;
+      purpose: distinguish bad tokens, invalid payloads, and relay regressions.
+- [ ] Heartbeat/poll failure counter: count compute-node poll failures by bounded outcome/status
+      class; purpose: detect control-plane breakage.
+- [ ] In-flight request count gauge: aggregate claimed-but-not-completed API v1 requests; purpose:
+      saturation and stuck-provider detection.
+- [ ] In-flight request age gauge or histogram: expose oldest/p95 age without request IDs; purpose:
+      timeout and stuck-work alerting.
+- [ ] Completed request counter: count successful relay completions by bounded route/outcome;
+      purpose: throughput and success-rate evidence.
+- [ ] Cancelled request counter: count requester, server-unregister, and provider cancellation using
+      fixed reasons; purpose: cancellation regression and UX impact.
+- [ ] Expired request counter: count TTL expiry by fixed reason; purpose: stale queue/in-flight
+      cleanup evidence.
+- [ ] Timed-out request counter: count provider/client timeout outcomes; purpose: timeout alerting.
+- [ ] Failed request counter: count dependency, validation, unavailable, and unknown failures using
+      fixed outcomes; purpose: error-ratio and release regression detection.
+- [ ] Rate-limit and quota rejection counters: count rejections by bounded route class and outcome;
+      purpose: abuse controls, capacity planning, and false-positive detection.
+- [ ] Upstream inference availability gauge/counter: expose aggregate availability of upstream or
+      compute-node inference path using bounded provider-mode/category only; purpose: dependency
+      health without labeling model names or node IDs.
+- [ ] Upstream inference latency histogram: measure aggregate inference latency with coarse seconds
+      buckets and bounded provider mode; purpose: latency and timeout baselines.
+- [ ] Pod/process health metrics: ensure pod readiness, restarts, CPU, memory, and process liveness
+      are visible through Kubernetes metrics and/or safe app build/process gauges; purpose: separate
+      app failures from platform failures.
+- [ ] Deployed release identity metric: expose a low-cardinality build-info gauge such as
+      `tokenplace_build_info{version,revision,release,environment,image_tag}` with value `1`, using
+      immutable image tags/digests and never arbitrary labels; purpose: correlate dashboards and
+      rollback with the deployed artifact.
+- [ ] Accepted in-memory relay-constraint metrics: expose restart visibility and queue/node state
+      reset evidence using pod restart metrics plus aggregate queue/node gauges; purpose: acknowledge
+      single-pod, one-worker, in-memory state loss without implying queued state survives pod
+      replacement.
+
+## Scrape and deployment contract
+
+- [ ] The canonical `charts/tokenplace` chart exposes the metrics port and `/metrics` path only on
+      the internal ClusterIP Service or an equivalent cluster-internal scrape target.
+- [ ] ServiceMonitor discovery works with Sugarkube's kube-prometheus-stack convention, including the
+      current `release: kube-prometheus-stack` selector unless Sugarkube intentionally migrates the
+      selector contract.
+- [ ] ServiceMonitor namespace selection explicitly includes the `tokenplace` namespace or an
+      equivalent Sugarkube-owned static scrape configuration is documented as temporary.
+- [ ] PrometheusRule resources are opt-in, chart-versioned, disabled by default until staging
+      evidence exists, and rendered only by a later implementation PR.
+- [ ] Prometheus, Grafana, `/metrics`, and any metrics-only ports are not exposed through public
+      ingress by default.
+- [ ] NetworkPolicy or equivalent cluster controls allow Prometheus in `monitoring` to scrape the
+      tokenplace Service while keeping public ingress away from metrics endpoints.
+- [ ] Release metadata can be correlated with an immutable image tag and, where available, a digest;
+      mutable tags such as `latest`, `main-latest`, `staging`, `prod`, and `production` are not
+      production promotion evidence.
+
+## token.place dashboard requirement
+
+- [ ] Relay availability row: blackbox and internal `/livez`/`/healthz` availability, scrape health,
+      and current environment/release.
+- [ ] API v1 row: request rate, p50/p95/p99 latency, status-class ratio, and fixed outcome mix.
+- [ ] Queue row: queue depth, oldest queued age, enqueue/dequeue/completion rates, and backlog
+      baseline bands from staging.
+- [ ] Compute-node pool row: registered nodes, healthy nodes, and no-healthy-node periods while
+      demand exists.
+- [ ] Lease and poll row: lease age, stale evictions, register failures, heartbeat failures, and poll
+      failures.
+- [ ] In-flight row: in-flight count, oldest/p95 in-flight age, timeout counts, and stuck-work
+      indicators.
+- [ ] Rate-limit row: rate-limit and quota rejection counts by bounded route class.
+- [ ] Upstream inference row: availability, latency, dependency failures, cancellations, and
+      timeouts by bounded provider mode/category.
+- [ ] Pod/process row: pod readiness, restarts, CPU, memory, and resource saturation.
+- [ ] Release identity row: current immutable image tag/digest, chart version, app version, Helm
+      release, namespace, and deployment timestamp when safely available.
+- [ ] E2EE invariant note: dashboard text states that panels intentionally exclude prompts,
+      responses, ciphertext, keys, public-key material, client identifiers, IP addresses, raw request
+      IDs, model names, URLs, and arbitrary exception strings.
+
+## Provisional actionable alerts
+
+Thresholds must be tuned from staging data before production paging. Alerts without a tested response
+path stay warning-only or disabled.
+
+- [ ] `TokenplaceRelayUnavailable`: relay blackbox or internal health is unavailable for the chosen
+      window; action: inspect pod, ingress, Cloudflare, and rollback if release-related.
+- [ ] `TokenplaceNoHealthyComputeNodesWithDemand`: healthy compute nodes are zero while API v1
+      requests are arriving or queue depth is positive; action: restart/register compute node or
+      rollback relay if registration regressed.
+- [ ] `TokenplaceQueueBacklogGrowing`: queue depth or oldest queued age exceeds staging baseline;
+      action: add/restart compute capacity, inspect upstream latency, or rollback regression.
+- [ ] `TokenplaceApiV1ErrorRatioHigh`: API v1 `5xx` or failure-outcome ratio is elevated; action:
+      inspect relay errors, dependencies, and recent release.
+- [ ] `TokenplaceTimeoutCancellationRatioHigh`: timeout/cancellation ratio exceeds staging baseline;
+      action: inspect compute-node health, in-flight ages, and upstream latency.
+- [ ] `TokenplaceStaleNodeEvictionsSpike`: stale-node eviction counter spikes; action: inspect
+      heartbeat/poll paths, network, and desktop compute-node versions.
+- [ ] `TokenplaceRateLimitRejectionsSpike`: rate-limit or quota rejections spike by bounded route
+      class; action: separate attack/abuse from false-positive quota regression.
+- [ ] `TokenplacePodRestartingRepeatedly`: pod restarts exceed threshold; action: inspect events,
+      logs, resource pressure, and rollback if release-related.
+- [ ] `TokenplacePrometheusScrapeFailure`: Prometheus `up` for token.place metrics is zero; action:
+      inspect ServiceMonitor labels, metrics path, NetworkPolicy, and endpoint health; do not treat as
+      user-impacting outage unless paired with service health failures.
+
+## Required staging evidence before production promotion
+
+- [ ] Target discovery evidence: Prometheus target page or `up{app="tokenplace"}` query shows the
+      staging token.place target discovered with expected labels.
+- [ ] Scrape success evidence: `up` is `1`, scrape duration and sample counts are healthy, and no
+      public ingress path is needed to scrape `/metrics`.
+- [ ] Representative PromQL evidence: include queries/results for API request rate, latency,
+      outcomes, queue depth, oldest queue age, registered/healthy nodes, in-flight count/age,
+      rate-limit rejections, upstream latency, pod restarts, and build info.
+- [ ] Dashboard evidence: screenshot or exported panel evidence from real staging metrics, not
+      placeholder JSON or mock data.
+- [ ] Controlled compute-node loss drill: stop or isolate a staging compute node, capture healthy-node
+      count drop, queue behavior under synthetic demand, alert behavior if enabled, recovery, and
+      relay-blind logs.
+- [ ] Controlled relay restart drill: restart the staging relay pod and document expected in-memory
+      loss for registrations, queues, replies, and in-flight work; verify dashboards show restart and
+      state reset without claiming state durability.
+- [ ] At least one tested alert: prove Alertmanager/notification or Prometheus alert firing path with
+      a controlled, reversible staging condition.
+- [ ] Sensitive-label inspection: inspect `/metrics` and Prometheus label values to prove no prompts,
+      responses, ciphertext, keys, public-key material, raw request IDs, client IDs, IP addresses,
+      auth headers, model names, raw URLs, or arbitrary exception strings appear.
+- [ ] High-cardinality inspection: show active series count and label cardinality remain within the
+      reviewed budget, targeting fewer than 100 active app-level time series per environment unless
+      explicitly approved.
+- [ ] Staging soak: run a staging soak long enough to establish queue, latency, timeout, restart, and
+      scrape baselines before production thresholds are finalized.
+- [ ] Rollback rehearsal: document rollback to the previous immutable image tag and chart package,
+      expected recovery time, and accepted in-memory state-loss caveat.
+
+## v0.1.2 blockers
+
+- [ ] Safe relay/API v1 metrics listed in this plan exist with documented purposes and bounded label
+      guidance.
+- [ ] Relay-blind E2EE observability invariants are tested and reviewed against metrics, logs,
+      dashboards, alerts, and release evidence.
+- [ ] Canonical chart scrape contract is implemented and verified without exposing metrics publicly.
+- [ ] ServiceMonitor discovery works in staging with Sugarkube labels or a documented temporary static
+      scrape config exists with an app-chart follow-up.
+- [ ] Opt-in PrometheusRule resources or equivalent Sugarkube-owned provisional alert rules are
+      versioned, disabled/controlled by values or platform config, and backed by staging evidence.
+- [ ] token.place Grafana dashboard is backed by real staging metrics and includes release identity
+      and in-memory restart/state-reset visibility.
+- [ ] Required alerts have provisional thresholds, runbook actions, and at least one tested alert
+      path.
+- [ ] Required staging drills, privacy/cardinality inspection, staging soak, and rollback evidence are
+      captured before production promotion.
+
+## Required staging evidence record
+
+Use this section for the final v0.1.2 evidence links or paste summaries. Keep all items unchecked in
+this planning PR.
+
+- [ ] Artifact identifiers: Git commit, Git tag if present, image tag, image digest, chart version,
+      chart digest if available, and Helm release name.
+- [ ] Prometheus target discovery and scrape evidence.
+- [ ] PromQL query/result bundle.
+- [ ] Dashboard screenshot/export evidence.
+- [ ] Controlled compute-node loss drill notes.
+- [ ] Controlled relay restart drill notes and accepted state-loss explanation.
+- [ ] Tested alert evidence.
+- [ ] Sensitive-label and cardinality inspection evidence.
+- [ ] Staging soak start/end timestamps and findings.
+- [ ] Rollback command and previous immutable image/chart identifiers.
+
+## Post-v0.1.2 work, not blockers
+
+- [ ] Loki/log aggregation and log-derived dashboards.
+- [ ] Distributed tracing or Tempo.
+- [ ] Long-term metrics storage beyond the initial Sugarkube retention budget.
+- [ ] Multi-cluster federation or global dashboards.
+- [ ] Per-user, per-client, or per-node analytics.
+- [ ] Durable relay queues, multi-replica relay state, or HA relay architecture.
+- [ ] Model-level or URL-level analytics unless a future privacy design approves bounded categories.
+- [ ] Public Grafana, public Prometheus, kiosk mode, or unauthenticated observability endpoints.


### PR DESCRIPTION
### Motivation

- Make production-grade, privacy-preserving observability an explicit release requirement for token.place v0.1.2 following the Sugarkube observability design and the repo's E2EE guardrails. 
- Provide an unchecked QA gate that captures required metrics, dashboard rows, provisional alerts, scrape/deployment contract, staging evidence, and blockers without implementing runtime or chart changes.

### Description

- Add `docs/releases/v0.1.2.md` with a detailed, unchecked release plan covering the canonical chart identification, current metrics baseline, non-negotiable E2EE/privacy invariants, a bounded metrics contract (labels/outcomes/routes), scrape/deployment contract, dashboard requirements, provisional actionable alerts, required staging evidence, v0.1.2 blockers, and post-release follow-ups; this file is planning-only and does not implement metrics, alerts, dashboards, or version bumps. 
- Link the new release plan from `docs/README.md` and the repository `README.md` so the v0.1.2 observability gate is discoverable next to the Sugarkube release workflow. 
- Document that `charts/tokenplace` is the canonical Sugarkube chart, that `k8s/` and legacy chart paths remain compatibility-only, and that no ServiceMonitor/PrometheusRule resources are claimed deployed yet. 
- Preserve relay-blind E2EE requirements and API v1 non-streaming guardrails in the plan and make privacy/cardinality inspection an explicit staging requirement.

### Testing

- `python -m pytest tests/unit/test_relay_logging_and_metrics.py -q` — passed (2 tests ran, both passed). 
- `pre-commit run --all-files` — passed (pre-commit checks completed with all hooks passing). 
- `git diff --check` — passed (no trailing-whitespace / check failures reported). 

Files added/modified: `docs/releases/v0.1.2.md` (new), `docs/README.md` (updated link), `README.md` (updated link).

All checklist items in the new plan remain intentionally unchecked; no runtime, chart, or version changes were made in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ebb64e20832fa2080583a2210bc0)