### PR TITLE
Route API v1 chat to distributed compute in relay‑only deployments

### DIFF
--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -5,7 +5,7 @@ This module follows OpenAI API conventions to serve as a drop-in replacement.
 
 from __future__ import annotations
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, current_app, request, jsonify
 import base64
 import time
 import zlib
@@ -232,6 +232,60 @@ def _request_relay_base_url() -> str:
     """Return a trusted API v1 relay base URL for desktop bridge work."""
 
     return _request_relay_target_selection().url
+
+
+def _current_app_is_relay_only() -> bool:
+    """Return True when this Flask app is configured as a relay-only deployment."""
+
+    configured_servers = current_app.config.get("relay_configured_servers")
+    if configured_servers is None:
+        return False
+
+    if configured_servers:
+        return False
+
+    require_upstream_health = os.getenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "").strip().lower()
+    if require_upstream_health in {"1", "true", "yes", "on"}:
+        return False
+
+    if current_app.config.get("upstream_url"):
+        return False
+
+    return True
+
+
+def _relay_only_target_selection() -> DistributedTargetSelection:
+    """Return the relay URL public API v1 should use in relay-only mode."""
+
+    public_base_url = (current_app.config.get("public_base_url") or "").strip().rstrip("/")
+    if public_base_url:
+        return DistributedTargetSelection(
+            url=public_base_url,
+            source="relay_only_app:public_base_url",
+            relay_only=True,
+        )
+
+    return _request_relay_target_selection()
+
+
+def _select_chat_completion_provider(*, force_desktop_bridge_distributed: bool):
+    """Select the API v1 chat provider without falling through to local inference in relay-only mode."""
+
+    if force_desktop_bridge_distributed:
+        return get_api_v1_compute_provider_for_mode(
+            mode="distributed",
+            distributed_target_selection=_request_relay_target_selection(),
+            distributed_fallback_enabled=False,
+        )
+
+    if _current_app_is_relay_only():
+        return get_api_v1_compute_provider_for_mode(
+            mode="distributed",
+            distributed_target_selection=_relay_only_target_selection(),
+            distributed_fallback_enabled=False,
+        )
+
+    return get_api_v1_compute_provider()
 
 
 def _get_service_name() -> str:
@@ -493,14 +547,8 @@ def _handle_chat_completion_request(data):
         )
 
         log_info(f"Generating response using model {model_id}")
