### PR TITLE
API v1: Compute-side context admission and independent heartbeat

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import time
 import signal
+import threading
 import requests
 from pathlib import Path
 from typing import Dict, Any, Generator, List, Optional, Tuple
@@ -23,6 +24,14 @@ from playwright.sync_api import (
     BrowserContext,
     Error as PlaywrightError,
 )
+
+
+def _drain_process_stream(stream) -> None:
+    """Continuously drain a subprocess pipe so verbose test servers cannot block."""
+    if stream is None:
+        return
+    for _line in iter(stream.readline, ""):
+        pass
 
 # Add the project root to the path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -315,6 +324,19 @@ def setup_servers(
         text=True,
         env=test_env
     )
+    relay_stdout_thread = threading.Thread(
+        target=_drain_process_stream,
+        args=(relay_process.stdout,),
+        daemon=True,
+    )
+    relay_stderr_thread = threading.Thread(
+        target=_drain_process_stream,
+        args=(relay_process.stderr,),
+        daemon=True,
+    )
+    relay_stdout_thread.start()
+    relay_stderr_thread.start()
+
     if run_real_bridge_e2e:
         print(f"Started relay server on port {E2E_RELAY_PORT} with real-provider guardrails")
     else:
@@ -351,7 +373,11 @@ def setup_servers(
             print("Focused relay e2e mode enabled: skipping server registration bootstrap")
         yield relay_process, None
         relay_process.terminate()
-        relay_process.wait(timeout=5)
+        try:
+            relay_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            relay_process.kill()
+            relay_process.wait(timeout=5)
         return
 
     # Start the server with mock LLM enabled via environment variable

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -1733,9 +1733,15 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             consecutive_ready_observations_local = 0
             relay_server_selection_body_local = ""
             for _ in range(attempts):
-                next_server_response = page.request.get(
-                    f"{base_url}/api/v1/relay/servers/next"
-                )
+                try:
+                    next_server_response = page.request.get(
+                        f"{base_url}/api/v1/relay/servers/next",
+                        timeout=2_000,
+                    )
+                except Exception:
+                    consecutive_ready_observations_local = 0
+                    time.sleep(pause_seconds)
+                    continue
                 if next_server_response.ok:
                     relay_server_selection_body_local = next_server_response.text()
                     try:
@@ -1961,11 +1967,20 @@ def test_landing_chat_real_inference_with_desktop_bridge_api_v1(
             if "desktop.compute_node_bridge.api_v1_e2ee.work_received" in line
         ]
         assert work_received_lines, "desktop bridge should receive API v1 encrypted relay work"
-        response_submitted_lines = [
-            line
-            for line in stderr_lines
-            if "desktop.compute_node_bridge.api_v1_e2ee.response_submitted" in line
-        ]
+        response_submitted_deadline = time.time() + 3
+        response_submitted_lines = []
+        while time.time() < response_submitted_deadline:
+            response_submitted_lines = [
+                line
+                for line in stderr_lines
+                if (
+                    "desktop.compute_node_bridge.api_v1_e2ee.response_submitted" in line
+                    or "API v1 E2EE response submission" in line
+                )
+            ]
+            if response_submitted_lines:
+                break
+            time.sleep(0.05)
         assert response_submitted_lines, "desktop bridge should submit API v1 encrypted responses"
         bridge_stderr_text = "".join(stderr_lines)
         assert "E2EE_SENTINEL_SHOULD_NEVER_REACH_RELAY_PLAINTEXT" not in bridge_stderr_text

--- a/tests/integration/test_api_v1_desktop_bridge_e2ee.py
+++ b/tests/integration/test_api_v1_desktop_bridge_e2ee.py
@@ -45,6 +45,15 @@ class FakeDesktopRuntime:
     def __init__(self):
         self.calls = []
 
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        assert tokenize is False
+        return "".join(
+            f"<{message['role']}>{message['content']}" for message in messages
+        ) + ("<assistant>" if add_generation_prompt else "")
+
+    def tokenize(self, payload, _add_bos=False):
+        return list(range(len(payload)))
+
     def create_chat_completion(self, **kwargs):
         self.calls.append(kwargs)
         assert kwargs.get("stream") is False

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3855,3 +3855,24 @@ def test_subprocess_llama_proxy_prompt_helpers_mark_closed_on_eof(monkeypatch):
     with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
         proxy.tokenize(b'hello', add_bos=False)
     assert proxy._closed is True
+
+
+def test_get_llm_instance_with_recovery_returns_existing_runtime(standalone_model_manager):
+    runtime = object()
+    standalone_model_manager.get_llm_instance = MagicMock(return_value=runtime)
+    standalone_model_manager._ensure_replacement_llm = MagicMock()
+
+    assert standalone_model_manager.get_llm_instance_with_recovery() is runtime
+    standalone_model_manager.get_llm_instance.assert_called_once_with()
+    standalone_model_manager._ensure_replacement_llm.assert_not_called()
+
+
+def test_get_llm_instance_with_recovery_attempts_replacement_when_unavailable(standalone_model_manager):
+    replacement = object()
+    standalone_model_manager.get_llm_instance = MagicMock(return_value=None)
+    standalone_model_manager._ensure_replacement_llm = MagicMock(return_value=replacement)
+    standalone_model_manager._llm_generation = 7
+
+    assert standalone_model_manager.get_llm_instance_with_recovery() is replacement
+    standalone_model_manager.get_llm_instance.assert_called_once_with()
+    standalone_model_manager._ensure_replacement_llm.assert_called_once_with(7)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8,7 +8,7 @@ import threading
 import pytest
 import shutil
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 import json
 import sys
 import tempfile
@@ -118,13 +118,29 @@ class TestModelManager:
             tokenize=False,
             add_generation_prompt=True,
         )
