### PR TITLE
Distinguish relay error envelopes from inference success

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -841,7 +841,7 @@ def run(args: argparse.Namespace) -> int:
             "type": event_type,
             "running": running,
             "registered": fresh_registered,
-            "relay_runtime_state": relay_state,
+            "relay_runtime_state": payload_relay_state,
             "active_relay_url": active_relay_url,
             "configured_relay_urls": list(configured_relay_urls),
             "relay_statuses": statuses,
@@ -883,7 +883,13 @@ def run(args: argparse.Namespace) -> int:
             payload.update(extra)
         return payload
 
-    def emit_status_event(*, registered: bool, active_relay_url: str, current_last_error: Optional[str]) -> None:
+    def emit_status_event(
+        *,
+        registered: bool,
+        active_relay_url: str,
+        current_last_error: Optional[str],
+        relay_runtime_state: Optional[str] = None,
+    ) -> None:
         emit_operator_event(
             build_status_payload(
                 event_type="status",
@@ -891,6 +897,11 @@ def run(args: argparse.Namespace) -> int:
                 registered=registered,
                 active_relay_url=active_relay_url,
                 current_last_error=current_last_error,
+                extra=(
+                    {"relay_runtime_state": relay_runtime_state}
+                    if relay_runtime_state is not None
+                    else None
+                ),
             )
         )
 
@@ -1418,9 +1429,38 @@ def run(args: argparse.Namespace) -> int:
                 )
                 try:
                     with inference_lock:
-                        processed = relay_runtime.process_relay_request(relay_response)
+                        process_result = getattr(
+                            relay_runtime, "process_relay_request_result", None
+                        )
+                        if callable(process_result):
+                            processed = process_result(relay_response)
+                        else:
+                            submitted = bool(relay_runtime.process_relay_request(relay_response))
+                            processed = type(
+                                "LegacyRelayProcessingResult",
+                                (),
+                                {
+                                    "inference_succeeded": submitted,
+                                    "envelope_submitted": submitted,
+                                    "safe_error_code": None,
+                                    "runtime_remains_healthy": True,
+                                    "runtime_recovery_attempted": False,
+                                    "runtime_recovery_succeeded": False,
+                                },
+                            )()
                 except Exception as exc:
-                    processed = False
+                    processed = type(
+                        "RelayProcessingExceptionResult",
+                        (),
+                        {
+                            "inference_succeeded": False,
+                            "envelope_submitted": False,
+                            "safe_error_code": "compute_node_internal_error",
+                            "runtime_remains_healthy": True,
+                            "runtime_recovery_attempted": False,
+                            "runtime_recovery_succeeded": False,
+                        },
+                    )()
                     relay_last_error = "failed to process relay request"
                     last_error = relay_last_error
                     print(
@@ -1429,22 +1469,42 @@ def run(args: argparse.Namespace) -> int:
                         f"exc_type={type(exc).__name__}",
                         file=sys.stderr,
                     )
-                if not processed:
+                inference_succeeded = bool(getattr(processed, "inference_succeeded", bool(processed)))
+                envelope_submitted = bool(getattr(processed, "envelope_submitted", bool(processed)))
+                runtime_healthy = bool(getattr(processed, "runtime_remains_healthy", inference_succeeded))
+                safe_error_code = getattr(processed, "safe_error_code", None)
+                if not inference_succeeded:
                     relay_last_error = "failed to process relay request"
+                    if isinstance(safe_error_code, str) and safe_error_code:
+                        relay_last_error = f"failed to process relay request: {safe_error_code}"
                     last_error = relay_last_error
                     print(
                         "desktop.compute_node_bridge.process_request.failed "
-                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                        f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                        f"error_code={safe_error_code or 'unknown'} envelope_submitted={envelope_submitted} "
+                        f"runtime_healthy={runtime_healthy}",
                         file=sys.stderr,
                     )
