### PR TITLE
Remove legacy upstream diagnostic aliases

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -539,7 +539,6 @@ After (explicit relay-only semantics):
   "activeUpstreamServers": [],
   "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
-  "legacyConfiguredUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
   "details": {"knownServers": "empty"}
 }
@@ -556,10 +555,8 @@ Interpretation:
 - When `upstreamHealthRequired: true`, `requiredUpstreamServers` reports the concrete
   `upstream` URL that `/healthz` actually checks, not every URL retained in the
   compatibility/configured upstream pool.
-- `configuredUpstreamServers` is retained as a stable compatibility key and can
+- `configuredUpstreamServers` is retained as the stable configured upstream key and can
   differ from the explicit runtime upstream.
-- `legacyConfiguredUpstreamServers` represents compatibility/default config, not
-  active runtime state or a required staging dependency.
 - Operators should rely on `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`, `requiredUpstreamServers`, and registered compute-node counts when judging relay-only readiness.
 
 ## Guardrails

--- a/relay.py
+++ b/relay.py
@@ -333,21 +333,6 @@ def _active_upstream_reporting_servers(
     return configured_servers
 
 
-def _legacy_configured_upstream_reporting_servers(
-    configured_servers: List[str],
-    *,
-    explicit_upstream_config: bool,
-) -> List[str]:
-    """Return compatibility/default upstream config without relabeling custom pools."""
-
-    if (
-        explicit_upstream_config
-        and _normalise_upstream_server_pool(configured_servers)
-        != _normalise_upstream_server_pool(["https://token.place"])
-    ):
-        return []
-    return configured_servers
-
 
 def _load_upstream_config() -> Dict[str, Any]:
     upstream_override = os.environ.get(UPSTREAM_URL_ENV)
@@ -867,12 +852,6 @@ def healthz():
         "registeredServers": _live_server_diagnostics(),
     }
     status["configuredUpstreamServers"] = configured_servers
-    status["legacyConfiguredUpstreamServers"] = (
-        _legacy_configured_upstream_reporting_servers(
-            configured_servers,
-            explicit_upstream_config=explicit_upstream_config,
-        )
-    )
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -1140,12 +1119,6 @@ def relay_diagnostics():
         "api_v1_registered_compute_nodes": api_v1_live_nodes,
         "total_api_v1_registered_compute_nodes": len(api_v1_live_nodes),
         "configured_upstream_servers": configured_servers,
-        "legacy_configured_upstream_servers": (
-            _legacy_configured_upstream_reporting_servers(
-                configured_servers,
-                explicit_upstream_config=explicit_upstream_config,
-            )
-        ),
     }
     response = jsonify(diagnostics)
     response.headers["Cache-Control"] = "no-store"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1041,9 +1041,10 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
     payload = response.get_json()
 
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
+    # Intentional guard: the removed diagnostics alias must not reappear.
+    assert "legacy_configured_upstream_servers" not in payload
     assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["required_upstream_servers"] == []
-    assert payload["legacy_configured_upstream_servers"] == []
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
     assert payload["total_registered_compute_nodes"] == 1
@@ -1178,7 +1179,6 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
 
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
-    assert payload["legacy_configured_upstream_servers"] == []
     assert payload["active_upstream_servers"] == ["https://gpu.example.com:5015"]
     assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
@@ -1186,7 +1186,7 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
 
 
 def test_relay_diagnostics_relay_only_reports_no_active_or_required_upstreams(client, monkeypatch):
-    """Relay-only diagnostics should separate legacy fallback config from readiness dependencies."""
+    """Relay-only diagnostics should separate configured fallback URLs from readiness dependencies."""
     monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
     monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