+        structured_rendered = llm.apply_chat_template(
+            [{'role': 'user', 'content': [{'type': 'text', 'text': 'structured'}, {'ignored': 'metadata'}]}],
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+        template_tokens = llm.apply_chat_template(
+            [{'role': 'user', 'content': 'hello packaged parity'}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
         tokens = llm.tokenize(rendered.encode('utf-8'), add_bos=False)
+        bos_tokens = llm.tokenize(rendered, add_bos=True)
 
         assert isinstance(rendered, str)
         assert '<|user|>' in rendered
         assert '<|assistant|>' in rendered
+        assert structured_rendered == '<|user|>\nstructured'
+        assert isinstance(template_tokens, list)
+        assert template_tokens == tokens
         assert isinstance(tokens, list)
         assert len(tokens) > 0
+        assert bos_tokens[0] == 1
+        assert len(bos_tokens) == len(tokens) + 1
 
     def test_get_model_artifact_metadata(self, model_manager):
         """Test runtime model metadata includes expected keys and file state."""
@@ -3772,3 +3788,70 @@ class Llama:
     ])
     assert plaintext_prompt not in leak_checked_text
     assert plaintext_output not in leak_checked_text
+
+
+def test_subprocess_llama_proxy_prompt_helpers_use_runtime_stage_timeout(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._lock = model_manager_module.Lock()
+    proxy._process = SimpleNamespace(stdin=MagicMock())
+    proxy._timeout_seconds = 3.25
+    proxy._closed = False
+    proxy._send = MagicMock()
+    captured_reads = []
+
+    def _fake_read(_process, *, timeout_seconds, stage):
+        captured_reads.append((stage, timeout_seconds))
+        if stage == 'llama_cpp_prompt_render':
+            return {'status': 'ok', 'result': '<|user|>\nhello'}
+        return {'status': 'ok', 'result': [10, 11]}
+
+    monkeypatch.setattr(model_manager_module, '_read_llama_subprocess_message', _fake_read)
+
+    rendered = proxy.apply_chat_template([{'role': 'user', 'content': 'hello'}], tokenize=False)
+    tokens = proxy.tokenize(rendered.encode('utf-8'), add_bos=False)
+
+    assert rendered == '<|user|>\nhello'
+    assert tokens == [10, 11]
+    assert proxy._send.call_args_list == [
+        call({
+            'method': 'apply_chat_template',
+            'args': ([{'role': 'user', 'content': 'hello'}],),
+            'kwargs': {'tokenize': False},
+        }),
+        call({
+            'method': 'tokenize',
+            'args': (b'<|user|>\nhello',),
+            'kwargs': {'add_bos': False},
+        }),
+    ]
+    assert captured_reads == [
+        ('llama_cpp_prompt_render', 3.25),
+        ('llama_cpp_prompt_tokenize', 3.25),
+    ]
+
+
+def test_subprocess_llama_proxy_prompt_helpers_mark_closed_on_eof(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._lock = model_manager_module.Lock()
+    proxy._process = SimpleNamespace(stdin=MagicMock())
+    proxy._timeout_seconds = 0.01
+    proxy._closed = False
+    proxy._send = MagicMock()
+
+    def _raise_eof(*_args, **_kwargs):
+        raise model_manager_module.LlamaCppWorkerEOFError('worker closed')
+
+    monkeypatch.setattr(model_manager_module, '_read_llama_subprocess_message', _raise_eof)
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
+        proxy.apply_chat_template([], tokenize=False)
+    assert proxy._closed is True
+
+    proxy._closed = False
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
+        proxy.tokenize(b'hello', add_bos=False)
+    assert proxy._closed is True

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3822,7 +3822,7 @@ def test_subprocess_llama_proxy_prompt_helpers_use_runtime_stage_timeout(monkeyp
         }),
         call({
             'method': 'tokenize',
-            'args': (b'<|user|>\nhello',),
+            'args': ({'__token_place_bytes_utf8__': '<|user|>\nhello'},),
             'kwargs': {'add_bos': False},
         }),
     ]

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -108,6 +108,24 @@ class TestModelManager:
         assert model_manager.llm is None
         assert model_manager.use_mock_llm is False
 
+    def test_mock_llm_exposes_chat_template_and_tokenizer(self, model_manager):
+        """USE_MOCK_LLM runtime supports API v1 authoritative admission helpers."""
+        model_manager.use_mock_llm = True
+
+        llm = model_manager.get_llm_instance()
+        rendered = llm.apply_chat_template(
+            [{'role': 'user', 'content': 'hello packaged parity'}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        tokens = llm.tokenize(rendered.encode('utf-8'), add_bos=False)
+
+        assert isinstance(rendered, str)
+        assert '<|user|>' in rendered
+        assert '<|assistant|>' in rendered
+        assert isinstance(tokens, list)
+        assert len(tokens) > 0
+
     def test_get_model_artifact_metadata(self, model_manager):
         """Test runtime model metadata includes expected keys and file state."""
         metadata = model_manager.get_model_artifact_metadata()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -11,6 +11,7 @@ import threading
 import time
 import requests
 import jsonschema
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from pathlib import Path
 
@@ -4388,6 +4389,41 @@ def test_api_v1_context_admission_rejects_when_chat_template_fallback_raises():
     assert error["code"] != "compute_node_internal_error"
     assert error["retryable"] is False
     assert manager.runtime.calls == []
+
+
+def test_api_v1_context_admission_uses_llama_cpp_chat_format_fallback(monkeypatch):
+    manager = _AdmissionManager(window=64)
+    manager.runtime.apply_chat_template = None
+    manager.runtime.chat_format = "llama-2"
+
+    class FakeRendered:
+        prompt = "<s>[INST]x[/INST]"
+
+    fake_chat_format_module = SimpleNamespace(
+        format_llama2=MagicMock(return_value=FakeRendered())
+    )
+    original_import_module = relay_client_module.importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "llama_cpp.llama_chat_format":
+            return fake_chat_format_module
+        return original_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "utils.networking.relay_client.importlib.import_module",
+        fake_import_module,
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x", options={"max_tokens": 1})
+
+    assert "error" not in envelope["api_v1_response"]
+    fake_chat_format_module.format_llama2.assert_called_once_with(
+        [{"role": "user", "content": "x"}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    assert manager.runtime.calls
 
 
 def test_api_v1_64k_request_on_8k_runtime_reports_exact_admission_counts():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4394,13 +4394,13 @@ def test_api_v1_context_admission_rejects_when_chat_template_fallback_raises():
 def test_api_v1_context_admission_uses_llama_cpp_chat_format_fallback(monkeypatch):
     manager = _AdmissionManager(window=64)
     manager.runtime.apply_chat_template = None
-    manager.runtime.chat_format = "llama-2"
+    manager.runtime.chat_format = "llama-3"
 
     class FakeRendered:
-        prompt = "<s>[INST]x[/INST]"
+        prompt = "<|start_header_id|>user<|end_header_id|>\n\nx<|eot_id|>"
 
     fake_chat_format_module = SimpleNamespace(
-        format_llama2=MagicMock(return_value=FakeRendered())
+        format_llama3=MagicMock(return_value=FakeRendered())
     )
     original_import_module = relay_client_module.importlib.import_module
 
@@ -4418,12 +4418,31 @@ def test_api_v1_context_admission_uses_llama_cpp_chat_format_fallback(monkeypatc
     envelope = _admission_envelope(client, manager, "x", options={"max_tokens": 1})
 
     assert "error" not in envelope["api_v1_response"]
-    fake_chat_format_module.format_llama2.assert_called_once_with(
+    fake_chat_format_module.format_llama3.assert_called_once_with(
         [{"role": "user", "content": "x"}],
         tokenize=False,
         add_generation_prompt=True,
     )
     assert manager.runtime.calls
+
+
+def test_api_v1_chat_format_import_ignores_repo_local_llama_stub(monkeypatch):
+    repo_llama_stub = SimpleNamespace(__file__=str(Path.cwd() / "llama_cpp.py"))
+    fake_chat_format_module = SimpleNamespace(format_llama3=object())
+    monkeypatch.setitem(sys.modules, "llama_cpp", repo_llama_stub)
+
+    def fake_import_module(name, *args, **kwargs):
+        assert name == "llama_cpp.llama_chat_format"
+        assert sys.modules.get("llama_cpp") is not repo_llama_stub
+        return fake_chat_format_module
+
+    monkeypatch.setattr(
+        "utils.networking.relay_client.importlib.import_module",
+        fake_import_module,
+    )
+
+    assert RelayClient._api_v1_llama_chat_format_module() is fake_chat_format_module
+    assert sys.modules["llama_cpp"] is repo_llama_stub
 
 
 def test_api_v1_64k_request_on_8k_runtime_reports_exact_admission_counts():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -359,9 +359,19 @@ class TestRelayClient:
                 }
             ]
         }
+        mock.runtime.apply_chat_template.side_effect = (
+            lambda messages, tokenize=False, add_generation_prompt=True: "".join(
+                f"<{message['role']}>{message['content']}" for message in messages
+            ) + ("<assistant>" if add_generation_prompt else "")
+        )
+        mock.runtime.tokenize.side_effect = (
+            lambda payload, _add_bos=False: list(range(len(payload)))
+        )
         mock.get_llm_instance.return_value = mock.runtime
         mock.create_chat_completion_with_recovery = None
         mock.use_mock_llm = True
+        mock.context_tier = "8k-fast"
+        mock.context_window_tokens = 8192
         return mock
 
     @pytest.fixture
@@ -2474,6 +2484,13 @@ class TestRelayClient:
         mock_model_manager,
     ):
         mock_model_manager.context_tier = "8k-fast"
+        mock_model_manager.context_window_tokens = 8192
+        mock_model_manager.config.get.side_effect = lambda key, default: {
+            "model.max_tokens": 512,
+            "model.temperature": 0.7,
+            "model.top_p": 0.9,
+            "model.stop_tokens": [],
+        }.get(key, default)
         request_data = TEST_VALID_RESPONSE.copy()
         mock_crypto_manager.decrypt_message.return_value = {
             "protocol": "tokenplace_api_v1_relay_e2ee",
@@ -2491,15 +2508,25 @@ class TestRelayClient:
         source_response.status_code = 200
         mock_post.return_value = source_response
 
+        mock_model_manager.runtime.apply_chat_template.side_effect = (
+            lambda messages, tokenize=False, add_generation_prompt=True: "<s><user>Hello<assistant>"
+        )
+        mock_model_manager.runtime.tokenize.side_effect = (
+            lambda payload, _add_bos=False: list(range(len(payload)))
+        )
+
         assert relay_client.process_client_request(request_data) is True
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         error = encrypted_envelope["api_v1_response"]["error"]
-        assert error["code"] == "compute_node_context_tier_unsupported"
+        assert error["code"] == "compute_node_context_window_exceeded"
         assert error["active_context_tier"] == "8k-fast"
-        assert error["requested_context_tier"] == "64k-full"
-        assert "prompt_tokens" not in error
-        assert "recommended_context_tier" not in error
+        assert error["configured_context_tokens"] == 8192
+        assert error["prompt_tokens"] == len(b"<s><user>Hello<assistant>")
+        assert error["requested_output_tokens"] == 512
+        assert error["required_total_tokens"] == error["prompt_tokens"] + 512
+        assert error["recommended_context_tier"] == "64k-full"
+        assert error["retryable"] is True
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_strips_routing_context_tier(
@@ -2601,6 +2628,14 @@ class TestRelayClient:
                         }
                     ]
                 }
+                self.runtime.apply_chat_template.side_effect = (
+                    lambda messages, tokenize=False, add_generation_prompt=True: "".join(
+                        f"<{message['role']}>{message['content']}" for message in messages
+                    ) + ("<assistant>" if add_generation_prompt else "")
+                )
+                self.runtime.tokenize.side_effect = (
+                    lambda payload, _add_bos=False: list(range(len(payload)))
+                )
 
             def get_llm_instance(self):
                 return self.runtime
@@ -2838,6 +2873,12 @@ class TestRelayClient:
                         ]
                     }
                 )
+                self.apply_chat_template = (
+                    lambda messages, tokenize=False, add_generation_prompt=True: "".join(
+                        f"<{message['role']}>{message['content']}" for message in messages
+                    ) + ("<assistant>" if add_generation_prompt else "")
+                )
+                self.tokenize = lambda payload, _add_bos=False: list(range(len(payload)))
 
         class _Manager:
             use_mock_llm = False
@@ -2911,6 +2952,14 @@ class TestRelayClient:
         class _Runtime:
             def __init__(self):
                 self.calls = []
+
+            def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+                return "".join(
+                    f"<{message['role']}>{message['content']}" for message in messages
+                ) + ("<assistant>" if add_generation_prompt else "")
+
+            def tokenize(self, payload, _add_bos=False):
+                return list(range(len(payload)))
 
             def create_chat_completion(self, **kwargs):
                 self.calls.append(kwargs)
@@ -2998,6 +3047,14 @@ class TestRelayClient:
             def __init__(self):
                 self.calls = []
 
