### PR TITLE
Validate desktop API v1 inference requests

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2479,6 +2479,192 @@ class TestRelayClient:
         assert "compute_node_options_unsupported" not in observed_error_codes
 
     @patch('utils.networking.relay_client.requests.post')
+    @pytest.mark.parametrize(
+        ("options", "code"),
+        [
+            ({"unknown": 1}, "compute_node_options_unsupported"),
+            ({"stream": True}, "compute_node_options_unsupported"),
+            ({"max_tokens": True}, "compute_node_invalid_request"),
+            ({"max_tokens": 0}, "compute_node_invalid_request"),
+            ({"max_tokens": 4097}, "compute_node_invalid_request"),
+            ({"temperature": True}, "compute_node_invalid_request"),
+            ({"temperature": math.nan}, "compute_node_invalid_request"),
+            ({"top_p": math.inf}, "compute_node_invalid_request"),
+            ({"frequency_penalty": -2.1}, "compute_node_invalid_request"),
+            ({"presence_penalty": 2.1}, "compute_node_invalid_request"),
+            ({"seed": True}, "compute_node_invalid_request"),
+            ({"seed": -1}, "compute_node_invalid_request"),
+            ({"stop": ["x"] * 9}, "compute_node_invalid_request"),
+            ({"stop": ""}, "compute_node_invalid_request"),
+            ({"tools": [{"type": "function"}]}, "compute_node_options_unsupported"),
+            ({"tool_choice": "auto"}, "compute_node_options_unsupported"),
+            ({"response_format": {"type": "json_object"}}, "compute_node_options_unsupported"),
+        ],
+    )
+    def test_process_client_request_api_v1_rejects_poison_options_before_runtime(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+        options,
+        code,
+    ):
+        """Malformed and unsupported options fail before llama.cpp is invoked."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        relay_client._api_v1_registered_relays.add("http://localhost:5000")
+        relay_client._api_v1_last_heartbeat_at["http://localhost:5000"] = 123.0
+        before_registered = set(relay_client._api_v1_registered_relays)
+        before_heartbeat = dict(relay_client._api_v1_last_heartbeat_at)
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-poison-option",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "secret prompt must stay encrypted"}],
+                "options": options,
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        error = encrypted_envelope["api_v1_response"]["error"]
+        assert error["code"] == code
+        assert "secret prompt" not in json.dumps(error)
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+        assert relay_client._api_v1_registered_relays == before_registered
+        assert relay_client._api_v1_last_heartbeat_at == before_heartbeat
+
+    @patch('utils.networking.relay_client.requests.post')
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            [],
+            [{"role": "developer", "content": "x"}],
+            [{"role": "user"}],
+            [{"role": "user", "content": None}],
+            [{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}],
+            [{"role": "user", "content": "x", "tool_calls": []}],
+            [{"role": "user", "content": "x"}] * 65,
+            [{"role": "user", "content": "x" * 32769}],
+        ],
+    )
+    def test_process_client_request_api_v1_rejects_poison_messages_before_runtime(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+        messages,
+    ):
+        """Malformed or oversized messages fail with relay-blind invalid-request errors."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-poison-message",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": messages,
+                "options": {},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        error = encrypted_envelope["api_v1_response"]["error"]
+        assert error == {
+            "code": "compute_node_invalid_request",
+            "message": "Invalid chat message format",
+        }
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        mock_model_manager.llama_cpp_get_response.assert_not_called()
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_valid_boundaries_after_rejected_request_succeeds(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """A rejected request does not poison the worker for the next valid request."""
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        invalid_payload = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-invalid-first",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "bad first"}],
+                "options": {"temperature": math.inf},
+            },
+        }
+        valid_payload = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-valid-second",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [
+                    {"role": "system", "content": "s"},
+                    {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+                ],
+                "options": {
+                    "max_tokens": 1,
+                    "temperature": 0.0,
+                    "top_p": 1.0,
+                    "frequency_penalty": -2.0,
+                    "presence_penalty": 2.0,
+                    "seed": 0,
+                    "stop": ["x"],
+                    "stream": False,
+                    "response_format": {"type": "text"},
+                    "tools": [],
+                    "tool_choice": "none",
+                },
+            },
+        }
+        mock_crypto_manager.decrypt_message.side_effect = [invalid_payload, valid_payload]
+
+        assert relay_client.process_client_request(request_data) is True
+        mock_model_manager.runtime.create_chat_completion.assert_not_called()
+        assert relay_client.process_client_request(request_data) is True
+
+        mock_model_manager.runtime.create_chat_completion.assert_called_once()
+        completion_kwargs = mock_model_manager.runtime.create_chat_completion.call_args.kwargs
+        assert completion_kwargs["messages"][1]["content"] == "hello"
+        assert completion_kwargs["max_tokens"] == 1
+        assert completion_kwargs["temperature"] == 0.0
+        assert completion_kwargs["top_p"] == 1.0
+        assert completion_kwargs["frequency_penalty"] == -2.0
+        assert completion_kwargs["presence_penalty"] == 2.0
+        assert completion_kwargs["seed"] == 0
+        assert completion_kwargs["stop"] == ["x"]
+        assert completion_kwargs["stream"] is False
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_rejects_streaming_option(
         self,
         mock_post,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -493,6 +493,18 @@ class RelayClient:
     }
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant", "function"}
+    _API_V1_MAX_MESSAGES = 64
+    _API_V1_MAX_MESSAGE_CHARS = 32_768
+    _API_V1_MAX_TOTAL_CHARS = 131_072
+    _API_V1_MAX_CONTENT_BLOCKS = 32
+    _API_V1_MAX_STOP_SEQUENCES = 8
+    _API_V1_MAX_STOP_CHARS = 256
+    _API_V1_MAX_MODEL_ID_CHARS = 256
+    _API_V1_MAX_MAX_TOKENS = 4096
+    _API_V1_MAX_SEED = 2**31 - 1
+    _API_V1_MIN_PENALTY = -2.0
+    _API_V1_MAX_PENALTY = 2.0
+
 
     def __init__(
         self,
@@ -1930,8 +1942,52 @@ class RelayClient:
         return False
 
     @staticmethod
-    def _api_v1_supported_options(options: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
-        passthrough_options = {
+    def _api_v1_number_is_finite(value: Any) -> bool:
+        return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+    @classmethod
+    def _api_v1_invalid_request(cls, request_id: str, message: str) -> Dict[str, Any]:
+        return cls._api_v1_response_envelope(
+            request_id,
+            error={"code": "compute_node_invalid_request", "message": message},
+        )
+
+    @classmethod
+    def _api_v1_unsupported_options(cls, request_id: str, option: str) -> Dict[str, Any]:
+        return cls._api_v1_response_envelope(
+            request_id,
+            error={
+                "code": "compute_node_options_unsupported",
+                "message": f"Requested option is unsupported by the desktop runtime: {option}",
+            },
+        )
+
+    @classmethod
+    def _validate_api_v1_stop(cls, value: Any) -> Tuple[bool, Optional[Any]]:
+        if isinstance(value, str):
+            if not value or len(value) > cls._API_V1_MAX_STOP_CHARS:
+                return False, None
+            return True, value
+        if not isinstance(value, list) or len(value) > cls._API_V1_MAX_STOP_SEQUENCES:
+            return False, None
+        normalised = []
+        for item in value:
+            if not isinstance(item, str) or not item or len(item) > cls._API_V1_MAX_STOP_CHARS:
+                return False, None
+            normalised.append(item)
+        return True, normalised
+
+    @classmethod
+    def _validate_api_v1_options(
+        cls, options: Dict[str, Any], *, default_max_tokens: Any = None
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[str]]:
+        """Validate and normalize explicitly supported desktop llama.cpp options.
+
+        Returns ``(safe_options, error_code, detail)``. Details are option names or
+        structural labels only and never include rejected user payload values.
+        """
+
+        allowed = {
             "frequency_penalty",
             "max_tokens",
             "presence_penalty",
@@ -1944,12 +2000,109 @@ class RelayClient:
             "tools",
             "top_p",
         }
-        unsupported = sorted(key for key in options if key not in passthrough_options)
-        if unsupported:
-            return False, ", ".join(unsupported)
-        if bool(options.get("stream", False)):
-            return False, "stream"
-        return True, None
+        unknown = sorted(str(key) for key in options if key not in allowed)
+        if unknown:
+            return None, "compute_node_options_unsupported", unknown[0]
+
+        safe: Dict[str, Any] = {}
+        max_tokens_cap = cls._API_V1_MAX_MAX_TOKENS
+        if isinstance(default_max_tokens, int) and not isinstance(default_max_tokens, bool):
+            max_tokens_cap = max(1, min(max_tokens_cap, default_max_tokens))
+
+        for key, value in options.items():
+            if key == "stream":
+                if value is not False:
+                    return None, "compute_node_options_unsupported", "stream"
+                continue
+            if key == "max_tokens":
+                if not isinstance(value, int) or isinstance(value, bool) or not (1 <= value <= max_tokens_cap):
+                    return None, "compute_node_invalid_request", "max_tokens"
+                safe[key] = value
+            elif key in {"temperature", "top_p"}:
+                if not cls._api_v1_number_is_finite(value):
+                    return None, "compute_node_invalid_request", key
+                upper = 2.0 if key == "temperature" else 1.0
+                if not (0.0 <= float(value) <= upper):
+                    return None, "compute_node_invalid_request", key
+                safe[key] = float(value)
+            elif key in {"frequency_penalty", "presence_penalty"}:
+                if not cls._api_v1_number_is_finite(value) or not (
+                    cls._API_V1_MIN_PENALTY <= float(value) <= cls._API_V1_MAX_PENALTY
+                ):
+                    return None, "compute_node_invalid_request", key
+                safe[key] = float(value)
+            elif key == "seed":
+                if not isinstance(value, int) or isinstance(value, bool) or not (0 <= value <= cls._API_V1_MAX_SEED):
+                    return None, "compute_node_invalid_request", key
+                safe[key] = value
+            elif key == "stop":
+                valid, normalised = cls._validate_api_v1_stop(value)
+                if not valid:
+                    return None, "compute_node_invalid_request", key
+                safe[key] = normalised
+            elif key == "response_format":
+                if value != {"type": "text"}:
+                    return None, "compute_node_options_unsupported", key
+                safe[key] = value
+            elif key == "tools":
+                if value != []:
+                    return None, "compute_node_options_unsupported", key
+                safe[key] = []
+            elif key == "tool_choice":
+                if value != "none":
+                    return None, "compute_node_options_unsupported", key
+                safe[key] = value
+        return safe, None, None
+
+    @classmethod
+    def _validate_and_normalise_api_v1_messages(
+        cls, messages: Any
+    ) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+        if not isinstance(messages, list) or not messages or len(messages) > cls._API_V1_MAX_MESSAGES:
+            return None, "messages"
+        normalised: List[Dict[str, Any]] = []
+        total_chars = 0
+        for message in messages:
+            if not isinstance(message, dict):
+                return None, "messages"
+            allowed_keys = {"role", "content", "name"}
+            if any(key not in allowed_keys for key in message):
+                return None, "messages"
+            role = message.get("role")
+            if not isinstance(role, str) or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES:
+                return None, "messages"
+            if "content" not in message:
+                return None, "messages"
+            content = message.get("content")
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, list) and content and len(content) <= cls._API_V1_MAX_CONTENT_BLOCKS:
+                parts: List[str] = []
+                for block in content:
+                    if not isinstance(block, dict) or set(block.keys()) != {"type", "text"}:
+                        return None, "messages"
+                    if block.get("type") not in {"input_text", "text"}:
+                        return None, "messages"
+                    block_text = block.get("text")
+                    if not isinstance(block_text, str) or not block_text:
+                        return None, "messages"
+                    parts.append(block_text)
+                text = "\n\n".join(parts)
+            else:
+                return None, "messages"
+            if len(text) > cls._API_V1_MAX_MESSAGE_CHARS:
+                return None, "messages"
+            total_chars += len(text)
+            if total_chars > cls._API_V1_MAX_TOTAL_CHARS:
+                return None, "messages"
+            updated = {"role": role, "content": text}
+            name = message.get("name")
+            if name is not None:
+                if not isinstance(name, str) or not name or len(name) > 128:
+                    return None, "messages"
+                updated["name"] = name
+            normalised.append(updated)
+        return normalised, None
 
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]
@@ -2003,14 +2156,29 @@ class RelayClient:
     ) -> Dict[str, Any]:
         """Generate an API v1 assistant message with the desktop runtime model."""
 
