### PR TITLE
Add desktop operator context tier selection

### DIFF
--- a/desktop-tauri/README.md
+++ b/desktop-tauri/README.md
@@ -214,6 +214,18 @@ It prints:
   CUDA availability/usage with GPU offload and non-CPU KV cache. If the bridge exits before
   startup, errors will use the phrase `compute-node bridge exited before emitting a startup event`.
 
+
+## Operator context tiers
+
+Before **Start operator**, choose one static context tier in the desktop operator controls:
+
+- **8K Fast** (`8k-fast`) warms a single llama.cpp runtime with `n_ctx=8192`.
+- **64K Full** (`64k-full`) warms a single llama.cpp runtime with `n_ctx=65536`.
+
+The selected tier is persisted in the desktop config and is locked while the operator is starting,
+warming, running, stopping, or recovering. To switch tiers, stop the operator, select the new tier,
+and start again. Registration still happens only after the selected runtime warm-load succeeds.
+
 ## Packaged operator debug logs
 
 The packaged desktop app writes compute-node operator diagnostics to a per-session

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -76,6 +76,9 @@ _stdin_reader_lock = threading.Lock()
 _stop_requested_latched = threading.Event()
 EARLY_STARTUP_EXIT_ERROR = "compute-node bridge exited before emitting a startup event"
 WARM_LOAD_DEFAULT = "1"
+
+from context_profiles import normalize_context_tier, require_context_profile
+
 RUNTIME_PATH_DEFAULT = "bridge"
 API_V1_WARM_LOAD_WAIT_DEFAULT_SECONDS = 120.0
 PRE_REGISTRATION_PROGRESS_INTERVAL_SECONDS = 30.0
@@ -551,6 +554,8 @@ def _structured_startup_error_payload(
         "warm_load_duration_ms": None,
         "runtime_path": _runtime_path_from_env(),
         "relay_runtime_path": "bridge",
+        "context_tier": normalize_context_tier(getattr(args, "context_tier", "")),
+        "context_window_tokens": require_context_profile(normalize_context_tier(getattr(args, "context_tier", ""))).total_context_tokens,
     }
     if operator_session_id is not None:
         payload["operator_session_id"] = operator_session_id
@@ -695,6 +700,8 @@ def run(args: argparse.Namespace) -> int:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
 
+    context_profile = require_context_profile(normalize_context_tier(getattr(args, "context_tier", "")))
+    args.context_tier = context_profile.profile_id
     relay_urls = _normalize_relay_urls(
         getattr(args, "relay_url", None),
         getattr(args, "relay_urls", None),
@@ -705,7 +712,7 @@ def run(args: argparse.Namespace) -> int:
     print(
         "desktop.compute_node_bridge.start "
         f"operator_session_id={bridge_session_id} "
-        f"model={args.model} mode={args.mode} "
+        f"model={args.model} mode={args.mode} context_tier={context_profile.profile_id} "
         f"relay_count={len(relay_urls)} "
         f"relay_url={_sanitize_relay_target(relay_url)} "
         f"relay_port={relay_port if relay_port is not None else 'none'}",
@@ -761,6 +768,12 @@ def run(args: argparse.Namespace) -> int:
         )
 
     runtime.model_manager.model_path = args.model
+    set_context_profile = getattr(runtime.model_manager, "set_context_profile", None)
+    if callable(set_context_profile):
+        set_context_profile(context_profile.profile_id, context_profile.total_context_tokens)
+    else:
+        setattr(runtime.model_manager, "context_tier", context_profile.profile_id)
+        setattr(runtime.model_manager, "context_window_tokens", context_profile.total_context_tokens)
     apply_compute_mode(runtime.model_manager, args.mode)
     try:
         runtime.model_manager.desktop_runtime_probe = dict(runtime_setup)
@@ -927,6 +940,8 @@ def run(args: argparse.Namespace) -> int:
             "warm_load_duration_ms": warm_load_duration_ms,
             "runtime_path": runtime_path,
             "relay_runtime_path": relay_runtime_path,
+            "context_tier": context_profile.profile_id,
+            "context_window_tokens": context_profile.total_context_tokens,
         }
         payload.update(worker_lifecycle_status())
         if extra:
@@ -1974,10 +1989,12 @@ def main() -> int:
         help="JSON array or comma-separated relay URL list (can be repeated)",
     )
     parser.add_argument("--relay-port", type=int, default=None)
+    parser.add_argument("--context-tier", default="8k-fast")
     args = parser.parse_args()
 
     try:
         args.mode = _normalize_compute_mode_local(args.mode)
+        args.context_tier = require_context_profile(args.context_tier).profile_id
         return run(args)
     except Exception as exc:  # pragma: no cover - last resort failure handling
         message = f"{EARLY_STARTUP_EXIT_ERROR}: {exc}"

--- a/desktop-tauri/src-tauri/python/context_profiles.py
+++ b/desktop-tauri/src-tauri/python/context_profiles.py
@@ -1,0 +1,40 @@
+"""Static context profile registry for the desktop compute-node bridge."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ContextProfile:
+    profile_id: str
+    display_label: str
+    total_context_tokens: int
+    default_output_reservation_tokens: int
+    enabled: bool = True
+
+
+DEFAULT_CONTEXT_TIER = "8k-fast"
+CONTEXT_PROFILES = {
+    "8k-fast": ContextProfile("8k-fast", "8K Fast", 8192, 512),
+    "64k-full": ContextProfile("64k-full", "64K Full", 65536, 1024),
+}
+
+
+def resolve_context_profile(profile_id: str) -> Optional[ContextProfile]:
+    profile = CONTEXT_PROFILES.get((profile_id or "").strip())
+    if profile is None or not profile.enabled:
+        return None
+    return profile
+
+
+def normalize_context_tier(profile_id: str) -> str:
+    profile = resolve_context_profile(profile_id)
+    return profile.profile_id if profile else DEFAULT_CONTEXT_TIER
+
+
+def require_context_profile(profile_id: str) -> ContextProfile:
+    profile = resolve_context_profile(profile_id)
+    if profile is None:
+        raise ValueError(f"unknown context profile: {profile_id}")
+    return profile

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1,5 +1,6 @@
 use crate::backend::ComputeMode;
 use crate::config::normalize_relay_base_urls;
+use crate::context_profiles::{normalize_context_tier, resolve_context_profile};
 use crate::operator_logs::{
     append_line_to_path, sanitize_operator_diagnostic_line, sanitize_operator_path_display,
     OperatorLogSink,
@@ -31,6 +32,8 @@ pub struct ComputeNodeRequest {
     #[serde(default)]
     pub relay_base_urls: Vec<String>,
     pub mode: ComputeMode,
+    #[serde(default)]
+    pub context_tier: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -75,6 +78,8 @@ pub struct ComputeNodeStatus {
     pub sequence: Option<u64>,
     pub updated_at_ms: Option<u64>,
     pub log_file_path: Option<String>,
+    pub context_tier: Option<String>,
+    pub context_window_tokens: Option<u32>,
 }
 
 #[derive(Clone, Default)]
@@ -218,6 +223,17 @@ fn sanitize_relay_target(relay_url: &str) -> String {
     "unknown".into()
 }
 
+fn normalized_request_context_tier(request: &ComputeNodeRequest) -> String {
+    normalize_context_tier(&request.context_tier)
+}
+
+fn request_context_window_tokens(request: &ComputeNodeRequest) -> u32 {
+    let tier = normalized_request_context_tier(request);
+    resolve_context_profile(&tier)
+        .map(|profile| profile.total_context_tokens)
+        .unwrap_or_default()
+}
+
 fn normalized_request_relay_urls(request: &ComputeNodeRequest) -> Vec<String> {
     normalize_relay_base_urls(&request.relay_base_urls, &request.relay_base_url)
 }
@@ -277,6 +293,8 @@ fn startup_failure_status(
         sequence: None,
         updated_at_ms: Some(current_time_ms()),
         log_file_path,
+        context_tier: Some(normalized_request_context_tier(request)),
+        context_window_tokens: Some(request_context_window_tokens(request)),
     }
 }
 
@@ -463,6 +481,14 @@ fn update_status_from_event(status: &mut ComputeNodeStatus, payload: &Value) -> 
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
     }
+    if let Some(context_tier) = payload.get("context_tier").and_then(Value::as_str) {
+        status.context_tier = Some(context_tier.into());
+    }
+    if let Some(context_window_tokens) =
+        payload.get("context_window_tokens").and_then(Value::as_u64)
+    {
+        status.context_window_tokens = Some(context_window_tokens as u32);
+    }
     if payload.get("type").and_then(Value::as_str) == Some("error") {
         status.last_error = payload
             .get("message")
@@ -553,6 +579,8 @@ fn finalize_bridge_exit(
             "last_error": last_error,
             "message": last_error,
             "operator_session_id": expected_session_id,
+            "context_tier": status.context_tier,
+            "context_window_tokens": status.context_window_tokens,
             "sequence": sequence,
             "updated_at_ms": updated_at_ms,
         })
@@ -890,6 +918,8 @@ pub async fn start_compute_node(
         .arg(&request.model_path)
         .arg("--mode")
         .arg(format!("{:?}", request.mode).to_lowercase())
+        .arg("--context-tier")
+        .arg(normalized_request_context_tier(&request))
         .args(
             relay_base_urls
                 .iter()
@@ -987,6 +1017,8 @@ pub async fn start_compute_node(
                 sequence: Some(0),
                 updated_at_ms: Some(current_time_ms()),
                 log_file_path: log_file_path.clone(),
+                context_tier: Some(normalized_request_context_tier(&request)),
+                context_window_tokens: Some(request_context_window_tokens(&request)),
             };
             true
         }
@@ -1978,6 +2010,7 @@ mod tests {
             relay_base_url: "https://relay.example".into(),
             relay_base_urls: vec![],
             mode: ComputeMode::Cpu,
+            context_tier: "64k-full".into(),
         };
         let status = startup_failure_status(
             &request,
@@ -2157,6 +2190,7 @@ mod tests {
             relay_base_url: "https://relay.example".into(),
             relay_base_urls: vec![],
             mode: ComputeMode::Auto,
+            context_tier: "unknown".into(),
         };
 
         let status = startup_failure_status(

--- a/desktop-tauri/src-tauri/src/config.rs
+++ b/desktop-tauri/src-tauri/src/config.rs
@@ -1,4 +1,5 @@
 use crate::backend::ComputeMode;
+use crate::context_profiles::{normalize_context_tier, DEFAULT_CONTEXT_TIER};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -15,6 +16,8 @@ pub struct DesktopConfig {
     pub relay_base_urls: Vec<String>,
     #[serde(default = "default_compute_mode")]
     pub preferred_mode: ComputeMode,
+    #[serde(default = "default_context_tier")]
+    pub selected_context_tier: String,
 }
 
 fn default_relay_base_url() -> String {
@@ -23,6 +26,10 @@ fn default_relay_base_url() -> String {
 
 fn default_compute_mode() -> ComputeMode {
     ComputeMode::Auto
+}
+
+fn default_context_tier() -> String {
+    DEFAULT_CONTEXT_TIER.into()
 }
 
 pub fn normalize_relay_base_urls(
@@ -63,6 +70,7 @@ impl DesktopConfig {
             .first()
             .cloned()
             .unwrap_or_else(default_relay_base_url);
+        self.selected_context_tier = normalize_context_tier(&self.selected_context_tier);
         self
     }
 }
@@ -74,6 +82,7 @@ impl Default for DesktopConfig {
             relay_base_url: DEFAULT_RELAY_BASE_URL.into(),
             relay_base_urls: vec![DEFAULT_RELAY_BASE_URL.into()],
             preferred_mode: ComputeMode::Auto,
+            selected_context_tier: DEFAULT_CONTEXT_TIER.into(),
         }
     }
 }
@@ -81,7 +90,8 @@ impl Default for DesktopConfig {
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_relay_base_urls, DesktopConfig, DEFAULT_RELAY_BASE_URL, MAX_RELAY_BASE_URLS,
+        normalize_relay_base_urls, DesktopConfig, DEFAULT_CONTEXT_TIER, DEFAULT_RELAY_BASE_URL,
+        MAX_RELAY_BASE_URLS,
     };
 
     #[test]
@@ -89,6 +99,7 @@ mod tests {
         let config = DesktopConfig::default();
         assert_eq!(config.relay_base_url, DEFAULT_RELAY_BASE_URL);
         assert_eq!(config.relay_base_urls, vec![DEFAULT_RELAY_BASE_URL]);
+        assert_eq!(config.selected_context_tier, DEFAULT_CONTEXT_TIER);
     }
 
     #[test]
@@ -106,6 +117,23 @@ mod tests {
         assert_eq!(config.relay_base_url, "https://staging.token.place");
         assert_eq!(config.relay_base_urls, vec!["https://staging.token.place"]);
         assert_eq!(config.model_path, "/tmp/model.gguf");
+        assert_eq!(config.selected_context_tier, DEFAULT_CONTEXT_TIER);
+    }
+
+    #[test]
+    fn unknown_context_tier_normalizes_to_default() {
+        let config: DesktopConfig = serde_json::from_str::<DesktopConfig>(
+            r#"{
+                "model_path": "/tmp/model.gguf",
+                "relay_base_url": "https://token.place",
+                "preferred_mode": "auto",
+                "selected_context_tier": "unknown"
+            }"#,
+        )
+        .expect("config should deserialize")
+        .normalized();
+
+        assert_eq!(config.selected_context_tier, DEFAULT_CONTEXT_TIER);
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/context_profiles.rs
+++ b/desktop-tauri/src-tauri/src/context_profiles.rs
@@ -1,0 +1,40 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextProfile {
+    pub id: &'static str,
+    pub display_label: &'static str,
+    pub total_context_tokens: u32,
+    pub default_output_reservation_tokens: u32,
+    pub enabled: bool,
+}
+
+pub const DEFAULT_CONTEXT_TIER: &str = "8k-fast";
+
+pub const CONTEXT_PROFILES: &[ContextProfile] = &[
+    ContextProfile {
+        id: "8k-fast",
+        display_label: "8K Fast",
+        total_context_tokens: 8192,
+        default_output_reservation_tokens: 512,
+        enabled: true,
+    },
+    ContextProfile {
+        id: "64k-full",
+        display_label: "64K Full",
+        total_context_tokens: 65536,
+        default_output_reservation_tokens: 1024,
+        enabled: true,
+    },
+];
+
+pub fn resolve_context_profile(id: &str) -> Option<&'static ContextProfile> {
+    let normalized = id.trim();
+    CONTEXT_PROFILES
+        .iter()
+        .find(|profile| profile.enabled && profile.id == normalized)
+}
+
+pub fn normalize_context_tier(id: &str) -> String {
+    resolve_context_profile(id)
+        .map(|profile| profile.id.to_string())
+        .unwrap_or_else(|| DEFAULT_CONTEXT_TIER.to_string())
+}

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod compute_node;
 mod config;
+mod context_profiles;
 pub mod forward;
 pub mod keygen;
 mod logging;

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -91,6 +91,7 @@ describe('desktop app start failure handling', () => {
       relay_base_url: 'https://token.place',
       relay_base_urls: ['https://token.place', 'https://staging.token.place'],
       preferred_mode: 'auto',
+      selected_context_tier: '8k-fast',
     });
   });
 
@@ -1695,4 +1696,36 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last worker error code:/).textContent).toContain('fatal_worker_exit');
   });
 
+});
+
+it('normalizes unknown context tiers to 8k fast', () => {
+  expect(normalizeDesktopConfig({ selected_context_tier: 'bogus' }).selected_context_tier).toBe('8k-fast');
+  expect(normalizeDesktopConfig({ selected_context_tier: '64k-full' }).selected_context_tier).toBe('64k-full');
+});
+
+it('persists context tier changes and disables selector while starting operator', async () => {
+  render(<App />);
+
+  const selector = await screen.findByLabelText('Context tier');
+  fireEvent.change(selector, { target: { value: '64k-full' } });
+
+  await waitFor(() =>
+    expect(invokeMock).toHaveBeenCalledWith(
+      'save_config',
+      expect.objectContaining({
+        config: expect.objectContaining({ selected_context_tier: '64k-full' }),
+      })
+    )
+  );
+
+  fireEvent.click(screen.getByText('Start operator'));
+  expect((selector as HTMLSelectElement).disabled).toBe(true);
+  await waitFor(() =>
+    expect(invokeMock).toHaveBeenCalledWith(
+      'start_compute_node',
+      expect.objectContaining({
+        request: expect.objectContaining({ context_tier: '64k-full' }),
+      })
+    )
+  );
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 type UiState = 'idle' | 'starting' | 'streaming' | 'canceled' | 'completed' | 'failed';
 type BackendMode = 'auto' | 'cpu' | 'gpu' | 'hybrid';
+type ContextTier = '8k-fast' | '64k-full';
 
 interface BackendInfo {
   platform_label: string;
@@ -18,16 +19,23 @@ interface DesktopConfig {
   relay_base_url: string;
   relay_base_urls: string[];
   preferred_mode: BackendMode;
+  selected_context_tier: ContextTier;
 }
 
 const DEFAULT_RELAY_BASE_URL = 'https://token.place';
+const DEFAULT_CONTEXT_TIER: ContextTier = '8k-fast';
+const CONTEXT_PROFILES: Array<{ id: ContextTier; label: string; contextWindowTokens: number }> = [
+  { id: '8k-fast', label: '8K Fast', contextWindowTokens: 8192 },
+  { id: '64k-full', label: '64K Full', contextWindowTokens: 65536 },
+];
 export const MAX_RELAY_BASE_URLS = 10;
 
-type PartialDesktopConfig = Omit<Partial<DesktopConfig>, 'model_path' | 'relay_base_url' | 'relay_base_urls' | 'preferred_mode'> & {
+type PartialDesktopConfig = Omit<Partial<DesktopConfig>, 'model_path' | 'relay_base_url' | 'relay_base_urls' | 'preferred_mode' | 'selected_context_tier'> & {
   model_path?: unknown;
   relay_base_url?: unknown;
   relay_base_urls?: unknown;
   preferred_mode?: unknown;
+  selected_context_tier?: unknown;
 };
 
 interface RelayStatus {
@@ -74,6 +82,8 @@ interface ComputeNodeStatus {
   sequence: number | null;
   updated_at_ms: number | null;
   log_file_path: string | null;
+  context_tier: string | null;
+  context_window_tokens: number | null;
 }
 
 interface ModelArtifactInfo {
@@ -129,10 +139,16 @@ const defaultComputeStatus: ComputeNodeStatus = {
   sequence: null,
   updated_at_ms: null,
   log_file_path: null,
+  context_tier: DEFAULT_CONTEXT_TIER,
+  context_window_tokens: 8192,
 };
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeContextTier(value: unknown): ContextTier {
+  return CONTEXT_PROFILES.some((profile) => profile.id === value) ? (value as ContextTier) : DEFAULT_CONTEXT_TIER;
 }
 
 function displayStatusValue(value: string | null | undefined, fallback: string): string {
@@ -220,6 +236,7 @@ export function normalizeDesktopConfig(config: PartialDesktopConfig): DesktopCon
     relay_base_url: relayBaseUrls[0] || DEFAULT_RELAY_BASE_URL,
     relay_base_urls: relayBaseUrls,
     preferred_mode: normalizeBackendMode(config.preferred_mode),
+    selected_context_tier: normalizeContextTier(config.selected_context_tier),
   };
 }
 
@@ -453,6 +470,12 @@ function mergeComputeStatusEvent(
           : typeof payload.message === 'string'
             ? payload.message
             : prev.last_error,
+    context_tier:
+      typeof payload.context_tier === 'string' ? payload.context_tier : prev.context_tier,
+    context_window_tokens:
+      typeof payload.context_window_tokens === 'number'
+        ? payload.context_window_tokens
+        : prev.context_window_tokens,
   };
 }
 
@@ -473,6 +496,7 @@ export function App() {
     relay_base_url: DEFAULT_RELAY_BASE_URL,
     relay_base_urls: [DEFAULT_RELAY_BASE_URL],
     preferred_mode: 'auto',
+    selected_context_tier: DEFAULT_CONTEXT_TIER,
   });
   const [computeStatus, setComputeStatus] = useState<ComputeNodeStatus>(defaultComputeStatus);
   const [prompt, setPrompt] = useState('');
@@ -718,6 +742,8 @@ export function App() {
         worker_state: 'starting',
         worker_alive: false,
         log_file_path: null,
+        context_tier: config.selected_context_tier,
+        context_window_tokens: CONTEXT_PROFILES.find((profile) => profile.id === config.selected_context_tier)?.contextWindowTokens ?? 8192,
       };
       computeStatusRef.current = optimisticStatus;
       setComputeStatus(optimisticStatus);
@@ -727,6 +753,7 @@ export function App() {
           relay_base_url: primaryRelayUrl(config),
           relay_base_urls: normalizeRelayUrls(config.relay_base_urls, config.relay_base_url),
           mode: config.preferred_mode,
+          context_tier: config.selected_context_tier,
         },
       });
     } catch (e) {
@@ -868,6 +895,21 @@ export function App() {
         partial offload. Unsupported platforms fall back to CPU with diagnostics.
       </p>
 
+      <label htmlFor="context-tier-select" style={{ display: 'block', marginTop: 12 }}>Context tier</label>
+      <select
+        id="context-tier-select"
+        value={config.selected_context_tier}
+        disabled={computeStatus.running || isStartingComputeNode}
+        onChange={(e) => updateConfig({ ...config, selected_context_tier: normalizeContextTier(e.target.value) })}
+      >
+        {CONTEXT_PROFILES.map((profile) => (
+          <option key={profile.id} value={profile.id}>{profile.label}</option>
+        ))}
+      </select>
+      <p style={{ marginTop: 8, fontSize: 12, color: '#555' }}>
+        Changing tiers requires Stop Operator followed by Start Operator. The active operator warms one selected tier per process.
+      </p>
+
       <section aria-labelledby="relay-urls-heading" style={{ marginTop: 12 }}>
         <h2 id="relay-urls-heading" style={{ fontSize: 16, marginBottom: 8 }}>Relay URLs</h2>
         {(computeStatus.running || isStartingComputeNode) && (
@@ -953,6 +995,8 @@ export function App() {
             </ul>
           </div>
         )}
+        <p style={{ marginBottom: 0 }}>Context tier: <code>{displayStatusValue(computeStatus.context_tier, config.selected_context_tier)}</code></p>
+        <p style={{ marginBottom: 0 }}>Context window: <code>{computeStatus.context_window_tokens ?? (CONTEXT_PROFILES.find((profile) => profile.id === config.selected_context_tier)?.contextWindowTokens ?? 8192)} tokens</code></p>
         <p style={{ marginBottom: 0 }}>Requested mode: <code>{displayStatusValue(computeStatus.requested_mode, config.preferred_mode)}</code></p>
         <p style={{ marginBottom: 0 }}>Effective mode: <code>{displayStatusValue(computeStatus.effective_mode, 'pending')}</code></p>
         <p style={{ marginBottom: 0 }}>Backend available: <code>{displayStatusValue(computeStatus.backend_available, 'pending')}</code></p>

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2019,6 +2019,10 @@ def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_pat
         path_bootstrap_path.read_text(encoding='utf-8'),
         encoding='utf-8',
     )
+    (python_dir / 'context_profiles.py').write_text(
+        (MODULE_PATH.parent / 'context_profiles.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
     (python_dir / 'desktop_runtime_setup.py').write_text(
         """
 def desktop_gpu_runtime_failure_message(_mode, _runtime_setup):
