### PR TITLE
Validate desktop API v1 requests before inference

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2590,13 +2590,13 @@ class TestRelayClient:
         )
 
     @patch('utils.networking.relay_client.requests.post')
-    def test_process_client_request_api_v1_forwards_openai_options_with_defaults(
+    def test_process_client_request_api_v1_rejects_unsupported_openai_features(
         self,
         mock_post,
         relay_client,
         mock_crypto_manager,
     ):
-        """OpenAI-style API v1 options should pass through with manager defaults."""
+        """Unsupported OpenAI feature options must not pass through to llama.cpp."""
 
         class _Config:
             def get(self, key, default):
@@ -2669,23 +2669,230 @@ class TestRelayClient:
 
         assert relay_client.process_client_request(request_data) is True
 
-        assert len(manager.runtime.calls) == 1
-        completion_kwargs = manager.runtime.calls[0]
-        assert completion_kwargs["messages"] == [{"role": "user", "content": "Hello"}]
-        assert completion_kwargs["max_tokens"] == 64
-        assert completion_kwargs["top_p"] == 0.9
-        assert completion_kwargs["stop"] == ["</s>"]
-        assert completion_kwargs["stream"] is False
-        assert completion_kwargs["temperature"] == 0.2
-        assert completion_kwargs["frequency_penalty"] == 0.1
-        assert completion_kwargs["presence_penalty"] == 0.2
-        assert completion_kwargs["response_format"] == {"type": "text"}
-        assert completion_kwargs["seed"] == 7
-        assert completion_kwargs["tools"] == []
-        assert completion_kwargs["tool_choice"] == "none"
+        assert manager.runtime.calls == []
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
-        assert encrypted_envelope["api_v1_response"]["message"]["content"] == (
-            "Tool-aware response"
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_options_unsupported"
+        )
+
+    @pytest.mark.parametrize(
+        "options,expected",
+        [
+            ({"max_tokens": 1}, {"max_tokens": 1}),
+            ({"max_tokens": 4096}, {"max_tokens": 4096}),
+            ({"temperature": 0.0}, {"temperature": 0.0}),
+            ({"temperature": 2.0}, {"temperature": 2.0}),
+            ({"top_p": 0.0}, {"top_p": 0.0}),
+            ({"top_p": 1.0}, {"top_p": 1.0}),
+            ({"frequency_penalty": -2.0}, {"frequency_penalty": -2.0}),
+            ({"frequency_penalty": 2.0}, {"frequency_penalty": 2.0}),
+            ({"presence_penalty": -2.0}, {"presence_penalty": -2.0}),
+            ({"presence_penalty": 2.0}, {"presence_penalty": 2.0}),
+            ({"seed": 0}, {"seed": 0}),
+            ({"seed": 2**31 - 1}, {"seed": 2**31 - 1}),
+            ({"stop": "END"}, {"stop": "END"}),
+            ({"stop": ["END"]}, {"stop": ["END"]}),
+            ({"stream": False}, {}),
+        ],
+    )
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_accepts_option_boundaries(
+        self,
+        mock_post,
+        options,
+        expected,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Every supported option accepts documented boundary values."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-option-boundary",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": options,
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        completion_kwargs = mock_model_manager.runtime.create_chat_completion.call_args.kwargs
+        for key, value in expected.items():
+            assert completion_kwargs[key] == value
+        assert completion_kwargs["stream"] is False
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert "error" not in encrypted_envelope["api_v1_response"]
+
+    @pytest.mark.parametrize(
+        "options,expected_code",
+        [
+            ({"max_tokens": True}, "compute_node_invalid_request"),
+            ({"max_tokens": 1.5}, "compute_node_invalid_request"),
+            ({"max_tokens": 0}, "compute_node_invalid_request"),
+            ({"max_tokens": 4097}, "compute_node_invalid_request"),
+            ({"temperature": False}, "compute_node_invalid_request"),
+            ({"temperature": float("nan")}, "compute_node_invalid_request"),
+            ({"temperature": float("inf")}, "compute_node_invalid_request"),
+            ({"temperature": -0.1}, "compute_node_invalid_request"),
+            ({"top_p": 1.1}, "compute_node_invalid_request"),
+            ({"frequency_penalty": -2.1}, "compute_node_invalid_request"),
+            ({"presence_penalty": 2.1}, "compute_node_invalid_request"),
+            ({"seed": -1}, "compute_node_invalid_request"),
+            ({"seed": 2**31}, "compute_node_invalid_request"),
+            ({"stop": ""}, "compute_node_invalid_request"),
+            ({"stop": ["END"] * 9}, "compute_node_invalid_request"),
+            ({"stop": "x" * 257}, "compute_node_invalid_request"),
+            ({"stream": True}, "compute_node_options_unsupported"),
+            ({"tools": []}, "compute_node_options_unsupported"),
+            ({"tool_choice": "none"}, "compute_node_options_unsupported"),
+            ({"response_format": {"type": "text"}}, "compute_node_options_unsupported"),
+            ({"unknown": 1}, "compute_node_options_unsupported"),
+        ],
+    )
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_rejects_invalid_options_before_worker(
+        self,
+        mock_post,
+        options,
+        expected_code,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Invalid, non-finite, oversized, and unsupported options are poison-safe."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-option",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "secret prompt text"}],
+                "options": options,
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        error = encrypted_envelope["api_v1_response"]["error"]
+        assert error["code"] == expected_code
+        assert "secret prompt text" not in json.dumps(error)
+
+    @pytest.mark.parametrize(
+        "messages,expected_code",
+        [
+            ([], "compute_node_invalid_request"),
+            ([{"role": "developer", "content": "x"}], "compute_node_invalid_request"),
+            ([{"role": "user"}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": 123}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": "x" * 16385}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": [{"type": "text", "text": ""}]}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": [{"type": "text", "text": "x", "extra": "y"}]}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": [{"type": "text", "text": "x"}] * 17}], "compute_node_invalid_request"),
+            ([{"role": "user", "content": "x"}] * 65, "compute_node_invalid_request"),
+        ],
+    )
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_rejects_invalid_messages_before_worker(
+        self,
+        mock_post,
+        messages,
+        expected_code,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Malformed and oversized messages are rejected before llama.cpp."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-message",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": messages,
+                "options": {},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == expected_code
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_rejection_does_not_degrade_next_valid_request(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Rejected validation failures do not alter health/recovery before valid work."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+        original_registered_relays = set(relay_client._api_v1_registered_relays)
+        invalid_payload = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-then-valid",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "secret rejected text"}],
+                "options": {"temperature": float("inf")},
+            },
+        }
+        valid_payload = {
+            **invalid_payload,
+            "request_id": "req-valid-after-invalid",
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+
+        mock_crypto_manager.decrypt_message.return_value = invalid_payload
+        assert relay_client.process_client_request(request_data) is True
+        first_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert first_envelope["api_v1_response"]["error"]["code"] == "compute_node_invalid_request"
+        assert mock_model_manager.runtime.create_chat_completion.call_count == 0
+        assert set(relay_client._api_v1_registered_relays) == original_registered_relays
+
+        mock_crypto_manager.decrypt_message.return_value = valid_payload
+        assert relay_client.process_client_request(request_data) is True
+        assert mock_model_manager.runtime.create_chat_completion.call_count == 1
+        second_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert second_envelope["api_v1_response"]["message"]["content"] == (
+            "The capital of France is Paris."
         )
 
     @patch('utils.networking.relay_client.requests.post')

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -22,6 +22,15 @@ logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
 
 
+class ApiV1RequestValidationError(ValueError):
+    """Structured, prompt-safe API v1 request validation failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
 def _load_jsonschema():
     """Lazy-load jsonschema; return ``None`` when unavailable in packaged runtimes."""
     try:
@@ -493,6 +502,37 @@ class RelayClient:
     }
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant", "function"}
+    _API_V1_MAX_MESSAGES = 64
+    _API_V1_MAX_MESSAGE_CHARS = 16_384
+    _API_V1_MAX_TOTAL_CONTENT_CHARS = 65_536
+    _API_V1_MAX_CONTENT_BLOCKS = 16
+    _API_V1_MAX_STOP_VALUES = 8
+    _API_V1_MAX_STOP_CHARS = 256
+    _API_V1_MAX_MODEL_CHARS = 256
+    _API_V1_MAX_REQUEST_ID_CHARS = 256
+    _API_V1_MIN_MAX_TOKENS = 1
+    _API_V1_MAX_MAX_TOKENS = 4096
+    _API_V1_MIN_SEED = 0
+    _API_V1_MAX_SEED = 2**31 - 1
+    _API_V1_SUPPORTED_OPTION_NAMES = {
+        "frequency_penalty",
+        "max_tokens",
+        "presence_penalty",
+        "seed",
+        "stop",
+        "stream",
+        "temperature",
+        "top_p",
+    }
+    _API_V1_UNSUPPORTED_FEATURE_OPTIONS = {
+        "logit_bias",
+        "logprobs",
+        "parallel_tool_calls",
+        "response_format",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+    }
 
     def __init__(
         self,
@@ -1680,6 +1720,246 @@ class RelayClient:
         return True
 
     @classmethod
+    def _api_v1_validate_string(
+        cls,
+        value: Any,
+        *,
+        field: str,
+        max_chars: int,
+        allow_empty: bool = False,
+    ) -> str:
+        if not isinstance(value, str):
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} must be a string",
+            )
+        if not allow_empty and not value:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} must be non-empty",
+            )
+        if len(value) > max_chars:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} exceeds size limit",
+            )
+        return value
+
+    @classmethod
+    def _api_v1_validate_number(
+        cls,
+        value: Any,
+        *,
+        field: str,
+        minimum: float,
+        maximum: float,
+        integer: bool = False,
+    ) -> Union[int, float]:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            expected = "integer" if integer else "number"
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} must be a finite {expected}",
+            )
+        if not math.isfinite(float(value)):
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} must be finite",
+            )
+        if integer and not isinstance(value, int):
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} must be an integer",
+            )
+        if value < minimum or value > maximum:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                f"Invalid API v1 request: {field} is outside supported range",
+            )
+        return value
+
+    @classmethod
+    def _api_v1_normalize_stop(cls, value: Any) -> Union[str, List[str]]:
+        if isinstance(value, str):
+            return cls._api_v1_validate_string(
+                value,
+                field="stop",
+                max_chars=cls._API_V1_MAX_STOP_CHARS,
+            )
+        if not isinstance(value, list) or not value:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                "Invalid API v1 request: stop must be a string or non-empty string list",
+            )
+        if len(value) > cls._API_V1_MAX_STOP_VALUES:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                "Invalid API v1 request: stop has too many values",
+            )
+        return [
+            cls._api_v1_validate_string(
+                item,
+                field="stop",
+                max_chars=cls._API_V1_MAX_STOP_CHARS,
+            )
+            for item in value
+        ]
+
+    @classmethod
+    def _validate_and_normalize_api_v1_messages(
+        cls, messages: Any
+    ) -> List[Dict[str, Any]]:
+        if not isinstance(messages, list) or not messages:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                "Invalid API v1 request: messages must be a non-empty list",
+            )
+        if len(messages) > cls._API_V1_MAX_MESSAGES:
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                "Invalid API v1 request: too many messages",
+            )
+        normalized: List[Dict[str, Any]] = []
+        total_chars = 0
+        for message in messages:
+            if not isinstance(message, dict):
+                raise ApiV1RequestValidationError(
+                    "compute_node_invalid_request",
+                    "Invalid API v1 request: each message must be an object",
+                )
+            role = message.get("role")
+            if not isinstance(role, str) or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES:
+                raise ApiV1RequestValidationError(
+                    "compute_node_invalid_request",
+                    "Invalid API v1 request: unsupported message role",
+                )
+            if "content" not in message:
+                raise ApiV1RequestValidationError(
+                    "compute_node_invalid_request",
+                    "Invalid API v1 request: message content is required",
+                )
+            content = message.get("content")
+            if isinstance(content, str):
+                cls._api_v1_validate_string(
+                    content,
+                    field="message content",
+                    max_chars=cls._API_V1_MAX_MESSAGE_CHARS,
+                    allow_empty=True,
+                )
+                total_chars += len(content)
+            elif isinstance(content, list) and content:
+                if len(content) > cls._API_V1_MAX_CONTENT_BLOCKS:
+                    raise ApiV1RequestValidationError(
+                        "compute_node_invalid_request",
+                        "Invalid API v1 request: too many content blocks",
+                    )
+                block_chars = 0
+                for block in content:
+                    if not isinstance(block, dict):
+                        raise ApiV1RequestValidationError(
+                            "compute_node_invalid_request",
+                            "Invalid API v1 request: content blocks must be objects",
+                        )
+                    if block.get("type") not in {"input_text", "text"}:
+                        raise ApiV1RequestValidationError(
+                            "compute_node_invalid_request",
+                            "Invalid API v1 request: message content must be text",
+                        )
+                    if set(block) - {"type", "text"}:
+                        raise ApiV1RequestValidationError(
+                            "compute_node_invalid_request",
+                            "Invalid API v1 request: unsupported content block shape",
+                        )
+                    text = cls._api_v1_validate_string(
+                        block.get("text"),
+                        field="content block text",
+                        max_chars=cls._API_V1_MAX_MESSAGE_CHARS,
+                    )
+                    block_chars += len(text)
+                if block_chars > cls._API_V1_MAX_MESSAGE_CHARS:
+                    raise ApiV1RequestValidationError(
+                        "compute_node_invalid_request",
+                        "Invalid API v1 request: message content exceeds size limit",
+                    )
+                total_chars += block_chars
+            else:
+                raise ApiV1RequestValidationError(
+                    "compute_node_invalid_request",
+                    "Invalid API v1 request: message content must be text",
+                )
+            if total_chars > cls._API_V1_MAX_TOTAL_CONTENT_CHARS:
+                raise ApiV1RequestValidationError(
+                    "compute_node_invalid_request",
+                    "Invalid API v1 request: total message content exceeds size limit",
+                )
+            normalized.append(dict(message))
+        return normalized
+
+    def _validate_and_normalize_api_v1_options(
+        self, options: Any
+    ) -> Dict[str, Any]:
+        if not isinstance(options, dict):
+            raise ApiV1RequestValidationError(
+                "compute_node_invalid_request",
+                "Invalid API v1 request: options must be an object",
+            )
+        unsupported_features = sorted(
+            key for key in options if key in self._API_V1_UNSUPPORTED_FEATURE_OPTIONS
+        )
+        if unsupported_features:
+            raise ApiV1RequestValidationError(
+                "compute_node_options_unsupported",
+                "Unsupported API v1 request feature",
+            )
+        unknown = sorted(key for key in options if key not in self._API_V1_SUPPORTED_OPTION_NAMES)
+        if unknown:
+            raise ApiV1RequestValidationError(
+                "compute_node_options_unsupported",
+                "Unsupported API v1 request option",
+            )
+        normalized: Dict[str, Any] = {}
+        for key, value in options.items():
+            if key == "stream":
+                if value is not False:
+                    raise ApiV1RequestValidationError(
+                        "compute_node_options_unsupported",
+                        "Unsupported API v1 request feature: streaming",
+                    )
+            elif key == "max_tokens":
+                normalized[key] = self._api_v1_validate_number(
+                    value,
+                    field=key,
+                    minimum=self._API_V1_MIN_MAX_TOKENS,
+                    maximum=self._API_V1_MAX_MAX_TOKENS,
+                    integer=True,
+                )
+            elif key in {"temperature", "top_p"}:
+                normalized[key] = self._api_v1_validate_number(
+                    value,
+                    field=key,
+                    minimum=0.0,
+                    maximum=2.0 if key == "temperature" else 1.0,
+                )
+            elif key in {"frequency_penalty", "presence_penalty"}:
+                normalized[key] = self._api_v1_validate_number(
+                    value,
+                    field=key,
+                    minimum=-2.0,
+                    maximum=2.0,
+                )
+            elif key == "seed":
+                normalized[key] = self._api_v1_validate_number(
+                    value,
+                    field=key,
+                    minimum=self._API_V1_MIN_SEED,
+                    maximum=self._API_V1_MAX_SEED,
+                    integer=True,
+                )
+            elif key == "stop":
+                normalized[key] = self._api_v1_normalize_stop(value)
+        return normalized
+
+    @classmethod
     def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
         if not isinstance(messages, list) or not messages:
             return False
@@ -2003,12 +2283,26 @@ class RelayClient:
     ) -> Dict[str, Any]:
         """Generate an API v1 assistant message with the desktop runtime model."""
 
-        if not self._messages_are_valid_api_v1_chat(messages):
+        try:
+            request_id = self._api_v1_validate_string(
+                request_id,
+                field="request_id",
+                max_chars=self._API_V1_MAX_REQUEST_ID_CHARS,
+            )
+            model_id = self._api_v1_validate_string(
+                model_id,
+                field="model",
+                max_chars=self._API_V1_MAX_MODEL_CHARS,
+            ).strip()
+            messages = self._validate_and_normalize_api_v1_messages(messages)
+            options = self._validate_and_normalize_api_v1_options(options)
+        except ApiV1RequestValidationError as exc:
+            log_error("Rejected API v1 relay request during validation: {}", exc.code)
             return self._api_v1_response_envelope(
                 request_id,
                 error={
-                    "code": "compute_node_invalid_request",
-                    "message": "Invalid chat message format",
+                    "code": exc.code,
+                    "message": exc.message,
                 },
             )
 
@@ -2020,19 +2314,6 @@ class RelayClient:
                 error={
                     "code": "compute_node_model_unsupported",
                     "message": "Requested model is not available in the desktop runtime",
-                },
-            )
-
-        options_supported, unsupported_option = self._api_v1_supported_options(options)
-        if not options_supported:
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
-                    "code": "compute_node_options_unsupported",
-                    "message": (
-                        "Requested option is unsupported by the desktop runtime: "
-                        f"{unsupported_option}"
-                    ),
                 },
             )
 


### PR DESCRIPTION
### Motivation
- Prevent malformed or unsupported API v1 desktop relay inputs from reaching llama.cpp and becoming poison requests. 
- Enforce deterministic structural and byte/character bounds (not tokenizer estimates) and map validation failures to safe relay-blind error codes. 
- Keep the existing API v1 surface (non-streaming desktop path) and documented launch contract intact while rejecting unsupported features early. 

### Description
- Add a prompt-safe `ApiV1RequestValidationError` and a set of desktop API v1 bounds/constants for message counts, per-message and total content sizes, stop values, request/model/request_id lengths, numeric ranges, and supported option names. 
- Implement validation helpers: `_api_v1_validate_string`, `_api_v1_validate_number`, `_api_v1_normalize_stop`, `_validate_and_normalize_api_v1_messages`, and `_validate_and_normalize_api_v1_options` to reject booleans-as-numbers, non-finite values, oversized inputs, unsupported option names (e.g., `tools`, `tool_choice`, `response_format`, streaming), and unsupported content blocks before acquiring or invoking the runtime. 
- Wire validation into the desktop non-streaming path (`_generate_api_v1_response_with_runtime_model`) so invalid requests return encrypted, relay-blind error envelopes with codes `compute_node_invalid_request` or `compute_node_options_unsupported` and the runtime worker is never called for rejected requests. 
- Remove silent passthrough of unsupported options and add table-driven unit tests covering valid boundary cases, invalid/poison inputs, and the requirement that a valid request after a rejected request succeeds without altering worker health. 

### Testing
- Ran unit subset focused on API v1/message/option validation with `python -m pytest -q tests/unit/test_relay_client.py -k "option or invalid or message or api_v1"`, which passed (129 passed, 58 deselected in local run). 
- Ran relay unit tests with `python -m pytest -q tests/test_relay.py -k "compute_node or api_v1"`, which passed (79 passed, 41 deselected). 
- Ran integration desktop bridge tests with `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py`, which passed (10 passed). 
- Ran repository checks with `pre-commit run --all-files`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3732d0f220832fada266006d47eeae)