### PR TITLE
Coordinate desktop shared runtime recovery

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -762,6 +762,34 @@ def run(args: argparse.Namespace) -> int:
     }
     inference_lock = threading.Lock()
     poll_failure_fatal = False
+    recovery_lock = threading.Lock()
+    recovery_done = threading.Event()
+    recovery_done.set()
+    recovery_active = False
+    recovery_started_count = 0
+    recovery_exhausted = False
+
+    def _bounded_env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
+        raw_value = os.environ.get(name)
+        if raw_value is None:
+            return default
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            return default
+        if not math.isfinite(value) or value < minimum:
+            return default
+        return value
+
+    def _bounded_env_int(name: str, default: int, *, minimum: int = 1) -> int:
+        raw_value = os.environ.get(name)
+        if raw_value is None:
+            return default
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return default
+        return max(value, minimum)
 
     def update_relay_status(relay_url_value: str, **updates: Any) -> None:
         with relay_status_lock:
@@ -893,6 +921,61 @@ def run(args: argparse.Namespace) -> int:
                 current_last_error=current_last_error,
             )
         )
+
+    def mark_all_relays_recovering(error_message: Optional[str]) -> None:
+        for relay_url_value in configured_relay_urls:
+            update_relay_status(
+                relay_url_value,
+                registered=False,
+                relay_runtime_state="recovering",
+                last_error=error_message,
+            )
+
+    def mark_all_relay_clients_unregistered() -> None:
+        for relay_runtime in runtimes:
+            relay_client = getattr(relay_runtime, "relay_client", None)
+            registered_relays = getattr(relay_client, "_api_v1_registered_relays", None)
+            if isinstance(registered_relays, set):
+                registered_relays.clear()
+
+    def unregister_all_relays(reason: str) -> None:
+        mark_all_relay_clients_unregistered()
+        for relay_runtime in runtimes:
+            relay_client = getattr(relay_runtime, "relay_client", None)
+            active_url = getattr(relay_client, "relay_url", "unknown")
+            unregister = getattr(relay_client, "unregister_from_relay", None)
+            if callable(unregister):
+                try:
+                    unregister()
+                except Exception as exc:
+                    print(
+                        "desktop.compute_node_bridge.recovery.unregister_failed "
+                        f"reason={reason} relay={_sanitize_relay_target(active_url)} "
+                        f"exc_type={type(exc).__name__}",
+                        file=sys.stderr,
+                    )
+            stop_relay = getattr(relay_client, "stop", None)
+            if callable(stop_relay):
+                try:
+                    stop_relay()
+                except Exception as exc:
+                    print(
+                        "desktop.compute_node_bridge.recovery.relay_stop_failed "
+                        f"reason={reason} relay={_sanitize_relay_target(active_url)} "
+                        f"exc_type={type(exc).__name__}",
+                        file=sys.stderr,
+                    )
+
+    def restart_all_relay_sessions() -> None:
+        for relay_runtime in runtimes:
+            start_relay_session = getattr(relay_runtime, "start_relay_session", None)
+            relay_client = getattr(relay_runtime, "relay_client", None)
+            if callable(start_relay_session):
+                start_relay_session()
+            else:
+                relay_start = getattr(relay_client, "start", None)
+                if callable(relay_start):
+                    relay_start()
 
     def submit_api_v1_error_response(
         relay_response: Dict[str, Any],
@@ -1039,6 +1122,153 @@ def run(args: argparse.Namespace) -> int:
             )
         print(_runtime_diagnostics_summary(compute_mode_diagnostics(runtime.model_manager)), file=sys.stderr)
         return True
