### PR TITLE
API v1: add context-tier capability registration and tier-aware node selection

### DIFF
--- a/docs/design/context-tiered-compute.md
+++ b/docs/design/context-tiered-compute.md
@@ -225,55 +225,39 @@ The initial desktop UX is intentionally static and operator-controlled:
 
 ## Privacy-safe capability registration
 
-After warm-load validation, a compute node registers these API v1 capabilities:
+P9 compute nodes register only a coarse API v1 capability contract. The relay
+stores the normalized fields below and discards unsafe extras. Older API v1 nodes
+that omit `capabilities` remain accepted as bounded `8k-fast` compatibility
+nodes with the default supported API v1 model IDs; they are not wildcards for
+arbitrary requested models.
 
 ```json
 {
   "server_public_key": "base64-public-key",
-  "api_version": "v1",
-  "supported_model_ids": ["llama-3.1-8b-instruct"],
-  "active_context_profile": {
-    "profile_id": "64k-full",
-    "display_name": "64K full context",
-    "model_ids": ["llama-3.1-8b-instruct"],
-    "total_context_tokens": 65536,
+  "capabilities": {
+    "api_version": "v1",
+    "supported_model_ids": ["llama-3.1-8b-instruct"],
+    "active_context_tier": "64k-full",
+    "maximum_total_context_tokens": 65536,
     "default_output_token_reservation": 1024,
-    "maximum_output_tokens": 4096,
+    "maximum_output_tokens": 8192,
     "max_concurrency": 1,
-    "kv_cache_type": "runtime_default",
-    "kqv_offload_policy": "runtime_default",
-    "gpu_layers": "runtime_default",
-    "batch_defaults": {
-      "n_batch": "runtime_default",
-      "n_ubatch": "runtime_default",
-      "flash_attention": "runtime_default"
-    },
-    "enabled": true,
-    "safe_diagnostics": {
-      "backend_class": "cuda",
-      "throughput_band": "long_context_baseline",
-      "last_warm_load_status": "ok"
-    }
-  },
-  "maximum_total_context_tokens": 65536,
-  "maximum_output_tokens": 4096,
-  "max_concurrency": 1,
-  "backend_class": "cuda",
-  "throughput_band": "long_context_baseline"
+    "backend_class": "cuda"
+  }
 }
 ```
 
-Allowed fields:
+Allowed normalized capability fields:
 
-- server public key;
-- API version;
-- supported model IDs;
-- active context profile;
-- maximum total context tokens;
-- maximum output tokens;
-- max concurrency;
-- backend class such as `cpu`, `cuda`, or `metal`;
-- optional coarse throughput bands.
+- `api_version`;
+- `supported_model_ids`;
+- `active_context_tier`;
+- `maximum_total_context_tokens`;
+- `default_output_token_reservation`;
+- `maximum_output_tokens`;
+- `max_concurrency`;
+- optional coarse `backend_class` such as `cpu`, `cuda`, `metal`, `hybrid`, or
+  `unknown`.
 
 Forbidden fields:
 
@@ -286,9 +270,9 @@ Forbidden fields:
 - raw `gpu_layers` counts, device-derived GPU tuning values, or any other
   relay-visible hardware fingerprinting detail.
 
-Relay-visible `gpu_layers` values in profile examples are policy labels only.
-Allowed labels include `runtime_default`, `auto`, and `profile_default`; they do
-not disclose actual layer counts or operator-specific hardware tuning.
+Relay-visible `backend_class` is a coarse class only. It must not disclose
+operator-specific hardware inventory, raw memory, hostnames, serials, private
+keys, or plaintext request content.
 
 ## API v1 extension proposal
 
@@ -306,42 +290,25 @@ Response:
 ```json
 {
   "server_public_key": "base64-public-key",
-  "selected_context_profile": {
-    "profile_id": "64k-full",
-    "display_name": "64K full context",
-    "model_ids": ["llama-3.1-8b-instruct"],
-    "total_context_tokens": 65536,
-    "default_output_token_reservation": 1024,
-    "maximum_output_tokens": 4096,
-    "max_concurrency": 1,
-    "kv_cache_type": "runtime_default",
-    "kqv_offload_policy": "runtime_default",
-    "gpu_layers": "runtime_default",
-    "batch_defaults": {
-      "n_batch": "runtime_default",
-      "n_ubatch": "runtime_default",
-      "flash_attention": "runtime_default"
-    },
-    "enabled": true,
-    "safe_diagnostics": {
-      "backend_class": "cuda",
-      "throughput_band": "long_context_baseline"
-    }
-  }
+  "selected_context_tier": "64k-full",
+  "selected_context_window_tokens": 65536,
+  "selected_model_support": ["llama-3.1-8b-instruct"],
+  "selection_policy": "registration_order_round_robin_with_capability_filter"
 }
 ```
 
-The selection response contains only the public key plus safe selected-profile
-metadata. It must not include private hardware details or anything derived from
-plaintext prompt inspection.
+The selection response keeps existing compatibility for clients that only read
+`server_public_key`. Additional fields are safe coarse metadata derived from the
+normalized capability contract. It must not include private hardware details,
+plaintext prompts/messages, exact decrypted token counts, raw VRAM/RAM,
+hostnames, serials, or keys beyond the selected public key.
 
 ### Encrypted API v1 request addition
 
-The plaintext that is encrypted to the compute node distinguishes the requested
-minimum tier from the relay-selected active profile. Clients may keep the legacy
-top-level `context_tier` for the requested tier, but new implementations should
-prefer the explicit `routing` object so the selected-profile echo is
-unambiguous:
+The plaintext that is encrypted to the compute node may include coarse routing
+metadata under `api_v1_request.routing`. In P9 the implemented routing field is
+`routing.context_tier`; when omitted, the compute node normalizes it to
+`8k-fast` after decryption.
 
 ```json
 {
@@ -350,11 +317,8 @@ unambiguous:
   "client_public_key": "...",
   "api_v1_request": {
     "model": "llama-3.1-8b-instruct",
-    "context_tier": "8k-fast",
     "routing": {
-      "requested_context_tier": "8k-fast",
-      "selected_context_profile_id": "64k-full",
-      "selected_profile_echo": "selected_profile_echo_v1"
+      "context_tier": "64k-full"
     },
     "messages": [],
     "options": {
@@ -364,44 +328,18 @@ unambiguous:
 }
 ```
 
-`context_tier` and `routing.requested_context_tier` mean the requested minimum
-tier. `routing.selected_context_profile_id` is the relay-selected active profile
-that the client copied from `selected_context_profile.profile_id` after node
-selection. `routing.selected_profile_echo` records the selected-profile echo contract
-version and must be `selected_profile_echo_v1` whenever
-`routing.selected_context_profile_id` is used. Missing requested tier defaults
-to `8k-fast` for compatibility. A selected-profile mismatch or missing/unknown
-echo version fails closed with an encrypted structured error. Legacy exact-tier
-behavior is allowed only when no selected profile echo is used.
-
-### Client capability negotiation
-
-`GET /api/v1/relay/servers/next` also accepts a relay-visible capability flag:
-
-| Query parameter | Required | Meaning |
-| --- | --- | --- |
-| `client_capabilities` | optional | Comma-separated client feature flags. `selected_profile_echo_v1` means the client will copy `selected_context_profile.profile_id` into encrypted `routing.selected_context_profile_id`. |
-
-Clients without `selected_profile_echo_v1` support get exact-tier selection only:
-missing `context_tier` still defaults to `8k-fast`, and the relay must not assign
-such requests to `64k-full` even if the larger profile could satisfy the token
-limit. This preserves backward compatibility for encrypted payloads that omit
-the selected active profile.
-
-Clients that advertise `client_capabilities=selected_profile_echo_v1` may receive
-the smallest capable selected profile instead of an exact profile. They must copy
-the returned `selected_context_profile.profile_id` into
-`routing.selected_context_profile_id` inside the encrypted API v1 request before
-dispatch. The relay must keep smallest-capable/spillover selection disabled for
-clients that do not advertise this capability.
+Malformed `routing` or unsupported `routing.context_tier` values are rejected
+only after decryption by the compute node, and the relay continues to handle only
+ciphertext plus safe routing metadata. P9 does not require clients to echo a
+selected profile ID for 64K fallback.
 
 ### Registration extension
 
