### PR TITLE
Route relay-only API v1 chat through compute nodes

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -5,7 +5,7 @@ This module follows OpenAI API conventions to serve as a drop-in replacement.
 
 from __future__ import annotations
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, current_app, request, jsonify
 import base64
 import time
 import zlib
@@ -232,6 +232,81 @@ def _request_relay_base_url() -> str:
     """Return a trusted API v1 relay base URL for desktop bridge work."""
 
     return _request_relay_target_selection().url
+
+
+def _env_truthy(value: str | None, *, default: bool = False) -> bool:
+    """Parse common boolean environment values without importing relay.py."""
+
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _has_explicit_relay_upstream_config() -> bool:
+    """Return True when relay upstreams were explicitly configured."""
+
+    for env_name in (
+        "TOKEN_PLACE_RELAY_UPSTREAMS",
+        "PERSONAL_GAMING_PC_URL",
+        "TOKENPLACE_RELAY_UPSTREAM_URL",
+    ):
+        if os.environ.get(env_name, "").strip():
+            return True
+
+    configured_servers = current_app.config.get("relay_configured_servers", [])
+    if not isinstance(configured_servers, list):
+        return False
+
+    normalized_servers = {
+        server.strip().rstrip("/").lower()
+        for server in configured_servers
+        if isinstance(server, str) and server.strip()
+    }
+    return bool(normalized_servers and normalized_servers != {"https://token.place"})
+
+
+def _request_relay_only_target_selection() -> DistributedTargetSelection | None:
+    """Select same-relay API v1 routing when this process is relay-only."""
+
+    if _env_truthy(os.environ.get("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH"), default=False):
+        return None
+    if _has_explicit_relay_upstream_config():
+        return None
+
+    target_selection = get_api_v1_distributed_target_selection()
+    if target_selection.url and target_selection.relay_only:
+        return target_selection
+
+    public_base_url = current_app.config.get("public_base_url") or os.environ.get("TOKENPLACE_PUBLIC_BASE_URL")
+    if isinstance(public_base_url, str) and public_base_url.strip():
+        return DistributedTargetSelection(
+            url=public_base_url.strip().rstrip("/"),
+            source="relay_only_public_base_url",
+            relay_only=True,
+        )
+
+    return None
+
+
+def _select_chat_completion_provider(*, force_desktop_bridge_distributed: bool):
+    """Resolve the API v1 chat provider with relay-only precedence."""
+
+    if force_desktop_bridge_distributed:
+        return get_api_v1_compute_provider_for_mode(
+            mode="distributed",
+            distributed_target_selection=_request_relay_target_selection(),
+            distributed_fallback_enabled=False,
+        )
+
+    relay_only_target = _request_relay_only_target_selection()
+    if relay_only_target is not None:
+        return get_api_v1_compute_provider_for_mode(
+            mode="distributed",
+            distributed_target_selection=relay_only_target,
+            distributed_fallback_enabled=False,
+        )
+
+    return get_api_v1_compute_provider()
 
 
 def _get_service_name() -> str:
@@ -493,14 +568,8 @@ def _handle_chat_completion_request(data):
         )
 
         log_info(f"Generating response using model {model_id}")