-                    submit_api_v1_error_response(
-                        relay_response,
-                        code="compute_node_process_failed",
-                        message=last_error,
-                        active_relay_url=active_relay_url,
-                        request_id=request_id,
-                        relay_runtime=relay_runtime,
-                    )
+                    if envelope_submitted:
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.error_envelope_submitted "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                            f"code={safe_error_code or 'unknown'}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        submit_api_v1_error_response(
+                            relay_response,
+                            code="compute_node_process_failed",
+                            message=last_error,
+                            active_relay_url=active_relay_url,
+                            request_id=request_id,
+                            relay_runtime=relay_runtime,
+                        )
+                    if not runtime_healthy:
+                        relay_state = "failed"
+                        registered = False
+                        poll_failure_fatal = True
                 else:
                     last_error = None
                     print(
@@ -1452,6 +1512,9 @@ def run(args: argparse.Namespace) -> int:
                         f"relay={_sanitize_relay_target(active_relay_url)} "
                         f"request_id={request_id}",
                         file=sys.stderr,
+                    )
+                    relay_state = _relay_runtime_state(
+                        warm_load_state, running=True, warm_load_enabled=warm_load_enabled
                     )
                 wait_seconds = 0.0
                 print(
@@ -1480,6 +1543,7 @@ def run(args: argparse.Namespace) -> int:
                 registered=registered,
                 active_relay_url=active_relay_url,
                 current_last_error=last_error,
+                relay_runtime_state=relay_state,
             )
             if _sleep_with_cancel(wait_seconds):
                 print(
@@ -1554,6 +1618,7 @@ def run(args: argparse.Namespace) -> int:
             registered=False,
             active_relay_url=runtime.relay_client.relay_url,
             current_last_error=last_error,
+            extra={"relay_runtime_state": "failed"} if poll_failure_fatal else None,
         )
     )
     return 1 if warm_load_fatal or poll_failure_fatal else 0

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from utils.compute_node_runtime import RelayProcessingResult
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[2]
@@ -2805,6 +2806,76 @@ def test_run_reports_api_v1_processing_failure(capsys, monkeypatch):
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     status_events = [event for event in events if event.get("type") == "status"]
     assert status_events[-1]["last_error"] == "failed to process relay request"
+
+
+def test_run_api_v1_error_envelope_is_not_success_response(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class ApiV1ErrorEnvelopeRuntime(ApiV1Runtime):
+        def process_relay_request_result(self, payload):
+            self._processed.append(payload)
+            return RelayProcessingResult.submitted_error(
+                safe_error_code="compute_node_internal_error",
+                runtime_remains_healthy=True,
+                runtime_recovery_attempted=True,
+                runtime_recovery_succeeded=True,
+                request_id=payload["request_id"],
+                relay_url="https://token.place",
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1ErrorEnvelopeRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: bool(ApiV1ErrorEnvelopeRuntime.last_instance._processed),
+    )
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 0
+    output = capsys.readouterr()
+    assert "desktop.compute_node_bridge.api_v1_e2ee.error_envelope_submitted" in output.err
+    assert "desktop.compute_node_bridge.api_v1_e2ee.response_submitted" not in output.err
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get("type") == "status"]
+    assert status_events[-1]["last_error"] == (
+        "failed to process relay request: compute_node_internal_error"
+    )
+
+
+def test_run_api_v1_unhealthy_result_is_not_ready_or_registered(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class ApiV1FatalRuntime(ApiV1Runtime):
+        def process_relay_request_result(self, payload):
+            self._processed.append(payload)
+            return RelayProcessingResult.submitted_error(
+                safe_error_code="compute_node_internal_error",
+                runtime_remains_healthy=False,
+                runtime_recovery_attempted=True,
+                runtime_recovery_succeeded=False,
+                request_id=payload["request_id"],
+                relay_url="https://token.place",
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ApiV1FatalRuntime)
+    monkeypatch.setenv("TOKENPLACE_DESKTOP_WARM_LOAD", "0")
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'stop_requested',
+        lambda: bool(ApiV1FatalRuntime.last_instance._processed),
+    )
+    args = SimpleNamespace(model='/tmp/model.gguf', mode='cpu', relay_url='https://token.place', relay_port=None)
+
+    status = compute_node_bridge.run(args)
+
+    assert status == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get("type") == "status"]
+    assert status_events[-1]["registered"] is False
+    assert status_events[-1]["relay_runtime_state"] == "failed"
 
 
 def test_run_logs_api_v1_processing_exception_type(capsys, monkeypatch):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2073,6 +2073,11 @@ class TestRelayClient:
         mock_post.return_value = source_response
 
         assert relay_client.process_client_request(request_data) is True
+        result = relay_client.process_client_request_result(request_data)
+        assert result.inference_succeeded is False
+        assert result.envelope_submitted is True
+        assert result.safe_error_code == "compute_node_invalid_request"
+        assert bool(result) is True
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
@@ -2173,6 +2178,11 @@ class TestRelayClient:
         mock_post.return_value = source_response
 
         assert relay_client.process_client_request(request_data) is True