@@ -1202,7 +1202,6 @@ def test_relay_diagnostics_relay_only_reports_no_active_or_required_upstreams(cl
     assert payload["active_upstream_servers"] == []
     assert payload["required_upstream_servers"] == []
     assert payload["configured_upstream_servers"] == ["https://token.place"]
-    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
 
 
 def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
@@ -1234,11 +1233,12 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     payload = response.get_json()
 
     assert payload["configuredUpstreamServers"] == configured_servers
+    # Intentional guard: the removed healthz alias must not reappear.
+    assert "legacyConfiguredUpstreamServers" not in payload
     assert payload["activeUpstreamServers"] == configured_servers
     assert payload["requiredUpstreamServers"] == []
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
-    assert payload["legacyConfiguredUpstreamServers"] == []
     assert payload["registeredServers"][0]["server_public_key"] == live_server_key
     assert payload["registeredServers"][0]["age_seconds"] >= 0
     assert payload["registeredServers"][0]["queue_depth"] == 1
@@ -1294,7 +1294,6 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["gpuHost"] == "definitely-not-resolvable.invalid"
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is True
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
@@ -1370,7 +1369,6 @@ def test_explicit_runtime_upstream_reports_active_without_required_dependency(
     assert payload["activeUpstreamServers"] == ["https://gpu.example.test:3000"]
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
     diagnostics_response = client.get("/relay/diagnostics")
     diagnostics_payload = diagnostics_response.get_json()
@@ -1383,9 +1381,6 @@ def test_explicit_runtime_upstream_reports_active_without_required_dependency(
     ]
     assert diagnostics_payload["required_upstream_servers"] == []
     assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
-    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
-        "https://token.place"
-    ]
 
 
 def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
@@ -1411,7 +1406,6 @@ def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
     assert payload["requiredUpstreamServers"] == ["https://gpu.example.test:3000"]
     assert "https://token.place" not in payload["requiredUpstreamServers"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
     diagnostics_response = client.get("/relay/diagnostics")
     diagnostics_payload = diagnostics_response.get_json()
@@ -1425,9 +1419,6 @@ def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
     ]
     assert "https://token.place" not in diagnostics_payload["required_upstream_servers"]
     assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
-    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
-        "https://token.place"
-    ]
 
 
 def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeypatch):
@@ -1449,15 +1440,14 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["knownServers"] == 0
     assert payload["relayOnly"] is True
     assert payload["upstreamHealthRequired"] is False
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
-def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeypatch):
-    """Malformed upstream list env should not mark fallback default as explicit config."""
+def test_healthz_malformed_upstreams_env_keeps_default_configured_upstream(client, monkeypatch):
+    """Malformed upstream list env should keep the fallback default configured upstream."""
     monkeypatch.setenv("TOKEN_PLACE_RELAY_UPSTREAMS", '{"url":"https://ignored"}')
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
     monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
@@ -1472,11 +1462,10 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
 
 
-def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, monkeypatch):
-    """Custom configured server pools should be treated as explicit/non-legacy."""
+def test_healthz_custom_configured_servers_are_reported_as_configured(client, monkeypatch):
+    """Custom configured server pools should be reported as configured upstreams."""
     monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
     monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
@@ -1491,7 +1480,6 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
     assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
-    assert payload["legacyConfiguredUpstreamServers"] == []
 
 
 def test_relay_entrypoint_defaults_to_one_worker_and_multiple_threads():


### PR DESCRIPTION
### Motivation
- Public health and diagnostics endpoints currently expose duplicate legacy-named upstream fields that are misleading and not required for API v1 behavior, so the legacy aliases should be removed while keeping canonical fields intact.

### Description
- Removed the legacy `legacyConfiguredUpstreamServers` field from the `/healthz` response construction in `relay.py` and removed the `legacy_configured_upstream_servers` field from the `/relay/diagnostics` response construction. 
- Deleted the now-unused helper `_legacy_configured_upstream_reporting_servers` from `relay.py` as it was only used to populate the removed aliases.
- Updated `tests/test_relay.py` to stop asserting the removed aliases, added intentional negative-assert guards ensuring the legacy keys do not reappear, and renamed a couple of tests and docstrings to match the updated semantics.
- Updated `docs/relay_sugarkube_onboarding.md` to remove the legacy-named field from the example payload and adjusted explanatory text to reference only the canonical `configuredUpstreamServers` key.

### Testing
- Ran the focused relay/health tests with `python -m pytest tests/test_relay.py -k 'healthz or diagnostics'` and all selected tests passed (`17 passed, 103 deselected`).
- Ran repository checks with `pre-commit run --all-files` and the hooks completed successfully (all checks passed).
- Verified no remaining legacy aliases with `rg -n "legacyConfiguredUpstreamServers|legacy_configured_upstream_servers" . -g '!api/v2/**'`, and confirmed canonical fields are still present with `rg -n "configuredUpstreamServers|configured_upstream_servers" tests api static docs -g '!api/v2/**'` (matches in tests/docs are expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38d10a2144832f88e571472ac8a317)