-        provider = (
-            get_api_v1_compute_provider_for_mode(
-                mode="distributed",
-                distributed_target_selection=_request_relay_target_selection(),
-                distributed_fallback_enabled=False,
-            )
-            if force_desktop_bridge_distributed
-            else get_api_v1_compute_provider()
+        provider = _select_chat_completion_provider(
+            force_desktop_bridge_distributed=force_desktop_bridge_distributed,
         )
         resolved_provider_name = provider.__class__.__name__
         resolved_provider_path = get_api_v1_resolved_provider_path(provider)

--- a/tests/unit/test_api_v1_routes_additional.py
+++ b/tests/unit/test_api_v1_routes_additional.py
@@ -286,6 +286,90 @@ def test_chat_completion_sets_provider_path_and_stream_mode_headers(client, monk
     assert response.headers["X-Tokenplace-API-V1-Stream-Mode"] == "non-streaming"
 
 
+def test_chat_completion_relay_only_uses_compute_node_path_without_local_llama(client, monkeypatch):
+    captured = {}
+
+    class _RelayOnlyProvider:
+        def complete_chat(self, model_id, messages, options):
+            assert model_id == "llama-3.1-8b-instruct"
+            return {"role": "assistant", "content": "Relay reply"}
+
+    def fake_provider_for_mode(**kwargs):
+        captured.update(kwargs)
+        return _RelayOnlyProvider()
+
+    def local_provider_should_not_be_used():
+        raise AssertionError("relay-only chat must not select local llama.cpp inference")
+
+    payload = {
+        "model": "llama-3.1-8b-instruct",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3.1-8b-instruct"}])
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", local_provider_should_not_be_used)
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider_for_mode", fake_provider_for_mode)
+    monkeypatch.setattr(routes, "get_api_v1_resolved_provider_path", lambda _provider: "distributed")
+
+    response = client.post("/api/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert response.get_json()["choices"][0]["message"]["content"] == "Relay reply"
+    assert captured["mode"] == "distributed"
+    assert captured["distributed_fallback_enabled"] is False
+    assert captured["distributed_target_selection"].relay_only is True
+    assert captured["distributed_target_selection"].url == "https://staging.token.place"
+
+
+def test_chat_completion_relay_only_no_compute_node_returns_relay_specific_error(client, monkeypatch):
+    class _RelayOnlyProvider:
+        def complete_chat(self, model_id, messages, options):
+            raise compute_provider.ComputeProviderError(
+                "relay reported no registered compute nodes",
+                code="no_registered_compute_nodes",
+                error_type="service_unavailable_error",
+                public_message="No LLM servers are available right now.",
+                status_code=503,
+            )
+
+    payload = {
+        "model": "llama-3.1-8b-instruct",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.delenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", raising=False)
+    monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
+    monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
+    monkeypatch.setitem(app.config, "relay_configured_servers", ["https://token.place"])
+    monkeypatch.setattr(routes, "get_models_info", lambda: [{"id": "llama-3.1-8b-instruct"}])
+    monkeypatch.setattr(routes, "evaluate_messages_for_policy", lambda _messages: SimpleNamespace(allowed=True))
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider_for_mode", lambda **_kwargs: _RelayOnlyProvider())
+    monkeypatch.setattr(routes, "get_api_v1_resolved_provider_path", lambda _provider: "distributed")
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json=payload,
+        headers={"Origin": "https://staging.democratized.space"},
+    )
+
+    assert response.status_code == 503
+    body = response.get_json()
+    assert body["error"]["code"] == "no_registered_compute_nodes"
+    assert body["error"]["type"] == "service_unavailable_error"
+    assert "llama-cpp-python is not installed" not in body["error"]["message"]
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
 def test_chat_completion_rejects_streaming_for_api_v1(client, monkeypatch):
     provider_called = {"value": False}
 


### PR DESCRIPTION
### Motivation
- In relay-only deployments the public API v1 `/chat/completions` must not attempt to load local `llama-cpp-python` and must route to registered compute nodes instead of failing with a local-dependency message.
- When no compute node is available the API should return an explicit relay-specific error (e.g. `no_registered_compute_nodes`) that operators can act on, while preserving existing local-inference behavior for non-relay deployments.

### Description
- Added relay-only provider selection helpers and heuristics in `api/v1/routes.py`: `_env_truthy`, `_has_explicit_relay_upstream_config`, `_request_relay_only_target_selection`, and `_select_chat_completion_provider` to prefer a distributed (relay) compute-node path in relay-only mode.
- Replaced the inline provider selection in the chat handler with ` _select_chat_completion_provider(...)` so relay-only routing is evaluated before any local model/loading paths are considered.
- Preserved forced desktop-bridge distributed routing and the existing local fallback behavior when relay-only heuristics do not apply.
- Added focused tests in `tests/unit/test_api_v1_routes_additional.py` covering: relay-only selects the distributed compute-node path without calling local llama, and relay-only with no compute node returns the relay-specific `no_registered_compute_nodes` error and preserves public CORS headers.

### Testing
- Ran the focused unit tests with `pytest -q tests/unit/test_api_v1_routes_additional.py tests/unit/test_api_v1_cors.py` and they passed.
- Ran the broader suites `pytest -q tests/test_relay.py tests/unit/test_api_v1_launch_contract.py tests/unit/test_api_v1_cors.py tests/unit` and observed `170 passed` in the run recorded in the transcript.
- Ran repository checks `pre-commit run --all-files` which completed successfully, and an `rg` search for deployed/error strings to verify the new error semantics was executed.
- New tests added: `test_chat_completion_relay_only_uses_compute_node_path_without_local_llama` and `test_chat_completion_relay_only_no_compute_node_returns_relay_specific_error`, both passing in CI-local runs; residual risk: the relay-only heuristics use environment/config heuristics (public base URL and upstream flags), so monitor staging to ensure the selection matches actual deployment environment in production promotion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ffe0e7e4832f9b02f997a8e712c8)