### PR TITLE
Fix relay-only API v1 chat routing

### DIFF
--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -774,8 +774,6 @@ def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
     """
 
     configured_mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip().lower()
-    mode = configured_mode or "local"
-    target_selection = _select_distributed_target()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
@@ -783,9 +781,10 @@ def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
 
     implicit_relay_public_target = _select_implicit_relay_public_target()
     if is_api_v1_implicit_relay_only_selection(implicit_relay_public_target):
-        mode = "distributed"
-        distributed_fallback_enabled = False
-        target_selection = implicit_relay_public_target
+        return "distributed", implicit_relay_public_target, False
+
+    mode = configured_mode or "local"
+    target_selection = _select_distributed_target()
 
     return mode, target_selection, distributed_fallback_enabled
 

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -640,6 +640,23 @@ def _select_distributed_target() -> DistributedTargetSelection:
     return DistributedTargetSelection(url="", source="unset", relay_only=False)
 
 
+def _select_implicit_relay_public_target() -> DistributedTargetSelection:
+    """Resolve only public relay URLs eligible for implicit relay-only selection."""
+
+    for env_name in _RELAY_PUBLIC_URL_ENVS:
+        target = _validated_target_url(
+            os.environ.get(env_name),
+            source=f"env:{env_name}",
+        )
+        if target:
+            return DistributedTargetSelection(
+                url=target,
+                source=f"relay_public_env:{env_name}",
+                relay_only=True,
+            )
+    return DistributedTargetSelection(url="", source="unset", relay_only=False)
+
+
 @lru_cache(maxsize=16)
 def _build_api_v1_compute_provider(
     mode: str,
@@ -741,11 +758,9 @@ def is_api_v1_implicit_relay_only_selection(
 
     if os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip():
         return False
-    selection = target_selection or _select_distributed_target()
-    return (
-        bool(selection.url)
-        and selection.relay_only
-        and selection.source.startswith("relay_public_env:")
+    selection = target_selection or _select_implicit_relay_public_target()
+    return bool(selection.url) and selection.relay_only and selection.source.startswith(
+        "relay_public_env:"
     )
 
 
@@ -766,9 +781,11 @@ def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
         not in {"0", "false", "no", "off"}
     )
 
-    if is_api_v1_implicit_relay_only_selection(target_selection):
+    implicit_relay_public_target = _select_implicit_relay_public_target()
+    if is_api_v1_implicit_relay_only_selection(implicit_relay_public_target):
         mode = "distributed"
         distributed_fallback_enabled = False
+        target_selection = implicit_relay_public_target
 
     return mode, target_selection, distributed_fallback_enabled
 

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -730,14 +730,27 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
 
 
 def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
-    """Read and normalize API v1 provider environment configuration."""
+    """Read and normalize API v1 provider environment configuration.
 
-    mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local").strip().lower()
+    Relay-only deployments publish the relay URL instead of a local model
+    runtime. Treat that as an explicit distributed API v1 target so public chat
+    requests do not fall through to the in-process llama.cpp loader. Local mode
+    remains the default when no relay-only target is configured.
+    """
+
+    configured_mode = os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip().lower()
+    mode = configured_mode or "local"
+    target_selection = _select_distributed_target()
     distributed_fallback_enabled = (
         os.environ.get("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    return mode, _select_distributed_target(), distributed_fallback_enabled
+
+    if not configured_mode and target_selection.relay_only and target_selection.url:
+        mode = "distributed"
+        distributed_fallback_enabled = False
+
+    return mode, target_selection, distributed_fallback_enabled
 
 
 def get_api_v1_distributed_target_selection() -> DistributedTargetSelection:

--- a/api/v1/compute_provider.py
+++ b/api/v1/compute_provider.py
@@ -729,6 +729,26 @@ def get_api_v1_compute_provider() -> ApiV1ComputeProvider:
     )
 
 
+def is_api_v1_implicit_relay_only_selection(
+    target_selection: DistributedTargetSelection | None = None,
+) -> bool:
+    """Return True when env should implicitly select relay-only distributed mode.
+
+    Only public relay URLs are auto-selected. Internal loopback relay URLs may
+    point back at the same Gunicorn worker pool, so they require an explicit
+    provider mode to avoid blocking relay self-dispatch by default.
+    """
+
+    if os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip():
+        return False
+    selection = target_selection or _select_distributed_target()
+    return (
+        bool(selection.url)
+        and selection.relay_only
+        and selection.source.startswith("relay_public_env:")
+    )
+
+
 def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
     """Read and normalize API v1 provider environment configuration.
 