-`POST /api/v1/relay/servers/register` adds the capability body described above.
-The relay stores the safe metadata and uses it for filtering/scheduling.
-Registration must occur only after warm-load and profile memory validation.
-Heartbeat renewals may repeat the same capability payload or send a stable
-capability revision ID plus the public key.
+`POST /api/v1/relay/servers/register` adds the `capabilities` body described
+above. The relay stores only the normalized safe fields and uses them for
+filtering. Heartbeat renewals may repeat the same capability payload. If a
+heartbeat omits capabilities, the previously stored normalized capabilities are
+preserved.
 
 ### Unregister extension
 
@@ -438,69 +376,28 @@ profile validation.
 
 Selection happens before encryption because the client needs a public key. The
 client provides coarse `model` and `context_tier`; exact token count remains
-inside the encrypted request.
+inside the encrypted request and is not a P9 relay input.
 
 Decision flow:
 
 1. Normalize missing `context_tier` to `8k-fast`.
-2. Read `client_capabilities` from the relay-visible selection request. Treat
-   `selected_profile_echo_v1` as the only activation signal for selected-profile
-   echo support.
-3. Filter live API v1 nodes by API version, enabled profile, model ID, requested
-   tier capability, max concurrency availability, and lease freshness. Without
-   `selected_profile_echo_v1`, selection is exact-tier only: omitted-tier and
-   explicit `8k-fast` requests remain eligible for exact `8k-fast` profiles only,
-   and the relay must not spill them to `64k-full`. With
-   `selected_profile_echo_v1`, the relay may select the smallest capable active
-   profile, and the client must echo that profile ID into the encrypted request.
-   This prevents an omitted-tier encrypted request from being selected onto a
-   larger node without a compute-visible selected-profile signal.
-4. Return `503 no_registered_compute_nodes` if no live API v1 nodes exist.
-5. Return a capability-specific `503 no_capable_compute_nodes` if nodes exist but
-   none support the requested safe metadata and capability contract.
-6. Schedule among equivalent nodes without exposing prompt size.
-7. Return the public key plus safe selected-profile metadata.
+2. Filter live API v1 nodes by normalized `api_version`, requested model ID, and
+   requested tier capability. A `64k-full` node may satisfy an `8k-fast` request;
+   an `8k-fast` node must never satisfy a `64k-full` request.
+3. Return `503 no_registered_compute_nodes` if no live API v1 nodes exist.
+4. Return `503 no_matching_compute_node` if nodes exist but none match the
+   requested safe metadata and capability contract.
+5. Preserve deterministic registration-order round robin among the equivalent
+   eligible nodes. Broader load balancing, weighted scheduling, concurrency-aware
+   placement, and exact token admission remain deferred.
+6. Return `server_public_key` plus safe selected capability metadata.
 
 ### Scheduler decision table
 
 | Stage | Eligible nodes | Selection rule | Relay-visible inputs | Reason |
 | --- | --- | --- | --- | --- |
-| Current | Live API v1 nodes | Registration-order round robin | public key, API v1 marker | Existing behavior. |
-| Step 1 | Nodes matching model + tier | Preserve round robin among equivalent nodes | registration capabilities | Minimal capability correctness. |
-| Step 2 | Nodes matching model + at least requested tier, only when `client_capabilities=selected_profile_echo_v1` is present | Smallest capable tier | profile token limit, tier order, client capability flag | Avoid burning scarce 64K capacity while preserving exact-tier compatibility for clients that cannot echo `selected_context_profile.profile_id`. |
-| Step 3 | Smallest capable tier set | Lowest queued + in-flight work | queue depth, in-flight count, max concurrency | Reduce avoidable latency with safe metadata. |
-| Step 4 | Load-aware candidate set | Expected completion time | coarse throughput band, queue/in-flight, tier | Account for heterogeneous hardware without raw device inventory. |
-| Step 5 | Policy overlay | Fairness, long-tier reservation, optional selection reservation | safe tenant-neutral counters, reservation expiry | Prevent starvation and racey over-selection. |
-
-Relay-visible scheduling inputs remain metadata-only. The relay must never learn
-exact prompt tokens, decrypted messages, or model output text.
-
-## Dispatch and admission sequence
-
-```mermaid
-sequenceDiagram
-  participant Client
-  participant Relay
-  participant Compute
-  participant Runtime as Llama runtime
-
-  Client->>Relay: GET /api/v1/relay/servers/next?model=M&context_tier=8k-fast&client_capabilities=selected_profile_echo_v1
-  Relay-->>Client: server_public_key + safe selected profile
-  Client->>Relay: POST /api/v1/relay/requests encrypted to selected key
-  Compute->>Relay: POST /api/v1/relay/servers/poll heartbeat/poll
-  Relay-->>Compute: encrypted envelope
-  Compute->>Compute: decrypt and verify selected profile == active profile
-  Compute->>Runtime: render chat template and tokenize exact prompt
-  Compute->>Compute: prompt tokens + output reservation <= profile limit?
-  alt fits
-    Compute->>Runtime: non-streaming create_chat_completion
-    Compute->>Relay: encrypted success response
-    Relay-->>Client: encrypted response retrieval
-  else overflow
-    Compute->>Relay: encrypted structured overflow error
-    Relay-->>Client: encrypted error retrieval
-  end
-```
+| Current | Live API v1 nodes matching requested `model` and a sufficient `active_context_tier` | Registration-order round robin among equivalent eligible nodes | public key, API v1 marker, normalized capabilities | Minimal P9 capability correctness without P12 load balancing. |
+| Deferred | Nodes matching exact decrypted token admission, current queue depth, and richer load signals | Broader load balancing / smallest capable placement | exact admission and scheduler metadata | Out of scope for P9. |
 
 ## Compute-side exact admission control
 
@@ -510,49 +407,40 @@ use the same tokenizer/template as inference.
 Algorithm:
 
 1. Decrypt the API v1 envelope.
-2. Validate protocol, client key binding, model, messages, options, requested
-   `context_tier` or `routing.requested_context_tier`, and optional
-   `routing.selected_context_profile_id`.
-3. Default missing requested tier to `8k-fast`.
-4. If `routing.selected_context_profile_id` is present, require
-   `routing.selected_profile_echo == "selected_profile_echo_v1"` and require the
-   selected profile ID to match the node's active `profile_id`. Missing or
-   unknown echo versions fail closed through the same tier/profile mismatch
-   path. If no selected profile echo is used, fall back only to legacy exact-tier
-   behavior and require the requested tier to match the active profile.
-5. Verify that the active profile can satisfy the requested tier. A `64k-full`
-   active profile may satisfy an `8k-fast` requested tier only when the encrypted
-   request echoed both `routing.selected_context_profile_id` for this active
-   profile and `routing.selected_profile_echo == "selected_profile_echo_v1"`.
-6. Render the prompt with the same chat template that will be used for
+2. Validate protocol, client key binding, model, messages, options, and optional
+   `api_v1_request.routing.context_tier`.
+3. Default missing `routing.context_tier` to `8k-fast`.
+4. Verify that the active profile can satisfy the requested tier. A `64k-full`
+   active profile may satisfy an `8k-fast` requested tier; an `8k-fast` active
+   profile must fail closed for a `64k-full` requested tier.
+5. Render the prompt with the same chat template that will be used for
    `create_chat_completion`.
-7. Count exact input tokens with the active `Llama` runtime tokenizer.
-8. Determine requested output tokens from API v1 options, or use the profile's
+6. Count exact input tokens with the active `Llama` runtime tokenizer.
+7. Determine requested output tokens from API v1 options, or use the profile's
    default output reservation.
-9. Reject requests above the profile's max output tokens.
-10. Compute `required_total_tokens = prompt_tokens + output_reservation`.
-11. Admit only if the required total fits `total_context_tokens`.
-12. Do not silently shrink output below the requested budget.
-13. Return success or encrypted structured error. Do not expose exact counts to
+8. Reject requests above the profile's max output tokens.
+9. Compute `required_total_tokens = prompt_tokens + output_reservation`.
+10. Admit only if the required total fits `total_context_tokens`.
+11. Do not silently shrink output below the requested budget.
+12. Return success or encrypted structured error. Do not expose exact counts to
     the relay.
 
-Encrypted tier/profile mismatch error body:
+Encrypted tier mismatch error body:
 
 ```json
 {
   "error": {
     "code": "compute_node_context_tier_mismatch",
-    "message": "The request was encrypted for a different context profile than this compute node is serving.",
-    "active_context_tier": "64k-full",
-    "requested_context_tier": "8k-fast",
-    "selected_context_profile_id": "8k-fast",
+    "message": "The request requires a context tier this compute node is not currently serving.",
+    "active_context_tier": "8k-fast",
+    "requested_context_tier": "64k-full",
     "retryable": false
   }
 }
 ```
 
 This mismatch error is encrypted to the client and is separate from
