### PR TITLE
Route relay-only API v1 chat through compute nodes

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -730,14 +730,27 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
 
 
 def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
-    """Read and normalize API v1 provider environment configuration."""
+    """Read and normalize API v1 provider environment configuration.
+
+    Relay-only deployments publish API v1 from ``relay.py`` and rely on
+    registered compute nodes instead of an in-process llama.cpp runtime.  When
+    a relay-only public/internal relay URL is configured, select the
+    distributed provider before local inference can attempt to import or load
+    llama-cpp-python.  Disable local fallback for this mode so relay
+    availability failures stay explicit and do not degrade into local model
+    dependency errors.
+    """
 
     mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return mode, _select_distributed_target(), distributed_fallback_enabled
+    target_selection = _select_distributed_target()
+    if target_selection.relay_only:
+        mode = "distributed"
+        distributed_fallback_enabled = False
+    return mode, target_selection, distributed_fallback_enabled
 
 
 def get_api_v1_distributed_target_selection() -> DistributedTargetSelection:

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -162,6 +162,135 @@ def test_api_v1_chat_completions_rejects_stream_true(client):
     assert "Streaming is not supported" in payload["error"]["message"]
 
 
+
+def _clear_api_v1_relay_env(monkeypatch):
+    for env_name in (
+        "TOKENPLACE_API_V1_COMPUTE_PROVIDER",
+        "TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK",
+        "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+        "TOKENPLACE_RELAY_INTERNAL_URL",
+        "TOKEN_PLACE_RELAY_INTERNAL_URL",
+        "RELAY_INTERNAL_URL",
+        "TOKENPLACE_RELAY_PUBLIC_URL",
+        "TOKEN_PLACE_RELAY_PUBLIC_URL",
+        "RELAY_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_relay_only_chat_uses_compute_node_without_local_llama(client, monkeypatch):
+    _clear_api_v1_relay_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    def fail_local_generate(*_args, **_kwargs):
+        raise AssertionError("relay-only chat must not call local llama inference")
+
+    def fake_distributed_complete(self, *, model_id, messages, options=None):
+        assert self.base_url == "https://staging.token.place"
+        assert model_id == "llama-3.1-8b-instruct"
+        assert messages == [{"role": "user", "content": "hello relay"}]
+        assert options == {}
+        compute_provider._last_backend_path.set("distributed_relay_e2ee")
+        return {"role": "assistant", "content": "hello from relay compute"}
+
+    monkeypatch.setattr(routes, "generate_response", fail_local_generate)
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "complete_chat",
+        fake_distributed_complete,
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello relay"}],
+        },
+        headers={"Origin": "https://staging.democratized.space"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
+    payload = response.get_json()
+    assert payload["object"] == "chat.completion"
+    assert payload["choices"][0]["message"]["content"] == "hello from relay compute"
+
+
+def test_relay_only_chat_no_compute_node_returns_relay_specific_503(client, monkeypatch):
+    _clear_api_v1_relay_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "staging")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+    class NoNodesResponse:
+        status_code = 503
+
+        def json(self):
+            return {
+                "error": {
+                    "message": "No LLM servers are available right now.",
+                    "code": "no_registered_compute_nodes",
+                }
+            }
+
+    def fake_get(url, timeout):
+        assert url == "https://staging.token.place/api/v1/relay/servers/next"
+        return NoNodesResponse()
+
+    def fail_local_generate(*_args, **_kwargs):
+        raise AssertionError("relay-only no-node failures must not call local llama inference")
+
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(routes, "generate_response", fail_local_generate)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello relay"}],
+        },
+        headers={"Origin": "https://staging.democratized.space"},
+    )
+
+    assert response.status_code == 503
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    payload = response.get_json()
+    assert payload["error"]["code"] == "no_registered_compute_nodes"
+    assert "llama-cpp-python" not in payload["error"]["message"]
+    assert payload["error"]["type"] == "service_unavailable_error"
+
+
+def test_local_chat_still_reports_missing_llama_dependency(client, monkeypatch):
+    from api.v1 import models
+
+    _clear_api_v1_relay_env(monkeypatch)
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "development")
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local")
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    models._loaded_models.clear()
+    monkeypatch.setattr(models, "USE_MOCK_LLM", False)
+    monkeypatch.setattr(models, "Llama", None)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello local"}],
+        },
+    )
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["type"] == "model_unavailable"
+    assert "llama-cpp-python is not installed" in payload["error"]["message"]
+
+
 def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
     response = client.get("/api/v1/models")
 


### PR DESCRIPTION
### Motivation

- Relay-only deployments that publish API v1 via a public/internal relay URL must route chat requests to registered compute nodes and must not require local `llama-cpp-python` to be installed, nor surface the local dependency error when relay dispatch is expected.

### Description

- Force distributed provider selection when the resolved distributed target is marked `relay_only` by changing `_read_api_v1_provider_env` to set `mode="distributed"` and `distributed_fallback_enabled=False` so relay-only public/internal relay targets are used before any local inference path.
- Preserve existing behavior for explicit local deployments by leaving non-relay and explicit `local` modes unchanged.
- Add regression tests in `tests/unit/test_api_v1_launch_contract.py` that verify (1) relay-only chat exercises the distributed compute-node path and does not call local llama inference, (2) relay-only with no registered compute node returns a relay-specific 503 (no `llama-cpp-python` message) and preserves public API v1 CORS, and (3) explicit local mode still reports missing `llama-cpp-python` when local inference is selected.

### Testing

- Ran `pytest -q tests/unit/test_api_v1_launch_contract.py` and the targeted launch-contract tests passed.
- Ran `pytest -q tests/unit/test_api_v1_launch_contract.py tests/unit/test_api_v1_cors.py tests/test_relay.py` and the combined suite passed.
- Ran the full unit suite with `pytest -q tests/unit` and it passed (all unit tests passed in this environment).
- Verified CORS and error-string search with `rg` and ran `pre-commit run --all-files`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ffc88e38832f89b1237841b6c485)