### PR TITLE
Keep llama subprocess worker alive after request errors

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2850,3 +2850,123 @@ def test_detect_llama_runtime_capabilities_cpu_facade_reports_probe_exception(mo
     assert diagnostics['detected_device'] == 'none'
     assert diagnostics['llama_module_path'] == '/site/llama_cpp/__init__.py'
     assert diagnostics['error'] == 'probe crashed'
+
+
+def _write_fake_llama_cpp(tmp_path, body):
+    fake_site = tmp_path / 'fake_llama_site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(body, encoding='utf-8')
+    return fake_site
+
+
+def test_subprocess_llama_proxy_initialization_failure_remains_fatal(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        raise RuntimeError('init failed clearly')\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+
+    assert not isinstance(exc_info.value, model_manager_module.LlamaCppInferenceRequestError)
+    assert 'init failed clearly' in str(exc_info.value)
+
+
+def test_subprocess_llama_proxy_non_streaming_request_error_does_not_kill_worker(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = 0\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        self.calls += 1\n"
+        "        if self.calls == 1:\n"
+        "            raise RuntimeError('secret prompt should not leak')\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}]}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+        proxy.create_chat_completion(messages=[{'role': 'user', 'content': 'private prompt'}], stream=False)
+
+    assert exc_info.value.diagnostics['reason'] == 'inference_exception'
+    assert exc_info.value.diagnostics['method'] == 'create_chat_completion'
+    assert exc_info.value.diagnostics['stream'] is False
+    assert 'private prompt' not in str(exc_info.value)
+    assert 'secret prompt' not in str(exc_info.value)
+    assert proxy._process.poll() is None
+    assert proxy.create_chat_completion(messages=[], stream=False)['choices'][0]['message']['content'] == 'ok'
+
+
+def test_subprocess_llama_proxy_streaming_request_error_does_not_poison_next_request(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = 0\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        self.calls += 1\n"
+        "        if kwargs.get('stream') and self.calls == 1:\n"
+        "            def bad():\n"
+        "                yield {'choices': [{'delta': {'content': 'before'}}]}\n"
+        "                raise RuntimeError('generated text should not leak')\n"
+        "            return bad()\n"
+        "        if kwargs.get('stream'):\n"
+        "            return iter([{'choices': [{'delta': {'content': 'ok'}}]}])\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}]}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    stream = proxy.create_chat_completion(messages=[{'role': 'user', 'content': 'private'}], stream=True)
+    assert next(stream)['choices'][0]['delta']['content'] == 'before'
+    with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+        next(stream)
+    assert exc_info.value.diagnostics['stream'] is True
+    assert 'generated text' not in str(exc_info.value)
+    assert proxy._process.poll() is None
+    assert proxy.create_chat_completion(messages=[], stream=False)['choices'][0]['message']['content'] == 'ok'
+
+
+def test_subprocess_llama_proxy_unsupported_method_is_request_scoped(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = _write_fake_llama_cpp(
+        tmp_path,
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_chat_completion(self, *args, **kwargs):\n"
+        "        return {'choices': [{'message': {'content': 'ok'}}]}\n",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf', timeout_seconds=5)
+    with proxy._lock:
+        proxy._send({'method': 'unsupported', 'kwargs': {'stream': False}, 'prompt': 'private prompt'})
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            model_manager_module._read_llama_subprocess_message(
+                proxy._process,
+                timeout_seconds=5,
+                stage='llama_cpp_inference',
+            )
+
+    assert exc_info.value.diagnostics == {
+        'reason': 'unsupported_method',
+        'method': 'unsupported',
+        'stream': False,
+    }
+    assert 'private prompt' not in str(exc_info.value)
+    assert proxy._process.poll() is None
+    assert proxy.create_chat_completion(messages=[], stream=False)['choices'][0]['message']['content'] == 'ok'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -127,6 +127,14 @@ DESKTOP_RUNTIME_PROBE_ENV = 'TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON'
 _LLAMA_CPP_IMPORT_PATH_LOCK = Lock()
 
 
+class LlamaCppInferenceRequestError(RuntimeError):
+    """Raised when a live llama_cpp worker reports a request-scoped inference failure."""
+
+    def __init__(self, message: str, *, diagnostics: Optional[Dict[str, Any]] = None) -> None:
+        self.diagnostics = diagnostics or {}
+        super().__init__(message)
+
+
 class LlamaCppRuntimeStageTimeout(TimeoutError):
     """Raised when a llama_cpp discovery/import stage exceeds its bounded timeout."""
 
@@ -766,6 +774,9 @@ def _read_llama_subprocess_message(
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'error':
         error = str(message.get('error') or f'{stage} failed')
+        diagnostics = message.get('diagnostics') if isinstance(message.get('diagnostics'), dict) else {}
+        if stage == 'llama_cpp_inference' and message.get('error_type') == 'request_error':
+            raise LlamaCppInferenceRequestError(error, diagnostics=diagnostics)
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
             error = f"{error}; child_traceback_tail={traceback_text[-2000:]}"
@@ -926,6 +937,24 @@ def _jsonable(value):
 def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
+def _safe_request_error(reason, request=None, exc=None):
+    diagnostics = {'reason': reason}
+    if isinstance(request, dict):
+        method = request.get('method')
+        if isinstance(method, str):
+            diagnostics['method'] = method
+        kwargs = request.get('kwargs')
+        if isinstance(kwargs, dict):
+            diagnostics['stream'] = bool(kwargs.get('stream'))
+    if exc is not None:
+        diagnostics['exception_type'] = type(exc).__name__
+    return {
+        'status': 'error',
+        'error_type': 'request_error',
+        'error': 'llama_cpp subprocess request failed',
+        'diagnostics': diagnostics,
+    }
+
 try:
     init_line = sys.stdin.readline()
     if not init_line:
@@ -934,21 +963,32 @@ try:
     llama_cpp = importlib.import_module('llama_cpp')
     llama = llama_cpp.Llama(*init_payload.get('args', []), **init_payload.get('kwargs', {}))
     _emit({'status': 'ok', 'module_path': getattr(llama_cpp, '__file__', None)})
-    for line in sys.stdin:
-        request = json.loads(line)
-        if request.get('method') == 'create_chat_completion':
-            kwargs = request.get('kwargs', {})
-            result = llama.create_chat_completion(*request.get('args', []), **kwargs)
-            if kwargs.get('stream'):
-                for chunk in result:
-                    _emit({'status': 'ok', 'chunk': chunk, 'done': False})
-                _emit({'status': 'ok', 'done': True})
-            else:
-                _emit({'status': 'ok', 'result': result})
-        else:
-            _emit({'status': 'error', 'error': 'unsupported llama_cpp subprocess method'})
 except Exception as exc:
     _emit({'status': 'error', 'error': str(exc), 'traceback': traceback.format_exc()})
+    raise SystemExit(1)
+
+for line in sys.stdin:
+    request = None
+    try:
+        request = json.loads(line)
+        if not isinstance(request, dict):
+            _emit(_safe_request_error('malformed_request'))
+            continue
+        if request.get('method') != 'create_chat_completion':
+            _emit(_safe_request_error('unsupported_method', request))
+            continue
+        kwargs = request.get('kwargs', {})
+        result = llama.create_chat_completion(*request.get('args', []), **kwargs)
+        if kwargs.get('stream'):
+            for chunk in result:
+                _emit({'status': 'ok', 'chunk': chunk, 'done': False})
+            _emit({'status': 'ok', 'done': True})
+        else:
+            _emit({'status': 'ok', 'result': result})
+    except json.JSONDecodeError as exc:
+        _emit(_safe_request_error('malformed_json', exc=exc))
+    except Exception as exc:
+        _emit(_safe_request_error('inference_exception', request, exc))
 """
 
 


### PR DESCRIPTION
### Motivation
- Prevent a single inference exception, malformed request, or unsupported method from terminating a long-lived subprocess-backed llama.cpp worker while preserving fatal initialization semantics.
- Make parent-side code able to distinguish request-scoped failures from worker death, broken transport, or init timeouts via a typed exception.
- Ensure protocol and streaming/non-streaming framing remain unchanged and that diagnostics do not leak prompts, generated text, or sensitive encryption material.

### Description
- Added a typed parent-side exception `LlamaCppInferenceRequestError` for request-scoped inference failures so callers can distinguish request errors by type.
- Updated `_read_llama_subprocess_message` to raise `LlamaCppInferenceRequestError` when a subprocess emits a structured `request_error` at the `llama_cpp_inference` stage while preserving existing `RuntimeError` and timeout semantics for transport/early-exit errors.
- Reworked the embedded `_LLAMA_CPP_RUNTIME_WORKER_CODE` so initialization runs once (and remains fatal on failure) and the request loop handles each request inside its own exception boundary, emitting privacy-safe structured error payloads (`error_type: 'request_error'` and `diagnostics` containing only safe metadata like `method` and `stream`).
- Added regression tests to `tests/unit/test_model_manager.py` that assert init failures remain fatal, non-streaming and streaming request errors do not kill the worker and do not leak private content, unsupported methods are request-scoped, and diagnostics are restricted to safe fields.

### Testing
- Ran `python -m pytest -q tests/unit/test_model_manager.py -k "subprocess or worker or inference or streaming"` and the selected tests passed (`24 passed`).
- Ran `python -m pytest -q tests/unit/test_compute_node_runtime.py tests/unit/test_relay_client.py` and the suites passed (`190 passed`).
- Ran `pre-commit run --all-files` which completed successfully (`Passed`).
- Residual risk: further soak and fault-injection CI is recommended to validate long-lived worker behavior under sustained load and relay recovery scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3711e7d8e0832fa519bc8bae5ecb9a)