### PR TITLE
docs: add v0.1.2 observability release plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
 ```
 
 - GHCR-first release workflow: [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md)
+- v0.1.2 observability release plan: [`docs/releases/v0.1.2.md`](docs/releases/v0.1.2.md)
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:
   - [`docs/k3s-sugarkube-dev.md`](docs/k3s-sugarkube-dev.md)

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,216 @@
+# token.place v0.1.2 observability release plan
+
+This is an unchecked release plan and QA gate for making production-grade,
+privacy-preserving observability an explicit release requirement for token.place
+`v0.1.2`. Do not mark items complete until staging evidence is attached in the
+release issue or a follow-up validation record.
+
+This page is planning only. It must not be used as evidence that metrics,
+dashboards, alerts, ServiceMonitors, or PrometheusRules are deployed.
+
+## Source-of-truth context
+
+- Sugarkube observability contract: `futuroptimist/sugarkube` canonical design at
+  `docs/observability-design.md`.
+- token.place relay runtime: repository-root `relay.py`.
+- token.place compute-node entrypoint: repository-root `server.py`.
+- Active API runtime target: API v1 only, non-streaming for relay/client-server
+  inference paths.
+- Canonical Sugarkube chart: `charts/tokenplace`, published as
+  `oci://ghcr.io/futuroptimist/charts/tokenplace` with chart name `tokenplace`.
+- Legacy or compatibility deployment paths, including local Docker Compose,
+  raw `k8s/` manifests if present, and deprecated relay endpoints, are not the
+  Sugarkube release contract for this plan.
+
+## Current implementation inventory
+
+- Current relay metrics implementation: `relay.py` exposes `/metrics` as
+  Prometheus text and increments `tokenplace_relay_requests_total` with
+  `method`, Flask `endpoint`, and exact numeric `status` labels.
+- Current compute-node resource metrics implementation: `server.py` exposes
+  `/metrics/resource` as JSON for CPU, memory, and GPU resource usage; it is not
+  the relay `/metrics` Prometheus endpoint.
+- Current structured relay logging: `relay.py` emits JSON logs for HTTP requests
+  and ignores `/livez`, `/healthz`, and `/metrics`; current log fields include
+  the HTTP path, status, duration, generated/request-provided request ID, and
+  user agent.
+- Current relay diagnostics: `/relay/diagnostics` returns live legacy and API v1
+  registered compute-node counts and safe node metadata; it is necessary but not
+  sufficient for production observability.
+- Current canonical Helm chart scaffolding: `charts/tokenplace` renders a
+  ClusterIP Service, Deployment, optional Ingress, and ServiceAccount. It does
+  not currently render ServiceMonitor or PrometheusRule resources.
+- Current ingress contract: the chart Ingress routes `/` to the HTTP Service
+  when enabled. Prometheus and metrics endpoints must not be exposed through
+  public ingress by default for `v0.1.2`.
+
+## E2EE and privacy invariants
+
+These are `v0.1.2` blockers and must be testable before production promotion:
+
+- [ ] Relay-owned metrics, labels, logs, dashboards, alerts, and diagnostics
+      never contain prompts, responses, tool arguments, model output, API keys,
+      cryptographic keys, ciphertext, public-key material, raw request IDs,
+      client identifiers, IP addresses, auth headers, or arbitrary exception
+      strings.
+- [ ] Relay-owned diagnostics remain ciphertext-blind and fail closed when an
+      observable path cannot preserve relay-blind E2EE.
+- [ ] Metrics use fixed outcome enums and normalized route names instead of raw
+      paths, raw IDs, arbitrary exception text, URLs, model names, prompt length,
+      response length, or user-controlled metadata.
+- [ ] Prompt length, response length, model names, URLs, and user-controlled
+      metadata are not labels unless an approved bounded representation is
+      documented in the implementation PR.
+- [ ] API v1 remains the only active runtime target for relay/client-server
+      inference paths; no API v1 streaming, API v2 runtime routing, or deprecated
+      legacy relay fallback is introduced for observability.
+
+## v0.1.2 blockers
+
+### Relay and API metrics contract
+
+Every required metric must have unit tests or staging PromQL evidence proving the
+label set is bounded and privacy-preserving.
+
+- [ ] API v1 request totals are emitted with bounded `route`, `status_class`,
+      `provider_mode`, and `outcome` labels. Purpose: measure request volume,
+      success/error ratios, provider path usage, and release regressions without
+      exposing raw paths, prompts, IDs, or exception strings.
+- [ ] API v1 request duration histograms are emitted with the same bounded
+      labels. Purpose: quantify user-visible latency and set staging-derived
+      alert thresholds.
+- [ ] Relay queue depth gauge is emitted. Purpose: detect stuck work and compute
+      capacity shortfalls while preserving the accepted in-memory queue model.
+- [ ] Relay oldest queued request age gauge is emitted. Purpose: detect stale
+      queue buildup earlier than depth alone.
+- [ ] Registered compute-node count gauge is emitted. Purpose: identify whether
+      any compute capacity is registered with the relay.
+- [ ] Healthy compute-node count gauge is emitted. Purpose: distinguish total
+      registered nodes from nodes eligible to serve API v1 work.
+- [ ] Compute-node lease age gauge or histogram is emitted with bounded lease
+      state labels only. Purpose: detect stale nodes before requests accumulate.
+- [ ] Stale-node eviction counter is emitted. Purpose: explain compute capacity
+      drops and correlate with queue growth.
+- [ ] Compute-node registration failure counter is emitted with fixed outcome or
+      reason enums only. Purpose: detect auth, validation, and compatibility
+      failures without exposing submitted metadata or tokens.
+- [ ] Compute-node heartbeat/poll failure counter is emitted with bounded
+      route-class and outcome labels. Purpose: detect control-plane degradation.
+- [ ] In-flight request count gauge is emitted. Purpose: show active relay work
+      and saturation during staging drills.
+- [ ] In-flight request age gauge or histogram is emitted. Purpose: detect hung
+      requests and tune timeout thresholds.
+- [ ] Completed, cancelled, expired, timed-out, and failed request counters are
+      emitted with fixed `outcome` enum labels. Purpose: explain end-state mix
+      without arbitrary exception labels.
+- [ ] Rate-limit and quota rejection counters are emitted by bounded route class.
+      Purpose: separate protective throttling from application failures.
+- [ ] Upstream inference availability gauge or counter is emitted. Purpose:
+      distinguish relay health from compute/upstream availability.
+- [ ] Upstream inference latency histogram is emitted with bounded provider-mode
+      labels only. Purpose: track dependency latency without model names, URLs,
+      prompts, responses, or user metadata.
+- [ ] Pod/process health and deployed release identity metric is emitted.
+      Purpose: correlate behavior with immutable image tag and release metadata.
+- [ ] Single-pod/in-memory relay constraint metrics are emitted, including
+      process start time or restart-generation visibility. Purpose: make pod
+      replacement and expected loss of registrations, queues, and replies
+      visible without pretending relay state survives replacement.
+
+### Scrape and deployment contract
+
+- [ ] The canonical Helm chart `charts/tokenplace` exposes the internal metrics
+      port/path to Prometheus without changing public ingress defaults.
+- [ ] ServiceMonitor discovery works with Sugarkube kube-prometheus-stack labels,
+      including the current `release: kube-prometheus-stack` convention unless a
+      Sugarkube platform PR intentionally changes selectors.
+- [ ] PrometheusRule resources are opt-in, chart-versioned, disabled by default
+      until staging thresholds are proven, and documented as chart behavior only
+      after implementation.
+- [ ] Prometheus and metrics endpoints are not exposed through public ingress by
+      default.
+- [ ] Release metadata can be correlated with an immutable image tag such as
+      `main-<shortsha>` or `vX.Y.Z`; mutable tags are rejected for promotion
+      evidence.
+- [ ] Any NetworkPolicy or namespace-default-deny posture allows Prometheus in
+      `monitoring` to scrape only the intended internal metrics endpoint.
+
+### Dashboard requirement
+
+- [ ] A token.place dashboard exists and is reviewed with panels for relay
+      availability, API v1 request rate, API v1 latency, API v1 outcomes, queue
+      depth, oldest queue age, registered compute nodes, healthy compute nodes,
+      lease age, stale-node evictions, poll/heartbeat health, in-flight
+      requests, in-flight age/timeouts, rate-limit rejections, upstream inference
+      availability/latency, pod restarts/resources, and current immutable
+      release identity.
+- [ ] Dashboard variables are bounded to environment, namespace, release, and
+      immutable image tag; they do not include raw request IDs, client IDs, IPs,
+      user-controlled metadata, model names, URLs, or content-derived values.
+
+### Alert requirement
+
+Provisional thresholds must be derived from staging soak data before production
+enforcement.
+
+- [ ] Relay unavailable alert is actionable and includes a runbook pointer.
+- [ ] No healthy compute node while requests are arriving alert is actionable.
+- [ ] Growing queue depth or queue age alert is actionable.
+- [ ] Elevated API v1 error ratio alert is actionable and uses status class plus
+      fixed outcome enums.
+- [ ] Elevated timeout/cancellation ratio alert is actionable.
+- [ ] Stale-node eviction spike alert is actionable.
+- [ ] Rate-limit rejection spike alert is actionable and separated from server
+      errors.
+- [ ] Repeated pod restart alert is actionable and calls out expected
+      single-pod/in-memory state loss.
+- [ ] Prometheus scrape failure alert is actionable and identifies whether the
+      failure is observability-only or user-impacting.
+
+## Required staging evidence
+
+Attach concrete evidence before production promotion:
+
+- [ ] Target discovery output showing the token.place metrics target is
+      discovered in the correct namespace with the intended Sugarkube labels.
+- [ ] Scrape success output for the internal `/metrics` endpoint.
+- [ ] Representative PromQL results for every v0.1.2 blocker metric, including
+      empty or zero-valued cases where applicable.
+- [ ] Dashboard screenshot or export showing all required panels with staging
+      data and no sensitive/high-cardinality labels.
+- [ ] Controlled compute-node loss drill showing healthy-node count drop,
+      stale-node eviction or lease expiry behavior, queue impact, alert or
+      dashboard visibility, and recovery.
+- [ ] Controlled relay restart drill documenting expected in-memory loss of
+      registrations, queues, replies, in-flight work, and restart visibility.
+- [ ] At least one tested alert with evidence of firing, notification or visible
+      Prometheus alert state, runbook action, and resolution.
+- [ ] Metrics and dashboard label inspection proving no prompts, responses, tool
+      arguments, model output, API keys, cryptographic keys, ciphertext,
+      public-key material, raw request IDs, client identifiers, IP addresses,
+      auth headers, arbitrary exception strings, URLs, model names, prompt
+      length, response length, or user-controlled metadata appear as labels.
+- [ ] Staging soak completed long enough to establish baseline latency, error,
+      timeout, queue, eviction, restart, scrape, Prometheus storage, and resource
+      behavior.
+- [ ] Rollback to the previous immutable image tag is rehearsed or documented
+      with exact image tag, chart version, and expected state-loss implications.
+
+## Post-v0.1.2 work, not blockers
+
+Keep these out of the `v0.1.2` blocker set unless a later release manager
+explicitly expands scope:
+
+- [ ] Loki log aggregation.
+- [ ] Distributed tracing or Tempo.
+- [ ] Long-term metrics storage or object-storage retention.
+- [ ] Multi-cluster federation.
+- [ ] Per-user analytics.
+- [ ] Multi-pod relay high availability or durable queue/state architecture.
+- [ ] Public Grafana access or kiosk mode.
+
+## Verification commands for this documentation change
+
+- [ ] `python -m pytest tests/unit/test_relay_logging_and_metrics.py -q`
+- [ ] `pre-commit run --all-files`
+- [ ] `git diff --check`


