### PR TITLE
Remove legacy upstream diagnostic aliases

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -539,7 +539,6 @@ After (explicit relay-only semantics):
   "activeUpstreamServers": [],
   "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
-  "legacyConfiguredUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
   "details": {"knownServers": "empty"}
 }
@@ -558,8 +557,6 @@ Interpretation:
   compatibility/configured upstream pool.
 - `configuredUpstreamServers` is retained as a stable compatibility key and can
   differ from the explicit runtime upstream.
-- `legacyConfiguredUpstreamServers` represents compatibility/default config, not
-  active runtime state or a required staging dependency.
 - Operators should rely on `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`, `requiredUpstreamServers`, and registered compute-node counts when judging relay-only readiness.
 
 ## Guardrails

--- a/relay.py
+++ b/relay.py
@@ -333,22 +333,6 @@ def _active_upstream_reporting_servers(
     return configured_servers
 
 
-def _legacy_configured_upstream_reporting_servers(
-    configured_servers: List[str],
-    *,
-    explicit_upstream_config: bool,
-) -> List[str]:
-    """Return compatibility/default upstream config without relabeling custom pools."""
-
-    if (
-        explicit_upstream_config
-        and _normalise_upstream_server_pool(configured_servers)
-        != _normalise_upstream_server_pool(["https://token.place"])
-    ):
-        return []
-    return configured_servers
-
-
 def _load_upstream_config() -> Dict[str, Any]:
     upstream_override = os.environ.get(UPSTREAM_URL_ENV)
     parsed_host = None
@@ -867,12 +851,6 @@ def healthz():
         "registeredServers": _live_server_diagnostics(),
     }
     status["configuredUpstreamServers"] = configured_servers
-    status["legacyConfiguredUpstreamServers"] = (
-        _legacy_configured_upstream_reporting_servers(
-            configured_servers,
-            explicit_upstream_config=explicit_upstream_config,
-        )
-    )
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -1140,12 +1118,6 @@ def relay_diagnostics():
         "api_v1_registered_compute_nodes": api_v1_live_nodes,
         "total_api_v1_registered_compute_nodes": len(api_v1_live_nodes),
         "configured_upstream_servers": configured_servers,
-        "legacy_configured_upstream_servers": (
-            _legacy_configured_upstream_reporting_servers(
-                configured_servers,
-                explicit_upstream_config=explicit_upstream_config,
-            )
-        ),
     }
     response = jsonify(diagnostics)
     response.headers["Cache-Control"] = "no-store"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1043,7 +1043,6 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["required_upstream_servers"] == []
-    assert payload["legacy_configured_upstream_servers"] == []
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
     assert payload["total_registered_compute_nodes"] == 1
@@ -1178,7 +1177,6 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
 
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
-    assert payload["legacy_configured_upstream_servers"] == []
     assert payload["active_upstream_servers"] == ["https://gpu.example.com:5015"]
     assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
@@ -1202,7 +1200,6 @@ def test_relay_diagnostics_relay_only_reports_no_active_or_required_upstreams(cl
     assert payload["active_upstream_servers"] == []
     assert payload["required_upstream_servers"] == []
     assert payload["configured_upstream_servers"] == ["https://token.place"]
-    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
 
 
 def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
@@ -1238,7 +1235,6 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     assert payload["requiredUpstreamServers"] == []
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
-    assert payload["legacyConfiguredUpstreamServers"] == []
     assert payload["registeredServers"][0]["server_public_key"] == live_server_key
     assert payload["registeredServers"][0]["age_seconds"] >= 0
     assert payload["registeredServers"][0]["queue_depth"] == 1
@@ -1294,7 +1290,6 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["gpuHost"] == "definitely-not-resolvable.invalid"
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is True
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
@@ -1370,7 +1365,6 @@ def test_explicit_runtime_upstream_reports_active_without_required_dependency(
     assert payload["activeUpstreamServers"] == ["https://gpu.example.test:3000"]
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
     diagnostics_response = client.get("/relay/diagnostics")
     diagnostics_payload = diagnostics_response.get_json()
@@ -1383,9 +1377,6 @@ def test_explicit_runtime_upstream_reports_active_without_required_dependency(
     ]
     assert diagnostics_payload["required_upstream_servers"] == []
     assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
-    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
-        "https://token.place"
-    ]
 
 
 def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
@@ -1411,7 +1402,6 @@ def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
     assert payload["requiredUpstreamServers"] == ["https://gpu.example.test:3000"]
     assert "https://token.place" not in payload["requiredUpstreamServers"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
     diagnostics_response = client.get("/relay/diagnostics")
     diagnostics_payload = diagnostics_response.get_json()
@@ -1425,9 +1415,6 @@ def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
     ]
     assert "https://token.place" not in diagnostics_payload["required_upstream_servers"]
     assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
-    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
-        "https://token.place"
-    ]
 
 
 def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeypatch):
@@ -1449,15 +1436,14 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["knownServers"] == 0
     assert payload["relayOnly"] is True
     assert payload["upstreamHealthRequired"] is False
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
-def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeypatch):
-    """Malformed upstream list env should not mark fallback default as explicit config."""
+def test_healthz_malformed_upstreams_env_keeps_default_configured(client, monkeypatch):
+    """Malformed upstream list env should keep fallback default configured but inactive."""
     monkeypatch.setenv("TOKEN_PLACE_RELAY_UPSTREAMS", '{"url":"https://ignored"}')
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
     monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
@@ -1472,11 +1458,10 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
 
-def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, monkeypatch):
-    """Custom configured server pools should be treated as explicit/non-legacy."""
+def test_healthz_custom_configured_servers_are_active(client, monkeypatch):
+    """Custom configured server pools should be treated as explicit active config."""
     monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
     monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
@@ -1491,7 +1476,6 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
     assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
-    assert payload["legacyConfiguredUpstreamServers"] == []
 
 
 def test_relay_entrypoint_defaults_to_one_worker_and_multiple_threads():


### PR DESCRIPTION
### Motivation
- Health and diagnostics endpoints exposed duplicate "legacy" upstream fields that are misleading the current API surface and public smoke tests.
- Remove the obsolete alias fields so responses and docs only present the canonical configured-upstream keys while preserving API v1 behavior.

### Description
- Removed `legacyConfiguredUpstreamServers` from the `/healthz` JSON payload and `legacy_configured_upstream_servers` from `/relay/diagnostics`, keeping `configuredUpstreamServers` and `configured_upstream_servers` respectively.
- Removed the `_legacy_configured_upstream_reporting_servers` helper (no longer needed) and the code paths that produced the legacy aliases.
- Updated tests in `tests/test_relay.py` to stop asserting the removed legacy fields and adjusted a few test names/strings to reflect the canonical terminology.
- Updated `docs/relay_sugarkube_onboarding.md` to remove the legacy field from the example payload and related explanatory text.

### Testing
- Ran the relay unit tests with `python -m pytest tests/test_relay.py -q`, which completed successfully: `120 passed` (with warnings).
- Ran repository checks with `pre-commit run --all-files`, which completed successfully (all hooks passed).
- Verified no remaining non-api-v2 references with `rg -n "legacyConfiguredUpstreamServers|legacy_configured_upstream_servers" . -g '!api/v2/**'`, which returned no matches.
- Verified canonical fields remain referenced with `rg -n "configuredUpstreamServers|configured_upstream_servers" tests api static docs -g '!api/v2/**'`, which returned expected occurrences in tests and docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38d1020de4832fa509ffce415fab78)