-`compute_node_context_window_exceeded`: it reports a routing/profile contract
+`compute_node_context_window_exceeded`: it reports a coarse routing/tier contract
 failure before exact token admission. The relay must forward only ciphertext and
 must not inspect or synthesize plaintext mismatch details.
 
@@ -684,7 +572,7 @@ and recovery requires warm-load validation before re-registration.
 | Failure | Detection | Recovery | Privacy note |
 | --- | --- | --- | --- |
 | Profile warm-load OOM | Local warm-load validation fails before registration | Do not register; surface local operator error; allow tier change after Stop | Relay never sees failed profile details beyond absence of registration. |
-| Encrypted tier/profile mismatch | Compute decrypts request and compares `routing.selected_context_profile_id` to the active profile, then checks the active profile can satisfy the requested tier | Encrypted `compute_node_context_tier_mismatch`; client reselects/re-encrypts only after fixing capability echo or exact-tier routing | Relay sees only ciphertext error. |
+| Encrypted tier mismatch | Compute decrypts request and checks whether its active context tier can satisfy `routing.context_tier` | Encrypted `compute_node_context_tier_mismatch`; client reselects/re-encrypts after selecting a capable node | Relay sees only ciphertext error. |
 | Context overflow | Exact tokenizer admission fails | Encrypted `compute_node_context_window_exceeded`; recommend next tier when known | Exact counts remain encrypted. |
 | 64K inference exceeds lease | Heartbeat thread renews lease | Continue processing; unregister only on missed independent heartbeats | Relay sees heartbeat metadata only. |
 | Node crash during inference | Heartbeats stop; in-flight TTL expires | Relay evicts/cancels; client retries selection | Relay must not log plaintext. |
@@ -712,12 +600,11 @@ and recovery requires warm-load validation before re-registration.
 ### Phase 2: capability-aware/load-aware routing
 
 - Filter by model and context tier.
-- Preserve round robin among equivalent nodes first.
-- Add smallest-capable-tier selection only for clients that advertise
-  `client_capabilities=selected_profile_echo_v1` and echo the selected profile in
-  the encrypted request.
-- Add queue/in-flight load awareness.
-- Add optional coarse throughput-aware expected completion time.
+- Preserve round robin among equivalent eligible nodes first.
+- Allow `64k-full` nodes to satisfy `8k-fast` requests while preventing
+  `8k-fast` nodes from satisfying `64k-full`.
+- Defer queue/in-flight load awareness.
+- Defer optional coarse throughput-aware expected completion time.
 
 ### Phase 3: long-context runtime tuning
 
@@ -746,20 +633,14 @@ and recovery requires warm-load validation before re-registration.
 
 ## Compatibility plan
 
-- Clients that omit `context_tier` are treated as requesting `8k-fast`. Without
-  `client_capabilities=selected_profile_echo_v1`, they remain exact-tier only and
-  must not be assigned to `64k-full`.
+- Clients that omit `context_tier` are treated as requesting `8k-fast`; a
+  `64k-full` node may satisfy that default request, while `8k-fast` must never
+  satisfy `64k-full`.
 - Compute nodes that do not advertise a profile are treated as legacy API v1
   `8k-fast` candidates only after they have warm-loaded the current 8,192-token
   default runtime.
-- The encrypted request may omit `context_tier` during migration; compute nodes
-  normalize missing to `8k-fast`. Relay selection must therefore keep omitted-tier
-  requests on exact `8k-fast` profiles until clients are upgraded to echo the
-  returned `selected_context_profile.profile_id` into
-  `routing.selected_context_profile_id` in the encrypted request.
-- Clients that advertise `client_capabilities=selected_profile_echo_v1` may use
-  smallest-capable selection, but only if they include the same capability
-  version in the encrypted routing object.
+- The encrypted request may omit `routing.context_tier` during migration; compute
+  nodes normalize missing routing to `8k-fast` after decryption.
 - Once the migration completes, documentation and diagnostics should encourage
   explicit tier selection, but the default remains for compatibility.
 

--- a/relay.py
+++ b/relay.py
@@ -515,6 +515,7 @@ API_V1_LEASE_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS"
 DEFAULT_API_V1_LEASE_SECONDS = 30
 API_V1_IN_FLIGHT_TTL_SECONDS_ENV = "TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS"
 DEFAULT_CONTEXT_TIER = "8k-fast"
+MAX_API_V1_MODEL_IDS_PER_NODE = 64
 CONTEXT_TIER_ORDER = {"8k-fast": 8192, "64k-full": 65536}
 DEFAULT_MODEL_IDS = ["llama-3.1-8b-instruct", "llama-3-8b-instruct"]
 ALLOWED_BACKEND_CLASSES = {"cpu", "cuda", "metal", "vulkan", "gpu", "unknown"}
@@ -586,6 +587,8 @@ def _api_v1_default_capabilities() -> dict[str, Any]:
 
 def _normalise_model_ids(value: Any) -> list[str] | None:
     if not isinstance(value, list) or not value:
+        return None
+    if len(value) > MAX_API_V1_MODEL_IDS_PER_NODE:
         return None
     normalized: list[str] = []
     for item in value:
