### PR TITLE
Add API v1 context capability registration and tier-aware node selection

### DIFF
--- a/docs/design/context-tiered-compute.md
+++ b/docs/design/context-tiered-compute.md
@@ -223,6 +223,46 @@ The initial desktop UX is intentionally static and operator-controlled:
 9. No in-place resize and no per-request model reconstruction are part of the
    initial design.
 
+## API v1 capability registration and tier-aware selection (P9)
+
+Compute nodes may now include an optional `capabilities` object on
+`POST /api/v1/relay/servers/register` heartbeats. The relay stores only
+normalized, privacy-safe fields:
+
+- API version (`v1`);
+- supported model IDs;
+- active context tier (`8k-fast` or `64k-full`);
+- maximum total context tokens for the active tier;
+- default and maximum output-token reservation;
+- maximum concurrency, initially `1`;
+- coarse backend class when the desktop runtime can safely report one.
+
+Older API v1 nodes that omit capabilities are treated as `8k-fast`
+compatibility nodes. Malformed capability payloads are rejected before updating
+relay registration state. The initial contract intentionally does not advertise
+raw VRAM/RAM values, hostnames, hardware serials, keys beyond the existing
+public-key routing field, prompt text, or exact prompt token counts.
+
+`GET /api/v1/relay/servers/next` accepts optional `model` and `context_tier`
+query parameters. Missing `context_tier` defaults to `8k-fast`. Selection
+filters to live API v1 nodes that support the requested model, when supplied,
+and whose active context tier can satisfy the requested tier. A `64k-full` node
+may satisfy an `8k-fast` request, but an `8k-fast` node must not satisfy a
+`64k-full` request. Among equivalent eligible nodes, registration-order
+round-robin remains the scheduling policy; broader load balancing is still a
+later task.
+
+Successful selection returns the existing `server_public_key` plus safe metadata:
+selected context tier, selected context-window tokens, selected model support,
+and the selection policy. If no compute nodes are registered the relay preserves
+`no_registered_compute_nodes`; if nodes exist but none match the requested
+model/tier, it returns `no_matching_compute_node`.
+
+Encrypted API v1 request payloads may include `api_v1_request.routing` with
+`routing.context_tier`. This routing field is validated only after the compute
+node decrypts the E2EE envelope; plaintext relay dispatch still carries no
+prompt text, message content, exact token count, or client-derived message size.
+
 ## Privacy-safe capability registration
 
 After warm-load validation, a compute node registers these API v1 capabilities:

--- a/relay.py
+++ b/relay.py
@@ -490,6 +490,12 @@ known_servers = {}
 server_round_robin_lock = threading.RLock()
 server_round_robin_next_index = 0
 API_V1_SERVER_MARKER = "api_v1_registered"
+API_V1_DEFAULT_CONTEXT_TIER = "8k-fast"
+API_V1_CONTEXT_TIER_TOKENS = {
+    "8k-fast": 8192,
+    "64k-full": 65536,
+}
+API_V1_SELECTION_POLICY = "registration_order_round_robin_with_capability_filter"
 client_inference_requests = {}
 client_responses = {}
 client_responses_lock = threading.Lock()
@@ -565,6 +571,97 @@ def _api_v1_in_flight_ttl_seconds() -> float:
     except ValueError:
         return max(float(_api_v1_lease_seconds()), 1.0)
     return max(value, 1.0)