@@ -4375,3 +4379,8 @@ def test_api_v1_unhealthy_result_without_recovery_attempt_sets_terminal_state(
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     status_events = [event for event in events if event.get('type') == 'status']
     assert status_events[-1]['relay_runtime_state'] == expected_state
+
+
+def test_context_profile_registry_validates_known_profiles():
+    assert compute_node_bridge.normalize_context_tier("unknown") == "8k-fast"
+    assert compute_node_bridge.require_context_profile("64k-full").total_context_tokens == 65536

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3711,3 +3711,45 @@ class Llama:
     ])
     assert plaintext_prompt not in leak_checked_text
     assert plaintext_output not in leak_checked_text
+
+
+def test_model_manager_context_profile_sets_llama_n_ctx(monkeypatch, tmp_path):
+    import types
+    import utils.llm.model_manager as model_manager_module
+
+    captured = {}
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    fake_module = types.SimpleNamespace(Llama=FakeLlama, __file__="/tmp/llama_cpp.py")
+    monkeypatch.setattr(model_manager_module, "_import_llama_cpp_runtime", lambda **_: fake_module)
+
+    class Config:
+        is_production = True
+        def __init__(self):
+            self.config = {"paths": {"models_dir": str(tmp_path)}, "model": {"context_size": 8192}}
+        def get(self, key, default=None):
+            value = self.config
+            try:
+                for part in key.split('.'):
+                    value = value[part]
+                return value
+            except Exception:
+                return default
+        def set(self, key, value):
+            target = self.config
+            parts = key.split('.')
+            for part in parts[:-1]:
+                target = target.setdefault(part, {})
+            target[parts[-1]] = value
+
+    model_path = tmp_path / "model.gguf"
+    model_path.write_text("fake")
+    manager = model_manager_module.ModelManager(Config())
+    manager.model_path = str(model_path)
+    manager.set_context_profile("64k-full", 65536)
+
+    assert manager.get_llm_instance() is not None
+    assert captured["n_ctx"] == 65536

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1488,6 +1488,8 @@ class ModelManager:
         self.download_timeout = config.get('model.download_timeout', 30)
         self.models_dir = config.get('paths.models_dir')
         self.model_path = os.path.join(self.models_dir, self.file_name)