@@ -1121,20 +1124,27 @@ def _select_round_robin_server_key(*, model: str | None = None, context_tier: st
             if not _context_tier_can_satisfy(capabilities.get("active_context_tier"), context_tier):
                 continue
             ordered_keys.append(server_public_key)
+        registered_count = len(all_api_v1_keys)
+        current_index = server_round_robin_next_index % registered_count if registered_count else 0
         if not ordered_keys:
-            server_round_robin_next_index = 0
             return None, {
                 "eligible_count": 0,
-                "registered_api_v1_count": len(all_api_v1_keys),
-                "round_robin_index": 0,
+                "registered_api_v1_count": registered_count,
+                "round_robin_index": current_index,
                 "round_robin_position": None,
             }, None
 
         eligible_count = len(ordered_keys)
-        round_robin_index = server_round_robin_next_index % eligible_count
-        server_public_key = ordered_keys[round_robin_index]
+        selected_position = next(
+            index
+            for index in range(registered_count)
+            if all_api_v1_keys[(current_index + index) % registered_count] in ordered_keys
+        )
+        selected_global_index = (current_index + selected_position) % registered_count
+        server_public_key = all_api_v1_keys[selected_global_index]
+        round_robin_index = ordered_keys.index(server_public_key)
         server_payload = dict(known_servers[server_public_key])
-        server_round_robin_next_index = (round_robin_index + 1) % eligible_count
+        server_round_robin_next_index = (selected_global_index + 1) % registered_count
         return server_public_key, {
             "eligible_count": eligible_count,
             "round_robin_index": server_round_robin_next_index,
@@ -1877,9 +1887,11 @@ def api_v1_relay_servers_poll():
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
     capabilities = None
     if 'capabilities' in data:
-        capabilities, capability_error = _normalise_api_v1_capabilities(data.get('capabilities'))
-        if capability_error:
-            return jsonify({'error': {'message': capability_error, 'code': 'invalid_capabilities'}}), 400
+        raw_capabilities = data.get('capabilities')
+        if raw_capabilities is not None:
+            capabilities, capability_error = _normalise_api_v1_capabilities(raw_capabilities)
+            if capability_error:
+                return jsonify({'error': {'message': capability_error, 'code': 'invalid_capabilities'}}), 400
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     lease_seconds = _api_v1_lease_seconds()

--- a/relay.py
+++ b/relay.py
@@ -514,6 +514,10 @@ DEFAULT_API_V1_POLL_WAIT_SECONDS = 10
 API_V1_LEASE_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS"
 DEFAULT_API_V1_LEASE_SECONDS = 30
 API_V1_IN_FLIGHT_TTL_SECONDS_ENV = "TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS"
+DEFAULT_CONTEXT_TIER = "8k-fast"
+CONTEXT_TIER_ORDER = {"8k-fast": 8192, "64k-full": 65536}
+DEFAULT_MODEL_IDS = ["llama-3.1-8b-instruct", "llama-3-8b-instruct"]
+ALLOWED_BACKEND_CLASSES = {"cpu", "cuda", "metal", "vulkan", "gpu", "unknown"}
 
 
 def _server_ping_age_seconds(last_ping: Any) -> float:
@@ -565,6 +569,102 @@ def _api_v1_in_flight_ttl_seconds() -> float:
     except ValueError:
         return max(float(_api_v1_lease_seconds()), 1.0)
     return max(value, 1.0)
+
+
+def _api_v1_default_capabilities() -> dict[str, Any]:
+    return {
+        "api_version": "v1",
+        "supported_model_ids": list(DEFAULT_MODEL_IDS),
+        "active_context_tier": DEFAULT_CONTEXT_TIER,
+        "maximum_total_context_tokens": CONTEXT_TIER_ORDER[DEFAULT_CONTEXT_TIER],
+        "default_output_token_reservation": 1024,
+        "maximum_output_tokens": 1024,
+        "max_concurrency": 1,
+        "backend_class": "unknown",
+    }
+
+
+def _normalise_model_ids(value: Any) -> list[str] | None:
+    if not isinstance(value, list) or not value:
+        return None
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None
+        model_id = item.strip().lower()
+        if not model_id or len(model_id) > 128:
+            return None
+        if model_id not in normalized:
+            normalized.append(model_id)
+    return normalized
+
+
+def _normalise_positive_int(value: Any, *, min_value: int = 1, max_value: int = 1_000_000) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if min_value <= value <= max_value:
+        return value
+    return None
+
+
+def _normalise_api_v1_capabilities(value: Any) -> tuple[dict[str, Any] | None, str | None]:
+    if value is None:
+        return _api_v1_default_capabilities(), None
+    if not isinstance(value, dict):
+        return None, "capabilities must be an object"
+
+    api_version = value.get("api_version", "v1")
+    if api_version not in {"v1", 1}:
+        return None, "capabilities.api_version must be v1"
+
+    active_context_tier = value.get("active_context_tier") or value.get("context_tier")
+    if not isinstance(active_context_tier, str):
+        return None, "capabilities.active_context_tier must be a string"
+    active_context_tier = active_context_tier.strip()
+    if active_context_tier not in CONTEXT_TIER_ORDER:
+        return None, "capabilities.active_context_tier is unsupported"
+
+    supported_model_ids = _normalise_model_ids(value.get("supported_model_ids") or value.get("model_ids"))
+    if supported_model_ids is None:
+        return None, "capabilities.supported_model_ids must be a non-empty string list"
+
+    max_context = _normalise_positive_int(value.get("maximum_total_context_tokens"))
+    if max_context is None:
+        return None, "capabilities.maximum_total_context_tokens must be a positive integer"
+    if max_context < CONTEXT_TIER_ORDER[active_context_tier]:
+        return None, "capabilities.maximum_total_context_tokens is below the active tier"
+
+    default_reservation = _normalise_positive_int(value.get("default_output_token_reservation"))
+    maximum_output = _normalise_positive_int(value.get("maximum_output_tokens"))
+    max_concurrency = _normalise_positive_int(value.get("max_concurrency"), max_value=128)
+    if default_reservation is None or maximum_output is None or max_concurrency is None:
+        return None, "capability token reservations and concurrency must be positive integers"
+    if default_reservation > maximum_output:
+        return None, "default output reservation cannot exceed maximum output tokens"
+
+    backend_class = value.get("backend_class", "unknown")
+    if not isinstance(backend_class, str):
+        return None, "capabilities.backend_class must be a string"
+    backend_class = backend_class.strip().lower() or "unknown"
+    if backend_class not in ALLOWED_BACKEND_CLASSES:
+        backend_class = "unknown"
+
+    return {
+        "api_version": "v1",
+        "supported_model_ids": supported_model_ids,
+        "active_context_tier": active_context_tier,
+        "maximum_total_context_tokens": max_context,
+        "default_output_token_reservation": default_reservation,
+        "maximum_output_tokens": maximum_output,
+        "max_concurrency": max_concurrency,
+        "backend_class": backend_class,
+    }, None
+
+
+def _context_tier_can_satisfy(active_tier: Any, requested_tier: str) -> bool:
+    if not isinstance(active_tier, str):
+        return False
+    return CONTEXT_TIER_ORDER.get(active_tier, 0) >= CONTEXT_TIER_ORDER[requested_tier]
 
 def _pop_next_api_v1_request(public_key: str):
     queued_requests = client_inference_requests.get(public_key, [])
@@ -657,6 +757,7 @@ def _live_server_diagnostics(*, api_v1_only: bool = False) -> list[dict[str, Any
             "age_seconds": round(_server_ping_age_seconds(payload.get("last_ping")), 3),
             "next_ping_in_x_seconds": payload.get("last_ping_duration"),
             "queue_depth": len(client_inference_requests.get(server_public_key, [])),
+            "capabilities": payload.get("capabilities"),
         })
     diagnostics.sort(key=lambda node: node["server_public_key"])
     return diagnostics
@@ -1002,16 +1103,29 @@ def _legacy_route_deprecated_response(route_name: str):
     }), 410
 
 
-def _select_round_robin_server_key() -> tuple[str | None, dict[str, Any], dict[str, Any] | None]:
+def _select_round_robin_server_key(*, model: str | None = None, context_tier: str = DEFAULT_CONTEXT_TIER) -> tuple[str | None, dict[str, Any], dict[str, Any] | None]:
     """Select and snapshot the next API v1 compute node in registration-order round-robin order."""
 
     global server_round_robin_next_index
     with server_round_robin_lock:
-        ordered_keys = _api_v1_round_robin_keys()
+        all_api_v1_keys = _api_v1_round_robin_keys()
+        ordered_keys = []
+        requested_model = model.strip().lower() if isinstance(model, str) and model.strip() else None
+        for server_public_key in all_api_v1_keys:
+            payload = known_servers.get(server_public_key, {})
+            capabilities = payload.get("capabilities") if isinstance(payload, dict) else None
+            if not isinstance(capabilities, dict):
+                continue
+            if requested_model and requested_model not in capabilities.get("supported_model_ids", []):
+                continue
+            if not _context_tier_can_satisfy(capabilities.get("active_context_tier"), context_tier):
+                continue
+            ordered_keys.append(server_public_key)
         if not ordered_keys:
             server_round_robin_next_index = 0
             return None, {
                 "eligible_count": 0,
+                "registered_api_v1_count": len(all_api_v1_keys),
                 "round_robin_index": 0,
                 "round_robin_position": None,
             }, None
@@ -1047,8 +1161,27 @@ def _select_next_server_payload(*, api_v1: bool = False):
             server_payload = dict(known_servers[server_public_key])
             return jsonify({'server_public_key': server_payload['public_key']})
 
-    server_public_key, selection, server_payload = _select_round_robin_server_key()
+    model = request.args.get("model") if api_v1 else None
+    context_tier = request.args.get("context_tier") if api_v1 else None
+    context_tier = context_tier.strip() if isinstance(context_tier, str) and context_tier.strip() else DEFAULT_CONTEXT_TIER
+    if api_v1 and context_tier not in CONTEXT_TIER_ORDER:
+        return jsonify({'error': {'message': 'Unsupported context_tier', 'code': 'invalid_context_tier'}}), 400
+
+    server_public_key, selection, server_payload = _select_round_robin_server_key(
+        model=model,
+        context_tier=context_tier,
+    )
     if not server_public_key or server_payload is None:
+        if selection.get("registered_api_v1_count", 0):
+            return jsonify({
+                'error': {
+                    'message': 'Registered compute nodes are available, but none match the requested model/context tier.',
+                    'code': 'no_matching_compute_node',
+                    'selection_policy': 'registration_order_round_robin_with_capability_filter',
+                    'requested_context_tier': context_tier,
+                    'requested_model': model,
+                }
+            }), 503
         return jsonify({
             'error': {
                 'message': 'No registered compute nodes are available on this relay.',
@@ -1060,7 +1193,7 @@ def _select_next_server_payload(*, api_v1: bool = False):
         "relay.server_selected",
         extra={
             "server_fingerprint": _safe_key_fingerprint(server_public_key),
-            "selection_policy": "registration_order_round_robin",
+            "selection_policy": "registration_order_round_robin_with_capability_filter",
             "round_robin_index": selection.get("round_robin_index"),
             "round_robin_position": selection.get("round_robin_position"),
             "eligible_count": selection.get("eligible_count"),
@@ -1068,7 +1201,14 @@ def _select_next_server_payload(*, api_v1: bool = False):
             "api_v1": api_v1,
         },
     )
-    return jsonify({'server_public_key': server_payload['public_key']})
+    capabilities = server_payload.get("capabilities") if isinstance(server_payload, dict) else {}
+    return jsonify({
+        'server_public_key': server_payload['public_key'],
+        'selected_context_tier': capabilities.get("active_context_tier"),
+        'selected_context_window_tokens': capabilities.get("maximum_total_context_tokens"),
+        'selected_model_support': capabilities.get("supported_model_ids", []),
+        'selection_policy': 'registration_order_round_robin_with_capability_filter',
+    })
 
 @app.route('/next_server', methods=['GET'])
 def next_server():
@@ -1653,6 +1793,9 @@ def api_v1_relay_servers_register():
     public_key = data.get('server_public_key')
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
+    capabilities, capability_error = _normalise_api_v1_capabilities(data.get('capabilities'))
+    if capability_error:
+        return jsonify({'error': {'message': capability_error, 'code': 'invalid_capabilities'}}), 400
 
     lease_seconds = _api_v1_lease_seconds()
     with server_round_robin_lock:
@@ -1678,6 +1821,7 @@ def api_v1_relay_servers_register():
             log_event = "server.registered"
         known_servers[public_key]['last_ping_duration'] = lease_seconds
         known_servers[public_key][API_V1_SERVER_MARKER] = True
+        known_servers[public_key]['capabilities'] = capabilities
     LOGGER.info(log_event, extra={"server_public_key": public_key})
 
     return jsonify({
@@ -1731,6 +1875,11 @@ def api_v1_relay_servers_poll():
     public_key = data.get('server_public_key')
     if not public_key:
         return jsonify({'error': {'message': 'Missing server public key', 'code': 400}}), 400
+    capabilities = None
+    if 'capabilities' in data:
+        capabilities, capability_error = _normalise_api_v1_capabilities(data.get('capabilities'))
+        if capability_error:
+            return jsonify({'error': {'message': capability_error, 'code': 'invalid_capabilities'}}), 400
 
     poll_wait_seconds = _api_v1_poll_wait_seconds()
     lease_seconds = _api_v1_lease_seconds()
@@ -1740,6 +1889,8 @@ def api_v1_relay_servers_poll():
             return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
         server_payload['last_ping'] = datetime.now()
         server_payload['last_ping_duration'] = lease_seconds
+        if capabilities is not None:
+            server_payload['capabilities'] = capabilities
         server_payload['polling_until_monotonic'] = time.monotonic() + max(poll_wait_seconds, 0.0)
     LOGGER.info("server.heartbeat", extra={"server_public_key": public_key})
 

--- a/relay.py
+++ b/relay.py
@@ -489,6 +489,7 @@ def _validate_server_registration():
 known_servers = {}
 server_round_robin_lock = threading.RLock()
 server_round_robin_next_index = 0
+api_v1_filtered_round_robin_next_positions: dict[tuple[str, ...], int] = {}
 API_V1_SERVER_MARKER = "api_v1_registered"
 client_inference_requests = {}
 client_responses = {}
@@ -1135,20 +1136,28 @@ def _select_round_robin_server_key(*, model: str | None = None, context_tier: st
             }, None
 
         eligible_count = len(ordered_keys)
-        selected_position = next(
-            index
-            for index in range(registered_count)
-            if all_api_v1_keys[(current_index + index) % registered_count] in ordered_keys
-        )
-        selected_global_index = (current_index + selected_position) % registered_count
-        server_public_key = all_api_v1_keys[selected_global_index]
-        round_robin_index = ordered_keys.index(server_public_key)
+        eligible_key = tuple(ordered_keys)
+        if eligible_key in api_v1_filtered_round_robin_next_positions:
+            selected_eligible_index = (
+                api_v1_filtered_round_robin_next_positions[eligible_key] % eligible_count
+            )
+        else:
+            selected_eligible_index = next(
+                ordered_keys.index(all_api_v1_keys[(current_index + index) % registered_count])
+                for index in range(registered_count)
+                if all_api_v1_keys[(current_index + index) % registered_count] in ordered_keys
+            )
+        server_public_key = ordered_keys[selected_eligible_index]
+        selected_global_index = all_api_v1_keys.index(server_public_key)
         server_payload = dict(known_servers[server_public_key])
+        api_v1_filtered_round_robin_next_positions[eligible_key] = (
+            selected_eligible_index + 1
+        ) % eligible_count
         server_round_robin_next_index = (selected_global_index + 1) % registered_count
         return server_public_key, {
             "eligible_count": eligible_count,
             "round_robin_index": server_round_robin_next_index,
-            "round_robin_position": round_robin_index,
+            "round_robin_position": selected_eligible_index,
         }, server_payload
 
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -366,6 +366,50 @@ def test_api_v1_selection_model_filter_round_robin_and_no_match(client):
     assert no_match.get_json()["error"]["code"] == "no_matching_compute_node"
 
 
+def test_api_v1_no_match_does_not_reset_round_robin_cursor(client):
+    a = _server_key("fair-a")
+    b = _server_key("fair-b")
+    c = _server_key("fair-c")
+    for key in (a, b, c):
+        _register_api_v1_server_with_capabilities(client, key, _capabilities("8k-fast"))
+
+    assert client.get("/api/v1/relay/servers/next?context_tier=8k-fast").get_json()["server_public_key"] == a
+    no_match = client.get("/api/v1/relay/servers/next?context_tier=64k-full")
+    assert no_match.status_code == 503
+
+    assert client.get("/api/v1/relay/servers/next?context_tier=8k-fast").get_json()["server_public_key"] == b
+
+
+def test_api_v1_rejects_excessive_capability_model_ids(client):
+    server = _server_key("too-many-models")
+    capabilities = _capabilities(
+        "8k-fast",
+        [f"model-{index}" for index in range(relay_module.MAX_API_V1_MODEL_IDS_PER_NODE + 1)],
+    )
+
+    response = client.post(
+        "/api/v1/relay/servers/register",
+        json={"server_public_key": server, "capabilities": capabilities},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "invalid_capabilities"
+    assert server not in known_servers
+
+
+def test_api_v1_poll_capabilities_null_preserves_registered_tier(client):
+    server = _server_key("null-heartbeat")
+    _register_api_v1_server_with_capabilities(client, server, _capabilities("64k-full"))
+
+    response = client.post(
+        "/api/v1/relay/servers/poll",
+        json={"server_public_key": server, "capabilities": None},
+    )
+
+    assert response.status_code == 200
+    assert known_servers[server]["capabilities"]["active_context_tier"] == "64k-full"
+
+
 def test_api_v1_diagnostics_expose_only_normalized_capabilities(client):
     server = _server_key("diagnostic-cap")
     _register_api_v1_server_with_capabilities(

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -268,10 +268,118 @@ def _register_api_v1_server(client, server_public_key):
     return response
 
 
+def _capabilities(tier="8k-fast", models=None):
+    tokens = 65536 if tier == "64k-full" else 8192
+    return {
+        "api_version": "v1",
+        "supported_model_ids": models or ["llama-3.1-8b-instruct"],
+        "active_context_tier": tier,
+        "maximum_total_context_tokens": tokens,
+        "default_output_token_reservation": 1024,
+        "maximum_output_tokens": 2048,
+        "max_concurrency": 1,
+        "backend_class": "cuda" if tier == "64k-full" else "metal",
+    }
+
+
+def _register_api_v1_server_with_capabilities(client, server_public_key, capabilities):
+    response = client.post(
+        '/api/v1/relay/servers/register',
+        json={'server_public_key': server_public_key, 'capabilities': capabilities},
+    )
+    assert response.status_code == 200
+    return response
+
+
 def _next_api_v1_server_key(client):
     response = client.get('/api/v1/relay/servers/next')
     assert response.status_code == 200
     return response.get_json()['server_public_key']
+
+
+def test_api_v1_capability_registration_and_tier_selection(client):
+    fast = _server_key("fast-cap")
+    full = _server_key("full-cap")
+    _register_api_v1_server_with_capabilities(client, fast, _capabilities("8k-fast"))
+    _register_api_v1_server_with_capabilities(client, full, _capabilities("64k-full"))
+
+    fast_response = client.get("/api/v1/relay/servers/next?context_tier=8k-fast")
+    assert fast_response.status_code == 200
+    fast_payload = fast_response.get_json()
+    assert fast_payload["server_public_key"] == fast
+    assert fast_payload["selected_context_tier"] == "8k-fast"
+    assert fast_payload["selected_context_window_tokens"] == 8192
+
+    full_response = client.get("/api/v1/relay/servers/next?context_tier=64k-full")
+    assert full_response.status_code == 200
+    assert full_response.get_json()["server_public_key"] == full
+
+
+def test_api_v1_old_node_compatibility_and_64k_can_satisfy_8k(client):
+    old = _server_key("old-node")
+    full = _server_key("full-only")
+    _register_api_v1_server(client, old)
+    _register_api_v1_server_with_capabilities(client, full, _capabilities("64k-full"))
+
+    assert client.get("/api/v1/relay/servers/next?context_tier=8k-fast").get_json()["server_public_key"] == old
+    client.post("/api/v1/relay/servers/unregister", json={"server_public_key": old})
+    assert client.get("/api/v1/relay/servers/next?context_tier=8k-fast").get_json()["server_public_key"] == full
+
+
+def test_api_v1_malformed_capabilities_are_rejected_without_registration(client):
+    server = _server_key("malformed-cap")
+    response = client.post(
+        "/api/v1/relay/servers/register",
+        json={
+            "server_public_key": server,
+            "capabilities": {
+                "active_context_tier": "64k-full",
+                "supported_model_ids": ["llama-3.1-8b-instruct"],
+                "maximum_total_context_tokens": 8192,
+                "default_output_token_reservation": 1024,
+                "maximum_output_tokens": 2048,
+                "max_concurrency": 1,
+            },
+        },
+    )
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "invalid_capabilities"
+    assert server not in known_servers
+
+
+def test_api_v1_selection_model_filter_round_robin_and_no_match(client):
+    a = _server_key("tier-a")
+    b = _server_key("tier-b")
+    c = _server_key("other-model")
+    _register_api_v1_server_with_capabilities(client, a, _capabilities("8k-fast", ["model-a"]))
+    _register_api_v1_server_with_capabilities(client, b, _capabilities("8k-fast", ["model-a"]))
+    _register_api_v1_server_with_capabilities(client, c, _capabilities("64k-full", ["model-b"]))
+
+    selected = [
+        client.get("/api/v1/relay/servers/next?model=model-a&context_tier=8k-fast").get_json()["server_public_key"]
+        for _ in range(4)
+    ]
+    assert selected == [a, b, a, b]
+
+    no_match = client.get("/api/v1/relay/servers/next?model=model-a&context_tier=64k-full")
+    assert no_match.status_code == 503
+    assert no_match.get_json()["error"]["code"] == "no_matching_compute_node"
+
+
+def test_api_v1_diagnostics_expose_only_normalized_capabilities(client):
+    server = _server_key("diagnostic-cap")
+    _register_api_v1_server_with_capabilities(
+        client,
+        server,
+        {**_capabilities("64k-full"), "hostname": "private-host", "raw_vram_gb": 24},
+    )
+
+    diagnostics = client.get("/relay/diagnostics")
+    assert diagnostics.status_code == 200
+    node = diagnostics.get_json()["api_v1_registered_compute_nodes"][0]
+    assert node["capabilities"] == _capabilities("64k-full")
+    assert "hostname" not in json.dumps(node)
+    assert "raw_vram" not in json.dumps(node)
 
 
 def _queue_api_v1_request(client, *, server_public_key, request_id, client_public_key=None):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -46,6 +46,7 @@ def client():
     # Reset state before each test
     known_servers.clear()
     relay_module.server_round_robin_next_index = 0
+    relay_module.api_v1_filtered_round_robin_next_positions.clear()
     client_inference_requests.clear()
     client_pending_request_ids.clear()
     client_terminal_request_ids.clear()
@@ -64,6 +65,7 @@ def client():
     # Clean up state after test (optional, as fixture resets before)
     known_servers.clear()
     relay_module.server_round_robin_next_index = 0
+    relay_module.api_v1_filtered_round_robin_next_positions.clear()
     client_inference_requests.clear()
     client_pending_request_ids.clear()
     client_terminal_request_ids.clear()
@@ -364,6 +366,24 @@ def test_api_v1_selection_model_filter_round_robin_and_no_match(client):
     no_match = client.get("/api/v1/relay/servers/next?model=model-a&context_tier=64k-full")
     assert no_match.status_code == 503
     assert no_match.get_json()["error"]["code"] == "no_matching_compute_node"
+
+
+def test_api_v1_filtered_round_robin_is_stable_across_alternating_filters(client):
+    fast = _server_key("mixed-fast")
+    full_a = _server_key("mixed-full-a")
+    full_b = _server_key("mixed-full-b")
+    _register_api_v1_server_with_capabilities(client, fast, _capabilities("8k-fast", ["fast-model"]))
+    _register_api_v1_server_with_capabilities(client, full_a, _capabilities("64k-full", ["full-model"]))
+    _register_api_v1_server_with_capabilities(client, full_b, _capabilities("64k-full", ["full-model"]))
+
+    selections = [
+        client.get("/api/v1/relay/servers/next?model=full-model&context_tier=64k-full").get_json()["server_public_key"],
+        client.get("/api/v1/relay/servers/next?model=fast-model").get_json()["server_public_key"],
+        client.get("/api/v1/relay/servers/next?model=full-model&context_tier=64k-full").get_json()["server_public_key"],
+        client.get("/api/v1/relay/servers/next?model=fast-model").get_json()["server_public_key"],
+    ]
+
+    assert selections == [full_a, fast, full_b, fast]
 
 
 def test_api_v1_no_match_does_not_reset_round_robin_cursor(client):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -1015,6 +1015,26 @@ class TestRelayClient:
         assert result['relay_http_diagnostic']['path'] == '/api/v1/relay/servers/register'
 
     @patch('utils.networking.relay_client.requests.post')
+    def test_register_api_v1_compute_node_sends_context_capabilities(self, mock_post, relay_client):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {'next_ping_in_x_seconds': 30, 'poll_wait_seconds': 0}
+        mock_post.return_value = response
+        relay_client.model_manager.context_tier = "64k-full"
+        relay_client.model_manager.context_window_tokens = 65536
+        relay_client.model_manager.last_compute_diagnostics = {"backend_used": "cuda"}
+
+        result = relay_client.register_api_v1_compute_node('http://relay-a.example')
+
+        assert result['next_ping_in_x_seconds'] == 30
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["server_public_key"] == "mock_public_key_b64"
+        assert payload["capabilities"]["active_context_tier"] == "64k-full"
+        assert payload["capabilities"]["maximum_total_context_tokens"] == 65536
+        assert payload["capabilities"]["max_concurrency"] == 1
+        assert payload["capabilities"]["backend_class"] == "cuda"
+        assert "llama-3.1-8b-instruct" in payload["capabilities"]["supported_model_ids"]
+
+    @patch('utils.networking.relay_client.requests.post')
     def test_register_api_v1_compute_node_403_html_logs_cloudflare_diagnostic(
         self, mock_post, relay_client, caplog
     ):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2379,6 +2379,95 @@ class TestRelayClient:
             "req-unsupported-model"
         )
 
+    def test_api_v1_supported_model_ids_ignores_none_model_path(self, relay_client, mock_model_manager):
+        mock_model_manager.api_model_id = None
+        mock_model_manager.model_id = None
+        mock_model_manager.file_name = None
+        mock_model_manager.model_path = None
+
+        supported_model_ids = relay_client._api_v1_supported_model_ids()
+
+        assert "none" not in supported_model_ids
+
+    def test_api_v1_supported_model_ids_respects_manager_support_hook(self, relay_client):
+        class _Manager:
+            api_model_id = "custom-local-api-v1-model"
+            model_id = None
+            file_name = None
+            model_path = None
+
+            def supports_api_v1_model(self, model_id):
+                return model_id == "custom-local-api-v1-model"
+
+        relay_client.model_manager = _Manager()
+
+        assert relay_client._api_v1_supported_model_ids() == ["custom-local-api-v1-model"]
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_rejects_unsatisfied_context_tier(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        mock_model_manager.context_tier = "8k-fast"
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-context-tier",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+                "routing": {"context_tier": "64k-full"},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
+            "compute_node_context_tier_unsupported"
+        )
+
+    @patch('utils.networking.relay_client.requests.post')
+    def test_process_client_request_api_v1_strips_routing_context_tier(
+        self,
+        mock_post,
+        relay_client,
+        mock_crypto_manager,
+        mock_model_manager,
+    ):
+        mock_model_manager.context_tier = "64k-full"
+        request_data = TEST_VALID_RESPONSE.copy()
+        mock_crypto_manager.decrypt_message.return_value = {
+            "protocol": "tokenplace_api_v1_relay_e2ee",
+            "version": 1,
+            "request_id": "req-context-tier-space",
+            "client_public_key": request_data["client_public_key"],
+            "api_v1_request": {
+                "model": "llama-3-8b-instruct",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "options": {},
+                "routing": {"context_tier": "64k-full "},
+            },
+        }
+        source_response = MagicMock()
+        source_response.status_code = 200
+        mock_post.return_value = source_response
+
+        assert relay_client.process_client_request(request_data) is True
+
+        encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
+        assert "error" not in encrypted_envelope["api_v1_response"]
+        assert encrypted_envelope["api_v1_response"]["message"]["role"] == "assistant"
+
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_rejects_wrong_llama_family_model(
         self,

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -59,6 +59,52 @@ def _load_compute_node_bridge_module():
     return module
 
 
+def _api_v1_decrypted_payload(*, request_id="req-routing", client_public_key=TEST_VALID_RESPONSE["client_public_key"], routing_marker=...):
+    api_v1_request = {
+        "model": "llama-3-8b-instruct",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "options": {},
+    }
+    if routing_marker is not ...:
+        api_v1_request["routing"] = routing_marker
+    return {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "request_id": request_id,
+        "client_public_key": client_public_key,
+        "api_v1_request": api_v1_request,
+    }
+
+
+def test_extract_api_v1_request_payload_defaults_missing_routing_to_8k_fast():
+    payload = relay_client_module._extract_api_v1_request_payload(
+        _api_v1_decrypted_payload(routing_marker=...),
+        TEST_VALID_RESPONSE["client_public_key"],
+    )
+
+    assert payload is not None
+    assert payload["routing"] == {"context_tier": "8k-fast"}
+
+
+def test_extract_api_v1_request_payload_accepts_valid_64k_routing():
+    payload = relay_client_module._extract_api_v1_request_payload(
+        _api_v1_decrypted_payload(routing_marker={"context_tier": "64k-full"}),
+        TEST_VALID_RESPONSE["client_public_key"],
+    )
+
+    assert payload is not None
+    assert payload["routing"] == {"context_tier": "64k-full"}
+
+
+def test_extract_api_v1_request_payload_rejects_malformed_decrypted_routing():
+    payload = relay_client_module._extract_api_v1_request_payload(
+        _api_v1_decrypted_payload(routing_marker="64k-full"),
+        TEST_VALID_RESPONSE["client_public_key"],
+    )
+
+    assert payload is None
+
+
 def test_sanitize_relay_target_handles_malformed_ports_and_ipv6():
     assert relay_client_module._sanitize_relay_target('https://relay.example:bad') == 'unknown'
     assert relay_client_module._sanitize_relay_target('http://[::1') == 'unknown'
@@ -1790,6 +1836,7 @@ class TestRelayClient:
                 "model": "llama-3-8b-instruct",
                 "messages": [{"role": "user", "content": "Hello"}],
                 "options": {},
+                "routing": {"context_tier": "8k-fast"},
             },
         }
         mock_crypto_manager.decrypt_message.return_value = decrypted_payload
@@ -1838,6 +1885,20 @@ class TestRelayClient:
             },
             timeout=relay_client._request_timeout,
         )
+        posted_payload = mock_post.call_args.kwargs["json"]
+        posted_json = json.dumps(posted_payload)
+        for forbidden in (
+            "api_v1_response",
+            "messages",
+            "prompt",
+            "model",
+            "routing",
+            "context_tier",
+            "llama-3-8b-instruct",
+            "8k-fast",
+            "Hello",
+        ):
+            assert forbidden not in posted_json
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_no_options_does_not_depend_on_api_imports(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -463,8 +463,10 @@ def _extract_api_v1_request_payload(
     if not isinstance(routing, dict):
         log_error("Rejected API v1 relay payload: routing must be an object")
         return None
-    context_tier = normalize_context_tier(routing.get("context_tier"))
-    if routing.get("context_tier") is not None and context_tier != routing.get("context_tier"):
+    raw_context_tier = routing.get("context_tier")
+    normalized_raw_context_tier = raw_context_tier.strip() if isinstance(raw_context_tier, str) else raw_context_tier
+    context_tier = normalize_context_tier(normalized_raw_context_tier)
+    if normalized_raw_context_tier is not None and context_tier != normalized_raw_context_tier:
         log_error("Rejected API v1 relay payload: routing.context_tier is unsupported")
         return None
 
@@ -1237,21 +1239,58 @@ class RelayClient:
             )
         return response.json()
 
+    @staticmethod
+    def _api_v1_model_path_basename(model_path: Any) -> Optional[str]:
+        """Return a safe basename only for concrete path-like model paths."""
+
+        if isinstance(model_path, (str, bytes, os.PathLike)):
+            basename = os.path.basename(os.fspath(model_path))
+            return basename if basename else None
+        return None
+
+    def _active_context_tier_can_satisfy(self, requested_context_tier: str) -> bool:
+        """Return whether the active runtime profile can satisfy a requested tier."""
+
+        active_context_tier = normalize_context_tier(
+            getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)
+        )
+        try:
+            active_profile = get_context_profile(active_context_tier)
+            requested_profile = get_context_profile(requested_context_tier)
+        except Exception:
+            return False
+        return active_profile.total_context_tokens >= requested_profile.total_context_tokens
+
     def _api_v1_supported_model_ids(self) -> List[str]:
         configured = [
             getattr(self.model_manager, "api_model_id", None),
             getattr(self.model_manager, "model_id", None),
             getattr(self.model_manager, "file_name", None),
-            os.path.basename(str(getattr(self.model_manager, "model_path", ""))),
+            self._api_v1_model_path_basename(getattr(self.model_manager, "model_path", None)),
         ]
         model_ids = {
             str(value).strip().lower()
             for value in configured
             if isinstance(value, str) and value.strip()
         }
-        model_ids.update(self._API_V1_LOCAL_LLAMA_RUNTIME_IDS)
-        model_ids.update(self._API_V1_LOCAL_MODEL_ALIASES)
-        model_ids.update(self._API_V1_LOCAL_MODEL_ALIASES.values())
+        supports_api_v1_model = getattr(self.model_manager, "supports_api_v1_model", None)
+        manager_defines_supports_model = callable(
+            getattr(type(self.model_manager), "supports_api_v1_model", None)
+        )
+        if callable(supports_api_v1_model) and manager_defines_supports_model:
+            candidate_ids = set(model_ids)
+            candidate_ids.update(self._API_V1_LOCAL_LLAMA_RUNTIME_IDS)
+            candidate_ids.update(self._API_V1_LOCAL_MODEL_ALIASES)
+            candidate_ids.update(self._API_V1_LOCAL_MODEL_ALIASES.values())
+            model_ids = {
+                model_id
+                for model_id in candidate_ids
+                if supports_api_v1_model(model_id)
+            }
+        else:
+            model_ids.update(self._API_V1_LOCAL_LLAMA_RUNTIME_IDS)
+            model_ids.update(self._API_V1_LOCAL_MODEL_ALIASES)
+            model_ids.update(self._API_V1_LOCAL_MODEL_ALIASES.values())
         return sorted(model_ids)
 
     def _api_v1_compute_node_capabilities(self) -> Dict[str, Any]:
@@ -1274,7 +1313,10 @@ class RelayClient:
             "active_context_tier": profile.profile_id,
             "maximum_total_context_tokens": profile.total_context_tokens,
             "default_output_token_reservation": profile.default_output_reservation_tokens,
-            "maximum_output_tokens": max(profile.default_output_reservation_tokens, 1024),
+            "maximum_output_tokens": max(
+                profile.default_output_reservation_tokens,
+                self._API_V1_MAX_TOKENS_LIMIT,
+            ),
             "max_concurrency": 1,
             "backend_class": backend_class,
         }
@@ -1986,7 +2028,7 @@ class RelayClient:
                 getattr(self.model_manager, "api_model_id", None),
                 getattr(self.model_manager, "model_id", None),
                 getattr(self.model_manager, "file_name", None),
-                os.path.basename(str(getattr(self.model_manager, "model_path", ""))),
+                self._api_v1_model_path_basename(getattr(self.model_manager, "model_path", None)),
             )
             if value
         }
