### PR TITLE
Reject legacy full-chat-array responses; enforce API v1 assistant envelope handling

### DIFF
--- a/client.py
+++ b/client.py
@@ -332,7 +332,8 @@ class ChatClient:
                                     logger.warning("Invalid assistant message format in API v1 response.")
                                     return None
                                 return list(chat_history or self.chat_history) + [assistant_message]
-                            return decrypted_payload
+                            logger.warning("Unexpected API v1 response envelope type: %s", type(decrypted_payload).__name__)
+                            return None
                         else:
                             logger.debug("Decryption failed. Skipping this response.")
                     else:

--- a/static/chat.js
+++ b/static/chat.js
@@ -1054,7 +1054,7 @@ new Vue({
                             content: normalizedError.userMessage
                         });
                     }
-                    // For API response, extract last message
+                    // For API v1 response envelopes, extract the assistant message.
                     else if (response.message && typeof response.message === 'object') {
                         const assistantMessage = response.message;
                         if (this.isInvalidAssistantResponseContent(assistantMessage && assistantMessage.content)) {
@@ -1068,18 +1068,6 @@ new Vue({
                             throw new Error('invalid_assistant_response_content');
                         }
                         this.appendAssistantMessage(assistantMessage);
-                    }
-                    // For legacy response format (full chat history)
-                    else if (Array.isArray(response)) {
-                        const history = response.slice();
-                        const candidate = history.length > 0 ? history[history.length - 1] : null;
-                        if (candidate && candidate.role === 'assistant' && typeof candidate.content === 'string') {
-                            history.pop();
-                            this.chatHistory = history;
-                            this.appendAssistantMessage(candidate);
-                        } else {
-                            this.chatHistory = response;
-                        }
                     }
                     else {
                         throw new Error('Unexpected response format');

--- a/tests/test_crypto_helpers.py
+++ b/tests/test_crypto_helpers.py
@@ -145,21 +145,26 @@ def test_error_handling():
 
 @patch('utils.crypto_helpers.requests')
 @patch('utils.crypto_helpers.time')  # Mock time.sleep
-def test_send_chat_message(_mock_time, mock_requests):
+@patch('utils.crypto_helpers.uuid.uuid4')
+def test_send_chat_message(mock_uuid4, _mock_time, mock_requests):
     """Test sending a chat message"""
     # Mock responses
+    mock_uuid4.return_value.hex = 'abc123'
     mock_faucet_response = MagicMock()
     mock_faucet_response.status_code = 200
     mock_faucet_response.json.return_value = {'success': True}
 
     mock_retrieve_response = MagicMock()
     mock_retrieve_response.status_code = 200
-    chat_history = json.dumps([
-        {"role": "user", "content": "Test message"},
-        {"role": "assistant", "content": "Mock Response: Test reply"}
-    ])
+    api_v1_response = json.dumps({
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "request_id": "crypto-client-abc123",
+        "api_v1_response": {
+            "message": {"role": "assistant", "content": "Mock Response: Test reply"}
+        },
+    })
     mock_retrieve_response.json.return_value = {
-        'chat_history': base64.b64encode(chat_history.encode()).decode(),
+        'chat_history': base64.b64encode(api_v1_response.encode()).decode(),
         'cipherkey': base64.b64encode(b'mock_key').decode(),
         'iv': base64.b64encode(b'mock_iv').decode()
     }
@@ -178,8 +183,8 @@ def test_send_chat_message(_mock_time, mock_requests):
             b'mock_iv'
         )
 
-        # Mock decrypt to return the chat history
-        mock_decrypt.return_value = chat_history.encode()
+        # Mock decrypt to return an API v1 response envelope
+        mock_decrypt.return_value = api_v1_response.encode()
 
         # Create client and set server key
         client = CryptoClient('https://test-server.com')
@@ -859,6 +864,7 @@ def test_retrieve_chat_response_api_v1_invalid_envelopes(monkeypatch):
         {'protocol': 'tokenplace_api_v1_relay_e2ee', 'api_v1_response': {'error': {'message': 'boom'}}},
         {'protocol': 'tokenplace_api_v1_relay_e2ee', 'api_v1_response': {}},
         {'protocol': 'tokenplace_api_v1_relay_e2ee', 'api_v1_response': {'message': {'role': 'assistant'}}},
+        [{'role': 'user', 'content': 'hi'}, {'role': 'assistant', 'content': 'legacy ok'}],
     ]
 
     for envelope in invalid_envelopes:

--- a/tests/unit/test_chat_client.py
+++ b/tests/unit/test_chat_client.py
@@ -62,6 +62,26 @@ def test_send_message_flow():
         )
 
 
