### PR TITLE
Distinguish relay error envelopes from inference success

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1260,7 +1260,7 @@ def run(args: argparse.Namespace) -> int:
             )
 
     def poll_relay_loop(relay_runtime: Any) -> None:
-        nonlocal last_error, poll_failure_fatal
+        nonlocal last_error, poll_failure_fatal, warm_load_state
         active_relay_url = relay_runtime.relay_client.relay_url
         worker = relay_poll_workers[active_relay_url]
         while not stop_requested():
@@ -1416,11 +1416,35 @@ def run(args: argparse.Namespace) -> int:
                         extra={"relay_runtime_state": "processing"},
                     )
                 )
+                process_result = None
                 try:
                     with inference_lock:
-                        processed = relay_runtime.process_relay_request(relay_response)
+                        process_relay_request_result = getattr(
+                            relay_runtime,
+                            "process_relay_request_result",
+                            None,
+                        )
+                        if callable(process_relay_request_result):
+                            process_result = process_relay_request_result(relay_response)
+                        else:
+                            processed_bool = relay_runtime.process_relay_request(relay_response)
+                            process_result = {
+                                "inference_succeeded": bool(processed_bool),
+                                "submitted": bool(processed_bool),
+                                "safe_error_code": None,
+                                "runtime_healthy": True,
+                                "recovery_attempted": False,
+                                "recovery_succeeded": False,
+                            }
                 except Exception as exc:
-                    processed = False
+                    process_result = {
+                        "inference_succeeded": False,
+                        "submitted": False,
+                        "safe_error_code": "compute_node_process_failed",
+                        "runtime_healthy": False,
+                        "recovery_attempted": False,
+                        "recovery_succeeded": False,
+                    }
                     relay_last_error = "failed to process relay request"
                     last_error = relay_last_error
                     print(
@@ -1429,22 +1453,58 @@ def run(args: argparse.Namespace) -> int:
                         f"exc_type={type(exc).__name__}",
                         file=sys.stderr,
                     )
-                if not processed:
+                inference_succeeded = bool(
+                    getattr(process_result, "inference_succeeded", False)
+                    if not isinstance(process_result, dict)
+                    else process_result.get("inference_succeeded")
+                )
+                submitted = bool(
+                    getattr(process_result, "submitted", bool(process_result))
+                    if not isinstance(process_result, dict)
+                    else process_result.get("submitted")
+                )
+                safe_error_code = (
+                    getattr(process_result, "safe_error_code", None)
+                    if not isinstance(process_result, dict)
+                    else process_result.get("safe_error_code")
+                )
+                runtime_healthy = bool(
+                    getattr(process_result, "runtime_healthy", True)
+                    if not isinstance(process_result, dict)
+                    else process_result.get("runtime_healthy", True)
+                )
+                if not inference_succeeded:
                     relay_last_error = "failed to process relay request"
+                    if safe_error_code:
+                        relay_last_error = f"relay request failed: {safe_error_code}"
                     last_error = relay_last_error
                     print(
                         "desktop.compute_node_bridge.process_request.failed "
-                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                        f"safe_error_code={safe_error_code or 'none'} submitted={submitted} "
+                        f"runtime_healthy={runtime_healthy}",
                         file=sys.stderr,
                     )
-                    submit_api_v1_error_response(
-                        relay_response,
-                        code="compute_node_process_failed",
-                        message=last_error,
-                        active_relay_url=active_relay_url,
-                        request_id=request_id,
-                        relay_runtime=relay_runtime,
-                    )
+                    if submitted:
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.error_envelope_submitted "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            f"request_id={request_id} safe_error_code={safe_error_code or 'unknown'}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        submit_api_v1_error_response(
+                            relay_response,
+                            code="compute_node_process_failed",
+                            message=last_error,
+                            active_relay_url=active_relay_url,
+                            request_id=request_id,
+                            relay_runtime=relay_runtime,
+                        )
+                    if not runtime_healthy:
+                        warm_load_state = "failed"
+                        registered = False
+                        relay_state = "failed"
                 else:
                     last_error = None
                     print(

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1435,6 +1435,8 @@ def run(args: argparse.Namespace) -> int:
                                 "submitted": bool(processed_bool),
                                 "safe_error_code": None,
                                 "runtime_healthy": True,
+                                "recovery_attempted": False,
+                                "recovery_succeeded": False,
                             }
                 except Exception as exc:
                     process_result = {
@@ -1442,6 +1444,8 @@ def run(args: argparse.Namespace) -> int:
                         "submitted": False,
                         "safe_error_code": "compute_node_process_failed",
                         "runtime_healthy": False,
+                        "recovery_attempted": True,
+                        "recovery_succeeded": False,
                     }
                     relay_last_error = "failed to process relay request"
                     last_error = relay_last_error
@@ -1471,6 +1475,16 @@ def run(args: argparse.Namespace) -> int:
                     if not isinstance(process_result, dict)
                     else process_result.get("runtime_healthy", True)
                 )