@@ -2223,6 +2265,7 @@ class RelayClient:
         model_id: str,
         messages: List[Dict[str, Any]],
         options: Dict[str, Any],
+        requested_context_tier: str = DEFAULT_CONTEXT_TIER,
     ) -> Dict[str, Any]:
         """Generate an API v1 assistant message with the desktop runtime model."""
 
@@ -2248,6 +2291,15 @@ class RelayClient:
         has_direct_runtime_completion = callable(get_llm_instance) or callable(
             recovery_completion
         )
+        if not self._active_context_tier_can_satisfy(requested_context_tier):
+            return self._api_v1_response_envelope(
+                request_id,
+                error={
+                    "code": "compute_node_context_tier_unsupported",
+                    "message": "Requested context tier is not available in the desktop runtime",
+                },
+            )
+
         if not self._runtime_model_can_satisfy(model_id):
             return self._api_v1_response_envelope(
                 request_id,
@@ -2435,6 +2487,7 @@ class RelayClient:
                     model_id=api_v1_request_payload["model"],
                     messages=api_v1_request_payload["messages"],
                     options=dict(api_v1_request_payload["options"]),
+                    requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
                 )
                 api_v1_response = response_envelope.get("api_v1_response", {})
                 error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -18,6 +18,7 @@ from utils.processing_result import RelayProcessingResult
 from urllib.parse import urlparse, urlunparse
 
 from utils.networking.http_requests_compat import requests