+
+def test_retrieve_response_rejects_raw_array_payload():
+    client = ChatClient('http://test', relay_port=5000)
+    encrypted_response = {
+        'chat_history': base64.b64encode(b'ciphertext').decode('utf-8'),
+        'cipherkey': base64.b64encode(b'cipherkey').decode('utf-8'),
+        'iv': base64.b64encode(b'iv').decode('utf-8'),
+    }
+    with patch('client.requests.post') as m_post, patch('client.decrypt') as m_dec:
+        m_post.return_value = MagicMock(status_code=200)
+        m_post.return_value.json.return_value = encrypted_response
+        m_dec.return_value = json.dumps([
+            {'role': 'user', 'content': 'hi'},
+            {'role': 'assistant', 'content': 'legacy ok'},
+        ]).encode('utf-8')
+
+        response = client.retrieve_response(timeout=0.1, request_id='req-1')
+
+    assert response is None
+
 def test_send_message_returns_none_when_no_server_public_key():
     client = ChatClient('http://test', relay_port=5000)
     with patch.object(client, 'get_server_public_key', return_value=None), \

--- a/tests/unit/test_crypto_helpers_additional.py
+++ b/tests/unit/test_crypto_helpers_additional.py
@@ -57,7 +57,10 @@ def test_retrieve_chat_success(monkeypatch):
         "utils.crypto_helpers.requests.post",
         lambda *a, **k: _FakeResponse(status_code=200, payload=enc),
     )
-    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value=[{'role':'assistant','content':'ok'}]))
+    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value={
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'api_v1_response': {'message': {'role': 'assistant', 'content': 'ok'}},
+    }))
     monkeypatch.setattr('utils.crypto_helpers.time.sleep', lambda x: None)
     result = client.retrieve_chat_response(max_retries=1, retry_delay=0)
     assert result[0]['content'] == 'ok'
@@ -74,7 +77,10 @@ def test_retrieve_chat_invalid_message_structure(monkeypatch):
         "utils.crypto_helpers.requests.post",
         lambda *a, **k: _FakeResponse(status_code=200, payload=enc),
     )
-    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value=[{'role': 'assistant'}]))
+    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value={
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'api_v1_response': {'message': {'role': 'assistant'}},
+    }))
     res = client.retrieve_chat_response(max_retries=1, retry_delay=0)
     assert res is None
 

--- a/tests/unit/test_crypto_helpers_edge.py
+++ b/tests/unit/test_crypto_helpers_edge.py
@@ -34,16 +34,22 @@ def test_base_url_requires_scheme(url: str) -> None:
         CryptoClient(url)
 
 
-def test_send_chat_message_list_branch():
+def test_send_chat_message_list_input_uses_api_v1_envelope():
     client = _prep_client()
     msgs = [{'role': 'user', 'content': 'hi'}]
     with patch.object(client, 'fetch_server_public_key', return_value=True), \
+         patch('utils.crypto_helpers.uuid.uuid4') as mock_uuid4, \
          patch('utils.crypto_helpers.encrypt', return_value=({'ciphertext': b'c', 'iv': b'i'}, b'k', b'i')), \
          patch.object(client, 'send_encrypted_message', return_value={'success': True}), \
          patch('utils.crypto_helpers.requests.post', return_value=_FakeResponse(status_code=200, payload={'chat_history': 'c', 'cipherkey': 'k', 'iv': 'i'})), \
-         patch.object(client, 'decrypt_message', return_value=msgs), \
+         patch.object(client, 'decrypt_message', return_value={
+             'protocol': 'tokenplace_api_v1_relay_e2ee',
+             'request_id': 'crypto-client-abc123',
+             'api_v1_response': {'message': {'role': 'assistant', 'content': 'ok'}},
+         }), \
          patch('utils.crypto_helpers.time.sleep'):
-        assert client.send_chat_message(msgs) == msgs
+        mock_uuid4.return_value.hex = 'abc123'
+        assert client.send_chat_message(msgs) == msgs + [{'role': 'assistant', 'content': 'ok'}]
 
 
 def test_retrieve_chat_response_error_list():
@@ -57,6 +63,7 @@ def test_send_api_request_old_format_decrypt_exception():
     client = _prep_client()
     enc = {'ciphertext': 'c', 'cipherkey': 'k', 'iv': 'i'}
     with patch.object(client, 'send_encrypted_message', return_value={'encrypted': True, 'encrypted_content': enc}), \
+         patch('utils.crypto_helpers.uuid.uuid4') as mock_uuid4, \
          patch('utils.crypto_helpers.encrypt', return_value=({'ciphertext': b'c', 'iv': b'i'}, b'k', b'i')), \
          patch.object(client, 'decrypt_message', side_effect=Exception('fail')):
         assert client.send_api_request([{'role': 'user', 'content': 'hi'}]) is None

--- a/tests/unit/test_crypto_helpers_failures.py
+++ b/tests/unit/test_crypto_helpers_failures.py
@@ -70,7 +70,10 @@ def test_retrieve_chat_response_retry(monkeypatch):
         _FakeResponse(200, {'chat_history': 'c', 'cipherkey': 'k', 'iv': 'i'}),
     ])
     monkeypatch.setattr('utils.crypto_helpers.requests.post', lambda *a, **k: next(seq))
-    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value=[{'role': 'assistant', 'content': 'ok'}]))
+    monkeypatch.setattr(client, 'decrypt_message', MagicMock(return_value={
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'api_v1_response': {'message': {'role': 'assistant', 'content': 'ok'}},
+    }))
     result = client.retrieve_chat_response(max_retries=2, retry_delay=0)
     assert result[0]['content'] == 'ok'
 

