### PR TITLE
Remove legacy upstream diagnostic aliases

### DIFF
--- a/docs/relay_sugarkube_onboarding.md
+++ b/docs/relay_sugarkube_onboarding.md
@@ -539,7 +539,6 @@ After (explicit relay-only semantics):
   "activeUpstreamServers": [],
   "requiredUpstreamServers": [],
   "configuredUpstreamServers": ["https://token.place"],
-  "legacyConfiguredUpstreamServers": ["https://token.place"],
   "upstream": "http://gpu-server:3000",
   "details": {"knownServers": "empty"}
 }
@@ -558,8 +557,6 @@ Interpretation:
   compatibility/configured upstream pool.
 - `configuredUpstreamServers` is retained as a stable compatibility key and can
   differ from the explicit runtime upstream.
-- `legacyConfiguredUpstreamServers` represents compatibility/default config, not
-  active runtime state or a required staging dependency.
 - Operators should rely on `relayOnly`, `upstreamHealthRequired`, `activeUpstreamServers`, `requiredUpstreamServers`, and registered compute-node counts when judging relay-only readiness.
 
 ## Guardrails

--- a/relay.py
+++ b/relay.py
@@ -333,22 +333,6 @@ def _active_upstream_reporting_servers(
     return configured_servers
 
 
-def _legacy_configured_upstream_reporting_servers(
-    configured_servers: List[str],
-    *,
-    explicit_upstream_config: bool,
-) -> List[str]:
-    """Return compatibility/default upstream config without relabeling custom pools."""
-
-    if (
-        explicit_upstream_config
-        and _normalise_upstream_server_pool(configured_servers)
-        != _normalise_upstream_server_pool(["https://token.place"])
-    ):
-        return []
-    return configured_servers
-
-
 def _load_upstream_config() -> Dict[str, Any]:
     upstream_override = os.environ.get(UPSTREAM_URL_ENV)
     parsed_host = None
@@ -867,12 +851,6 @@ def healthz():
         "registeredServers": _live_server_diagnostics(),
     }
     status["configuredUpstreamServers"] = configured_servers
-    status["legacyConfiguredUpstreamServers"] = (
-        _legacy_configured_upstream_reporting_servers(
-            configured_servers,
-            explicit_upstream_config=explicit_upstream_config,
-        )
-    )
     if app.config.get("public_base_url"):
         status["publicBaseUrl"] = app.config["public_base_url"]
 
@@ -1140,12 +1118,6 @@ def relay_diagnostics():
         "api_v1_registered_compute_nodes": api_v1_live_nodes,
         "total_api_v1_registered_compute_nodes": len(api_v1_live_nodes),
         "configured_upstream_servers": configured_servers,
