### PR TITLE
Coordinate shared model runtime recovery

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -79,6 +79,8 @@ WARM_LOAD_DEFAULT = "1"
 RUNTIME_PATH_DEFAULT = "bridge"
 API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
+RECOVERY_ATTEMPTS_DEFAULT = 2
+RECOVERY_BACKOFF_DEFAULT_SECONDS = 0.25
 
 
 def _drain_stale_stdin_cancel_messages() -> int:
@@ -241,6 +243,32 @@ def _api_v1_warm_load_wait_seconds(default: float = API_V1_WARM_LOAD_WAIT_DEFAUL
     """Return bounded API v1 warm-load wait before fail-closed response submission."""
 
     raw_value = os.environ.get("TOKENPLACE_DESKTOP_API_V1_WARM_LOAD_WAIT_SECONDS")
+    if raw_value is None:
+        return default
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(value) or value < 0:
+        return default
+    return value
+
+
+def _api_v1_recovery_attempts(default: int = RECOVERY_ATTEMPTS_DEFAULT) -> int:
+    raw_value = os.environ.get("TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS")
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return default
+    return max(value, 0)
+
+
+def _api_v1_recovery_backoff_seconds(
+    default: float = RECOVERY_BACKOFF_DEFAULT_SECONDS,
+) -> float:
+    raw_value = os.environ.get("TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS")
     if raw_value is None:
         return default
     try:
@@ -1191,6 +1219,10 @@ def run(args: argparse.Namespace) -> int:
     poll_cancel_requested_by_relay: Dict[str, bool] = {}
     registration_succeeded_by_relay: Dict[str, bool] = {}
     poll_threads: List[threading.Thread] = []
+    recovery_lock = threading.Lock()
+    recovery_done = threading.Event()
+    recovery_done.set()
+    recovery_fatal = False
 
     def request_poll_cancel(relay_runtime: Any, active_relay_url: str) -> None:
         if poll_cancel_requested_by_relay.get(active_relay_url):
@@ -1259,12 +1291,227 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
 
+    def mark_all_relays_unregistered(
+        *,
+        relay_runtime_state: str,
+        error: Optional[str],
+        request_id: Optional[str] = None,
+    ) -> None:
+        for relay_runtime in runtimes:
+            relay_url_value = getattr(
+                getattr(relay_runtime, "relay_client", None),
+                "relay_url",
+                relay_url,
+            )
+            update_relay_status(
+                relay_url_value,
+                registered=False,
+                relay_runtime_state=relay_runtime_state,
+                last_error=error,
+                last_request_id=request_id if request_id and request_id != "none" else None,
+            )
+
+    def best_effort_unadvertise_all_relays() -> None:
+        for relay_runtime in runtimes:
+            relay_url_value = getattr(
+                getattr(relay_runtime, "relay_client", None),
+                "relay_url",
+                relay_url,
+            )
+            relay_client = getattr(relay_runtime, "relay_client", None)
+            unregister = getattr(relay_client, "unregister_from_relay", None)
+            if callable(unregister):
+                print(
+                    "desktop.compute_node_bridge.recovery.unregister.attempted "
+                    f"relay={_sanitize_relay_target(relay_url_value)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)}",
+                    file=sys.stderr,
+                )
+                try:
+                    unregistered = bool(unregister())
+                except Exception as exc:
+                    print(
+                        "desktop.compute_node_bridge.recovery.unregister.failed "
+                        f"relay={_sanitize_relay_target(relay_url_value)} "
+                        f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                        f"exc_type={type(exc).__name__}",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        "desktop.compute_node_bridge.recovery.unregister.succeeded "
+                        f"relay={_sanitize_relay_target(relay_url_value)} "
+                        f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                        f"success={unregistered}",
+                        file=sys.stderr,
+                    )
+            else:
+                relay_stop = getattr(relay_client, "stop", None)
+                if callable(relay_stop):
+                    try:
+                        relay_stop()
+                    except Exception as exc:
+                        print(
+                            "desktop.compute_node_bridge.recovery.stop_failed "
+                            f"relay={_sanitize_relay_target(relay_url_value)} "
+                            f"exc_type={type(exc).__name__}",
+                            file=sys.stderr,
+                        )
+
+    def recover_shared_runtime(active_relay_url: str, request_id: str) -> bool:
+        """Coordinate fail-closed recovery for the one shared model_manager."""
+
+        nonlocal warm_load_state, warm_load_failed, last_error, recovery_fatal
+
+        if recovery_lock.acquire(blocking=False):
+            coordinator = True
+            recovery_done.clear()
+        else:
+            coordinator = False
+
+        if not coordinator:
+            print(
+                "desktop.compute_node_bridge.recovery.join_existing "
+                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
+                file=sys.stderr,
+            )
+            while not recovery_done.wait(timeout=0.05):
+                if stop_requested():
+                    return False
+            return warm_load_state == "ready"
+
+        try:
+            attempts = _api_v1_recovery_attempts()
+            backoff_seconds = _api_v1_recovery_backoff_seconds()
+            last_error = "shared model runtime recovery in progress"
+            warm_load_state = "recovering"
+            mark_all_relays_unregistered(
+                relay_runtime_state="recovering",
+                error=last_error,
+                request_id=request_id,
+            )
+            emit_operator_event(
+                build_status_payload(
+                    event_type="status",
+                    running=True,
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                    extra={"relay_runtime_state": "recovering"},
+                )
+            )
+            print(
+                "desktop.compute_node_bridge.recovery.start "
+                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                f"attempts={attempts} backoff_seconds={backoff_seconds:g}",
+                file=sys.stderr,
+            )
+            best_effort_unadvertise_all_relays()
+            for attempt in range(1, attempts + 1):
+                if stop_requested():
+                    print(
+                        "desktop.compute_node_bridge.recovery.cancelled "
+                        f"attempt={attempt} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    return False
+                print(
+                    "desktop.compute_node_bridge.recovery.attempt "
+                    f"attempt={attempt} request_id={request_id}",
+                    file=sys.stderr,
+                )
+                try:
+                    if bool(runtime.ensure_api_v1_runtime_ready()):
+                        warm_load_state = "ready"
+                        warm_load_failed = None
+                        last_error = None
+                        for relay_runtime in runtimes:
+                            relay_start = getattr(relay_runtime, "start_relay_session", None)
+                            if callable(relay_start):
+                                relay_start()
+                            else:
+                                client_start = getattr(
+                                    getattr(relay_runtime, "relay_client", None), "start", None
+                                )
+                                if callable(client_start):
+                                    client_start()
+                        mark_all_relays_unregistered(relay_runtime_state="ready", error=None)
+                        emit_operator_event(
+                            build_status_payload(
+                                event_type="status",
+                                running=True,
+                                registered=False,
+                                active_relay_url=active_relay_url,
+                                current_last_error=None,
+                                extra={"relay_runtime_state": "ready"},
+                            )
+                        )
+                        print(
+                            "desktop.compute_node_bridge.recovery.succeeded "
+                            f"attempt={attempt} request_id={request_id}",
+                            file=sys.stderr,
+                        )
+                        return True
+                except Exception as exc:
+                    print(
+                        "desktop.compute_node_bridge.recovery.attempt_exception "
+                        f"attempt={attempt} request_id={request_id} "
+                        f"exc_type={type(exc).__name__}",
+                        file=sys.stderr,
+                    )
+                if attempt < attempts and _sleep_with_cancel(backoff_seconds):
+                    print(
+                        "desktop.compute_node_bridge.recovery.cancelled_during_backoff "
+                        f"attempt={attempt} request_id={request_id}",
+                        file=sys.stderr,
+                    )
+                    return False
+
+            warm_load_state = "failed"
+            warm_load_failed = "shared model runtime recovery exhausted; restart the desktop compute node"
+            last_error = warm_load_failed
+            recovery_fatal = True
+            mark_all_relays_unregistered(
+                relay_runtime_state="failed",
+                error=last_error,
+                request_id=request_id,
+            )
+            emit_operator_event(
+                build_status_payload(
+                    event_type="error",
+                    running=False,
+                    registered=False,
+                    active_relay_url=active_relay_url,
+                    current_last_error=last_error,
+                    extra={"relay_runtime_state": "failed", "message": last_error},
+                )
+            )
+            print(
+                "desktop.compute_node_bridge.recovery.exhausted "
+                f"request_id={request_id} action=restart_desktop_compute_node",
+                file=sys.stderr,
+            )
+            return False
+        finally:
+            recovery_done.set()
+            recovery_lock.release()
+
     def poll_relay_loop(relay_runtime: Any) -> None:
         nonlocal last_error, poll_failure_fatal, warm_load_state
         active_relay_url = relay_runtime.relay_client.relay_url
         worker = relay_poll_workers[active_relay_url]
         while not stop_requested():
             active_relay_url = relay_runtime.relay_client.relay_url
+            if warm_load_state == "recovering":
+                update_relay_status(
+                    active_relay_url,
+                    registered=False,
+                    relay_runtime_state="recovering",
+                    last_error=last_error,
+                )
+                if recovery_done.wait(timeout=0.05):
+                    continue
+                continue
             if warm_load_state == "failed":
                 update_relay_status(
                     active_relay_url,
@@ -1519,7 +1766,7 @@ def run(args: argparse.Namespace) -> int:
                             f"request_id={request_id} safe_error_code={safe_error_code or 'unknown'}",
                             file=sys.stderr,
                         )
-                    else:
+                    elif runtime_healthy:
                         submit_api_v1_error_response(
                             relay_response,
                             code="compute_node_process_failed",
@@ -1528,30 +1775,28 @@ def run(args: argparse.Namespace) -> int:
                             request_id=request_id,
                             relay_runtime=relay_runtime,
                         )
+                    else:
+                        print(
+                            "desktop.compute_node_bridge.api_v1_e2ee.error_response.skipped "
+                            f"relay={_sanitize_relay_target(active_relay_url)} "
+                            f"request_id={request_id} reason=shared_runtime_recovery",
+                            file=sys.stderr,
+                        )
                     if not runtime_healthy:
                         registered = False
-                        if recovery_attempted and not recovery_succeeded:
+                        if recovery_succeeded:
+                            relay_state = "ready"
+                            warm_load_state = "ready"
+                        elif recovery_attempted:
                             relay_state = "recovering"
-                            warm_load_state = "recovering"
-                            update_relay_status(
-                                active_relay_url,
-                                registered=False,
-                                relay_runtime_state="recovering",
-                                last_error=relay_last_error,
-                                last_request_id=request_id if request_id != "none" else None,
-                            )
-                            emit_operator_event(
-                                build_status_payload(
-                                    event_type="status",
-                                    running=True,
-                                    registered=False,
-                                    active_relay_url=active_relay_url,
-                                    current_last_error=last_error,
-                                    extra={"relay_runtime_state": "recovering"},
-                                )
-                            )
-                        relay_state = "failed"
-                        warm_load_state = "failed"
+                            recovered = recover_shared_runtime(active_relay_url, request_id)
+                            if recovered:
+                                relay_state = "ready"
+                            else:
+                                relay_state = "failed" if warm_load_state == "failed" else "recovering"
+                        else:
+                            relay_state = "failed"
+                            warm_load_state = "failed"
                 else:
                     last_error = None
                     print(
@@ -1664,7 +1909,7 @@ def run(args: argparse.Namespace) -> int:
             current_last_error=last_error,
         )
     )
-    return 1 if warm_load_fatal or poll_failure_fatal else 0
+    return 1 if warm_load_fatal or poll_failure_fatal or recovery_fatal else 0
 
 
 def main() -> int:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -262,7 +262,9 @@ def _api_v1_recovery_attempts(default: int = RECOVERY_ATTEMPTS_DEFAULT) -> int:
         value = int(raw_value)
     except (TypeError, ValueError):
         return default
-    return max(value, 0)
+    if value < 0:
+        return default
+    return value
 
 
 def _api_v1_recovery_backoff_seconds(
@@ -1320,7 +1322,11 @@ def run(args: argparse.Namespace) -> int:
             )
             relay_client = getattr(relay_runtime, "relay_client", None)
             unregister = getattr(relay_client, "unregister_from_relay", None)
-            if callable(unregister):
+            registered_relays = getattr(relay_client, "_api_v1_registered_relays", None)
+            was_registered = registration_succeeded_by_relay.get(relay_url_value, False) or (
+                isinstance(registered_relays, set) and bool(registered_relays)
+            )
+            if callable(unregister) and was_registered:
                 print(
                     "desktop.compute_node_bridge.recovery.unregister.attempted "
                     f"relay={_sanitize_relay_target(relay_url_value)} "
@@ -1345,6 +1351,14 @@ def run(args: argparse.Namespace) -> int:
                         f"success={unregistered}",
                         file=sys.stderr,
                     )
+            elif callable(unregister):
+                print(
+                    "desktop.compute_node_bridge.recovery.unregister.skipped "
+                    f"relay={_sanitize_relay_target(relay_url_value)} "
+                    f"key_fingerprint={_relay_key_fingerprint(relay_client)} "
+                    "reason=not_registered",
+                    file=sys.stderr,
+                )
             else:
                 relay_stop = getattr(relay_client, "stop", None)
                 if callable(relay_stop):
@@ -1375,7 +1389,10 @@ def run(args: argparse.Namespace) -> int:
                 f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id}",
                 file=sys.stderr,
             )