+            def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+                return "".join(
+                    f"<{message['role']}>{message['content']}" for message in messages
+                ) + ("<assistant>" if add_generation_prompt else "")
+
+            def tokenize(self, payload, _add_bos=False):
+                return list(range(len(payload)))
+
             def create_chat_completion(self, **kwargs):
                 self.calls.append(kwargs)
                 return {
@@ -3084,6 +3141,14 @@ class TestRelayClient:
         class _Runtime:
             def __init__(self):
                 self.calls = []
+
+            def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+                return "".join(
+                    f"<{message['role']}>{message['content']}" for message in messages
+                ) + ("<assistant>" if add_generation_prompt else "")
+
+            def tokenize(self, payload, _add_bos=False):
+                return list(range(len(payload)))
 
             def create_chat_completion(self, **kwargs):
                 self.calls.append(kwargs)
@@ -3971,6 +4036,14 @@ class _ApiV1RuntimeManager:
         self.runtime.create_chat_completion.return_value = {
             "choices": [{"message": {"role": "assistant", "content": "ok"}}]
         }
+        self.runtime.apply_chat_template.side_effect = (
+            lambda messages, tokenize=False, add_generation_prompt=True: "".join(
+                f"<{message['role']}>{message['content']}" for message in messages
+            ) + ("<assistant>" if add_generation_prompt else "")
+        )
+        self.runtime.tokenize.side_effect = (
+            lambda payload, _add_bos=False: list(range(len(payload)))
+        )
         self.use_mock_llm = True
         self.worker_health = "healthy"
         self.recovery_count = 0
@@ -3984,7 +4057,7 @@ class _ApiV1RuntimeManager:
     [
         ({}, {"stream": False}),
         ({"max_tokens": 1}, {"max_tokens": 1}),
-        ({"max_tokens": 8192}, {"max_tokens": 8192}),
+        ({"max_tokens": 8000}, {"max_tokens": 8000}),
         ({"temperature": 0}, {"temperature": 0.0}),
         ({"temperature": 2.0}, {"temperature": 2.0}),
         ({"top_p": 0}, {"top_p": 0.0}),
@@ -4181,7 +4254,7 @@ class _AdmissionRuntime:
             rendered += "<assistant>"
         return rendered
 
-    def tokenize(self, payload, _add_bos=False):
+    def tokenize(self, payload, *args):
         if isinstance(payload, bytes):
             payload = payload.decode("utf-8")
         token_count = len(payload)
@@ -4249,6 +4322,43 @@ def test_api_v1_context_admission_uses_default_output_budget_for_omitted_max_tok
     assert error["prompt_tokens"] == 29
 
 
+def test_api_v1_context_admission_rejects_when_runtime_count_unavailable():
+    manager = _AdmissionManager(window=32)
+    manager.runtime.apply_chat_template = lambda *args, **kwargs: None
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x")
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_admission_unavailable"
+    assert error["retryable"] is False
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_64k_request_on_8k_runtime_reports_exact_admission_counts():
+    manager = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=4)
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        "x" * 8169,
+        options={"max_tokens": 3},
+        requested_tier="64k-full",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["active_context_tier"] == "8k-fast"
+    assert error["configured_context_tokens"] == 8192
+    assert error["prompt_tokens"] == 8189
+    assert error["requested_output_tokens"] == 3
+    assert error["required_total_tokens"] == 8192
+    assert error["recommended_context_tier"] == "64k-full"
+    assert error["retryable"] is True
+    assert manager.runtime.calls == []
+
+
 def test_api_v1_context_admission_exact_64k_boundaries_and_unicode_structured_text():
     manager = _AdmissionManager(tier="64k-full", window=65536, default_max_tokens=1)
     client = _api_v1_validation_client(manager)
@@ -4312,6 +4422,58 @@ def test_api_v1_heartbeat_worker_refreshes_during_blocked_inference():
 
     assert calls == [relay_client.relay_url]
     assert relay_client._api_v1_heartbeat_thread is None
+
+
+def test_api_v1_heartbeat_stops_when_response_posting_raises():
+    manager = _AdmissionManager()
+    client = _api_v1_validation_client(manager)
+    client._api_v1_registered_relays.add(client.relay_url)
+    client.crypto_manager.decrypt_message.return_value = {
+        "protocol": "tokenplace_api_v1_relay_e2ee",
+        "version": 1,
+        "request_id": "req-post-raises",
+        "client_public_key": TEST_VALID_RESPONSE["client_public_key"],
+        "api_v1_request": {
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "options": {},
+            "routing": {"context_tier": "8k-fast"},
+        },
+    }
+    client._post_api_v1_response = MagicMock(side_effect=RuntimeError("post failed"))
+
+    result = client.process_client_request_result(TEST_VALID_RESPONSE.copy())
+
+    assert result.submitted is False
+    assert client._api_v1_heartbeat_thread is None
+
+
+def test_api_v1_heartbeat_logs_sanitized_relay_targets():
+    relay_client = _api_v1_validation_client()
+    relay_url = "https://user:secret@example.test:443/path?token=abc#frag"
+    relay_client._api_v1_registered_relays.add(relay_url)
+    relay_client._api_v1_last_heartbeat_at[relay_url] = 0.0
+    relay_client._api_v1_relay_wait_hints = {
+        relay_url: {"next_ping_in_x_seconds": 1, "poll_wait_seconds": 1}
+    }
+    logged = []
+
+    def register(url):
+        relay_client.stop()
+        return {"next_ping_in_x_seconds": 1, "poll_wait_seconds": 1}
+
+    relay_client.register_api_v1_compute_node = register
+    with patch("utils.networking.relay_client.log_info") as mock_log_info:
+        mock_log_info.side_effect = lambda message, *args: logged.append(message.format(*args))
+        relay_client._api_v1_start_heartbeat_worker()
+        deadline = time.monotonic() + 2.0
+        while relay_client._api_v1_heartbeat_thread is not None and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    joined = "\n".join(logged)
+    assert "https://example.test" in joined
+    assert "secret" not in joined
+    assert "token=abc" not in joined
 
 
 def test_api_v1_stop_unregister_terminates_heartbeat_cleanly():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2495,9 +2495,11 @@ class TestRelayClient:
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         error = encrypted_envelope["api_v1_response"]["error"]
-        assert error["code"] == "compute_node_context_window_exceeded"
+        assert error["code"] == "compute_node_context_tier_unsupported"
         assert error["active_context_tier"] == "8k-fast"
-        assert error["recommended_context_tier"] == "64k-full"
+        assert error["requested_context_tier"] == "64k-full"
+        assert "prompt_tokens" not in error
+        assert "recommended_context_tier" not in error
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_strips_routing_context_tier(
@@ -4303,7 +4305,10 @@ def test_api_v1_heartbeat_worker_refreshes_during_blocked_inference():
 
     relay_client.register_api_v1_compute_node = register
     relay_client._api_v1_start_heartbeat_worker()
-    time.sleep(0.4)
+    deadline = time.monotonic() + 2.0
+    while not calls and time.monotonic() < deadline:
+        time.sleep(0.01)
+    relay_client.stop()
 
     assert calls == [relay_client.relay_url]
     assert relay_client._api_v1_heartbeat_thread is None

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4340,6 +4340,7 @@ def test_api_v1_context_admission_uses_recovered_runtime_before_rejecting():
     manager.create_chat_completion_with_recovery.assert_called_once()
     assert manager.runtime.calls == []
 
+
 def test_api_v1_context_admission_rejects_when_runtime_count_unavailable():
     manager = _AdmissionManager(window=32)
     manager.runtime.apply_chat_template = lambda *args, **kwargs: None
@@ -4349,6 +4350,42 @@ def test_api_v1_context_admission_rejects_when_runtime_count_unavailable():
 
     error = envelope["api_v1_response"]["error"]
     assert error["code"] == "compute_node_context_admission_unavailable"
+    assert error["retryable"] is False
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_context_admission_rejects_when_tokenizer_fallbacks_raise():
+    manager = _AdmissionManager(window=32)
+
+    def reject_all_tokenize_signatures(*args, **kwargs):
+        raise TypeError("unsupported tokenizer signature")
+
+    manager.runtime.tokenize = reject_all_tokenize_signatures
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x")
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_admission_unavailable"
+    assert error["code"] != "compute_node_internal_error"
+    assert error["retryable"] is False
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_context_admission_rejects_when_chat_template_fallback_raises():
+    manager = _AdmissionManager(window=32)
+
+    def reject_all_template_signatures(*args, **kwargs):
+        raise TypeError("unsupported chat template signature")
+
+    manager.runtime.apply_chat_template = reject_all_template_signatures
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x")
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_admission_unavailable"
+    assert error["code"] != "compute_node_internal_error"
     assert error["retryable"] is False
     assert manager.runtime.calls == []
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -2519,14 +2519,15 @@ class TestRelayClient:
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
         error = encrypted_envelope["api_v1_response"]["error"]
-        assert error["code"] == "compute_node_context_window_exceeded"
+        assert error["code"] == "compute_node_context_tier_unsupported"
         assert error["active_context_tier"] == "8k-fast"
+        assert error["requested_context_tier"] == "64k-full"
         assert error["configured_context_tokens"] == 8192
         assert error["prompt_tokens"] == len(b"<s><user>Hello<assistant>")
         assert error["requested_output_tokens"] == 512
         assert error["required_total_tokens"] == error["prompt_tokens"] + 512
-        assert error["recommended_context_tier"] == "64k-full"
-        assert error["retryable"] is True
+        assert error["retryable"] is False
+        assert "recommended_context_tier" not in error
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_strips_routing_context_tier(
@@ -4342,7 +4343,7 @@ def test_api_v1_64k_request_on_8k_runtime_reports_exact_admission_counts():
     envelope = _admission_envelope(
         client,
         manager,
-        "x" * 8169,
+        "x" * 8170,
         options={"max_tokens": 3},
         requested_tier="64k-full",
     )
@@ -4351,11 +4352,37 @@ def test_api_v1_64k_request_on_8k_runtime_reports_exact_admission_counts():
     assert error["code"] == "compute_node_context_window_exceeded"
     assert error["active_context_tier"] == "8k-fast"
     assert error["configured_context_tokens"] == 8192
-    assert error["prompt_tokens"] == 8189
+    assert error["prompt_tokens"] == 8190
     assert error["requested_output_tokens"] == 3
-    assert error["required_total_tokens"] == 8192
+    assert error["required_total_tokens"] == 8193
     assert error["recommended_context_tier"] == "64k-full"
     assert error["retryable"] is True
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_64k_request_on_8k_runtime_reports_tier_unsupported_when_it_fits():
+    manager = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=4)
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        "small",
+        options={"max_tokens": 10},
+        requested_tier="64k-full",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_tier_unsupported"
+    assert error["message"] == "Requested context tier is not active on this compute node"
+    assert error["active_context_tier"] == "8k-fast"
+    assert error["requested_context_tier"] == "64k-full"
+    assert error["configured_context_tokens"] == 8192
+    assert error["prompt_tokens"] == 25
+    assert error["requested_output_tokens"] == 10
+    assert error["required_total_tokens"] == 35
+    assert error["retryable"] is False
+    assert "recommended_context_tier" not in error
     assert manager.runtime.calls == []
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4391,6 +4391,26 @@ def test_api_v1_context_admission_rejects_when_chat_template_fallback_raises():
     assert manager.runtime.calls == []
 
 
+def test_api_v1_context_admission_rejects_when_tokenizer_template_branch_raises():
+    manager = _AdmissionManager(window=32)
+    manager.runtime.apply_chat_template = None
+
+    class RejectingTokenizerTemplate:
+        def apply_chat_template(self, *args, **kwargs):
+            raise RuntimeError("template render failed")
+
+    manager.runtime.tokenizer = lambda: RejectingTokenizerTemplate()
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x")
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_admission_unavailable"
+    assert error["code"] != "compute_node_internal_error"
+    assert error["retryable"] is False
+    assert manager.runtime.calls == []
+
+
 def test_api_v1_context_admission_uses_llama_cpp_chat_format_fallback(monkeypatch):
     manager = _AdmissionManager(window=64)
     manager.runtime.apply_chat_template = None

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -7,6 +7,7 @@ import json
 import math
 import pytest
 import sys
+import threading
 import time
 import requests
 import jsonschema
@@ -4323,6 +4324,22 @@ def test_api_v1_context_admission_uses_default_output_budget_for_omitted_max_tok
     assert error["prompt_tokens"] == 29
 
 
+def test_api_v1_context_admission_uses_recovered_runtime_before_rejecting():
+    manager = _AdmissionManager(window=64, default_max_tokens=4)
+    manager.get_llm_instance = MagicMock(side_effect=[None])
+    manager.get_llm_instance_with_recovery = MagicMock(return_value=manager.runtime)
+    manager.create_chat_completion_with_recovery = MagicMock(
+        return_value={"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "hello", options={"max_tokens": 4})
+
+    assert "error" not in envelope["api_v1_response"]
+    manager.get_llm_instance_with_recovery.assert_called_once()
+    manager.create_chat_completion_with_recovery.assert_called_once()
+    assert manager.runtime.calls == []
+
 def test_api_v1_context_admission_rejects_when_runtime_count_unavailable():
     manager = _AdmissionManager(window=32)
     manager.runtime.apply_chat_template = lambda *args, **kwargs: None
@@ -4425,6 +4442,35 @@ def test_api_v1_context_admission_recommends_64k_for_8k_overflow():
     assert error["recommended_context_tier"] == "64k-full"
     assert error["retryable"] is True
 
+
+def test_api_v1_stop_prevents_racing_start_from_leaving_live_heartbeat():
+    relay_client = _api_v1_validation_client()
+    relay_client._api_v1_registered_relays.add(relay_client.relay_url)
+    relay_client._api_v1_last_heartbeat_at[relay_client.relay_url] = time.monotonic()
+    relay_client._api_v1_start_heartbeat_worker()
+    original = relay_client._api_v1_heartbeat_thread
+    assert original is not None
+
+    entered_join = threading.Event()
+    release_join = threading.Event()
+    original_join = original.join
+
+    def blocking_join(timeout=None):
+        entered_join.set()
+        release_join.wait(timeout=1.0)
+        return original_join(timeout=timeout)
+
+    original.join = blocking_join
+    stopper = threading.Thread(target=relay_client._api_v1_stop_heartbeat_worker)
+    stopper.start()
+    assert entered_join.wait(timeout=1.0)
+
+    relay_client._api_v1_start_heartbeat_worker()
+    release_join.set()
+    stopper.join(timeout=2.0)
+
+    assert not stopper.is_alive()
+    assert relay_client._api_v1_heartbeat_thread is None
 
 def test_api_v1_heartbeat_worker_refreshes_during_blocked_inference():
     relay_client = _api_v1_validation_client()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -7,6 +7,7 @@ import json
 import math
 import pytest
 import sys
+import time
 import requests
 import jsonschema
 from unittest.mock import MagicMock, patch
@@ -2493,9 +2494,10 @@ class TestRelayClient:
         assert relay_client.process_client_request(request_data) is True
 
         encrypted_envelope = mock_crypto_manager.encrypt_message.call_args.args[0]
-        assert encrypted_envelope["api_v1_response"]["error"]["code"] == (
-            "compute_node_context_tier_unsupported"
-        )
+        error = encrypted_envelope["api_v1_response"]["error"]
+        assert error["code"] == "compute_node_context_window_exceeded"
+        assert error["active_context_tier"] == "8k-fast"
+        assert error["recommended_context_tier"] == "64k-full"
 
     @patch('utils.networking.relay_client.requests.post')
     def test_process_client_request_api_v1_strips_routing_context_tier(
@@ -4146,3 +4148,174 @@ def test_api_v1_valid_request_succeeds_immediately_after_rejected_request():
     assert rejected["api_v1_response"]["error"]["code"] == "compute_node_invalid_request"
     assert accepted["api_v1_response"]["message"]["content"] == "ok"
     manager.runtime.create_chat_completion.assert_called_once()
+
+
+class _AdmissionConfig:
+    def __init__(self, max_tokens=16):
+        self.max_tokens = max_tokens
+
+    def get(self, key, default):
+        return {
+            "model.max_tokens": self.max_tokens,
+            "model.temperature": 0.7,
+            "model.top_p": 0.9,
+            "model.stop_tokens": [],
+        }.get(key, default)
+
+
+class _AdmissionRuntime:
+    def __init__(self):
+        self.calls = []
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        assert tokenize is False
+        rendered = "<s>"
+        for message in messages:
+            content = message["content"]
+            if isinstance(content, list):
+                content = "".join(block["text"] for block in content)
+            rendered += f"<{message['role']}>" + content
+        if add_generation_prompt:
+            rendered += "<assistant>"
+        return rendered
+
+    def tokenize(self, payload, _add_bos=False):
+        if isinstance(payload, bytes):
+            payload = payload.decode("utf-8")
+        token_count = len(payload)
+        if "雪" in payload:
+            token_count = 20 + ((len(payload) - 20) * 2)
+        return list(range(token_count))
+
+    def create_chat_completion(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+
+class _AdmissionManager:
+    api_model_id = "llama-3-8b-instruct"
+    use_mock_llm = False
+
+    def __init__(self, tier="8k-fast", window=8192, default_max_tokens=16):
+        self.context_tier = tier
+        self.context_window_tokens = window
+        self.config = _AdmissionConfig(default_max_tokens)
+        self.runtime = _AdmissionRuntime()
+        self.worker_restart_count = 0
+
+    def get_llm_instance(self):
+        return self.runtime
+
+
+def _admission_envelope(client, manager, content, *, options=None, requested_tier=None):
+    client.model_manager = manager
+    return client._generate_api_v1_response_with_runtime_model(
+        request_id="req-admission",
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": content}],
+        options=options or {},
+        requested_context_tier=requested_tier or manager.context_tier,
+    )
+
+
+def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget():
+    manager = _AdmissionManager(window=32)
+    client = _api_v1_validation_client(manager)
+    # Rendered prompt is len("<s><user>" + content + "<assistant>") = 20 + content.
+    accepted = _admission_envelope(client, manager, "x" * 7, options={"max_tokens": 5})
+    rejected = _admission_envelope(client, manager, "x" * 8, options={"max_tokens": 5})
+
+    assert "error" not in accepted["api_v1_response"]
+    assert manager.runtime.calls[-1]["max_tokens"] == 5
+    error = rejected["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 28
+    assert error["requested_output_tokens"] == 5
+    assert error["required_total_tokens"] == 33
+
+
+def test_api_v1_context_admission_uses_default_output_budget_for_omitted_max_tokens():
+    manager = _AdmissionManager(window=32, default_max_tokens=4)
+    client = _api_v1_validation_client(manager)
+
+    accepted = _admission_envelope(client, manager, "x" * 8)
+    rejected = _admission_envelope(client, manager, "x" * 9)
+
+    assert "error" not in accepted["api_v1_response"]
+    error = rejected["api_v1_response"]["error"]
+    assert error["requested_output_tokens"] == 4
+    assert error["prompt_tokens"] == 29
+
+
+def test_api_v1_context_admission_exact_64k_boundaries_and_unicode_structured_text():
+    manager = _AdmissionManager(tier="64k-full", window=65536, default_max_tokens=1)
+    client = _api_v1_validation_client(manager)
+    content = [{"type": "text", "text": "雪" * 32757}]
+    accepted = _admission_envelope(client, manager, content, requested_tier="8k-fast")
+    rejected = _admission_envelope(client, manager, [{"type": "input_text", "text": "雪" * 32758}])
+
+    assert "error" not in accepted["api_v1_response"]
+    error = rejected["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["active_context_tier"] == "64k-full"
+    assert error["configured_context_tokens"] == 65536
+    assert error["prompt_tokens"] == 65536
+    assert error["requested_output_tokens"] == 1
+    assert error["retryable"] is False
+
+
+def test_api_v1_context_overflow_is_request_scoped_and_does_not_restart_worker():
+    manager = _AdmissionManager(window=24, default_max_tokens=5)
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x" * 10)
+
+    assert envelope["api_v1_response"]["error"]["code"] == "compute_node_context_window_exceeded"
+    assert manager.worker_restart_count == 0
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_context_admission_recommends_64k_for_8k_overflow():
+    manager = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=1)
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, "x" * 8172)
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["recommended_context_tier"] == "64k-full"
+    assert error["retryable"] is True
+
+
+def test_api_v1_heartbeat_worker_refreshes_during_blocked_inference():
+    relay_client = _api_v1_validation_client()
+    relay_client._api_v1_registered_relays.add(relay_client.relay_url)
+    relay_client._api_v1_last_heartbeat_at[relay_client.relay_url] = 0.0
+    relay_client._api_v1_relay_wait_hints = {
+        relay_client.relay_url: {"next_ping_in_x_seconds": 1, "poll_wait_seconds": 1}
+    }
+    calls = []
+
+    def register(url):
+        calls.append(url)
+        relay_client.stop()
+        return {"next_ping_in_x_seconds": 1, "poll_wait_seconds": 1}
+
+    relay_client.register_api_v1_compute_node = register
+    relay_client._api_v1_start_heartbeat_worker()
+    time.sleep(0.4)
+
+    assert calls == [relay_client.relay_url]
+    assert relay_client._api_v1_heartbeat_thread is None
+
+
+def test_api_v1_stop_unregister_terminates_heartbeat_cleanly():
+    relay_client = _api_v1_validation_client()
+    relay_client._api_v1_registered_relays.add(relay_client.relay_url)
+    relay_client._api_v1_last_heartbeat_at[relay_client.relay_url] = time.monotonic()
+    relay_client._api_v1_start_heartbeat_worker()
+    assert relay_client._api_v1_heartbeat_thread is not None
+
+    relay_client.stop()
+
+    assert relay_client._api_v1_heartbeat_thread is None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1132,6 +1132,8 @@ for line in sys.stdin:
                         if formatter_key == "llama_2"
                         else "format_" + formatter_key
                     )
+                    if formatter_name == "format_llama_3":
+                        formatter_name = "format_llama3"
                     formatter = getattr(chat_format_module, formatter_name, None)
                     if not callable(formatter):
                         _emit(_safe_request_error('prompt_render_unavailable', request=request))

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -950,8 +950,14 @@ class _SubprocessLlamaProxy:
         return message.get('result')
 
     def tokenize(self, *args, **kwargs):
+        serializable_args = tuple(
+            {'__token_place_bytes_utf8__': arg.decode('utf-8')}
+            if isinstance(arg, (bytes, bytearray))
+            else arg
+            for arg in args
+        )
         with self._lock:
-            self._send({'method': 'tokenize', 'args': args, 'kwargs': kwargs})
+            self._send({'method': 'tokenize', 'args': serializable_args, 'kwargs': kwargs})
             try:
                 message = _read_llama_subprocess_message(
                     self._process,
@@ -1110,9 +1116,37 @@ for line in sys.stdin:
             render = getattr(llama, 'apply_chat_template', None)
             if not callable(render):
                 tokenizer = getattr(llama, 'tokenizer', None)
+                if callable(tokenizer):
+                    try:
+                        tokenizer = tokenizer()
+                    except Exception:
+                        tokenizer = None
                 render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
             if not callable(render):
-                _emit(_safe_request_error('prompt_render_unavailable', request=request))
+                try:
+                    chat_format = getattr(llama, 'chat_format', None) or 'llama-2'
+                    chat_format_module = importlib.import_module('llama_cpp.llama_chat_format')
+                    formatter_key = str(chat_format).replace("-", "_")
+                    formatter_name = (
+                        "format_llama2"
+                        if formatter_key == "llama_2"
+                        else "format_" + formatter_key
+                    )
+                    formatter = getattr(chat_format_module, formatter_name, None)
+                    if not callable(formatter):
+                        _emit(_safe_request_error('prompt_render_unavailable', request=request))
+                        continue
+                    rendered = formatter(*request.get('args', []), **kwargs)
+                    prompt = getattr(rendered, 'prompt', rendered)
+                    if kwargs.get('tokenize'):
+                        tokenize = getattr(llama, 'tokenize', None)
+                        if not callable(tokenize):
+                            _emit(_safe_request_error('tokenizer_unavailable', request=request))
+                            continue
+                        prompt = tokenize(str(prompt).encode('utf-8'), add_bos=False)
+                    _emit({'status': 'ok', 'result': prompt})
+                except Exception as exc:
+                    _emit(_safe_request_error('prompt_render_unavailable', request=request, exc=exc))
                 continue
             _emit({'status': 'ok', 'result': render(*request.get('args', []), **kwargs)})
             continue
@@ -1121,7 +1155,13 @@ for line in sys.stdin:
             if not callable(tokenize):
                 _emit(_safe_request_error('tokenizer_unavailable', request=request))
                 continue
-            _emit({'status': 'ok', 'result': tokenize(*request.get('args', []), **kwargs)})
+            tokenize_args = []
+            for arg in request.get('args', []):
+                if isinstance(arg, dict) and set(arg) == {'__token_place_bytes_utf8__'}:
+                    tokenize_args.append(arg['__token_place_bytes_utf8__'].encode('utf-8'))
+                else:
+                    tokenize_args.append(arg)
+            _emit({'status': 'ok', 'result': tokenize(*tokenize_args, **kwargs)})
             continue
         result = llama.create_chat_completion(*request.get('args', []), **kwargs)
         if kwargs.get('stream'):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -934,6 +934,35 @@ class _SubprocessLlamaProxy:
                 raise
         return message.get('result')
 
+
+    def apply_chat_template(self, *args, **kwargs):
+        with self._lock:
+            self._send({'method': 'apply_chat_template', 'args': args, 'kwargs': kwargs})
+            try:
+                message = _read_llama_subprocess_message(
+                    self._process,
+                    timeout_seconds=self._timeout_seconds,
+                    stage='llama_cpp_prompt_render',
+                )
+            except LlamaCppWorkerEOFError:
+                self._closed = True
+                raise
+        return message.get('result')
+
+    def tokenize(self, *args, **kwargs):
+        with self._lock:
+            self._send({'method': 'tokenize', 'args': args, 'kwargs': kwargs})
+            try:
+                message = _read_llama_subprocess_message(
+                    self._process,
+                    timeout_seconds=self._timeout_seconds,
+                    stage='llama_cpp_prompt_tokenize',
+                )
+            except LlamaCppWorkerEOFError:
+                self._closed = True
+                raise
+        return message.get('result')
+
     def _stream_chat_completion(self, *args, **kwargs):
         with self._lock:
             self._send({'method': 'create_chat_completion', 'args': args, 'kwargs': kwargs})
@@ -1069,12 +1098,30 @@ for line in sys.stdin:
         if not isinstance(request, dict):
             _emit(_safe_request_error('malformed_request'))
             continue
-        if request.get('method') != 'create_chat_completion':
+        method = request.get('method')
+        if method not in {'create_chat_completion', 'apply_chat_template', 'tokenize'}:
             _emit(_safe_request_error('unsupported_method', request=request))
             continue
         kwargs = request.get('kwargs', {})
         if not isinstance(kwargs, dict):
             _emit(_safe_request_error('malformed_kwargs', request=request))
+            continue
+        if method == 'apply_chat_template':
+            render = getattr(llama, 'apply_chat_template', None)
+            if not callable(render):
+                tokenizer = getattr(llama, 'tokenizer', None)
+                render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
+            if not callable(render):
+                _emit(_safe_request_error('prompt_render_unavailable', request=request))
+                continue
+            _emit({'status': 'ok', 'result': render(*request.get('args', []), **kwargs)})
+            continue
+        if method == 'tokenize':
+            tokenize = getattr(llama, 'tokenize', None)
+            if not callable(tokenize):
+                _emit(_safe_request_error('tokenizer_unavailable', request=request))
+                continue
+            _emit({'status': 'ok', 'result': tokenize(*request.get('args', []), **kwargs)})
             continue
         result = llama.create_chat_completion(*request.get('args', []), **kwargs)
         if kwargs.get('stream'):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -2164,6 +2164,15 @@ class ModelManager:
             self.log_warning(replacement_attempt_log_message)
         return self.get_llm_instance()
 
+    def get_llm_instance_with_recovery(self):
+        """Return a live LLM runtime, attempting one replacement if unavailable."""
+        llm_instance = self.get_llm_instance()
+        if llm_instance is not None:
+            return llm_instance
+        with self.llm_lock:
+            observed_generation = self._llm_generation
+        return self._ensure_replacement_llm(observed_generation)
+
     def create_chat_completion_with_recovery(self, *args, **kwargs):
         """Create a completion, replacing a dead subprocess worker at most once.
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1858,6 +1858,42 @@ class ModelManager:
             self.log_info("Using Mock LLM instance based on USE_MOCK_LLM configuration.")
             self.last_compute_diagnostics = self._mock_compute_plan()
             mock_llama_instance = MagicMock()
+
+            def _mock_apply_chat_template(messages, tokenize=False, add_generation_prompt=True):
+                rendered_parts = []
+                for message in messages:
+                    role = message.get('role', 'user') if isinstance(message, dict) else 'user'
+                    content = message.get('content', '') if isinstance(message, dict) else str(message)
+                    if isinstance(content, list):
+                        content = ''.join(
+                            str(item.get('text', ''))
+                            for item in content
+                            if isinstance(item, dict)
+                        )
+                    rendered_parts.append(f"<|{role}|>\n{content}")
+                if add_generation_prompt:
+                    rendered_parts.append("<|assistant|>\n")
+                rendered = "\n".join(rendered_parts)
+                if tokenize:
+                    return _mock_tokenize(rendered.encode('utf-8'), add_bos=False)
+                return rendered
+
+            def _mock_tokenize(content, add_bos=True):
+                if isinstance(content, bytes):
+                    text = content.decode('utf-8', errors='ignore')
+                else:
+                    text = str(content)
+                # Deterministic approximation for USE_MOCK_LLM test/runtime paths.
+                # Production context admission still uses the warmed llama.cpp
+                # runtime tokenizer; this mock only keeps local packaged parity
+                # e2e on the same render/tokenize surface.
+                tokens = text.split()
+                if add_bos:
+                    return [1] + list(range(2, len(tokens) + 2))
+                return list(range(1, len(tokens) + 1))
+
+            mock_llama_instance.apply_chat_template.side_effect = _mock_apply_chat_template
+            mock_llama_instance.tokenize.side_effect = _mock_tokenize
             mock_response = {
                 'choices': [
                     {

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -11,6 +11,7 @@ import math
 import os
 import hashlib
 import re
+import threading
 import time
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
@@ -661,7 +662,89 @@ class RelayClient:
         self._api_v1_last_heartbeat_at: Dict[str, float] = {}
         self._unregister_attempted = False
         self._unregister_complete = False
+        self._api_v1_heartbeat_lock = threading.Lock()
+        self._api_v1_heartbeat_stop = threading.Event()
+        self._api_v1_heartbeat_thread: Optional[threading.Thread] = None
 
+
+
+    def _api_v1_start_heartbeat_worker(self) -> None:
+        """Start an independent API v1 lease refresher for long inferences."""
+
+        lock = getattr(self, "_api_v1_heartbeat_lock", None)
+        if lock is None:
+            return
+        with lock:
+            thread = getattr(self, "_api_v1_heartbeat_thread", None)
+            if thread is not None and thread.is_alive():
+                return
+            self._api_v1_heartbeat_stop.clear()
+            thread = threading.Thread(
+                target=self._api_v1_heartbeat_worker,
+                name="tokenplace-api-v1-heartbeat",
+                daemon=True,
+            )
+            self._api_v1_heartbeat_thread = thread
+            thread.start()
+
+    def _api_v1_stop_heartbeat_worker(self) -> None:
+        """Stop the API v1 heartbeat worker without leaving shutdown heartbeats behind."""
+
+        stop_event = getattr(self, "_api_v1_heartbeat_stop", None)
+        if stop_event is None:
+            return
+        stop_event.set()
+        thread = getattr(self, "_api_v1_heartbeat_thread", None)
+        if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=2.0)
+        if thread is not None and not thread.is_alive():
+            self._api_v1_heartbeat_thread = None
+
+    def _api_v1_heartbeat_worker(self) -> None:
+        """Refresh relay leases independently from polling/inference work."""
+
+        while not self._api_v1_heartbeat_stop.wait(0.25):
+            if getattr(self, "_polling_stopped_by_request", False):
+                break
+            relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
+            for candidate_url in list(getattr(self, "_api_v1_registered_relays", set())):
+                if self._api_v1_heartbeat_stop.is_set():
+                    break
+                hints = relay_wait_hints.get(candidate_url, {})
+                lease = self._normalise_positive_seconds(
+                    hints.get("next_ping_in_x_seconds"), DEFAULT_API_V1_LEASE_SECONDS
+                )
+                threshold = self._api_v1_refresh_threshold_seconds(lease)
+                last = self._api_v1_last_heartbeat_at.get(candidate_url, 0.0)
+                if threshold > 0 and time.monotonic() - float(last or 0.0) < threshold:
+                    continue
+                try:
+                    response = self.register_api_v1_compute_node(candidate_url)
+                except Exception as exc:
+                    log_error("server.heartbeat.background_failed relay={} error={}", candidate_url, str(exc))
+                    continue
+                if isinstance(response, dict) and not response.get("error"):
+                    refreshed_lease = self._normalise_positive_seconds(
+                        response.get("next_ping_in_x_seconds"), lease
+                    )
+                    relay_wait_hints[candidate_url] = {
+                        "next_ping_in_x_seconds": refreshed_lease,
+                        "poll_wait_seconds": self._normalise_poll_wait_seconds(
+                            response.get("poll_wait_seconds", refreshed_lease)
+                        ),
+                        "server_public_key": self.crypto_manager.public_key_b64,
+                    }
+                    self._api_v1_registered_relays.add(candidate_url)
+                    self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
+                    log_info(
+                        "server.heartbeat.background relay={} lease_seconds={} key_fingerprint={}",
+                        candidate_url,
+                        refreshed_lease,
+                        self._api_v1_public_key_fingerprint(self.crypto_manager.public_key_b64),
+                    )
+        with self._api_v1_heartbeat_lock:
+            if self._api_v1_heartbeat_thread is threading.current_thread():
+                self._api_v1_heartbeat_thread = None
 
     @staticmethod
     def _api_v1_public_key_fingerprint(public_key: Any) -> str:
@@ -862,9 +945,12 @@ class RelayClient:
         log_info("Stopping relay polling")
         self.stop_polling = True
         self._polling_stopped_by_request = True
+        self._api_v1_stop_heartbeat_worker()
 
     def unregister_from_relay(self) -> bool:
         """Best-effort unregister call for graceful compute-node shutdown."""
+
+        self._api_v1_stop_heartbeat_worker()
 
         registered_relays = getattr(self, "_api_v1_registered_relays", set())
         if not isinstance(registered_relays, set):
@@ -2216,6 +2302,140 @@ class RelayClient:
                 return None
         return total
 
+    @staticmethod
+    def _api_v1_tokenize_rendered_prompt(llm_instance: Any, rendered_prompt: str) -> Optional[int]:
+        """Count prompt tokens with the active llama.cpp runtime tokenizer."""
+
+        tokenize = getattr(llm_instance, "tokenize", None)
+        if not callable(tokenize) or not isinstance(rendered_prompt, str):
+            return None
+        try:
+            tokens = tokenize(rendered_prompt.encode("utf-8"), add_bos=False)
+        except TypeError:
+            try:
+                tokens = tokenize(rendered_prompt.encode("utf-8"))
+            except TypeError:
+                tokens = tokenize(rendered_prompt)
+        if isinstance(tokens, (list, tuple)):
+            return len(tokens)
+        return None
+
+    @staticmethod
+    def _api_v1_render_chat_prompt(llm_instance: Any, messages: List[Dict[str, Any]]) -> Optional[str]:
+        """Render chat messages with the active runtime chat template."""
+
+        apply_chat_template = getattr(llm_instance, "apply_chat_template", None)
+        if callable(apply_chat_template):
+            try:
+                rendered = apply_chat_template(
+                    messages, tokenize=False, add_generation_prompt=True
+                )
+            except TypeError:
+                rendered = apply_chat_template(messages)
+            if isinstance(rendered, str):
+                return rendered
+        tokenizer = getattr(llm_instance, "tokenizer", None)
+        if tokenizer is not None:
+            tokenizer_template = getattr(tokenizer, "apply_chat_template", None)
+            if callable(tokenizer_template):
+                rendered = tokenizer_template(
+                    messages, tokenize=False, add_generation_prompt=True
+                )
+                if isinstance(rendered, str):
+                    return rendered
+        return None
+
+    def _api_v1_context_admission_error(
+        self,
+        *,
+        active_context_tier: str,
+        configured_context_tokens: int,
+        prompt_tokens: int,
+        requested_output_tokens: int,
+        requested_context_tier: str,
+    ) -> Dict[str, Any]:
+        required_total = prompt_tokens + requested_output_tokens
+        recommended_context_tier = None
+        retryable = False
+        try:
+            full_profile = get_context_profile("64k-full")
+            requested_profile = get_context_profile(requested_context_tier)
+            if (
+                required_total <= full_profile.total_context_tokens
+                and configured_context_tokens < full_profile.total_context_tokens
+                and requested_profile.total_context_tokens <= full_profile.total_context_tokens
+            ):
+                recommended_context_tier = "64k-full"
+                retryable = True
+        except Exception:
+            recommended_context_tier = None
+        error = {
+            "code": "compute_node_context_window_exceeded",
+            "type": "validation_error",
+            "message": "Requested prompt and output reservation exceed the active context window",
+            "active_context_tier": active_context_tier,
+            "configured_context_tokens": configured_context_tokens,
+            "prompt_tokens": prompt_tokens,
+            "requested_output_tokens": requested_output_tokens,
+            "required_total_tokens": required_total,
+            "retryable": retryable,
+        }
+        if recommended_context_tier is not None:
+            error["recommended_context_tier"] = recommended_context_tier
+        return error
+
+    def _api_v1_authoritative_context_admission(
+        self,
+        *,
+        llm_instance: Any,
+        messages: List[Dict[str, Any]],
+        requested_output_tokens: int,
+        requested_context_tier: str,
+    ) -> Tuple[bool, Optional[Dict[str, Any]], Optional[int]]:
+        active_context_tier = normalize_context_tier(
+            getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)
+        )
+        active_profile = get_context_profile(active_context_tier)
+        configured_context_tokens = int(
+            getattr(
+                self.model_manager,
+                "context_window_tokens",
+                active_profile.total_context_tokens,
+            )
+            or active_profile.total_context_tokens
+        )
+        rendered_prompt = self._api_v1_render_chat_prompt(llm_instance, messages)
+        prompt_tokens = (
+            self._api_v1_tokenize_rendered_prompt(llm_instance, rendered_prompt)
+            if rendered_prompt is not None
+            else None
+        )
+        if prompt_tokens is None:
+            return True, None, None
+        required_total = prompt_tokens + requested_output_tokens
+        admitted = required_total <= configured_context_tokens
+        log_info(
+            "api_v1.context_admission active_tier={} prompt_tokens={} output_reservation={} result={} duration_ms=0 safe_error_code={}",
+            active_context_tier,
+            prompt_tokens,
+            requested_output_tokens,
+            "admitted" if admitted else "rejected",
+            "none" if admitted else "compute_node_context_window_exceeded",
+        )
+        if admitted:
+            return True, None, prompt_tokens
+        return (
+            False,
+            self._api_v1_context_admission_error(
+                active_context_tier=active_context_tier,
+                configured_context_tokens=configured_context_tokens,
+                prompt_tokens=prompt_tokens,
+                requested_output_tokens=requested_output_tokens,
+                requested_context_tier=requested_context_tier,
+            ),
+            prompt_tokens,
+        )
+
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -2292,12 +2512,26 @@ class RelayClient:
             recovery_completion
         )
         if not self._active_context_tier_can_satisfy(requested_context_tier):
+            active_context_tier = normalize_context_tier(
+                getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)
+            )
+            active_profile = get_context_profile(active_context_tier)
             return self._api_v1_response_envelope(
                 request_id,
-                error={
-                    "code": "compute_node_context_tier_unsupported",
-                    "message": "Requested context tier is not available in the desktop runtime",
-                },
+                error=self._api_v1_context_admission_error(
+                    active_context_tier=active_context_tier,
+                    configured_context_tokens=int(
+                        getattr(
+                            self.model_manager,
+                            "context_window_tokens",
+                            active_profile.total_context_tokens,
+                        )
+                        or active_profile.total_context_tokens
+                    ),
+                    prompt_tokens=0,
+                    requested_output_tokens=0,
+                    requested_context_tier=requested_context_tier,
+                ),
             )
 
         if not self._runtime_model_can_satisfy(model_id):
@@ -2353,24 +2587,34 @@ class RelayClient:
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
-            llm_instance = None
+            llm_instance = get_llm_instance() if callable(get_llm_instance) else None
+            if llm_instance is None and not callable(recovery_completion):
+                self._last_api_v1_runtime_health = {
+                    "runtime_healthy": False,
+                    "recovery_attempted": False,
+                    "recovery_succeeded": False,
+                }
+                log_error("Desktop runtime LLM initialization failed for API v1 relay request")
+                return self._api_v1_response_envelope(
+                    request_id,
+                    error={
+                        "code": "compute_node_internal_error",
+                        "message": "Desktop runtime inference failed",
+                    },
+                )
+
+            completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+            admitted, admission_error, prompt_tokens = self._api_v1_authoritative_context_admission(
+                llm_instance=llm_instance,
+                messages=runtime_messages,
+                requested_output_tokens=int(completion_kwargs["max_tokens"]),
+                requested_context_tier=requested_context_tier,
+            )
+            if not admitted:
+                return self._api_v1_response_envelope(request_id, error=admission_error)
+
             create_chat_completion = recovery_completion
-            if not callable(create_chat_completion) and has_direct_runtime_completion:
-                llm_instance = get_llm_instance()
-                if llm_instance is None:
-                    self._last_api_v1_runtime_health = {
-                        "runtime_healthy": False,
-                        "recovery_attempted": False,
-                        "recovery_succeeded": False,
-                    }
-                    log_error("Desktop runtime LLM initialization failed for API v1 relay request")
-                    return self._api_v1_response_envelope(
-                        request_id,
-                        error={
-                            "code": "compute_node_internal_error",
-                            "message": "Desktop runtime inference failed",
-                        },
-                    )
+            if not callable(create_chat_completion) and llm_instance is not None:
                 create_chat_completion = getattr(llm_instance, "create_chat_completion", None)
 
             if callable(create_chat_completion):
@@ -2385,10 +2629,18 @@ class RelayClient:
                     "/api/v1/relay/responses",
                     "direct_non_streaming_completion",
                 )
-                completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+                started = time.monotonic()
                 completion = create_chat_completion(
                     messages=runtime_messages,
                     **completion_kwargs,
+                )
+                inference_duration = time.monotonic() - started
+                log_info(
+                    "api_v1.inference_complete active_tier={} prompt_tokens={} output_reservation={} admission_result=admitted inference_duration_seconds={} safe_error_code=none",
+                    normalize_context_tier(getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)),
+                    prompt_tokens if prompt_tokens is not None else "unknown",
+                    completion_kwargs["max_tokens"],
+                    round(inference_duration, 3),
                 )
                 assistant_message = self._assistant_message_from_runtime_completion(
                     completion
@@ -2482,6 +2734,8 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if api_v1_request_payload is not None:
+                if getattr(self, "_api_v1_registered_relays", set()):
+                    self._api_v1_start_heartbeat_worker()
                 response_envelope = self._generate_api_v1_response_with_runtime_model(
                     request_id=api_v1_request_payload["request_id"],
                     model_id=api_v1_request_payload["model"],
@@ -2506,6 +2760,7 @@ class RelayClient:
                     client_pub_key_b64=client_pub_key_b64,
                     client_pub_key=client_pub_key,
                 )
+                self._api_v1_stop_heartbeat_worker()
                 return RelayProcessingResult(
                     inference_succeeded=safe_error_code is None and submitted,
                     submitted=submitted,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -665,7 +665,7 @@ class RelayClient:
         self._api_v1_heartbeat_lock = threading.Lock()
         self._api_v1_heartbeat_stop = threading.Event()
         self._api_v1_heartbeat_thread: Optional[threading.Thread] = None
-
+        self._api_v1_heartbeat_stopping = False
 
 
     def _api_v1_start_heartbeat_worker(self) -> None:
@@ -675,6 +675,8 @@ class RelayClient:
         if lock is None:
             return
         with lock:
+            if getattr(self, "_api_v1_heartbeat_stopping", False):
+                return
             thread = getattr(self, "_api_v1_heartbeat_thread", None)
             if thread is not None and thread.is_alive():
                 return
@@ -693,11 +695,13 @@ class RelayClient:
         stop_event = getattr(self, "_api_v1_heartbeat_stop", None)
         if stop_event is None:
             return
-        stop_event.set()
         lock = getattr(self, "_api_v1_heartbeat_lock", None)
         if lock is None:
+            stop_event.set()
             return
         with lock:
+            self._api_v1_heartbeat_stopping = True
+            stop_event.set()
             thread = getattr(self, "_api_v1_heartbeat_thread", None)
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():
             join_timeout = max(float(getattr(self, "_request_timeout", 10) or 10) + 1.0, 2.0)
@@ -707,6 +711,7 @@ class RelayClient:
                 thread is None or not thread.is_alive()
             ):
                 self._api_v1_heartbeat_thread = None
+            self._api_v1_heartbeat_stopping = False
 
     def _api_v1_heartbeat_worker(self) -> None:
         """Refresh relay leases independently from polling/inference work."""
@@ -2651,6 +2656,16 @@ class RelayClient:
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             llm_instance = get_llm_instance() if callable(get_llm_instance) else None
+            if llm_instance is None and callable(recovery_completion):
+                recover_runtime = getattr(
+                    self.model_manager, "get_llm_instance_with_recovery", None
+                )
+                if callable(recover_runtime):
+                    self._last_api_v1_runtime_health["recovery_attempted"] = True
+                    llm_instance = recover_runtime()
+                    self._last_api_v1_runtime_health["recovery_succeeded"] = (
+                        llm_instance is not None
+                    )
             if llm_instance is None and not callable(recovery_completion):
                 self._last_api_v1_runtime_health = {
                     "runtime_healthy": False,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -694,11 +694,18 @@ class RelayClient:
         if stop_event is None:
             return
         stop_event.set()
-        thread = getattr(self, "_api_v1_heartbeat_thread", None)
+        lock = getattr(self, "_api_v1_heartbeat_lock", None)
+        if lock is None:
+            return
+        with lock:
+            thread = getattr(self, "_api_v1_heartbeat_thread", None)
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():
             thread.join(timeout=2.0)
-        if thread is not None and not thread.is_alive():
-            self._api_v1_heartbeat_thread = None
+        with lock:
+            if getattr(self, "_api_v1_heartbeat_thread", None) is thread and (
+                thread is None or not thread.is_alive()
+            ):
+                self._api_v1_heartbeat_thread = None
 
     def _api_v1_heartbeat_worker(self) -> None:
         """Refresh relay leases independently from polling/inference work."""
@@ -706,7 +713,10 @@ class RelayClient:
         while not self._api_v1_heartbeat_stop.wait(0.25):
             if getattr(self, "_polling_stopped_by_request", False):
                 break
-            relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", {})
+            relay_wait_hints = getattr(self, "_api_v1_relay_wait_hints", None)
+            if not isinstance(relay_wait_hints, dict):
+                relay_wait_hints = {}
+                self._api_v1_relay_wait_hints = relay_wait_hints
             for candidate_url in list(getattr(self, "_api_v1_registered_relays", set())):
                 if self._api_v1_heartbeat_stop.is_set():
                     break
@@ -2313,9 +2323,12 @@ class RelayClient:
             tokens = tokenize(rendered_prompt.encode("utf-8"), add_bos=False)
         except TypeError:
             try:
-                tokens = tokenize(rendered_prompt.encode("utf-8"))
+                tokens = tokenize(rendered_prompt.encode("utf-8"), False)
             except TypeError:
-                tokens = tokenize(rendered_prompt)
+                try:
+                    tokens = tokenize(rendered_prompt.encode("utf-8"))
+                except TypeError:
+                    tokens = tokenize(rendered_prompt)
         if isinstance(tokens, (list, tuple)):
             return len(tokens)
         return None
@@ -2344,6 +2357,23 @@ class RelayClient:
                 if isinstance(rendered, str):
                     return rendered
         return None
+
+    def _api_v1_context_tier_unsupported_error(
+        self,
+        *,
+        active_context_tier: str,
+        configured_context_tokens: int,
+        requested_context_tier: str,
+    ) -> Dict[str, Any]:
+        return {
+            "code": "compute_node_context_tier_unsupported",
+            "type": "validation_error",
+            "message": "Requested context tier is not active on this compute node",
+            "active_context_tier": active_context_tier,
+            "requested_context_tier": requested_context_tier,
+            "configured_context_tokens": configured_context_tokens,
+            "retryable": False,
+        }
 
     def _api_v1_context_admission_error(
         self,
@@ -2411,6 +2441,11 @@ class RelayClient:
             else None
         )
         if prompt_tokens is None:
+            log_info(
+                "api_v1.context_admission_skipped active_tier={} reason={} safe_error_code=none",
+                active_context_tier,
+                "runtime_tokenizer_unavailable",
+            )
             return True, None, None
         required_total = prompt_tokens + requested_output_tokens
         admitted = required_total <= configured_context_tokens
@@ -2518,7 +2553,7 @@ class RelayClient:
             active_profile = get_context_profile(active_context_tier)
             return self._api_v1_response_envelope(
                 request_id,
-                error=self._api_v1_context_admission_error(
+                error=self._api_v1_context_tier_unsupported_error(
                     active_context_tier=active_context_tier,
                     configured_context_tokens=int(
                         getattr(
@@ -2528,8 +2563,6 @@ class RelayClient:
                         )
                         or active_profile.total_context_tokens
                     ),
-                    prompt_tokens=0,
-                    requested_output_tokens=0,
                     requested_context_tier=requested_context_tier,
                 ),
             )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2330,23 +2330,22 @@ class RelayClient:
         tokenize = getattr(llm_instance, "tokenize", None)
         if not callable(tokenize) or not isinstance(rendered_prompt, str):
             return None
-        try:
-            tokens = tokenize(rendered_prompt.encode("utf-8"), add_bos=False)
-        except TypeError:
+        attempts = (
+            lambda: tokenize(rendered_prompt.encode("utf-8"), add_bos=False),
+            lambda: tokenize(rendered_prompt.encode("utf-8"), False),
+            lambda: tokenize(rendered_prompt.encode("utf-8")),
+            lambda: tokenize(rendered_prompt),
+        )
+        for tokenize_attempt in attempts:
             try:
-                tokens = tokenize(rendered_prompt.encode("utf-8"), False)
+                tokens = tokenize_attempt()
             except TypeError:
-                try:
-                    tokens = tokenize(rendered_prompt.encode("utf-8"))
-                except TypeError:
-                    try:
-                        tokens = tokenize(rendered_prompt)
-                    except Exception:
-                        return None
-        except Exception:
+                continue
+            except Exception:
+                return None
+            if isinstance(tokens, (list, tuple)):
+                return len(tokens)
             return None
-        if isinstance(tokens, (list, tuple)):
-            return len(tokens)
         return None
 
     @staticmethod

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2368,6 +2368,11 @@ class RelayClient:
             if isinstance(rendered, str):
                 return rendered
         tokenizer = getattr(llm_instance, "tokenizer", None)
+        if callable(tokenizer):
+            try:
+                tokenizer = tokenizer()
+            except Exception:
+                tokenizer = None
         if tokenizer is not None:
             tokenizer_template = getattr(tokenizer, "apply_chat_template", None)
             if callable(tokenizer_template):
@@ -2379,6 +2384,25 @@ class RelayClient:
                     rendered = None
                 if isinstance(rendered, str):
                     return rendered
+        try:
+            if not hasattr(llm_instance, "chat_format"):
+                return None
+            chat_format = getattr(llm_instance, "chat_format", None) or "llama-2"
+            chat_format_module = importlib.import_module("llama_cpp.llama_chat_format")
+            formatter_key = str(chat_format).replace("-", "_")
+            formatter_name = (
+                "format_llama2" if formatter_key == "llama_2" else "format_" + formatter_key
+            )
+            formatter = getattr(chat_format_module, formatter_name, None)
+            if callable(formatter):
+                rendered = formatter(
+                    messages, tokenize=False, add_generation_prompt=True
+                )
+                prompt = getattr(rendered, "prompt", rendered)
+                if isinstance(prompt, str):
+                    return prompt
+        except Exception:
+            return None
         return None
 
     def _api_v1_context_tier_unsupported_error(

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -11,6 +11,7 @@ import math
 import os
 import hashlib
 import re
+import sys
 import threading
 import time
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
@@ -2388,11 +2389,13 @@ class RelayClient:
             if not hasattr(llm_instance, "chat_format"):
                 return None
             chat_format = getattr(llm_instance, "chat_format", None) or "llama-2"
-            chat_format_module = importlib.import_module("llama_cpp.llama_chat_format")
+            chat_format_module = RelayClient._api_v1_llama_chat_format_module()
             formatter_key = str(chat_format).replace("-", "_")
             formatter_name = (
                 "format_llama2" if formatter_key == "llama_2" else "format_" + formatter_key
             )
+            if formatter_name == "format_llama_3":
+                formatter_name = "format_llama3"
             formatter = getattr(chat_format_module, formatter_name, None)
             if callable(formatter):
                 rendered = formatter(
@@ -2404,6 +2407,32 @@ class RelayClient:
         except Exception:
             return None
         return None
+
+    @staticmethod
+    def _api_v1_llama_chat_format_module() -> Any:
+        """Import llama.cpp chat formatting without the repo-local llama_cpp stub."""
+
+        repo_root = os.path.abspath(os.getcwd())
+        original_path = list(sys.path)
+        original_parent_module = sys.modules.get("llama_cpp")
+        parent_module_path = os.path.abspath(
+            str(getattr(original_parent_module, "__file__", ""))
+        )
+        try:
+            if (
+                original_parent_module is not None
+                and parent_module_path == os.path.join(repo_root, "llama_cpp.py")
+            ):
+                sys.modules.pop("llama_cpp", None)
+            sys.path = [
+                entry for entry in sys.path
+                if entry and os.path.abspath(entry) != repo_root
+            ]
+            return importlib.import_module("llama_cpp.llama_chat_format")
+        finally:
+            sys.path = original_path
+            if original_parent_module is not None:
+                sys.modules["llama_cpp"] = original_parent_module
 
     def _api_v1_context_tier_unsupported_error(
         self,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -700,7 +700,8 @@ class RelayClient:
         with lock:
             thread = getattr(self, "_api_v1_heartbeat_thread", None)
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():
-            thread.join(timeout=2.0)
+            join_timeout = max(float(getattr(self, "_request_timeout", 10) or 10) + 1.0, 2.0)
+            thread.join(timeout=join_timeout)
         with lock:
             if getattr(self, "_api_v1_heartbeat_thread", None) is thread and (
                 thread is None or not thread.is_alive()
@@ -731,7 +732,11 @@ class RelayClient:
                 try:
                     response = self.register_api_v1_compute_node(candidate_url)
                 except Exception as exc:
-                    log_error("server.heartbeat.background_failed relay={} error={}", candidate_url, str(exc))
+                    log_error(
+                        "server.heartbeat.background_failed relay={} error={}",
+                        _sanitize_relay_target(candidate_url),
+                        str(exc),
+                    )
                     continue
                 if isinstance(response, dict) and not response.get("error"):
                     refreshed_lease = self._normalise_positive_seconds(
@@ -748,7 +753,7 @@ class RelayClient:
                     self._api_v1_last_heartbeat_at[candidate_url] = time.monotonic()
                     log_info(
                         "server.heartbeat.background relay={} lease_seconds={} key_fingerprint={}",
-                        candidate_url,
+                        _sanitize_relay_target(candidate_url),
                         refreshed_lease,
                         self._api_v1_public_key_fingerprint(self.crypto_manager.public_key_b64),
                     )
@@ -2375,6 +2380,26 @@ class RelayClient:
             "retryable": False,
         }
 
+    def _api_v1_context_admission_unavailable_error(
+        self,
+        *,
+        active_context_tier: str,
+        configured_context_tokens: int,
+        requested_context_tier: str,
+    ) -> Dict[str, Any]:
+        return {
+            "code": "compute_node_context_admission_unavailable",
+            "type": "validation_error",
+            "message": (
+                "Compute node cannot authoritatively render and tokenize the "
+                "API v1 prompt for context admission"
+            ),
+            "active_context_tier": active_context_tier,
+            "requested_context_tier": requested_context_tier,
+            "configured_context_tokens": configured_context_tokens,
+            "retryable": False,
+        }
+
     def _api_v1_context_admission_error(
         self,
         *,
@@ -2441,14 +2466,26 @@ class RelayClient:
             else None
         )
         if prompt_tokens is None:
-            log_info(
-                "api_v1.context_admission_skipped active_tier={} reason={} safe_error_code=none",
+            log_error(
+                "api_v1.context_admission active_tier={} result=rejected reason={} safe_error_code={}",
                 active_context_tier,
                 "runtime_tokenizer_unavailable",
+                "compute_node_context_admission_unavailable",
             )
-            return True, None, None
+            return (
+                False,
+                self._api_v1_context_admission_unavailable_error(
+                    active_context_tier=active_context_tier,
+                    configured_context_tokens=configured_context_tokens,
+                    requested_context_tier=requested_context_tier,
+                ),
+                None,
+            )
         required_total = prompt_tokens + requested_output_tokens
-        admitted = required_total <= configured_context_tokens
+        admitted = (
+            self._active_context_tier_can_satisfy(requested_context_tier)
+            and required_total <= configured_context_tokens
+        )
         log_info(
             "api_v1.context_admission active_tier={} prompt_tokens={} output_reservation={} result={} duration_ms=0 safe_error_code={}",
             active_context_tier,
@@ -2546,27 +2583,6 @@ class RelayClient:
         has_direct_runtime_completion = callable(get_llm_instance) or callable(
             recovery_completion
         )
-        if not self._active_context_tier_can_satisfy(requested_context_tier):
-            active_context_tier = normalize_context_tier(
-                getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)
-            )
-            active_profile = get_context_profile(active_context_tier)
-            return self._api_v1_response_envelope(
-                request_id,
-                error=self._api_v1_context_tier_unsupported_error(
-                    active_context_tier=active_context_tier,
-                    configured_context_tokens=int(
-                        getattr(
-                            self.model_manager,
-                            "context_window_tokens",
-                            active_profile.total_context_tokens,
-                        )
-                        or active_profile.total_context_tokens
-                    ),
-                    requested_context_tier=requested_context_tier,
-                ),
-            )
-
         if not self._runtime_model_can_satisfy(model_id):
             return self._api_v1_response_envelope(
                 request_id,
@@ -2767,41 +2783,43 @@ class RelayClient:
                 client_pub_key_b64,
             )
             if api_v1_request_payload is not None:
-                if getattr(self, "_api_v1_registered_relays", set()):
-                    self._api_v1_start_heartbeat_worker()
-                response_envelope = self._generate_api_v1_response_with_runtime_model(
-                    request_id=api_v1_request_payload["request_id"],
-                    model_id=api_v1_request_payload["model"],
-                    messages=api_v1_request_payload["messages"],
-                    options=dict(api_v1_request_payload["options"]),
-                    requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
-                )
-                api_v1_response = response_envelope.get("api_v1_response", {})
-                error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None
-                safe_error_code = error.get("code") if isinstance(error, dict) else None
-                runtime_health = getattr(self, "_last_api_v1_runtime_health", {})
-                runtime_healthy = bool(runtime_health.get("runtime_healthy", True))
-                recovery_attempted = bool(runtime_health.get("recovery_attempted", False))
-                recovery_succeeded = bool(runtime_health.get("recovery_succeeded", False))
-                if safe_error_code not in {
-                    "compute_node_internal_error",
-                    "compute_node_process_failed",
-                }:
-                    runtime_healthy = True
-                submitted = self._post_api_v1_response(
-                    response_envelope,
-                    client_pub_key_b64=client_pub_key_b64,
-                    client_pub_key=client_pub_key,
-                )
-                self._api_v1_stop_heartbeat_worker()
-                return RelayProcessingResult(
-                    inference_succeeded=safe_error_code is None and submitted,
-                    submitted=submitted,
-                    safe_error_code=safe_error_code,
-                    runtime_healthy=runtime_healthy,
-                    recovery_attempted=recovery_attempted,
-                    recovery_succeeded=recovery_succeeded,
-                )
+                try:
+                    if getattr(self, "_api_v1_registered_relays", set()):
+                        self._api_v1_start_heartbeat_worker()
+                    response_envelope = self._generate_api_v1_response_with_runtime_model(
+                        request_id=api_v1_request_payload["request_id"],
+                        model_id=api_v1_request_payload["model"],
+                        messages=api_v1_request_payload["messages"],
+                        options=dict(api_v1_request_payload["options"]),
+                        requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
+                    )
+                    api_v1_response = response_envelope.get("api_v1_response", {})
+                    error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None
+                    safe_error_code = error.get("code") if isinstance(error, dict) else None
+                    runtime_health = getattr(self, "_last_api_v1_runtime_health", {})
+                    runtime_healthy = bool(runtime_health.get("runtime_healthy", True))
+                    recovery_attempted = bool(runtime_health.get("recovery_attempted", False))
+                    recovery_succeeded = bool(runtime_health.get("recovery_succeeded", False))
+                    if safe_error_code not in {
+                        "compute_node_internal_error",
+                        "compute_node_process_failed",
+                    }:
+                        runtime_healthy = True
+                    submitted = self._post_api_v1_response(
+                        response_envelope,
+                        client_pub_key_b64=client_pub_key_b64,
+                        client_pub_key=client_pub_key,
+                    )
+                    return RelayProcessingResult(
+                        inference_succeeded=safe_error_code is None and submitted,
+                        submitted=submitted,
+                        safe_error_code=safe_error_code,
+                        runtime_healthy=runtime_healthy,
+                        recovery_attempted=recovery_attempted,
+                        recovery_succeeded=recovery_succeeded,
+                    )
+                finally:
+                    self._api_v1_stop_heartbeat_worker()
 
             chat_history = _extract_chat_history_and_validate_key_binding(
                 decrypted_chat_history,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2338,7 +2338,12 @@ class RelayClient:
                 try:
                     tokens = tokenize(rendered_prompt.encode("utf-8"))
                 except TypeError:
-                    tokens = tokenize(rendered_prompt)
+                    try:
+                        tokens = tokenize(rendered_prompt)
+                    except Exception:
+                        return None
+        except Exception:
+            return None
         if isinstance(tokens, (list, tuple)):
             return len(tokens)
         return None
@@ -2354,16 +2359,24 @@ class RelayClient:
                     messages, tokenize=False, add_generation_prompt=True
                 )
             except TypeError:
-                rendered = apply_chat_template(messages)
+                try:
+                    rendered = apply_chat_template(messages)
+                except Exception:
+                    rendered = None
+            except Exception:
+                rendered = None
             if isinstance(rendered, str):
                 return rendered
         tokenizer = getattr(llm_instance, "tokenizer", None)
         if tokenizer is not None:
             tokenizer_template = getattr(tokenizer, "apply_chat_template", None)
             if callable(tokenizer_template):
-                rendered = tokenizer_template(
-                    messages, tokenize=False, add_generation_prompt=True
-                )
+                try:
+                    rendered = tokenizer_template(
+                        messages, tokenize=False, add_generation_prompt=True
+                    )
+                except Exception:
+                    rendered = None
                 if isinstance(rendered, str):
                     return rendered
         return None

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2369,6 +2369,8 @@ class RelayClient:
         active_context_tier: str,
         configured_context_tokens: int,
         requested_context_tier: str,
+        prompt_tokens: int,
+        requested_output_tokens: int,
     ) -> Dict[str, Any]:
         return {
             "code": "compute_node_context_tier_unsupported",
@@ -2377,6 +2379,9 @@ class RelayClient:
             "active_context_tier": active_context_tier,
             "requested_context_tier": requested_context_tier,
             "configured_context_tokens": configured_context_tokens,
+            "prompt_tokens": prompt_tokens,
+            "requested_output_tokens": requested_output_tokens,
+            "required_total_tokens": prompt_tokens + requested_output_tokens,
             "retryable": False,
         }
 
@@ -2482,31 +2487,40 @@ class RelayClient:
                 None,
             )
         required_total = prompt_tokens + requested_output_tokens
-        admitted = (
-            self._active_context_tier_can_satisfy(requested_context_tier)
-            and required_total <= configured_context_tokens
-        )
+        tier_supported = self._active_context_tier_can_satisfy(requested_context_tier)
+        admitted = tier_supported and required_total <= configured_context_tokens
+        if admitted:
+            safe_error_code = "none"
+            admission_error = None
+        elif not tier_supported and required_total <= configured_context_tokens:
+            safe_error_code = "compute_node_context_tier_unsupported"
+            admission_error = self._api_v1_context_tier_unsupported_error(
+                active_context_tier=active_context_tier,
+                configured_context_tokens=configured_context_tokens,
+                requested_context_tier=requested_context_tier,
+                prompt_tokens=prompt_tokens,
+                requested_output_tokens=requested_output_tokens,
+            )
+        else:
+            safe_error_code = "compute_node_context_window_exceeded"
+            admission_error = self._api_v1_context_admission_error(
+                active_context_tier=active_context_tier,
+                configured_context_tokens=configured_context_tokens,
+                prompt_tokens=prompt_tokens,
+                requested_output_tokens=requested_output_tokens,
+                requested_context_tier=requested_context_tier,
+            )
         log_info(
             "api_v1.context_admission active_tier={} prompt_tokens={} output_reservation={} result={} duration_ms=0 safe_error_code={}",
             active_context_tier,
             prompt_tokens,
             requested_output_tokens,
             "admitted" if admitted else "rejected",
-            "none" if admitted else "compute_node_context_window_exceeded",
+            safe_error_code,
         )
         if admitted:
             return True, None, prompt_tokens
-        return (
-            False,
-            self._api_v1_context_admission_error(
-                active_context_tier=active_context_tier,
-                configured_context_tokens=configured_context_tokens,
-                prompt_tokens=prompt_tokens,
-                requested_output_tokens=requested_output_tokens,
-                requested_context_tier=requested_context_tier,
-            ),
-            prompt_tokens,
-        )
+        return False, admission_error, prompt_tokens
 
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]


### PR DESCRIPTION
### Motivation
- Enforce authoritative, compute-side context-window admission using the actual runtime tokenizer/template so nodes can reject requests that truly won't fit their active profile. 
- Keep long-running 64K inferences from causing healthy compute nodes to drop from the relay by refreshing leases independently while inference runs.

### Description
- Added authoritative context admission that renders the chat prompt with the active runtime template and tokenizes it with the runtime tokenizer, then validates `prompt_tokens + requested_output_tokens <= configured_context_tokens` before inference. 
- Introduced structured encrypted validation error `compute_node_context_window_exceeded` containing active tier, configured tokens, prompt tokens, requested output tokens, required total tokens, retryable flag, and a `recommended_context_tier` when appropriate. 
- Added a small dedicated API v1 heartbeat worker that refreshes existing relay registrations during long inferences and stops cleanly on response submission, stop, or unregister while avoiding duplicate threads and races. 
- Updated the API v1 relay client to start the heartbeat when processing E2EE API v1 work from already-registered relays and to stop it after posting the encrypted response, and added focused unit tests that exercise admission boundaries, explicit/default output budgets, template overhead, Unicode structured content, request-scoped overflow, 8K-on-64K and 64K-on-8K cases, encrypted overflow responses, and heartbeat lifecycle.

### Testing
- Ran focused unit and integration suites: `pytest tests/unit/test_model_manager.py -q` (passed), `pytest tests/unit/test_relay_client.py -q` (passed), `pytest tests/unit/test_desktop_compute_node_bridge.py -q` (passed), and `pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed). 
- Ran repository checks `pre-commit run --all-files` (passed) and `git diff --check` (no issues). 
- Added/updated unit tests in `tests/unit/test_relay_client.py` to validate admission behavior and heartbeat lifecycle, all included tests passed in the runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b6b35b87c832fb6f2f2ec21ceeb2f)