+        result = relay_client.process_client_request_result(request_data)
+        assert result.inference_succeeded is False
+        assert result.envelope_submitted is True
+        assert result.safe_error_code == "compute_node_internal_error"
+        assert bool(result) is True
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         assert encrypted_envelope["api_v1_response"]["error"]["code"] == (

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -51,6 +51,86 @@ class ComputeNodeRuntimeConfig:
     relay_urls: Tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class RelayProcessingResult:
+    """Typed outcome for a relay work item.
+
+    ``bool(result)`` intentionally preserves the legacy submission-oriented
+    semantics used by older poll loops: it is true only when an encrypted
+    response or safe error envelope was submitted to the relay. Callers that
+    need to know whether model inference actually succeeded must inspect
+    ``inference_succeeded`` instead.
+    """
+
+    inference_succeeded: bool
+    envelope_submitted: bool
+    safe_error_code: Optional[str] = None
+    runtime_remains_healthy: bool = True
+    runtime_recovery_attempted: bool = False
+    runtime_recovery_succeeded: bool = False
+    request_id: Optional[str] = None
+    relay_url: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        return self.envelope_submitted
+
+    @classmethod
+    def submitted_success(
+        cls, *, request_id: Optional[str] = None, relay_url: Optional[str] = None
+    ) -> "RelayProcessingResult":
+        return cls(
+            inference_succeeded=True,
+            envelope_submitted=True,
+            runtime_remains_healthy=True,
+            request_id=request_id,
+            relay_url=relay_url,
+        )
+
+    @classmethod
+    def submitted_error(
+        cls,
+        *,
+        safe_error_code: str,
+        runtime_remains_healthy: bool,
+        runtime_recovery_attempted: bool = False,
+        runtime_recovery_succeeded: bool = False,
+        request_id: Optional[str] = None,
+        relay_url: Optional[str] = None,
+    ) -> "RelayProcessingResult":
+        return cls(
+            inference_succeeded=False,
+            envelope_submitted=True,
+            safe_error_code=safe_error_code,
+            runtime_remains_healthy=runtime_remains_healthy,
+            runtime_recovery_attempted=runtime_recovery_attempted,
+            runtime_recovery_succeeded=runtime_recovery_succeeded,
+            request_id=request_id,
+            relay_url=relay_url,
+        )
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        safe_error_code: Optional[str] = None,
+        runtime_remains_healthy: bool = False,
+        runtime_recovery_attempted: bool = False,
+        runtime_recovery_succeeded: bool = False,
+        request_id: Optional[str] = None,
+        relay_url: Optional[str] = None,
+    ) -> "RelayProcessingResult":
+        return cls(
+            inference_succeeded=False,
+            envelope_submitted=False,
+            safe_error_code=safe_error_code,
+            runtime_remains_healthy=runtime_remains_healthy,
+            runtime_recovery_attempted=runtime_recovery_attempted,
+            runtime_recovery_succeeded=runtime_recovery_succeeded,
+            request_id=request_id,
+            relay_url=relay_url,
+        )
+
+
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
 
 
@@ -87,8 +167,11 @@ class RelayRequestAdapter(Protocol):
     def can_process(self, request_data: Dict[str, Any]) -> bool:
         """Return True when the adapter can process ``request_data``."""
 
+    def process_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        """Process ``request_data`` and return a typed outcome."""
+
     def process(self, request_data: Dict[str, Any]) -> bool:
-        """Process ``request_data`` and return success."""
+        """Process ``request_data`` and return envelope-submission success."""
 
 
 class LegacyRelayRequestAdapter:
@@ -100,8 +183,23 @@ class LegacyRelayRequestAdapter:
     def can_process(self, request_data: Dict[str, Any]) -> bool:
         return is_legacy_relay_payload(request_data)
 
+    def process_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        process_result = (
+            getattr(self._relay_client, "process_client_request_result", None)
+            if hasattr(type(self._relay_client), "process_client_request_result")
+            else None
+        )
+        if callable(process_result):
+            return process_result(request_data)
+        submitted = bool(self._relay_client.process_client_request(request_data))
+        return RelayProcessingResult(
+            inference_succeeded=submitted,
+            envelope_submitted=submitted,
+            runtime_remains_healthy=submitted,
+        )
+
     def process(self, request_data: Dict[str, Any]) -> bool:
-        return self._relay_client.process_client_request(request_data)
+        return bool(self.process_result(request_data))
 
 
 class ApiV1RelayRequestAdapter:
@@ -113,8 +211,24 @@ class ApiV1RelayRequestAdapter:
     def can_process(self, request_data: Dict[str, Any]) -> bool:
         return is_api_v1_relay_payload(request_data)
 
+    def process_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
+        process_result = (
+            getattr(self._relay_client, "process_client_request_result", None)
+            if hasattr(type(self._relay_client), "process_client_request_result")
+            else None
+        )
+        if callable(process_result):
+            return process_result(request_data)
+        submitted = bool(self._relay_client.process_client_request(request_data))
+        return RelayProcessingResult(
+            inference_succeeded=submitted,
+            envelope_submitted=submitted,
+            runtime_remains_healthy=submitted,
+            request_id=request_data.get("request_id"),
+        )
+
     def process(self, request_data: Dict[str, Any]) -> bool:
-        return self._relay_client.process_client_request(request_data)
+        return bool(self.process_result(request_data))
 
 
 def first_env(keys: List[str]) -> Optional[str]:
@@ -395,17 +509,27 @@ class ComputeNodeRuntime:
         _log_info(f"Started relay polling thread for {relay_target}")
         return relay_thread
 
-    def process_relay_request(self, request_data: Dict[str, Any]) -> bool:
+    def process_relay_request_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
         """Process relay payloads via registered protocol adapters."""
 
         for adapter in self.request_adapters:
             if adapter.can_process(request_data):
-                return adapter.process(request_data)
+                return adapter.process_result(request_data)
 
         _log_error(
             f"No relay request adapter matched payload keys: {sorted(request_data.keys())}"
         )
-        return False
+        return RelayProcessingResult.failed(
+            safe_error_code="compute_node_invalid_request",
+            runtime_remains_healthy=True,
+            request_id=request_data.get("request_id"),
+            relay_url=self.config.relay_url,
+        )
+
+    def process_relay_request(self, request_data: Dict[str, Any]) -> bool:
+        """Process relay payloads and return encrypted-envelope submission success."""
+
+        return bool(self.process_relay_request_result(request_data))
 
     def start_relay_session(self) -> None:
         """Reset relay-client stop state before a fresh operator session polls."""

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
 from utils.networking.http_requests_compat import requests
+from utils.compute_node_runtime import RelayProcessingResult
 
 # Configure logging
 logger = logging.getLogger('relay_client')
@@ -1609,6 +1610,34 @@ class RelayClient:
             )
             return False
 
+    def _api_v1_runtime_health_after_result(self, safe_error_code: Optional[str]) -> bool:
+        """Return a privacy-safe runtime health verdict after an API v1 result."""
+
+        health_probe = getattr(self.model_manager, "api_v1_runtime_is_healthy", None)
+        if callable(health_probe):
+            try:
+                return bool(health_probe())
+            except Exception:
+                log_error("API v1 runtime health probe failed", exc_info=True)
+                return False
+        if safe_error_code in {
+            "compute_node_invalid_request",
+            "compute_node_options_unsupported",
+            "compute_node_model_unsupported",
+        }:
+            return True
+        return safe_error_code != "compute_node_internal_error"
+
+    def _api_v1_response_error_code(self, response_envelope: Dict[str, Any]) -> Optional[str]:
+        api_v1_response = response_envelope.get("api_v1_response")
+        if not isinstance(api_v1_response, dict):
+            return None
+        error = api_v1_response.get("error")
+        if not isinstance(error, dict):
+            return None
+        code = error.get("code")
+        return code if isinstance(code, str) and code else "compute_node_internal_error"
+
 
     def submit_api_v1_error_response(
         self,
@@ -2281,7 +2310,7 @@ class RelayClient:
                 },
             )
 
-    def process_client_request(self, request_data: Dict[str, Any]) -> bool:
+    def process_client_request_result(self, request_data: Dict[str, Any]) -> RelayProcessingResult:
         """
         Process a client request from the relay.
 
@@ -2289,32 +2318,55 @@ class RelayClient:
             request_data: Data received from the relay containing the encrypted client request
 
         Returns:
-            bool: True if processing succeeded, False otherwise
+            RelayProcessingResult: typed result separating inference success from
+            encrypted response/error envelope submission success.
         """
+        request_id = request_data.get("request_id") if isinstance(request_data, dict) else None
+        relay_url = self._api_v1_response_relay_url()
         try:
             try:
                 _validate_with_fallback(request_data, MESSAGE_SCHEMA)
             except ValueError as e:
                 log_error("Invalid request data format: {}", str(e))