@@ -746,7 +766,7 @@ def _read_api_v1_provider_env() -> tuple[str, DistributedTargetSelection, bool]:
         not in {"0", "false", "no", "off"}
     )
 
-    if not configured_mode and target_selection.relay_only and target_selection.url:
+    if is_api_v1_implicit_relay_only_selection(target_selection):
         mode = "distributed"
         distributed_fallback_enabled = False
 

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -42,6 +42,7 @@ from api.v1.compute_provider import (
     get_api_v1_compute_provider,
     get_api_v1_compute_provider_for_mode,
     get_api_v1_distributed_target_selection,
+    is_api_v1_implicit_relay_only_selection,
     get_api_v1_last_backend_path,
     get_api_v1_resolved_provider_path,
     reset_api_v1_generate_response_override,
@@ -614,18 +615,15 @@ def _handle_chat_completion_request(data):
             f"path={execution_backend_path} detail={str(e)}"
         )
         try:
-            relay_only_error = get_api_v1_distributed_target_selection().relay_only
+            implicit_relay_only_error = is_api_v1_implicit_relay_only_selection()
         except Exception:
-            relay_only_error = False
-        provider_mode_configured = bool(
-            os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip()
-        )
+            implicit_relay_only_error = False
         public_code = (
             "no_compute_node_available"
             if (
                 e.code == "no_registered_compute_nodes"
-                and relay_only_error
-                and not provider_mode_configured
+                and implicit_relay_only_error
+                and not force_desktop_bridge_distributed
             )
             else e.code
         )

--- a/api/v1/routes.py
+++ b/api/v1/routes.py
@@ -613,10 +613,26 @@ def _handle_chat_completion_request(data):
             f"code={e.code} status={e.status_code} "
             f"path={execution_backend_path} detail={str(e)}"
         )
