### PR TITLE
Validate desktop API v1 relay requests

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2679,10 +2679,10 @@ class TestRelayClient:
         assert completion_kwargs["temperature"] == 0.2
         assert completion_kwargs["frequency_penalty"] == 0.1
         assert completion_kwargs["presence_penalty"] == 0.2
-        assert completion_kwargs["response_format"] == {"type": "text"}
         assert completion_kwargs["seed"] == 7
-        assert completion_kwargs["tools"] == []
-        assert completion_kwargs["tool_choice"] == "none"
+        assert "response_format" not in completion_kwargs
+        assert "tools" not in completion_kwargs
+        assert "tool_choice" not in completion_kwargs
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["message"]["content"] == (
             "Tool-aware response"
@@ -2751,6 +2751,216 @@ class TestRelayClient:
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["message"]["content"] == (
             "Non-streaming response"
+        )
+
+
+    @pytest.mark.parametrize(
+        "option_name,option_value,expected_value",
+        [
+            ("max_tokens", 1, 1),
+            (
+                "max_tokens",
+                relay_client_module.RelayClient._API_V1_MAX_TOKENS_LIMIT,
+                relay_client_module.RelayClient._API_V1_MAX_TOKENS_LIMIT,
+            ),
+            ("temperature", 0.0, 0.0),
+            ("temperature", 2.0, 2.0),
+            ("top_p", 0.0, 0.0),
+            ("top_p", 1.0, 1.0),
+            ("frequency_penalty", -2.0, -2.0),
+            ("frequency_penalty", 2.0, 2.0),
+            ("presence_penalty", -2.0, -2.0),
+            ("presence_penalty", 2.0, 2.0),
+            ("seed", 0, 0),
+            (
+                "seed",
+                relay_client_module.RelayClient._API_V1_MAX_SEED,
+                relay_client_module.RelayClient._API_V1_MAX_SEED,
+            ),
+            ("stop", "END", ["END"]),
+            ("stop", ["A", "B"], ["A", "B"]),
+        ],
+    )
+    def test_api_v1_option_boundary_values_are_normalised(
+        self, option_name, option_value, expected_value
+    ):
+        ok, code, message, normalised = (
+            relay_client_module.RelayClient._validate_and_normalise_api_v1_options(
+                {option_name: option_value}
+            )
+        )
+
+        assert ok is True
+        assert code == ""
+        assert message == ""
+        assert normalised[option_name] == expected_value
+
+    @pytest.mark.parametrize(
+        "options,code",
+        [
+            ({"max_tokens": True}, "compute_node_invalid_request"),
+            ({"max_tokens": 0}, "compute_node_invalid_request"),
+            (
+                {
+                    "max_tokens": (
+                        relay_client_module.RelayClient._API_V1_MAX_TOKENS_LIMIT + 1
+                    )
+                },
+                "compute_node_invalid_request",
+            ),
+            ({"temperature": True}, "compute_node_invalid_request"),
+            ({"temperature": math.nan}, "compute_node_invalid_request"),
+            ({"temperature": math.inf}, "compute_node_invalid_request"),
+            ({"top_p": 1.1}, "compute_node_invalid_request"),
+            ({"frequency_penalty": -2.1}, "compute_node_invalid_request"),
+            ({"presence_penalty": 2.1}, "compute_node_invalid_request"),
+            ({"seed": -1}, "compute_node_invalid_request"),
+            (
+                {
+                    "stop": ["x"]
+                    * (relay_client_module.RelayClient._API_V1_MAX_STOP_SEQUENCES + 1)
+                },
+                "compute_node_invalid_request",
+            ),
+            ({"unknown": 1}, "compute_node_options_unsupported"),
+            ({"stream": True}, "compute_node_options_unsupported"),
+            ({"tools": [{"type": "function"}]}, "compute_node_options_unsupported"),
+            ({"tool_choice": "auto"}, "compute_node_options_unsupported"),
+            (
+                {"response_format": {"type": "json_object"}},
+                "compute_node_options_unsupported",
+            ),
+        ],
+    )
+    @patch('utils.networking.relay_client.requests.post')
+    def test_api_v1_invalid_options_are_rejected_before_runtime(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+        options,
+        code,
+    ):
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-option",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "safe"}],
+                "options": options,
+            },
+        }
+        mock_post.return_value = MagicMock(status_code=200)
+        before_health = getattr(mock_model_manager, "worker_health", None)
+
+        assert relay_client.process_client_request(request_data) is True
+
+        error = mock_crypto_manager.encrypt_message.call_args.args[0][
+            "api_v1_response"
+        ]["error"]
+        assert error["code"] == code
+        assert "safe" not in json.dumps(error)
+        assert mock_model_manager.worker_health == before_health
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        mock_model_manager.get_llm_instance.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            [],
+            [{"role": "tool", "content": "safe"}],
+            [{"role": "user"}],
+            [{"role": "user", "content": "x", "tool_calls": []}],
+            [{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}],
+            [
+                {
+                    "role": "user",
+                    "content": "x"
+                    * (relay_client_module.RelayClient._API_V1_MAX_MESSAGE_CHARS + 1),
+                }
+            ],
+            [
+                {"role": "user", "content": "x"}
+            ] * (relay_client_module.RelayClient._API_V1_MAX_MESSAGES + 1),
+        ],
+    )
+    @patch('utils.networking.relay_client.requests.post')
+    def test_api_v1_invalid_messages_are_rejected_before_runtime(
+        self, mock_post, relay_client, mock_crypto_manager, mock_model_manager, messages
+    ):
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-message",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": messages,
+                "options": {},
+            },
+        }
+        mock_post.return_value = MagicMock(status_code=200)
+
+        assert relay_client.process_client_request(request_data) is True
+
+        error = mock_crypto_manager.encrypt_message.call_args.args[0][
+            "api_v1_response"
+        ]["error"]
+        assert error["code"] == "compute_node_invalid_request"
+        assert "safe" not in json.dumps(error)
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        mock_model_manager.get_llm_instance.assert_not_called()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_api_v1_valid_request_after_rejected_request_succeeds(
+        self, mock_post, relay_client, mock_crypto_manager, mock_model_manager
+    ):
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_post.return_value = MagicMock(status_code=200)
+        invalid_payload = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-then-valid",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "poison"}],
+                "options": {"temperature": math.inf},
+            },
+        }
+        valid_payload = {
+            **invalid_payload,
+            "request_id": "req-valid-after-invalid",
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "hello"}],
+                "options": {},
+            },
+        }
+        mock_crypto_manager.decrypt_message.side_effect = [invalid_payload, valid_payload]
+
+        assert relay_client.process_client_request(request_data) is True
+        assert relay_client.process_client_request(request_data) is True
+
+        assert mock_model_manager.runtime.create_chat_completion.call_count == 1
+        assert mock_model_manager.runtime.create_chat_completion.call_args.kwargs[
+            "messages"
+        ] == [{"role": "user", "content": "hello"}]
+        envelopes = [
+            call.args[0] for call in mock_crypto_manager.encrypt_message.call_args_list
+        ]
+        assert (
+            envelopes[0]["api_v1_response"]["error"]["code"]
+            == "compute_node_invalid_request"
+        )
+        assert (
+            envelopes[1]["api_v1_response"]["message"]["content"]
+            == "The capital of France is Paris."
         )
 
     @patch('utils.networking.relay_client.requests.post')

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -493,6 +493,16 @@ class RelayClient:
     }
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant", "function"}
+    _API_V1_MAX_MESSAGES = 64
+    _API_V1_MAX_MESSAGE_CHARS = 16_384
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = 131_072
+    _API_V1_MAX_CONTENT_BLOCKS = 32
+    _API_V1_MAX_STOP_SEQUENCES = 8
+    _API_V1_MAX_STOP_CHARS = 256
+    _API_V1_MAX_MODEL_CHARS = 256
+    _API_V1_MAX_TOKENS_LIMIT = 4096
+    _API_V1_MAX_SEED = 2**32 - 1
+
 
     def __init__(
         self,
@@ -1930,8 +1940,95 @@ class RelayClient:
         return False
 
     @staticmethod
-    def _api_v1_supported_options(options: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
-        passthrough_options = {
+    def _api_v1_is_finite_number(value: Any) -> bool:
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(float(value))
+        )
+
+    @classmethod
+    def _api_v1_invalid_request_error(
+        cls, message: str = "Invalid API v1 request"
+    ) -> Tuple[bool, str, str, Dict[str, Any]]:
+        return False, "compute_node_invalid_request", message, {}
+
+    @classmethod
+    def _api_v1_unsupported_options_error(
+        cls, option_name: str
+    ) -> Tuple[bool, str, str, Dict[str, Any]]:
+        return (
+            False,
+            "compute_node_options_unsupported",
+            f"Requested option is unsupported by the desktop runtime: {option_name}",
+            {},
+        )
+
+    @classmethod
+    def _api_v1_content_size(cls, content: Any) -> Optional[int]:
+        if isinstance(content, str):
+            return len(content)
+        if not isinstance(content, list) or not content:
+            return None
+        if len(content) > cls._API_V1_MAX_CONTENT_BLOCKS:
+            return None
+
+        total = 0
+        for item in content:
+            if not isinstance(item, dict) or set(item) != {"type", "text"}:
+                return None
+            if item.get("type") not in {"input_text", "text"}:
+                return None
+            text = item.get("text")
+            if not isinstance(text, str) or not text:
+                return None
+            total += len(text)
+        return total
+
+    @classmethod
+    def _validate_and_normalise_api_v1_messages(
+        cls, messages: Any
+    ) -> Tuple[bool, str, str, List[Dict[str, Any]]]:
+        if not isinstance(messages, list) or not messages:
+            return False, "compute_node_invalid_request", "Invalid chat message format", []
+        if len(messages) > cls._API_V1_MAX_MESSAGES:
+            return False, "compute_node_invalid_request", "Invalid chat message format", []
+
+        total_chars = 0
+        normalised: List[Dict[str, Any]] = []
+        for message in messages:
+            if not isinstance(message, dict):
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            if not set(message).issubset({"role", "content", "name"}):
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            role = message.get("role")
+            if (
+                not isinstance(role, str)
+                or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES
+            ):
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            if "content" not in message:
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            content_size = cls._api_v1_content_size(message.get("content"))
+            if (
+                content_size is None
+                or content_size > cls._API_V1_MAX_MESSAGE_CHARS
+            ):
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            total_chars += content_size + len(role)
+            if total_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            name = message.get("name")
+            if "name" in message and (not isinstance(name, str) or len(name) > 128):
+                return False, "compute_node_invalid_request", "Invalid chat message format", []
+            normalised.append(dict(message))
+        return True, "", "", normalised
+
+    @classmethod
+    def _validate_and_normalise_api_v1_options(
+        cls, options: Dict[str, Any]
+    ) -> Tuple[bool, str, str, Dict[str, Any]]:
+        supported = {
             "frequency_penalty",
             "max_tokens",
             "presence_penalty",
@@ -1944,12 +2041,98 @@ class RelayClient:
             "tools",
             "top_p",
         }
-        unsupported = sorted(key for key in options if key not in passthrough_options)
+        unsupported = sorted(key for key in options if key not in supported)
         if unsupported:
-            return False, ", ".join(unsupported)
-        if bool(options.get("stream", False)):
-            return False, "stream"
-        return True, None
+            return cls._api_v1_unsupported_options_error(unsupported[0])
+
+        normalised: Dict[str, Any] = {}
+        for key, value in options.items():
+            if key == "stream":
+                if value is not False:
+                    return cls._api_v1_unsupported_options_error("stream")
+                continue
+            if key == "max_tokens":
+                if not isinstance(value, int) or isinstance(value, bool):
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                if value < 1 or value > cls._API_V1_MAX_TOKENS_LIMIT:
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                normalised[key] = value
+                continue
+            if key in {"temperature", "top_p"}:
+                if not cls._api_v1_is_finite_number(value):
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                numeric = float(value)
+                upper = 2.0 if key == "temperature" else 1.0
+                if numeric < 0.0 or numeric > upper:
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                normalised[key] = numeric
+                continue
+            if key in {"frequency_penalty", "presence_penalty"}:
+                if not cls._api_v1_is_finite_number(value):
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                numeric = float(value)
+                if numeric < -2.0 or numeric > 2.0:
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                normalised[key] = numeric
+                continue
+            if key == "seed":
+                if not isinstance(value, int) or isinstance(value, bool):
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                if value < 0 or value > cls._API_V1_MAX_SEED:
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                normalised[key] = value
+                continue
+            if key == "stop":
+                stop_values = [value] if isinstance(value, str) else value
+                if (
+                    not isinstance(stop_values, list)
+                    or len(stop_values) > cls._API_V1_MAX_STOP_SEQUENCES
+                ):
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                if not all(
+                    isinstance(item, str) and len(item) <= cls._API_V1_MAX_STOP_CHARS
+                    for item in stop_values
+                ):
+                    return cls._api_v1_invalid_request_error("Invalid API v1 option value")
+                normalised[key] = stop_values
+                continue
+            if key == "response_format":
+                if value != {"type": "text"}:
+                    return cls._api_v1_unsupported_options_error("response_format")
+                continue
+            if key == "tools":
+                if value != []:
+                    return cls._api_v1_unsupported_options_error("tools")
+                continue
+            if key == "tool_choice":
+                if value != "none":
+                    return cls._api_v1_unsupported_options_error("tool_choice")
+                continue
+        return True, "", "", normalised
+
+    @classmethod
+    def _validate_and_normalise_api_v1_request(
+        cls, model_id: Any, messages: Any, options: Any
+    ) -> Tuple[bool, str, str, List[Dict[str, Any]], Dict[str, Any]]:
+        if (
+            not isinstance(model_id, str)
+            or not model_id.strip()
+            or len(model_id) > cls._API_V1_MAX_MODEL_CHARS
+        ):
+            return False, "compute_node_invalid_request", "Invalid API v1 request", [], {}
+        messages_ok, msg_code, msg_text, normalised_messages = (
+            cls._validate_and_normalise_api_v1_messages(messages)
+        )
+        if not messages_ok:
+            return False, msg_code, msg_text, [], {}
+        if not isinstance(options, dict):
+            return False, "compute_node_invalid_request", "Invalid API v1 request", [], {}
+        options_ok, opt_code, opt_text, normalised_options = (
+            cls._validate_and_normalise_api_v1_options(options)
+        )
+        if not options_ok:
+            return False, opt_code, opt_text, [], {}
+        return True, "", "", normalised_messages, normalised_options
 
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]
@@ -1964,13 +2147,14 @@ class RelayClient:
                 return config_get(key, default)
             return default
 
-        completion_kwargs = {
+        defaults = {
             "max_tokens": configured("model.max_tokens", 512),
             "temperature": configured("model.temperature", 0.7),
             "top_p": configured("model.top_p", 0.9),
             "stop": configured("model.stop_tokens", []),
-            "stream": False,
         }
+        _, _, _, safe_defaults = self._validate_and_normalise_api_v1_options(defaults)
+        completion_kwargs = {"stream": False, **safe_defaults}
         completion_kwargs.update(safe_options)
         return completion_kwargs
 
@@ -2003,12 +2187,19 @@ class RelayClient:
     ) -> Dict[str, Any]:
         """Generate an API v1 assistant message with the desktop runtime model."""
 
-        if not self._messages_are_valid_api_v1_chat(messages):
+        (
+            request_valid,
+            validation_code,
+            validation_message,
+            normalised_messages,
+            safe_options,
+        ) = self._validate_and_normalise_api_v1_request(model_id, messages, options)
+        if not request_valid:
             return self._api_v1_response_envelope(
                 request_id,
                 error={
-                    "code": "compute_node_invalid_request",
-                    "message": "Invalid chat message format",
+                    "code": validation_code,
+                    "message": validation_message,
                 },
             )
 
@@ -2023,20 +2214,6 @@ class RelayClient:
                 },
             )
 
