### PR TITLE
Expose desktop worker lifecycle diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -928,7 +928,7 @@ def run(args: argparse.Namespace) -> int:
             "runtime_path": runtime_path,
             "relay_runtime_path": relay_runtime_path,
         }
-        payload.update({key: value for key, value in worker_lifecycle_status().items() if value is not None})
+        payload.update(worker_lifecycle_status())
         if extra:
             payload.update(extra)
         return payload

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -843,6 +843,25 @@ def run(args: argparse.Namespace) -> int:
             )
         return statuses, registered_count, error_summary or None
 
+    def worker_lifecycle_status() -> Dict[str, Any]:
+        status_fn = getattr(runtime.model_manager, "worker_lifecycle_status", None)
+        if callable(status_fn):
+            try:
+                status = status_fn()
+                if isinstance(status, dict):
+                    return dict(status)
+            except Exception:
+                pass
+        return {
+            "worker_state": "ready" if warm_load_state == "ready" else ("recovering" if warm_load_state == "recovering" else ("failed" if warm_load_state == "failed" else "starting")),
+            "worker_generation": None,
+            "worker_restart_count": None,
+            "worker_alive": warm_load_state == "ready",
+            "last_worker_error_code": None,
+            "last_worker_exit_code": None,
+            "last_worker_restart_at_ms": None,
+        }
+
     def build_status_payload(
         *,
         event_type: str,
@@ -909,6 +928,7 @@ def run(args: argparse.Namespace) -> int:
             "runtime_path": runtime_path,
             "relay_runtime_path": relay_runtime_path,
         }
+        payload.update({key: value for key, value in worker_lifecycle_status().items() if value is not None})
         if extra:
             payload.update(extra)
         return payload
@@ -1417,9 +1437,13 @@ def run(args: argparse.Namespace) -> int:
                     extra={"relay_runtime_state": "recovering"},
                 )
             )
+            worker_status = worker_lifecycle_status()
             print(
                 "desktop.compute_node_bridge.recovery.start "
                 f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                f"safe_error_code={worker_status.get('last_worker_error_code') or 'runtime_recovery'} "
+                f"worker_generation={worker_status.get('worker_generation', 'unknown')} "
+                f"worker_restart_count={worker_status.get('worker_restart_count', 'unknown')} "
                 f"attempts={attempts} backoff_seconds={backoff_seconds:g}",
                 file=sys.stderr,
             )
@@ -1463,9 +1487,13 @@ def run(args: argparse.Namespace) -> int:
                                 extra={"relay_runtime_state": "ready"},
                             )
                         )
+                        worker_status = worker_lifecycle_status()
                         print(
                             "desktop.compute_node_bridge.recovery.succeeded "
-                            f"attempt={attempt} request_id={request_id}",
+                            f"attempt={attempt} request_id={request_id} "
+                            f"safe_error_code={worker_status.get('last_worker_error_code') or 'none'} "
+                            f"worker_generation={worker_status.get('worker_generation', 'unknown')} "
+                            f"worker_restart_count={worker_status.get('worker_restart_count', 'unknown')}",
                             file=sys.stderr,
                         )
                         return True
@@ -1503,9 +1531,14 @@ def run(args: argparse.Namespace) -> int:
                     extra={"relay_runtime_state": "failed", "message": last_error},
                 )
             )
+            worker_status = worker_lifecycle_status()
             print(
                 "desktop.compute_node_bridge.recovery.exhausted "
-                f"request_id={request_id} action=restart_desktop_compute_node",
+                f"request_id={request_id} action=restart_desktop_compute_node "
+                f"safe_error_code={worker_status.get('last_worker_error_code') or 'recovery_exhausted'} "
+                f"worker_generation={worker_status.get('worker_generation', 'unknown')} "
+                f"worker_restart_count={worker_status.get('worker_restart_count', 'unknown')} "
+                f"exit_code={worker_status.get('last_worker_exit_code')}",
                 file=sys.stderr,
             )
             return False

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1801,6 +1801,91 @@ mod tests {
     }
 
     #[test]