-                return False
+                return RelayProcessingResult.failed(
+                    safe_error_code="compute_node_invalid_request",
+                    runtime_remains_healthy=True,
+                    request_id=request_id,
+                    relay_url=relay_url,
+                )
 
             client_pub_key_b64 = _normalize_client_public_key_b64(request_data['client_public_key'])
             if client_pub_key_b64 is None:
                 log_error("Invalid client_public_key format in relay request metadata")
-                return False
+                return RelayProcessingResult.failed(
+                    safe_error_code="compute_node_invalid_request",
+                    runtime_remains_healthy=True,
+                    request_id=request_id,
+                    relay_url=relay_url,
+                )
             stream_requested = request_data.get('stream') is True
             stream_session_id = request_data.get('stream_session_id')
             try:
                 client_pub_key = base64.b64decode(client_pub_key_b64, validate=True)
             except (AttributeError, binascii.Error, ValueError):
                 log_error("Invalid client_public_key encoding in relay request metadata")
-                return False
+                return RelayProcessingResult.failed(
+                    safe_error_code="compute_node_invalid_request",
+                    runtime_remains_healthy=True,
+                    request_id=request_id,
+                    relay_url=relay_url,
+                )
 
             log_info("Decrypting client request...")
             decrypted_chat_history = self.crypto_manager.decrypt_message(request_data)
             if decrypted_chat_history is None:
                 log_info("Decryption failed. Skipping.")
-                return False
+                return RelayProcessingResult.failed(
+                    safe_error_code="compute_node_invalid_request",
+                    runtime_remains_healthy=True,
+                    request_id=request_id,
+                    relay_url=relay_url,
+                )
 
             log_info("Decrypted client request")
             api_v1_request_payload = _extract_api_v1_request_payload(
@@ -2328,10 +2380,37 @@ class RelayClient:
                     messages=api_v1_request_payload["messages"],
                     options=dict(api_v1_request_payload["options"]),
                 )