+        self.context_tier = None
+        self.context_window_tokens = int(config.get('model.context_size', 8192) or 8192)
 
         # LLM instance and lock for thread safety
         self.llm = None
@@ -1930,7 +1932,7 @@ class ModelManager:
                             self.llm = Llama(
                                 model_path=self.model_path,
                                 n_gpu_layers=n_gpu_layers,
-                                n_ctx=self.config.get('model.context_size', 8192),
+                                n_ctx=self.active_context_window_tokens(),
                                 chat_format=self.config.get('model.chat_format', 'llama-3'),
                                 verbose=llama_cpp_verbose_logging_enabled(),
                             )
@@ -1965,7 +1967,8 @@ class ModelManager:
                                 f"kv_cache={compute_plan['kv_cache_device']} "
                                 f"interpreter={runtime_identity.get('interpreter', sys.executable)} "
                                 f"llama_module_path={runtime_identity.get('llama_module_path', 'unknown')} "
-                                f"fallback_reason={compute_plan['fallback_reason'] or 'none'}"
+                                f"fallback_reason={compute_plan['fallback_reason'] or 'none'} "
+                                f"context_window_tokens={self.active_context_window_tokens()}"
                             )
                             self.worker_state = 'ready'
                             self.last_worker_error_code = None
@@ -1986,6 +1989,21 @@ class ModelManager:
                             return None
 
         return self.llm
