### PR TITLE
Recover dead llama.cpp subprocess workers once (liveness + one-shot recovery)

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3089,3 +3089,165 @@ def test_subprocess_llama_proxy_secret_method_value_is_not_echoed(request_scoped
     result = proxy.create_chat_completion(messages=[], stream=False)
     assert result['choices'][0]['message']['content'] == 'ok'
     assert result['choices'][0]['pid'] == proxy._process.pid
+
+
+class _RestartTestLlama:
+    created = []
+    fail_next_replacement = False
+
+    def __init__(self, **kwargs):
+        self.closed = False
+        self.dead = False
+        self.calls = 0
+        self.id = len(type(self).created) + 1
+        type(self).created.append(self)
+
+    def is_alive(self):
+        return not self.closed and not self.dead
+
+    def close(self):
+        self.closed = True
+
+    def create_chat_completion(self, *args, **kwargs):
+        self.calls += 1
+        if self.dead:
+            raise __import__('utils.llm.model_manager', fromlist=['LlamaCppWorkerDeadError']).LlamaCppWorkerDeadError(
+                'dead worker'
+            )
+        if type(self).fail_next_replacement and self.id > 1:
+            raise __import__('utils.llm.model_manager', fromlist=['LlamaCppWorkerEOFError']).LlamaCppWorkerEOFError(
+                'replacement eof'
+            )
+        return {'choices': [{'message': {'role': 'assistant', 'content': f'ok-{self.id}'}}]}
+
+
+@pytest.fixture
+def restartable_manager(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    _RestartTestLlama.created = []
+    _RestartTestLlama.fail_next_replacement = False
+    model_path = tmp_path / 'test_model.gguf'
+    model_path.write_bytes(b'model')
+    config = MagicMock()
+    values = {
+        'model.filename': model_path.name,
+        'paths.models_dir': str(tmp_path),
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.context_size': 128,
+        'model.chat_format': 'llama-3',
+        'model.max_tokens': 8,
+        'model.temperature': 0.1,
+        'model.top_p': 0.9,
+        'model.stop_tokens': [],
+        'model.enforce_gpu_memory_headroom': False,
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.is_production = True
+    manager = ModelManager(config)
+    monkeypatch.setattr(
+        model_manager_module,
+        '_import_llama_cpp_runtime',
+        lambda **kwargs: SimpleNamespace(Llama=_RestartTestLlama, __file__='fake_llama_cpp.py'),
+    )
+    return manager
+
+
+def test_model_manager_restart_replaces_worker_killed_between_requests(restartable_manager):
+    first = restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+    old_worker = restartable_manager.llm
+    old_worker.dead = True
+
+    second = restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+
+    assert first['choices'][0]['message']['content'] == 'ok-1'
+    assert second['choices'][0]['message']['content'] == 'ok-2'
+    assert old_worker.closed is True
+    assert restartable_manager.llm is _RestartTestLlama.created[1]
+
+
+def test_model_manager_restart_broken_pipe_or_eof_triggers_one_replacement(restartable_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    restartable_manager.get_llm_instance()
+    old_worker = restartable_manager.llm
+    monkeypatch.setattr(
+        old_worker,
+        'create_chat_completion',
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            model_manager_module.LlamaCppWorkerBrokenPipeError('broken pipe')
+        ),
+    )
+
+    result = restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+
+    assert result['choices'][0]['message']['content'] == 'ok-2'
+    assert len(_RestartTestLlama.created) == 2
+    assert old_worker.closed is True
+
+
+def test_model_manager_request_scoped_inference_error_does_not_restart(restartable_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    worker = restartable_manager.get_llm_instance()
+    monkeypatch.setattr(
+        worker,
+        'create_chat_completion',
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            model_manager_module.LlamaCppInferenceRequestError('request failed')
+        ),
+    )
+
+    with pytest.raises(model_manager_module.LlamaCppInferenceRequestError):
+        restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+
+    assert restartable_manager.llm is worker
+    assert worker.closed is False
+    assert len(_RestartTestLlama.created) == 1
+
+
+def test_model_manager_concurrent_dead_worker_creates_one_restart_replacement(restartable_manager):
+    restartable_manager.get_llm_instance()
+    old_worker = restartable_manager.llm
+    old_worker.dead = True
+    barrier = threading.Barrier(2)
+    results = []
+
+    def call():
+        barrier.wait(timeout=5)
+        results.append(restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False))
+
+    threads = [threading.Thread(target=call) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(results) == 2
+    assert {item['choices'][0]['message']['content'] for item in results} == {'ok-2'}
+    assert len(_RestartTestLlama.created) == 2
+    assert old_worker.closed is True
+
+
+def test_model_manager_restart_replacement_failure_attempted_once(restartable_manager):
+    from utils.llm import model_manager as model_manager_module
+
+    restartable_manager.get_llm_instance()
+    restartable_manager.llm.dead = True
+    _RestartTestLlama.fail_next_replacement = True
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError, match='replacement eof'):
+        restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+
+    assert len(_RestartTestLlama.created) == 2
+
+
+def test_model_manager_healthy_requests_do_not_restart_or_liveness_probe(restartable_manager):
+    first = restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+    second = restartable_manager.create_chat_completion_with_recovery(messages=[], stream=False)
+
+    assert first['choices'][0]['message']['content'] == 'ok-1'
+    assert second['choices'][0]['message']['content'] == 'ok-1'
+    assert len(_RestartTestLlama.created) == 1
+    assert restartable_manager.llm.calls == 2

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -144,6 +144,22 @@ class LlamaCppRuntimeStageTimeout(TimeoutError):
         super().__init__(f"{stage} after {timeout_seconds:g}s")
 
 
+class LlamaCppRestartableWorkerError(RuntimeError):
+    """Raised when the subprocess worker transport is unusable and may be replaced."""
+
+
+class LlamaCppWorkerDeadError(LlamaCppRestartableWorkerError):
+    """Raised when a request is attempted against a dead subprocess worker."""
+
+
+class LlamaCppWorkerEOFError(LlamaCppRestartableWorkerError):
+    """Raised when a subprocess worker exits before returning a response."""
+
+
+class LlamaCppWorkerBrokenPipeError(LlamaCppRestartableWorkerError):
+    """Raised when the subprocess worker pipe breaks during request dispatch."""
+
+
 def _format_runtime_stage_timeout(exc: LlamaCppRuntimeStageTimeout) -> str:
     return f"{exc.stage}_timeout after {exc.timeout_seconds:g}s"
 
@@ -797,6 +813,7 @@ class _SubprocessLlamaProxy:
     ) -> None:
         self._timeout_seconds = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
         self._lock = Lock()
+        self._closed = False
         command = [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)]
         env = _llama_cpp_runtime_worker_env()
         cwd = _llama_cpp_probe_subprocess_cwd()