-            while not recovery_done.wait(timeout=0.05):
+            while True:
+                recovery_done.wait(timeout=0.05)
+                if recovery_done.is_set() and not recovery_lock.locked():
+                    break
                 if stop_requested():
                     return False
             return warm_load_state == "ready"

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -41,6 +41,52 @@ def test_api_v1_recovery_attempts_negative_value_uses_default(monkeypatch):
     assert compute_node_bridge._api_v1_recovery_attempts(default=3) == 3
 
 
+@pytest.mark.parametrize(
+    ('raw_value', 'expected'),
+    [
+        (None, 4),
+        ('0', 0),
+        ('5', 5),
+        ('not-an-int', 4),
+    ],
+)
+def test_api_v1_recovery_attempts_parses_valid_values_and_defaults(
+    monkeypatch,
+    raw_value,
+    expected,
+):
+    if raw_value is None:
+        monkeypatch.delenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', raising=False)
+    else:
+        monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', raw_value)
+
+    assert compute_node_bridge._api_v1_recovery_attempts(default=4) == expected
+
+
+@pytest.mark.parametrize(
+    ('raw_value', 'expected'),
+    [
+        (None, 1.5),
+        ('0', 0.0),
+        ('2.25', 2.25),
+        ('not-a-float', 1.5),
+        ('nan', 1.5),
+        ('-0.01', 1.5),
+    ],
+)
+def test_api_v1_recovery_backoff_seconds_parses_valid_values_and_defaults(
+    monkeypatch,
+    raw_value,
+    expected,
+):
+    if raw_value is None:
+        monkeypatch.delenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', raising=False)
+    else:
+        monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', raw_value)
+
+    assert compute_node_bridge._api_v1_recovery_backoff_seconds(default=1.5) == expected
+
+
 class FakeModelManager:
     def __init__(self):
         self.model_path = ''
