### PR TITLE
Remove legacy static chat array responses

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1054,7 +1054,8 @@ new Vue({
                             content: normalizedError.userMessage
                         });
                     }
-                    // For API response, extract last message
+                    // API v1 success responses are either token.place message envelopes
+                    // or OpenAI-compatible choices envelopes.
                     else if (response.message && typeof response.message === 'object') {
                         const assistantMessage = response.message;
                         if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
@@ -1068,18 +1069,6 @@ new Vue({
                             throw new Error('invalid_assistant_response_content');
                         }
                         this.appendAssistantMessage(assistantMessage);
-                    }
-                    // For legacy response format (full chat history)
-                    else if (Array.isArray(response)) {
-                        const history = response.slice();
-                        const candidate = history.length > 0 ? history[history.length - 1] : null;
-                        if (candidate && candidate.role === 'assistant' && typeof candidate.content === 'string') {
-                            history.pop();
-                            this.chatHistory = history;
-                            this.appendAssistantMessage(candidate);
-                        } else {
-                            this.chatHistory = response;
-                        }
                     }
                     else {
                         throw new Error('Unexpected response format');

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -75,12 +75,21 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "distributed provider request failed" not in chat_js
 
 
-def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes():
+def test_landing_chat_js_preserves_context_and_handles_api_v1_success_envelopes():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "createApiV1Messages" in chat_js
     assert "this.chatHistory" in chat_js
     assert "messages: this.createApiV1Messages(messageContent)" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
+    assert "response.choices[0].message" in chat_js
+
+
+def test_landing_chat_js_rejects_raw_array_chat_responses():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "Array.isArray(response)" not in chat_js
+    assert "response.slice()" not in chat_js
+    assert "legacy response format" not in chat_js.lower()
+    assert "full chat history" not in chat_js.lower()
 
 
 def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():


### PR DESCRIPTION
### Motivation
- Standardize the landing chat implementation on API v1-only success envelopes and remove legacy handling that treated a raw array (full chat history) as a successful assistant reply.
- Preserve API v1 E2EE behavior and keep support for `response.message`, OpenAI-compatible `response.choices[0].message`, and structured `response.error` handling.

### Description
- Removed the successful legacy raw-array / full-chat-history branch from `static/chat.js` so successful assistant rendering only accepts `response.message` or `response.choices[0].message` and otherwise treats unexpected arrays as invalid.
- Updated nearby comments in `static/chat.js` to describe API v1-only success envelopes (token.place message envelopes or OpenAI-compatible choices envelopes).
- Updated unit guards in `tests/unit/test_touch_ui.py` to assert `response.choices[0].message` remains supported and to assert raw-array/full-chat-history handling and legacy phrasing are no longer present in `static/chat.js`.
- Changes are limited to `static/chat.js` and `tests/unit/test_touch_ui.py` and do not touch any API v2 files or tests.

### Testing
- Ran the focused unit tests: `pytest -q tests/unit/test_touch_ui.py` — 9 tests passed (all tests in that file passed).
- Ran a repo scan excluding API v2 to detect legacy-array success handling: `rg -n "legacy response|full chat history|response\.slice\(|Array\.isArray\(response\)" . -g '!api/v2/**'` — results show the removed array-handling only in `static/chat.js` and the new guard assertions in `tests/unit/test_touch_ui.py` (no remaining non-API-v1 successful raw-array chat response handling outside API v2).
- Ran lint/pre-commit checks: `pre-commit run --all-files` — hooks passed.
- Note: changes were kept minimal and targeted to the landing chat JS and its unit guard; follow-up reviews can expand scanning if additional legacy wording should be removed from docs or other tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38c03fc6e4832f90975a316414c40e)