-        provider = (
-            get_api_v1_compute_provider_for_mode(
-                mode="distributed",
-                distributed_target_selection=_request_relay_target_selection(),
-                distributed_fallback_enabled=False,
-            )
-            if force_desktop_bridge_distributed
-            else get_api_v1_compute_provider()
+        provider = _select_chat_completion_provider(
+            force_desktop_bridge_distributed=force_desktop_bridge_distributed
         )
         resolved_provider_name = provider.__class__.__name__
         resolved_provider_path = get_api_v1_resolved_provider_path(provider)

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -162,6 +162,85 @@ def test_api_v1_chat_completions_rejects_stream_true(client):
     assert "Streaming is not supported" in payload["error"]["message"]
 
 
+def test_relay_only_chat_uses_distributed_provider_without_local_llama(monkeypatch, client):
+    monkeypatch.setitem(relay.app.config, "relay_configured_servers", [])
+    monkeypatch.setitem(relay.app.config, "upstream_url", None)
+    monkeypatch.setitem(relay.app.config, "public_base_url", "https://staging.token.place")
+
+    captured = {}
+
+    class _DistributedProvider:
+        def complete_chat(self, *, model_id, messages, options):
+            captured["model_id"] = model_id
+            captured["messages"] = messages
+            captured["options"] = options
+            return {"role": "assistant", "content": "relay response"}
+
+    def fail_local_provider():
+        raise AssertionError("relay-only chat must not select the local provider")
+
+    def fake_provider_for_mode(**kwargs):
+        captured["provider_kwargs"] = kwargs
+        return _DistributedProvider()
+
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", fail_local_provider)
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider_for_mode", fake_provider_for_mode)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["choices"][0]["message"]["content"] == "relay response"
+    provider_kwargs = captured["provider_kwargs"]
+    assert provider_kwargs["mode"] == "distributed"
+    assert provider_kwargs["distributed_fallback_enabled"] is False
+    target_selection = provider_kwargs["distributed_target_selection"]
+    assert target_selection.url == "https://staging.token.place"
+    assert target_selection.relay_only is True
+    assert captured["model_id"] == "llama-3.1-8b-instruct"
+
+
+def test_relay_only_chat_no_compute_node_reports_relay_specific_error_with_cors(
+    monkeypatch,
+    client,
+):
+    monkeypatch.setitem(relay.app.config, "relay_configured_servers", [])
+    monkeypatch.setitem(relay.app.config, "upstream_url", None)
+    monkeypatch.setitem(relay.app.config, "public_base_url", "https://staging.token.place")
+
+    def fake_provider_for_mode(**_kwargs):
+        raise compute_provider.ComputeProviderError(
+            "relay reported no registered compute nodes",
+            code="no_registered_compute_nodes",
+            error_type="service_unavailable_error",
+            public_message="No registered relay compute node is available right now.",
+            status_code=503,
+        )
+
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider_for_mode", fake_provider_for_mode)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        headers={"Origin": "https://staging.democratized.space"},
+    )
+
+    assert response.status_code == 503
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    payload = response.get_json()
+    assert payload["error"]["code"] == "no_registered_compute_nodes"
+    assert "relay compute node" in payload["error"]["message"]
+    assert "llama-cpp-python is not installed" not in payload["error"]["message"]
+
+
 def test_api_v1_model_listing_is_not_api_v2_catalog_dump(client):
     response = client.get("/api/v1/models")
 


### PR DESCRIPTION
### Motivation
- Relay-only staging was incorrectly selecting the local inference path and failing with "llama-cpp-python is not installed" instead of dispatching to registered compute nodes or returning a relay-specific error. 
- Public API v1 chat must not require local `llama-cpp-python` when the process is acting as a relay-only deployment, and errors must be actionable and distinguish relay availability from local dependency failures.

### Description
- Add relay-only detection and provider selection in `api/v1/routes.py` via `_current_app_is_relay_only()` and `_select_chat_completion_provider()` so the chat handler prefers the `distributed` provider with `distributed_fallback_enabled=False` when the Flask app is relay-only. 
- Use configured `public_base_url` for relay-only dispatch with `_relay_only_target_selection()` so relay-only public relays route to their own compute target. 
- Replace the inline provider selection in the chat handler with the new `_select_chat_completion_provider()` to avoid falling through to local inference when relay-only. 
- Add regression tests in `tests/unit/test_api_v1_launch_contract.py` to assert that relay-only chat chooses a distributed provider (not local), returns an OpenAI-compatible completion on success, and returns a relay-specific 503 with wildcard CORS and an explicit `no_registered_compute_nodes` error when no compute node is available.

### Testing
- Ran focused unit and integration suites: `pytest -q tests/test_relay.py` (still passing), `pytest -q tests/unit/test_api_v1_launch_contract.py` (passed), `pytest -q tests/unit/test_api_v1_cors.py` (passed), and `pytest -q tests/unit` (all unit tests passed). 
- Verified the staging relay regression: `pytest -q tests/test_api.py::test_api_v1_chat_completion_staging_no_nodes_returns_clear_503` passed and the new relay-specific test `tests/unit/test_api_v1_launch_contract.py::test_relay_only_chat_no_compute_node_reports_relay_specific_error_with_cors` passed. 
- Ran repository checks via `pre-commit run --all-files` which executed project checks and the test runner hooks; the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ffd586e4832f9ce70abe26f110f3)