### PR TITLE
Remove legacy full-chat-array response handling from static/chat.js

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1054,7 +1054,7 @@ new Vue({
                             content: normalizedError.userMessage
                         });
                     }
-                    // For API response, extract last message
+                    // API v1 response.message envelope.
                     else if (response.message && typeof response.message === 'object') {
                         const assistantMessage = response.message;
                         if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
@@ -1062,24 +1062,13 @@ new Vue({
                         }
                         this.appendAssistantMessage(assistantMessage);
                     }
+                    // OpenAI-compatible API v1 choices envelope.
                     else if (response.choices && response.choices.length > 0) {
                         const assistantMessage = response.choices[0].message;
                         if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
                             throw new Error('invalid_assistant_response_content');
                         }
                         this.appendAssistantMessage(assistantMessage);
-                    }
-                    // For legacy response format (full chat history)
-                    else if (Array.isArray(response)) {
-                        const history = response.slice();
-                        const candidate = history.length > 0 ? history[history.length - 1] : null;
-                        if (candidate && candidate.role === 'assistant' && typeof candidate.content === 'string') {
-                            history.pop();
-                            this.chatHistory = history;
-                            this.appendAssistantMessage(candidate);
-                        } else {
-                            this.chatHistory = response;
-                        }
                     }
                     else {
                         throw new Error('Unexpected response format');

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -85,16 +85,26 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
 
 
 def test_landing_chat_js_rejects_raw_array_chat_responses():
+    # Landing chat invariants currently use static string guards here rather
+    # than an executable static/chat.js harness. Keep these assertions focused
+    # on the API v1 response contract so unexpected raw arrays stay on the
+    # invalid response path instead of being appended as assistant replies.
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     forbidden_array_branch = "Array.isArray" + "(response)"
     forbidden_slice_branch = "response" + ".slice"
     forbidden_history_comment = "full chat" + " history"
     forbidden_compat_comment = "legacy" + " response" + " format"
+
     assert forbidden_array_branch not in chat_js
     assert forbidden_slice_branch not in chat_js
     assert forbidden_history_comment not in chat_js
     assert forbidden_compat_comment not in chat_js.lower()
-    assert "Unexpected response format" in chat_js
+    assert "else if (response.message && typeof response.message === 'object')" in chat_js
+    assert "const assistantMessage = response.message;" in chat_js
+    assert "else if (response.choices && response.choices.length > 0)" in chat_js
+    assert "const assistantMessage = response.choices[0].message;" in chat_js
+    assert "this.appendAssistantMessage(assistantMessage);" in chat_js
+    assert "throw new Error('Unexpected response format');" in chat_js
 
 
 def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -81,6 +81,20 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     assert "this.chatHistory" in chat_js
     assert "messages: this.createApiV1Messages(messageContent)" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
+    assert "response.choices[0].message" in chat_js
+
+
+def test_landing_chat_js_rejects_raw_array_chat_responses():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    forbidden_array_branch = "Array.isArray" + "(response)"
+    forbidden_slice_branch = "response" + ".slice"
+    forbidden_history_comment = "full chat" + " history"
+    forbidden_compat_comment = "legacy" + " response" + " format"
+    assert forbidden_array_branch not in chat_js
+    assert forbidden_slice_branch not in chat_js
+    assert forbidden_history_comment not in chat_js
+    assert forbidden_compat_comment not in chat_js.lower()
+    assert "Unexpected response format" in chat_js
 
 
 def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():


### PR DESCRIPTION
### Motivation
- Standardize the frontend landing chat to API v1 envelopes only and remove an old compatibility branch that treated raw full-chat-history arrays as successful responses. 
- Preserve API v1 E2EE behavior and existing valid API v1 success/error shapes while preventing accidental acceptance of legacy raw-array responses.

### Description
- Removed the successful legacy raw-array/full-chat-history branch (Array.isArray(response)) from `static/chat.js` so successful assistant rendering only accepts `response.message` or OpenAI-compatible `response.choices[0].message` or structured `response.error` envelopes. 
- Updated nearby comments to describe API v1-only handling and added a small frontend test asserting the raw-array branch/comment is no longer present. 
- Only touched `static/chat.js` and the unit test `tests/unit/test_touch_ui.py`; API v2 files were not modified.

### Testing
- Ran unit tests: `pytest tests/unit/test_touch_ui.py -q`, which passed (9 passed). 
- Searched repo for legacy-compatible array branches with: `rg -n "legacy response|full chat history|response\.slice\(|Array\.isArray\(response\)" . -g '!api/v2/**'`, which returned no remaining matches for the forbidden patterns. 
- Verified static/tests/docs grep guardrails with: `rg -n "legacy response|full chat history" static tests api docs -g '!api/v2/**'`, which returned no problematic matches. 
- Ran pre-commit hooks: `pre-commit run --all-files`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38c055bae4832fbf275436f8bc094c)