+
+    def coordinate_shared_recovery(*, active_relay_url: str, request_id: str, cause: str) -> bool:
+        nonlocal warm_load_state, warm_load_failed, last_error, recovery_active
+        nonlocal recovery_started_count, recovery_exhausted, warm_load_duration_ms
+        with recovery_lock:
+            if recovery_active:
+                local_done = recovery_done
+                leader = False
+            elif recovery_exhausted:
+                return False
+            else:
+                recovery_active = True
+                recovery_started_count += 1
+                recovery_done.clear()
+                local_done = recovery_done
+                leader = True
+        if not leader:
+            while not local_done.wait(timeout=0.05):
+                if stop_requested():
+                    return False
+            return warm_load_state == "ready" and not recovery_exhausted
+
+        recovery_message = "shared model runtime recovery in progress"
+        last_error = recovery_message
+        warm_load_state = "recovering"
+        warm_load_failed = None
+        mark_all_relays_recovering(recovery_message)
+        emit_operator_event(
+            build_status_payload(
+                event_type="status",
+                running=True,
+                registered=False,
+                active_relay_url=active_relay_url,
+                current_last_error=last_error,
+                extra={"relay_runtime_state": "recovering"},
+            )
+        )
+        print(
+            "desktop.compute_node_bridge.recovery.start "
+            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+            f"cause={cause} coordinator_count={recovery_started_count}",
+            file=sys.stderr,
+        )
+        unregister_all_relays("shared_runtime_recovery")
+
+        attempts = _bounded_env_int("TOKENPLACE_DESKTOP_RECOVERY_MAX_ATTEMPTS", 3)
+        backoff = _bounded_env_float("TOKENPLACE_DESKTOP_RECOVERY_BACKOFF_SECONDS", 0.2)
+        success = False
+        terminal_error = "shared model runtime recovery attempts exhausted"
+        try:
+            for attempt in range(1, attempts + 1):
+                if stop_requested():
+                    terminal_error = "shared model runtime recovery cancelled"
+                    break
+                warm_load_started_at_local = time.perf_counter()
+                print(
+                    "desktop.compute_node_bridge.recovery.attempt "
+                    f"attempt={attempt} max_attempts={attempts} "
+                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                    file=sys.stderr,
+                )
+                try:
+                    ready = bool(runtime.ensure_api_v1_runtime_ready())
+                except Exception as exc:
+                    ready = False
+                    terminal_error = "shared model runtime recovery failed"
+                    print(
+                        "desktop.compute_node_bridge.recovery.attempt_failed "
+                        f"attempt={attempt} exc_type={type(exc).__name__}",
+                        file=sys.stderr,
+                    )
+                else:
+                    if not ready:
+                        terminal_error = "shared model runtime recovery failed runtime readiness check"
+                warm_load_duration_ms = int((time.perf_counter() - warm_load_started_at_local) * 1000)
+                if ready:
+                    success = True
+                    break
+                if attempt < attempts:
+                    deadline = time.monotonic() + backoff
+                    while time.monotonic() < deadline:
+                        if stop_requested():
+                            terminal_error = "shared model runtime recovery cancelled"
+                            break
+                        time.sleep(min(0.02, max(0.0, deadline - time.monotonic())))
+                    if stop_requested():
+                        break
+            if success:
+                warm_load_state = "ready"
+                last_error = None
+                restart_all_relay_sessions()
+                for relay_url_value in configured_relay_urls:
+                    update_relay_status(
+                        relay_url_value,
+                        registered=False,
+                        relay_runtime_state="ready",
+                        last_error=None,
+                    )
+                print(
+                    "desktop.compute_node_bridge.recovery.succeeded "
+                    f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                    file=sys.stderr,
+                )
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=None,
+                )
+                return True
+            if stop_requested():
+                warm_load_state = "recovering"
+                last_error = terminal_error
+                mark_all_relays_recovering(last_error)
+                return False
+            recovery_exhausted = True
+            warm_load_state = "failed"
+            warm_load_failed = terminal_error
+            last_error = terminal_error
+            for relay_url_value in configured_relay_urls:
+                update_relay_status(
+                    relay_url_value,
+                    registered=False,
+                    relay_runtime_state="failed",
+                    last_error=terminal_error,
+                )
+            mark_all_relay_clients_unregistered()
+            print(
+                "desktop.compute_node_bridge.recovery.exhausted "
+                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                "action=bridge_exit_nonzero",
+                file=sys.stderr,
+            )
+            emit_operator_event(
+                build_status_payload(
+                    event_type="error",
+                    running=False,
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                    extra={"relay_runtime_state": "failed", "message": terminal_error},
+                )
+            )
+            return False
+        finally:
+            with recovery_lock:
+                recovery_active = False
+                recovery_done.set()
 
     def fail_on_warm_load_error(*, active_relay_url: str) -> None:
         nonlocal last_error, warm_load_fatal