+
+
+def _api_v1_compat_capabilities() -> dict[str, Any]:
+    return {
+        "api_version": "v1",
+        "supported_model_ids": ["llama-3.1-8b-instruct"],
+        "active_context_tier": API_V1_DEFAULT_CONTEXT_TIER,
+        "max_total_context_tokens": API_V1_CONTEXT_TIER_TOKENS[API_V1_DEFAULT_CONTEXT_TIER],
+        "default_output_token_reservation": 1024,
+        "maximum_output_tokens": 4096,
+        "max_concurrency": 1,
+    }
+
+
+def _normalise_api_v1_capabilities(raw: Any) -> tuple[dict[str, Any] | None, str | None]:
+    """Return relay-safe, normalized API v1 capabilities or an error message."""
+
+    if raw is None:
+        return _api_v1_compat_capabilities(), None
+    if not isinstance(raw, dict):
+        return None, "capabilities must be an object"
+
+    allowed_keys = {
+        "api_version",
+        "supported_model_ids",
+        "active_context_tier",
+        "max_total_context_tokens",
+        "default_output_token_reservation",
+        "maximum_output_tokens",
+        "max_concurrency",
+        "backend_class",
+    }
+    capabilities: dict[str, Any] = {}
+    for key in raw:
+        if key not in allowed_keys:
+            return None, f"unsupported capability field: {key}"
+
+    api_version = raw.get("api_version", "v1")
+    if api_version != "v1":
+        return None, "api_version must be v1"
+    capabilities["api_version"] = "v1"
+
+    models = raw.get("supported_model_ids", _api_v1_compat_capabilities()["supported_model_ids"])
+    if (
+        not isinstance(models, list)
+        or not models
+        or len(models) > 32
+        or any(not isinstance(model, str) or not model.strip() or len(model) > 128 for model in models)
+    ):
+        return None, "supported_model_ids must be a non-empty string list"
+    capabilities["supported_model_ids"] = sorted({model.strip() for model in models})
+
+    tier = raw.get("active_context_tier", API_V1_DEFAULT_CONTEXT_TIER)
+    if tier not in API_V1_CONTEXT_TIER_TOKENS:
+        return None, "active_context_tier is unsupported"
+    capabilities["active_context_tier"] = tier
+
+    expected_tokens = API_V1_CONTEXT_TIER_TOKENS[tier]
+    max_total_context_tokens = raw.get("max_total_context_tokens", expected_tokens)
+    if (
+        isinstance(max_total_context_tokens, bool)
+        or not isinstance(max_total_context_tokens, int)
+        or max_total_context_tokens < expected_tokens
+    ):
+        return None, "max_total_context_tokens is invalid for active_context_tier"
+    capabilities["max_total_context_tokens"] = max_total_context_tokens
+
+    for field, default in (
+        ("default_output_token_reservation", 1024),
+        ("maximum_output_tokens", 4096),
+        ("max_concurrency", 1),
+    ):
+        value = raw.get(field, default)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            return None, f"{field} must be a positive integer"
+        capabilities[field] = value
+    if capabilities["default_output_token_reservation"] > capabilities["maximum_output_tokens"]:
+        return None, "default_output_token_reservation cannot exceed maximum_output_tokens"
+    if capabilities["max_concurrency"] != 1:
+        return None, "max_concurrency must be 1"
+
+    backend_class = raw.get("backend_class")
+    if backend_class is not None:
+        if backend_class not in {"cpu", "cuda", "metal", "gpu", "hybrid", "unknown"}:
+            return None, "backend_class is unsupported"
+        capabilities["backend_class"] = backend_class
+    return capabilities, None
+
+
+def _api_v1_context_tier_satisfies(active_tier: str, requested_tier: str) -> bool:
+    return API_V1_CONTEXT_TIER_TOKENS.get(active_tier, 0) >= API_V1_CONTEXT_TIER_TOKENS.get(requested_tier, 0)
 
 def _pop_next_api_v1_request(public_key: str):
     queued_requests = client_inference_requests.get(public_key, [])
@@ -657,6 +754,7 @@ def _live_server_diagnostics(*, api_v1_only: bool = False) -> list[dict[str, Any
             "age_seconds": round(_server_ping_age_seconds(payload.get("last_ping")), 3),
             "next_ping_in_x_seconds": payload.get("last_ping_duration"),
             "queue_depth": len(client_inference_requests.get(server_public_key, [])),
+            "capabilities": payload.get("capabilities", _api_v1_compat_capabilities()),
         })
     diagnostics.sort(key=lambda node: node["server_public_key"])
     return diagnostics
@@ -670,6 +768,23 @@ def _api_v1_round_robin_keys() -> list[str]:
         for server_public_key, payload in known_servers.items()
         if bool(payload.get(API_V1_SERVER_MARKER))
     ]
+
+
+def _api_v1_eligible_round_robin_keys(*, model: str | None, context_tier: str) -> list[str]:
+    ordered: list[str] = []
+    for server_public_key, payload in known_servers.items():
+        if not bool(payload.get(API_V1_SERVER_MARKER)):
+            continue
+        capabilities = payload.get("capabilities", _api_v1_compat_capabilities())
+        if not isinstance(capabilities, dict):
+            continue
+        if model and model not in capabilities.get("supported_model_ids", []):
+            continue
+        active_tier = capabilities.get("active_context_tier")
+        if not isinstance(active_tier, str) or not _api_v1_context_tier_satisfies(active_tier, context_tier):
+            continue
+        ordered.append(server_public_key)
+    return ordered
 
 
 def _remove_known_server(server_public_key: str) -> bool:
@@ -1002,18 +1117,30 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
-def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any], dict[str, Any] | None]:
+def _select_round_robin_server_key(
+    *, model: str | None = None, context_tier: str = API_V1_DEFAULT_CONTEXT_TIER
+) -> tuple[str | None, dict[str, Any], dict[str, Any] | None]:
     """Select and snapshot the next API v1 compute node in registration-order round-robin order."""
 
     global server_round_robin_next_index
     with server_round_robin_lock:
-        ordered_keys = _api_v1_round_robin_keys()
-        if not ordered_keys:
+        all_api_v1_keys = _api_v1_round_robin_keys()
+        if not all_api_v1_keys:
             server_round_robin_next_index = 0
             return None, {
                 "eligible_count": 0,
                 "round_robin_index": 0,
                 "round_robin_position": None,
+                "registered_api_v1_count": 0,
+            }, None
+
+        ordered_keys = _api_v1_eligible_round_robin_keys(model=model, context_tier=context_tier)
+        if not ordered_keys:
+            return None, {
+                "eligible_count": 0,
+                "round_robin_index": server_round_robin_next_index,
+                "round_robin_position": None,
+                "registered_api_v1_count": len(all_api_v1_keys),
             }, None
 
         eligible_count = len(ordered_keys)
@@ -1025,6 +1152,7 @@ def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any], dict[s
             "eligible_count": eligible_count,
             "round_robin_index": server_round_robin_next_index,
             "round_robin_position": round_robin_index,
+            "registered_api_v1_count": len(all_api_v1_keys),
         }, server_payload
 
 
@@ -1047,8 +1175,32 @@ def _select_next_server_payload(*, api_v1: bool = False):
             server_payload = dict(known_servers[server_public_key])
             return jsonify({'server_public_key': server_payload['public_key']})
 
-    server_public_key, selection, server_payload = _select_round_robin_server_key()
+    requested_model = request.args.get("model")
+    if isinstance(requested_model, str):
+        requested_model = requested_model.strip() or None
+    requested_context_tier = request.args.get("context_tier", API_V1_DEFAULT_CONTEXT_TIER)
+    if requested_context_tier not in API_V1_CONTEXT_TIER_TOKENS:
+        return jsonify({
+            'error': {
+                'message': 'Requested context tier is not supported.',
+                'code': 'invalid_context_tier',
+            }
+        }), 400
+
+    server_public_key, selection, server_payload = _select_round_robin_server_key(
+        model=requested_model,
+        context_tier=requested_context_tier,
+    )
     if not server_public_key or server_payload is None:
+        if selection.get("registered_api_v1_count", 0):
+            return jsonify({
+                'error': {
+                    'message': 'No registered compute nodes match the requested model and context tier.',
+                    'code': 'no_matching_compute_node',
+                    'requested_model': requested_model,
+                    'requested_context_tier': requested_context_tier,
+                }
+            }), 503
         return jsonify({
             'error': {
                 'message': 'No registered compute nodes are available on this relay.',
@@ -1060,7 +1212,7 @@ def _select_next_server_payload(*, api_v1: bool = False):
         "relay.server_selected",
         extra={
             "server_fingerprint": _safe_key_fingerprint(server_public_key),
-            "selection_policy": "registration_order_round_robin",
+            "selection_policy": API_V1_SELECTION_POLICY,
             "round_robin_index": selection.get("round_robin_index"),
             "round_robin_position": selection.get("round_robin_position"),
             "eligible_count": selection.get("eligible_count"),
@@ -1068,7 +1220,17 @@ def _select_next_server_payload(*, api_v1: bool = False):
             "api_v1": api_v1,
         },
     )
-    return jsonify({'server_public_key': server_payload['public_key']})
+    capabilities = server_payload.get("capabilities", _api_v1_compat_capabilities())
+    return jsonify({
+        'server_public_key': server_payload['public_key'],
+        'selected_context_tier': capabilities.get("active_context_tier", API_V1_DEFAULT_CONTEXT_TIER),
+        'selected_context_window_tokens': capabilities.get(
+            "max_total_context_tokens",
+            API_V1_CONTEXT_TIER_TOKENS[API_V1_DEFAULT_CONTEXT_TIER],
+        ),
+        'selected_model_support': capabilities.get("supported_model_ids", []),
+        'selection_policy': API_V1_SELECTION_POLICY,
+    })
 
 @app.route('/next_server', methods=['GET'])
 def next_server():
@@ -1653,6 +1815,14 @@ def api_v1_relay_servers_register():
     public_key = data.get('server_public_key')
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
+    capabilities, capabilities_error = _normalise_api_v1_capabilities(data.get("capabilities"))
+    if capabilities_error:
+        return jsonify({
+            'error': {
+                'message': f'Invalid capabilities: {capabilities_error}',
+                'code': 'invalid_capabilities',
+            }
+        }), 400
 
     lease_seconds = _api_v1_lease_seconds()
     with server_round_robin_lock:
@@ -1678,6 +1848,7 @@ def api_v1_relay_servers_register():
             log_event = "server.registered"
         known_servers[public_key]['last_ping_duration'] = lease_seconds
         known_servers[public_key][API_V1_SERVER_MARKER] = True
+        known_servers[public_key]['capabilities'] = capabilities
     LOGGER.info(log_event, extra={"server_public_key": public_key})
 
     return jsonify({

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -259,19 +259,114 @@ def _server_key(label):
     return base64.b64encode(f"server_public_key_{label}".encode()).decode("utf-8")
 
 
-def _register_api_v1_server(client, server_public_key):
+def _capabilities(tier="8k-fast", models=None):
+    return {
+        "api_version": "v1",
+        "supported_model_ids": models or ["llama-3.1-8b-instruct"],
+        "active_context_tier": tier,
+        "max_total_context_tokens": 65536 if tier == "64k-full" else 8192,
+        "default_output_token_reservation": 1024,
+        "maximum_output_tokens": 4096,
+        "max_concurrency": 1,
+        "backend_class": "metal" if tier == "8k-fast" else "cuda",
+    }
+
+
+def _register_api_v1_server(client, server_public_key, capabilities=None):
+    payload = {'server_public_key': server_public_key}
+    if capabilities is not None:
+        payload["capabilities"] = capabilities
     response = client.post(
         '/api/v1/relay/servers/register',
-        json={'server_public_key': server_public_key},
+        json=payload,
     )
     assert response.status_code == 200
     return response
 
 
-def _next_api_v1_server_key(client):
-    response = client.get('/api/v1/relay/servers/next')
+def _next_api_v1_server_key(client, **query):
+    response = client.get('/api/v1/relay/servers/next', query_string=query)
     assert response.status_code == 200
     return response.get_json()['server_public_key']
+
+
+def test_api_v1_registers_normalized_8k_and_64k_capabilities(client):
+    server_a = _server_key("cap-8k")
+    server_b = _server_key("cap-64k")
+    _register_api_v1_server(client, server_a, _capabilities("8k-fast"))
+    _register_api_v1_server(client, server_b, _capabilities("64k-full"))
+
+    nodes = client.get("/relay/diagnostics").get_json()["api_v1_registered_compute_nodes"]
+    capabilities = {node["server_public_key"]: node["capabilities"] for node in nodes}
+    assert capabilities[server_a]["active_context_tier"] == "8k-fast"
+    assert capabilities[server_a]["max_total_context_tokens"] == 8192
+    assert capabilities[server_b]["active_context_tier"] == "64k-full"
+    assert capabilities[server_b]["max_total_context_tokens"] == 65536
+    assert "hostname" not in capabilities[server_b]
+    assert "vram" not in capabilities[server_b]
+
+
+def test_api_v1_rejects_malformed_capabilities_without_registering(client):
+    response = client.post(
+        "/api/v1/relay/servers/register",
+        json={"server_public_key": _server_key("bad-cap"), "capabilities": {"active_context_tier": "raw-host"}},
+    )
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "invalid_capabilities"
+    assert known_servers == {}
+
+
+def test_api_v1_old_node_defaults_to_8k_compatibility(client):
+    server = _server_key("old-node")
+    _register_api_v1_server(client, server)
+    payload = client.get("/api/v1/relay/servers/next").get_json()
+    assert payload["server_public_key"] == server
+    assert payload["selected_context_tier"] == "8k-fast"
+    assert payload["selected_context_window_tokens"] == 8192
+
+
+def test_api_v1_tier_and_model_selection(client):
+    node_8k = _server_key("tier-8k")
+    node_64k = _server_key("tier-64k")
+    _register_api_v1_server(client, node_8k, _capabilities("8k-fast", ["small-model"]))
+    _register_api_v1_server(client, node_64k, _capabilities("64k-full", ["small-model", "long-model"]))
+
+    assert _next_api_v1_server_key(client, context_tier="8k-fast", model="small-model") == node_8k
+    assert _next_api_v1_server_key(client, context_tier="64k-full") == node_64k
+    assert _next_api_v1_server_key(client, context_tier="8k-fast", model="long-model") == node_64k
+
+
+def test_api_v1_8k_request_may_select_64k_when_no_8k_node(client):
+    node_64k = _server_key("only-64k")
+    _register_api_v1_server(client, node_64k, _capabilities("64k-full"))
+    assert _next_api_v1_server_key(client, context_tier="8k-fast") == node_64k
+
+
+def test_api_v1_deterministic_round_robin_within_eligible_tier(client):
+    node_a = _server_key("rr-64k-a")
+    node_b = _server_key("rr-64k-b")
+    _register_api_v1_server(client, _server_key("rr-8k"), _capabilities("8k-fast"))
+    _register_api_v1_server(client, node_a, _capabilities("64k-full"))
+    _register_api_v1_server(client, node_b, _capabilities("64k-full"))
+
+    assert [_next_api_v1_server_key(client, context_tier="64k-full") for _ in range(4)] == [
+        node_a,
+        node_b,
+        node_a,
+        node_b,
+    ]
+
+
+def test_api_v1_no_matching_node_error_when_registered_nodes_are_ineligible(client):
+    _register_api_v1_server(client, _server_key("only-8k"), _capabilities("8k-fast", ["small-model"]))
+
+    response = client.get("/api/v1/relay/servers/next", query_string={"context_tier": "64k-full"})
+    assert response.status_code == 503
+    assert response.get_json()["error"]["code"] == "no_matching_compute_node"
+
+    response = client.get("/api/v1/relay/servers/next", query_string={"model": "other-model"})
+    assert response.status_code == 503
+    assert response.get_json()["error"]["code"] == "no_matching_compute_node"
 
 
 def _queue_api_v1_request(client, *, server_public_key, request_id, client_public_key=None):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -17,7 +17,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # Import the module to test
 from utils.networking import relay_client as relay_client_module
-from utils.networking.relay_client import RelayClient, MESSAGE_SCHEMA, RELAY_RESPONSE_SCHEMA
+from utils.networking.relay_client import (
+    RelayClient,
+    MESSAGE_SCHEMA,
+    RELAY_RESPONSE_SCHEMA,
+    _extract_api_v1_request_payload,
+)
 
 # Common test data
 TEST_VALID_RESPONSE = {
@@ -155,6 +160,40 @@ def test_validate_with_fallback_rejects_missing_required_field_without_jsonschem
     ):
         with pytest.raises(ValueError, match="Missing required field: iv"):
             relay_client_module._validate_with_fallback(payload, MESSAGE_SCHEMA)
+
+
+def test_api_v1_encrypted_request_routing_defaults_to_8k_after_decryption():
+    payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "request_id": "req-1",
+        "client_public_key": "client-key",
+        "api_v1_request": {
+            "model": "llama-3.1-8b-instruct",
+            "messages": [],
+            "options": {},
+        },
+    }
+
+    extracted = _extract_api_v1_request_payload(payload, "client-key")
+
+    assert extracted is not None
+    assert extracted["routing"] == {"context_tier": "8k-fast"}
+
+
+def test_api_v1_encrypted_request_rejects_malformed_routing_after_decryption():
+    payload = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "request_id": "req-1",
+        "client_public_key": "client-key",
+        "api_v1_request": {
+            "model": "llama-3.1-8b-instruct",
+            "messages": [],
+            "options": {},
+            "routing": {"context_tier": "128k-raw"},
+        },
+    }
+
+    assert _extract_api_v1_request_payload(payload, "client-key") is None
 
 # Create a better time mock with a context manager
 class TimeMock:
@@ -1013,6 +1052,27 @@ class TestRelayClient:
         assert result['http_status'] == 503
         assert result['relay_error_kind'] == 'http_status_no_json_body'
         assert result['relay_http_diagnostic']['path'] == '/api/v1/relay/servers/register'
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_register_api_v1_compute_node_sends_active_context_capabilities(self, mock_post, relay_client):
+        relay_client.model_manager.context_tier = "64k-full"
+        relay_client.model_manager.last_compute_diagnostics = {"backend_used": "cuda"}
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"next_ping_in_x_seconds": 30, "poll_wait_seconds": 10}
+        mock_post.return_value = response
+
+        result = relay_client.register_api_v1_compute_node("http://relay-a.example")
+
+        assert result["next_ping_in_x_seconds"] == 30
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["server_public_key"] == relay_client.crypto_manager.public_key_b64
+        assert payload["capabilities"]["api_version"] == "v1"
+        assert payload["capabilities"]["active_context_tier"] == "64k-full"
+        assert payload["capabilities"]["max_total_context_tokens"] == 65536
+        assert payload["capabilities"]["max_concurrency"] == 1
+        assert payload["capabilities"]["backend_class"] == "cuda"
+        assert "hostname" not in payload["capabilities"]
+        assert "vram" not in payload["capabilities"]
 
     @patch('utils.networking.relay_client.requests.post')
     def test_register_api_v1_compute_node_403_html_logs_cloudflare_diagnostic(

--- a/utils/context_profiles.py
+++ b/utils/context_profiles.py
@@ -15,6 +15,7 @@ class ContextProfile:
     display_label: str
     total_context_tokens: int
     default_output_reservation_tokens: int
+    maximum_output_tokens: int = 4096
     enabled: bool = True
 
 
@@ -22,8 +23,8 @@ class ContextProfile:
 # codegen/manifest loading. Keep these IDs and token counts synchronized with
 # desktop-tauri/src-tauri/src/context_profiles.rs and desktop-tauri/src/App.tsx.
 _CONTEXT_PROFILES = (
-    ContextProfile("8k-fast", "8K Fast", 8192, 1024, True),
-    ContextProfile("64k-full", "64K Full", 65536, 1024, True),
+    ContextProfile("8k-fast", "8K Fast", 8192, 1024, 4096, True),
+    ContextProfile("64k-full", "64K Full", 65536, 1024, 4096, True),
 )
 
 CONTEXT_PROFILES: Dict[str, ContextProfile] = {

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -18,6 +18,7 @@ from utils.processing_result import RelayProcessingResult
 from urllib.parse import urlparse, urlunparse
 
 from utils.networking.http_requests_compat import requests
+from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile
 
 # Configure logging
 logger = logging.getLogger('relay_client')
@@ -447,6 +448,7 @@ def _extract_api_v1_request_payload(
     model = api_v1_request.get("model")
     messages = api_v1_request.get("messages")
     options = api_v1_request.get("options", {})
+    routing = api_v1_request.get("routing", {})
     if not isinstance(model, str) or not model.strip():
         log_error("Rejected API v1 relay payload: model must be a non-empty string")
         return None
@@ -456,12 +458,22 @@ def _extract_api_v1_request_payload(
     if not isinstance(options, dict):
         log_error("Rejected API v1 relay payload: options must be an object")
         return None
+    if routing is None:
+        routing = {}
+    if not isinstance(routing, dict):
+        log_error("Rejected API v1 relay payload: routing must be an object")
+        return None
+    context_tier = routing.get("context_tier", DEFAULT_CONTEXT_TIER)
+    if context_tier not in {"8k-fast", "64k-full"}:
+        log_error("Rejected API v1 relay payload: routing.context_tier is unsupported")
+        return None
 
     return {
         "request_id": request_id,
         "model": model,
         "messages": messages,
         "options": options,
+        "routing": {"context_tier": context_tier},
     }
 
 
@@ -1200,7 +1212,10 @@ class RelayClient:
 
     def register_api_v1_compute_node(self, relay_url: Optional[str] = None) -> Dict[str, Any]:
         target_url = relay_url or self.relay_url
-        payload = {'server_public_key': self.crypto_manager.public_key_b64}
+        payload = {
+            'server_public_key': self.crypto_manager.public_key_b64,
+            'capabilities': self._api_v1_compute_capabilities(),
+        }
         request_kwargs: Dict[str, Any] = {'json': payload, 'timeout': self._request_timeout}
         headers = self._auth_headers()
         if headers:
@@ -1221,6 +1236,26 @@ class RelayClient:
                 next_ping_in_x_seconds=self._request_timeout,
             )
         return response.json()
+
+    def _api_v1_compute_capabilities(self) -> Dict[str, Any]:
+        context_tier = getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)
+        profile = get_context_profile(context_tier if isinstance(context_tier, str) else DEFAULT_CONTEXT_TIER)
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", {})
+        backend_class = None
+        if isinstance(diagnostics, dict):
+            backend_class = diagnostics.get("backend_used") or diagnostics.get("backend_selected")
+        capabilities: Dict[str, Any] = {
+            "api_version": "v1",
+            "supported_model_ids": sorted(self._API_V1_LOCAL_LLAMA_RUNTIME_IDS),
+            "active_context_tier": profile.profile_id,
+            "max_total_context_tokens": profile.total_context_tokens,
+            "default_output_token_reservation": profile.default_output_reservation_tokens,
+            "maximum_output_tokens": profile.maximum_output_tokens,
+            "max_concurrency": 1,
+        }
+        if backend_class in {"cpu", "cuda", "metal", "gpu", "hybrid", "unknown"}:
+            capabilities["backend_class"] = backend_class
+        return capabilities
 
     @staticmethod
     def _build_api_v1_url(relay_url: str, route: str) -> str:


### PR DESCRIPTION
### Motivation
- Allow compute nodes to advertise privacy-safe capability metadata (model support, active context tier, token windows, output reservations, concurrency, coarse backend class) so the relay can route encrypted API v1 requests to nodes that can satisfy requested model/context constraints while preserving relay-blind E2EE.
- Preserve backwards compatibility so older nodes without capabilities behave as safe `8k-fast` compatibility nodes and existing API v1 clients keep working.

### Description
- Add a normalized `capabilities` object for API v1 compute-node registration with strict validation and a safe fallback for older nodes, and store only normalized, privacy-safe fields; malformed capability payloads are rejected before registration state is changed (`relay.py`).
- Extend relay diagnostics to include the normalized `capabilities` metadata while keeping `Cache-Control: no-store` and avoiding any private machine details (`relay.py`).
- Add `model` and `context_tier` query parameters to `GET /api/v1/relay/servers/next` and implement filtering by live API v1 nodes, requested model, and whether a node's active tier satisfies the requested tier, keeping registration-order round robin among eligible nodes and returning structured `no_matching_compute_node` vs `no_registered_compute_nodes` errors (`relay.py`).
- Return safe selection metadata alongside the existing `server_public_key`: `selected_context_tier`, `selected_context_window_tokens`, `selected_model_support`, and `selection_policy` while preserving compatibility (`relay.py`).
- Validate `api_v1_request.routing.context_tier` only after decryption of the E2EE envelope and default missing routing to `8k-fast` (`utils/networking/relay_client.py`).
- Have the desktop/compute-side relay client include the active context profile (capabilities) during `register`/heartbeat, emitting only safe fields (supported models, active tier, token windows, output reservations, max concurrency, coarse backend class) (`utils/networking/relay_client.py`).
- Add `maximum_output_tokens` to context profiles and surface it via `utils/context_profiles.py` for use in capability emission.
- Add tests for capability registration (8K/64K), malformed capability rejection, old-node compatibility, tier/model selection semantics, 64K->8K fallback, deterministic eligible round robin, `no_matching_compute_node` behavior, diagnostics redaction, and encrypted routing validation (`tests/test_relay.py`, `tests/unit/test_relay_client.py`).
- Document the capability contract and selection behavior in `docs/design/context-tiered-compute.md`.

### Testing
- Ran `pytest tests/test_relay.py -q` and it passed: `127 passed`.
- Ran `pytest tests/unit/test_relay_client.py -q` and it passed: `203 passed`.
- Ran `pytest tests/unit/test_compute_node_runtime.py tests/unit/test_context_profiles.py -q` and they passed: `54 passed`.
- Ran `pre-commit run --all-files` and it passed (lint/hooks and checks completed).
- Ran `git diff --check` and there were no whitespace or diff-check issues.
- Residual risks: capability fields are intentionally conservative (no raw VRAM/host identifiers); follow-ups include broader load-balancing (beyond filtering) and compute-side exact admission control after decryption as scoped for later tasks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b57d5ca50832fa596a1137a44366b)