@@ -3962,3 +4008,133 @@ def test_multi_relay_stop_during_recovery_backoff_exits_without_threads(capsys, 
         thread.name.startswith('tokenplace-relay-poller') and thread.is_alive()
         for thread in threading.enumerate()
     )
+
+
+def test_multi_relay_recovery_logs_unregister_failure_and_retries_after_exception(
+    capsys,
+    monkeypatch,
+):
+    _reset_cancel_queue()
+    recovery_calls = {'count': 0}
+
+    class RaisingUnregisterClient(FakeRelayClient):
+        def __init__(self, relay_url):
+            self.relay_url = relay_url
+            self._api_v1_registered_relays = {relay_url}
+            self.unregister_calls = 0
+            self.start_calls = 0
+
+        def unregister_from_relay(self):
+            self.unregister_calls += 1
+            raise TimeoutError('unregister timed out')
+
+        def start(self):
+            self.start_calls += 1
+
+    class ExceptionThenSuccessRuntime(ApiV1Runtime):
+        instances = []
+
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = RaisingUnregisterClient(config.relay_url)
+            ExceptionThenSuccessRuntime.instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            recovery_calls['count'] += 1
+            if recovery_calls['count'] == 1:
+                raise RuntimeError('first warm-load failed')
+            return True
+
+        def process_relay_request_result(self, _payload):
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=False,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=ExceptionThenSuccessRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '2')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '0')
+    stop_checks = {'count': 0}
+
+    def stop_after_recovery():
+        stop_checks['count'] += 1
+        return recovery_calls['count'] >= 2 and stop_checks['count'] > 6
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_recovery)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=['https://relay-b.example'],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert recovery_calls['count'] == 2
+    assert output.err.count('desktop.compute_node_bridge.recovery.attempt_exception') == 1
+    assert output.err.count('desktop.compute_node_bridge.recovery.unregister.failed') >= 1
+    assert all(instance.relay_client.start_calls >= 1 for instance in ExceptionThenSuccessRuntime.instances)
+
+
+def test_multi_relay_recovery_cancelled_before_first_attempt(capsys, monkeypatch):
+    _reset_cancel_queue()
+    cancel_recovery = {'value': False}
+    recovery_calls = {'count': 0}
+
+    class CancelledRecoveryRuntime(ApiV1Runtime):
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = FakeRelayClientRouting()
+            self.relay_client.relay_url = config.relay_url
+            self.relay_client._api_v1_registered_relays = {config.relay_url}
+            self.relay_client.unregister_from_relay = lambda: True
+
+        def ensure_api_v1_runtime_ready(self):
+            recovery_calls['count'] += 1
+            return True
+
+        def process_relay_request_result(self, _payload):
+            cancel_recovery['value'] = True
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=False,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    def stop_during_recovery():
+        return cancel_recovery['value']
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=CancelledRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '2')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '0')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_during_recovery)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=[],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert recovery_calls['count'] == 0
+    assert 'desktop.compute_node_bridge.recovery.cancelled' in output.err

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -35,6 +35,12 @@ def _default_desktop_runtime_arch(monkeypatch):
         monkeypatch.setattr(runtime_setup.platform_module, 'machine', lambda: 'AMD64')
 
 
