### PR TITLE
Expose privacy-safe desktop worker lifecycle diagnostics to UI and logs

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -424,6 +424,36 @@ def _runtime_diagnostics_summary(diagnostics: Dict[str, Any]) -> str:
     )
 
 
+
+def _worker_lifecycle_diagnostics(model_manager: Any) -> Dict[str, Any]:
+    diagnostics = getattr(model_manager, "worker_lifecycle_diagnostics", None)
+    if callable(diagnostics):
+        try:
+            value = diagnostics()
+        except Exception:
+            value = {}
+        if isinstance(value, dict):
+            return value
+    return {
+        "worker_state": "ready" if getattr(model_manager, "llm", None) is not None else "stopped",
+        "worker_generation": 0,
+        "worker_restart_count": 0,
+        "worker_alive": getattr(model_manager, "llm", None) is not None,
+        "last_worker_error_code": None,
+        "last_worker_exit_code": None,
+        "last_worker_restart_at_ms": None,
+    }
+
+def _worker_log_fields(model_manager: Any) -> str:
+    meta = _worker_lifecycle_diagnostics(model_manager)
+    return (
+        f"worker_generation={meta.get('worker_generation', 0)} "
+        f"worker_restart_count={meta.get('worker_restart_count', 0)} "
+        f"worker_state={meta.get('worker_state', 'unknown')} "
+        f"last_worker_error_code={meta.get('last_worker_error_code') or 'none'} "
+        f"last_worker_exit_code={meta.get('last_worker_exit_code') if meta.get('last_worker_exit_code') is not None else 'none'}"
+    )
+
 def _env_enabled(name: str, default: str = "0") -> bool:
     value = os.getenv(name, default)
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
@@ -551,6 +581,13 @@ def _structured_startup_error_payload(
         "warm_load_duration_ms": None,
         "runtime_path": _runtime_path_from_env(),
         "relay_runtime_path": "bridge",
+        "worker_state": "failed",
+        "worker_generation": 0,
+        "worker_restart_count": 0,
+        "worker_alive": False,
+        "last_worker_error_code": "startup_failed",
+        "last_worker_exit_code": None,
+        "last_worker_restart_at_ms": None,
     }
     if operator_session_id is not None:
         payload["operator_session_id"] = operator_session_id
@@ -909,6 +946,7 @@ def run(args: argparse.Namespace) -> int:
             "runtime_path": runtime_path,
             "relay_runtime_path": relay_runtime_path,
         }
+        payload.update(_worker_lifecycle_diagnostics(runtime.model_manager))
         if extra:
             payload.update(extra)
         return payload
@@ -984,6 +1022,13 @@ def run(args: argparse.Namespace) -> int:
                 "desktop.compute_node_bridge.model_init.start "
                 f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
                 f"request_id={request_id} state={warm_load_state}",
+                file=sys.stderr,
+            )
+            print(
+                "desktop.compute_node_bridge.worker.initialization "
+                f"reason={reason} relay={_sanitize_relay_target(active_relay_url)} "
+                f"request_id={request_id} state={warm_load_state} "
+                f"{_worker_log_fields(runtime.model_manager)}",
                 file=sys.stderr,
             )
         if warm_load_future is None:
@@ -1423,6 +1468,13 @@ def run(args: argparse.Namespace) -> int:
                 f"attempts={attempts} backoff_seconds={backoff_seconds:g}",
                 file=sys.stderr,
             )
+            print(
+                "desktop.compute_node_bridge.worker.recovery_start "
+                f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
+                f"attempts={attempts} backoff_seconds={backoff_seconds:g} "
+                f"{_worker_log_fields(runtime.model_manager)}",
+                file=sys.stderr,
+            )
             best_effort_unadvertise_all_relays()
             for attempt in range(1, attempts + 1):
                 if stop_requested():