+from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile, normalize_context_tier
 
 # Configure logging
 logger = logging.getLogger('relay_client')
@@ -447,6 +448,7 @@ def _extract_api_v1_request_payload(
     model = api_v1_request.get("model")
     messages = api_v1_request.get("messages")
     options = api_v1_request.get("options", {})
+    routing = api_v1_request.get("routing", {})
     if not isinstance(model, str) or not model.strip():
         log_error("Rejected API v1 relay payload: model must be a non-empty string")
         return None
@@ -456,12 +458,22 @@ def _extract_api_v1_request_payload(
     if not isinstance(options, dict):
         log_error("Rejected API v1 relay payload: options must be an object")
         return None
+    if routing is None:
+        routing = {}
+    if not isinstance(routing, dict):
+        log_error("Rejected API v1 relay payload: routing must be an object")
+        return None
+    context_tier = normalize_context_tier(routing.get("context_tier"))
+    if routing.get("context_tier") is not None and context_tier != routing.get("context_tier"):
+        log_error("Rejected API v1 relay payload: routing.context_tier is unsupported")
+        return None
 
     return {
         "request_id": request_id,
         "model": model,
         "messages": messages,
         "options": options,
+        "routing": {"context_tier": context_tier},
     }
 
 
@@ -1200,7 +1212,10 @@ class RelayClient:
 
     def register_api_v1_compute_node(self, relay_url: Optional[str] = None) -> Dict[str, Any]:
         target_url = relay_url or self.relay_url
-        payload = {'server_public_key': self.crypto_manager.public_key_b64}
+        payload = {
+            'server_public_key': self.crypto_manager.public_key_b64,
+            'capabilities': self._api_v1_compute_node_capabilities(),
+        }
         request_kwargs: Dict[str, Any] = {'json': payload, 'timeout': self._request_timeout}
         headers = self._auth_headers()
         if headers:
@@ -1221,6 +1236,48 @@ class RelayClient:
                 next_ping_in_x_seconds=self._request_timeout,
             )
         return response.json()
+
+    def _api_v1_supported_model_ids(self) -> List[str]:
+        configured = [
+            getattr(self.model_manager, "api_model_id", None),
+            getattr(self.model_manager, "model_id", None),
+            getattr(self.model_manager, "file_name", None),
+            os.path.basename(str(getattr(self.model_manager, "model_path", ""))),
+        ]
+        model_ids = {
+            str(value).strip().lower()
+            for value in configured
+            if isinstance(value, str) and value.strip()
+        }
+        model_ids.update(self._API_V1_LOCAL_LLAMA_RUNTIME_IDS)
+        model_ids.update(self._API_V1_LOCAL_MODEL_ALIASES)
+        model_ids.update(self._API_V1_LOCAL_MODEL_ALIASES.values())
+        return sorted(model_ids)
+
+    def _api_v1_compute_node_capabilities(self) -> Dict[str, Any]:
+        context_tier = normalize_context_tier(getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER))
+        profile = get_context_profile(context_tier)
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        backend_class = "unknown"
+        if isinstance(diagnostics, dict):
+            backend_class = str(
+                diagnostics.get("backend_used")
+                or diagnostics.get("backend_selected")
+                or diagnostics.get("backend_available")
+                or "unknown"
+            ).strip().lower()
+        if backend_class not in {"cpu", "cuda", "metal", "vulkan", "gpu", "unknown"}:
+            backend_class = "unknown"
+        return {
+            "api_version": "v1",
+            "supported_model_ids": self._api_v1_supported_model_ids(),
+            "active_context_tier": profile.profile_id,
+            "maximum_total_context_tokens": profile.total_context_tokens,
+            "default_output_token_reservation": profile.default_output_reservation_tokens,
+            "maximum_output_tokens": max(profile.default_output_reservation_tokens, 1024),
+            "max_concurrency": 1,
+            "backend_class": backend_class,
+        }
 
     @staticmethod
     def _build_api_v1_url(relay_url: str, route: str) -> str:
