### PR TITLE
docs: add v0.1.2 observability release plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
 ```
 
 - GHCR-first release workflow: [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md)
+- v0.1.2 observability release requirement: [`docs/releases/v0.1.2.md`](docs/releases/v0.1.2.md)
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:
   - [`docs/k3s-sugarkube-dev.md`](docs/k3s-sugarkube-dev.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,10 +44,9 @@ testing, and deploying token.place. For an expanded overview of every directory,
   hardening checklist and threat model; use
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
 - **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
-  [CHANGELOG_STEP.md](CHANGELOG_STEP.md). Historical launch evidence lives in
-  [releases/v0.1.0.md](releases/v0.1.0.md). The v0.1.1 release validation
-  record lives in [releases/v0.1.1.md](releases/v0.1.1.md), and the unchecked
-  v0.1.2 observability release plan lives in
+  [CHANGELOG_STEP.md](CHANGELOG_STEP.md). Historical launch/release evidence lives in
+  [releases/v0.1.0.md](releases/v0.1.0.md) and [releases/v0.1.1.md](releases/v0.1.1.md),
+  and the unchecked v0.1.2 observability release plan lives in
   [releases/v0.1.2.md](releases/v0.1.2.md).
 
 ## Prompt docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,8 @@ testing, and deploying token.place. For an expanded overview of every directory,
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
 - **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
   [CHANGELOG_STEP.md](CHANGELOG_STEP.md). Historical launch evidence lives in
-  [releases/v0.1.0.md](releases/v0.1.0.md).
+  [releases/v0.1.0.md](releases/v0.1.0.md), and the unchecked v0.1.2
+  observability release plan lives in [releases/v0.1.2.md](releases/v0.1.2.md).
 
 ## Prompt docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,10 @@ testing, and deploying token.place. For an expanded overview of every directory,
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
 - **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
   [CHANGELOG_STEP.md](CHANGELOG_STEP.md). Historical launch evidence lives in
-  [releases/v0.1.0.md](releases/v0.1.0.md), and the unchecked v0.1.2
-  observability release plan lives in [releases/v0.1.2.md](releases/v0.1.2.md).
+  [releases/v0.1.0.md](releases/v0.1.0.md). The v0.1.1 release validation
+  record lives in [releases/v0.1.1.md](releases/v0.1.1.md), and the unchecked
+  v0.1.2 observability release plan lives in
+  [releases/v0.1.2.md](releases/v0.1.2.md).
 
 ## Prompt docs
 

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,222 @@
+# token.place v0.1.2 observability release plan
+
+This is an unchecked release plan and QA gate for making production-grade,
+privacy-preserving observability an explicit token.place `v0.1.2` release
+requirement. It is documentation and release planning only: do not implement new
+metrics, alerts, dashboards, chart templates, runtime behavior, or version bumps
+as part of this plan.
+
+## Current-source baseline
+
+- [ ] Treat `charts/tokenplace` as the canonical Sugarkube/GHCR chart source,
+  published as `oci://ghcr.io/futuroptimist/charts/tokenplace` with chart name
+  `tokenplace`. The local-development and compatibility chart paths
+  `deploy/charts/tokenplace-relay` and `k8s/charts/tokenplace-relay` are not the
+  staging or production Sugarkube release path.
+- [ ] Treat `relay.py` as the only token.place runtime component deployed in
+  Sugarkube for this phase; `server.py` and desktop/host compute nodes remain
+  external to the relay pod.
+- [ ] Preserve the accepted Sugarkube relay constraints: one pod, one Gunicorn
+  worker, one replica, in-memory registrations/queues/replies, and expected
+  relay state loss on pod restart or replacement until shared-state architecture
+  lands.
+- [ ] Treat the current metrics implementation as a source-level baseline only:
+  `api.init_app()` installs `PrometheusMetrics(app)`, `relay.py` adds
+  `tokenplace_relay_requests_total{method,endpoint,status}`, `/metrics` is
+  tested for Prometheus text output, and `server.py` exposes JSON resource usage
+  at `/metrics/resource` for compute-node monitoring. This baseline is not proof
+  that Sugarkube staging or production scrapes token.place metrics.
+- [ ] Audit the existing legacy ServiceMonitor and PrometheusRule scaffolding in
+  `deploy/charts/tokenplace-relay` before implementation work. Do not describe
+  that scaffolding as deployed in Sugarkube without live evidence, and do not
+  port it blindly to the canonical chart.
+- [ ] Align the implementation plan with the canonical Sugarkube observability
+  design in
+  `futuroptimist/sugarkube/docs/observability-design.md`, especially ownership
+  boundaries, `release: kube-prometheus-stack` ServiceMonitor discovery unless
+  the platform selector intentionally changes, conservative staging-derived
+  thresholds, internal-only metrics, and no claims of production Prometheus or
+  Grafana experience without evidence.
+
+## Non-negotiable E2EE and privacy invariants
+
+- [ ] Keep relay observability relay-blind: metrics, labels, logs, diagnostics,
+  dashboards, and alerts must never include plaintext prompts, plaintext
+  responses, tool arguments, model output, API keys, cryptographic keys,
+  ciphertext, public-key material, raw request IDs, client identifiers, IP
+  addresses, auth headers, or arbitrary exception strings.
+- [ ] Do not use prompt length, response length, model names, URLs, user-agent
+  strings, hostnames supplied by users, or user-controlled metadata as labels
+  unless a future approved design explicitly defines a bounded representation.
+- [ ] Use normalized route names, status classes such as `2xx`/`4xx`/`5xx`,
+  provider-mode enums, and fixed outcome enums. Do not label by raw path,
+  exception text, request ID, public key, client key, token, IP address, or any
+  unbounded input.
+- [ ] Keep relay-owned diagnostics ciphertext-blind and fail closed. Any
+  diagnostic or log field that would expose plaintext payloads, ciphertext,
+  public-key material, keys, raw IDs, headers, or client identifiers blocks
+  `v0.1.2`.
+- [ ] Prove privacy with inspection evidence for every new metric, label,
+  dashboard variable, alert annotation, and log line touched by observability
+  work.
+
+## v0.1.2 blockers
+
+### Relay and API metrics contract
+
+Each required metric below must include a stated purpose, bounded label guidance,
+and regression coverage before `v0.1.2` can be promoted.
+
+- [ ] API v1 request totals: count API v1 requests by normalized route, status
+  class, provider mode, and outcome so operators can identify traffic, failures,
+  and fail-closed paths without exposing payload content or identities.
+- [ ] API v1 request duration histograms: measure latency by the same bounded
+  route/status-class/provider-mode/outcome labels so staging can establish
+  dashboard panels and alert thresholds.
+- [ ] Relay queue depth: expose current queued encrypted request count by bounded
+  provider mode or aggregate relay scope so operators can see saturation without
+  per-server or per-client labels.
+- [ ] Oldest queued request age: expose the oldest queued encrypted request age
+  so operators can detect stuck queues even when depth is low.
+- [ ] Registered compute-node count: expose API v1 registered node count so
+  dashboard and alerts can distinguish no-capacity events from request errors.
+- [ ] Healthy compute-node count: expose nodes whose heartbeat/lease is fresh so
+  operators can alert when capacity disappears while requests arrive.
+- [ ] Compute-node lease age: expose bounded lease-age observations or gauges so
+  stale nodes are visible before eviction, without labeling by node key or raw
+  client address.
+- [ ] Stale-node evictions: count eviction outcomes so operators can correlate
+  queue cancellations and capacity loss with stale heartbeats.
+- [ ] Registration failures: count failed compute-node registration attempts by
+  bounded outcome/status class so token/WAF/config regressions are visible.
+- [ ] Heartbeat and poll failures: count compute-node heartbeat/poll failures by
+  bounded outcome/status class so unreachable or unauthorized compute nodes are
+  visible.
+- [ ] In-flight request count: expose encrypted relay requests currently claimed
+  by a compute node so operators can detect provider-side stalls.
+- [ ] In-flight request age: expose oldest or histogrammed in-flight age so
+  timeout risk is visible before terminal failures.
+- [ ] Completed request count: count requests that successfully returned an
+  encrypted response envelope to clients.
+- [ ] Cancelled request count: count user/system cancellations with fixed reason
+  enums such as `client_cancelled`, `server_unregistered`, or `shutdown`.
+- [ ] Expired request count: count requests expired by relay TTL or stale pending
+  state with fixed reason enums.
+- [ ] Timed-out request count: count provider/compute-node timeouts separately
+  from generic failures.
+- [ ] Failed request count: count failed terminal outcomes with fixed,
+  low-cardinality outcome enums; do not label by exception text.
+- [ ] Rate-limit and quota rejections: count rejections by bounded route class
+  such as `public_api`, `relay_client_read`, or `compute_node_control_plane` and
+  by status class/outcome, never by raw bucket key, client, IP, or token.
+- [ ] Upstream inference availability: expose whether the configured upstream or
+  compute-node path is available from the relay's perspective without reporting
+  URLs, model names, public keys, or raw errors.
+- [ ] Upstream inference latency: histogram upstream/compute-node round-trip or
+  relay dispatch/retrieve latency with bounded provider-mode/outcome labels.
+- [ ] Pod/process health: expose process health, start time, and readiness-safe
+  gauges that let dashboards distinguish app unavailability from Prometheus
+  scrape failure.
+- [ ] Deployed release identity: expose a low-cardinality build/release info
+  metric or equivalent metadata that correlates with immutable image tag, chart
+  version, git revision, environment, and app version.
+- [ ] Single-pod/in-memory constraint visibility: expose accepted constraints
+  such as replica count intent, one-worker mode, process start time, and restart
+  visibility. The dashboard and docs must make clear that registrations, queues,
+  in-flight requests, and replies do not survive pod replacement in this phase.
+
+### Scrape and deployment contract
+
+- [ ] The canonical `charts/tokenplace` chart exposes the metrics port/path only
+  inside the cluster and does not route `/metrics` through public ingress by
+  default.
+- [ ] ServiceMonitor discovery works with current Sugarkube/kube-prometheus-stack
+  labels, including `release: kube-prometheus-stack`, unless Sugarkube has a
+  documented selector migration.
+- [ ] PrometheusRule resources are opt-in and chart-versioned when implemented;
+  they are not enabled silently by existing deployments.
+- [ ] Prometheus, Grafana, Alertmanager, and metrics endpoints remain internal by
+  default. Public endpoint availability should be monitored by Sugarkube-owned
+  blackbox probes, not by exposing Prometheus or token.place `/metrics` through
+  public ingress.
+- [ ] Release metadata in metrics, dashboard panels, and staging evidence can be
+  correlated with an immutable image tag such as `main-<shortsha>` or `vX.Y.Z`.
+
+### Dashboard requirement
+
+- [ ] Provide a token.place dashboard covering relay availability.
+- [ ] Provide API v1 request rate, latency, and outcome panels.
+- [ ] Provide queue depth and oldest queue age panels.
+- [ ] Provide registered and healthy compute-node count panels.
+- [ ] Provide lease age, stale-node eviction, and heartbeat/poll health panels.
+- [ ] Provide in-flight request count, in-flight age, and timeout panels.
+- [ ] Provide rate-limit and quota rejection panels by bounded route class.
+- [ ] Provide upstream inference availability and latency panels.
+- [ ] Provide pod restart and CPU/memory/resource panels using Kubernetes metrics.
+- [ ] Provide current immutable release identity and chart/app version panels.
+
+### Alert requirement
+
+All provisional alerts must be actionable, conservative, and tuned from staging
+so noisy alerts can be disabled until an operator has a mitigation path.
+
+- [ ] Relay unavailable: alert when token.place relay scrape/health signals show
+  the relay is unavailable for a sustained window.
+- [ ] No healthy compute node while requests are arriving: alert when API v1
+  requests or queue growth occur while healthy compute-node count is zero.
+- [ ] Growing queue depth or queue age: alert on sustained queue growth or oldest
+  queued request age above staging-derived thresholds.
+- [ ] Elevated API v1 error ratio: alert on sustained bounded `5xx` or
+  fail-closed error ratio above staging-derived thresholds.
+- [ ] Elevated timeout/cancellation ratio: alert when timeout/cancelled terminal
+  outcomes rise above staging baseline.
+- [ ] Stale-node eviction spike: alert when stale evictions spike, indicating
+  compute-node instability or network/WAF regressions.
+- [ ] Rate-limit rejection spike: alert on sustained public or control-plane
+  rejection spikes by bounded route class.
+- [ ] Repeated pod restart: alert when Kubernetes restart count or process start
+  time indicates repeated relay restarts.
+- [ ] Prometheus scrape failure: alert when token.place scrape target discovery
+  exists but `up` stays down.
+
+## Required staging evidence
+
+- [ ] Record target discovery for token.place in Prometheus, including namespace,
+  service, ServiceMonitor or equivalent source, scrape interval, and last scrape
+  status.
+- [ ] Record scrape success for `/metrics` from inside the cluster without public
+  ingress exposure.
+- [ ] Capture representative PromQL results for every v0.1.2 blocker metric,
+  including empty/zero results where appropriate during controlled idle periods.
+- [ ] Capture dashboard screenshots or exported JSON evidence showing every
+  required dashboard panel and variables.
+- [ ] Run a controlled compute-node loss drill: stop or unregister the staging
+  compute node, verify healthy-node count drops, stale eviction or unregister
+  counters change as expected, queued/in-flight outcomes are terminalized with
+  fixed enums, and no sensitive labels appear.
+- [ ] Run a controlled relay restart drill: restart the single relay pod, verify
+  process start/restart visibility, document expected in-memory loss of
+  registrations, queues, in-flight requests, and replies, then re-register a
+  compute node and complete an encrypted API v1 request.
+- [ ] Test at least one alert end-to-end in staging and record the PromQL,
+  firing condition, Alertmanager route or fallback evidence, and runbook action.
+- [ ] Inspect all metric names, labels, log fields, alert annotations, and
+  dashboard variables to prove they contain no sensitive or high-cardinality
+  values listed in the privacy invariants.
+- [ ] Complete a staging soak long enough to establish baseline latency, error
+  ratio, queue age, restart, scrape, and resource thresholds before production
+  promotion.
+- [ ] Demonstrate rollback to the previous immutable image tag and record the
+  previous tag, rollback command, chart version, post-rollback health, scrape,
+  and encrypted API v1 evidence.
+
+## Post-v0.1.2 work, explicitly not blockers
+
+- [ ] Loki log aggregation and log-derived dashboards.
+- [ ] Distributed tracing or Tempo/OpenTelemetry spans.
+- [ ] Long-term metrics storage or object-storage-backed retention.
+- [ ] Multi-cluster federation or cross-environment global dashboards.
+- [ ] Per-user analytics, user-level usage dashboards, or user-identifying
+  business metrics.
+- [ ] Durable relay queues, multi-replica relay state, or HA relay architecture
+  beyond documenting the current accepted single-pod/in-memory constraints.


