### PR TITLE
Keep llama.cpp subprocess worker alive after request errors

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2850,3 +2850,171 @@ def test_detect_llama_runtime_capabilities_cpu_facade_reports_probe_exception(mo
     assert diagnostics['detected_device'] == 'none'
     assert diagnostics['llama_module_path'] == '/site/llama_cpp/__init__.py'
     assert diagnostics['error'] == 'probe crashed'
+
+
+def _write_fake_llama_cpp(tmp_path, source):
+    fake_site = tmp_path / 'fake_llama_site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(source, encoding='utf-8')
+    return fake_site
+
+
+def test_subprocess_llama_proxy_initialization_failure_is_fatal(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        raise RuntimeError('fatal init failure')\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+
+    assert 'fatal init failure' in str(exc_info.value)
+
+
+def test_subprocess_llama_proxy_non_streaming_request_error_keeps_worker_alive(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = 0\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        self.calls += 1\n"
+        "        if self.calls == 1:\n"
+        "            raise RuntimeError('secret prompt should not appear')\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}], 'call': self.calls}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion(messages=[{'role': 'user', 'content': 'private prompt'}], stream=False)
+
+        message = str(exc_info.value)
+        assert 'llama_cpp subprocess request failed' in message
+        assert 'RuntimeError' in message
+        assert 'secret prompt should not appear' not in message
+        assert 'private prompt' not in message
+
+        result = proxy.create_chat_completion(messages=[], stream=False)
+        assert result['choices'][0]['message']['content'] == 'ok'
+        assert result['call'] == 2
+    finally:
+        proxy.close()
+
+
+def test_subprocess_llama_proxy_streaming_request_error_keeps_worker_alive(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = 0\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        self.calls += 1\n"
+        "        if kwargs.get('stream') and self.calls == 1:\n"
+        "            def broken():\n"
+        "                yield {'choices': [{'delta': {'content': 'first'}}]}\n"
+        "                raise RuntimeError('generated secret text')\n"
+        "            return broken()\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}], 'call': self.calls}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    try:
+        stream = proxy.create_chat_completion(messages=[{'role': 'user', 'content': 'private prompt'}], stream=True)
+        assert next(stream)['choices'][0]['delta']['content'] == 'first'
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            next(stream)
+
+        message = str(exc_info.value)
+        assert 'llama_cpp subprocess request failed' in message
+        assert 'generated secret text' not in message
+        assert 'private prompt' not in message
+
+        result = proxy.create_chat_completion(messages=[], stream=False)
+        assert result['choices'][0]['message']['content'] == 'ok'
+        assert result['call'] == 2
+    finally:
+        proxy.close()
+
+
+def test_subprocess_llama_proxy_malformed_request_keeps_worker_alive(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = 0\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        self.calls += 1\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}], 'call': self.calls}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    try:
+        with proxy._lock:
+            proxy._process.stdin.write('{not valid json with private prompt}\n')
+            proxy._process.stdin.flush()
+            with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+                model_manager_module._read_llama_subprocess_message(
+                    proxy._process,
+                    timeout_seconds=5,
+                    stage='llama_cpp_inference',
+                )
+
+        message = str(exc_info.value)
+        assert 'malformed llama_cpp subprocess request' in message
+        assert 'JSONDecodeError' in message
+        assert 'private prompt' not in message
+
+        result = proxy.create_chat_completion(messages=[], stream=False)
+        assert result['choices'][0]['message']['content'] == 'ok'
+    finally:
+        proxy.close()
+
+
+def test_subprocess_llama_proxy_unsupported_method_keeps_worker_alive(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = 0\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        self.calls += 1\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}], 'call': self.calls}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    try:
+        with proxy._lock:
+            proxy._send({'method': 'unsupported_method', 'args': [], 'kwargs': {}})
+            with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+                model_manager_module._read_llama_subprocess_message(
+                    proxy._process,
+                    timeout_seconds=5,
+                    stage='llama_cpp_inference',
+                )
+
+        assert 'unsupported llama_cpp subprocess method' in str(exc_info.value)
+        assert 'UnsupportedMethod' in str(exc_info.value)
+
+        result = proxy.create_chat_completion(messages=[], stream=False)
+        assert result['choices'][0]['message']['content'] == 'ok'
+    finally:
+        proxy.close()

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -127,6 +127,10 @@ DESKTOP_RUNTIME_PROBE_ENV = 'TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON'
 _LLAMA_CPP_IMPORT_PATH_LOCK = Lock()
 
 
+class LlamaCppInferenceRequestError(RuntimeError):
+    """Raised when a live llama.cpp worker reports a request-scoped failure."""
+
+
 class LlamaCppRuntimeStageTimeout(TimeoutError):
     """Raised when a llama_cpp discovery/import stage exceeds its bounded timeout."""
 