-        "legacy_configured_upstream_servers": (
-            _legacy_configured_upstream_reporting_servers(
-                configured_servers,
-                explicit_upstream_config=explicit_upstream_config,
-            )
-        ),
     }
     response = jsonify(diagnostics)
     response.headers["Cache-Control"] = "no-store"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -32,6 +32,10 @@ from relay import (
 DUMMY_SERVER_PUB_KEY = base64.b64encode(b"server_public_key_123").decode('utf-8')
 DUMMY_CLIENT_PUB_KEY = base64.b64encode(b"client_public_key_456").decode('utf-8')
 
+# Intentionally retained only as negative assertions for removed response aliases.
+REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS = "legacyConfiguredUpstreamServers"
+REMOVED_DIAGNOSTICS_CONFIGURED_UPSTREAM_ALIAS = "legacy_configured_upstream_servers"
+
 
 @pytest.fixture
 def client():
@@ -1043,7 +1047,7 @@ def test_relay_diagnostics_distinguishes_configured_and_live_nodes(client, monke
     assert payload["configured_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["active_upstream_servers"] == app.config["relay_configured_servers"]
     assert payload["required_upstream_servers"] == []
-    assert payload["legacy_configured_upstream_servers"] == []
+    assert REMOVED_DIAGNOSTICS_CONFIGURED_UPSTREAM_ALIAS not in payload
     assert payload["upstream_health_required"] is False
     assert payload["relay_only"] is False
     assert payload["total_registered_compute_nodes"] == 1
@@ -1178,7 +1182,7 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
 
     assert response.status_code == 200
     assert payload["configured_upstream_servers"] == configured_servers
-    assert payload["legacy_configured_upstream_servers"] == []
+    assert REMOVED_DIAGNOSTICS_CONFIGURED_UPSTREAM_ALIAS not in payload
     assert payload["active_upstream_servers"] == ["https://gpu.example.com:5015"]
     assert payload["required_upstream_servers"] == []
     assert payload["relay_only"] is False
@@ -1186,7 +1190,7 @@ def test_relay_diagnostics_reports_explicit_upstream_env(client, monkeypatch):
 
 
 def test_relay_diagnostics_relay_only_reports_no_active_or_required_upstreams(client, monkeypatch):
-    """Relay-only diagnostics should separate legacy fallback config from readiness dependencies."""
+    """Relay-only diagnostics should separate fallback config from readiness dependencies."""
     monkeypatch.setenv("TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH", "0")
     monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
@@ -1202,7 +1206,7 @@ def test_relay_diagnostics_relay_only_reports_no_active_or_required_upstreams(cl
     assert payload["active_upstream_servers"] == []
     assert payload["required_upstream_servers"] == []
     assert payload["configured_upstream_servers"] == ["https://token.place"]
-    assert payload["legacy_configured_upstream_servers"] == ["https://token.place"]
+    assert REMOVED_DIAGNOSTICS_CONFIGURED_UPSTREAM_ALIAS not in payload
 
 
 def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monkeypatch):
@@ -1238,7 +1242,7 @@ def test_healthz_reports_configured_upstreams_and_live_queue_depth(client, monke
     assert payload["requiredUpstreamServers"] == []
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is False
-    assert payload["legacyConfiguredUpstreamServers"] == []
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
     assert payload["registeredServers"][0]["server_public_key"] == live_server_key
     assert payload["registeredServers"][0]["age_seconds"] >= 0
     assert payload["registeredServers"][0]["queue_depth"] == 1
@@ -1294,7 +1298,7 @@ def test_healthz_default_allows_unresolvable_upstream_host(client, monkeypatch):
     assert payload["gpuHost"] == "definitely-not-resolvable.invalid"
     assert payload["upstreamHealthRequired"] is False
     assert payload["relayOnly"] is True
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
@@ -1370,7 +1374,7 @@ def test_explicit_runtime_upstream_reports_active_without_required_dependency(
     assert payload["activeUpstreamServers"] == ["https://gpu.example.test:3000"]
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
 
     diagnostics_response = client.get("/relay/diagnostics")
     diagnostics_payload = diagnostics_response.get_json()
@@ -1383,9 +1387,7 @@ def test_explicit_runtime_upstream_reports_active_without_required_dependency(
     ]
     assert diagnostics_payload["required_upstream_servers"] == []
     assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
-    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
-        "https://token.place"
-    ]
+    assert REMOVED_DIAGNOSTICS_CONFIGURED_UPSTREAM_ALIAS not in diagnostics_payload
 
 
 def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
@@ -1411,7 +1413,7 @@ def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
     assert payload["requiredUpstreamServers"] == ["https://gpu.example.test:3000"]
     assert "https://token.place" not in payload["requiredUpstreamServers"]
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
 
     diagnostics_response = client.get("/relay/diagnostics")
     diagnostics_payload = diagnostics_response.get_json()
@@ -1425,9 +1427,7 @@ def test_explicit_runtime_upstream_required_health_reports_checked_dependency(
     ]
     assert "https://token.place" not in diagnostics_payload["required_upstream_servers"]
     assert diagnostics_payload["configured_upstream_servers"] == ["https://token.place"]
-    assert diagnostics_payload["legacy_configured_upstream_servers"] == [
-        "https://token.place"
-    ]
+    assert REMOVED_DIAGNOSTICS_CONFIGURED_UPSTREAM_ALIAS not in diagnostics_payload
 
 
 def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeypatch):
@@ -1449,15 +1449,15 @@ def test_healthz_staging_relay_only_does_not_imply_prod_upstream(client, monkeyp
     assert payload["knownServers"] == 0
     assert payload["relayOnly"] is True
     assert payload["upstreamHealthRequired"] is False
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
     assert payload.get("details", {}).get("knownServers") == "empty"
 
 
-def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeypatch):
-    """Malformed upstream list env should not mark fallback default as explicit config."""
+def test_healthz_malformed_upstreams_env_keeps_default_configured(client, monkeypatch):
+    """Malformed upstream list env should keep fallback default as configured-only."""
     monkeypatch.setenv("TOKEN_PLACE_RELAY_UPSTREAMS", '{"url":"https://ignored"}')
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
     monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
@@ -1472,11 +1472,11 @@ def test_healthz_malformed_upstreams_env_keeps_default_as_legacy(client, monkeyp
     assert payload["activeUpstreamServers"] == []
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://token.place"]
-    assert payload["legacyConfiguredUpstreamServers"] == ["https://token.place"]
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
 
 
-def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, monkeypatch):
-    """Custom configured server pools should be treated as explicit/non-legacy."""
+def test_healthz_custom_configured_servers_remain_configured(client, monkeypatch):
+    """Custom configured server pools should be treated as explicit config."""
     monkeypatch.delenv("TOKEN_PLACE_RELAY_UPSTREAMS", raising=False)
     monkeypatch.delenv("PERSONAL_GAMING_PC_URL", raising=False)
     monkeypatch.delenv("TOKENPLACE_RELAY_UPSTREAM_URL", raising=False)
@@ -1491,7 +1491,7 @@ def test_healthz_custom_configured_servers_are_not_reported_as_legacy(client, mo
     assert payload["activeUpstreamServers"] == ["https://custom.upstream.example"]
     assert payload["requiredUpstreamServers"] == []
     assert payload["configuredUpstreamServers"] == ["https://custom.upstream.example"]
-    assert payload["legacyConfiguredUpstreamServers"] == []
+    assert REMOVED_HEALTHZ_CONFIGURED_UPSTREAM_ALIAS not in payload
 
 
 def test_relay_entrypoint_defaults_to_one_worker_and_multiple_threads():


### PR DESCRIPTION
### Motivation
- Remove duplicate legacy-named upstream-server aliases from public health/diagnostics payloads so the API surface exposes only the canonical configured-upstream fields and avoids misleading legacy naming.

### Description
- Remove `legacyConfiguredUpstreamServers` from the `/healthz` response and `legacy_configured_upstream_servers` from the `/relay/diagnostics` response by deleting the generation and response entries in `relay.py` while preserving the canonical fields `configuredUpstreamServers` and `configured_upstream_servers`.
- Delete the `_legacy_configured_upstream_reporting_servers` helper since it is no longer referenced.
- Update `tests/test_relay.py` to assert the canonical fields remain and to assert the removed aliases are absent, adding small negative-assertion constants for clarity.
- Update `docs/relay_sugarkube_onboarding.md` to remove the legacy alias from the sample `/healthz` payload and related explanatory text.

### Testing
- Ran `pytest -q tests/test_relay.py -k "healthz or relay_diagnostics"` and the selected tests passed (`16 passed, 104 deselected`).
- Ran `pre-commit run --all-files` and the pre-commit checks completed successfully (all hooks passed).
- Ran repository searches to verify references: `rg -n "legacyConfiguredUpstreamServers|legacy_configured_upstream_servers" . -g '!api/v2/**'` which returned only the intentional negative-assertion constants in `tests/test_relay.py`; and `rg -n "configuredUpstreamServers|configured_upstream_servers" tests api static docs -g '!api/v2/**'` which confirmed canonical fields remain; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38d11082d8832fb3e9d4fa85cd0c8d)