### PR TITLE
Make macOS DMG validation resilient to transient hdiutil attach failures

### DIFF
--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import plistlib
 import subprocess
 import tempfile
@@ -24,6 +25,13 @@ DMG_PREVIEW_REQUIRED_PHRASES = (
 DMG_PREVIEW_SIGNING_PHRASE_OPTIONS = (
     "ad-hoc signed",
     "signed with the configured Apple signing identity",
+)
+DMG_ATTACH_TRANSIENT_MESSAGES = (
+    "Resource temporarily unavailable",
+    "Resource busy",
+    "busy",
+    "already attached",
+    "already mounted",
 )
 
 
@@ -74,6 +82,140 @@ def _run_with_retries(
     _fail(_format_command_failure(cmd, last_result))
 
 
+def _is_transient_attach_error(output: str) -> bool:
+    lower_output = output.lower()
+    return any(message.lower() in lower_output for message in DMG_ATTACH_TRANSIENT_MESSAGES)
+
+
+def _hdiutil_info_snapshot() -> str:
+    result = subprocess.run(["hdiutil", "info"], check=False, capture_output=True, text=True)
+    output = f"{result.stdout}\n{result.stderr}".strip()
+    if result.returncode != 0:
+        return f"hdiutil info failed with exit {result.returncode}:\n{output}"
+    return output
+
+
+def _redact_hdiutil_info(info: str) -> str:
+    # Keep diagnostics useful while avoiding runner-local usernames or temp directory details.
+    redacted = re.sub(r"/Users/[^/\s]+", "/Users/<redacted>", info)
+    redacted = re.sub(r"/private/var/folders/[^\s]+", "/private/var/folders/<redacted>", redacted)
+    return redacted
+
+
+def _matching_hdiutil_devices(info: str, dmg_path: Path) -> list[str]:
+    devices: list[str] = []
+    current_device: str | None = None
+    dmg_names = {str(dmg_path), str(dmg_path.resolve()), dmg_path.name}
+    for line in info.splitlines():
+        device_match = re.match(r"^(/dev/disk\S+)", line.strip())
+        if device_match:
+            current_device = device_match.group(1)
+        if current_device and any(name in line for name in dmg_names):
+            devices.append(current_device)
+    return sorted(set(devices))
+
+
+def _cleanup_dmg_attach_state(dmg_path: Path, mountpoint: Path) -> str:
+    diagnostics: list[str] = []
+    if mountpoint.exists():
+        result = subprocess.run(
+            ["hdiutil", "detach", str(mountpoint)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            diagnostics.append(_format_command_failure(["hdiutil", "detach", str(mountpoint)], result))
+
+    info = _hdiutil_info_snapshot()
+    for device in _matching_hdiutil_devices(info, dmg_path):
+        result = subprocess.run(["hdiutil", "detach", device], check=False, capture_output=True, text=True)
+        if result.returncode != 0:
+            diagnostics.append(_format_command_failure(["hdiutil", "detach", device], result))
+
+    return "\n".join(diagnostics)
+
+
+def _inspect_mounted_dmg(root: Path, *, expect_signing: bool) -> None:
+    apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == ".app")
+    if len(apps) != 1:
+        _fail(f"DMG must contain exactly one .app at root; found {len(apps)}")
+    readme_path = next((root / name for name in DMG_PREVIEW_README_NAMES if (root / name).is_file()), None)
+    if readme_path is None:
+        _fail(f"DMG must include one preview README at root: {DMG_PREVIEW_README_NAMES}")
+    readme_text = readme_path.read_text(encoding="utf-8")
+    missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
+    if missing:
+        _fail(f"DMG preview README missing required phrases: {missing}")
+    if expect_signing:
+        if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
+            _fail(
+                "DMG preview README must describe configured Apple signing identity when --expect-signing is set"
+            )
+    elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
+        _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
+
+
+def _attach_and_validate_dmg_with_retries(
+    dmg_path: Path,
+    *,
+    expect_signing: bool,
+    attempts: int = 8,
+    delay_seconds: float = 2.0,
+    max_delay_seconds: float = 15.0,
+) -> None:
+    last_result: subprocess.CompletedProcess[str] | None = None
+    mountpoints: list[str] = []
+    cleanup_messages: list[str] = []
+    for attempt in range(1, attempts + 1):
+        with tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-") as mount_dir:
+            mountpoint = Path(mount_dir)
+            mountpoints.append(str(mountpoint))
+            cleanup_output = _cleanup_dmg_attach_state(dmg_path, mountpoint)
+            if cleanup_output:
+                cleanup_messages.append(cleanup_output)
+
+            cmd = ["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", str(mountpoint), str(dmg_path)]
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            last_result = result
+            if result.returncode == 0:
+                try:
+                    _inspect_mounted_dmg(mountpoint, expect_signing=expect_signing)
+                    return
+                finally:
+                    _run(["hdiutil", "detach", str(mountpoint)])
+
+            combined_output = f"{result.stdout}\n{result.stderr}"
+            if attempt >= attempts or not _is_transient_attach_error(combined_output):
+                break
+
+            retry_delay = min(delay_seconds * (2 ** (attempt - 1)), max_delay_seconds)
+            print(
+                f"::warning::hdiutil attach failed for {dmg_path} at {mountpoint} with a transient "
+                f"disk image error; retrying attempt {attempt + 1}/{attempts} after {retry_delay:g}s.\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+            cleanup_output = _cleanup_dmg_attach_state(dmg_path, mountpoint)
+            if cleanup_output:
+                cleanup_messages.append(cleanup_output)
+            time.sleep(retry_delay)
+
+    if last_result is None:
+        _fail(f"hdiutil attach failed for {dmg_path}: no attempts were run")
+
+    info = _redact_hdiutil_info(_hdiutil_info_snapshot())
+    _fail(
+        "DMG attach failed during macOS artifact validation.\n"
+        f"DMG path: {dmg_path}\n"
+        f"Mountpoints attempted: {mountpoints}\n"
+        f"Attach attempts: {attempts}\n"
+        f"Last stdout:\n{last_result.stdout}\n"
+        f"Last stderr:\n{last_result.stderr}\n"
+        f"Cleanup diagnostics:\n{chr(10).join(cleanup_messages) if cleanup_messages else '<none>'}\n"
+        f"Redacted hdiutil info:\n{info}"
+    )
+
+
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -93,33 +235,7 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
-    with tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-") as mount_dir:
-        _run_with_retries(
-            ["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", mount_dir, str(dmg_path)],
-            attempts=8,
-            retry_messages=("Resource temporarily unavailable", "Resource busy"),
-        )
-        try:
-            root = Path(mount_dir)
-            apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == ".app")
-            if len(apps) != 1:
-                _fail(f"DMG must contain exactly one .app at root; found {len(apps)}")
-            readme_path = next((root / name for name in DMG_PREVIEW_README_NAMES if (root / name).is_file()), None)
-            if readme_path is None:
-                _fail(f"DMG must include one preview README at root: {DMG_PREVIEW_README_NAMES}")
-            readme_text = readme_path.read_text(encoding="utf-8")
-            missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
-            if missing:
-                _fail(f"DMG preview README missing required phrases: {missing}")
-            if expect_signing:
-                if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
-                    _fail(
-                        "DMG preview README must describe configured Apple signing identity when --expect-signing is set"
-                    )
-            elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
-                _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
-        finally:
-            _run(["hdiutil", "detach", mount_dir])
+    _attach_and_validate_dmg_with_retries(dmg_path, expect_signing=expect_signing)
 
 
 def main() -> None:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -243,59 +243,116 @@ def test_validator_rejects_zero_retry_attempts(monkeypatch) -> None:
 
 def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()
-    mount_dir = tmp_path / 'mounted-dmg'
-    mount_dir.mkdir()
-    (mount_dir / 'token.place desktop.app').mkdir()
-    readme = mount_dir / 'README BEFORE OPENING.txt'
-    readme.write_text(
-        '\n'.join(
-            [
-                'This preview build is ad-hoc signed and not notarized.',
-                'Apple could not verify token.place desktop is free of malware.',
-                'Open System Settings -> Privacy & Security.',
-                'Developer ID signing + notarization is required for public trust.',
-            ]
-        ),
-        encoding='utf-8',
-    )
     dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
     dmg_path.write_bytes(b'dmg')
+    attach_calls = []
+
+    def fake_attach_and_validate(path, *, expect_signing):
+        attach_calls.append((path, expect_signing))
+
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_attach_and_validate_dmg_with_retries', fake_attach_and_validate)
+
+    validator._validate_dmg_contents(dmg_path, expect_signing=False)
+
+    assert attach_calls == [(dmg_path, False)]
+
+
+def test_validator_attach_retry_uses_fresh_mountpoints_and_cleans_up(monkeypatch, tmp_path) -> None:
+    import subprocess
+
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    dmg_path.write_bytes(b'dmg')
+    mount_dirs = []
+    cleanup_calls = []
     attach_calls = []
     detach_calls = []
 
     class FakeTemporaryDirectory:
         def __init__(self, *, prefix):
             assert prefix == 'token-place-dmg-mount-'
+            self.path = tmp_path / f'mount-{len(mount_dirs)}'
 
         def __enter__(self):
-            return str(mount_dir)
+            self.path.mkdir()
+            mount_dirs.append(self.path)
+            return str(self.path)
 
         def __exit__(self, *args):
             return False
 
-    def fake_run_with_retries(cmd, *, attempts, retry_messages):
-        attach_calls.append((cmd, attempts, retry_messages))
-        return '/dev/disk4'
-
-    def fake_run(cmd):
-        detach_calls.append(cmd)
+    def fake_cleanup(path, mountpoint):
+        cleanup_calls.append((path, mountpoint))
         return ''
 
-    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    def fake_run(cmd, *, check=False, capture_output=True, text=True):
+        if cmd[:2] == ['hdiutil', 'attach']:
+            attach_calls.append(cmd)
+            if len(attach_calls) < 3:
+                return subprocess.CompletedProcess(cmd, 1, '', 'hdiutil: attach failed - Resource temporarily unavailable')
+            (mount_dirs[-1] / 'token.place desktop.app').mkdir()
+            (mount_dirs[-1] / 'README BEFORE OPENING.txt').write_text(
+                '\n'.join(
+                    [
+                        'This preview build is ad-hoc signed and not notarized.',
+                        'Apple could not verify token.place desktop is free of malware.',
+                        'Open System Settings -> Privacy & Security.',
+                        'Developer ID signing + notarization is required for public trust.',
+                    ]
+                ),
+                encoding='utf-8',
+            )
+            return subprocess.CompletedProcess(cmd, 0, '/dev/disk4', '')
+        if cmd[:2] == ['hdiutil', 'detach']:
+            detach_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, '', '')
+        raise AssertionError(f'unexpected command: {cmd}')
+
     monkeypatch.setattr(validator.tempfile, 'TemporaryDirectory', FakeTemporaryDirectory)
-    monkeypatch.setattr(validator, '_run_with_retries', fake_run_with_retries)
-    monkeypatch.setattr(validator, '_run', fake_run)
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup)
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    monkeypatch.setattr(validator.time, 'sleep', lambda _delay: None)
 
-    validator._validate_dmg_contents(dmg_path, expect_signing=False)
+    validator._attach_and_validate_dmg_with_retries(dmg_path, expect_signing=False, delay_seconds=0.01)
 
-    assert attach_calls == [
-        (
-            ['hdiutil', 'attach', '-nobrowse', '-readonly', '-mountpoint', str(mount_dir), str(dmg_path)],
-            8,
-            ('Resource temporarily unavailable', 'Resource busy'),
-        )
+    assert [cmd[5] for cmd in attach_calls] == [str(path) for path in mount_dirs]
+    assert len(set(cmd[5] for cmd in attach_calls)) == 3
+    assert cleanup_calls == [
+        (dmg_path, mount_dirs[0]),
+        (dmg_path, mount_dirs[0]),
+        (dmg_path, mount_dirs[1]),
+        (dmg_path, mount_dirs[1]),
+        (dmg_path, mount_dirs[2]),
     ]
-    assert detach_calls == [['hdiutil', 'detach', str(mount_dir)]]
+    assert detach_calls == [['hdiutil', 'detach', str(mount_dirs[2])]]
+
+
+def test_validator_attach_retry_stops_on_non_transient_attach_error(monkeypatch, tmp_path) -> None:
+    import subprocess
+
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    dmg_path.write_bytes(b'dmg')
+    attach_calls = []
+
+    def fake_run(cmd, *, check=False, capture_output=True, text=True):
+        attach_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 1, 'mount failed', 'permission denied')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda _path, _mountpoint: '')
+    monkeypatch.setattr(validator, '_hdiutil_info_snapshot', lambda: 'no images')
+
+    try:
+        validator._attach_and_validate_dmg_with_retries(dmg_path, expect_signing=False, delay_seconds=0.01)
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('expected non-transient attach failure to exit')
+
+    assert len(attach_calls) == 1
+    assert 'permission denied' in message
 
 
 def test_validator_run_formats_command_failures(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- The macOS DMG validation step could fail on GitHub macOS runners when `hdiutil attach` hits transient races (e.g. `Resource temporarily unavailable`), causing otherwise-correct builds to abort.
- Improve reliability of the validator without weakening any mounted-content checks or removing the `hdiutil` attach validation.

### Description
- Replaced the single-attach path with a DMG-specific attach-and-validate helper `_attach_and_validate_dmg_with_retries` that uses a fresh temporary mountpoint per attempt and bounded exponential backoff on known transient attach errors.
- Added best-effort cleanup before retries via `_cleanup_dmg_attach_state` which detaches by mountpoint and attempts to detach matching devices reported by `hdiutil info`, and redacts sensitive local paths in diagnostics via `_redact_hdiutil_info`.
- Kept strict content validation by factoring checks into `_inspect_mounted_dmg` and always detaching in a `finally` path after a successful attach.
- Improved diagnostics on final failure to include the attempted DMG path, attempted mountpoints, last attach stdout/stderr, cleanup diagnostics, and a redacted `hdiutil info` snapshot; limited retrying to known transient messages only.
- Added focused unit tests covering: transient attach retry behavior, fresh mountpoint usage and cleanup across retries, and stopping on non-transient errors; touched files: `scripts/validate_desktop_tauri_release_artifacts.py` and `tests/unit/test_desktop_release_artifacts.py`.

### Testing
- Ran focused unit tests: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` — PASSED (all tests in that file passed).
- Ran full unit suite: `python -m pytest tests/unit -q` — PASSED (1719 passed, 1 skipped in this environment).
- Checked script help: `python scripts/validate_desktop_tauri_release_artifacts.py --help` — printed usage successfully.
- Ran repository checks: `pre-commit run --all-files` — PASSED.

Notes and residual risk: the CI environment here is Linux so `hdiutil` cannot be exercised end-to-end; unit tests mock and assert the retry/cleanup logic but I recommend monitoring the next macOS workflow run and, if failures persist, collecting the new final-failure diagnostics (redacted `hdiutil info` snapshot included by the script) to iterate further.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c3cd4a54c832f90bfef3f6b94e536)