### PR DESCRIPTION
### Motivation
- Make production-grade, privacy-preserving observability an explicit release requirement for token.place `v0.1.2` aligned with the Sugarkube observability design.
- Emphasize relay-blind E2EE and bounded/low-cardinality metric/label guidance so observability does not leak plaintext, ciphertext, keys, request IDs, IPs, or other sensitive/high-cardinality values.
- Provide a staging QA gate (checklist, dashboard/alert expectations, drills, and rollback guidance) without implementing runtime metrics, alerts, dashboards, or chart changes.

### Description
- Add `docs/releases/v0.1.2.md` as an unchecked release plan and QA gate that records the canonical chart (`charts/tokenplace` / `oci://ghcr.io/futuroptimist/charts/tokenplace`), current metric/log/diagnostics inventory, E2EE/privacy invariants, required bounded metrics, scrape/deployment contract, dashboard and alert requirements, staging evidence, and post-release non-blockers.
- Link the new plan from the README Sugarkube release section with a single-line README change so the v0.1.2 observability plan is discoverable.
- Keep the change documentation-only and explicitly avoid bumping app/chart versions or deploying/claiming any runtime observability resources.

### Testing
- Ran `python -m pytest tests/unit/test_relay_logging_and_metrics.py -q` and it passed (2 tests, 0 failures) with a DeprecationWarning noted for `datetime.utcnow()`.
- Ran `pre-commit run --all-files` which completed successfully (all configured hooks passed).
- Ran `git diff --check` which reported no whitespace or index-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eb85b048832f8bb009b46b336763)