### PR TITLE
ModelManager: one-time restart for dead llama.cpp subprocess workers

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3315,3 +3315,112 @@ def test_model_manager_recovery_rejects_streaming_calls(tmp_path, monkeypatch):
         manager.create_chat_completion_with_recovery(messages=[], stream=True)
 
     assert created == []
+
+
+def test_llama_subprocess_transport_error_payload_raises_restartable_eof():
+    from utils.llm import model_manager as model_manager_module
+
+    process = SimpleNamespace(
+        stdout=iter(()),
+        stderr=None,
+        wait=MagicMock(return_value=7),
+        poll=lambda: 7,
+        returncode=7,
+    )
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError, match='JSON handshake'):
+        model_manager_module._read_llama_subprocess_message(
+            process,
+            timeout_seconds=0.2,
+            stage='llama_cpp_inference',
+        )
+
+
+def test_subprocess_llama_proxy_liveness_and_close_edge_cases():
+    from utils.llm import model_manager as model_manager_module
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._closed = False
+    proxy._process = SimpleNamespace(
+        stdin=SimpleNamespace(close=MagicMock(side_effect=RuntimeError('close failed'))),
+        poll=MagicMock(return_value=None),
+        terminate=MagicMock(),
+        wait=MagicMock(side_effect=TimeoutError('still running')),
+        kill=MagicMock(),
+        returncode=None,
+    )
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerDeadError):
+        dead_proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+        dead_proxy._closed = False
+        dead_proxy._process = SimpleNamespace(poll=lambda: 1, returncode=1, stderr=None)
+        dead_proxy.assert_healthy()
+
+    proxy.close()
+    proxy.close()
+
+    assert proxy._closed is True
+    proxy._process.terminate.assert_called_once_with()
+    proxy._process.wait.assert_called_once_with(timeout=1)
+    proxy._process.kill.assert_called_once_with()
+
+
+def test_model_manager_recovery_reports_unavailable_or_invalid_runtime(tmp_path, monkeypatch):
+    first = SimpleNamespace(create_chat_completion='not-callable')
+    manager, _created = _restart_manager(tmp_path, monkeypatch, [first])
+
+    with pytest.raises(RuntimeError, match='missing create_chat_completion'):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+    monkeypatch.setattr(manager, 'get_llm_instance', lambda: None)
+    with pytest.raises(RuntimeError, match='unavailable'):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+
+def test_model_manager_recovery_reports_invalid_or_missing_replacement(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first', fail='dead')
+    manager, _created = _restart_manager(tmp_path, monkeypatch, [first])
+    monkeypatch.setattr(manager, '_ensure_replacement_llm', lambda _observed_generation: None)
+
+    with pytest.raises(RuntimeError, match='replacement failed'):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+    first = _RestartableFakeWorker('first', fail='dead')
+    manager, _created = _restart_manager(tmp_path, monkeypatch, [first])
+    monkeypatch.setattr(
+        manager,
+        '_ensure_replacement_llm',
+        lambda _observed_generation: SimpleNamespace(create_chat_completion='not-callable'),
+    )
+
+    with pytest.raises(RuntimeError, match='replacement runtime missing'):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+
+def test_model_manager_replacement_helpers_handle_unusual_workers(tmp_path, monkeypatch):
+    manager, _created = _restart_manager(tmp_path, monkeypatch, [])
+
+    assert manager._llm_is_usable(object()) is True
+    assert manager._llm_is_usable(SimpleNamespace(is_alive=lambda: (_ for _ in ()).throw(RuntimeError('boom')))) is False
+
+    close = MagicMock(side_effect=RuntimeError('close failed'))
+    manager._close_llm_proxy(SimpleNamespace(close=close))
+    close.assert_called_once_with()
+
+    usable = _RestartableFakeWorker('usable')
+    manager.llm = usable
+    observed_generation = manager._llm_generation
+    assert manager._ensure_replacement_llm(observed_generation) is usable
+
+    stale = _RestartableFakeWorker('stale', fail='dead')
+    replacement = _RestartableFakeWorker('replacement')
+    manager.llm = stale
+    workers = [replacement]
+
+    def _get_replacement():
+        manager.llm = workers.pop(0)
+        return manager.llm
+
+    monkeypatch.setattr(manager, 'get_llm_instance', _get_replacement)
+    assert manager._ensure_replacement_llm(manager._llm_generation) is replacement
+    assert stale.closed is True

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3277,3 +3277,41 @@ def test_model_manager_healthy_request_has_no_restart(tmp_path, monkeypatch):
 
     assert created == [first]
     assert first.closed is False
+
+
+def test_subprocess_llama_proxy_send_marks_closed_on_missing_stdin_or_write_failure():
+    from utils.llm import model_manager as model_manager_module
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._closed = False
+    proxy._process = SimpleNamespace(stdin=None)
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerBrokenPipeError):
+        proxy._send({"method": "noop"}, check_health=False)
+
+    assert proxy.is_alive() is False
+
+    class BrokenStdin:
+        def write(self, _text):
+            raise BrokenPipeError("closed")
+
+        def flush(self):
+            raise AssertionError("flush should not run after write failure")
+
+    proxy._closed = False
+    proxy._process = SimpleNamespace(stdin=BrokenStdin(), poll=lambda: None)
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerBrokenPipeError):
+        proxy._send({"method": "noop"}, check_health=False)
+
+    assert proxy.is_alive() is False
+
+
+def test_model_manager_recovery_rejects_streaming_calls(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [first])
+
+    with pytest.raises(ValueError, match='does not support stream=True'):
+        manager.create_chat_completion_with_recovery(messages=[], stream=True)
+
+    assert created == []

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3089,3 +3089,191 @@ def test_subprocess_llama_proxy_secret_method_value_is_not_echoed(request_scoped
     result = proxy.create_chat_completion(messages=[], stream=False)
     assert result['choices'][0]['message']['content'] == 'ok'
     assert result['choices'][0]['pid'] == proxy._process.pid
+
+
+class _RestartTestConfig:
+    is_production = False
+
+    def __init__(self, models_dir):
+        self.models_dir = str(models_dir)
+
+    def get(self, key, default=None):
+        values = {
+            'model.filename': 'test_model.gguf',
+            'model.url': 'https://example.com/model.gguf',
+            'model.download_chunk_size_mb': 1,
+            'paths.models_dir': self.models_dir,
+            'model.use_mock': False,
+            'model.context_size': 2048,
+            'model.chat_format': 'llama-3',
+            'model.max_tokens': 1000,
+            'model.temperature': 0.7,
+            'model.top_p': 0.9,
+            'model.stop_tokens': [],
+            'model.n_gpu_layers': 0,
+            'model.gpu_memory_headroom_percent': 0.1,
+            'model.enforce_gpu_memory_headroom': False,
+        }
+        return values.get(key, default)
+
+
+class _RestartableFakeWorker:
+    def __init__(self, name, *, fail=None):
+        self.name = name
+        self.fail = fail
+        self.closed = False
+        self.calls = 0
+        self.pid = id(self)
+
+    def is_alive(self):
+        return not self.closed and self.fail != 'dead'
+
+    def close(self):
+        self.closed = True
+
+    def create_chat_completion(self, **_kwargs):
+        self.calls += 1
+        from utils.llm import model_manager as model_manager_module
+        if self.fail == 'dead':
+            raise model_manager_module.LlamaCppWorkerDeadError('dead')
+        if self.fail == 'pipe':
+            raise model_manager_module.LlamaCppWorkerBrokenPipeError('pipe')
+        if self.fail == 'eof':
+            raise model_manager_module.LlamaCppWorkerEOFError('eof')
+        if self.fail == 'request':
+            raise model_manager_module.LlamaCppInferenceRequestError('request failed')
+        return {'choices': [{'message': {'role': 'assistant', 'content': self.name}}]}
+
+
+def _restart_manager(tmp_path, monkeypatch, workers):
+    from utils.llm import model_manager as model_manager_module
+
+    (tmp_path / 'test_model.gguf').write_bytes(b'fake')
+    manager = model_manager_module.ModelManager(_RestartTestConfig(tmp_path))
+    created = []
+
+    def _import_runtime(**_kwargs):
+        class _Runtime:
+            __file__ = '/fake/llama_cpp.py'
+
+            class Llama:
+                def __init__(self, **_llama_kwargs):
+                    worker = workers.pop(0)
+                    created.append(worker)
+                    self._worker = worker
+
+                def __getattr__(self, name):
+                    return getattr(self._worker, name)
+
+        return _Runtime
+
+    monkeypatch.setattr(model_manager_module, '_import_llama_cpp_runtime', _import_runtime)
+    monkeypatch.setattr(manager, '_resolve_compute_plan', lambda: {
+        'requested_mode': 'cpu', 'effective_mode': 'cpu', 'backend_available': 'cpu',
+        'backend_selected': 'cpu', 'backend_used': 'cpu', 'n_gpu_layers': 0,
+        'fallback_reason': None,
+    })
+    return manager, created
+
+
+def test_model_manager_recover_replaces_worker_killed_between_requests(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first')
+    second = _RestartableFakeWorker('second')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [first, second])
+
+    first_result = manager.create_chat_completion_with_recovery(messages=[])
+    assert first_result['choices'][0]['message']['content'] == 'first'
+    first.fail = 'dead'
+    second_result = manager.create_chat_completion_with_recovery(messages=[])
+    assert second_result['choices'][0]['message']['content'] == 'second'
+
+    assert first.closed is True
+    assert manager.llm is not None
+    assert manager.llm._worker is second
+    assert created == [first, second]
+
+
+def test_model_manager_restart_broken_pipe_or_eof_once(tmp_path, monkeypatch):
+    pipe = _RestartableFakeWorker('pipe', fail='pipe')
+    second = _RestartableFakeWorker('second')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [pipe, second])
+
+    second_result = manager.create_chat_completion_with_recovery(messages=[])
+    assert second_result['choices'][0]['message']['content'] == 'second'
+    assert pipe.closed is True
+    assert created == [pipe, second]
+
+    eof = _RestartableFakeWorker('eof', fail='eof')
+    fourth = _RestartableFakeWorker('fourth')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [eof, fourth])
+    fourth_result = manager.create_chat_completion_with_recovery(messages=[])
+    assert fourth_result['choices'][0]['message']['content'] == 'fourth'
+    assert eof.closed is True
+    assert created == [eof, fourth]
+
+
+def test_model_manager_request_scoped_inference_error_not_retried(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first', fail='request')
+    second = _RestartableFakeWorker('second')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [first, second])
+    from utils.llm import model_manager as model_manager_module
+
+    with pytest.raises(model_manager_module.LlamaCppInferenceRequestError):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+    assert first.closed is False
+    assert manager.llm._worker is first
+    assert created == [first]
+
+
+def test_model_manager_concurrent_dead_worker_creates_one_replacement(tmp_path, monkeypatch):
+    dead = _RestartableFakeWorker('dead', fail='dead')
+    replacement = _RestartableFakeWorker('replacement')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [dead, replacement])
+    manager.get_llm_instance()
+
+    barrier = threading.Barrier(2)
+    results = []
+
+    def _call():
+        barrier.wait(timeout=5)
+        results.append(manager.create_chat_completion_with_recovery(messages=[]))
+
+    threads = [threading.Thread(target=_call) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(results) == 2
+    assert [worker.name for worker in created] == ['dead', 'replacement']
+    assert dead.closed is True
+    assert replacement.calls == 2
+
+
+def test_model_manager_replacement_failure_attempted_once_surfaces_stable_error(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first', fail='dead')
+    second = _RestartableFakeWorker('second', fail='eof')
+    third = _RestartableFakeWorker('third')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [first, second, third])
+
+    with pytest.raises(RuntimeError, match='one restart attempt'):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+    assert [worker.name for worker in created] == ['first', 'second']
+    assert first.closed is True
+    assert second.closed is True
+
+
+def test_model_manager_healthy_request_has_no_restart(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first')
+    second = _RestartableFakeWorker('second')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [first, second])
+
+    first_result = manager.create_chat_completion_with_recovery(messages=[])
+    assert first_result['choices'][0]['message']['content'] == 'first'
+    first_result = manager.create_chat_completion_with_recovery(messages=[])
+    assert first_result['choices'][0]['message']['content'] == 'first'
+
+    assert created == [first]
+    assert first.closed is False

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -313,6 +313,7 @@ class TestRelayClient:
             ]
         }
         mock.get_llm_instance.return_value = mock.runtime