### PR DESCRIPTION
### Motivation

- Make production-grade, privacy-preserving observability an explicit release requirement for token.place `v0.1.2`, aligned with the Sugarkube observability design and existing Sugarkube/GHCR chart contracts. 
- Ensure relay-blind E2EE invariants are enforced in observability (no plaintext/ciphertext/identifying labels) and define a conservative, testable gating checklist for staging-to-production promotion.

### Description

- Add `docs/releases/v0.1.2.md` as an unchecked release plan and QA gate listing required metrics, bounded-label guidance, dashboard panels, provisional alerts, scrape/deployment contract, staging evidence, rollback, and post-release exclusions. 
- Link the new plan from the documentation index and the README Sugarkube release section so the requirement is discoverable. 
- Record the canonical chart and current metrics baseline in the plan (use `charts/tokenplace` as canonical chart and the existing `PrometheusMetrics(app)` + `tokenplace_relay_requests_total` baseline), explicitly avoiding any runtime, chart, or version changes in this PR. 
- Keep every checklist item unchecked and do not implement metrics, alerts, dashboards, or chart changes in this PR.

### Testing

- Ran `python -m pytest tests/unit/test_relay_logging_and_metrics.py -q`, which passed (2 tests passed). 
- Ran `pre-commit run --all-files`, which completed with all checks passing. 
- Ran `git diff --check`, which reported no issues; changes were committed as `docs: add v0.1.2 observability release plan` and include `docs/releases/v0.1.2.md`, `README.md`, and `docs/README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eb904f6c832f85ab02ea267afbc3)