### PR TITLE
docs: add v0.1.2 observability release plan (unchecked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
 ```
 
 - GHCR-first release workflow: [`docs/ops/sugarkube-release.md`](docs/ops/sugarkube-release.md)
+- v0.1.2 observability release plan: [`docs/releases/v0.1.2.md`](docs/releases/v0.1.2.md)
 - Relay onboarding: [`docs/relay_sugarkube_onboarding.md`](docs/relay_sugarkube_onboarding.md)
 - Environment runbooks:
   - [`docs/k3s-sugarkube-dev.md`](docs/k3s-sugarkube-dev.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,9 @@ testing, and deploying token.place. For an expanded overview of every directory,
   [SECURITY_REVIEW_CHECKLIST.md](SECURITY_REVIEW_CHECKLIST.md) during release sign-off.
 - **Release notes:** Track changes in [CHANGELOG.md](CHANGELOG.md) and stepwise updates in
   [CHANGELOG_STEP.md](CHANGELOG_STEP.md). Historical launch evidence lives in
-  [releases/v0.1.0.md](releases/v0.1.0.md).
+  [releases/v0.1.0.md](releases/v0.1.0.md); active release gates include
+  [releases/v0.1.1.md](releases/v0.1.1.md) and the unchecked
+  [v0.1.2 observability plan](releases/v0.1.2.md).
 
 ## Prompt docs
 

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,156 @@
+# token.place v0.1.2 observability release plan
+
+This unchecked plan is the release gate for making production-grade, privacy-preserving observability an explicit token.place v0.1.2 requirement. It is planning and QA evidence only: do not implement new metrics, alerts, dashboards, chart templates, runtime behavior, or version bumps in this document change.
+
+## Source baseline
+
+- Canonical external design: Sugarkube `docs/observability-design.md` on `futuroptimist/sugarkube` `main` is the source of truth for phased productionization, ownership, privacy, release gates, and current-state claims.
+- Canonical Sugarkube deployment path for token.place: GHCR relay image `ghcr.io/futuroptimist/tokenplace-relay` deployed with the OCI Helm chart `oci://ghcr.io/futuroptimist/charts/tokenplace` sourced from `charts/tokenplace`.
+- Canonical chart metadata at planning time: `charts/tokenplace/Chart.yaml` has chart `version: 0.1.3`, `appVersion: "0.1.1"`, and chart name `tokenplace`. Do not bump either version for v0.1.2 planning.
+- Legacy or compatibility chart paths exist and must not be treated as the Sugarkube production chart unless a future migration explicitly says so:
+  - `deploy/charts/tokenplace-relay` includes historical ServiceMonitor and PrometheusRule scaffolding.
+  - `k8s/charts/tokenplace-relay` is a local or legacy chart path.
+  - raw `k8s/` manifests are developer or compatibility assets, not the GHCR/Sugarkube release contract.
+- Current metrics implementation at planning time: `relay.py` exposes `/metrics` through the Flask app initialized by `api.init_app`, and `relay.py` increments `tokenplace_relay_requests_total` with `method`, Flask `endpoint`, and raw `status` labels after each request. Existing unit coverage verifies `/metrics` returns Prometheus plaintext and includes that counter.
+- Current diagnostics implementation at planning time: `/relay/diagnostics`, `/healthz`, `/livez`, `/api/v1/meta`, and `/api/v1/version` are public-safe operational endpoints, but diagnostics and generic HTTP/TLS health are not sufficient proof that relay-compute traffic is healthy or that Prometheus is scraping staging/production.
+- Runtime architecture baseline: API v1 is the active non-streaming runtime target; Sugarkube deploys `relay.py` as a single pod, one worker, one replica, with in-memory registrations, queue, and replies. Pod restart or replacement may lose in-memory state in this phase and observability must make that visible without implying state survives replacement.
+
+## Release classification
+
+### v0.1.2 blockers
+
+- [ ] Metrics, scrape hooks, dashboards, alerts, staging drills, and release evidence below are implemented, privacy-reviewed, and proven in staging before production promotion.
+- [ ] API v1 remains non-streaming and active runtime relay paths do not route through API v2 or deprecated legacy relay endpoints.
+- [ ] Relay-owned state, logs, metrics, diagnostics, dashboards, and alerts remain relay-blind: ciphertext-only plus safe routing metadata, with no plaintext model payload content and no sensitive labels or payloads.
+- [ ] The canonical `charts/tokenplace` chart, not a legacy chart path, is the chart used for staging and production evidence.
+- [ ] Prometheus and metrics endpoints are not exposed through public ingress by default.
+- [ ] Production promotion records rollback to the previous immutable image tag.
+
+### Required staging evidence
+
+- [ ] Prometheus target discovery shows the token.place target discovered from Sugarkube-approved labels/selectors and scraping successfully.
+- [ ] Representative PromQL results prove each required metric family is present with bounded labels only.
+- [ ] Grafana dashboard evidence shows real staging data, not placeholders or mock data.
+- [ ] A controlled compute-node loss drill proves alerts/dashboard panels show no healthy compute node while demand exists and recovery after node return.
+- [ ] A controlled relay restart drill documents expected in-memory state loss for registrations, queued requests, in-flight work, and replies; restart visibility is explicit and does not claim durability.
+- [ ] At least one alert is exercised end-to-end through the chosen Alertmanager route or test receiver.
+- [ ] Label inspection proves no sensitive, user-controlled, raw identifier, or high-cardinality labels are emitted.
+- [ ] Staging soak completes before production promotion with scrape health, dashboard panels, provisional thresholds, Prometheus resource usage, and noisy-alert review recorded.
+- [ ] Rollback to the previous immutable image tag is tested or rehearsed and the exact previous tag is recorded.
+
+### Post-v0.1.2 work, not blockers
+
+- [ ] Loki/log aggregation.
+- [ ] Distributed tracing or Tempo.
+- [ ] Long-term metrics storage beyond the initial Sugarkube Prometheus retention window.
+- [ ] Multi-cluster federation.
+- [ ] Per-user analytics.
+- [ ] Durable relay queue/shared-state architecture, except where future release requirements explicitly move it into scope.
+- [ ] Custom Sugarkube ServiceMonitor selector-label migration unless the platform values are intentionally changed.
+
+## E2EE and privacy invariants
+
+These are release blockers and must be testable in code review, staging inspection, and dashboard/alert review.
+
+- [ ] Metrics, metric labels, logs used for dashboards, dashboards, and alerts never contain prompts, responses, tool arguments, model output, API keys, cryptographic keys, ciphertext, public-key material, raw request IDs, client identifiers, IP addresses, auth headers, arbitrary exception strings, raw URLs, or user-controlled metadata.
+- [ ] Prompt length, response length, raw payload size, model names, URLs, user agents, client-provided IDs, and user-controlled metadata are not used as metric labels unless a future design explicitly approves a bounded representation.
+- [ ] Relay-owned diagnostics remain ciphertext-blind and fail closed if preserving E2EE is not possible.
+- [ ] Route labels use fixed normalized route names or route classes, never raw URLs or path parameters.
+- [ ] Outcome labels use fixed enumerations only, such as `success`, `validation_error`, `rate_limited`, `quota_rejected`, `cancelled`, `expired`, `timeout`, `dependency_failure`, and `unknown_error`.
+- [ ] Provider-mode labels use bounded categories only, such as `local`, `distributed`, `mock`, `disabled`, or `unknown`; do not label by model name, node ID, host, URL, or provider account.
+- [ ] Status labels use `status_class` such as `2xx`, `3xx`, `4xx`, and `5xx`; raw `status_code` is allowed only if explicitly reviewed as bounded and necessary.
+
+## Required metric contract
+
+Every metric must include or be safely relabeled with the common Sugarkube dimensions `app="tokenplace"`, `environment`, `cluster`, `namespace`, and `release` or immutable release identity. New app-owned labels must stay bounded and should keep the active series count under the Sugarkube app budget unless explicitly reviewed.
+
+| Required signal | Purpose | Bounded label guidance |
+| --- | --- | --- |
+| API v1 request totals | Show request rate and route/outcome mix for active API v1 paths. | `route`, `status_class`, `provider_mode`, `outcome`; normalized route names only. |
+| API v1 duration histograms | Show latency and p95/p99 trend for API v1 paths. | Same labels as request totals; seconds buckets suitable for Raspberry Pi/SBC clusters. |
+| Relay queue depth | Show backlog and demand that compute nodes have not processed yet. | No request IDs or node IDs; optionally `queue="api_v1"`. |
+| Oldest queued request age | Detect stale work before users experience indefinite waits. | No request IDs; seconds gauge/histogram with queue class only. |
+| Registered compute-node count | Show available relay-compute capacity known to the relay. | Aggregate counts only; no public keys, node IDs, hostnames, or IPs. |
+| Healthy compute-node count | Distinguish registered but stale/unhealthy nodes from usable capacity. | Aggregate counts only; bounded health state if needed. |
+| Compute-node lease age | Detect stale leases before they cause stuck queues. | Age buckets or aggregate gauges; no node identifiers. |
+| Stale-node evictions | Prove stale registrations are removed and catch eviction spikes. | `outcome` or `reason` enum only. |
+| Registration failures | Detect token, schema, compatibility, and WAF-related registration problems. | `outcome` enum and route class; no token, public key, request body, or remote address. |
+| Heartbeat/poll failures | Detect compute nodes that cannot receive or poll work. | `outcome` enum only; no node identifiers. |
+| In-flight request count | Show work assigned but not yet completed. | Queue/request class only. |
+| In-flight request age | Detect hung compute work and long tails. | Queue/request class only; no request ID. |
+| Completed request count | Track successful relay-compute completions. | `outcome="completed"`, route/request class. |
+| Cancelled request count | Detect user/system cancellations. | `outcome="cancelled"`, route/request class. |
+| Expired request count | Detect work that aged out. | `outcome="expired"`, route/request class. |
+| Timed-out request count | Detect work breaching relay/client deadlines. | `outcome="timeout"`, route/request class. |
+| Failed request count | Detect relay or compute-node failures without exposing errors. | `outcome` enum; no exception strings. |
+| Rate-limit rejections | Show pressure from intentional throttling and protect availability. | Bounded `route_class` and `outcome="rate_limited"`; no identity labels. |
+| Quota rejections | Show capacity/policy rejection pressure separately from generic errors. | Bounded `route_class` and `outcome="quota_rejected"`. |
+| Upstream inference availability | Show whether relay-compute dependencies are usable. | Bounded `provider_mode` or `dependency="compute_node_pool"`; no model names or URLs. |
+| Upstream inference latency | Track dependency latency separately from HTTP handler latency. | Bounded provider/dependency category and outcome. |
+| Pod/process health | Correlate application symptoms with restarts, readiness, CPU, and memory. | Kubernetes labels from kube-state/cAdvisor plus app/release labels; no user data. |
+| Deployed release identity | Correlate metrics and dashboards with immutable image/chart provenance. | Low-cardinality build info such as app version, chart version, git revision, Helm release, environment, and immutable image tag/digest. |
+| Single-pod/in-memory constraint visibility | Make accepted relay state loss visible during pod replacement without claiming durability. | Restart count, process start time, build info, queue/node gauges resetting to zero; no request IDs or payload data. |
+
+## Scrape and deployment contract
+
+- [ ] The canonical `charts/tokenplace` chart exposes the metrics port/path internally for Prometheus scraping while keeping public ingress focused on the application routes.
+- [ ] ServiceMonitor discovery works with Sugarkube's kube-prometheus-stack label convention, including `release: kube-prometheus-stack`, unless Sugarkube intentionally changes selectors.
+- [ ] The ServiceMonitor or equivalent scrape discovery uses an explicit namespace selector for the `tokenplace` namespace or an approved Sugarkube-owned static scrape config with a tracked follow-up to move hooks into the app chart.
+- [ ] If NetworkPolicy is enabled, ingress from the `monitoring` namespace to the app metrics port and egress from Prometheus to that port are verified before release sign-off.
+- [ ] PrometheusRule resources are opt-in, chart-versioned, and rendered only when intentionally enabled by values.
+- [ ] Existing historical ServiceMonitor and PrometheusRule scaffolding in `deploy/charts/tokenplace-relay` is audited for useful patterns but is not described as deployed through the canonical GHCR/Sugarkube chart without evidence.
+- [ ] Public ingress does not expose Prometheus or metrics endpoints by default; blackbox probes use public-safe health or app routes instead.
+- [ ] Release metadata can be correlated with an immutable image tag, image digest where available, Helm chart version, app version, and Git revision.
+
+## Dashboard requirement
+
+Create a token.place dashboard backed by real Prometheus data. Include an E2EE/privacy note in the dashboard description stating that panels intentionally exclude prompts, responses, ciphertext, keys, raw request IDs, client identifiers, IP addresses, public-key material, and arbitrary errors.
+
+- [ ] Relay availability and public/internal health.
+- [ ] API v1 request rate, latency, status class, and outcome.
+- [ ] Queue depth and oldest queued request age.
+- [ ] Registered and healthy compute-node counts.
+- [ ] Lease age, stale-node evictions, and poll/heartbeat health.
+- [ ] In-flight request count, in-flight age, and timeout trend.
+- [ ] Rate-limit and quota rejection trend.
+- [ ] Upstream inference availability and latency.
+- [ ] Pod restarts, readiness, CPU, memory, and resource saturation.
+- [ ] Current immutable release identity: image tag/digest, chart version, app version, Git revision, environment, and Helm release.
+- [ ] Single-pod/in-memory relay constraint visibility: process start/restart panels and state reset expectations.
+
+## Alert requirement
+
+Alerts are provisional until staging establishes normal behavior. They must be actionable, have runbook notes, avoid sensitive annotations, and start conservative enough to avoid noisy paging.
+
+- [ ] Relay unavailable: app scrape or public/internal health down for the configured window.
+- [ ] No healthy compute node while requests are arriving: demand exists and healthy node count is zero.
+- [ ] Growing queue depth or queue age: depth or oldest age exceeds the staging baseline for a sustained window.
+- [ ] Elevated API v1 error ratio: bounded `5xx` or failure outcome ratio exceeds staging baseline.
+- [ ] Elevated timeout/cancellation ratio: timeout/cancel outcomes exceed staging baseline.
+- [ ] Stale-node eviction spike: eviction count exceeds baseline and suggests node churn or lease bugs.
+- [ ] Rate-limit rejection spike: rate-limited or quota-rejected outcomes exceed expected baseline.
+- [ ] Repeated pod restart: restart count or CrashLoopBackOff exceeds the app runbook threshold.
+- [ ] Prometheus scrape failure: `up` for the token.place target is down for the configured window.
+
+## Staging QA evidence template
+
+Record exact commands, timestamps, environment, immutable image tag, image digest where available, chart version, Git revision, and links/screenshots in the promotion issue or this release record.
+
+- [ ] `kubectl -n monitoring get servicemonitor,prometheusrule` output proves intended discovery and opt-in alert resources.
+- [ ] Prometheus target page or API output shows token.place target discovered and `health: up`.
+- [ ] PromQL output includes request totals, duration histograms, queue gauges, compute-node gauges, lease/eviction counters, in-flight metrics, rejection counters, upstream metrics, build info, and scrape `up`.
+- [ ] Label audit output lists labels for each metric family and confirms no prohibited labels or high-cardinality values.
+- [ ] Dashboard screenshot or exported JSON shows all required rows backed by live staging data.
+- [ ] Controlled compute-node loss drill: stop or isolate a staging compute node while safe synthetic requests arrive; record queue/node metrics, alert behavior, recovery, and absence of sensitive labels/logs.
+- [ ] Controlled relay restart drill: restart the staging relay pod; record pod restart/process start metrics, queue/node state reset, expected in-memory state loss, re-registration behavior, and user-facing recovery notes.
+- [ ] Tested alert evidence: trigger one non-destructive alert path and record Alertmanager receiver/test route delivery.
+- [ ] Staging soak evidence: record duration, request mix, scrape health, dashboard stability, Prometheus resource usage, threshold changes, and noisy alerts disabled or tuned.
+- [ ] Rollback evidence: identify the previous immutable image tag and chart version, rehearse or execute rollback, and verify health/diagnostics/metrics after rollback.
+
+## Production promotion gate
+
+- [ ] All v0.1.2 blockers are checked in staging evidence before production.
+- [ ] Production deploy uses the canonical GHCR image and `oci://ghcr.io/futuroptimist/charts/tokenplace` chart with immutable image tag or digest.
+- [ ] Production promotion repeats target discovery, scrape success, dashboard health, at least representative PromQL checks, release identity correlation, and privacy label inspection.
+- [ ] Rollback command and previous immutable image tag are recorded before changing production.
+- [ ] If any E2EE/privacy invariant is violated, promotion fails closed and the release is rolled back or held.


### PR DESCRIPTION
### Motivation

- Make production-grade, privacy-preserving observability an explicit token.place v0.1.2 release requirement while preserving the relay-blind E2EE and API v1-only guardrails. 
- Record the canonical Sugarkube/GHCR chart and current metrics/diagnostics baseline so staging and production evidence use the correct chart and do not rely on legacy scaffolding. 
- Provide an explicit, testable QA gate (dashboards, alerts, drill procedures, label-audit, and rollback) so promotions fail closed on privacy or E2EE invariant violations.

### Description

- Added `docs/releases/v0.1.2.md`, an unchecked release plan that enumerates the canonical chart and image baseline, required metric families with bounded-label guidance, E2EE/privacy invariants, scrape/deployment contract, dashboard and alert requirements, staging evidence templates, and rollback gates. 
- Linked the new plan from `docs/README.md` and the repository `README.md` with minimal targeted edits so the plan is discoverable from the docs index and Sugarkube release section. 
- Explicitly called out legacy/compatibility chart paths (for auditing only) and documented that no runtime, chart, or version changes are made in this PR. 
- All checklist items in the new plan are intentionally left unchecked and no metrics/alert/dashboard implementations or version bumps were introduced.

### Testing

- Ran unit checks with `python -m pytest tests/unit/test_relay_logging_and_metrics.py -q`, which passed (`2 passed`).
- Ran repository checks with `pre-commit run --all-files`, which completed successfully (`Passed`).
- Verified repository cleanliness with `git diff --check`, which produced no whitespace/merge errors (`Passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eb78bad0832fa15ceb67de3e7d1d)