-        options_supported, unsupported_option = self._api_v1_supported_options(options)
-        if not options_supported:
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": "compute_node_options_unsupported",
-                    "message": (
-                        "Requested option is unsupported by the desktop runtime: "
-                        f"{unsupported_option}"
-                    ),
-                },
-            )
-
-        safe_options = {key: value for key, value in options.items() if key != "stream"}
         if not has_direct_runtime_completion:
             # API v1 desktop relay generation must fail closed rather than
             # falling back to legacy chat-history runtimes. This is intentional
@@ -2052,7 +2229,7 @@ class RelayClient:
                 },
             )
 
-        runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
+        runtime_messages = self._prepare_api_v1_runtime_messages(model_id, normalised_messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             llm_instance = None


### PR DESCRIPTION
### Motivation
- Prevent malformed or unsupported API v1 desktop relay requests from reaching the local llama.cpp/runtime and becoming poison requests. 
- Enforce relay-blind error handling so rejected inputs produce safe structured error envelopes instead of logging or returning plaintext request content. 
- Keep the existing API v1 surface (non-streaming, E2EE) and honor the documented desktop bridge contract while rejecting unsupported features early.

### Description
- Added deterministic bounds and limits for API v1 requests and options (message counts, per-message and total characters, content block counts, stop sequences, model id length, token/seed limits, etc.).
- Implemented structural validation and normalization helpers: `_api_v1_content_size`, `_validate_and_normalise_api_v1_messages`, `_validate_and_normalise_api_v1_options`, and `_validate_and_normalise_api_v1_request` to check types, reject booleans-as-numbers, non-finite numerics, unsupported combinations, and oversized inputs.
- Integrated validation into the desktop path so validation runs before acquiring/invoking a direct runtime and returns relay-safe error envelopes with codes `compute_node_invalid_request` or `compute_node_options_unsupported` when appropriate.
- Normalized runtime completion args so only explicitly supported, validated options reach `create_chat_completion`; no-op fields (`tools`, `tool_choice`, `response_format`) are rejected or stripped rather than passed through.
- Added table-driven unit tests that exercise accepted boundary cases, invalid types/non-finite values, oversized inputs, unsupported options/combinations, guarantee the model worker is not called for rejected requests, assert worker health is unchanged, and confirm a valid request immediately after a rejected request succeeds.

### Testing
- Ran unit tests covering the API v1 validation surface: `python -m pytest -q tests/unit/test_relay_client.py -k "option or invalid or message or api_v1"` — PASS (selected tests passed).
- Ran relay-level tests: `python -m pytest -q tests/test_relay.py -k "compute_node or api_v1"` — PASS.
- Ran integration E2EE desktop-bridge tests: `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — PASS.
- Ran repo checks: `pre-commit run --all-files` — PASS.
- Residual risks / follow-ups: validate runtime-specific numeric/clamping expectations with upstream llama.cpp tokenizer-aware heuristics if/when a more precise context estimator is desired, and ensure any future API v1 feature additions update the supported-options whitelist to maintain fail-closed behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3732ca6a90832fa3cde732d1b8c728)