+def test_api_v1_recovery_attempts_negative_value_uses_default(monkeypatch):
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '-1')
+
+    assert compute_node_bridge._api_v1_recovery_attempts(default=3) == 3
+
+
 class FakeModelManager:
     def __init__(self):
         self.model_path = ''

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4138,3 +4138,124 @@ def test_multi_relay_recovery_cancelled_before_first_attempt(capsys, monkeypatch
     assert status == 0
     assert recovery_calls['count'] == 0
     assert 'desktop.compute_node_bridge.recovery.cancelled' in output.err
+
+
+def test_multi_relay_recovery_stops_unregistered_client_without_unregister_hook(capsys, monkeypatch):
+    _reset_cancel_queue()
+    recovery_calls = {'count': 0}
+
+    class StopOnlyRelayClient(FakeRelayClient):
+        def __init__(self, relay_url):
+            self.relay_url = relay_url
+            self.stop_calls = 0
+
+        def stop(self):
+            self.stop_calls += 1
+            raise RuntimeError('stop failed')
+
+    class StopOnlyRecoveryRuntime(ApiV1Runtime):
+        instances = []
+
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = StopOnlyRelayClient(config.relay_url)
+            StopOnlyRecoveryRuntime.instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            recovery_calls['count'] += 1
+            return True
+
+        def process_relay_request_result(self, _payload):
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=False,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=StopOnlyRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '1')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '0')
+    stop_checks = {'count': 0}
+
+    def stop_after_recovery():
+        stop_checks['count'] += 1
+        return recovery_calls['count'] >= 1 and stop_checks['count'] > 5
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_recovery)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=[],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert recovery_calls['count'] == 1
+    assert StopOnlyRecoveryRuntime.instances[0].relay_client.stop_calls >= 1
+    assert 'desktop.compute_node_bridge.recovery.stop_failed' in output.err
+
+
+@pytest.mark.parametrize(
+    ('recovery_succeeded', 'expected_state'),
+    [
+        (True, 'ready'),
+        (False, 'failed'),
+    ],
+)
+def test_api_v1_unhealthy_result_without_recovery_attempt_sets_terminal_state(
+    capsys,
+    monkeypatch,
+    recovery_succeeded,
+    expected_state,
+):
+    _reset_cancel_queue()
+    processed = {'count': 0}
+
+    class UnhealthyTerminalRuntime(ApiV1Runtime):
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client.relay_url = config.relay_url
+
+        def process_relay_request_result(self, _payload):
+            processed['count'] += 1
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=False,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=False,
+                recovery_succeeded=recovery_succeeded,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=UnhealthyTerminalRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: processed['count'] >= 1)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_urls=[],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert processed['count'] == 1
+    assert 'desktop.compute_node_bridge.api_v1_e2ee.error_response.skipped' in output.err
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    status_events = [event for event in events if event.get('type') == 'status']
+    assert status_events[-1]['relay_runtime_state'] == expected_state

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -3682,3 +3682,277 @@ def test_run_error_envelope_submission_is_not_success_marker(capsys, monkeypatch
     assert status_events[-1]['registered'] is False
     assert status_events[-1]['relay_runtime_state'] == 'failed'
     assert status_events[-1]['last_error'] == 'relay request failed: compute_node_internal_error'
+
+
+def test_multi_relay_shared_dead_worker_uses_one_recovery_and_restores_registrations(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class SharedManager(FakeModelManager):
+        def __init__(self):
+            super().__init__()
+            self.dead = True
+            self.recovery_calls = 0
+            self.process_calls = 0
+
+    shared_manager = SharedManager()
+
+    class RelayClient(FakeRelayClient):
+        def __init__(self, relay_url):
+            self.relay_url = relay_url
+            self.unregister_calls = 0
+            self.start_calls = 0
+
+        def unregister_from_relay(self):
+            self.unregister_calls += 1
+            return True
+
+        def start(self):
+            self.start_calls += 1
+
+    class MultiRelayRecoveryRuntime(FakeRuntime):
+        instances = []
+
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            self.model_manager = model_manager or shared_manager
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = RelayClient(config.relay_url)
+            self._sent_payload = False
+            self._processed = []
+            MultiRelayRecoveryRuntime.instances.append(self)
+
+        def start_relay_session(self):
+            self.relay_client.start()
+
+        def ensure_api_v1_runtime_ready(self):
+            self.model_manager.recovery_calls += 1
+            self.model_manager.dead = False
+            return True
+
+        def register_and_poll_once(self):
+            if not self._sent_payload:
+                self._sent_payload = True
+                return {
+                    'protocol': 'tokenplace_api_v1_relay_e2ee',
+                    'version': 1,
+                    'request_id': f"req-{self.relay_client.relay_url.rsplit('/', 1)[-1]}",
+                    'client_public_key': 'client-key',
+                    'chat_history': 'ciphertext',
+                    'cipherkey': 'key',
+                    'iv': 'iv',
+                    'next_ping_in_x_seconds': 0,
+                }
+            return {'next_ping_in_x_seconds': 0}
+
+        def process_relay_request_result(self, payload):
+            self._processed.append(payload)
+            self.model_manager.process_calls += 1
+            if self.model_manager.dead:
+                return SimpleNamespace(
+                    inference_succeeded=False,
+                    submitted=True,
+                    safe_error_code='compute_node_internal_error',
+                    runtime_healthy=False,
+                    recovery_attempted=True,
+                    recovery_succeeded=False,
+                )
+            return SimpleNamespace(
+                inference_succeeded=True,
+                submitted=True,
+                safe_error_code=None,
+                runtime_healthy=True,
+                recovery_attempted=False,
+                recovery_succeeded=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=MultiRelayRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '2')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '0.01')
+    stop_calls = {'count': 0}
+
+    def fake_stop_requested():
+        stop_calls['count'] += 1
+        return shared_manager.dead is False and stop_calls['count'] > 20
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', fake_stop_requested)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=['https://relay-b.example'],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert shared_manager.recovery_calls == 1
+    assert output.err.count('desktop.compute_node_bridge.recovery.start') == 1
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    recovering_events = [event for event in events if event.get('relay_runtime_state') == 'recovering']
+    assert recovering_events
+    assert all(event['registered'] is False for event in recovering_events)
+    ready_registered = [
+        event for event in events
+        if event.get('type') == 'status' and event.get('registered_relay_count') == 2
+    ]
+    assert ready_registered
+    assert all(instance.relay_client.unregister_calls >= 1 for instance in MultiRelayRecoveryRuntime.instances)
+    assert 'ciphertext' not in output.err
+
+
+def test_multi_relay_recovery_exhaustion_reports_none_registered_or_ready(capsys, monkeypatch):
+    _reset_cancel_queue()
+
+    class FailingRecoveryRuntime(ApiV1Runtime):
+        instances = []
+
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = FakeRelayClientRouting()
+            self.relay_client.relay_url = config.relay_url
+            self.relay_client.unregister_from_relay = lambda: True
+            FailingRecoveryRuntime.instances.append(self)
+
+        def ensure_api_v1_runtime_ready(self):
+            return False
+
+        def process_relay_request_result(self, _payload):
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=True,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=FailingRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '1')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '0')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: False)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=['https://relay-b.example'],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 1
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    error_event = next(event for event in events if event.get('type') == 'error')
+    assert error_event['relay_runtime_state'] == 'failed'
+    assert error_event['registered'] is False
+    assert error_event['registered_relay_count'] == 0
+    assert all(not status['registered'] for status in error_event['relay_statuses'])
+    assert 'shared model runtime recovery exhausted' in error_event['message']
+
+
+def test_multi_relay_network_failure_does_not_trigger_shared_model_recovery(capsys, monkeypatch):
+    _reset_cancel_queue()
+    calls = {'warm': 0, 'poll': 0}
+
+    class NetworkFailureRuntime(FakeRuntime):
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = FakeRelayClient()
+            self.relay_client.relay_url = config.relay_url
+
+        def ensure_api_v1_runtime_ready(self):
+            calls['warm'] += 1
+            return True
+
+        def register_and_poll_once(self):
+            calls['poll'] += 1
+            if self.relay_client.relay_url.endswith('a.example'):
+                return {'error': 'temporary relay outage', 'next_ping_in_x_seconds': 0}
+            return {'next_ping_in_x_seconds': 0}
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=NetworkFailureRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: calls['poll'] > 3)
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=['https://relay-b.example'],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert calls['warm'] == 0
+    assert 'desktop.compute_node_bridge.recovery.start' not in output.err
+    events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
+    assert any(event.get('registered_relay_count') == 1 for event in events)
+
+
+def test_multi_relay_stop_during_recovery_backoff_exits_without_threads(capsys, monkeypatch):
+    _reset_cancel_queue()
+    attempts = {'count': 0}
+    sleep_calls = {'count': 0}
+
+    class BackoffRecoveryRuntime(ApiV1Runtime):
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or FakeModelManager()
+            self.crypto_manager = crypto_manager or object()
+            self.relay_client = FakeRelayClientRouting()
+            self.relay_client.relay_url = config.relay_url
+            self.relay_client.unregister_from_relay = lambda: True
+
+        def ensure_api_v1_runtime_ready(self):
+            attempts['count'] += 1
+            return False
+
+        def process_relay_request_result(self, _payload):
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=True,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    def cancel_sleep(_seconds):
+        sleep_calls['count'] += 1
+        compute_node_bridge._stop_requested_latched.set()
+        return True
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=BackoffRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '2')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '1')
+    monkeypatch.setattr(compute_node_bridge, '_sleep_with_cancel', cancel_sleep)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: compute_node_bridge._stop_requested_latched.is_set())
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://relay-a.example',
+        relay_urls=['https://relay-b.example'],
+        relay_port=None,
+    )
+
+    status = compute_node_bridge.run(args)
+
+    output = capsys.readouterr()
+    assert status == 0
+    assert attempts['count'] == 1
+    assert sleep_calls['count'] >= 1
+    assert 'desktop.compute_node_bridge.recovery.cancelled_during_backoff' in output.err
+    assert not any(
+        thread.name.startswith('tokenplace-relay-poller') and thread.is_alive()
+        for thread in threading.enumerate()
+    )