-        if not self._messages_are_valid_api_v1_chat(messages):
-            return self._api_v1_response_envelope(
+        normalised_messages, message_error = self._validate_and_normalise_api_v1_messages(messages)
+        if normalised_messages is None:
+            return self._api_v1_invalid_request(
                 request_id,
-                error={
-                    "code": "compute_node_invalid_request",
-                    "message": "Invalid chat message format",
-                },
+                "Invalid chat message format",
             )
+
+        config = getattr(self.model_manager, "config", None)
+        config_get = getattr(config, "get", None)
+        configured_max_tokens = None
+        if callable(config_get):
+            configured_max_tokens = config_get("model.max_tokens", None)
+        safe_options, option_error_code, option_detail = self._validate_api_v1_options(
+            options,
+            default_max_tokens=configured_max_tokens,
+        )
+        if option_error_code == "compute_node_invalid_request":
+            return self._api_v1_invalid_request(
+                request_id,
+                "Invalid API v1 option value",
+            )
+        if option_error_code == "compute_node_options_unsupported":
+            return self._api_v1_unsupported_options(request_id, option_detail or "options")
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
         has_direct_runtime_completion = callable(get_llm_instance)
@@ -2023,20 +2191,12 @@ class RelayClient:
                 },
             )
 
-        options_supported, unsupported_option = self._api_v1_supported_options(options)
-        if not options_supported:
-            return self._api_v1_response_envelope(
+        if safe_options is None:
+            return self._api_v1_invalid_request(
                 request_id,
-                error={
-                    "code": "compute_node_options_unsupported",
-                    "message": (
-                        "Requested option is unsupported by the desktop runtime: "
-                        f"{unsupported_option}"
-                    ),
-                },
+                "Invalid API v1 option value",
             )
 
-        safe_options = {key: value for key, value in options.items() if key != "stream"}
         if not has_direct_runtime_completion:
             # API v1 desktop relay generation must fail closed rather than
             # falling back to legacy chat-history runtimes. This is intentional
@@ -2052,7 +2212,7 @@ class RelayClient:
                 },
             )
 
