### PR TITLE
Remove legacy landing chat array response handling

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1054,7 +1054,7 @@ new Vue({
                             content: normalizedError.userMessage
                         });
                     }
-                    // For API response, extract last message
+                    // API v1 responses may be native token.place envelopes or OpenAI-compatible choices.
                     else if (response.message && typeof response.message === 'object') {
                         const assistantMessage = response.message;
                         if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
@@ -1068,18 +1068,6 @@ new Vue({
                             throw new Error('invalid_assistant_response_content');
                         }
                         this.appendAssistantMessage(assistantMessage);
-                    }
-                    // For legacy response format (full chat history)
-                    else if (Array.isArray(response)) {
-                        const history = response.slice();
-                        const candidate = history.length > 0 ? history[history.length - 1] : null;
-                        if (candidate && candidate.role === 'assistant' && typeof candidate.content === 'string') {
-                            history.pop();
-                            this.chatHistory = history;
-                            this.appendAssistantMessage(candidate);
-                        } else {
-                            this.chatHistory = response;
-                        }
                     }
                     else {
                         throw new Error('Unexpected response format');

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -81,6 +81,15 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     assert "this.chatHistory" in chat_js
     assert "messages: this.createApiV1Messages(messageContent)" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
+    assert "response.choices[0].message" in chat_js
+
+
+def test_landing_chat_js_rejects_raw_array_chat_responses():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "legacy " + "response format" not in chat_js
+    assert "full " + "chat history" not in chat_js
+    assert "Array.isArray" + "(response)" not in chat_js
+    assert "response." + "slice()" not in chat_js
 
 
 def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():


### PR DESCRIPTION
### Motivation
- Standardize the landing chat renderer on API v1 response shapes only and remove support for legacy raw-array/full-chat-history success responses.
- Ensure the client no longer accepts raw array responses as successful assistant replies while preserving API v1 E2EE and structured error behavior.

### Description
- Removed the legacy successful raw-array/full-chat-history branch from `static/chat.js` so unexpected arrays now fall through to the existing unexpected response error path.
- Kept API v1 success parsing for `response.message` and OpenAI-compatible `response.choices[0].message`, and retained structured `response.error` handling and user-facing mapping.
- Updated nearby comment in `static/chat.js` to reflect API v1-only behavior and added a unit assertion in `tests/unit/test_touch_ui.py` to assert the legacy raw-array handling is absent.

### Testing
- Ran `pytest tests/unit/test_touch_ui.py -q` and it passed (`9 passed`).
- Ran `pre-commit run --all-files` and all configured hooks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38c05fbbcc832fb769cd464be363a9)