-                return self._post_api_v1_response(
+                safe_error_code = self._api_v1_response_error_code(response_envelope)
+                submitted = self._post_api_v1_response(
                     response_envelope,
                     client_pub_key_b64=client_pub_key_b64,
                     client_pub_key=client_pub_key,
+                )
+                if safe_error_code is None:
+                    return RelayProcessingResult(
+                        inference_succeeded=submitted,
+                        envelope_submitted=submitted,
+                        runtime_remains_healthy=True,
+                        request_id=api_v1_request_payload["request_id"],
+                        relay_url=relay_url,
+                    )
+                runtime_healthy = self._api_v1_runtime_health_after_result(safe_error_code)
+                if submitted:
+                    return RelayProcessingResult.submitted_error(
+                        safe_error_code=safe_error_code,
+                        runtime_remains_healthy=runtime_healthy,
+                        runtime_recovery_attempted=safe_error_code == "compute_node_internal_error",
+                        runtime_recovery_succeeded=runtime_healthy,
+                        request_id=api_v1_request_payload["request_id"],
+                        relay_url=relay_url,
+                    )
+                return RelayProcessingResult.failed(
+                    safe_error_code=safe_error_code,
+                    runtime_remains_healthy=runtime_healthy,
+                    runtime_recovery_attempted=safe_error_code == "compute_node_internal_error",
+                    runtime_recovery_succeeded=runtime_healthy,
+                    request_id=api_v1_request_payload["request_id"],
+                    relay_url=relay_url,
                 )
 
             chat_history = _extract_chat_history_and_validate_key_binding(
@@ -2339,7 +2418,12 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if chat_history is None:
-                return False
+                return RelayProcessingResult.failed(
+                    safe_error_code="compute_node_invalid_request",
+                    runtime_remains_healthy=True,
+                    request_id=request_id,
+                    relay_url=relay_url,
+                )
 
             if stream_requested and isinstance(stream_session_id, str) and stream_session_id.strip():
                 log_info("Processing streaming relay request for session {}", stream_session_id)
@@ -2370,8 +2454,8 @@ class RelayClient:
                 )
                 if stream_response.status_code != 200:
                     log_error("Error status from /stream/source: {}", stream_response.status_code)
-                    return False
-                return True
+                    return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
+                return RelayProcessingResult.submitted_success(request_id=request_id, relay_url=relay_url)
 
             log_info("Getting response from LLM...")
             response_history = self.model_manager.llama_cpp_get_response(chat_history)
@@ -2392,7 +2476,7 @@ class RelayClient:
                 _validate_with_fallback(source_payload, MESSAGE_SCHEMA)
             except ValueError as e:
                 log_error("Invalid response payload format: {}", str(e))
-                return False
+                return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
 
             log_info("Posting response to {}/source. Payload keys: {}", self.relay_url, list(source_payload.keys()))
 
@@ -2419,27 +2503,37 @@ class RelayClient:
 
             if source_response.status_code != 200:
                 log_error("Error status from /source: {}", source_response.status_code)
-                return False
+                return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
 
             response_content = source_response.text.strip()
             if not response_content:
                 log_error("Empty response from /source")
-                return False
+                return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
 
-            return True
+            return RelayProcessingResult.submitted_success(request_id=request_id, relay_url=relay_url)
 
         except requests.ConnectionError as e:
             log_error("Connection error when posting to relay source endpoint: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
         except requests.Timeout as e:
             log_error("Request timeout when posting to relay source endpoint: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
         except requests.RequestException as e:
             log_error("Request exception when posting to relay source endpoint: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.failed(request_id=request_id, relay_url=relay_url)
         except Exception as e:
             log_error("Exception during request processing: {}", str(e), exc_info=True)
-            return False
+            return RelayProcessingResult.failed(
+                safe_error_code="compute_node_internal_error",
+                runtime_remains_healthy=False,
+                request_id=request_id,
+                relay_url=relay_url,
+            )
+
+    def process_client_request(self, request_data: Dict[str, Any]) -> bool:
+        """Process a relay request and return encrypted-envelope submission success."""
+
+        return bool(self.process_client_request_result(request_data))
 
     def process_api_v1_chat_request(self, request_data: Dict[str, Any]) -> bool:
         """Relay API v1 plaintext dispatch is disabled pending an E2EE-compatible design."""


### PR DESCRIPTION
### Motivation
- Prevent treating successful delivery of an encrypted error envelope as successful model inference and stop the UI from returning to `ready` when the shared runtime is unhealthy. 
- Provide a typed, immutable processing-result contract so callers can distinguish inference success, envelope submission, safe error codes, and runtime health/recovery attempts. 
- Preserve relay-blind E2EE invariants by keeping relay-owned state ciphertext-only and avoid exposing plaintext in results or logs.

### Description
- Add an immutable `RelayProcessingResult` dataclass with fields for `inference_succeeded`, `envelope_submitted`, `safe_error_code`, `runtime_remains_healthy`, `runtime_recovery_attempted`, `runtime_recovery_succeeded`, `request_id`, and `relay_url` and a `__bool__` that preserves legacy envelope-submission semantics (truthy when envelope submitted). (utils/compute_node_runtime.py)
- Thread typed outcomes through adapters and runtime: added `process_result`/`process_relay_request_result` APIs and preserved compatibility `process`/`process_relay_request` boolean wrappers so older callers keep expected semantics. (utils/compute_node_runtime.py)
- Replace boolean-only relay processing in the RelayClient with `process_client_request_result` that returns `RelayProcessingResult`, classifies API v1 response envelopes (extracting safe error codes), and performs a privacy-safe runtime-health judgement. Backwards-compatible `process_client_request` still returns envelope-submission success. (utils/networking/relay_client.py)
- Update desktop bridge to consume typed results: emit `response_submitted` only for real assistant output, emit `api_v1_e2ee.error_envelope_submitted` for encrypted error envelopes, retain `last_error` when inference failed, avoid clearing error on successful envelope post, and transition status to `recovering/failed` when runtime is reported unhealthy. Also wire `relay_runtime_state` into status events. (desktop-tauri/src-tauri/python/compute_node_bridge.py)
- Add unit regression tests to assert error envelopes do not count as inference success, that the bridge does not emit successful-response markers for error envelopes, and that unhealthy runtime outcomes prevent `registered/ready` status. (tests/unit/test_relay_client.py, tests/unit/test_desktop_compute_node_bridge.py)

### Testing
- Ran targeted unit suites and bridge checks: `python -m pytest -q tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py` — passed. 
- Ran desktop bridge focused tests: `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py -k "process or error or status or ready or registered"` — passed.
- Ran integration E2EE round-trip: `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — passed.
- Ran repo checks: `pre-commit run --all-files` — passed.
- Notes: the change preserves legacy boolean return compatibility (the boolean value indicates whether an encrypted envelope was submitted), while callers needing more detail can inspect `RelayProcessingResult` fields; no plaintext is added to result objects, events, or logs, and relay-owned state remains ciphertext-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376210dad0832f8dcfe95de49186a1)