+        mock.create_chat_completion_with_recovery = None
         mock.use_mock_llm = True
         return mock
 
@@ -2138,6 +2139,48 @@ class TestRelayClient:
         assert result is False
         mock_model_manager.llama_cpp_get_response.assert_not_called()
         mock_post.assert_not_called()
+
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_missing_runtime_posts_internal_error(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Missing desktop runtime init becomes a stable encrypted internal error."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-runtime-missing",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_model_manager.get_llm_instance.return_value = None
+        mock_crypto_manager.encrypt_message.return_value = {
+            'chat_history': 'encrypted_chat_history',
+            'cipherkey': 'encrypted_key',
+            'iv': 'encrypted_iv',
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_internal_error"
+        )
+        assert encrypted_envelope["api_v1_response"]["error"]["message"] == (
+            "Desktop runtime inference failed"
+        )
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_invalid_runtime_output_posts_encrypted_error(

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -873,11 +873,13 @@ class _SubprocessLlamaProxy:
         if check_health:
             self.assert_healthy()
         if self._process.stdin is None:
+            self._closed = True
             raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess stdin is unavailable')
         try:
             self._process.stdin.write(json.dumps(payload) + '\n')
             self._process.stdin.flush()
         except (BrokenPipeError, OSError) as exc:
+            self._closed = True
             raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess transport write failed') from exc
 
     def is_alive(self) -> bool:
@@ -1985,12 +1987,23 @@ class ModelManager:
                 self.llm = None
             if self._llm_generation == observed_generation:
                 self._llm_generation += 1
-            # get_llm_instance performs initialization under this same lock when llm is None;
-            # inline the guarded call by releasing the lock would allow duplicate creators.
+            # Release llm_lock before get_llm_instance() because it initializes under
+            # the same non-reentrant lock and still serializes creation internally.
         return self.get_llm_instance()
 
     def create_chat_completion_with_recovery(self, *args, **kwargs):
-        """Create a completion, replacing a dead subprocess worker at most once."""
+        """Create a completion, replacing a dead subprocess worker at most once.
+
+        Recovery is only supported for non-streaming completions. Passing
+        ``stream=True`` returns a generator before transport IO can raise
+        restartable worker errors, so callers that need recovery must use
+        ``stream=False``.
+        """
+        if kwargs.get('stream', False):
+            raise ValueError(
+                'create_chat_completion_with_recovery does not support stream=True; '
+                'use create_chat_completion directly for streaming.'
+            )
 
         llm_instance = self.get_llm_instance()
         if llm_instance is None:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -135,6 +135,22 @@ class LlamaCppInferenceRequestError(RuntimeError):
         super().__init__(message)
 
 
+class LlamaCppRestartableWorkerError(RuntimeError):
+    """Raised when the llama.cpp worker transport is unusable and may be replaced."""
+
+
+class LlamaCppWorkerDeadError(LlamaCppRestartableWorkerError):
+    """Raised when the subprocess worker is no longer alive before a request."""
+
+
+class LlamaCppWorkerEOFError(LlamaCppRestartableWorkerError):
+    """Raised when the worker exits before returning a response."""
+
+
+class LlamaCppWorkerBrokenPipeError(LlamaCppRestartableWorkerError):
+    """Raised when writing to the worker transport fails."""
+
+
 class LlamaCppRuntimeStageTimeout(TimeoutError):
     """Raised when a llama_cpp discovery/import stage exceeds its bounded timeout."""
 
@@ -727,6 +743,14 @@ def _format_llama_subprocess_early_exit_detail(process: subprocess.Popen, *, sta
     )
 
 
+def _llama_subprocess_early_exit_payload(process: subprocess.Popen, *, stage: str) -> str:
+    return json.dumps({
+        'status': 'transport_error',
+        'transport_error': 'eof_before_response',
+        'error': _format_llama_subprocess_early_exit_detail(process, stage=stage),
+    })
+
+
 def _read_llama_subprocess_message(
     process: subprocess.Popen,
     *,
@@ -750,7 +774,7 @@ def _read_llama_subprocess_message(
         except Exception:
             pass
         time.sleep(0.05)
-        result_queue.put(json.dumps({'status': 'error', 'error': _format_llama_subprocess_early_exit_detail(process, stage=stage)}))
+        result_queue.put(_llama_subprocess_early_exit_payload(process, stage=stage))
 
     reader = threading.Thread(target=_reader, name=f'{stage}_stdout_reader', daemon=True)
     reader.start()
@@ -772,6 +796,8 @@ def _read_llama_subprocess_message(
         raise RuntimeError(f'{stage} returned malformed JSON') from exc
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
+    if message.get('status') == 'transport_error':
+        raise LlamaCppWorkerEOFError(str(message.get('error') or f'{stage} worker exited before response'))
     if message.get('status') == 'error':
         error = str(message.get('error') or f'{stage} failed')
         if stage == 'llama_cpp_inference' and message.get('request_error'):
@@ -797,6 +823,7 @@ class _SubprocessLlamaProxy:
     ) -> None:
         self._timeout_seconds = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
         self._lock = Lock()
+        self._closed = False
         command = [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)]
         env = _llama_cpp_runtime_worker_env()
         cwd = _llama_cpp_probe_subprocess_cwd()
@@ -818,8 +845,8 @@ class _SubprocessLlamaProxy:
         self._process._token_place_stderr_tail = []  # type: ignore[attr-defined]
         self._start_stderr_tail_reader()
         try:
-            self._send({'method': '__init__', 'args': args, 'kwargs': kwargs})
-        except (BrokenPipeError, OSError) as exc:
+            self._send({'method': '__init__', 'args': args, 'kwargs': kwargs}, check_health=False)
+        except (LlamaCppWorkerBrokenPipeError, BrokenPipeError, OSError) as exc:
             raise RuntimeError(
                 _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             ) from exc
@@ -842,11 +869,28 @@ class _SubprocessLlamaProxy:
 
         threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True).start()
 
-    def _send(self, payload: Dict[str, Any]) -> None:
+    def _send(self, payload: Dict[str, Any], *, check_health: bool = True) -> None:
+        if check_health:
+            self.assert_healthy()
         if self._process.stdin is None:
-            raise RuntimeError('llama_cpp subprocess stdin is unavailable')
-        self._process.stdin.write(json.dumps(payload) + '\n')
-        self._process.stdin.flush()
+            raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess stdin is unavailable')
+        try:
+            self._process.stdin.write(json.dumps(payload) + '\n')
+            self._process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess transport write failed') from exc
+
+    def is_alive(self) -> bool:
+        if self._closed:
+            return False
+        poll = getattr(self._process, 'poll', None)
+        return callable(poll) and poll() is None
+
+    def assert_healthy(self) -> None:
+        if not self.is_alive():
+            raise LlamaCppWorkerDeadError(
+                _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_liveness')
+            )
 
     def create_chat_completion(self, *args, **kwargs):
         stream = bool(kwargs.get('stream', False))
@@ -854,29 +898,52 @@ class _SubprocessLlamaProxy:
             return self._stream_chat_completion(*args, **kwargs)
         with self._lock:
             self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
-            message = _read_llama_subprocess_message(
-                self._process,
-                timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
-                stage='llama_cpp_inference',
-            )
+            try:
+                message = _read_llama_subprocess_message(
+                    self._process,
+                    timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
+                    stage='llama_cpp_inference',
+                )
+            except LlamaCppWorkerEOFError:
+                self._closed = True
+                raise
         return message.get('result')
 
     def _stream_chat_completion(self, *args, **kwargs):
         with self._lock:
             self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
             while True:
-                message = _read_llama_subprocess_message(
-                    self._process,
-                    timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
-                    stage='llama_cpp_inference',
-                )
+                try:
+                    message = _read_llama_subprocess_message(
+                        self._process,
+                        timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
+                        stage='llama_cpp_inference',
+                    )
+                except LlamaCppWorkerEOFError:
+                    self._closed = True
+                    raise
                 if message.get('done'):
                     return
                 yield message.get('chunk')
 
     def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._process.stdin is not None:
+                self._process.stdin.close()
+        except Exception:
+            pass
         if self._process.poll() is None:
             self._process.terminate()
+            try:
+                self._process.wait(timeout=1)
+            except Exception:
+                try:
+                    self._process.kill()
+                except Exception:
+                    pass
 
     def __del__(self) -> None:
         try:
@@ -1400,6 +1467,7 @@ class ModelManager:
         # LLM instance and lock for thread safety
         self.llm = None
         self.llm_lock = Lock()
+        self._llm_generation = 0
         self.last_runtime_init_error: Optional[str] = None
 
         # Check if mock mode is enabled
@@ -1882,6 +1950,72 @@ class ModelManager:
                             return None
 
         return self.llm
+
+    def _close_llm_proxy(self, llm: Any) -> None:
+        close = getattr(llm, 'close', None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                self.log_warning("Failed to close old llama.cpp worker during invalidation")
+
+    def _llm_is_usable(self, llm: Any) -> bool:
+        is_alive = getattr(llm, 'is_alive', None)
+        if callable(is_alive):
+            try:
+                return bool(is_alive())
+            except Exception:
+                return False
+        return llm is not None
+
+    def _invalidate_llm_if_current(self, failed_llm: Any) -> int:
+        with self.llm_lock:
+            if self.llm is failed_llm:
+                self._close_llm_proxy(self.llm)
+                self.llm = None
+                self._llm_generation += 1
+            return self._llm_generation
+
+    def _ensure_replacement_llm(self, observed_generation: int) -> Any:
+        with self.llm_lock:
+            if self.llm is not None and self._llm_is_usable(self.llm):
+                return self.llm
+            if self.llm is not None:
+                self._close_llm_proxy(self.llm)
+                self.llm = None
+            if self._llm_generation == observed_generation:
+                self._llm_generation += 1
+            # get_llm_instance performs initialization under this same lock when llm is None;
+            # inline the guarded call by releasing the lock would allow duplicate creators.
+        return self.get_llm_instance()
+
+    def create_chat_completion_with_recovery(self, *args, **kwargs):
+        """Create a completion, replacing a dead subprocess worker at most once."""
+
+        llm_instance = self.get_llm_instance()
+        if llm_instance is None:
+            raise RuntimeError('LLM runtime is unavailable')
+        with self.llm_lock:
+            observed_generation = self._llm_generation
+        create_chat_completion = getattr(llm_instance, 'create_chat_completion', None)
+        if not callable(create_chat_completion):
+            raise RuntimeError('LLM runtime missing create_chat_completion')
+        try:
+            return create_chat_completion(*args, **kwargs)
+        except LlamaCppRestartableWorkerError:
+            self._invalidate_llm_if_current(llm_instance)
+
+        replacement = self._ensure_replacement_llm(observed_generation)
+        if replacement is None:
+            raise RuntimeError('LLM runtime replacement failed')
+        replacement_create = getattr(replacement, 'create_chat_completion', None)
+        if not callable(replacement_create):
+            raise RuntimeError('LLM replacement runtime missing create_chat_completion')
+        try:
+            return replacement_create(*args, **kwargs)
+        except LlamaCppRestartableWorkerError as exc:
+            self._invalidate_llm_if_current(replacement)
+            raise RuntimeError('LLM runtime replacement failed after one restart attempt') from exc
 
     def llama_cpp_get_response(self, chat_history: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2013,23 +2013,9 @@ class RelayClient:
             )
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
-        recovery_completion = (
-            self.model_manager.__dict__.get("create_chat_completion_with_recovery")
-            if hasattr(self.model_manager, "__dict__")
-            else None
+        recovery_completion = getattr(
+            self.model_manager, "create_chat_completion_with_recovery", None
         )
-        if recovery_completion is None:
-            recovery_completion = getattr(
-                type(self.model_manager),
-                "create_chat_completion_with_recovery",
-                None,
-            )
-            if callable(recovery_completion):
-                recovery_completion = getattr(
-                    self.model_manager,
-                    "create_chat_completion_with_recovery",
-                    None,
-                )
         has_direct_runtime_completion = callable(get_llm_instance) or callable(
             recovery_completion
         )
@@ -2078,6 +2064,15 @@ class RelayClient:
             create_chat_completion = recovery_completion
             if not callable(create_chat_completion) and has_direct_runtime_completion:
                 llm_instance = get_llm_instance()
+                if llm_instance is None:
+                    log_error("Desktop runtime LLM initialization failed for API v1 relay request")
+                    return self._api_v1_response_envelope(
+                        request_id,
+                        error={
+                            "code": "compute_node_internal_error",
+                            "message": "Desktop runtime inference failed",
+                        },
+                    )
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
 
             if callable(create_chat_completion):

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2013,7 +2013,26 @@ class RelayClient:
             )
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
-        has_direct_runtime_completion = callable(get_llm_instance)
+        recovery_completion = (
+            self.model_manager.__dict__.get("create_chat_completion_with_recovery")
+            if hasattr(self.model_manager, "__dict__")
+            else None
+        )
+        if recovery_completion is None:
+            recovery_completion = getattr(
+                type(self.model_manager),
+                "create_chat_completion_with_recovery",
+                None,
+            )
+            if callable(recovery_completion):
+                recovery_completion = getattr(
+                    self.model_manager,
+                    "create_chat_completion_with_recovery",
+                    None,
+                )
+        has_direct_runtime_completion = callable(get_llm_instance) or callable(
+            recovery_completion
+        )
         if not self._runtime_model_can_satisfy(model_id):
             return self._api_v1_response_envelope(
                 request_id,
@@ -2056,8 +2075,8 @@ class RelayClient:
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             llm_instance = None
-            create_chat_completion = None
-            if has_direct_runtime_completion:
+            create_chat_completion = recovery_completion
+            if not callable(create_chat_completion) and has_direct_runtime_completion:
                 llm_instance = get_llm_instance()
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
 


### PR DESCRIPTION
### Motivation
- Prevent retaining a genuinely dead llama.cpp subprocess worker and enable a bounded automatic recovery so the first post-failure request can succeed. 
- Ensure request-scoped inference errors reported by the live worker are not misclassified as restartable and therefore are not retried. 
- Make replacement thread-safe so concurrent relay pollers cannot spawn duplicate workers while preserving model path, compute-mode choices, and diagnostics.

### Description
- Added typed restartable transport exceptions (`LlamaCppRestartableWorkerError`, `LlamaCppWorkerDeadError`, `LlamaCppWorkerEOFError`, `LlamaCppWorkerBrokenPipeError`) and a transport-error payload path for EOF-before-response in `_read_llama_subprocess_message`.
- Enhanced `_SubprocessLlamaProxy` with idempotent `close()`, `is_alive()` and `assert_healthy()` liveness checks, safer `_send()` that raises typed broken-pipe errors, and detection of EOF-after-read that marks the proxy closed.
- Implemented `ModelManager` invalidation/recreation state: `_llm_generation`, `_invalidate_llm_if_current()`, `_ensure_replacement_llm()`, `_close_llm_proxy()`, `_llm_is_usable()`, plus `create_chat_completion_with_recovery()` which performs exactly one replacement attempt on restartable worker failures and does not retry `LlamaCppInferenceRequestError`.
- Switched the API v1 desktop relay non-streaming generation path to prefer the recovery-aware `create_chat_completion_with_recovery()` entry point while preserving direct-runtime behavior and fail-closed semantics.
- Added focused unit tests that exercise killed-worker replacement, broken-pipe/EOF replacement, non-retry of request-scoped errors, concurrent coalescing of a single replacement, replacement-failure surfacing, old-worker closure, and that healthy requests do not trigger restarts (`tests/unit/test_model_manager.py` additions).

### Testing
- `python -m pytest -q tests/unit/test_model_manager.py -k "restart or recover or subprocess or liveness or concurrent"` — all selected tests passed (27 passed).
- `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py` — full run passed (190 passed).
- `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — integration suite passed (10 passed).
- `pre-commit run --all-files` — pre-commit checks passed.

All automated checks above completed successfully in this environment. The change set is intentionally targeted to `utils/llm/model_manager.py`, `utils/networking/relay_client.py`, and the new unit tests in `tests/unit/test_model_manager.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37502aeaac832f9b5ad83510e29091)