@@ -818,8 +835,8 @@ class _SubprocessLlamaProxy:
         self._process._token_place_stderr_tail = []  # type: ignore[attr-defined]
         self._start_stderr_tail_reader()
         try:
-            self._send({'method': '__init__', 'args': args, 'kwargs': kwargs})
-        except (BrokenPipeError, OSError) as exc:
+            self._send({'method': '__init__', 'args': args, 'kwargs': kwargs}, check_alive=False)
+        except (BrokenPipeError, OSError, LlamaCppRestartableWorkerError) as exc:
             raise RuntimeError(
                 _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             ) from exc
@@ -842,41 +859,87 @@ class _SubprocessLlamaProxy:
 
         threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True).start()
 
-    def _send(self, payload: Dict[str, Any]) -> None:
+    def is_alive(self) -> bool:
+        """Return whether the worker process and request stdin are usable."""
+
+        if getattr(self, '_closed', False):
+            return False
+        poll = getattr(self._process, 'poll', None)
+        if callable(poll) and poll() is not None:
+            return False
+        stdin = getattr(self._process, 'stdin', None)
+        return stdin is not None and getattr(stdin, 'closed', False) is not True
+
+    def _send(self, payload: Dict[str, Any], *, check_alive: bool = True) -> None:
+        if check_alive and not self.is_alive():
+            raise LlamaCppWorkerDeadError('llama_cpp subprocess worker is not alive')
         if self._process.stdin is None:
             raise RuntimeError('llama_cpp subprocess stdin is unavailable')
