### PR TITLE
Add restartable llama.cpp worker detection and one-shot replacement

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3089,3 +3089,190 @@ def test_subprocess_llama_proxy_secret_method_value_is_not_echoed(request_scoped
     result = proxy.create_chat_completion(messages=[], stream=False)
     assert result['choices'][0]['message']['content'] == 'ok'
     assert result['choices'][0]['pid'] == proxy._process.pid
+
+
+def _patch_fake_llama_runtime(monkeypatch, manager, model_manager_module, llama_factory):
+    monkeypatch.setattr(
+        model_manager_module,
+        '_import_llama_cpp_runtime',
+        lambda **_kwargs: SimpleNamespace(Llama=llama_factory, __file__='/fake/llama_cpp/__init__.py'),
+    )
+    monkeypatch.setattr(manager, '_resolve_compute_plan', lambda: {
+        'requested_mode': 'cpu',
+        'effective_mode': 'cpu',
+        'backend_available': 'cpu',
+        'backend_selected': 'cpu',
+        'backend_used': 'cpu',
+        'n_gpu_layers': 0,
+        'fallback_reason': None,
+    })
+
+
+def test_model_manager_restart_replaces_dead_worker_and_second_request_succeeds(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created = []
+
+    class FakeLlama:
+        def __init__(self, **_kwargs):
+            self.closed = False
+            created.append(self)
+
+        def create_chat_completion(self, **_kwargs):
+            if self is created[0]:
+                raise model_manager_module.LlamaCppWorkerDeadError('dead')
+            return {'choices': [{'message': {'role': 'assistant', 'content': 'recovered'}}]}
+
+        def close(self):
+            self.closed = True
+
+    _patch_fake_llama_runtime(monkeypatch, standalone_model_manager, model_manager_module, FakeLlama)
+
+    completion = standalone_model_manager.complete_chat_once_with_recovery(messages=[])
+
+    assert completion['choices'][0]['message']['content'] == 'recovered'
+    assert len(created) == 2
+    assert created[0].closed is True
+    assert standalone_model_manager.llm is created[1]
+
+
+def test_model_manager_broken_pipe_triggers_one_replacement(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created = []
+
+    class FakeLlama:
+        def __init__(self, **_kwargs):
+            created.append(self)
+
+        def create_chat_completion(self, **_kwargs):
+            if self is created[0]:
+                raise model_manager_module.LlamaCppWorkerBrokenPipeError('pipe')
+            return {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+
+        def close(self):
+            self.closed = True
+
+    _patch_fake_llama_runtime(monkeypatch, standalone_model_manager, model_manager_module, FakeLlama)
+
+    assert standalone_model_manager.complete_chat_once_with_recovery(messages=[])['choices'][0]['message']['content'] == 'ok'
+    assert len(created) == 2
+
+
+def test_model_manager_request_scoped_inference_error_not_retried(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created = []
+
+    class FakeLlama:
+        def __init__(self, **_kwargs):
+            created.append(self)
+            self.closed = False
+
+        def create_chat_completion(self, **_kwargs):
+            raise model_manager_module.LlamaCppInferenceRequestError('request failed')
+
+        def close(self):
+            self.closed = True
+
+    _patch_fake_llama_runtime(monkeypatch, standalone_model_manager, model_manager_module, FakeLlama)
+
+    with pytest.raises(model_manager_module.LlamaCppInferenceRequestError):
+        standalone_model_manager.complete_chat_once_with_recovery(messages=[])
+
+    assert len(created) == 1
+    assert created[0].closed is False
+    assert standalone_model_manager.llm is created[0]
+
+
+def test_model_manager_concurrent_dead_worker_creates_one_replacement(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created = []
+    barrier = threading.Barrier(2)
+
+    class FakeLlama:
+        def __init__(self, **_kwargs):
+            self.closed = False
+            created.append(self)
+
+        def create_chat_completion(self, **_kwargs):
+            if self is created[0]:
+                barrier.wait(timeout=2)
+                raise model_manager_module.LlamaCppWorkerEOFError('eof')
+            return {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+
+        def close(self):
+            self.closed = True
+
+    _patch_fake_llama_runtime(monkeypatch, standalone_model_manager, model_manager_module, FakeLlama)
+    standalone_model_manager.get_llm_instance()
+    results = []
+
+    def _call():
+        results.append(standalone_model_manager.complete_chat_once_with_recovery(messages=[]))
+
+    threads = [threading.Thread(target=_call) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert len(results) == 2
+    assert len(created) == 2
+    assert created[0].closed is True
+    assert standalone_model_manager.llm is created[1]
+
+
+def test_model_manager_replacement_failure_attempted_once(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created = []
+
+    class FakeLlama:
+        def __init__(self, **_kwargs):
+            created.append(self)
+
+        def create_chat_completion(self, **_kwargs):
+            raise model_manager_module.LlamaCppWorkerDeadError('still dead')
+
+        def close(self):
+            self.closed = True
+
+    _patch_fake_llama_runtime(monkeypatch, standalone_model_manager, model_manager_module, FakeLlama)
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerDeadError, match='still dead'):
+        standalone_model_manager.complete_chat_once_with_recovery(messages=[])
+
+    assert len(created) == 2
+
+
+def test_model_manager_healthy_request_does_not_restart(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created = []
+
+    class FakeLlama:
+        def __init__(self, **_kwargs):
+            created.append(self)
+
+        def create_chat_completion(self, **_kwargs):
+            return {'choices': [{'message': {'role': 'assistant', 'content': 'healthy'}}]}
+
+    _patch_fake_llama_runtime(monkeypatch, standalone_model_manager, model_manager_module, FakeLlama)
+
+    result = standalone_model_manager.complete_chat_once_with_recovery(messages=[])
+
+    assert result['choices'][0]['message']['content'] == 'healthy'
+    assert len(created) == 1
+
+
+def test_subprocess_llama_proxy_detects_dead_before_write(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._closed = False
+    proxy._process = SimpleNamespace(stdin=MagicMock(), stdout=MagicMock(), poll=lambda: 13)
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerDeadError):
+        proxy._send({'method': 'create_chat_completion'})

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -135,6 +135,22 @@ class LlamaCppInferenceRequestError(RuntimeError):
         super().__init__(message)
 
 
+class RestartableLlamaWorkerError(RuntimeError):
+    """Raised when the llama.cpp subprocess transport is unusable and can be restarted."""
+
+
+class LlamaCppWorkerDeadError(RestartableLlamaWorkerError):
+    """Raised when the llama.cpp worker process has already exited."""
+
+
+class LlamaCppWorkerEOFError(RestartableLlamaWorkerError):
+    """Raised when the llama.cpp worker exits before returning an inference response."""
+
+
+class LlamaCppWorkerBrokenPipeError(RestartableLlamaWorkerError):
+    """Raised when a request cannot be written to the llama.cpp worker."""
+
+
 class LlamaCppRuntimeStageTimeout(TimeoutError):
     """Raised when a llama_cpp discovery/import stage exceeds its bounded timeout."""
 
@@ -750,7 +766,9 @@ def _read_llama_subprocess_message(
         except Exception:
             pass
         time.sleep(0.05)
-        result_queue.put(json.dumps({'status': 'error', 'error': _format_llama_subprocess_early_exit_detail(process, stage=stage)}))
+        detail = _format_llama_subprocess_early_exit_detail(process, stage=stage)
+        status = 'worker_eof' if stage == 'llama_cpp_inference' else 'error'
+        result_queue.put(json.dumps({'status': status, 'error': detail}))
 
     reader = threading.Thread(target=_reader, name=f'{stage}_stdout_reader', daemon=True)
     reader.start()
@@ -772,8 +790,10 @@ def _read_llama_subprocess_message(
         raise RuntimeError(f'{stage} returned malformed JSON') from exc
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
-    if message.get('status') == 'error':
+    if message.get('status') in {'error', 'worker_eof'}:
         error = str(message.get('error') or f'{stage} failed')
+        if stage == 'llama_cpp_inference' and message.get('status') == 'worker_eof':
+            raise LlamaCppWorkerEOFError(error)
         if stage == 'llama_cpp_inference' and message.get('request_error'):
             diagnostics = message.get('diagnostics')
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
@@ -800,6 +820,7 @@ class _SubprocessLlamaProxy:
         command = [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)]
         env = _llama_cpp_runtime_worker_env()
         cwd = _llama_cpp_probe_subprocess_cwd()
+        self._closed = False
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.PIPE,
@@ -819,7 +840,7 @@ class _SubprocessLlamaProxy:
         self._start_stderr_tail_reader()
         try:
             self._send({'method': '__init__', 'args': args, 'kwargs': kwargs})
-        except (BrokenPipeError, OSError) as exc:
+        except (RestartableLlamaWorkerError, BrokenPipeError, OSError) as exc:
             raise RuntimeError(
                 _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             ) from exc
@@ -842,11 +863,35 @@ class _SubprocessLlamaProxy:
 
         threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True).start()
 
+    def is_alive(self) -> bool:
+        """Return whether the subprocess transport can accept a request."""
+        process = getattr(self, '_process', None)
+        poll = getattr(process, 'poll', None)
+        return bool(
+            process is not None
+            and (not callable(poll) or poll() is None)
+            and getattr(process, 'stdin', None) is not None
+            and not getattr(self, '_closed', False)
+        )
+
+    def _raise_if_unusable(self) -> None:
+        if not self.is_alive():
+            process = getattr(self, '_process', None)
+            poll = getattr(process, 'poll', None)
+            exit_code = poll() if callable(poll) else 'unknown'
+            raise LlamaCppWorkerDeadError(f'llama_cpp subprocess is not alive exit_code={exit_code}')
+
     def _send(self, payload: Dict[str, Any]) -> None:
+        self._raise_if_unusable()
         if self._process.stdin is None:
-            raise RuntimeError('llama_cpp subprocess stdin is unavailable')
-        self._process.stdin.write(json.dumps(payload) + '\n')
-        self._process.stdin.flush()
+            raise LlamaCppWorkerDeadError('llama_cpp subprocess stdin is unavailable')
+        try:
+            self._process.stdin.write(json.dumps(payload) + '\n')
+            self._process.stdin.flush()
+        except BrokenPipeError as exc:
+            raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess pipe is broken') from exc
+        except OSError as exc:
+            raise LlamaCppWorkerBrokenPipeError(f'llama_cpp subprocess write failed: {exc}') from exc
 
     def create_chat_completion(self, *args, **kwargs):
         stream = bool(kwargs.get('stream', False))
@@ -854,17 +899,23 @@ class _SubprocessLlamaProxy:
             return self._stream_chat_completion(*args, **kwargs)
         with self._lock:
             self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
-            message = _read_llama_subprocess_message(
-                self._process,
-                timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
-                stage='llama_cpp_inference',
-            )
+            try:
+                message = _read_llama_subprocess_message(
+                    self._process,
+                    timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
+                    stage='llama_cpp_inference',
+                )
+            except RestartableLlamaWorkerError:
+                raise
+            except (BrokenPipeError, OSError) as exc:
+                raise LlamaCppWorkerBrokenPipeError(f'llama_cpp subprocess transport failed: {exc}') from exc
         return message.get('result')
 
     def _stream_chat_completion(self, *args, **kwargs):
         with self._lock:
             self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
             while True:
+                self._raise_if_unusable()
                 message = _read_llama_subprocess_message(
                     self._process,
                     timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
@@ -875,8 +926,21 @@ class _SubprocessLlamaProxy:
                 yield message.get('chunk')
 
     def close(self) -> None:
-        if self._process.poll() is None:
-            self._process.terminate()
+        if getattr(self, '_closed', False):
+            return
+        self._closed = True
+        process = getattr(self, '_process', None)
+        if process is None:
+            return
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=1)
+            except Exception:
+                try:
+                    process.kill()
+                except Exception:
+                    pass
 
     def __del__(self) -> None:
         try:
@@ -1400,6 +1464,7 @@ class ModelManager:
         # LLM instance and lock for thread safety
         self.llm = None
         self.llm_lock = Lock()
+        self._llm_restart_lock = Lock()
         self.last_runtime_init_error: Optional[str] = None
 
         # Check if mock mode is enabled
@@ -1882,6 +1947,48 @@ class ModelManager:
                             return None
 
         return self.llm
+
+
+    def _invalidate_llm_instance(self, expected_llm: Any = None) -> None:
+        """Close and clear the cached llama instance if it still matches expected_llm."""
+        with self.llm_lock:
+            current = self.llm
+            if expected_llm is not None and current is not expected_llm:
+                return
+            self.llm = None
+        close = getattr(current, 'close', None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                self.log_warning('Failed to close stale Llama worker during restart')
+
+    def complete_chat_once_with_recovery(self, *args, **kwargs):
+        """Run a non-streaming chat completion, restarting a dead worker exactly once."""
+        llm_instance = self.get_llm_instance()
+        if llm_instance is None:
+            raise RuntimeError('LLM is not initialized')
+        create_chat_completion = getattr(llm_instance, 'create_chat_completion', None)
+        if not callable(create_chat_completion):
+            raise RuntimeError('LLM does not support chat completion')
+        try:
+            return create_chat_completion(*args, **kwargs)
+        except RestartableLlamaWorkerError:
+            failed_llm = llm_instance
+
+        with self._llm_restart_lock:
+            if self.llm is failed_llm:
+                self._invalidate_llm_instance(expected_llm=failed_llm)
+                replacement = self.get_llm_instance()
+            else:
+                replacement = self.llm or self.get_llm_instance()
+
+        if replacement is None:
+            raise RuntimeError('LLM worker restart failed')
+        replacement_completion = getattr(replacement, 'create_chat_completion', None)
+        if not callable(replacement_completion):
+            raise RuntimeError('Replacement LLM does not support chat completion')
+        return replacement_completion(*args, **kwargs)
 
     def llama_cpp_get_response(self, chat_history: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2057,11 +2057,16 @@ class RelayClient:
             assistant_message: Optional[Dict[str, Any]] = None
             llm_instance = None
             create_chat_completion = None
-            if has_direct_runtime_completion:
+            recovery_completion = getattr(
+                self.model_manager, "complete_chat_once_with_recovery", None
+            )
+            if "complete_chat_once_with_recovery" not in dir(type(self.model_manager)):
+                recovery_completion = None
+            if has_direct_runtime_completion and not callable(recovery_completion):
                 llm_instance = get_llm_instance()
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
 
-            if callable(create_chat_completion):
+            if callable(recovery_completion) or callable(create_chat_completion):
                 log_info(
                     (
                         "API v1 runtime generation branch selected: "
@@ -2074,10 +2079,16 @@ class RelayClient:
                     "direct_non_streaming_completion",
                 )
                 completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
-                completion = create_chat_completion(
-                    messages=runtime_messages,
-                    **completion_kwargs,
-                )
+                if callable(recovery_completion):
+                    completion = recovery_completion(
+                        messages=runtime_messages,
+                        **completion_kwargs,
+                    )
+                else:
+                    completion = create_chat_completion(
+                        messages=runtime_messages,
+                        **completion_kwargs,
+                    )
                 assistant_message = self._assistant_message_from_runtime_completion(
                     completion
                 )


### PR DESCRIPTION
### Motivation
- Ensure the cached llama.cpp subprocess worker is detected as dead and replaced automatically when transport failures occur so API v1 desktop relay generation remains truthful.
- Restart only for actual transport-level failures (dead process, EOF-before-response, broken pipe) while preserving request-scoped inference errors as non-restartable and avoiding unbounded retries.

### Description
- Add typed restartable worker transport exceptions: `RestartableLlamaWorkerError`, `LlamaCppWorkerDeadError`, `LlamaCppWorkerEOFError`, and `LlamaCppWorkerBrokenPipeError` in `utils/llm/model_manager.py` to distinguish restartable transport failures from request-scoped `LlamaCppInferenceRequestError`.
- Extend `_SubprocessLlamaProxy` with an `is_alive()` check, `_raise_if_unusable()` guard before writes, robust `_send()` wrapping to raise restartable errors on broken-pipe/OSErrors, and an idempotent `close()` path that terminates/kills the subprocess safely.
- Update `_read_llama_subprocess_message()` to classify inference-stage early subprocess exits as EOF (`worker_eof`) and raise `LlamaCppWorkerEOFError` so the manager can treat this as restartable.
- Add a thread-safe `ModelManager._invalidate_llm_instance()` and `ModelManager.complete_chat_once_with_recovery()` that close the old worker, clear `self.llm`, and initialize exactly one replacement under `_llm_restart_lock`, retrying the inference exactly once for restartable errors; route the API v1 non-streaming desktop relay path to use this entry point when present in `utils/networking/relay_client.py`.

### Testing
- `python -m pytest -q tests/unit/test_model_manager.py -k "restart or recover or subprocess or liveness or concurrent"` — passed (new and existing unit coverage exercised the restart and liveness scenarios).
- `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py` — passed (relay client/compute runtime tests including API v1 desktop branch behavior succeeded).
- `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — passed (integration E2EE desktop-bridge scenarios passed).
- `pre-commit run --all-files` — passed (project linters and hooks succeeded).

Residual risk and follow-ups: monitor runtime logs for worker restart churn in real deployments and add observability/metrics for restart counts as a follow-up if restarts become frequent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3750203930832f8dec93138e6fca35)