+
+    def set_context_profile(self, profile_id: str, context_window_tokens: int) -> None:
+        """Set the single static context profile before Llama construction."""
+        if self.llm is not None:
+            raise RuntimeError("context profile cannot change after Llama initialization")
+        self.context_tier = profile_id
+        self.context_window_tokens = int(context_window_tokens)
+        set_config = getattr(self.config, 'set', None)
+        if callable(set_config):
+            set_config('model.context_size', self.context_window_tokens)
+        elif hasattr(self.config, 'config') and isinstance(self.config.config, dict):
+            self.config.config.setdefault('model', {})['context_size'] = self.context_window_tokens
+
+    def active_context_window_tokens(self) -> int:
+        return int(self.config.get('model.context_size', self.context_window_tokens) or self.context_window_tokens)
 
     def _close_llm_proxy(self, llm: Any) -> None:
         close = getattr(llm, 'close', None)


### PR DESCRIPTION
### Motivation

- Provide a small, centralized mechanism for choosing between two static context profiles (8K and 64K) for the desktop operator so the runtime is warmed with a known `n_ctx` before registration.

### Description

- Added a centralized context-profile registry in Rust and Python with stable IDs `8k-fast` and `64k-full`, display labels, total context tokens, default output reservation, and enabled state. (`desktop-tauri/src-tauri/src/context_profiles.rs`, `desktop-tauri/src-tauri/python/context_profiles.py`)
- Extended persisted desktop config to include `selected_context_tier` with default `8k-fast` and normalization/migration of unknown values. (Rust: `desktop-tauri/src-tauri/src/config.rs`; UI: `desktop-tauri/src/App.tsx`)
- Added a stopped-only dropdown in the Tauri UI to select context tier, persisted via `save_config`, disabled while the operator is starting/warming/running/stopping/recovering, and a small explanatory note. (`desktop-tauri/src/App.tsx`, `desktop-tauri/src/App.test.tsx`)
- Plumbed selected, normalized profile IDs through Rust `ComputeNodeRequest` into the Python bridge via `--context-tier`, and added `context_tier` / `context_window_tokens` to status payloads and ComputeNodeStatus. (`desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Configured `ModelManager` to accept a single static context profile before `Llama` construction, exposing `set_context_profile` and using `active_context_window_tokens()` to pass `n_ctx` into `llama_cpp.Llama`. (`utils/llm/model_manager.py`)
- Included operator-visible status fields `context_tier` and `context_window_tokens` in UI status and safe diagnostics, and added README documentation for operator context tiers. (`desktop-tauri/README.md`, UI status in `desktop-tauri/src/App.tsx`)
- Added focused unit tests for config migration/normalization, UI persistence/disabled behavior, Python bridge argument/profile validation, and ModelManager `n_ctx` propagation. (tests updated/added under `tests/unit/` and `desktop-tauri/src/App.test.tsx`)

### Testing

- Ran Python unit tests: `pytest -q tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_model_manager.py` and all targeted tests passed locally (240 tests passed for the focused suite including the new tests). — PASSED
- Ran desktop UI tests: `npm test` in `desktop-tauri` and all frontend tests passed (40 tests). — PASSED
- Ran `pre-commit run --all-files` and project hooks (linting, bandit, vulture, etc.) — PASSED
- Attempted Rust tests: `cargo test -q config::tests -- --nocapture` could not be executed in this environment due to missing system `glib-2.0.pc` needed by `glib-sys`/Tauri native build; this is an environment limitation rather than a code failure. — NOT RUN (environment missing system dependency)
- Performed `git diff --check` and ensured commits are staged; added files committed as "Add desktop operator context tier selection". — PASSED

Notes: The changes preserve the warm-before-register invariant and only pass normalized profile IDs (not raw `n_ctx`) from UI to bridge; the runtime still performs warm-load before registration and will fail-closed on invalid/failed 64K initialization. Cargo/Rust tests in this CI-like environment are blocked by host packages required for building Tauri native crates; they should be run in CI or a dev machine with `glib-2.0` / pkg-config available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac186d230832f8b57a62a9dfeb56a)