@@ -1464,8 +1516,9 @@ def run(args: argparse.Namespace) -> int:
                             )
                         )
                         print(
-                            "desktop.compute_node_bridge.recovery.succeeded "
-                            f"attempt={attempt} request_id={request_id}",
+                            "desktop.compute_node_bridge.worker.recovery_result "
+                            f"attempt={attempt} request_id={request_id} result=succeeded "
+                            f"{_worker_log_fields(runtime.model_manager)}",
                             file=sys.stderr,
                         )
                         return True
@@ -1504,8 +1557,9 @@ def run(args: argparse.Namespace) -> int:
                 )
             )
             print(
-                "desktop.compute_node_bridge.recovery.exhausted "
-                f"request_id={request_id} action=restart_desktop_compute_node",
+                "desktop.compute_node_bridge.worker.terminal_failure "
+                f"request_id={request_id} safe_error_code=worker_recovery_exhausted "
+                f"action=restart_desktop_compute_node {_worker_log_fields(runtime.model_manager)}",
                 file=sys.stderr,
             )
             return False
@@ -1768,12 +1822,13 @@ def run(args: argparse.Namespace) -> int:
                         relay_last_error = f"relay request failed: {safe_error_code}"
                     last_error = relay_last_error
                     print(
-                        "desktop.compute_node_bridge.process_request.failed "
+                        "desktop.compute_node_bridge.worker.request_failure "
                         f"relay={_sanitize_relay_target(active_relay_url)} request_id={request_id} "
                         f"safe_error_code={safe_error_code or 'none'} submitted={submitted} "
                         f"runtime_healthy={runtime_healthy} "
                         f"recovery_attempted={recovery_attempted} "
-                        f"recovery_succeeded={recovery_succeeded}",
+                        f"recovery_succeeded={recovery_succeeded} "
+                        f"{_worker_log_fields(runtime.model_manager)}",
                         file=sys.stderr,
                     )
                     if submitted:

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -68,6 +68,13 @@ pub struct ComputeNodeStatus {
     pub sequence: Option<u64>,
     pub updated_at_ms: Option<u64>,
     pub log_file_path: Option<String>,
+    pub worker_state: Option<String>,
+    pub worker_generation: Option<u64>,
+    pub worker_restart_count: Option<u64>,
+    pub worker_alive: Option<bool>,
+    pub last_worker_error_code: Option<String>,
+    pub last_worker_exit_code: Option<i64>,
+    pub last_worker_restart_at_ms: Option<u64>,
 }
 
 #[derive(Clone, Default)]
@@ -263,6 +270,13 @@ fn startup_failure_status(
         sequence: None,
         updated_at_ms: Some(current_time_ms()),
         log_file_path,
+        worker_state: Some("failed".into()),
+        worker_generation: Some(0),
+        worker_restart_count: Some(0),
+        worker_alive: Some(false),
+        last_worker_error_code: Some("startup_failed".into()),
+        last_worker_exit_code: None,
+        last_worker_restart_at_ms: None,
     }
 }
 
@@ -410,6 +424,39 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
             .get("log_file_path")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+    }