-        self._process.stdin.write(json.dumps(payload) + '\n')
-        self._process.stdin.flush()
+        try:
+            self._process.stdin.write(json.dumps(payload) + '\n')
+            self._process.stdin.flush()
+        except BrokenPipeError as exc:
+            raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess worker pipe is broken') from exc
+        except OSError as exc:
+            raise LlamaCppWorkerBrokenPipeError('llama_cpp subprocess worker pipe is unavailable') from exc
 
     def create_chat_completion(self, *args, **kwargs):
         stream = bool(kwargs.get('stream', False))
         if stream:
             return self._stream_chat_completion(*args, **kwargs)
         with self._lock:
+            if not self.is_alive():
+                raise LlamaCppWorkerDeadError('llama_cpp subprocess worker is not alive')
             self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
-            message = _read_llama_subprocess_message(
-                self._process,
-                timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
-                stage='llama_cpp_inference',
-            )
-        return message.get('result')
-
-    def _stream_chat_completion(self, *args, **kwargs):
-        with self._lock:
-            self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
-            while True:
+            try:
                 message = _read_llama_subprocess_message(
                     self._process,
                     timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
                     stage='llama_cpp_inference',
                 )
+            except RuntimeError as exc:
+                if not self.is_alive():
+                    raise LlamaCppWorkerEOFError(str(exc)) from exc
+                raise
+        return message.get('result')
+
+    def _stream_chat_completion(self, *args, **kwargs):
+        with self._lock:
+            if not self.is_alive():
+                raise LlamaCppWorkerDeadError('llama_cpp subprocess worker is not alive')
+            self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
+            while True:
+                try:
+                    message = _read_llama_subprocess_message(
+                        self._process,
+                        timeout_seconds=_llama_cpp_subprocess_inference_timeout_seconds(),
+                        stage='llama_cpp_inference',
+                    )
+                except RuntimeError as exc:
+                    if not self.is_alive():
+                        raise LlamaCppWorkerEOFError(str(exc)) from exc
+                    raise
                 if message.get('done'):
                     return
                 yield message.get('chunk')
 
     def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        stdin = getattr(self._process, 'stdin', None)
+        if stdin is not None:
+            try:
+                stdin.close()
+            except Exception:
+                pass
         if self._process.poll() is None:
             self._process.terminate()
+            try:
+                self._process.wait(timeout=2)
+            except (subprocess.TimeoutExpired, TimeoutError):
+                self._process.kill()
+                self._process.wait(timeout=2)
 
     def __del__(self) -> None:
         try:
@@ -1882,6 +1945,44 @@ class ModelManager:
                             return None
 
         return self.llm
+
+    def invalidate_llm_instance(self, failed_llm: Any = None) -> None:
+        """Thread-safely drop a dead cached runtime and close it when possible."""
+
+        with self.llm_lock:
+            if failed_llm is not None and self.llm is not failed_llm:
+                return
+            old_llm = self.llm
+            self.llm = None
+        close = getattr(old_llm, 'close', None)
+        if callable(close):
+            try:
+                close()
+            except Exception as exc:
+                self.log_warning(f"Failed to close invalidated Llama runtime: {exc}")
+
+    def create_chat_completion_with_recovery(self, *args, **kwargs):
+        """Create one completion, replacing a dead subprocess worker at most once."""
+
+        llm_instance = self.get_llm_instance()
+        if llm_instance is None:
+            raise RuntimeError("LLM runtime is unavailable")
+        create_chat_completion = getattr(llm_instance, 'create_chat_completion', None)
+        if not callable(create_chat_completion):
+            raise RuntimeError("LLM runtime does not expose create_chat_completion")
+
+        try:
+            return create_chat_completion(*args, **kwargs)
+        except LlamaCppRestartableWorkerError:
+            self.invalidate_llm_instance(llm_instance)
+
+        replacement = self.get_llm_instance()
+        if replacement is None:
+            raise RuntimeError("LLM runtime replacement is unavailable")
+        replacement_completion = getattr(replacement, 'create_chat_completion', None)
+        if not callable(replacement_completion):
+            raise RuntimeError("LLM runtime replacement does not expose create_chat_completion")
+        return replacement_completion(*args, **kwargs)
 
     def llama_cpp_get_response(self, chat_history: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2012,8 +2012,18 @@ class RelayClient:
                 },
             )
 