+                recovery_attempted = bool(
+                    getattr(process_result, "recovery_attempted", False)
+                    if not isinstance(process_result, dict)
+                    else process_result.get("recovery_attempted", False)
+                )
+                recovery_succeeded = bool(
+                    getattr(process_result, "recovery_succeeded", False)
+                    if not isinstance(process_result, dict)
+                    else process_result.get("recovery_succeeded", False)
+                )
                 if not inference_succeeded:
                     relay_last_error = "failed to process relay request"
                     if safe_error_code:
@@ -1480,7 +1494,9 @@ def run(args: argparse.Namespace) -> int:
                         "desktop.compute_node_bridge.process_request.failed "
                         f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
                         f"safe_error_code={safe_error_code or 'none'} submitted={submitted} "
-                        f"runtime_healthy={runtime_healthy}",
+                        f"runtime_healthy={runtime_healthy} "
+                        f"recovery_attempted={recovery_attempted} "
+                        f"recovery_succeeded={recovery_succeeded}",
                         file=sys.stderr,
                     )
                     if submitted:
@@ -1500,9 +1516,29 @@ def run(args: argparse.Namespace) -> int:
                             relay_runtime=relay_runtime,
                         )
                     if not runtime_healthy:
-                        warm_load_state = "failed"
                         registered = False
+                        if recovery_attempted and not recovery_succeeded:
+                            relay_state = "recovering"
+                            warm_load_state = "recovering"
+                            update_relay_status(
+                                active_relay_url,
+                                registered=False,
+                                relay_runtime_state="recovering",
+                                last_error=relay_last_error,
+                                last_request_id=request_id if request_id != "none" else None,
+                            )
+                            emit_operator_event(
+                                build_status_payload(
+                                    event_type="status",
+                                    running=True,
+                                    registered=False,
+                                    active_relay_url=active_relay_url,
+                                    current_last_error=last_error,
+                                    extra={"relay_runtime_state": "recovering"},
+                                )
+                            )
                         relay_state = "failed"
+                        warm_load_state = "failed"
                 else:
                     last_error = None
                     print(

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1594,8 +1594,9 @@ def run(args: argparse.Namespace) -> int:
                 )
                 poll_threads.append(thread)
                 thread.start()
-            while not stop_requested() and any(thread.is_alive() for thread in poll_threads):
-                time.sleep(0.05)
+            while any(thread.is_alive() for thread in poll_threads):
+                for thread in poll_threads:
+                    thread.join(timeout=0.05)
     except KeyboardInterrupt:
         pass
     finally:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1265,6 +1265,19 @@ def run(args: argparse.Namespace) -> int:
         worker = relay_poll_workers[active_relay_url]
         while not stop_requested():
             active_relay_url = relay_runtime.relay_client.relay_url
+            if warm_load_state == "failed":
+                update_relay_status(
+                    active_relay_url,
+                    registered=False,
+                    relay_runtime_state="failed",
+                    last_error=last_error,
+                )
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                )
+                break
             print(
                 "desktop.compute_node_bridge.api_v1_e2ee.register "
                 f"operator_session_id={bridge_session_id} "

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -1329,6 +1329,8 @@ def run(args: argparse.Namespace) -> int:
                 and (has_heartbeat or api_v1_payload)
                 and _registration_fresh(relay_runtime.relay_client, active_relay_url)
             )
+            if warm_load_state == "failed":
+                registered = False
             if registered:
                 registration_succeeded_by_relay[active_relay_url] = True
             wait_seconds = _safe_poll_wait_seconds(
@@ -1433,8 +1435,6 @@ def run(args: argparse.Namespace) -> int:
                                 "submitted": bool(processed_bool),
                                 "safe_error_code": None,
                                 "runtime_healthy": True,
-                                "recovery_attempted": False,
-                                "recovery_succeeded": False,
                             }
                 except Exception as exc:
                     process_result = {
@@ -1442,8 +1442,6 @@ def run(args: argparse.Namespace) -> int:
                         "submitted": False,
                         "safe_error_code": "compute_node_process_failed",
                         "runtime_healthy": False,
-                        "recovery_attempted": False,
-                        "recovery_succeeded": False,
                     }
                     relay_last_error = "failed to process relay request"
                     last_error = relay_last_error

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -584,7 +584,10 @@ def test_api_v1_relay_request_adapter_processes_api_v1_payload():
     }
     relay_client.process_client_request.return_value = True
     assert adapter.can_process(payload) is True
-    assert adapter.process(payload) is True
+    result = adapter.process(payload)
+    assert bool(result) is True
+    assert result.inference_succeeded is True
+    assert result.submitted is True
     relay_client.process_client_request.assert_called_once_with(payload)
 
 def test_legacy_relay_request_adapter_only_matches_legacy_contract():
@@ -947,3 +950,37 @@ def test_compute_node_runtime_stop_skips_unregister_for_non_set_registration_sta
 
     relay_client.stop.assert_called_once_with()
     relay_client.unregister_from_relay.assert_not_called()