-        runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
+        runtime_messages = self._prepare_api_v1_runtime_messages(model_id, normalised_messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             llm_instance = None


### PR DESCRIPTION
### Motivation
- Prevent malformed or unsupported API v1 desktop relay requests from reaching the local llama.cpp path and becoming poison inputs while preserving the existing non-streaming E2EE launch contract. 
- Keep relay-blind invariants by returning structured error envelopes without echoing prompt or option payloads.

### Description
- Added deterministic API v1 bounds and constants for desktop validation including message counts/sizes, content-block limits, stop sequence limits, max token caps, seed and penalty ranges, and related limits. 
- Implemented option validation and normalization in `_validate_api_v1_options` that rejects unknown keys, booleans-for-numbers, non-finite numerics, out-of-range values, streaming, unsupported tools/response formats, and only forwards explicitly safe values. 
- Implemented message validation/normalization in `_validate_and_normalise_api_v1_messages` that enforces roles, text-only block shapes, per-message and total-character caps, name limits, and produces normalized text content for runtime use. 
- Wired validation into the desktop API v1 runtime branch (`_generate_api_v1_response_with_runtime_model`) so invalid messages/options produce relay-blind envelopes mapped to `compute_node_invalid_request` or `compute_node_options_unsupported` before any model/runtime is called. 
- Added table-driven unit tests that exercise valid boundary cases and a wide set of invalid/poison inputs, asserting that rejected requests never call the model worker, do not mutate worker health/relay registration state, and allow a valid request immediately afterward.

### Testing
- Ran unit tests for the changed surface: `python -m pytest -q tests/unit/test_relay_client.py -k "option or invalid or message or api_v1"` — all selected tests passed (108 passed for the selection).
- Ran relay tests: `python -m pytest -q tests/test_relay.py -k "compute_node or api_v1"` — passed (79 passed for the selection).
- Ran integration desktop E2EE tests: `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — passed (10 passed).
- Ran repository hooks: `pre-commit run --all-files` — completed successfully.

All automated checks above passed in this environment; added table-driven tests demonstrate the worker is never invoked for rejected requests and that errors are relay-blind. Remaining risks: future API v1 feature additions must be explicitly added to the validation helpers to avoid accidental passthrough; follow-ups may include tuning numeric/string caps if product requirements change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3732da94a4832f9fa623aa226cddea)