### PR DESCRIPTION
### Motivation
- The desktop bridge runs one shared API v1 model runtime across multiple relay pollers, so a restartable worker death must be handled globally rather than per-relay to avoid advertising an unhealthy node. 
- Implement a fail-closed coordinated recovery lifecycle that prevents duplicate warm-loads, stops advertising while recovering, and makes exhaustion visible (non-zero exit) instead of leaving a registered zombie.

### Description
- Added configurable recovery controls and helpers: `TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS` and `TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS` with defaults and parsing helpers (`_api_v1_recovery_attempts`, `_api_v1_recovery_backoff_seconds`) in `compute_node_bridge.py`.
- Introduced a single shared recovery coordinator (`recovery_lock`, `recovery_done`, `recover_shared_runtime`) that serializes replacement/warm-load attempts and sets `warm_load_state` to `recovering` while in progress.
- During recovery the bridge marks all configured relays ineligible via `mark_all_relays_unregistered`, best-effort unregisters/stops advertising via `best_effort_unadvertise_all_relays`, and avoids holding inference locks while sleeping/unregistering/warming.
- Integrated recovery into the relay poll loop so pollers join an existing recovery instead of starting duplicates, skip submitting plaintext error responses for requests that triggered shared recovery, and transition to `ready` on successful verification of the API v1 runtime or to `failed` and a privacy-safe terminal error when recovery is exhausted; bridge exit code is non-zero on unrecoverable failure.
- Avoided duplicate error-envelope submission for the triggering request and preserved partial network isolation when relay network failures occur (network failure on one relay will not trigger shared model recovery).
- Added tests in `tests/unit/test_desktop_compute_node_bridge.py` covering multi-relay recovery semantics: one-coordinator replacement, relay ineligibility during recovery, successful restoration of registrations, exhaustion reporting, stop-during-backoff behavior, network-failure isolation, and plaintext-safety assertions.

### Testing
- Ran targeted desktop bridge unit tests: `python -m pytest -q tests/unit/test_desktop_compute_node_bridge.py -k "recover or multi_relay or registered or stop"` — PASSED.
- Ran broader unit suites: `python -m pytest -q tests/unit/test_compute_node_runtime.py tests/unit/test_relay_client.py` — PASSED.
- Ran integration bridge E2EE test: `python -m pytest -q tests/integration/test_api_v1_desktop_bridge_e2ee.py` — PASSED.
- Frontend tests: `cd desktop-tauri && npm test` — PASSED.
- Repo checks: `pre-commit run --all-files` — PASSED.

Residual risks and follow-ups:
- Recovery relies on `runtime.ensure_api_v1_runtime_ready()` to validate the replacement runtime; follow-up may be needed if runtime initialization semantics change upstream.
- Best-effort unadvertise/unregister may silently fail for rate-limited relays; the bridge emits diagnostics but policy-level retry/backoff tuning could be improved later.
- This PR keeps privacy invariants (no plaintext relay payloads in logs) and adds tests asserting the same, but CI Playwright/real-device E2E recovery scenarios remain out of scope and can be added as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3781cacac8832f882558e083762604)