+
+
+def test_process_relay_request_result_preserves_error_envelope_submission_semantics():
+    from utils.processing_result import RelayProcessingResult
+
+    class Adapter:
+        def can_process(self, _payload):
+            return True
+
+        def process(self, _payload):
+            return RelayProcessingResult(
+                inference_succeeded=False,
+                submitted=True,
+                safe_error_code="compute_node_internal_error",
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        relay_client=MagicMock(),
+        model_manager=MagicMock(use_mock_llm=True),
+        crypto_manager=MagicMock(),
+        request_adapters=[Adapter()],
+    )
+
+    result = runtime.process_relay_request_result({"request_id": "req-1"})
+    assert bool(result) is True
+    assert runtime.process_relay_request({"request_id": "req-1"}) is True
+    assert result.submitted is True
+    assert result.inference_succeeded is False
+    assert result.safe_error_code == "compute_node_internal_error"
+    assert result.runtime_healthy is False

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -965,8 +965,6 @@ def test_process_relay_request_result_preserves_error_envelope_submission_semant
                 submitted=True,
                 safe_error_code="compute_node_internal_error",
                 runtime_healthy=False,
-                recovery_attempted=True,
-                recovery_succeeded=False,
             )
 
     runtime = ComputeNodeRuntime(

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3640,8 +3640,13 @@ def test_run_keeps_registration_false_after_runtime_health_failure(capsys, monke
     failed_statuses = [
         event for event in status_events if event.get('relay_runtime_state') == 'failed'
     ]
+    assert ReRegisterAfterFailureRuntime.last_instance.poll_count == 1
     assert failed_statuses
     assert all(event['registered'] is False for event in failed_statuses)
+    assert not any(
+        event['registered'] is True and event.get('relay_runtime_state') == 'failed'
+        for event in status_events
+    )
 
 
 def test_run_error_envelope_submission_is_not_success_marker(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3588,3 +3588,38 @@ def test_runtime_setup_diagnostics_are_logged_and_in_status_without_noisy_last_e
     assert started['install_command_summary'].startswith('python -m pip install')
     assert started['cmake_args'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
     assert started['pip_stderr_tail'] == 'Metal headers missing'
+
+
+def test_run_error_envelope_submission_is_not_success_marker(capsys, monkeypatch):
+    from utils.processing_result import RelayProcessingResult
+
+    _reset_cancel_queue()
+
+    class ErrorEnvelopeRuntime(ApiV1Runtime):
+        def process_relay_request_result(self, payload):
+            self._processed.append(payload)
+            return RelayProcessingResult(
+                inference_succeeded=False,
+                submitted=True,
+                safe_error_code="compute_node_internal_error",
+                runtime_healthy=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ErrorEnvelopeRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: bool(ErrorEnvelopeRuntime.last_instance._processed),
+    )
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    assert compute_node_bridge.run(args) == 0
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.response_submitted' not in output.err
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_envelope_submitted' in output.err
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get('type') == 'status']
+    assert status_events[-1]['registered'] is False
+    assert status_events[-1]['relay_runtime_state'] == 'failed'
+    assert status_events[-1]['last_error'] == 'relay request failed: compute_node_internal_error'

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3589,6 +3589,60 @@ def test_runtime_setup_diagnostics_are_logged_and_in_status_without_noisy_last_e
     assert started['cmake_args'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
     assert started['pip_stderr_tail'] == 'Metal headers missing'
 
+def test_run_keeps_registration_false_after_runtime_health_failure(capsys, monkeypatch):
+    from utils.processing_result import RelayProcessingResult
+
+    _reset_cancel_queue()
+
+    class ReRegisterAfterFailureRuntime(ApiV1Runtime):
+        last_instance = None
+
+        def __init__(self, config):
+            super().__init__(config)
+            ReRegisterAfterFailureRuntime.last_instance = self
+            self._responses.append({'next_ping_in_x_seconds': 0})
+            self.poll_count = 0
+
+        def register_and_poll_once(self):
+            self.poll_count += 1
+            return super().register_and_poll_once()
+
+        def process_relay_request_result(self, payload):
+            self._processed.append(payload)
+            return RelayProcessingResult(
+                inference_succeeded=False,
+                submitted=True,
+                safe_error_code="compute_node_internal_error",
+                runtime_healthy=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ReRegisterAfterFailureRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: (
+            ReRegisterAfterFailureRuntime.last_instance is not None
+            and ReRegisterAfterFailureRuntime.last_instance.poll_count >= 2
+        ),
+    )
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 0
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get('type') == 'status']
+    failed_statuses = [
+        event for event in status_events if event.get('relay_runtime_state') == 'failed'
+    ]
+    assert failed_statuses
+    assert all(event['registered'] is False for event in failed_statuses)
+
 
 def test_run_error_envelope_submission_is_not_success_marker(capsys, monkeypatch):
     from utils.processing_result import RelayProcessingResult

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -998,7 +998,6 @@ class TestRelayClient:
         assert result['error'] == "Unexpected error"
         assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
 
-
     @patch('utils.networking.relay_client.requests.post')
     def test_register_api_v1_compute_node_non_200_returns_error(self, mock_post, relay_client):
         response = MagicMock(status_code=503)
@@ -1139,7 +1138,6 @@ class TestRelayClient:
         assert 'relay_control_plane_rate_limited' in caplog.text
         assert 'retry_after=37' in caplog.text
 
-
     @patch('utils.networking.relay_client.requests.post')
     def test_register_api_v1_compute_node_401_json_logs_relay_error_safely(
         self, mock_post, relay_client, caplog
@@ -1178,7 +1176,6 @@ class TestRelayClient:
         for forbidden in ('super-secret-token', 'server-public-key-secret'):
             assert forbidden not in logs
             assert forbidden not in json.dumps(result, sort_keys=True)
-
 
     @patch('utils.networking.relay_client.requests.post')
     def test_register_api_v1_compute_node_redacts_nested_json_error_and_hyphen_keys(
@@ -1364,7 +1361,6 @@ class TestRelayClient:
         }
         assert 'http://localhost:5000' in relay_client._api_v1_registered_relays
 
-
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_zero_poll_wait_timeout_is_failure(
         self, mock_post, relay_client, monkeypatch
@@ -1389,7 +1385,6 @@ class TestRelayClient:
         assert result['next_ping_in_x_seconds'] == relay_client._request_timeout
         assert relay_client._api_v1_last_heartbeat_at == {}
         assert relay_client.api_v1_registration_fresh() is False
-
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_no_work_hint_is_preserved(self, mock_post, relay_client):
@@ -1543,7 +1538,6 @@ class TestRelayClient:
             'http://localhost:5000/api/v1/relay/servers/register',
             'http://localhost:5000/api/v1/relay/servers/poll',
         ]
-
 
     @patch('utils.networking.relay_client.requests.post')
     def test_poll_api_v1_encrypted_work_reregisters_before_cached_lease_expires(
@@ -2140,7 +2134,6 @@ class TestRelayClient:
         mock_model_manager.llama_cpp_get_response.assert_not_called()
         mock_post.assert_not_called()
 
-
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_missing_runtime_posts_internal_error(
         self,
@@ -2186,6 +2179,52 @@ class TestRelayClient:
         )
         assert encrypted_envelope["api_v1_response"]["error"]["message"] == (
             "Desktop runtime inference failed"
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_request_scoped_inference_error_keeps_runtime_healthy(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Request-scoped llama.cpp failures submit errors without marking runtime unhealthy."""
+        from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-bad-prompt",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_model_manager.create_chat_completion_with_recovery = MagicMock(
+            side_effect=LlamaCppInferenceRequestError("bad request")
+        )
+        mock_crypto_manager.encrypt_message.return_value = {
+            'chat_history': 'encrypted_chat_history',
+            'cipherkey': 'encrypted_key',
+            'iv': 'encrypted_iv',
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        typed_result = relay_client.process_client_request_result(request_data)
+
+        assert typed_result.submitted is True
+        assert typed_result.inference_succeeded is False
+        assert typed_result.safe_error_code == "compute_node_inference_request_error"
+        assert typed_result.runtime_healthy is True
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_inference_request_error"
         )
 
     @patch('utils.networking.relay_client.requests.post')
@@ -2956,7 +2995,6 @@ class TestRelayClient:
 
         assert result is False
         mock_post.assert_not_called()
-
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_streaming_posts_to_stream_source(

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2220,12 +2220,58 @@ class TestRelayClient:
 
         assert typed_result.submitted is True
         assert typed_result.inference_succeeded is False
-        assert typed_result.safe_error_code == "compute_node_inference_request_error"
+        assert typed_result.safe_error_code == "compute_node_internal_error"
         assert typed_result.runtime_healthy is True
+        assert typed_result.recovery_attempted is False
+        assert typed_result.recovery_succeeded is False
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
-            "compute_node_inference_request_error"
+            "compute_node_internal_error"
         )
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_exhausted_replacement_reports_recovery_failed(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        """Exhausted worker replacement is submitted as an encrypted error with recovery metadata."""
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-worker-dead",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+            },
+        }
+        mock_model_manager.create_chat_completion_with_recovery = MagicMock(
+            side_effect=RuntimeError(
+                "LLM runtime replacement failed after one restart attempt"
+            )
+        )
+        mock_crypto_manager.encrypt_message.return_value = {
+            'chat_history': 'encrypted_chat_history',
+            'cipherkey': 'encrypted_key',
+            'iv': 'encrypted_iv',
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        typed_result = relay_client.process_client_request_result(request_data)
+
+        assert typed_result.submitted is True
+        assert typed_result.inference_succeeded is False
+        assert typed_result.safe_error_code == "compute_node_internal_error"
+        assert typed_result.runtime_healthy is False
+        assert typed_result.recovery_attempted is True
+        assert typed_result.recovery_succeeded is False
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_invalid_runtime_output_posts_encrypted_error(

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2172,6 +2172,12 @@ class TestRelayClient:
         source_response.status_code = 200
         mock_post.return_value = source_response
 
+        typed_result = relay_client.process_client_request_result(request_data)
+        assert bool(typed_result) is True
+        assert typed_result.submitted is True
+        assert typed_result.inference_succeeded is False
+        assert typed_result.safe_error_code == "compute_node_internal_error"
+        assert typed_result.runtime_healthy is False
         assert relay_client.process_client_request(request_data) is True
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -6,7 +6,10 @@ import os
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple
+
 from urllib.parse import urlparse
+
+from utils.processing_result import RelayProcessingResult
 
 if TYPE_CHECKING:
     from utils.networking.relay_client import RelayClient
@@ -87,8 +90,8 @@ class RelayRequestAdapter(Protocol):
     def can_process(self, request_data: Dict[str, Any]) -> bool:
         """Return True when the adapter can process ``request_data``."""
 
-    def process(self, request_data: Dict[str, Any]) -> bool:
-        """Process ``request_data`` and return success."""
+    def process(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        """Process ``request_data`` and return a typed outcome."""
 
 
 class LegacyRelayRequestAdapter:
@@ -100,8 +103,12 @@ class LegacyRelayRequestAdapter:
     def can_process(self, request_data: Dict[str, Any]) -> bool:
         return is_legacy_relay_payload(request_data)
 
-    def process(self, request_data: Dict[str, Any]) -> bool:
-        return self._relay_client.process_client_request(request_data)
+    def process(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        process_result = getattr(type(self._relay_client), "process_client_request_result", None)
+        if callable(process_result):
+            return process_result(self._relay_client, request_data)
+        submitted = bool(self._relay_client.process_client_request(request_data))
+        return RelayProcessingResult(inference_succeeded=submitted, submitted=submitted)
 
 
 class ApiV1RelayRequestAdapter:
@@ -113,8 +120,12 @@ class ApiV1RelayRequestAdapter:
     def can_process(self, request_data: Dict[str, Any]) -> bool:
         return is_api_v1_relay_payload(request_data)
 
-    def process(self, request_data: Dict[str, Any]) -> bool:
-        return self._relay_client.process_client_request(request_data)
+    def process(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        process_result = getattr(type(self._relay_client), "process_client_request_result", None)
+        if callable(process_result):
+            return process_result(self._relay_client, request_data)
+        submitted = bool(self._relay_client.process_client_request(request_data))
+        return RelayProcessingResult(inference_succeeded=submitted, submitted=submitted)
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -395,7 +406,7 @@ class ComputeNodeRuntime:
         _log_info(f"Started relay polling thread for {relay_target}")
         return relay_thread
 
-    def process_relay_request(self, request_data: Dict[str, Any]) -> bool:
+    def process_relay_request_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
         """Process relay payloads via registered protocol adapters."""
 
         for adapter in self.request_adapters:
@@ -405,7 +416,12 @@ class ComputeNodeRuntime:
         _log_error(
             f"No relay request adapter matched payload keys: {sorted(request_data.keys())}"
         )
-        return False
+        return RelayProcessingResult.submission_failed(safe_error_code="unsupported_relay_payload")
+
+    def process_relay_request(self, request_data: Dict[str, Any]) -> bool:
+        """Compatibility wrapper; True means encrypted response/error submission succeeded."""
+
+        return bool(self.process_relay_request_result(request_data))
 
     def start_relay_session(self) -> None:
         """Reset relay-client stop state before a fresh operator session polls."""

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -94,6 +94,22 @@ class RelayRequestAdapter(Protocol):
         """Process ``request_data`` and return a typed outcome."""
 
 
+def _process_relay_client_request(
+    relay_client: "RelayClient", request_data: Dict[str, Any]
+) -> RelayProcessingResult:
+    """Process a request through a relay client with typed-result fallback.
+
+    The class-level probe intentionally avoids MagicMock's auto-created instance
+    attributes while keeping adapter behavior compatible with older clients.
+    """
+
+    process_result = getattr(type(relay_client), "process_client_request_result", None)
+    if callable(process_result):
+        return process_result(relay_client, request_data)
+    submitted = bool(relay_client.process_client_request(request_data))
+    return RelayProcessingResult(inference_succeeded=submitted, submitted=submitted)
+
+
 class LegacyRelayRequestAdapter:
     """Compatibility adapter for the existing deprecated relay request shape."""
 
@@ -104,11 +120,7 @@ class LegacyRelayRequestAdapter:
         return is_legacy_relay_payload(request_data)
 
     def process(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
-        process_result = getattr(type(self._relay_client), "process_client_request_result", None)
-        if callable(process_result):
-            return process_result(self._relay_client, request_data)
-        submitted = bool(self._relay_client.process_client_request(request_data))
-        return RelayProcessingResult(inference_succeeded=submitted, submitted=submitted)
+        return _process_relay_client_request(self._relay_client, request_data)
 
 
 class ApiV1RelayRequestAdapter:
@@ -121,11 +133,7 @@ class ApiV1RelayRequestAdapter:
         return is_api_v1_relay_payload(request_data)
 
     def process(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
-        process_result = getattr(type(self._relay_client), "process_client_request_result", None)
-        if callable(process_result):
-            return process_result(self._relay_client, request_data)
-        submitted = bool(self._relay_client.process_client_request(request_data))
-        return RelayProcessingResult(inference_succeeded=submitted, submitted=submitted)
+        return _process_relay_client_request(self._relay_client, request_data)
 
 
 def first_env(keys: List[str]) -> Optional[str]:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -30,6 +30,12 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
     return exc.__class__.__name__ == "LlamaCppInferenceRequestError"
 
 
+def _is_llama_cpp_restartable_worker_error(exc: BaseException) -> bool:
+    """Return True for restartable llama.cpp worker failures without importing runtime internals."""
+
+    return exc.__class__.__name__.startswith("LlamaCpp") and "Worker" in exc.__class__.__name__
+
+
 def _load_jsonschema():
     """Lazy-load jsonschema; return ``None`` when unavailable in packaged runtimes."""
     try:
@@ -2160,6 +2166,12 @@ class RelayClient:
     ) -> Dict[str, Any]:
         """Generate an API v1 assistant message with the desktop runtime model."""
 
+        self._last_api_v1_runtime_health = {
+            "runtime_healthy": True,
+            "recovery_attempted": False,
+            "recovery_succeeded": False,
+        }
+
         if not self._messages_are_valid_api_v1_chat(messages):
             return self._api_v1_response_envelope(
                 request_id,
@@ -2234,6 +2246,11 @@ class RelayClient:
             if not callable(create_chat_completion) and has_direct_runtime_completion:
                 llm_instance = get_llm_instance()
                 if llm_instance is None:
+                    self._last_api_v1_runtime_health = {
+                        "runtime_healthy": False,
+                        "recovery_attempted": False,
+                        "recovery_succeeded": False,
+                    }
                     log_error("Desktop runtime LLM initialization failed for API v1 relay request")
                     return self._api_v1_response_envelope(
                         request_id,
@@ -2278,6 +2295,11 @@ class RelayClient:
             return self._api_v1_response_envelope(request_id, message=assistant_message)
         except Exception as exc:
             if _is_llama_cpp_inference_request_error(exc):
+                self._last_api_v1_runtime_health = {
+                    "runtime_healthy": True,
+                    "recovery_attempted": False,
+                    "recovery_succeeded": False,
+                }
                 log_error(
                     "Desktop runtime rejected API v1 relay inference request",
                     exc_info=True,
@@ -2285,10 +2307,24 @@ class RelayClient:
                 return self._api_v1_response_envelope(
                     request_id,
                     error={
-                        "code": "compute_node_inference_request_error",
+                        "code": "compute_node_internal_error",
                         "message": "Desktop runtime rejected the inference request",
                     },
                 )
+            recovery_attempted = (
+                "replacement" in str(exc).lower()
+                or "restart" in str(exc).lower()
+                or (
+                    exc.__cause__ is not None
+                    and _is_llama_cpp_restartable_worker_error(exc.__cause__)
+                )
+            )
+            runtime_healthy = not recovery_attempted
+            self._last_api_v1_runtime_health = {
+                "runtime_healthy": runtime_healthy,
+                "recovery_attempted": recovery_attempted,
+                "recovery_succeeded": False,
+            }
             log_error(
                 "Desktop runtime inference failed for API v1 relay request",
                 exc_info=True,
@@ -2343,6 +2379,15 @@ class RelayClient:
                 api_v1_response = response_envelope.get("api_v1_response", {})
                 error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None
                 safe_error_code = error.get("code") if isinstance(error, dict) else None
+                runtime_health = getattr(self, "_last_api_v1_runtime_health", {})
+                runtime_healthy = bool(runtime_health.get("runtime_healthy", True))
+                recovery_attempted = bool(runtime_health.get("recovery_attempted", False))
+                recovery_succeeded = bool(runtime_health.get("recovery_succeeded", False))
+                if safe_error_code not in {
+                    "compute_node_internal_error",
+                    "compute_node_process_failed",
+                }:
+                    runtime_healthy = True
                 submitted = self._post_api_v1_response(
                     response_envelope,
                     client_pub_key_b64=client_pub_key_b64,
@@ -2352,10 +2397,9 @@ class RelayClient:
                     inference_succeeded=safe_error_code is None and submitted,
                     submitted=submitted,
                     safe_error_code=safe_error_code,
-                    runtime_healthy=safe_error_code not in {
-                        "compute_node_internal_error",
-                        "compute_node_process_failed",
-                    },
+                    runtime_healthy=runtime_healthy,
+                    recovery_attempted=recovery_attempted,
+                    recovery_succeeded=recovery_succeeded,
                 )
 
             chat_history = _extract_chat_history_and_validate_key_binding(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -24,6 +24,12 @@ logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
 
 
+def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
+    """Return True for request-scoped llama.cpp inference validation failures."""
+
+    return exc.__class__.__name__ == "LlamaCppInferenceRequestError"
+
+
 def _load_jsonschema():
     """Lazy-load jsonschema; return ``None`` when unavailable in packaged runtimes."""
     try:
@@ -2270,7 +2276,19 @@ class RelayClient:
                 )
 
             return self._api_v1_response_envelope(request_id, message=assistant_message)
-        except Exception:
+        except Exception as exc:
+            if _is_llama_cpp_inference_request_error(exc):
+                log_error(
+                    "Desktop runtime rejected API v1 relay inference request",
+                    exc_info=True,
+                )
+                return self._api_v1_response_envelope(
+                    request_id,
+                    error={
+                        "code": "compute_node_inference_request_error",
+                        "message": "Desktop runtime rejected the inference request",
+                    },
+                )
             log_error(
                 "Desktop runtime inference failed for API v1 relay request",
                 exc_info=True,
@@ -2334,7 +2352,10 @@ class RelayClient:
                     inference_succeeded=safe_error_code is None and submitted,
                     submitted=submitted,
                     safe_error_code=safe_error_code,
-                    runtime_healthy=safe_error_code != "compute_node_internal_error",
+                    runtime_healthy=safe_error_code not in {
+                        "compute_node_internal_error",
+                        "compute_node_process_failed",
+                    },
                 )
 
             chat_history = _extract_chat_history_and_validate_key_binding(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -13,6 +13,8 @@ import hashlib
 import re
 import time
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+
+from utils.processing_result import RelayProcessingResult
 from urllib.parse import urlparse, urlunparse
 
 from utils.networking.http_requests_compat import requests
@@ -2281,40 +2283,32 @@ class RelayClient:
                 },
             )
 
-    def process_client_request(self, request_data: Dict[str, Any]) -> bool:
-        """
-        Process a client request from the relay.
-
-        Args:
-            request_data: Data received from the relay containing the encrypted client request
-
-        Returns:
-            bool: True if processing succeeded, False otherwise
-        """
+    def process_client_request_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        """Process a client request and return a typed, privacy-safe outcome."""
         try:
             try:
                 _validate_with_fallback(request_data, MESSAGE_SCHEMA)
             except ValueError as e:
                 log_error("Invalid request data format: {}", str(e))
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="invalid_relay_payload")
 
             client_pub_key_b64 = _normalize_client_public_key_b64(request_data['client_public_key'])
             if client_pub_key_b64 is None:
                 log_error("Invalid client_public_key format in relay request metadata")
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="invalid_relay_payload")
             stream_requested = request_data.get('stream') is True
             stream_session_id = request_data.get('stream_session_id')
             try:
                 client_pub_key = base64.b64decode(client_pub_key_b64, validate=True)
             except (AttributeError, binascii.Error, ValueError):
                 log_error("Invalid client_public_key encoding in relay request metadata")
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="invalid_relay_payload")
 
             log_info("Decrypting client request...")
             decrypted_chat_history = self.crypto_manager.decrypt_message(request_data)
             if decrypted_chat_history is None:
                 log_info("Decryption failed. Skipping.")
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="decrypt_failed")
 
             log_info("Decrypted client request")
             api_v1_request_payload = _extract_api_v1_request_payload(
@@ -2328,10 +2322,19 @@ class RelayClient:
                     messages=api_v1_request_payload["messages"],
                     options=dict(api_v1_request_payload["options"]),
                 )
-                return self._post_api_v1_response(
+                api_v1_response = response_envelope.get("api_v1_response", {})
+                error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None
+                safe_error_code = error.get("code") if isinstance(error, dict) else None
+                submitted = self._post_api_v1_response(
                     response_envelope,
                     client_pub_key_b64=client_pub_key_b64,
                     client_pub_key=client_pub_key,
+                )
+                return RelayProcessingResult(
+                    inference_succeeded=safe_error_code is None and submitted,
+                    submitted=submitted,
+                    safe_error_code=safe_error_code,
+                    runtime_healthy=safe_error_code != "compute_node_internal_error",
                 )
 
             chat_history = _extract_chat_history_and_validate_key_binding(
@@ -2339,7 +2342,7 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if chat_history is None:
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="invalid_relay_payload")
 
             if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
                 log_info("Processing streaming relay request for session {}", stream_session_id)
@@ -2370,8 +2373,8 @@ class RelayClient:
                 )
                 if stream_response.status_code != 200:
                     log_error("Error status from /stream/source: {}", stream_response.status_code)
-                    return False
-                return True
+                    return RelayProcessingResult.submission_failed(safe_error_code="stream_submission_failed")
+                return RelayProcessingResult(inference_succeeded=True, submitted=True)
 
             log_info("Getting response from LLM...")
             response_history = self.model_manager.llama_cpp_get_response(chat_history)
@@ -2392,7 +2395,7 @@ class RelayClient:
                 _validate_with_fallback(source_payload, MESSAGE_SCHEMA)
             except ValueError as e:
                 log_error("Invalid response payload format: {}", str(e))
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="invalid_response_payload")
 
             log_info("Posting response to {}/source. Payload keys: {}", self.relay_url, list(source_payload.keys()))
 
@@ -2419,27 +2422,32 @@ class RelayClient:
 
             if source_response.status_code != 200:
                 log_error("Error status from /source: {}", source_response.status_code)
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="response_submission_failed")
 
             response_content = source_response.text.strip()
             if not response_content:
                 log_error("Empty response from /source")
-                return False
+                return RelayProcessingResult.submission_failed(safe_error_code="empty_relay_response")
 
-            return True
+            return RelayProcessingResult(inference_succeeded=True, submitted=True)
 
         except requests.ConnectionError as e:
             log_error("Connection error when posting to relay source endpoint: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.submission_failed(safe_error_code="relay_connection_error")
         except requests.Timeout as e:
             log_error("Request timeout when posting to relay source endpoint: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.submission_failed(safe_error_code="relay_timeout")
         except requests.RequestException as e:
             log_error("Request exception when posting to relay source endpoint: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.submission_failed(safe_error_code="relay_request_exception")
         except Exception as e:
             log_error("Exception during request processing: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.submission_failed(safe_error_code="compute_node_internal_error", runtime_healthy=False)
+
+    def process_client_request(self, request_data: Dict[str, Any]) -> bool:
+        """Compatibility wrapper; True means encrypted response/error submission succeeded."""
+
+        return bool(self.process_client_request_result(request_data))
 
     def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
         """Relay API v1 plaintext dispatch is disabled pending an E2EE-compatible design."""

--- a/utils/processing_result.py
+++ b/utils/processing_result.py
@@ -1,0 +1,38 @@
+"""Typed relay processing outcomes shared by compute-node runtimes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class RelayProcessingResult:
+    """Immutable, privacy-safe outcome for one relay work item.
+
+    ``bool(result)`` and ``submitted`` intentionally mean only that an encrypted
+    response or safe error envelope reached the relay. Callers that need model
+    success must check ``inference_succeeded`` explicitly.
+    """
+
+    inference_succeeded: bool
+    submitted: bool
+    safe_error_code: Optional[str] = None
+    runtime_healthy: bool = True
+    recovery_attempted: bool = False
+    recovery_succeeded: bool = False
+
+    def __bool__(self) -> bool:
+        """Compatibility: True means encrypted response/error submission succeeded."""
+
+        return self.submitted
+
+    @classmethod
+    def submission_failed(
+        cls, *, safe_error_code: Optional[str] = None, runtime_healthy: bool = True
+    ) -> "RelayProcessingResult":
+        return cls(
+            inference_succeeded=False,
+            submitted=False,
+            safe_error_code=safe_error_code,
+            runtime_healthy=runtime_healthy,
+        )

--- a/utils/processing_result.py
+++ b/utils/processing_result.py
@@ -18,8 +18,6 @@ class RelayProcessingResult:
     submitted: bool
     safe_error_code: Optional[str] = None
     runtime_healthy: bool = True
-    recovery_attempted: bool = False
-    recovery_succeeded: bool = False
 
     def __bool__(self) -> bool:
         """Compatibility: True means encrypted response/error submission succeeded."""

--- a/utils/processing_result.py
+++ b/utils/processing_result.py
@@ -18,6 +18,8 @@ class RelayProcessingResult:
     submitted: bool
     safe_error_code: Optional[str] = None
     runtime_healthy: bool = True
+    recovery_attempted: bool = False
+    recovery_succeeded: bool = False
 
     def __bool__(self) -> bool:
         """Compatibility: True means encrypted response/error submission succeeded."""
@@ -33,4 +35,6 @@ class RelayProcessingResult:
             submitted=False,
             safe_error_code=safe_error_code,
             runtime_healthy=runtime_healthy,
+            recovery_attempted=False,
+            recovery_succeeded=False,
         )


### PR DESCRIPTION
### Motivation
- Prevent encrypted `compute_node_internal_error` envelope delivery from being treated as successful model inference. 
- Ensure the desktop bridge and UI do not report `ready`/`registered` when the shared runtime is demonstrably unhealthy after processing a request.

### Description
- Add an immutable `RelayProcessingResult` dataclass (`utils/processing_result.py`) carrying `inference_succeeded`, `submitted`, `safe_error_code`, `runtime_healthy`, `recovery_attempted`, and `recovery_succeeded`, with `bool(result)` meaning submission-success only.
- Thread the typed result through the relay stack by adding `process_client_request_result` in `RelayClient` and making API v1 / legacy adapters return `RelayProcessingResult`, while keeping boolean compatibility wrappers (`process_client_request`, `process_relay_request`) where callers expect a bool.
- Update `ComputeNodeRuntime` to expose `process_relay_request_result()` returning `RelayProcessingResult` and preserve `process_relay_request()` as a compatibility boolean wrapper.
- Update the desktop bridge to consume the typed result: emit `response_submitted` only for true assistant outputs, emit a distinct `api_v1_e2ee.error_envelope_submitted` when a safe encrypted error was posted, keep `last_error` for request-scoped failures, and transition runtime status to `recovering`/`failed` (and clear `registered`) when runtime health is negative after bounded recovery attempts.
- Add focused unit tests that assert error-envelope submission is not counted as inference success and that bridge events/status reflect the new semantics.

### Testing
- Ran unit tests: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py` — PASSED.
- Ran targeted desktop-bridge unit tests: `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py -k "process or error or status or ready or registered"` — PASSED.
- Ran integration guardrail: `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — PASSED.
- Ran project checks: `pre-commit run --all-files` — PASSED.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3761f149fc832fbf22c60182e27dfc)