@@ -1378,7 +1435,10 @@ class RelayClient:
                     )
 
                 request_kwargs: Dict[str, Any] = {
-                    'json': {'server_public_key': self.crypto_manager.public_key_b64},
+                    'json': {
+                        'server_public_key': self.crypto_manager.public_key_b64,
+                        'capabilities': self._api_v1_compute_node_capabilities(),
+                    },
                     'timeout': self._api_v1_poll_timeout_seconds(poll_wait),
                 }
                 log_info(


### PR DESCRIPTION
### Motivation
- Allow the relay to make privacy-safe, capability-aware selections of compute nodes by letting compute nodes advertise a normalized, coarse capability contract (model IDs, active context tier, token limits, output reservations, concurrency, backend class) while preserving relay-blind E2EE and backward compatibility with older nodes.
- Let clients express coarse routing requirements (`model` and `context_tier`) when asking `/api/v1/relay/servers/next` so the relay can filter eligible live API v1 nodes without exposing plaintext prompts or exact token counts.

### Description
- Add normalized capability schema, defaults, and validators in `relay.py` (`_api_v1_default_capabilities`, `_normalise_api_v1_capabilities`, tier ordering constants, and helpers) and store only normalized safe fields on register/heartbeat; older nodes that omit capabilities remain accepted as `8k-fast` compatibility nodes.
- Extend relay diagnostics to include the normalized `capabilities` field (no-store/coarse-only) while redacting private machine details.
- Extend `GET /api/v1/relay/servers/next` to accept optional `model` and `context_tier` query params, filter live API v1 nodes by model support and active context profile, preserve registration-order round-robin among eligible nodes, allow 64K nodes to satisfy 8K requests, and return structured `no_matching_compute_node` when nodes exist but none match; response now includes safe selection metadata in addition to `server_public_key` (`selected_context_tier`, `selected_context_window_tokens`, `selected_model_support`, `selection_policy`).
- Validate an optional `routing.context_tier` inside the encrypted `api_v1_request` after decryption in `utils/networking/relay_client.py`, default missing routing to `8k-fast`, and reject unsupported routing values before passing requests to the compute runtime.
- Have the compute-node client advertise capabilities on both registration and poll heartbeats by including a normalized `capabilities` object produced from the active context profile and model manager diagnostics in `utils/networking/relay_client.py`.
- Add focused tests covering capability registration (8K/64K), malformed capability rejection, old-node compatibility, model filtering, deterministic round robin among eligible nodes, `no_matching_compute_node` error, and diagnostics redaction (`tests/test_relay.py` and `tests/unit/test_relay_client.py`).

### Testing
- Ran `pytest tests/test_relay.py -q` (result: passed; full suite for relay tests passed).
- Ran `pytest tests/unit/test_relay_client.py -q` (result: passed; relay-client unit tests passed).
- Ran `pytest tests/unit/test_desktop_compute_node_bridge.py -q` (result: passed; desktop bridge tests passed).
- Verified code quality and packaging checks with `python -m py_compile relay.py utils/networking/relay_client.py`, `git diff --check`, and `pre-commit run --all-files` (result: all checks passed and no new warnings that block CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b57e1d33c832f81b07fcc0d7cac9c)