+    if let Some(worker_generation) = payload.get("worker_generation").and_then(Value::as_u64) {
+        if status
+            .worker_generation
+            .is_some_and(|current| worker_generation < current)
+        {
+            return true;
+        }
+        status.worker_generation = Some(worker_generation);
+    }
+    if let Some(worker_state) = payload.get("worker_state").and_then(Value::as_str) {
+        status.worker_state = Some(worker_state.into());
+    }
+    if let Some(worker_restart_count) = payload.get("worker_restart_count").and_then(Value::as_u64)
+    {
+        status.worker_restart_count = Some(worker_restart_count);
+    }
+    if payload.get("worker_alive").is_some() {
+        status.worker_alive = payload.get("worker_alive").and_then(Value::as_bool);
+    }
+    if payload.get("last_worker_error_code").is_some() {
+        status.last_worker_error_code = payload
+            .get("last_worker_error_code")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if payload.get("last_worker_exit_code").is_some() {
+        status.last_worker_exit_code = payload.get("last_worker_exit_code").and_then(Value::as_i64);
+    }
+    if payload.get("last_worker_restart_at_ms").is_some() {
+        status.last_worker_restart_at_ms = payload
+            .get("last_worker_restart_at_ms")
+            .and_then(Value::as_u64);
     }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
@@ -580,6 +627,13 @@ fn summarize_bridge_stdout_payload(payload: &Value) -> String {
         "last_error",
         "configured_relay_count",
         "registered_relay_count",
+        "worker_state",
+        "worker_generation",
+        "worker_restart_count",
+        "worker_alive",
+        "last_worker_error_code",
+        "last_worker_exit_code",
+        "last_worker_restart_at_ms",
     ] {
         if let Some(value) = map.get(key) {
             summary.insert(key.to_string(), sanitize_bridge_log_value(key, value));

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1610,4 +1610,54 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+
+  it('shows worker lifecycle states and ignores stale generations', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      relay_runtime_state: 'ready',
+      worker_state: 'ready',
+      worker_generation: 2,
+      worker_restart_count: 1,
+      worker_alive: true,
+      last_worker_error_code: null,
+    });
+    render(<App />);
+    await screen.findByText('Worker lifecycle:');
+    expect(screen.getByText('Worker lifecycle:').textContent).toContain('ready');
+    expect(screen.getByText('Worker alive:').textContent).toContain('yes');
+
+    eventHandlers.get('compute_node_event')?.({ payload: {
+      type: 'status', running: true, registered: false, operator_session_id: null,
+      sequence: 2, worker_state: 'recovering', worker_generation: 3,
+      worker_restart_count: 2, worker_alive: false,
+    }});
+    await waitFor(() => expect(screen.getByText('Worker lifecycle:').textContent).toContain('recovering'));
+    expect(screen.getByText('Worker restarts:').textContent).toContain('2');
+
+    eventHandlers.get('compute_node_event')?.({ payload: {
+      type: 'status', running: true, operator_session_id: null,
+      sequence: 3, worker_state: 'ready', worker_generation: 1,
+      worker_restart_count: 1, worker_alive: true,
+    }});
+    expect(screen.getByText('Worker lifecycle:').textContent).toContain('recovering');
+
+    eventHandlers.get('compute_node_event')?.({ payload: {
+      type: 'error', running: false, registered: false, operator_session_id: null,
+      sequence: 4, worker_state: 'failed', worker_generation: 3,
+      worker_restart_count: 3, worker_alive: false,
+      last_worker_error_code: 'worker_recovery_exhausted', message: 'terminal failure',
+    }});
+    await waitFor(() => expect(screen.getByText('Worker lifecycle:').textContent).toContain('failed'));
+    expect(screen.getByText('Last worker error code:').textContent).toContain('worker_recovery_exhausted');
+  });
+
+  it('renders older bridge statuses without worker fields', async () => {
+    mockInitialComputeStatus({ running: true, registered: true, relay_runtime_state: 'ready' });
+    render(<App />);
+    await screen.findByText('Worker lifecycle:');
+    expect(screen.getByText('Worker lifecycle:').textContent).toContain('unknown');
+    expect(screen.getByText('Worker restarts:').textContent).toContain('0');
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -67,6 +67,13 @@ interface ComputeNodeStatus {
   sequence: number | null;
   updated_at_ms: number | null;
   log_file_path: string | null;
+  worker_state: string | null;
+  worker_generation: number | null;
+  worker_restart_count: number | null;
+  worker_alive: boolean | null;
+  last_worker_error_code: string | null;
+  last_worker_exit_code: number | null;
+  last_worker_restart_at_ms: number | null;
 }
 
 interface ModelArtifactInfo {
@@ -115,6 +122,13 @@ const defaultComputeStatus: ComputeNodeStatus = {
   sequence: null,
   updated_at_ms: null,
   log_file_path: null,
+  worker_state: null,
+  worker_generation: null,
+  worker_restart_count: null,
+  worker_alive: null,
+  last_worker_error_code: null,
+  last_worker_exit_code: null,
+  last_worker_restart_at_ms: null,
 };
 
 function formatErrorMessage(error: unknown): string {
@@ -281,6 +295,10 @@ function mergeComputeStatusEvent(
   ) {
     return prev;
   }
+  const payloadWorkerGeneration = typeof payload.worker_generation === 'number' ? payload.worker_generation : null;
+  if (payloadWorkerGeneration !== null && prev.worker_generation !== null && payloadWorkerGeneration < prev.worker_generation) {
+    return prev;
+  }
 
   return {
     running:
@@ -387,6 +405,28 @@ function mergeComputeStatusEvent(
         : typeof payload.log_file_path === 'string'
           ? payload.log_file_path
           : prev.log_file_path,
+    worker_state: typeof payload.worker_state === 'string' ? payload.worker_state : prev.worker_state,
+    worker_generation: payloadWorkerGeneration ?? prev.worker_generation,
+    worker_restart_count: typeof payload.worker_restart_count === 'number' ? payload.worker_restart_count : prev.worker_restart_count,
+    worker_alive: typeof payload.worker_alive === 'boolean' ? payload.worker_alive : prev.worker_alive,
+    last_worker_error_code:
+      payload.last_worker_error_code === null
+        ? null
+        : typeof payload.last_worker_error_code === 'string'
+          ? payload.last_worker_error_code
+          : prev.last_worker_error_code,
+    last_worker_exit_code:
+      payload.last_worker_exit_code === null
+        ? null
+        : typeof payload.last_worker_exit_code === 'number'
+          ? payload.last_worker_exit_code
+          : prev.last_worker_exit_code,
+    last_worker_restart_at_ms:
+      payload.last_worker_restart_at_ms === null
+        ? null
+        : typeof payload.last_worker_restart_at_ms === 'number'
+          ? payload.last_worker_restart_at_ms
+          : prev.last_worker_restart_at_ms,
     last_error:
       payload.last_error === null
         ? null
@@ -658,6 +698,9 @@ export function App() {
         model_path: config.model_path,
         last_error: null,
         log_file_path: null,
+        worker_state: 'starting',
+        worker_alive: false,
+        last_worker_error_code: null,
       };
       computeStatusRef.current = optimisticStatus;
       setComputeStatus(optimisticStatus);
@@ -866,6 +909,12 @@ export function App() {
         <p style={{ marginBottom: 0 }}>Running: <strong>{computeStatus.running ? 'yes' : 'no'}</strong></p>
         <p style={{ marginBottom: 0 }}>Registered: <strong>{formatRegisteredLabel(computeStatus, normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).length)}</strong></p>
         <p style={{ marginBottom: 0 }}>Relay runtime state: <code>{relayRuntimeState}</code></p>
+        <p style={{ marginBottom: 0 }}>Worker lifecycle: <strong>{displayStatusValue(computeStatus.worker_state, 'unknown')}</strong></p>
+        <p style={{ marginBottom: 0 }}>Worker alive: <strong>{computeStatus.worker_alive === null ? 'unknown' : computeStatus.worker_alive ? 'yes' : 'no'}</strong></p>
+        <p style={{ marginBottom: 0 }}>Worker generation: <code>{computeStatus.worker_generation ?? 'unknown'}</code></p>
+        <p style={{ marginBottom: 0 }}>Worker restarts: <code>{computeStatus.worker_restart_count ?? 0}</code></p>
+        <p style={{ marginBottom: 0 }}>Last worker error code: <code>{computeStatus.last_worker_error_code || 'none'}</code></p>
+        <p style={{ marginBottom: 0 }}>Last worker exit code: <code>{computeStatus.last_worker_exit_code ?? 'none'}</code></p>
         <p style={{ marginBottom: 0 }}>Runtime path: <code>{displayStatusValue(computeStatus.runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Relay runtime path: <code>{displayStatusValue(computeStatus.relay_runtime_path, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Active relay URL: <code>{displayStatusValue(computeStatus.active_relay_url, primaryRelayUrl(config))}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4259,3 +4259,37 @@ def test_api_v1_unhealthy_result_without_recovery_attempt_sets_terminal_state(
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     status_events = [event for event in events if event.get('type') == 'status']
     assert status_events[-1]['relay_runtime_state'] == expected_state
+
+
+
+def test_worker_lifecycle_payload_and_log_fields_are_privacy_safe():
+    module = compute_node_bridge
+
+    class Manager:
+        llm = object()
+        def worker_lifecycle_diagnostics(self):
+            return {
+                'worker_state': 'recovering',
+                'worker_generation': 4,
+                'worker_restart_count': 2,
+                'worker_alive': False,
+                'last_worker_error_code': 'worker_dead',
+                'last_worker_exit_code': 9,
+                'last_worker_restart_at_ms': 12345,
+            }
+
+    manager = Manager()
+    diagnostics = module._worker_lifecycle_diagnostics(manager)
+    assert diagnostics['worker_state'] == 'recovering'
+    assert diagnostics['worker_generation'] == 4
+    fields = module._worker_log_fields(manager)
+    assert 'worker_generation=4' in fields
+    assert 'worker_restart_count=2' in fields
+    forbidden = [
+        'sentinel prompt secret',
+        'sentinel output secret',
+        '-----BEGIN PRIVATE KEY-----',
+        '/Users/alice/private/model.gguf',
+    ]
+    for value in forbidden:
+        assert value not in fields

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3424,3 +3424,34 @@ def test_model_manager_replacement_helpers_handle_unusual_workers(tmp_path, monk
     monkeypatch.setattr(manager, 'get_llm_instance', _get_replacement)
     assert manager._ensure_replacement_llm(manager._llm_generation) is replacement
     assert stale.closed is True
+
+def test_model_manager_worker_lifecycle_diagnostics_request_error_does_not_restart(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first', fail='request')
+    manager, created = _restart_manager(tmp_path, monkeypatch, [first])
+    from utils.llm import model_manager as model_manager_module
+
+    with pytest.raises(model_manager_module.LlamaCppInferenceRequestError):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+    diagnostics = manager.worker_lifecycle_diagnostics()
+    assert diagnostics['worker_generation'] == 0
+    assert diagnostics['worker_restart_count'] == 0
+    assert diagnostics['worker_alive'] is True
+    assert diagnostics['worker_state'] == 'ready'
+    assert diagnostics['last_worker_error_code'] is None
+    assert created == [first]
+
+
+def test_model_manager_worker_lifecycle_diagnostics_fatal_restart_code(tmp_path, monkeypatch):
+    first = _RestartableFakeWorker('first', fail='dead')
+    second = _RestartableFakeWorker('second', fail='eof')
+    manager, _created = _restart_manager(tmp_path, monkeypatch, [first, second])
+
+    with pytest.raises(RuntimeError, match='one restart attempt'):
+        manager.create_chat_completion_with_recovery(messages=[])
+
+    diagnostics = manager.worker_lifecycle_diagnostics()
+    assert diagnostics['worker_restart_count'] == 2
+    assert diagnostics['worker_generation'] == 2
+    assert diagnostics['worker_state'] == 'failed'
+    assert diagnostics['last_worker_error_code'] == 'worker_eof'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1470,6 +1470,11 @@ class ModelManager:
         self.llm = None
         self.llm_lock = Lock()
         self._llm_generation = 0
+        self._llm_restart_count = 0
+        self._llm_state = 'stopped'
+        self._llm_last_error_code: Optional[str] = None
+        self._llm_last_exit_code: Optional[int] = None
+        self._llm_last_restart_at_ms: Optional[int] = None
         self.last_runtime_init_error: Optional[str] = None
 
         # Check if mock mode is enabled
@@ -1490,6 +1495,39 @@ class ModelManager:
             'n_gpu_layers': self.default_n_gpu_layers,
             'fallback_reason': None,
         }
+
+
+    def worker_lifecycle_diagnostics(self) -> Dict[str, Any]:
+        """Return privacy-safe llama.cpp worker lifecycle diagnostics for local UI."""
+        llm = getattr(self, 'llm', None)
+        return {
+            'worker_state': self._llm_state,
+            'worker_generation': self._llm_generation,
+            'worker_restart_count': self._llm_restart_count,
+            'worker_alive': self._llm_is_usable(llm) if llm is not None else False,
+            'last_worker_error_code': self._llm_last_error_code,
+            'last_worker_exit_code': self._llm_last_exit_code,
+            'last_worker_restart_at_ms': self._llm_last_restart_at_ms,
+        }
+
+    def _set_worker_state(self, state: str, *, error_code: Optional[str] = None, exit_code: Optional[int] = None) -> None:
+        self._llm_state = state
+        if error_code is not None:
+            self._llm_last_error_code = error_code
+        if exit_code is not None:
+            self._llm_last_exit_code = exit_code
+
+    @staticmethod
+    def _worker_error_code(exc: BaseException) -> str:
+        if isinstance(exc, LlamaCppWorkerBrokenPipeError):
+            return 'worker_broken_pipe'
+        if isinstance(exc, LlamaCppWorkerEOFError):
+            return 'worker_eof'
+        if isinstance(exc, LlamaCppWorkerDeadError):
+            return 'worker_dead'
+        if isinstance(exc, LlamaCppInferenceRequestError):
+            return 'inference_request_failed'
+        return type(exc).__name__
 
     def _runtime_capabilities(self=None) -> Dict[str, Any]:
         probe = _coerce_desktop_runtime_probe(getattr(self, 'desktop_runtime_probe', None))
@@ -1854,6 +1892,7 @@ class ModelManager:
                     else:
                         try:
                             self.last_runtime_init_error = None
+                            self._set_worker_state('starting')
                             # Dynamically import Llama only when needed
                             self.log_info("Locating llama_cpp runtime for model initialization...")
                             llama_cpp = _import_llama_cpp_runtime(
@@ -1940,6 +1979,7 @@ class ModelManager:
                                 f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
                             )
                             self.log_info("Llama init completed successfully.")
+                            self._set_worker_state('ready', error_code=None)
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.last_runtime_init_error = str(e)
@@ -1949,6 +1989,7 @@ class ModelManager:
                                 f"Failed to initialize Llama model: {self.last_runtime_init_error}",
                                 exc_info=True,
                             )
+                            self._set_worker_state('failed', error_code='worker_initialization_failed')
                             return None
 
         return self.llm
@@ -1976,6 +2017,9 @@ class ModelManager:
                 self._close_llm_proxy(self.llm)
                 self.llm = None
                 self._llm_generation += 1
+                self._llm_restart_count += 1
+                self._llm_last_restart_at_ms = int(time.time() * 1000)
+                self._set_worker_state('recovering', error_code='worker_dead')
             return self._llm_generation
 
     def _ensure_replacement_llm(self, observed_generation: int) -> Any:
@@ -1987,6 +2031,9 @@ class ModelManager:
                 self.llm = None
             if self._llm_generation == observed_generation:
                 self._llm_generation += 1
+                self._llm_restart_count += 1
+                self._llm_last_restart_at_ms = int(time.time() * 1000)
+            self._set_worker_state('recovering', error_code='worker_dead')
             # Release llm_lock before get_llm_instance() because it initializes under
             # the same non-reentrant lock and still serializes creation internally.
         return self.get_llm_instance()
@@ -2015,7 +2062,8 @@ class ModelManager:
             raise RuntimeError('LLM runtime missing create_chat_completion')
         try:
             return create_chat_completion(*args, **kwargs)
-        except LlamaCppRestartableWorkerError:
+        except LlamaCppRestartableWorkerError as exc:
+            self._set_worker_state('recovering', error_code=self._worker_error_code(exc))
             self._invalidate_llm_if_current(llm_instance)
 
         replacement = self._ensure_replacement_llm(observed_generation)
@@ -2025,9 +2073,12 @@ class ModelManager:
         if not callable(replacement_create):
             raise RuntimeError('LLM replacement runtime missing create_chat_completion')
         try:
-            return replacement_create(*args, **kwargs)
+            result = replacement_create(*args, **kwargs)
+            self._set_worker_state('ready')
+            return result
         except LlamaCppRestartableWorkerError as exc:
             self._invalidate_llm_if_current(replacement)
+            self._set_worker_state('failed', error_code=self._worker_error_code(exc))
             raise RuntimeError('LLM runtime replacement failed after one restart attempt') from exc
 
     def llama_cpp_get_response(self, chat_history: List[Dict[str, str]]) -> List[Dict[str, str]]:


### PR DESCRIPTION
### Motivation
- Surface llama.cpp worker lifecycle, liveness, and replacement metadata to the local desktop operator without leaking model payloads, prompts, keys, or decrypted envelopes. 
- Make recovery, replacement attempts, and terminal failure visible in the desktop UI and operator log so operators can triage without weakening relay-blind E2EE.

### Description
- Python: extended `ModelManager` with worker lifecycle state tracking, restart counters, safe error/exit codes, and `worker_lifecycle_diagnostics()` plus `_set_worker_state()` and error-code mapping; updated recovery paths to update those fields and avoid incrementing restarts on request-scoped inference errors. (file: `utils/llm/model_manager.py`)
- Python bridge: added `_worker_lifecycle_diagnostics()` and `_worker_log_fields()` helpers, injected lifecycle fields into status payloads, and emitted concise structured operator-only log events for worker initialization, per-request failures, recovery start/result, and terminal failure; ensured logs sanitize relay targets and avoid sensitive payloads. (file: `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Rust: extended `ComputeNodeStatus` with optional worker fields (`worker_state`, `worker_generation`, `worker_restart_count`, `worker_alive`, `last_worker_error_code`, `last_worker_exit_code`, `last_worker_restart_at_ms`) and updated `update_status_from_event` to accept them with a stale-generation guard. (file: `desktop-tauri/src-tauri/src/compute_node.rs`)
- React UI: extended `ComputeNodeStatus` typing, `mergeComputeStatusEvent` to respect worker-generation freshness, and rendered worker lifecycle, liveness, generation, restart count and final safe codes in the operator UI; preserved backward compatibility for older bridge events. (file: `desktop-tauri/src/App.tsx`) 
- Tests: added unit tests covering Python lifecycle diagnostics survival, stale-generation protection, request-scoped failure non-restart, fatal restart behavior, bridge log field sanitization, UI rendering for ready/recovering/failed, and older-bridge compatibility. (files: `tests/unit/test_model_manager.py`, `tests/unit/test_desktop_compute_node_bridge.py`, `desktop-tauri/src/App.test.tsx`)

### Testing
- Ran Python unit tests: `python -m pytest -q tests/unit/test_model_manager.py tests/unit/test_desktop_compute_node_bridge.py` — result: all tests passed (239 passed).
- Ran desktop JS tests: `cd desktop-tauri && npm test` — result: passed (Vitest: 39 tests passed).
- Ran Rust tests (desktop compute_node and operator_logs): `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` and `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs` — blocked by missing system dependency: `pkg-config` could not find `glib-2.0` (`glib-2.0.pc`), so Cargo tests could not complete in this environment.
- Pre-commit checks: `pre-commit run --all-files` — result: passed.

Notes and residual risks
- Desktop operator logs now include concise structured worker metadata and a sanitized short string summary; no prompts, messages, model outputs, decrypted envelopes, private keys, or full file paths are emitted. Local operator log entries preserve a compact safe root-cause code to aid debugging.
- Cargo test blocking is environmental (missing native `glib-2.0` dev package); CI runners with system deps should complete the Rust tests.
- Playwright/browser screenshots were not captured here because Playwright browsers are not installed in the ephemeral environment (`npx playwright install` required).

Follow-ups
- Run the Rust test suites in CI or a dev environment with `glib-2.0` installed to validate Rust-side behavior end-to-end.
- Consider adding a brief operator-facing docs note summarizing the new worker lifecycle fields and their semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a50203c0832fbbadb806ffb63cac)