@@ -766,6 +770,11 @@ def _read_llama_subprocess_message(
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'error':
         error = str(message.get('error') or f'{stage} failed')
+        error_type = str(message.get('error_type') or '').strip()
+        if error_type:
+            error = f"{error}; error_type={error_type}"
+        if stage == 'llama_cpp_inference':
+            raise LlamaCppInferenceRequestError(error)
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
             error = f"{error}; child_traceback_tail={traceback_text[-2000:]}"
@@ -926,6 +935,13 @@ def _jsonable(value):
 def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
+def _safe_error(exc, message):
+    return {
+        'status': 'error',
+        'error': message,
+        'error_type': type(exc).__name__,
+    }
+
 try:
     init_line = sys.stdin.readline()
     if not init_line:
@@ -934,21 +950,33 @@ try:
     llama_cpp = importlib.import_module('llama_cpp')
     llama = llama_cpp.Llama(*init_payload.get('args', []), **init_payload.get('kwargs', {}))
     _emit({'status': 'ok', 'module_path': getattr(llama_cpp, '__file__', None)})
-    for line in sys.stdin:
-        request = json.loads(line)
-        if request.get('method') == 'create_chat_completion':
-            kwargs = request.get('kwargs', {})
-            result = llama.create_chat_completion(*request.get('args', []), **kwargs)
-            if kwargs.get('stream'):
-                for chunk in result:
-                    _emit({'status': 'ok', 'chunk': chunk, 'done': False})
-                _emit({'status': 'ok', 'done': True})
-            else:
-                _emit({'status': 'ok', 'result': result})
-        else:
-            _emit({'status': 'error', 'error': 'unsupported llama_cpp subprocess method'})
 except Exception as exc:
     _emit({'status': 'error', 'error': str(exc), 'traceback': traceback.format_exc()})
+    raise SystemExit(1)
+
+for line in sys.stdin:
+    try:
+        request = json.loads(line)
+        if not isinstance(request, dict):
+            raise TypeError('request payload must be a JSON object')
+        method = request.get('method')
+        if method != 'create_chat_completion':
+            _emit({'status': 'error', 'error': 'unsupported llama_cpp subprocess method', 'error_type': 'UnsupportedMethod'})
+            continue
+        kwargs = request.get('kwargs', {})
+        if not isinstance(kwargs, dict):
+            raise TypeError('request kwargs must be a JSON object')
+        result = llama.create_chat_completion(*request.get('args', []), **kwargs)
+        if kwargs.get('stream'):
+            for chunk in result:
+                _emit({'status': 'ok', 'chunk': chunk, 'done': False})
+            _emit({'status': 'ok', 'done': True})
+        else:
+            _emit({'status': 'ok', 'result': result})
+    except json.JSONDecodeError as exc:
+        _emit(_safe_error(exc, 'malformed llama_cpp subprocess request'))
+    except Exception as exc:
+        _emit(_safe_error(exc, 'llama_cpp subprocess request failed'))
 """
 
 


### PR DESCRIPTION
### Motivation
- Prevent a single inference exception from terminating or poisoning the long-lived subprocess-backed `llama.cpp` worker while preserving fatal behavior for initialization failures. 
- Make request-scoped failures distinguishable from worker death, transport errors, or initialization timeouts by exception type. 
- Ensure protocol framing, streaming behavior, and API v1 non‑streaming semantics remain unchanged while avoiding leakage of plaintext prompts, outputs, tool args, encryption material, or full keys in diagnostics. 

### Description
- Added a typed parent-side exception `LlamaCppInferenceRequestError` to differentiate request-scoped inference failures from process/transport/init failures. 
- Updated `_read_llama_subprocess_message` to surface structured request errors as `LlamaCppInferenceRequestError` when `stage == 'llama_cpp_inference'` while retaining existing fatal error handling for import/handshake stages. 
- Rewrote the in-worker `_LLAMA_CPP_RUNTIME_WORKER_CODE` to enforce a fatal init path, then handle every subsequent request inside its own try/except boundary that emits privacy-safe structured error payloads containing only `error` and `error_type` (no prompts/outputs/keys), supports malformed-request detection, unsupported methods, and preserves streaming framing. 
- Kept `_SubprocessLlamaProxy` behavior and stdout protocol framing intact and added tests that exercise recovery on the same cached proxy after request errors. 
- Added regression tests in `tests/unit/test_model_manager.py` that assert initialization failures remain fatal and that non-streaming, streaming, malformed, and unsupported-method request errors do not zombify the cached worker. 

### Testing
- Ran focused unit tests: `python -m pytest -q tests/unit/test_model_manager.py -k "subprocess or worker or inference or streaming"` and the selection passed (all focused tests passed). 
- Ran integration/unit suites: `python -m pytest -q tests/unit/test_compute_node_runtime.py tests/unit/test_relay_client.py` and they passed (`190 passed`). 
- Ran project checks: `pre-commit run --all-files` and it passed. 

All focused regressions and the existing related test suites passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3711cf8ce4832fbb272aa8a1be303b)