@@ -1278,6 +1508,22 @@ def run(args: argparse.Namespace) -> int:
                     current_last_error=last_error,
                 )
                 break
+            if warm_load_state == "recovering":
+                update_relay_status(
+                    active_relay_url,
+                    registered=False,
+                    relay_runtime_state="recovering",
+                    last_error=last_error,
+                )
+                emit_status_event(
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                )
+                while warm_load_state == "recovering" and not stop_requested():
+                    if recovery_done.wait(timeout=0.05):
+                        break
+                continue
             print(
                 "desktop.compute_node_bridge.api_v1_e2ee.register "
                 f"operator_session_id={bridge_session_id} "
@@ -1519,6 +1765,13 @@ def run(args: argparse.Namespace) -> int:
                             f"request_id={request_id} safe_error_code={safe_error_code or 'unknown'}",
                             file=sys.stderr,
                         )
+                    elif recovery_attempted:
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.error_response.skipped "
+                            f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                            "reason=runtime_recovery_triggered",
+                            file=sys.stderr,
+                        )
                     else:
                         submit_api_v1_error_response(
                             relay_response,
@@ -1530,28 +1783,24 @@ def run(args: argparse.Namespace) -> int:
                         )
                     if not runtime_healthy:
                         registered = False
+                        recovered = False
                         if recovery_attempted and not recovery_succeeded:
                             relay_state = "recovering"
-                            warm_load_state = "recovering"
-                            update_relay_status(
-                                active_relay_url,
-                                registered=False,
-                                relay_runtime_state="recovering",
-                                last_error=relay_last_error,
-                                last_request_id=request_id if request_id != "none" else None,
+                            recovered = coordinate_shared_recovery(
+                                active_relay_url=active_relay_url,
+                                request_id=request_id,
+                                cause=str(safe_error_code or "runtime_unhealthy"),
                             )
-                            emit_operator_event(
-                                build_status_payload(
-                                    event_type="status",
-                                    running=True,
-                                    registered=False,
-                                    active_relay_url=active_relay_url,
-                                    current_last_error=last_error,
-                                    extra={"relay_runtime_state": "recovering"},
-                                )
-                            )
-                        relay_state = "failed"
-                        warm_load_state = "failed"
+                        if recovered:
+                            relay_state = "ready"
+                            warm_load_state = "ready"
+                            relay_last_error = None
+                            last_error = None
+                        elif warm_load_state == "recovering":
+                            relay_state = "recovering"
+                        else:
+                            relay_state = "failed"
+                            warm_load_state = "failed"
                 else:
                     last_error = None
                     print(
@@ -1664,7 +1913,7 @@ def run(args: argparse.Namespace) -> int:
             current_last_error=last_error,
         )
     )
