### PR TITLE
Fix macOS DMG artifact validation retries

### DIFF
--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import plistlib
+import shutil
 import subprocess
 import tempfile
 import time
@@ -24,6 +25,13 @@ DMG_PREVIEW_REQUIRED_PHRASES = (
 DMG_PREVIEW_SIGNING_PHRASE_OPTIONS = (
     "ad-hoc signed",
     "signed with the configured Apple signing identity",
+)
+DMG_ATTACH_TRANSIENT_MESSAGES = (
+    "Resource temporarily unavailable",
+    "Resource busy",
+    "busy",
+    "already attached",
+    "already mounted",
 )
 
 
@@ -74,6 +82,95 @@ def _run_with_retries(
     _fail(_format_command_failure(cmd, last_result))
 
 
+def _is_transient_hdiutil_attach_error(output: str) -> bool:
+    output_lower = output.lower()
+    return any(message.lower() in output_lower for message in DMG_ATTACH_TRANSIENT_MESSAGES)
+
+
+def _hdiutil_info_snapshot() -> str:
+    result = subprocess.run(["hdiutil", "info"], check=False, capture_output=True, text=True)
+    snapshot = f"{result.stdout}\n{result.stderr}".strip()
+    if result.returncode != 0:
+        return f"hdiutil info failed with exit {result.returncode}:\n{snapshot}"
+    return snapshot
+
+
+def _matching_hdiutil_devices(dmg_path: Path) -> list[str]:
+    result = subprocess.run(["hdiutil", "info"], check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        return []
+
+    devices: list[str] = []
+    current_device: str | None = None
+    dmg_resolved = str(dmg_path.resolve())
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith("/dev/disk"):
+            current_device = line.split()[0]
+            continue
+        if current_device and dmg_resolved in line:
+            devices.append(current_device)
+            current_device = None
+    return devices
+
+
+def _detach_hdiutil_target(target: str) -> None:
+    result = subprocess.run(["hdiutil", "detach", target], check=False, capture_output=True, text=True)
+    if result.returncode == 0:
+        return
+    # A failed detach during retry cleanup should not hide the original attach
+    # error, but logging it makes runner races easier to diagnose.
+    combined = f"{result.stdout}\n{result.stderr}".strip()
+    print(f"::warning::Best-effort hdiutil detach failed for {target}:\n{combined}")
+
+
+def _cleanup_dmg_mount_attempt(dmg_path: Path, mount_dir: Path) -> None:
+    _detach_hdiutil_target(str(mount_dir))
+    for device in _matching_hdiutil_devices(dmg_path):
+        _detach_hdiutil_target(device)
+    shutil.rmtree(mount_dir, ignore_errors=True)
+
+
+def _attach_dmg_with_retries(dmg_path: Path, *, attempts: int = 8) -> Path:
+    last_result: subprocess.CompletedProcess[str] | None = None
+    attempted_mountpoints: list[str] = []
+
+    for attempt in range(1, attempts + 1):
+        mount_dir = Path(tempfile.mkdtemp(prefix=f"token-place-dmg-mount-{attempt}-"))
+        attempted_mountpoints.append(str(mount_dir))
+        cmd = ["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", str(mount_dir), str(dmg_path)]
+        print(f"Attaching DMG for validation (attempt {attempt}/{attempts}) at {mount_dir}")
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        if result.returncode == 0:
+            return mount_dir
+
+        last_result = result
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        _cleanup_dmg_mount_attempt(dmg_path, mount_dir)
+        if attempt >= attempts or not _is_transient_hdiutil_attach_error(combined_output):
+            break
+
+        retry_delay = min(2.0 * (2 ** (attempt - 1)), 15.0)
+        print(
+            f"::warning::hdiutil attach failed with a transient disk image error for {dmg_path}; "
+            f"retrying attempt {attempt + 1}/{attempts} after {retry_delay:g}s.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        time.sleep(retry_delay)
+
+    if last_result is None:
+        _fail(f"hdiutil attach failed for {dmg_path}: no attempts were run")
+    _fail(
+        "hdiutil attach failed during DMG validation.\n"
+        f"DMG path: {dmg_path}\n"
+        f"Attach attempts: {len(attempted_mountpoints)}/{attempts}\n"
+        f"Attempted mountpoints: {attempted_mountpoints}\n"
+        f"Last stdout:\n{last_result.stdout}\n"
+        f"Last stderr:\n{last_result.stderr}\n"
+        f"hdiutil info snapshot:\n{_hdiutil_info_snapshot()}"
+    )
+
+
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -93,33 +190,27 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
-    with tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-") as mount_dir:
-        _run_with_retries(
-            ["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", mount_dir, str(dmg_path)],
-            attempts=8,
-            retry_messages=("Resource temporarily unavailable", "Resource busy"),
-        )
-        try:
-            root = Path(mount_dir)
-            apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == ".app")
-            if len(apps) != 1:
-                _fail(f"DMG must contain exactly one .app at root; found {len(apps)}")
-            readme_path = next((root / name for name in DMG_PREVIEW_README_NAMES if (root / name).is_file()), None)
-            if readme_path is None:
-                _fail(f"DMG must include one preview README at root: {DMG_PREVIEW_README_NAMES}")
-            readme_text = readme_path.read_text(encoding="utf-8")
-            missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
-            if missing:
-                _fail(f"DMG preview README missing required phrases: {missing}")
-            if expect_signing:
-                if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
-                    _fail(
-                        "DMG preview README must describe configured Apple signing identity when --expect-signing is set"
-                    )
-            elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
-                _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
-        finally:
-            _run(["hdiutil", "detach", mount_dir])
+    mount_dir = _attach_dmg_with_retries(dmg_path)
+    try:
+        root = mount_dir
+        apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == ".app")
+        if len(apps) != 1:
+            _fail(f"DMG must contain exactly one .app at root; found {len(apps)}")
+        readme_path = next((root / name for name in DMG_PREVIEW_README_NAMES if (root / name).is_file()), None)
+        if readme_path is None:
+            _fail(f"DMG must include one preview README at root: {DMG_PREVIEW_README_NAMES}")
+        readme_text = readme_path.read_text(encoding="utf-8")
+        missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
+        if missing:
+            _fail(f"DMG preview README missing required phrases: {missing}")
+        if expect_signing:
+            if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
+                _fail("DMG preview README must describe configured Apple signing identity when --expect-signing is set")
+        elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
+            _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
+    finally:
+        _detach_hdiutil_target(str(mount_dir))
+        shutil.rmtree(mount_dir, ignore_errors=True)
 
 
 def main() -> None:

--- a/tests/unit/test_desktop_artifact_validator.py
+++ b/tests/unit/test_desktop_artifact_validator.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "validate_desktop_tauri_release_artifacts.py"
+SPEC = importlib.util.spec_from_file_location("validate_desktop_tauri_release_artifacts", SCRIPT_PATH)
+validator = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(validator)
+
+
+def _completed(args: list[str], returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=args, returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_attach_dmg_retries_transient_errors_with_fresh_mountpoints_and_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    dmg_path = Path("/tmp/release-artifacts/token.place-desktop-0.1.2-apple-silicon.dmg")
+    mountpoints = [Path(f"/tmp/token-place-dmg-mount-{index}") for index in range(1, 4)]
+    mkdtemp_calls: list[str] = []
+    commands: list[list[str]] = []
+    removed: list[Path] = []
+
+    def fake_mkdtemp(*, prefix: str) -> str:
+        mkdtemp_calls.append(prefix)
+        return str(mountpoints[len(mkdtemp_calls) - 1])
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        if cmd[:2] == ["hdiutil", "attach"]:
+            attempt = len([seen for seen in commands if seen[:2] == ["hdiutil", "attach"]])
+            if attempt < 3:
+                return _completed(cmd, 1, stderr="hdiutil: attach failed - Resource temporarily unavailable")
+            return _completed(cmd, 0, stdout="/dev/disk4")
+        if cmd == ["hdiutil", "info"]:
+            return _completed(cmd, 0, stdout=f"/dev/disk9\n    image-path      : {dmg_path.resolve()}\n")
+        if cmd[:2] == ["hdiutil", "detach"]:
+            return _completed(cmd, 0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(validator.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(validator.subprocess, "run", fake_run)
+    monkeypatch.setattr(validator.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(validator.shutil, "rmtree", lambda path, **_kwargs: removed.append(Path(path)))
+
+    assert validator._attach_dmg_with_retries(dmg_path) == mountpoints[2]
+
+    attach_commands = [cmd for cmd in commands if cmd[:2] == ["hdiutil", "attach"]]
+    assert [cmd[5] for cmd in attach_commands] == [str(mountpoint) for mountpoint in mountpoints]
+    assert ["hdiutil", "detach", str(mountpoints[0])] in commands
+    assert ["hdiutil", "detach", str(mountpoints[1])] in commands
+    assert ["hdiutil", "detach", "/dev/disk9"] in commands
+    assert removed == mountpoints[:2]
+
+
+def test_attach_dmg_does_not_retry_non_transient_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    dmg_path = Path("/tmp/release-artifacts/token.place-desktop-0.1.2-apple-silicon.dmg")
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(validator.tempfile, "mkdtemp", lambda prefix: "/tmp/token-place-dmg-mount-1")
+    monkeypatch.setattr(validator.shutil, "rmtree", lambda path, **_kwargs: None)
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        if cmd[:2] == ["hdiutil", "attach"]:
+            return _completed(cmd, 1, stderr="hdiutil: attach failed - image not recognized")
+        if cmd == ["hdiutil", "info"]:
+            return _completed(cmd, 0, stdout="")
+        if cmd[:2] == ["hdiutil", "detach"]:
+            return _completed(cmd, 0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(validator.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        validator._attach_dmg_with_retries(dmg_path)
+
+    assert "image not recognized" in str(exc_info.value)
+    assert len([cmd for cmd in commands if cmd[:2] == ["hdiutil", "attach"]]) == 1

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -263,39 +263,21 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
     attach_calls = []
     detach_calls = []
 
-    class FakeTemporaryDirectory:
-        def __init__(self, *, prefix):
-            assert prefix == 'token-place-dmg-mount-'
+    def fake_attach_dmg_with_retries(path):
+        attach_calls.append(path)
+        return mount_dir
 
-        def __enter__(self):
-            return str(mount_dir)
-
-        def __exit__(self, *args):
-            return False
-
-    def fake_run_with_retries(cmd, *, attempts, retry_messages):
-        attach_calls.append((cmd, attempts, retry_messages))
-        return '/dev/disk4'
-
-    def fake_run(cmd):
-        detach_calls.append(cmd)
-        return ''
+    def fake_detach_hdiutil_target(target):
+        detach_calls.append(target)
 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
-    monkeypatch.setattr(validator.tempfile, 'TemporaryDirectory', FakeTemporaryDirectory)
-    monkeypatch.setattr(validator, '_run_with_retries', fake_run_with_retries)
-    monkeypatch.setattr(validator, '_run', fake_run)
+    monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach_dmg_with_retries)
+    monkeypatch.setattr(validator, '_detach_hdiutil_target', fake_detach_hdiutil_target)
 
     validator._validate_dmg_contents(dmg_path, expect_signing=False)
 
-    assert attach_calls == [
-        (
-            ['hdiutil', 'attach', '-nobrowse', '-readonly', '-mountpoint', str(mount_dir), str(dmg_path)],
-            8,
-            ('Resource temporarily unavailable', 'Resource busy'),
-        )
-    ]
-    assert detach_calls == [['hdiutil', 'detach', str(mount_dir)]]
+    assert attach_calls == [dmg_path]
+    assert detach_calls == [str(mount_dir)]
 
 
 def test_validator_run_formats_command_failures(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- The DMG validation step could fail on macOS GitHub runners when `hdiutil attach` hit transient races like "Resource temporarily unavailable", causing otherwise-successful desktop builds to fail.

### Description
- Add a dedicated attach helper `_attach_dmg_with_retries` that uses a fresh temporary mountpoint per attempt, performs bounded exponential backoff, and recognizes transient `hdiutil` errors.  
- Add cleanup helpers `_cleanup_dmg_mount_attempt`, `_matching_hdiutil_devices`, `_detach_hdiutil_target`, and `_hdiutil_info_snapshot` to best-effort detach stale state and collect diagnostics.  
- Swap the DMG mount logic in `_validate_dmg_contents` to use the new attach helper and ensure detach + mountpoint removal in a `finally` path while preserving strict content checks.  
- Add unit tests `tests/unit/test_desktop_artifact_validator.py` covering transient retry behavior and non-transient failures, and update `tests/unit/test_desktop_release_artifacts.py` to assert the new helper boundary.

### Testing
- Ran the focused unit tests: `python -m pytest tests/unit/test_desktop_artifact_validator.py -q` and `python -m pytest tests/unit/test_desktop_release_artifacts.py -q`, both suites passed.  
- Ran the combined validator tests: `python -m pytest tests/unit/test_desktop_artifact_validator.py tests/unit/test_desktop_release_artifacts.py -q`, which passed (21 tests).  
- Verified script help: `python scripts/validate_desktop_tauri_release_artifacts.py --help` returned usage without error.  
- Ran repository checks: `rg -n "hdiutil attach|validate_desktop_tauri_release_artifacts|Resource temporarily unavailable" scripts .github` and `git diff --check` with no issues, and `pre-commit run --all-files` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c3cf1ab28832fa89e9c73b3da6338)