--- a/tests/unit/test_crypto_helpers_simple.py
+++ b/tests/unit/test_crypto_helpers_simple.py
@@ -34,12 +34,17 @@ def test_encrypt_decrypt_message():
 def test_send_chat_message():
     with patch('utils.crypto_helpers.encrypt') as mock_enc, \
          patch('utils.crypto_helpers.decrypt') as mock_dec, \
-         patch('utils.crypto_helpers.requests') as mock_requests:
+         patch('utils.crypto_helpers.requests') as mock_requests, \
+         patch('utils.crypto_helpers.uuid.uuid4') as mock_uuid4:
+        mock_uuid4.return_value.hex = 'abc123'
         mock_enc.return_value = ({'ciphertext': b'd', 'iv': b'i'}, b'k', b'i')
-        mock_dec.return_value = json.dumps([
-            {'role': 'user', 'content': 'hi'},
-            {'role': 'assistant', 'content': 'hey'}
-        ]).encode()
+        mock_dec.return_value = json.dumps({
+            'protocol': 'tokenplace_api_v1_relay_e2ee',
+            'request_id': 'crypto-client-abc123',
+            'api_v1_response': {
+                'message': {'role': 'assistant', 'content': 'hey'},
+            },
+        }).encode()
         get_resp = MagicMock(status_code=200)
         get_resp.json.return_value = {'server_public_key': base64.b64encode(b'k').decode()}
         post_resp = MagicMock(status_code=200)

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -81,6 +81,17 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     assert "this.chatHistory" in chat_js
     assert "messages: this.createApiV1Messages(messageContent)" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
+    assert "response.choices && response.choices.length > 0" in chat_js
+    assert "response.choices[0].message" in chat_js
+
+
+def test_landing_chat_js_rejects_raw_array_chat_responses():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "legacy" + " response format" not in chat_js
+    assert "full chat" + " history" not in chat_js
+    assert "response" + ".slice(" not in chat_js
+    assert "Array.isArray" + "(response)" not in chat_js
+    assert "Unexpected response format" in chat_js
 
 
 def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():

--- a/utils/crypto_helpers.py
+++ b/utils/crypto_helpers.py
@@ -493,16 +493,8 @@ class CryptoClient:
                             return [assistant_message]
                         return list(chat_history) + [assistant_message]
 
-                    # Validate the response structure for legacy-compatible test fixtures.
-                    if isinstance(decrypted_data, list) and len(decrypted_data) > 0:
-                        for msg in decrypted_data:
-                            if not isinstance(msg, dict) or 'role' not in msg or 'content' not in msg:
-                                logger.warning("Invalid message format in response")
-                                return None
-                        return decrypted_data
-                    else:
-                        logger.warning("Unexpected response format type: %s", type(decrypted_data).__name__)
-                        return None
+                    logger.warning("Unexpected response format type: %s", type(decrypted_data).__name__)
+                    return None
                 except Exception as e:
                     logger.error(
                         "Failed to decrypt response: %s",


### PR DESCRIPTION
### Motivation
- Standardize landing chat and client-side response handling on API v1 envelopes only and remove legacy successful raw full-chat-history array handling.
- Preserve API v1 E2EE semantics and structured error rendering while avoiding acceptance of ambiguous/legacy array payloads as successful assistant replies.

### Description
- Removed the legacy successful raw-array/full-chat-history branch from `static/chat.js` so successful assistant rendering only accepts `response.message` or `response.choices[0].message`, with structured API v1 `error` handling unchanged.
- Updated `utils/crypto_helpers.py` to treat decrypted non-dict payloads (including raw arrays) as invalid API v1 envelopes and return `None` with a warning instead of returning/accepting raw arrays.
- Updated `client.py` `retrieve_response` flow to reject decrypted payloads that are not API v1 envelope objects and log an explanatory warning instead of returning raw-array chat histories.
- Updated and added tests and fixtures to assert API v1 envelope handling (`response.message` and `response.choices[0].message`) and to assert raw-array/full-history responses are rejected; preserved API v2 files untouched.

### Testing
- Ran the focused JS/Python unit subset verifying the landing chat and client changes: `python -m pytest tests/unit/test_touch_ui.py tests/unit/test_chat_client.py tests/test_crypto_helpers.py -q` — all tests in that run passed.
- Ran the unit suite and adjusted affected test fixtures where necessary: `python -m pytest tests/unit -q` — after targeted fixes the unit suite passed locally (previous transient expectations for legacy array fixtures were updated to API v1 envelopes).
- Ran repository checks and hooks: `pre-commit run --all-files` — passed.
- Performed grep checks to ensure no remaining non-API-v1 legacy-success branches outside API v2: `rg -n "legacy response|full chat history|response\.slice\(|Array\.isArray\(response\)" . -g '!api/v2/**'` and `rg -n "legacy response|full chat history" static tests api docs -g '!api/v2/**'` — returned no matches.

All changes are limited to non-API-v2 files, preserve API v1 E2EE behavior, and keep diffs minimal and focused on removing legacy raw-array success handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38c0679bc4832f98d78099866f82c6)