+        complete_with_recovery = getattr(
+            self.model_manager,
+            "create_chat_completion_with_recovery",
+            None,
+        )
+        if (
+            "create_chat_completion_with_recovery" not in vars(self.model_manager)
+            and getattr(type(self.model_manager), "create_chat_completion_with_recovery", None) is None
+        ):
+            complete_with_recovery = None
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
-        has_direct_runtime_completion = callable(get_llm_instance)
+        has_direct_runtime_completion = callable(complete_with_recovery) or callable(get_llm_instance)
         if not self._runtime_model_can_satisfy(model_id):
             return self._api_v1_response_envelope(
                 request_id,
@@ -2055,13 +2065,7 @@ class RelayClient:
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
-            llm_instance = None
-            create_chat_completion = None
-            if has_direct_runtime_completion:
-                llm_instance = get_llm_instance()
-                create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
-
-            if callable(create_chat_completion):
+            if callable(complete_with_recovery):
                 log_info(
                     (
                         "API v1 runtime generation branch selected: "
@@ -2074,13 +2078,36 @@ class RelayClient:
                     "direct_non_streaming_completion",
                 )
                 completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
-                completion = create_chat_completion(
+                completion = complete_with_recovery(
                     messages=runtime_messages,
                     **completion_kwargs,
                 )
                 assistant_message = self._assistant_message_from_runtime_completion(
                     completion
                 )
+            else:
+                llm_instance = get_llm_instance()
+                create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
+                if callable(create_chat_completion):
+                    log_info(
+                        (
+                            "API v1 runtime generation branch selected: "
+                            "request_id={} model_id={} protocol={} route={} branch={}"
+                        ),
+                        request_id,
+                        model_id,
+                        "tokenplace_api_v1_relay_e2ee",
+                        "/api/v1/relay/responses",
+                        "direct_non_streaming_completion",
+                    )
+                    completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+                    completion = create_chat_completion(
+                        messages=runtime_messages,
+                        **completion_kwargs,
+                    )
+                    assistant_message = self._assistant_message_from_runtime_completion(
+                        completion
+                    )
 
             if assistant_message is None:
                 log_error("Desktop runtime returned invalid API v1 assistant output")


### PR DESCRIPTION
### Motivation
- Make desktop/runtime-backed API v1 inference truthful and robust by detecting genuinely dead llama.cpp subprocess workers and replacing them exactly once when transport failures occur. 
- Avoid retaining unusable subprocess proxies or spawning duplicate replacements under concurrent relay pollers while preserving request-scoped inference semantics (no retry for request errors).

### Description
- Added typed restartable transport exceptions (`LlamaCppRestartableWorkerError`, `LlamaCppWorkerDeadError`, `LlamaCppWorkerEOFError`, `LlamaCppWorkerBrokenPipeError`) to classify dead/transport-failure conditions. 
- Implemented `_SubprocessLlamaProxy.is_alive()` checks, safer `_send()` with BrokenPipe/OSError -> typed restartable errors, EOF detection after read failures, and idempotent `close()` that closes stdin and ensures subprocess termination. 
- Added `ModelManager.invalidate_llm_instance()` to safely drop and close the old runtime, and `ModelManager.create_chat_completion_with_recovery()` which retries exactly once after a restartable worker failure while not retrying request-scoped inference errors. 
- Updated API v1 desktop relay generation path to prefer the recovery-aware `create_chat_completion_with_recovery()` when available while preserving the existing direct-runtime fallback for legacy/test doubles. 
- Added targeted unit tests covering: worker killed between requests, broken-pipe/EOF restart, request-scoped inference errors not triggering restart, concurrent callers coalescing into a single replacement, a single retry attempt when replacement also fails, that old workers are closed, and that healthy requests do not probe/restart unnecessarily. Files changed: `utils/llm/model_manager.py`, `utils/networking/relay_client.py`, `tests/unit/test_model_manager.py`.

### Testing
- Ran the focused unit tests: `python -m pytest -q tests/unit/test_model_manager.py -k "restart or recover or subprocess or liveness or concurrent"` — PASSED (final run: 29 passed, 97 deselected).
- Ran broader unit suites: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py` — PASSED (190 passed).
- Ran integration coverage for desktop/API v1: `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — PASSED (10 passed).
- Ran repository checks: `pre-commit run --all-files` — PASSED.
- Notes/risks: replacement is bounded to one retry per request and coalesced under `llm_lock`; follow-ups may include exposing additional diagnostics or metrics for replacement events and adding soak/fault-injection CI scenarios as separate PRs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a375033e574832fae5f8d3d076b62e8)