+        try:
+            relay_only_error = get_api_v1_distributed_target_selection().relay_only
+        except Exception:
+            relay_only_error = False
+        provider_mode_configured = bool(
+            os.environ.get("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "").strip()
+        )
+        public_code = (
+            "no_compute_node_available"
+            if (
+                e.code == "no_registered_compute_nodes"
+                and relay_only_error
+                and not provider_mode_configured
+            )
+            else e.code
+        )
         return format_error_response(
             e.public_message,
             error_type=e.error_type,
-            code=e.code,
+            code=public_code,
             status_code=e.status_code,
         )
     except Exception as e:  # pragma: no cover - defensive guard for unexpected errors

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -572,6 +572,23 @@ def test_public_relay_url_implicitly_selects_distributed_without_fallback(monkey
     try:
         provider = compute_provider.get_api_v1_compute_provider()
         assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://staging.token.place"
+        assert compute_provider.is_api_v1_implicit_relay_only_selection() is True
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_public_relay_url_wins_implicit_selection_when_internal_url_is_set(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELAY_INTERNAL_URL", "http://127.0.0.1:5010")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://staging.token.place"
         assert compute_provider.is_api_v1_implicit_relay_only_selection() is True
     finally:
         compute_provider._build_api_v1_compute_provider.cache_clear()

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -13,6 +13,21 @@ from api.v1.compute_provider import (
 from relay import app
 
 
+def _clear_distributed_target_env(monkeypatch):
+    for env_name in (
+        "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+        "TOKENPLACE_RELAY_INTERNAL_URL",
+        "TOKEN_PLACE_RELAY_INTERNAL_URL",
+        "RELAY_INTERNAL_URL",
+        "TOKENPLACE_RELAY_PUBLIC_URL",
+        "TOKEN_PLACE_RELAY_PUBLIC_URL",
+        "RELAY_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+
 class _FakeResponse:
     def __init__(self, status_code, payload):
         self.status_code = status_code
@@ -546,6 +561,34 @@ def test_distributed_compute_provider_maps_compute_node_payload_errors(monkeypat
     except ComputeProviderError as exc:
         assert exc.code == "compute_node_bridge_error"
         assert "compute node reported error" in str(exc)
+
+def test_public_relay_url_implicitly_selects_distributed_without_fallback(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_FALLBACK", "1")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert compute_provider.is_api_v1_implicit_relay_only_selection() is True
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def test_internal_relay_url_does_not_implicitly_self_dispatch(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELAY_INTERNAL_URL", "http://127.0.0.1:8080")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+        assert isinstance(provider, compute_provider.LocalApiV1ComputeProvider)
+        assert compute_provider.is_api_v1_implicit_relay_only_selection() is False
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
 def test_get_provider_disables_local_fallback_when_configured(monkeypatch):

--- a/tests/unit/test_api_v1_compute_provider.py
+++ b/tests/unit/test_api_v1_compute_provider.py
@@ -594,6 +594,22 @@ def test_public_relay_url_wins_implicit_selection_when_internal_url_is_set(monke
         compute_provider._build_api_v1_compute_provider.cache_clear()
 
 
+def test_public_relay_url_implicit_selection_ignores_invalid_internal_url(monkeypatch):
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELAY_INTERNAL_URL", "127.0.0.1:5010")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    try:
+        provider = compute_provider.get_api_v1_compute_provider()
+        assert isinstance(provider, compute_provider.DistributedApiV1ComputeProvider)
+        assert provider.base_url == "https://staging.token.place"
+        assert compute_provider.is_api_v1_implicit_relay_only_selection() is True
+    finally:
+        compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
 def test_internal_relay_url_does_not_implicitly_self_dispatch(monkeypatch):
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     _clear_distributed_target_env(monkeypatch)

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -466,3 +466,42 @@ def test_explicit_local_public_chat_ignores_relay_public_url(monkeypatch, client
         "no_compute_node_available",
         "no_registered_compute_nodes",
     }
+
+
+def test_compute_error_remap_fails_closed_when_implicit_relay_check_fails(
+    monkeypatch, client
+):
+    _reset_api_v1_provider_state()
+
+    class FailingProvider:
+        def complete_chat(self, *, model_id, messages, options=None):
+            raise compute_provider.ComputeProviderError(
+                "No registered compute nodes",
+                code="no_registered_compute_nodes",
+                status_code=503,
+            )
+
+    monkeypatch.setattr(routes, "get_api_v1_compute_provider", lambda: FailingProvider())
+    monkeypatch.setattr(
+        routes,
+        "get_api_v1_resolved_provider_path",
+        lambda _provider: "distributed",
+    )
+    monkeypatch.setattr(
+        routes,
+        "is_api_v1_implicit_relay_only_selection",
+        lambda: (_ for _ in ()).throw(RuntimeError("predicate failed")),
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["code"] == "no_registered_compute_nodes"
+    assert payload["error"]["message"] == "Unable to generate a response right now."

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 import relay
-from api.v1 import compute_provider, routes
+from api.v1 import compute_provider, models, routes
 
 INDEX_HTML = Path(relay.INDEX_HTML_PATH)
 
@@ -90,6 +90,16 @@ def _clear_distributed_target_env(monkeypatch):
         "RELAY_PUBLIC_URL",
     ):
         monkeypatch.delenv(env_name, raising=False)
+
+
+def _reset_api_v1_provider_state():
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+
+
+def _force_local_llama_missing(monkeypatch):
+    monkeypatch.setattr(models, "USE_MOCK_LLM", False)
+    monkeypatch.setattr(models, "Llama", None)
+    models._loaded_models.clear()
 
 
 @pytest.fixture
@@ -288,7 +298,7 @@ class _FakeCryptoManager:
 def test_relay_only_public_chat_uses_compute_node_without_local_llama(
     monkeypatch, client
 ):
-    compute_provider._build_api_v1_compute_provider.cache_clear()
+    _reset_api_v1_provider_state()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     _clear_distributed_target_env(monkeypatch)
     monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
@@ -350,7 +360,7 @@ def test_relay_only_public_chat_uses_compute_node_without_local_llama(
 def test_relay_only_public_chat_without_compute_node_returns_relay_error(
     monkeypatch, client
 ):
-    compute_provider._build_api_v1_compute_provider.cache_clear()
+    _reset_api_v1_provider_state()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     _clear_distributed_target_env(monkeypatch)
     monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
@@ -392,9 +402,21 @@ def test_relay_only_public_chat_without_compute_node_returns_relay_error(
 
 
 def test_local_public_chat_still_reports_missing_llama_dependency(monkeypatch, client):
-    compute_provider._build_api_v1_compute_provider.cache_clear()
+    _reset_api_v1_provider_state()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     _clear_distributed_target_env(monkeypatch)
+    _force_local_llama_missing(monkeypatch)
+    _reset_api_v1_provider_state()
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: pytest.fail("relay dispatch was called"),
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "post",
+        lambda *_args, **_kwargs: pytest.fail("relay dispatch was called"),
+    )
 
     response = client.post(
         "/api/v1/chat/completions",
@@ -408,3 +430,39 @@ def test_local_public_chat_still_reports_missing_llama_dependency(monkeypatch, c
     payload = response.get_json()
     assert payload["error"]["type"] == "model_unavailable"
     assert "llama-cpp-python is not installed" in payload["error"]["message"]
+
+
+def test_explicit_local_public_chat_ignores_relay_public_url(monkeypatch, client):
+    _reset_api_v1_provider_state()
+    _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", "local")
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    _force_local_llama_missing(monkeypatch)
+    _reset_api_v1_provider_state()
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: pytest.fail("relay dispatch was called"),
+    )
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "post",
+        lambda *_args, **_kwargs: pytest.fail("relay dispatch was called"),
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["type"] == "model_unavailable"
+    assert "llama-cpp-python is not installed" in payload["error"]["message"]
+    assert payload["error"].get("code") not in {
+        "no_compute_node_available",
+        "no_registered_compute_nodes",
+    }

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -77,6 +77,21 @@ def _registered_routes() -> set[tuple[str, str]]:
     return routes
 
 
+def _clear_distributed_target_env(monkeypatch):
+    for env_name in (
+        "TOKENPLACE_API_V1_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_RELAY_URL",
+        "TOKENPLACE_DISTRIBUTED_COMPUTE_URL",
+        "TOKENPLACE_RELAY_INTERNAL_URL",
+        "TOKEN_PLACE_RELAY_INTERNAL_URL",
+        "RELAY_INTERNAL_URL",
+        "TOKENPLACE_RELAY_PUBLIC_URL",
+        "TOKEN_PLACE_RELAY_PUBLIC_URL",
+        "RELAY_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+
 @pytest.fixture
 def client():
     relay.app.config["TESTING"] = True
@@ -275,6 +290,7 @@ def test_relay_only_public_chat_uses_compute_node_without_local_llama(
 ):
     compute_provider._build_api_v1_compute_provider.cache_clear()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    _clear_distributed_target_env(monkeypatch)
     monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS", "5")
     monkeypatch.setattr(
@@ -336,6 +352,7 @@ def test_relay_only_public_chat_without_compute_node_returns_relay_error(
 ):
     compute_provider._build_api_v1_compute_provider.cache_clear()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    _clear_distributed_target_env(monkeypatch)
     monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
     monkeypatch.setattr(
         routes,
@@ -377,8 +394,7 @@ def test_relay_only_public_chat_without_compute_node_returns_relay_error(
 def test_local_public_chat_still_reports_missing_llama_dependency(monkeypatch, client):
     compute_provider._build_api_v1_compute_provider.cache_clear()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
-    monkeypatch.delenv("TOKENPLACE_RELAY_PUBLIC_URL", raising=False)
-    monkeypatch.delenv("TOKENPLACE_RELAY_INTERNAL_URL", raising=False)
+    _clear_distributed_target_env(monkeypatch)
 
     response = client.post(
         "/api/v1/chat/completions",

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -59,7 +59,9 @@ INTERNAL_RELAY_LIFECYCLE_ROUTES = {
     ("POST", "/relay/api/v1/source"),
 }
 
-DOCUMENTED_INTERNAL_ROUTES = COMPUTE_NODE_CONTROL_PLANE_ROUTES | INTERNAL_RELAY_LIFECYCLE_ROUTES
+DOCUMENTED_INTERNAL_ROUTES = (
+    COMPUTE_NODE_CONTROL_PLANE_ROUTES | INTERNAL_RELAY_LIFECYCLE_ROUTES
+)
 
 
 def _normalise_rule(rule: str) -> str:
@@ -94,7 +96,9 @@ def test_no_unclassified_api_v1_routes_leak_into_launch_contract():
     registered_api_v1 = {
         (method, path)
         for method, path in _registered_routes()
-        if path.startswith("/api/v1/") or path.startswith("/v1/") or path.startswith("/relay/api/v1/")
+        if path.startswith("/api/v1/")
+        or path.startswith("/v1/")
+        or path.startswith("/relay/api/v1/")
     }
     expected = PUBLIC_CLIENT_ROUTES | OPENAI_V1_ALIASES | DOCUMENTED_INTERNAL_ROUTES
 
@@ -109,7 +113,7 @@ def test_landing_page_documents_every_public_client_api_v1_route():
     public_section = html.split("Internal relay control-plane routes", 1)[0]
 
     for method, path in sorted(PUBLIC_CLIENT_ROUTES):
-        assert f"{method}</span> <span class=\"api-path\">{path}</span>" in public_section
+        assert f'{method}</span> <span class="api-path">{path}</span>' in public_section
 
 
 def test_landing_page_documents_openai_aliases_and_excludes_api_v2_launch_docs():
@@ -133,7 +137,9 @@ def test_landing_page_freezes_single_meta_llama_model_without_owner_display():
 
 def test_compute_node_control_plane_routes_are_documented_separately():
     html = INDEX_HTML.read_text(encoding="utf-8")
-    public_section, internal_section = html.split("Internal relay control-plane routes", 1)
+    public_section, internal_section = html.split(
+        "Internal relay control-plane routes", 1
+    )
 
     for method, path in sorted(COMPUTE_NODE_CONTROL_PLANE_ROUTES):
         assert f"{method} {path}" not in public_section
@@ -231,3 +237,158 @@ def test_route_level_generate_response_bridge_is_request_local(monkeypatch):
     assert result == {"role": "assistant", "content": "request-local bridge"}
     assert compute_provider.generate_response is original_compute_generator
     assert compute_provider._active_generate_response() is original_compute_generator
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        import copy
+
+        return copy.deepcopy(self._payload)
+
+
+class _FakeCryptoManager:
+    public_key_b64 = "client-public-key"
+
+    def __init__(self):
+        self._encrypted = {}
+
+    def encrypt_message(self, message, _server_public_key):
+        token = f"cipher-{len(self._encrypted) + 1}"
+        self._encrypted[token] = message.copy()
+        return {
+            "chat_history": token,
+            "cipherkey": "encrypted-key",
+            "iv": "encrypted-iv",
+        }
+
+    def decrypt_message(self, encrypted_payload):
+        payload = self._encrypted.get(encrypted_payload.get("chat_history"))
+        return payload.copy() if isinstance(payload, dict) else payload
+
+
+def test_relay_only_public_chat_uses_compute_node_without_local_llama(
+    monkeypatch, client
+):
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS", "5")
+    monkeypatch.setattr(
+        routes,
+        "generate_response",
+        lambda *_args, **_kwargs: pytest.fail("local inference was called"),
+    )
+    fake_crypto = _FakeCryptoManager()
+
+    def fake_get(url, timeout):
+        assert url == "https://staging.token.place/api/v1/relay/servers/next"
+        return _FakeResponse(200, {"server_public_key": "server-public-key"})
+
+    def fake_post(url, json, timeout):
+        if url == "https://staging.token.place/api/v1/relay/requests":
+            assert "messages" not in json
+            return _FakeResponse(200, {"status": "queued"})
+        if url == "https://staging.token.place/api/v1/relay/responses/retrieve":
+            encrypted = fake_crypto.encrypt_message(
+                {
+                    "protocol": "tokenplace_api_v1_relay_e2ee",
+                    "request_id": json["request_id"],
+                    "client_public_key": fake_crypto.public_key_b64,
+                    "api_v1_response": {
+                        "message": {"role": "assistant", "content": "hello from relay"}
+                    },
+                },
+                fake_crypto.public_key_b64,
+            )
+            return _FakeResponse(200, encrypted)
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(
+        compute_provider.DistributedApiV1ComputeProvider,
+        "_build_request_crypto_manager",
+        lambda _self: fake_crypto,
+    )
+    monkeypatch.setattr(compute_provider.requests, "get", fake_get)
+    monkeypatch.setattr(compute_provider.requests, "post", fake_post)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["choices"][0]["message"]["content"] == "hello from relay"
+    assert (
+        response.headers["X-Tokenplace-API-V1-Resolved-Provider-Path"] == "distributed"
+    )
+
+
+def test_relay_only_public_chat_without_compute_node_returns_relay_error(
+    monkeypatch, client
+):
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
+    monkeypatch.setattr(
+        routes,
+        "generate_response",
+        lambda *_args, **_kwargs: pytest.fail("local inference was called"),
+    )
+
+    monkeypatch.setattr(
+        compute_provider.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(
+            503,
+            {
+                "error": {
+                    "code": "no_registered_compute_nodes",
+                    "message": "No registered compute nodes",
+                }
+            },
+        ),
+    )
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        headers={"Origin": "https://staging.democratized.space"},
+    )
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["type"] == "service_unavailable_error"
+    assert payload["error"]["code"] == "no_compute_node_available"
+    assert "llama-cpp-python is not installed" not in payload["error"]["message"]
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+def test_local_public_chat_still_reports_missing_llama_dependency(monkeypatch, client):
+    compute_provider._build_api_v1_compute_provider.cache_clear()
+    monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("TOKENPLACE_RELAY_INTERNAL_URL", raising=False)
+
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama-3.1-8b-instruct",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"]["type"] == "model_unavailable"
+    assert "llama-cpp-python is not installed" in payload["error"]["message"]

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -301,6 +301,7 @@ def test_relay_only_public_chat_uses_compute_node_without_local_llama(
     _reset_api_v1_provider_state()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELAY_INTERNAL_URL", "http://127.0.0.1:5010")
     monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
     monkeypatch.setenv("TOKENPLACE_API_V1_DISTRIBUTED_TIMEOUT_SECONDS", "5")
     monkeypatch.setattr(
@@ -363,6 +364,7 @@ def test_relay_only_public_chat_without_compute_node_returns_relay_error(
     _reset_api_v1_provider_state()
     monkeypatch.delenv("TOKENPLACE_API_V1_COMPUTE_PROVIDER", raising=False)
     _clear_distributed_target_env(monkeypatch)
+    monkeypatch.setenv("TOKENPLACE_RELAY_INTERNAL_URL", "http://127.0.0.1:5010")
     monkeypatch.setenv("TOKENPLACE_RELAY_PUBLIC_URL", "https://staging.token.place")
     monkeypatch.setattr(
         routes,
@@ -370,10 +372,9 @@ def test_relay_only_public_chat_without_compute_node_returns_relay_error(
         lambda *_args, **_kwargs: pytest.fail("local inference was called"),
     )
 
-    monkeypatch.setattr(
-        compute_provider.requests,
-        "get",
-        lambda *_args, **_kwargs: _FakeResponse(
+    def fake_no_node_get(url, timeout):
+        assert url == "https://staging.token.place/api/v1/relay/servers/next"
+        return _FakeResponse(
             503,
             {
                 "error": {
@@ -381,8 +382,9 @@ def test_relay_only_public_chat_without_compute_node_returns_relay_error(
                     "message": "No registered compute nodes",
                 }
             },
-        ),
-    )
+        )
+
+    monkeypatch.setattr(compute_provider.requests, "get", fake_no_node_get)
 
     response = client.post(
         "/api/v1/chat/completions",


### PR DESCRIPTION
### Motivation
- In relay-only deployments the public `/api/v1/chat/completions` route must dispatch to registered compute nodes rather than trying to load local models and requiring `llama-cpp-python`.
- When relay-only mode has no registered compute node, the API should return an explicit relay-specific error rather than a misleading local-dependency message.

### Description
- Auto-select distributed API v1 compute routing when a relay-only target URL is present and no explicit `TOKENPLACE_API_V1_COMPUTE_PROVIDER` is configured, and disable local fallback for that implicit relay-only selection (changes in `api/v1/compute_provider.py`).
- Map `no_registered_compute_nodes` -> `no_compute_node_available` for public error payloads only when the request is implicitly relay-only (so operators see a relay-specific, actionable error) while preserving existing codes for explicitly configured modes (changes in `api/v1/routes.py`).
- Add regression tests that verify: relay-only public chat uses compute-node path without importing local inference; relay-only with no nodes returns the relay-specific error and preserves public CORS; and local inference mode still reports missing `llama-cpp-python` when appropriate (tests added/updated in `tests/unit/test_api_v1_launch_contract.py`).

### Testing
- Ran focused unit suites and smoke checks: `pytest -q tests/test_relay.py tests/unit/test_api_v1_launch_contract.py tests/unit/test_api_v1_cors.py tests/unit/test_api_v1_compute_provider.py tests/test_api.py::test_api_v1_chat_completion_staging_no_nodes_returns_clear_503`, all passed locally.
- Ran broader unit collection during development and received passing results for the exercised suites (final run: `202 passed` for the selected set run in CI-like verification).
- Ran `pre-commit run --all-files` and project checks, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ffab81b8832f9858740d06a12318)