+    fn update_status_from_event_rejects_stale_worker_generation_without_overwriting_status() {
+        let mut status = ComputeNodeStatus {
+            running: true,
+            registered: true,
+            relay_runtime_state: Some("ready".into()),
+            worker_state: Some("ready".into()),
+            worker_generation: Some(5),
+            worker_restart_count: Some(2),
+            worker_alive: Some(true),
+            last_worker_error_code: None,
+            operator_session_id: Some("session-1".into()),
+            sequence: Some(10),
+            ..ComputeNodeStatus::default()
+        };
+
+        let stale_worker_event = serde_json::json!({
+            "type": "status",
+            "running": false,
+            "registered": false,
+            "relay_runtime_state": "failed",
+            "last_error": "stale event should not overwrite non-worker status",
+            "worker_state": "failed",
+            "worker_generation": 4,
+            "worker_restart_count": 99,
+            "worker_alive": false,
+            "last_worker_error_code": "stale_worker_failure",
+            "operator_session_id": "session-1",
+            "sequence": 11
+        });
+
+        assert!(!update_status_from_event(&mut status, &stale_worker_event));
+        assert!(status.running);
+        assert!(status.registered);
+        assert_eq!(status.relay_runtime_state.as_deref(), Some("ready"));
+        assert!(status.last_error.is_none());
+        assert_eq!(status.worker_state.as_deref(), Some("ready"));
+        assert_eq!(status.worker_generation, Some(5));
+        assert_eq!(status.worker_restart_count, Some(2));
+        assert_eq!(status.worker_alive, Some(true));
+        assert!(status.last_worker_error_code.is_none());
+    }
+
+    #[test]
+    fn update_status_from_event_allows_fresh_new_session_to_reset_worker_generation() {
+        let mut status = ComputeNodeStatus {
+            running: false,
+            registered: false,
+            relay_runtime_state: Some("stopped".into()),
+            worker_state: Some("failed".into()),
+            worker_generation: Some(9),
+            worker_restart_count: Some(4),
+            worker_alive: Some(false),
+            last_worker_error_code: Some("old_failure".into()),
+            operator_session_id: Some("old-session".into()),
+            sequence: Some(20),
+            ..ComputeNodeStatus::default()
+        };
+
+        let fresh_started_event = serde_json::json!({
+            "type": "started",
+            "running": true,
+            "registered": false,
+            "relay_runtime_state": "starting",
+            "worker_state": "starting",
+            "worker_generation": 1,
+            "worker_restart_count": 0,
+            "worker_alive": false,
+            "last_worker_error_code": null,
+            "operator_session_id": "new-session",
+            "sequence": 1
+        });
+
+        assert!(update_status_from_event(&mut status, &fresh_started_event));
+        assert!(status.running);
+        assert_eq!(status.operator_session_id.as_deref(), Some("new-session"));
+        assert_eq!(status.sequence, Some(1));
+        assert_eq!(status.relay_runtime_state.as_deref(), Some("starting"));
+        assert_eq!(status.worker_state.as_deref(), Some("starting"));
+        assert_eq!(status.worker_generation, Some(1));
+        assert_eq!(status.worker_restart_count, Some(0));
+        assert_eq!(status.worker_alive, Some(false));
+        assert!(status.last_worker_error_code.is_none());
+    }
+
+    #[test]
     fn compute_node_status_cache_replays_warming_relay_runtime_fields() {
         let state = ComputeNodeState::default();
         let cached_status = ComputeNodeStatus {

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -423,8 +423,8 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
     }
-    if payload.get("worker_generation").is_some() {
-        status.worker_generation = payload.get("worker_generation").and_then(Value::as_u64);
+    if let Some(worker_generation) = payload.get("worker_generation").and_then(Value::as_u64) {
+        status.worker_generation = Some(worker_generation);
     }
     if payload.get("worker_restart_count").is_some() {
         status.worker_restart_count = payload.get("worker_restart_count").and_then(Value::as_u64);
@@ -1836,6 +1836,65 @@ mod tests {
         assert!(status.registered);
         assert_eq!(status.relay_runtime_state.as_deref(), Some("ready"));
         assert!(status.last_error.is_none());
+        assert_eq!(status.worker_state.as_deref(), Some("ready"));
+        assert_eq!(status.worker_generation, Some(5));
+        assert_eq!(status.worker_restart_count, Some(2));
+        assert_eq!(status.worker_alive, Some(true));
+        assert!(status.last_worker_error_code.is_none());
+    }
+
+    #[test]
+    fn update_status_from_event_preserves_generation_on_null_payload_for_stale_guard() {
+        let mut status = ComputeNodeStatus {
+            running: true,
+            registered: true,
+            relay_runtime_state: Some("ready".into()),
+            worker_state: Some("ready".into()),
+            worker_generation: Some(5),
+            worker_restart_count: Some(2),
+            worker_alive: Some(true),
+            last_worker_error_code: Some("previous_worker_failure".into()),
+            operator_session_id: Some("session-1".into()),
+            sequence: Some(10),
+            ..ComputeNodeStatus::default()
+        };
+
+        let fallback_status_event = serde_json::json!({
+            "type": "status",
+            "running": true,
+            "registered": true,
+            "relay_runtime_state": "ready",
+            "worker_generation": null,
+            "last_worker_error_code": null,
+            "operator_session_id": "session-1",
+            "sequence": 11
+        });
+
+        assert!(update_status_from_event(
+            &mut status,
+            &fallback_status_event
+        ));
+        assert_eq!(status.worker_generation, Some(5));
+        assert!(status.last_worker_error_code.is_none());
+
+        let stale_worker_event = serde_json::json!({
+            "type": "status",
+            "running": false,
+            "registered": false,
+            "relay_runtime_state": "failed",
+            "worker_state": "failed",
+            "worker_generation": 4,
+            "worker_restart_count": 99,
+            "worker_alive": false,
+            "last_worker_error_code": "stale_worker_failure",
+            "operator_session_id": "session-1",
+            "sequence": 12
+        });
+
+        assert!(!update_status_from_event(&mut status, &stale_worker_event));
+        assert!(status.running);
+        assert!(status.registered);
+        assert_eq!(status.relay_runtime_state.as_deref(), Some("ready"));
         assert_eq!(status.worker_state.as_deref(), Some("ready"));
         assert_eq!(status.worker_generation, Some(5));
         assert_eq!(status.worker_restart_count, Some(2));

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -64,6 +64,13 @@ pub struct ComputeNodeStatus {
     pub warm_load_duration_ms: Option<u64>,
     pub runtime_path: Option<String>,
     pub relay_runtime_path: Option<String>,
+    pub worker_state: Option<String>,
+    pub worker_generation: Option<u64>,
+    pub worker_restart_count: Option<u64>,
+    pub worker_alive: Option<bool>,
+    pub last_worker_error_code: Option<String>,
+    pub last_worker_exit_code: Option<i64>,
+    pub last_worker_restart_at_ms: Option<u64>,
     pub operator_session_id: Option<String>,
     pub sequence: Option<u64>,
     pub updated_at_ms: Option<u64>,
@@ -259,6 +266,13 @@ fn startup_failure_status(
         warm_load_duration_ms: None,
         runtime_path: Some("bridge".into()),
         relay_runtime_path: Some("bridge".into()),
+        worker_state: Some("failed".into()),
+        worker_generation: None,
+        worker_restart_count: None,
+        worker_alive: Some(false),
+        last_worker_error_code: None,
+        last_worker_exit_code: None,
+        last_worker_restart_at_ms: None,
         operator_session_id,
         sequence: None,
         updated_at_ms: Some(current_time_ms()),
@@ -283,6 +297,14 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
     }
     if let (Some(current_sequence), Some(payload_sequence)) = (status.sequence, payload_sequence) {
         if payload_sequence <= current_sequence && !is_fresh_start_event {
+            return false;
+        }
+    }
+    if let (Some(current_generation), Some(payload_generation)) = (
+        status.worker_generation,
+        payload.get("worker_generation").and_then(Value::as_u64),
+    ) {
+        if payload_generation < current_generation && !is_fresh_start_event {
             return false;
         }
     }
@@ -393,6 +415,36 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
     }
     if let Some(relay_runtime_state) = payload.get("relay_runtime_state").and_then(Value::as_str) {
         status.relay_runtime_state = Some(relay_runtime_state.into());
+    }
+
+    if payload.get("worker_state").is_some() {
+        status.worker_state = payload
+            .get("worker_state")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("worker_generation").is_some() {
+        status.worker_generation = payload.get("worker_generation").and_then(Value::as_u64);
+    }
+    if payload.get("worker_restart_count").is_some() {
+        status.worker_restart_count = payload.get("worker_restart_count").and_then(Value::as_u64);
+    }
+    if payload.get("worker_alive").is_some() {
+        status.worker_alive = payload.get("worker_alive").and_then(Value::as_bool);
+    }
+    if payload.get("last_worker_error_code").is_some() {
+        status.last_worker_error_code = payload
+            .get("last_worker_error_code")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("last_worker_exit_code").is_some() {
+        status.last_worker_exit_code = payload.get("last_worker_exit_code").and_then(Value::as_i64);
+    }
+    if payload.get("last_worker_restart_at_ms").is_some() {
+        status.last_worker_restart_at_ms = payload
+            .get("last_worker_restart_at_ms")
+            .and_then(Value::as_u64);
     }
     if let Some(operator_session_id) = payload.get("operator_session_id").and_then(Value::as_str) {
         status.operator_session_id = Some(operator_session_id.into());
@@ -924,6 +976,13 @@ pub async fn start_compute_node(
                 warm_load_duration_ms: None,
                 runtime_path: Some("bridge".into()),
                 relay_runtime_path: Some("bridge".into()),
+                worker_state: Some("starting".into()),
+                worker_generation: None,
+                worker_restart_count: None,
+                worker_alive: Some(false),
+                last_worker_error_code: None,
+                last_worker_exit_code: None,
+                last_worker_restart_at_ms: None,
                 operator_session_id: Some(session_id.clone()),
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1610,4 +1610,89 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+  it('renders worker lifecycle fields and ignores stale worker generations', async () => {
+    render(<App />);
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    await waitFor(() => expect(screen.getByText(/Worker state:/).textContent).toContain('stopped'));
+
+    computeHandler?.({
+      payload: {
+        type: 'started',
+        running: true,
+        registered: false,
+        active_relay_url: 'https://token.place',
+        relay_runtime_state: 'ready',
+        worker_state: 'ready',
+        worker_generation: 4,
+        worker_restart_count: 1,
+        worker_alive: true,
+        last_worker_error_code: null,
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Worker state:/).textContent).toContain('ready'));
+    expect(screen.getByText(/Worker alive:/).textContent).toContain('yes');
+    expect(screen.getByText(/Worker generation:/).textContent).toContain('4');
+    expect(screen.getByText(/Worker restart count:/).textContent).toContain('1');
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'failed',
+        worker_state: 'failed',
+        worker_generation: 3,
+        worker_restart_count: 9,
+        worker_alive: false,
+        last_worker_error_code: 'stale_failure',
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+    expect(screen.getByText(/Worker state:/).textContent).toContain('ready');
+    expect(screen.queryByText('stale_failure')).toBeNull();
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'recovering',
+        worker_state: 'recovering',
+        worker_generation: 5,
+        worker_restart_count: 2,
+        worker_alive: false,
+        last_worker_error_code: 'worker_dead',
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Worker state:/).textContent).toContain('recovering'));
+    expect(screen.getByText(/Worker alive:/).textContent).toContain('no');
+    expect(screen.getByText(/Worker restart count:/).textContent).toContain('2');
+    expect(screen.getByText(/Last worker error code:/).textContent).toContain('worker_dead');
+
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        worker_state: 'failed',
+        worker_generation: 5,
+        worker_restart_count: 3,
+        worker_alive: false,
+        last_worker_error_code: 'fatal_worker_exit',
+        operator_session_id: 'session-1',
+        sequence: 4,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/Worker state:/).textContent).toContain('failed'));
+    expect(screen.getByText(/Worker restart count:/).textContent).toContain('3');
+    expect(screen.getByText(/Last worker error code:/).textContent).toContain('fatal_worker_exit');
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -63,6 +63,13 @@ interface ComputeNodeStatus {
   warm_load_duration_ms: number | null;
   runtime_path: string | null;
   relay_runtime_path: string | null;
+  worker_state: string | null;
+  worker_generation: number | null;
+  worker_restart_count: number | null;
+  worker_alive: boolean | null;
+  last_worker_error_code: string | null;
+  last_worker_exit_code: number | null;
+  last_worker_restart_at_ms: number | null;
   operator_session_id: string | null;
   sequence: number | null;
   updated_at_ms: number | null;
@@ -111,6 +118,13 @@ const defaultComputeStatus: ComputeNodeStatus = {
   warm_load_duration_ms: null,
   runtime_path: null,
   relay_runtime_path: null,
+  worker_state: null,
+  worker_generation: null,
+  worker_restart_count: null,
+  worker_alive: null,
+  last_worker_error_code: null,
+  last_worker_exit_code: null,
+  last_worker_restart_at_ms: null,
   operator_session_id: null,
   sequence: null,
   updated_at_ms: null,
@@ -281,6 +295,16 @@ function mergeComputeStatusEvent(
   ) {
     return prev;
   }
+  const payloadWorkerGeneration =
+    typeof payload.worker_generation === 'number' ? payload.worker_generation : null;
+  if (
+    payloadWorkerGeneration !== null &&
+    prev.worker_generation !== null &&
+    payloadWorkerGeneration < prev.worker_generation &&
+    !isFreshSessionEvent
+  ) {
+    return prev;
+  }
 
   return {
     running:
@@ -377,6 +401,40 @@ function mergeComputeStatusEvent(
       typeof payload.relay_runtime_path === 'string'
         ? payload.relay_runtime_path
         : prev.relay_runtime_path,
+    worker_state:
+      typeof payload.worker_state === 'string'
+        ? payload.worker_state
+        : payload.type === 'error'
+          ? 'failed'
+          : prev.worker_state,
+    worker_generation:
+      typeof payload.worker_generation === 'number' ? payload.worker_generation : prev.worker_generation,
+    worker_restart_count:
+      typeof payload.worker_restart_count === 'number' ? payload.worker_restart_count : prev.worker_restart_count,
+    worker_alive:
+      typeof payload.worker_alive === 'boolean'
+        ? payload.worker_alive
+        : payload.type === 'error'
+          ? false
+          : prev.worker_alive,
+    last_worker_error_code:
+      payload.last_worker_error_code === null
+        ? null
+        : typeof payload.last_worker_error_code === 'string'
+          ? payload.last_worker_error_code
+          : prev.last_worker_error_code,
+    last_worker_exit_code:
+      payload.last_worker_exit_code === null
+        ? null
+        : typeof payload.last_worker_exit_code === 'number'
+          ? payload.last_worker_exit_code
+          : prev.last_worker_exit_code,
+    last_worker_restart_at_ms:
+      payload.last_worker_restart_at_ms === null
+        ? null
+        : typeof payload.last_worker_restart_at_ms === 'number'
+          ? payload.last_worker_restart_at_ms
+          : prev.last_worker_restart_at_ms,
     operator_session_id: payloadSession ?? prev.operator_session_id,
     sequence: payloadSequence ?? prev.sequence,
     updated_at_ms:
@@ -657,6 +715,8 @@ export function App() {
         fallback_reason: null,
         model_path: config.model_path,
         last_error: null,
+        worker_state: 'starting',
+        worker_alive: false,
         log_file_path: null,
       };
       computeStatusRef.current = optimisticStatus;
@@ -677,6 +737,8 @@ export function App() {
         running: false,
         registered: false,
         relay_runtime_state: 'failed',
+        worker_state: 'failed',
+        worker_alive: false,
         last_error: message,
       };
       computeStatusRef.current = failedStatus;
@@ -868,6 +930,12 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{displayStatusValue(computeStatus.runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{displayStatusValue(computeStatus.relay_runtime_path, 'pending')}</code></p>
+        <p style={{ marginBottom: 0 }}>Worker state: <strong>{displayStatusValue(computeStatus.worker_state, computeStatus.running ? 'starting' : 'stopped')}</strong></p>
+        <p style={{ marginBottom: 0 }}>Worker alive: <strong>{computeStatus.worker_alive === null ? 'unknown' : computeStatus.worker_alive ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Worker generation: <code>{computeStatus.worker_generation ?? 'unknown'}</code></p>
+        <p style={{ marginBottom: 0 }}>Worker restart count: <code>{computeStatus.worker_restart_count ?? 0}</code></p>
+        <p style={{ marginBottom: 0 }}>Last worker error code: <code>{computeStatus.last_worker_error_code || 'none'}</code></p>
+        <p style={{ marginBottom: 0 }}>Last worker exit code: <code>{computeStatus.last_worker_exit_code ?? 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, primaryRelayUrl(config))}</code></p>
         <p style={{ marginBottom: 0 }}>Configured relay URLs: <code>{((Array.isArray(computeStatus.configured_relay_urls) && computeStatus.configured_relay_urls.length) ? computeStatus.configured_relay_urls : normalizeRelayUrls(config.relay_base_urls, config.relay_base_url)).join(', ')}</code></p>
         {Array.isArray(computeStatus.relay_statuses) && computeStatus.relay_statuses.length > 0 && (

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4106,6 +4106,102 @@ def test_multi_relay_recovery_logs_unregister_failure_and_retries_after_exceptio
     assert all(instance.relay_client.start_calls >= 1 for instance in ExceptionThenSuccessRuntime.instances)
 
 
+def test_recovery_logs_redact_payload_keys_and_paths(capsys, monkeypatch):
+    _reset_cancel_queue()
+    recovery_calls = {'count': 0}
+    sentinels = {
+        'PROMPT_SENTINEL',
+        'OUTPUT_SENTINEL',
+        'PRIVATE_KEY',
+        'FULL_PUBLIC_KEY',
+        '/tmp/sentinel-model-path.gguf',
+        '/tmp/sentinel-runtime-path',
+        'path=/tmp/sentinel-path',
+    }
+
+    class SensitiveModelManager(FakeModelManager):
+        model_path = '/tmp/sentinel-model-path.gguf'
+
+        def worker_lifecycle_status(self):
+            return {
+                "worker_state": "recovering",
+                "worker_generation": 7,
+                "worker_restart_count": 1,
+                "worker_alive": False,
+                "last_worker_error_code": "worker_dead",
+                "last_worker_exit_code": None,
+                "last_worker_restart_at_ms": None,
+            }
+
+    class SensitiveRecoveryRuntime(ApiV1Runtime):
+        def __init__(self, config, *_, model_manager=None, crypto_manager=None):
+            super().__init__(config)
+            self.model_manager = model_manager or SensitiveModelManager()
+            self.crypto_manager = SimpleNamespace(
+                private_key='PRIVATE_KEY',
+                full_public_key='FULL_PUBLIC_KEY',
+            )
+            self.relay_client = FakeRelayClientRouting()
+            self.relay_client.relay_url = config.relay_url
+
+        def ensure_api_v1_runtime_ready(self):
+            recovery_calls['count'] += 1
+            if recovery_calls['count'] == 1:
+                raise RuntimeError(
+                    'PROMPT_SENTINEL OUTPUT_SENTINEL decrypted generated output '
+                    'model_path=/tmp/sentinel-model-path.gguf '
+                    'runtime_path=/tmp/sentinel-runtime-path path=/tmp/sentinel-path'
+                )
+            return True
+
+        def process_relay_request_result(self, _payload):
+            return SimpleNamespace(
+                inference_succeeded=False,
+                submitted=True,
+                safe_error_code='compute_node_internal_error',
+                runtime_healthy=False,
+                recovery_attempted=True,
+                recovery_succeeded=False,
+            )
+
+    _install_fake_runtime_module(monkeypatch, runtime_cls=SensitiveRecoveryRuntime)
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_ATTEMPTS', '2')
+    monkeypatch.setenv('TOKENPLACE_DESKTOP_API_V1_RECOVERY_BACKOFF_SECONDS', '0')
+    stop_checks = {'count': 0}
+
+    def stop_after_recovery():
+        stop_checks['count'] += 1
+        return recovery_calls['count'] >= 2 and stop_checks['count'] > 6
+
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', stop_after_recovery)
+    args = SimpleNamespace(
+        model='/tmp/sentinel-model-path.gguf',
+        mode='cpu',
+        relay_url='https://user:PRIVATE_KEY@relay-a.example/path?query=FULL_PUBLIC_KEY#fragment',
+        relay_urls=[],
+        relay_port=None,
+    )
+
+    assert compute_node_bridge.run(args) == 0
+
+    output = capsys.readouterr()
+    assert 'desktop.compute_node_bridge.recovery.start' in output.err
+    assert 'desktop.compute_node_bridge.recovery.attempt_exception' in output.err
+    assert 'desktop.compute_node_bridge.recovery.succeeded' in output.err
+    lifecycle_log_lines = '\n'.join(
+        line for line in output.err.splitlines()
+        if 'desktop.compute_node_bridge.recovery.' in line
+        or 'desktop.compute_node_bridge.worker.' in line
+    )
+    for sentinel in sentinels:
+        assert sentinel not in lifecycle_log_lines
+    assert 'decrypted' not in lifecycle_log_lines
+    assert 'generated output' not in lifecycle_log_lines
+    assert 'model_path' not in lifecycle_log_lines
+    assert 'runtime_path' not in lifecycle_log_lines
+
+
 def test_multi_relay_recovery_cancelled_before_first_attempt(capsys, monkeypatch):
     _reset_cancel_queue()
     cancel_recovery = {'value': False}

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -94,6 +94,17 @@ class FakeModelManager:
         self.requested_compute_mode = 'auto'
         self.last_compute_diagnostics = None
 
+    def worker_lifecycle_status(self):
+        return {
+            "worker_state": "ready",
+            "worker_generation": 2,
+            "worker_restart_count": 1,
+            "worker_alive": True,
+            "last_worker_error_code": None,
+            "last_worker_exit_code": None,
+            "last_worker_restart_at_ms": None,
+        }
+
 
 class FakeRelayClient:
     relay_url = 'https://token.place'
@@ -653,6 +664,13 @@ def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, mon
         'operator_session_id',
         'sequence',
         'updated_at_ms',
+        'worker_state',
+        'worker_generation',
+        'worker_restart_count',
+        'worker_alive',
+        'last_worker_error_code',
+        'last_worker_exit_code',
+        'last_worker_restart_at_ms',
     }
     for event in events:
         if event['type'] in {'started', 'status', 'stopped'}:
@@ -666,6 +684,8 @@ def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, mon
     assert stopped['running'] is False
     assert stopped['registered'] is False
     assert stopped['relay_runtime_state'] == 'stopped'
+    assert stopped['last_worker_error_code'] is None
+    assert stopped['last_worker_exit_code'] is None
 
 
 def test_run_reports_model_initialization_failures(capsys, monkeypatch):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3223,6 +3223,7 @@ def test_model_manager_request_scoped_inference_error_not_retried(tmp_path, monk
 
     assert first.closed is False
     assert manager.llm._worker is first
+    assert manager.last_worker_error_code == 'inference_request_error'
     assert created == [first]
 
 
@@ -3249,6 +3250,11 @@ def test_model_manager_concurrent_dead_worker_creates_one_replacement(tmp_path, 
     assert [worker.name for worker in created] == ['dead', 'replacement']
     assert dead.closed is True
     assert replacement.calls == 2
+    status = manager.worker_lifecycle_status()
+    assert status['worker_state'] == 'ready'
+    assert status['worker_restart_count'] == 1
+    assert status['last_worker_error_code'] is None
+    assert status['last_worker_exit_code'] is None
 
 
 def test_model_manager_replacement_failure_attempted_once_surfaces_stable_error(tmp_path, monkeypatch):
@@ -3263,6 +3269,10 @@ def test_model_manager_replacement_failure_attempted_once_surfaces_stable_error(
     assert [worker.name for worker in created] == ['first', 'second']
     assert first.closed is True
     assert second.closed is True
+    status = manager.worker_lifecycle_status()
+    assert status['worker_state'] == 'failed'
+    assert status['worker_restart_count'] == 2
+    assert status['last_worker_error_code'] == 'worker_eof'
 
 
 def test_model_manager_healthy_request_has_no_restart(tmp_path, monkeypatch):
@@ -3277,6 +3287,7 @@ def test_model_manager_healthy_request_has_no_restart(tmp_path, monkeypatch):
 
     assert created == [first]
     assert first.closed is False
+    assert manager.worker_lifecycle_status()['worker_restart_count'] == 0
 
 
 def test_subprocess_llama_proxy_send_marks_closed_on_missing_stdin_or_write_failure():

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1978,7 +1978,7 @@ class ModelManager:
                             if isinstance(e, LlamaCppRuntimeStageTimeout):
                                 self.last_runtime_init_error = _format_runtime_stage_timeout(e)
                             self.worker_state = 'failed'
-                            self.last_worker_error_code = _safe_worker_error_code(self.last_runtime_init_error)
+                            self.last_worker_error_code = _safe_worker_error_code(e)
                             self.log_error(
                                 f"Failed to initialize Llama model: {self.last_runtime_init_error}",
                                 exc_info=True,
@@ -2016,28 +2016,37 @@ class ModelManager:
         return None
 
     def worker_lifecycle_status(self) -> Dict[str, Any]:
-        llm = self.llm
+        with self.llm_lock:
+            llm = self.llm
+            state = self.worker_state
+            generation = self._llm_generation
+            restart_count = self.worker_restart_count
+            last_error_code = self.last_worker_error_code
+            last_exit_code = self.last_worker_exit_code
+            last_restart_at_ms = self.last_worker_restart_at_ms
         alive = self._llm_is_usable(llm) if llm is not None else False
-        state = self.worker_state
         if llm is None and state not in {'failed', 'recovering', 'starting'}:
             state = 'stopped'
         return {
             'worker_state': state,
-            'worker_generation': self._llm_generation,
-            'worker_restart_count': self.worker_restart_count,
+            'worker_generation': generation,
+            'worker_restart_count': restart_count,
             'worker_alive': alive,
-            'last_worker_error_code': self.last_worker_error_code,
-            'last_worker_exit_code': self.last_worker_exit_code,
-            'last_worker_restart_at_ms': self.last_worker_restart_at_ms,
+            'last_worker_error_code': last_error_code,
+            'last_worker_exit_code': last_exit_code,
+            'last_worker_restart_at_ms': last_restart_at_ms,
         }
 
     def _invalidate_llm_if_current(self, failed_llm: Any, error: Any = None) -> int:
+        dead_worker_log_message: Optional[str] = None
         with self.llm_lock:
             if self.llm is failed_llm:
                 self.last_worker_exit_code = self._worker_exit_code(failed_llm)
                 self.last_worker_error_code = _safe_worker_error_code(error) if error is not None else 'worker_dead'
                 self.worker_state = 'recovering'
-                self.log_warning(
+                self.worker_restart_count += 1
+                self.last_worker_restart_at_ms = int(time.time() * 1000)
+                dead_worker_log_message = (
                     "desktop.llama_cpp_worker.dead_detected event=dead_worker_detection "
                     f"safe_error_code={self.last_worker_error_code} worker_generation={self._llm_generation} "
                     f"worker_restart_count={self.worker_restart_count} exit_code={self.last_worker_exit_code}"
@@ -2045,9 +2054,13 @@ class ModelManager:
                 self._close_llm_proxy(self.llm)
                 self.llm = None
                 self._llm_generation += 1
-            return self._llm_generation
+            generation = self._llm_generation
+        if dead_worker_log_message is not None:
+            self.log_warning(dead_worker_log_message)
+        return generation
 
     def _ensure_replacement_llm(self, observed_generation: int) -> Any:
+        replacement_attempt_log_message: Optional[str] = None
         with self.llm_lock:
             if self.llm is not None and self._llm_is_usable(self.llm):
                 return self.llm
@@ -2056,12 +2069,12 @@ class ModelManager:
                 self.llm = None
             if self._llm_generation == observed_generation:
                 self._llm_generation += 1
-            self.worker_restart_count += 1
             self.worker_state = 'recovering'
-            self.last_worker_restart_at_ms = int(time.time() * 1000)
-            self.log_warning("desktop.llama_cpp_worker.replacement_attempt event=replacement_attempt worker_generation=%s worker_restart_count=%s" % (self._llm_generation, self.worker_restart_count))
+            replacement_attempt_log_message = "desktop.llama_cpp_worker.replacement_attempt event=replacement_attempt worker_generation=%s worker_restart_count=%s" % (self._llm_generation, self.worker_restart_count)
             # Release llm_lock before get_llm_instance() because it initializes under
             # the same non-reentrant lock and still serializes creation internally.
+        if replacement_attempt_log_message is not None:
+            self.log_warning(replacement_attempt_log_message)
         return self.get_llm_instance()
 
     def create_chat_completion_with_recovery(self, *args, **kwargs):
@@ -2089,8 +2102,12 @@ class ModelManager:
         try:
             return create_chat_completion(*args, **kwargs)
         except LlamaCppInferenceRequestError as exc:
-            self.last_worker_error_code = _safe_worker_error_code(exc)
-            self.log_warning("desktop.llama_cpp_worker.request_failure event=request_scoped_inference_failure safe_error_code=%s worker_generation=%s worker_restart_count=%s" % (self.last_worker_error_code, self._llm_generation, self.worker_restart_count))
+            safe_error_code = _safe_worker_error_code(exc)
+            with self.llm_lock:
+                self.last_worker_error_code = safe_error_code
+                generation = self._llm_generation
+                restart_count = self.worker_restart_count
+            self.log_warning("desktop.llama_cpp_worker.request_failure event=request_scoped_inference_failure safe_error_code=%s worker_generation=%s worker_restart_count=%s" % (safe_error_code, generation, restart_count))
             raise
         except LlamaCppRestartableWorkerError as exc:
             self._invalidate_llm_if_current(llm_instance, exc)
@@ -2103,13 +2120,23 @@ class ModelManager:
             raise RuntimeError('LLM replacement runtime missing create_chat_completion')
         try:
             result = replacement_create(*args, **kwargs)
-            self.worker_state = 'ready'
-            self.log_warning("desktop.llama_cpp_worker.replacement_result event=replacement_result result=succeeded worker_generation=%s worker_restart_count=%s" % (self._llm_generation, self.worker_restart_count))
+            with self.llm_lock:
+                self.worker_state = 'ready'
+                self.last_worker_error_code = None
+                self.last_worker_exit_code = None
+                generation = self._llm_generation
+                restart_count = self.worker_restart_count
+            self.log_info("desktop.llama_cpp_worker.replacement_result event=replacement_result result=succeeded worker_generation=%s worker_restart_count=%s" % (generation, restart_count))
             return result
         except LlamaCppRestartableWorkerError as exc:
             self._invalidate_llm_if_current(replacement, exc)
-            self.worker_state = 'failed'
-            self.log_error("desktop.llama_cpp_worker.terminal_failure event=terminal_failure safe_error_code=%s worker_generation=%s worker_restart_count=%s exit_code=%s" % (self.last_worker_error_code, self._llm_generation, self.worker_restart_count, self.last_worker_exit_code))
+            with self.llm_lock:
+                self.worker_state = 'failed'
+                safe_error_code = self.last_worker_error_code
+                generation = self._llm_generation
+                restart_count = self.worker_restart_count
+                exit_code = self.last_worker_exit_code
+            self.log_error("desktop.llama_cpp_worker.terminal_failure event=terminal_failure safe_error_code=%s worker_generation=%s worker_restart_count=%s exit_code=%s" % (safe_error_code, generation, restart_count, exit_code))
             raise RuntimeError('LLM runtime replacement failed after one restart attempt') from exc
 
     def llama_cpp_get_response(self, chat_history: List[Dict[str, str]]) -> List[Dict[str, str]]:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -811,6 +811,29 @@ def _read_llama_subprocess_message(
     return message
 
 
+
+
+def _safe_worker_error_code(value: Any) -> str:
+    text = str(value or '').strip().lower()
+    if isinstance(value, LlamaCppWorkerDeadError):
+        return 'worker_dead'
+    if isinstance(value, LlamaCppWorkerEOFError):
+        return 'worker_eof'
+    if isinstance(value, LlamaCppWorkerBrokenPipeError):
+        return 'worker_broken_pipe'
+    if isinstance(value, LlamaCppInferenceRequestError):
+        code = value.diagnostics.get('code') if isinstance(value.diagnostics, dict) else None
+        return str(code) if isinstance(code, str) and code else 'inference_request_error'
+    if 'broken pipe' in text:
+        return 'worker_broken_pipe'
+    if 'exited' in text or 'dead' in text or 'liveness' in text:
+        return 'worker_dead'
+    if 'timeout' in text:
+        return 'worker_timeout'
+    if text and all(ch.isalnum() or ch in {'_', '-'} for ch in text) and len(text) <= 80:
+        return text.replace('-', '_')
+    return type(value).__name__ if isinstance(value, BaseException) else 'worker_error'
+
 class _SubprocessLlamaProxy:
     """Minimal llama_cpp.Llama proxy for no-SIGALRM runtimes."""
 
@@ -1470,6 +1493,11 @@ class ModelManager:
         self.llm = None
         self.llm_lock = Lock()
         self._llm_generation = 0
+        self.worker_restart_count = 0
+        self.last_worker_error_code: Optional[str] = None
+        self.last_worker_exit_code: Optional[int] = None
+        self.last_worker_restart_at_ms: Optional[int] = None
+        self.worker_state = 'stopped'
         self.last_runtime_init_error: Optional[str] = None
 
         # Check if mock mode is enabled
@@ -1939,12 +1967,18 @@ class ModelManager:
                                 f"llama_module_path={runtime_identity.get('llama_module_path', 'unknown')} "
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
+                            self.worker_state = 'ready'
+                            self.last_worker_error_code = None
+                            self.last_worker_exit_code = None
+                            self.log_info("desktop.llama_cpp_worker.initialized event=worker_initialization worker_state=ready worker_generation=%s worker_restart_count=%s" % (self._llm_generation, self.worker_restart_count))
                             self.log_info("Llama init completed successfully.")
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.last_runtime_init_error = str(e)
                             if isinstance(e, LlamaCppRuntimeStageTimeout):
                                 self.last_runtime_init_error = _format_runtime_stage_timeout(e)
+                            self.worker_state = 'failed'
+                            self.last_worker_error_code = _safe_worker_error_code(self.last_runtime_init_error)
                             self.log_error(
                                 f"Failed to initialize Llama model: {self.last_runtime_init_error}",
                                 exc_info=True,
@@ -1970,9 +2004,44 @@ class ModelManager:
                 return False
         return llm is not None
 
-    def _invalidate_llm_if_current(self, failed_llm: Any) -> int:
+    def _worker_exit_code(self, llm: Any) -> Optional[int]:
+        process = getattr(llm, '_process', None)
+        poll = getattr(process, 'poll', None)
+        if callable(poll):
+            try:
+                code = poll()
+                return int(code) if code is not None else None
+            except Exception:
+                return None
+        return None
+
+    def worker_lifecycle_status(self) -> Dict[str, Any]:
+        llm = self.llm
+        alive = self._llm_is_usable(llm) if llm is not None else False
+        state = self.worker_state
+        if llm is None and state not in {'failed', 'recovering', 'starting'}:
+            state = 'stopped'
+        return {
+            'worker_state': state,
+            'worker_generation': self._llm_generation,
+            'worker_restart_count': self.worker_restart_count,
+            'worker_alive': alive,
+            'last_worker_error_code': self.last_worker_error_code,
+            'last_worker_exit_code': self.last_worker_exit_code,
+            'last_worker_restart_at_ms': self.last_worker_restart_at_ms,
+        }
+
+    def _invalidate_llm_if_current(self, failed_llm: Any, error: Any = None) -> int:
         with self.llm_lock:
             if self.llm is failed_llm:
+                self.last_worker_exit_code = self._worker_exit_code(failed_llm)
+                self.last_worker_error_code = _safe_worker_error_code(error) if error is not None else 'worker_dead'
+                self.worker_state = 'recovering'
+                self.log_warning(
+                    "desktop.llama_cpp_worker.dead_detected event=dead_worker_detection "
+                    f"safe_error_code={self.last_worker_error_code} worker_generation={self._llm_generation} "
+                    f"worker_restart_count={self.worker_restart_count} exit_code={self.last_worker_exit_code}"
+                )
                 self._close_llm_proxy(self.llm)
                 self.llm = None
                 self._llm_generation += 1
@@ -1987,6 +2056,10 @@ class ModelManager:
                 self.llm = None
             if self._llm_generation == observed_generation:
                 self._llm_generation += 1
+            self.worker_restart_count += 1
+            self.worker_state = 'recovering'
+            self.last_worker_restart_at_ms = int(time.time() * 1000)
+            self.log_warning("desktop.llama_cpp_worker.replacement_attempt event=replacement_attempt worker_generation=%s worker_restart_count=%s" % (self._llm_generation, self.worker_restart_count))
             # Release llm_lock before get_llm_instance() because it initializes under
             # the same non-reentrant lock and still serializes creation internally.
         return self.get_llm_instance()
@@ -2015,8 +2088,12 @@ class ModelManager:
             raise RuntimeError('LLM runtime missing create_chat_completion')
         try:
             return create_chat_completion(*args, **kwargs)
-        except LlamaCppRestartableWorkerError:
-            self._invalidate_llm_if_current(llm_instance)
+        except LlamaCppInferenceRequestError as exc:
+            self.last_worker_error_code = _safe_worker_error_code(exc)
+            self.log_warning("desktop.llama_cpp_worker.request_failure event=request_scoped_inference_failure safe_error_code=%s worker_generation=%s worker_restart_count=%s" % (self.last_worker_error_code, self._llm_generation, self.worker_restart_count))
+            raise
+        except LlamaCppRestartableWorkerError as exc:
+            self._invalidate_llm_if_current(llm_instance, exc)
 
         replacement = self._ensure_replacement_llm(observed_generation)
         if replacement is None:
@@ -2025,9 +2102,14 @@ class ModelManager:
         if not callable(replacement_create):
             raise RuntimeError('LLM replacement runtime missing create_chat_completion')
         try:
-            return replacement_create(*args, **kwargs)
+            result = replacement_create(*args, **kwargs)
+            self.worker_state = 'ready'
+            self.log_warning("desktop.llama_cpp_worker.replacement_result event=replacement_result result=succeeded worker_generation=%s worker_restart_count=%s" % (self._llm_generation, self.worker_restart_count))
+            return result
         except LlamaCppRestartableWorkerError as exc:
-            self._invalidate_llm_if_current(replacement)
+            self._invalidate_llm_if_current(replacement, exc)
+            self.worker_state = 'failed'
+            self.log_error("desktop.llama_cpp_worker.terminal_failure event=terminal_failure safe_error_code=%s worker_generation=%s worker_restart_count=%s exit_code=%s" % (self.last_worker_error_code, self._llm_generation, self.worker_restart_count, self.last_worker_exit_code))
             raise RuntimeError('LLM runtime replacement failed after one restart attempt') from exc
 
     def llama_cpp_get_response(self, chat_history: List[Dict[str, str]]) -> List[Dict[str, str]]:


### PR DESCRIPTION
### Motivation
- Make the desktop operator able to observe private, privacy-safe worker lifecycle metadata (alive/ready/recovering/failed, generation, restart count, safe error/exit codes and restart timestamp) so operators can reason about worker health and recovery without leaking model payloads or encryption material.
- Surface concise structured local lifecycle log events (initialization, request-scoped failure, dead-worker detection, replacement attempt/result, terminal failure) to aid local root-cause debugging while keeping relay-blind E2EE and public API semantics intact.
- Keep the status contract and UI backward-compatible and prevent stale/session events from overwriting newer worker state (stale generation rejection). 

### Description
- Python model manager (`utils/llm/model_manager.py`) now tracks worker lifecycle fields (`worker_state`, `worker_generation`, `worker_restart_count`, `worker_alive`, `last_worker_error_code`, `last_worker_exit_code`, `last_worker_restart_at_ms`), adds `_safe_worker_error_code()` for safe error codes, exposes `worker_lifecycle_status()` and emits concise structured log events for initialization, request failures, dead-worker detection, replacement attempts/results and terminal failures.
- Desktop bridge (`desktop-tauri/src-tauri/python/compute_node_bridge.py`) calls `runtime.model_manager.worker_lifecycle_status()` when available, merges the optional lifecycle fields into status payloads, and prints sanitized concise lifecycle logs during recovery attempts/success/exhaustion without exposing any prompt/output/encryption material.
- Rust desktop-side `ComputeNodeStatus` (`desktop-tauri/src-tauri/src/compute_node.rs`) was extended to include the optional lifecycle fields and `update_status_from_event` was updated to accept them and reject stale worker-generation events that are older than the cached generation.
- React UI (`desktop-tauri/src/App.tsx`) was extended with the new fields in the `ComputeNodeStatus` type, displays worker state/alive/generation/restart-count/last safe error/exit-code, and `mergeComputeStatusEvent` now rejects older `worker_generation` events to avoid stale overwrites; tests (`desktop-tauri/src/App.test.tsx`) were added/updated to cover propagation, stale-event rejection, and ready/recovering/failed rendering.
- All changes keep process IDs and any plaintext model payloads out of public relay endpoints and status payloads by using optional fields and sanitized local logs only. 

### Testing
- Ran focused Python unit tests: `python -m pytest -q tests/unit/test_model_manager.py tests/unit/test_desktop_compute_node_bridge.py` and they passed (both suites ran; full run reported `236 passed`).
- Ran desktop UI tests: `cd desktop-tauri && npm test` and the UI unit tests passed (`38 tests passed` in `src/App.test.tsx`).
- Ran pre-commit checks: `pre-commit run --all-files` and hooks passed in this environment.
- Attempted Rust tests: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` and `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs` were blocked in this environment due to a missing system dependency (`glib-2.0` / missing `glib-2.0.pc` / unset `PKG_CONFIG_PATH`), so those cargo targets could not complete here and should be run in CI or a machine with the proper GTK/GLib toolchain installed (this is an environment constraint, not a code failure).
- Residual risks and follow-ups: run the Rust integration tests in CI or on a developer machine with `pkg-config`/`glib-2.0` installed to validate the native-side build/test matrix; audit logging to ensure no accidental inclusion of sensitive fields in future changes; optionally add a lightweight e2e smoke in CI that exercises the new status propagation on a linux runner with the required system deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a4fc5ddc832fb36e0f2ff62fb6aa)