-    return 1 if warm_load_fatal or poll_failure_fatal else 0
+    return 1 if warm_load_fatal or poll_failure_fatal or recovery_exhausted else 0
 
 
 def main() -> int:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3682,3 +3682,220 @@ def test_run_error_envelope_submission_is_not_success_marker(capsys, monkeypatch
     assert status_events[-1]['registered'] is False
     assert status_events[-1]['relay_runtime_state'] == 'failed'
     assert status_events[-1]['last_error'] == 'relay request failed: compute_node_internal_error'
+
+
+def test_run_multi_relay_dead_shared_worker_uses_one_recovery_and_restores_registrations(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class RecoveringManager(FakeModelManager):
+        def __init__(self):
+            super().__init__()
+            self.dead = True
+            self.recovery_ready_calls = 0
+
+    shared_manager = RecoveringManager()
+    shared_crypto = object()
+
+    class RecoveryRelayClient(FakeRelayClient):
+        def __init__(self, relay_url):
+            self.relay_url = relay_url
+            self._api_v1_registered_relays = set()
+            self.unregister_calls = 0
+            self.stop_calls = 0
+            self.start_calls = 0
+
+        def api_v1_registration_fresh(self, relay_url=None):
+            return (relay_url or self.relay_url) in self._api_v1_registered_relays
+
+        def unregister_from_relay(self):
+            self.unregister_calls += 1
+            self._api_v1_registered_relays.clear()
+            return True
+
+        def stop(self):
+            self.stop_calls += 1
+
+        def start(self):
+            self.start_calls += 1
+
+    class SharedRecoveryRuntime(FakeRuntime):
+        instances = []
+
+        def __init__(self, config, **kwargs):
+            self.config = config
+            self.model_manager = kwargs.get('model_manager') or shared_manager
+            self.crypto_manager = kwargs.get('crypto_manager') or shared_crypto
+            self.relay_client = RecoveryRelayClient(config.relay_url)
+            self._processed = []
+            self.polls = 0
+            SharedRecoveryRuntime.instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            self.model_manager.recovery_ready_calls += 1
+            self.model_manager.dead = False
+            return True
+
+        def register_and_poll_once(self):
+            self.polls += 1
+            self.relay_client._api_v1_registered_relays.add(self.config.relay_url)
+            if self.polls == 1:
+                return {
+                    'protocol': 'tokenplace_api_v1_relay_e2ee',
+                    'version': 1,
+                    'request_id': f'req-{self.config.relay_url}',
+                    'client_public_key': 'client-key',
+                    'chat_history': 'ciphertext-secret-prompt',
+                    'cipherkey': 'key',
+                    'iv': 'iv',
+                    'next_ping_in_x_seconds': 0,
+                }
+            return {'next_ping_in_x_seconds': 0, 'error': None}
+
+        def process_relay_request_result(self, payload):
+            self._processed.append(payload)
+            if self.model_manager.dead:
+                return {
+                    'inference_succeeded': False,
+                    'submitted': True,
+                    'safe_error_code': 'compute_node_internal_error',
+                    'runtime_healthy': False,
+                    'recovery_attempted': True,
+                    'recovery_succeeded': False,
+                }
+            return {
+                'inference_succeeded': True,
+                'submitted': True,
+                'runtime_healthy': True,
+                'recovery_attempted': False,
+                'recovery_succeeded': False,
+            }
+
+        def stop(self):
+            self.relay_client.unregister_from_relay()
+
+    SharedRecoveryRuntime.instances = []
+    _install_fake_runtime_module(monkeypatch, runtime_cls=SharedRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_RECOVERY_MAX_ATTEMPTS', '2')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_RECOVERY_BACKOFF_SECONDS', '0.01')
+
+    stop_state = {'count': 0}
+
+    def stop_after_restored():
+        if len(SharedRecoveryRuntime.instances) >= 2 and all(
+            inst.polls >= 2 for inst in SharedRecoveryRuntime.instances
+        ):
+            stop_state['count'] += 1
+            return stop_state['count'] > 3
+        return False
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_restored)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url=['https://token.place', 'https://staging.token.place'],
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 0
+    output = capsys.readouterr()
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    recovering = [event for event in events if event.get('relay_runtime_state') == 'recovering']
+    assert recovering
+    assert any(status['registered'] is False for status in recovering[0]['relay_statuses'])
+    assert all(status['registered'] is False for status in recovering[0]['relay_statuses'])
+    restored = [
+        event for event in events
+        if event.get('registered_relay_count') == 2 and event.get('relay_runtime_state') == 'ready'
+    ]
+    assert restored
+    assert shared_manager.recovery_ready_calls == 1
+    assert output.err.count('desktop.compute_node_bridge.recovery.start') == 1
+    assert 'ciphertext-secret-prompt' not in output.err
+
+
+def test_run_exhausted_shared_recovery_exits_failed_and_unregistered(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class FailingRecoveryRuntime(ApiV1Runtime):
+        instances = []
+
+        def __init__(self, config, **kwargs):
+            super().__init__(config)
+            self.model_manager = kwargs.get('model_manager') or FakeModelManager()
+            self.relay_client.relay_url = config.relay_url
+            self.relay_client._api_v1_registered_relays = {config.relay_url}
+            FailingRecoveryRuntime.instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            return False
+
+        def process_relay_request_result(self, _payload):
+            return {
+                'inference_succeeded': False,
+                'submitted': True,
+                'safe_error_code': 'compute_node_internal_error',
+                'runtime_healthy': False,
+                'recovery_attempted': True,
+                'recovery_succeeded': False,
+            }
+
+    FailingRecoveryRuntime.instances = []
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_RECOVERY_MAX_ATTEMPTS', '1')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url=['https://token.place', 'https://staging.token.place'],
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    error = next(event for event in events if event['type'] == 'error')
+    assert error['relay_runtime_state'] == 'failed'
+    assert error['registered'] is False
+    assert error['registered_relay_count'] == 0
+    assert all(status['registered'] is False for status in error['relay_statuses'])
+
+
+def test_run_network_failure_on_one_relay_does_not_start_shared_recovery(capsys, monkeypatch):
+    _reset_cancel_queue()
+    # Use the existing partial-success scenario as a regression check: relay errors are
+    # transport-local and must not invoke the shared model recovery coordinator.
+    class OneBadRelayRuntime(FakeRuntime):
+        def __init__(self, config, **kwargs):
+            self.config = config
+            self.model_manager = kwargs.get('model_manager') or FakeModelManager()
+            self.crypto_manager = kwargs.get('crypto_manager') or object()
+            self.relay_client = FakeRelayClient()
+            self.relay_client.relay_url = config.relay_url
+            self.relay_client._api_v1_registered_relays = set()
+            self.polls = 0
+
+        def ensure_api_v1_runtime_ready(self):
+            return True
+
+        def register_and_poll_once(self):
+            self.polls += 1
+            if 'staging' in self.config.relay_url:
+                return {'next_ping_in_x_seconds': 0, 'error': 'network timeout'}
+            self.relay_client._api_v1_registered_relays.add(self.config.relay_url)
+            return {'next_ping_in_x_seconds': 0, 'error': None}
+
+        def stop(self):
+            return None
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=OneBadRelayRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    calls = {'n': 0}
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: calls.__setitem__('n', calls['n'] + 1) or calls['n'] > 5)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf', mode='cpu',
+        relay_url=['https://token.place', 'https://staging.token.place'], relay_port=None,
+    )
+    assert compute_node_bridge.run(args) == 0
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.recovery.start' not in output.err


### PR DESCRIPTION
### Motivation
- The desktop bridge runs multiple relay pollers that share a single `model_manager`, so a worker death must be coordinated and treated as shared runtime health instead of letting any relay remain advertised as ready.
- Prevent duplicate warm-loads or simultaneous replacement attempts from multiple pollers and ensure recovery is bounded, testable, and stop/cancel-aware.
- When immediate one-shot replacement fails, the bridge must fail-closed for all relays, attempt bounded and interruptible recovery, and exit visibly if recovery is exhausted.

### Description
- Added a single shared recovery coordinator with `recovery_lock`, `recovery_done` Event, bounded attempts/backoff helpers (`_bounded_env_int`, `_bounded_env_float`), and a `coordinate_shared_recovery` routine that verifies API v1 runtime readiness and transitions warm-load state to `recovering`/`ready`/`failed`.
- Added helpers to mark all relays as recovering, clear local registration eligibility, best-effort unregister/stop advertising to every configured relay (`mark_all_relays_recovering`, `mark_all_relay_clients_unregistered`, `unregister_all_relays`) and to restart relay sessions after recovery (`restart_all_relay_sessions`).
- Integrated coordinator into request-processing so pollers do not submit duplicate plaintext error envelopes for the same recovery-triggering request, and updated poll loop behavior to block registering/processing while shared recovery is active without holding the inference lock.
- Preserved shared crypto identity and single warmed model on success, and on exhausted recovery the bridge emits one privacy-safe actionable error, marks all relays unregistered, and returns non-zero so the process does not remain an indefinitely-registered zombie; unit tests added to exercise multi-relay scenarios.

### Testing
- Ran unit tests for the modified desktop bridge scenarios with `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py -k "recover or multi_relay or registered or stop"`, which passed (16 passed).
- Ran broader unit suites with `python -m pytest -q tests/unit/test_compute_node_runtime.py tests/unit/test_relay_client.py`, which passed (251 passed total across suites).
- Ran integration suite `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py`, which passed (10 passed).
- Ran desktop UI tests with `cd desktop-tauri && npm test`, which passed (37 JS tests passed), and ran `pre-commit run --all-files`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3781a8c618832fa7782b470b00b107)