### PR TITLE
Harden macOS DMG artifact validation

### DIFF
--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -93,12 +93,18 @@ def _redact_hdiutil_info(info: str) -> str:
     return re.sub(r"/private/var/folders/[^\s]+", "/private/var/folders/<redacted>", info)
 
 
-def _hdiutil_info_snapshot() -> str:
+def _hdiutil_info_raw() -> tuple[str, int]:
     result = subprocess.run(["hdiutil", "info"], check=False, capture_output=True, text=True)
     output = f"{result.stdout}\n{result.stderr}".strip()
-    if result.returncode != 0:
-        return f"hdiutil info failed with exit code {result.returncode}:\n{_redact_hdiutil_info(output)}"
-    return _redact_hdiutil_info(output)
+    return output, result.returncode
+
+
+def _hdiutil_info_snapshot(raw_info: str | None = None, returncode: int = 0) -> str:
+    if raw_info is None:
+        raw_info, returncode = _hdiutil_info_raw()
+    if returncode != 0:
+        return f"hdiutil info failed with exit code {returncode}:\n{_redact_hdiutil_info(raw_info)}"
+    return _redact_hdiutil_info(raw_info)
 
 
 def _hdiutil_info_plist() -> dict[str, object]:
@@ -125,12 +131,18 @@ def _image_matches_dmg(image: dict[str, object], dmg_path: Path) -> bool:
     image_path = image.get("image-path")
     if not isinstance(image_path, str):
         return False
+    return _path_matches_dmg(image_path, dmg_path)
+
+
+def _path_matches_dmg(image_path: str, dmg_path: Path) -> bool:
     if image_path == str(dmg_path) or image_path == str(dmg_path.resolve()):
         return True
     try:
-        return Path(image_path).resolve() == dmg_path.resolve()
+        if Path(image_path).resolve() == dmg_path.resolve():
+            return True
     except OSError:
-        return False
+        pass
+    return image_path.endswith(f"/{dmg_path}")
 
 
 def _mountpoint_referenced(mount_dir: Path, info_plist: dict[str, object]) -> bool:
@@ -145,7 +157,18 @@ def _mountpoint_referenced(mount_dir: Path, info_plist: dict[str, object]) -> bo
     return False
 
 
-def _matching_hdiutil_devices(dmg_path: Path, info_plist: dict[str, object]) -> list[str]:
+def _matching_hdiutil_devices_from_text(dmg_path: Path, raw_info: str) -> list[str]:
+    devices: list[str] = []
+    image_blocks = re.split(r"(?=^image-path\s*:)", raw_info, flags=re.MULTILINE)
+    for block in image_blocks:
+        image_match = re.search(r"^image-path\s*:\s*(.+)$", block, flags=re.MULTILINE)
+        if image_match is None or not _path_matches_dmg(image_match.group(1).strip(), dmg_path):
+            continue
+        devices.extend(re.findall(r"^(/dev/disk\S+)", block, flags=re.MULTILINE))
+    return devices
+
+
+def _matching_hdiutil_devices(dmg_path: Path, info_plist: dict[str, object], raw_info: str = "") -> list[str]:
     devices: list[str] = []
     for image in _image_entries(info_plist):
         if not _image_matches_dmg(image, dmg_path):
@@ -159,19 +182,23 @@ def _matching_hdiutil_devices(dmg_path: Path, info_plist: dict[str, object]) -> 
             device = entity.get("dev-entry")
             if isinstance(device, str) and device.startswith("/dev/disk"):
                 devices.append(device)
+    if raw_info:
+        devices.extend(_matching_hdiutil_devices_from_text(dmg_path, raw_info))
     return list(dict.fromkeys(devices))
 
 
 def _cleanup_dmg_attach_state(dmg_path: Path, mount_dir: Path) -> str:
+    raw_info, raw_returncode = _hdiutil_info_raw()
     info_plist = _hdiutil_info_plist()
     if mount_dir.exists() and _mountpoint_referenced(mount_dir, info_plist):
         _run_best_effort(["hdiutil", "detach", str(mount_dir)])
+        raw_info, raw_returncode = _hdiutil_info_raw()
         info_plist = _hdiutil_info_plist()
-    for device in _matching_hdiutil_devices(dmg_path, info_plist):
+    for device in _matching_hdiutil_devices(dmg_path, info_plist, raw_info):
         _run_best_effort(["hdiutil", "detach", device])
     shutil.rmtree(mount_dir, ignore_errors=True)
     mount_dir.mkdir(parents=True, exist_ok=True)
-    return _hdiutil_info_snapshot()
+    return _hdiutil_info_snapshot(raw_info, raw_returncode)
 
 
 def _is_transient_hdiutil_attach_failure(result: subprocess.CompletedProcess[str]) -> bool:

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -101,26 +101,77 @@ def _hdiutil_info_snapshot() -> str:
     return _redact_hdiutil_info(output)
 
 
-def _matching_hdiutil_devices(dmg_path: Path, info: str) -> list[str]:
-    devices: list[str] = []
-    resolved = str(dmg_path.resolve())
-    raw = str(dmg_path)
-    for block in re.split(r"\n\s*\n", info):
-        if resolved not in block and raw not in block and dmg_path.name not in block:
+def _hdiutil_info_plist() -> dict[str, object]:
+    result = subprocess.run(["hdiutil", "info", "-plist"], check=False, capture_output=True)
+    if result.returncode != 0:
+        return {}
+    try:
+        parsed = plistlib.loads(result.stdout)
+    except plistlib.InvalidFileException:
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    return {}
+
+
+def _image_entries(info_plist: dict[str, object]) -> list[dict[str, object]]:
+    images = info_plist.get("images", [])
+    if not isinstance(images, list):
+        return []
+    return [image for image in images if isinstance(image, dict)]
+
+
+def _image_matches_dmg(image: dict[str, object], dmg_path: Path) -> bool:
+    image_path = image.get("image-path")
+    if not isinstance(image_path, str):
+        return False
+    if image_path == str(dmg_path) or image_path == str(dmg_path.resolve()):
+        return True
+    try:
+        return Path(image_path).resolve() == dmg_path.resolve()
+    except OSError:
+        return False
+
+
+def _mountpoint_referenced(mount_dir: Path, info_plist: dict[str, object]) -> bool:
+    mount = str(mount_dir)
+    for image in _image_entries(info_plist):
+        entities = image.get("system-entities", [])
+        if not isinstance(entities, list):
             continue
-        devices.extend(re.findall(r"/dev/disk\S+", block))
+        for entity in entities:
+            if isinstance(entity, dict) and entity.get("mount-point") == mount:
+                return True
+    return False
+
+
+def _matching_hdiutil_devices(dmg_path: Path, info_plist: dict[str, object]) -> list[str]:
+    devices: list[str] = []
+    for image in _image_entries(info_plist):
+        if not _image_matches_dmg(image, dmg_path):
+            continue
+        entities = image.get("system-entities", [])
+        if not isinstance(entities, list):
+            continue
+        for entity in entities:
+            if not isinstance(entity, dict):
+                continue
+            device = entity.get("dev-entry")
+            if isinstance(device, str) and device.startswith("/dev/disk"):
+                devices.append(device)
     return list(dict.fromkeys(devices))
 
 
 def _cleanup_dmg_attach_state(dmg_path: Path, mount_dir: Path) -> str:
-    if mount_dir.exists():
+    info_plist = _hdiutil_info_plist()
+    if mount_dir.exists() and _mountpoint_referenced(mount_dir, info_plist):
         _run_best_effort(["hdiutil", "detach", str(mount_dir)])
-    info = _hdiutil_info_snapshot()
-    for device in _matching_hdiutil_devices(dmg_path, info):
+        info_plist = _hdiutil_info_plist()
+    for device in _matching_hdiutil_devices(dmg_path, info_plist):
         _run_best_effort(["hdiutil", "detach", device])
     shutil.rmtree(mount_dir, ignore_errors=True)
     mount_dir.mkdir(parents=True, exist_ok=True)
-    return info
+    return _hdiutil_info_snapshot()
 
 
 def _is_transient_hdiutil_attach_failure(result: subprocess.CompletedProcess[str]) -> bool:
@@ -160,8 +211,6 @@ def _attach_dmg_with_retries(
         print(f"Attaching DMG {dmg_path} at {mount_dir} (attempt {attempt}/{attempts}).")
         result = subprocess.run(cmd, check=False, capture_output=True, text=True)
         if result.returncode == 0:
-            for old_temp_dir in temp_dirs[:-1]:
-                old_temp_dir.cleanup()
             return temp_dir
 
         last_result = result
@@ -174,7 +223,7 @@ def _attach_dmg_with_retries(
         print(
             f"::warning::hdiutil attach failed with a transient disk image error for {dmg_path} "
             f"at {mount_dir}; retrying attempt {attempt + 1}/{attempts} after {retry_delay:g}s.\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}".strip()
+            f"stdout:\n{_redact_hdiutil_info(result.stdout)}\nstderr:\n{_redact_hdiutil_info(result.stderr)}".strip()
         )
         temp_dir.cleanup()
         temp_dirs.pop()
@@ -188,8 +237,8 @@ def _attach_dmg_with_retries(
         f"hdiutil attach failed for DMG: {dmg_path}",
         f"mountpoints attempted: {mount_dirs}",
         f"attach attempts: {len(mount_dirs)}/{attempts}",
-        f"last stdout:\n{last_result.stdout}",
-        f"last stderr:\n{last_result.stderr}",
+        f"last stdout:\n{_redact_hdiutil_info(last_result.stdout)}",
+        f"last stderr:\n{_redact_hdiutil_info(last_result.stderr)}",
         f"redacted hdiutil info snapshot:\n{last_info}",
     ]
     _fail("\n".join(details))
@@ -237,7 +286,7 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
             elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
                 _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
         finally:
-            _run_best_effort(["hdiutil", "detach", mount_dir])
+            _cleanup_dmg_attach_state(dmg_path, Path(mount_dir))
     finally:
         mount_temp_dir.cleanup()
 

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -7,6 +7,8 @@ import json
 import os
 import platform
 import plistlib
+import re
+import shutil
 import subprocess
 import tempfile
 import time
@@ -74,6 +76,125 @@ def _run_with_retries(
     _fail(_format_command_failure(cmd, last_result))
 
 
+def _run_best_effort(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(
+            f"::warning::Best-effort command failed ({' '.join(cmd)}):\n"
+            f"{result.stdout}\n{result.stderr}".strip()
+        )
+    return result
+
+
+def _redact_hdiutil_info(info: str) -> str:
+    home = str(Path.home())
+    if home and home != "/":
+        info = info.replace(home, "~")
+    return re.sub(r"/private/var/folders/[^\s]+", "/private/var/folders/<redacted>", info)
+
+
+def _hdiutil_info_snapshot() -> str:
+    result = subprocess.run(["hdiutil", "info"], check=False, capture_output=True, text=True)
+    output = f"{result.stdout}\n{result.stderr}".strip()
+    if result.returncode != 0:
+        return f"hdiutil info failed with exit code {result.returncode}:\n{_redact_hdiutil_info(output)}"
+    return _redact_hdiutil_info(output)
+
+
+def _matching_hdiutil_devices(dmg_path: Path, info: str) -> list[str]:
+    devices: list[str] = []
+    resolved = str(dmg_path.resolve())
+    raw = str(dmg_path)
+    for block in re.split(r"\n\s*\n", info):
+        if resolved not in block and raw not in block and dmg_path.name not in block:
+            continue
+        devices.extend(re.findall(r"/dev/disk\S+", block))
+    return list(dict.fromkeys(devices))
+
+
+def _cleanup_dmg_attach_state(dmg_path: Path, mount_dir: Path) -> str:
+    if mount_dir.exists():
+        _run_best_effort(["hdiutil", "detach", str(mount_dir)])
+    info = _hdiutil_info_snapshot()
+    for device in _matching_hdiutil_devices(dmg_path, info):
+        _run_best_effort(["hdiutil", "detach", device])
+    shutil.rmtree(mount_dir, ignore_errors=True)
+    mount_dir.mkdir(parents=True, exist_ok=True)
+    return info
+
+
+def _is_transient_hdiutil_attach_failure(result: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    transient_markers = (
+        "resource temporarily unavailable",
+        "resource busy",
+        "device busy",
+        "is busy",
+        "already attached",
+        "already mounted",
+        "couldn't open helper",
+        "diskimages-helper",
+    )
+    return any(marker in output for marker in transient_markers)
+
+
+def _attach_dmg_with_retries(
+    dmg_path: Path,
+    *,
+    attempts: int = 8,
+    delay_seconds: float = 2.0,
+    max_delay_seconds: float = 15.0,
+) -> tempfile.TemporaryDirectory[str]:
+    last_result: subprocess.CompletedProcess[str] | None = None
+    mount_dirs: list[str] = []
+    last_info = ""
+    temp_dirs: list[tempfile.TemporaryDirectory[str]] = []
+
+    for attempt in range(1, attempts + 1):
+        temp_dir = tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-")
+        temp_dirs.append(temp_dir)
+        mount_dir = Path(temp_dir.name)
+        mount_dirs.append(str(mount_dir))
+        last_info = _cleanup_dmg_attach_state(dmg_path, mount_dir)
+        cmd = ["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", str(mount_dir), str(dmg_path)]
+        print(f"Attaching DMG {dmg_path} at {mount_dir} (attempt {attempt}/{attempts}).")
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        if result.returncode == 0:
+            for old_temp_dir in temp_dirs[:-1]:
+                old_temp_dir.cleanup()
+            return temp_dir
+
+        last_result = result
+        if attempt >= attempts or not _is_transient_hdiutil_attach_failure(result):
+            last_info = _cleanup_dmg_attach_state(dmg_path, mount_dir)
+            break
+
+        last_info = _cleanup_dmg_attach_state(dmg_path, mount_dir)
+        retry_delay = min(delay_seconds * (2 ** (attempt - 1)), max_delay_seconds)
+        print(
+            f"::warning::hdiutil attach failed with a transient disk image error for {dmg_path} "
+            f"at {mount_dir}; retrying attempt {attempt + 1}/{attempts} after {retry_delay:g}s.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}".strip()
+        )
+        temp_dir.cleanup()
+        temp_dirs.pop()
+        time.sleep(retry_delay)
+
+    for temp_dir in temp_dirs:
+        temp_dir.cleanup()
+    if last_result is None:
+        _fail(f"hdiutil attach failed for {dmg_path}: no attempts were run")
+    details = [
+        f"hdiutil attach failed for DMG: {dmg_path}",
+        f"mountpoints attempted: {mount_dirs}",
+        f"attach attempts: {len(mount_dirs)}/{attempts}",
+        f"last stdout:\n{last_result.stdout}",
+        f"last stderr:\n{last_result.stderr}",
+        f"redacted hdiutil info snapshot:\n{last_info}",
+    ]
+    _fail("\n".join(details))
+
+
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -93,12 +214,9 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
-    with tempfile.TemporaryDirectory(prefix="token-place-dmg-mount-") as mount_dir:
-        _run_with_retries(
-            ["hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", mount_dir, str(dmg_path)],
-            attempts=8,
-            retry_messages=("Resource temporarily unavailable", "Resource busy"),
-        )
+    mount_temp_dir = _attach_dmg_with_retries(dmg_path)
+    mount_dir = mount_temp_dir.name
+    try:
         try:
             root = Path(mount_dir)
             apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == ".app")
@@ -119,7 +237,9 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
             elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
                 _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
         finally:
-            _run(["hdiutil", "detach", mount_dir])
+            _run_best_effort(["hdiutil", "detach", mount_dir])
+    finally:
+        mount_temp_dir.cleanup()
 
 
 def main() -> None:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -261,7 +261,7 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
     )
     dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
     dmg_path.write_bytes(b'dmg')
-    detach_calls = []
+    cleanup_state_calls = []
     cleaned = []
 
     class FakeMountTemporaryDirectory:
@@ -274,17 +274,17 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
         assert dmg == dmg_path
         return FakeMountTemporaryDirectory()
 
-    def fake_run_best_effort(cmd):
-        detach_calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, '', '')
+    def fake_cleanup_state(path, cleanup_mount_dir):
+        cleanup_state_calls.append((path, cleanup_mount_dir))
+        return 'hdiutil info snapshot'
 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach)
-    monkeypatch.setattr(validator, '_run_best_effort', fake_run_best_effort)
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup_state)
 
     validator._validate_dmg_contents(dmg_path, expect_signing=False)
 
-    assert detach_calls == [['hdiutil', 'detach', str(mount_dir)]]
+    assert cleanup_state_calls == [(dmg_path, mount_dir)]
     assert cleaned == [str(mount_dir)]
 
 
@@ -355,6 +355,98 @@ def test_validator_attach_retries_with_fresh_mountpoints_and_cleanup(monkeypatch
     assert sleeps == [0.01]
     temp_dir.cleanup()
 
+
+
+def test_validator_cleanup_only_detaches_referenced_mountpoint_and_matched_device(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'target.dmg'
+    dmg_path.write_bytes(b'dmg')
+    other_dmg_path = tmp_path / 'other.dmg'
+    other_dmg_path.write_bytes(b'dmg')
+    mount_dir = tmp_path / 'mount'
+    mount_dir.mkdir()
+    calls = []
+    plist_calls = []
+    snapshots = []
+
+    first_plist = {
+        'images': [
+            {
+                'image-path': str(dmg_path),
+                'system-entities': [
+                    {'dev-entry': '/dev/disk4', 'mount-point': str(mount_dir)},
+                    {'dev-entry': '/dev/disk4s1', 'mount-point': str(mount_dir)},
+                ],
+            },
+            {
+                'image-path': str(other_dmg_path),
+                'system-entities': [{'dev-entry': '/dev/disk9', 'mount-point': '/Volumes/Other'}],
+            },
+        ]
+    }
+    second_plist = {
+        'images': [
+            {
+                'image-path': str(dmg_path),
+                'system-entities': [{'dev-entry': '/dev/disk4s1'}],
+            },
+            {
+                'image-path': str(other_dmg_path),
+                'system-entities': [{'dev-entry': '/dev/disk9', 'mount-point': '/Volumes/Other'}],
+            },
+        ]
+    }
+
+    def fake_info_plist():
+        plist_calls.append('plist')
+        return first_plist if len(plist_calls) == 1 else second_plist
+
+    def fake_run_best_effort(cmd):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, '', '')
+
+    monkeypatch.setattr(validator, '_hdiutil_info_plist', fake_info_plist)
+    monkeypatch.setattr(validator, '_hdiutil_info_snapshot', lambda: snapshots.append('snapshot') or 'snapshot')
+    monkeypatch.setattr(validator, '_run_best_effort', fake_run_best_effort)
+
+    assert validator._cleanup_dmg_attach_state(dmg_path, mount_dir) == 'snapshot'
+
+    assert calls == [['hdiutil', 'detach', str(mount_dir)], ['hdiutil', 'detach', '/dev/disk4s1']]
+    assert len(plist_calls) == 2
+    assert snapshots == ['snapshot']
+    assert mount_dir.exists()
+
+
+def test_validator_cleanup_skips_unreferenced_mountpoint(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'target.dmg'
+    dmg_path.write_bytes(b'dmg')
+    mount_dir = tmp_path / 'mount'
+    mount_dir.mkdir()
+    calls = []
+
+    monkeypatch.setattr(
+        validator,
+        '_hdiutil_info_plist',
+        lambda: {
+            'images': [
+                {
+                    'image-path': str(dmg_path),
+                    'system-entities': [{'dev-entry': '/dev/disk5', 'mount-point': '/Volumes/Target'}],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(validator, '_hdiutil_info_snapshot', lambda: 'snapshot')
+    monkeypatch.setattr(
+        validator,
+        '_run_best_effort',
+        lambda cmd: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0, '', ''),
+    )
+
+    validator._cleanup_dmg_attach_state(dmg_path, mount_dir)
+
+    assert calls == [['hdiutil', 'detach', '/dev/disk5']]
 
 def test_validator_attach_stops_on_non_transient_failure(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 WORKFLOW = Path('.github/workflows/desktop-release.yml')
@@ -260,42 +261,31 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
     )
     dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
     dmg_path.write_bytes(b'dmg')
-    attach_calls = []
     detach_calls = []
+    cleaned = []
 
-    class FakeTemporaryDirectory:
-        def __init__(self, *, prefix):
-            assert prefix == 'token-place-dmg-mount-'
+    class FakeMountTemporaryDirectory:
+        name = str(mount_dir)
 
-        def __enter__(self):
-            return str(mount_dir)
+        def cleanup(self):
+            cleaned.append(self.name)
 
-        def __exit__(self, *args):
-            return False
+    def fake_attach(dmg):
+        assert dmg == dmg_path
+        return FakeMountTemporaryDirectory()
 
-    def fake_run_with_retries(cmd, *, attempts, retry_messages):
-        attach_calls.append((cmd, attempts, retry_messages))
-        return '/dev/disk4'
-
-    def fake_run(cmd):
+    def fake_run_best_effort(cmd):
         detach_calls.append(cmd)
-        return ''
+        return subprocess.CompletedProcess(cmd, 0, '', '')
 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
-    monkeypatch.setattr(validator.tempfile, 'TemporaryDirectory', FakeTemporaryDirectory)
-    monkeypatch.setattr(validator, '_run_with_retries', fake_run_with_retries)
-    monkeypatch.setattr(validator, '_run', fake_run)
+    monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach)
+    monkeypatch.setattr(validator, '_run_best_effort', fake_run_best_effort)
 
     validator._validate_dmg_contents(dmg_path, expect_signing=False)
 
-    assert attach_calls == [
-        (
-            ['hdiutil', 'attach', '-nobrowse', '-readonly', '-mountpoint', str(mount_dir), str(dmg_path)],
-            8,
-            ('Resource temporarily unavailable', 'Resource busy'),
-        )
-    ]
     assert detach_calls == [['hdiutil', 'detach', str(mount_dir)]]
+    assert cleaned == [str(mount_dir)]
 
 
 def test_validator_run_formats_command_failures(monkeypatch) -> None:
@@ -318,3 +308,88 @@ def test_validator_run_formats_command_failures(monkeypatch) -> None:
     assert 'Command failed (codesign --verify example.app)' in message
     assert 'stdout detail' in message
     assert 'stderr detail' in message
+
+
+def test_validator_attach_retries_with_fresh_mountpoints_and_cleanup(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    dmg_path.write_bytes(b'dmg')
+    mount_roots = [tmp_path / 'mount-1', tmp_path / 'mount-2']
+    cleanup_calls = []
+    run_calls = []
+    sleeps = []
+
+    class FakeTemporaryDirectory:
+        counter = 0
+
+        def __init__(self, *, prefix):
+            assert prefix == 'token-place-dmg-mount-'
+            self.name = str(mount_roots[FakeTemporaryDirectory.counter])
+            FakeTemporaryDirectory.counter += 1
+            Path(self.name).mkdir()
+
+        def cleanup(self):
+            cleanup_calls.append(self.name)
+
+    def fake_cleanup(path, mount_dir):
+        cleanup_calls.append(f'cleanup-state:{mount_dir}')
+        return f'image-path: {path}\n/dev/disk9s1 Apple_HFS'
+
+    def fake_run(cmd, *, check, capture_output, text):
+        run_calls.append(cmd)
+        if len(run_calls) == 1:
+            return subprocess.CompletedProcess(cmd, 1, '', 'hdiutil: attach failed - Resource temporarily unavailable')
+        return subprocess.CompletedProcess(cmd, 0, '/dev/disk4', '')
+
+    monkeypatch.setattr(validator.tempfile, 'TemporaryDirectory', FakeTemporaryDirectory)
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup)
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    monkeypatch.setattr(validator.time, 'sleep', sleeps.append)
+
+    temp_dir = validator._attach_dmg_with_retries(dmg_path, attempts=3, delay_seconds=0.01)
+
+    assert temp_dir.name == str(mount_roots[1])
+    assert [call[5] for call in run_calls] == [str(mount_roots[0]), str(mount_roots[1])]
+    assert f'cleanup-state:{mount_roots[0]}' in cleanup_calls
+    assert str(mount_roots[0]) in cleanup_calls
+    assert sleeps == [0.01]
+    temp_dir.cleanup()
+
+
+def test_validator_attach_stops_on_non_transient_failure(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    dmg_path.write_bytes(b'dmg')
+    mount_dir = tmp_path / 'mount-1'
+    run_calls = []
+
+    class FakeTemporaryDirectory:
+        def __init__(self, *, prefix):
+            self.name = str(mount_dir)
+            mount_dir.mkdir()
+
+        def cleanup(self):
+            pass
+
+    def fake_cleanup(path, _mount_dir):
+        return 'hdiutil info snapshot'
+
+    def fake_run(cmd, *, check, capture_output, text):
+        run_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 1, 'attach stdout', 'permission denied')
+
+    monkeypatch.setattr(validator.tempfile, 'TemporaryDirectory', FakeTemporaryDirectory)
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup)
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+
+    try:
+        validator._attach_dmg_with_retries(dmg_path, attempts=3, delay_seconds=0.01)
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('expected non-transient attach failure to exit')
+
+    assert len(run_calls) == 1
+    assert 'attach attempts: 1/3' in message
+    assert 'permission denied' in message
+    assert 'redacted hdiutil info snapshot' in message

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -521,3 +521,112 @@ def test_validator_attach_stops_on_non_transient_failure(monkeypatch, tmp_path) 
     assert 'attach attempts: 1/3' in message
     assert 'permission denied' in message
     assert 'redacted hdiutil info snapshot' in message
+
+
+def test_validator_hdiutil_info_helpers_preserve_raw_matching_and_redact(monkeypatch, tmp_path, capsys) -> None:
+    validator = _load_release_artifact_validator()
+    raw_path = '/private/var/folders/zz/example/release-artifacts/token.place-desktop-0.1.2-apple-silicon.dmg'
+
+    def fake_run(cmd, *, check, capture_output, text=None):
+        if cmd == ['hdiutil', 'info']:
+            return subprocess.CompletedProcess(cmd, 3, f'image-path: {raw_path}', 'raw stderr')
+        if cmd == ['hdiutil', 'info', '-plist']:
+            return subprocess.CompletedProcess(cmd, 0, b'not a plist', b'')
+        return subprocess.CompletedProcess(cmd, 7, 'best stdout', 'best stderr')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+
+    assert validator._hdiutil_info_raw() == (f'image-path: {raw_path}\nraw stderr', 3)
+    snapshot = validator._hdiutil_info_snapshot()
+    assert 'hdiutil info failed with exit code 3' in snapshot
+    assert '/private/var/folders/<redacted>' in snapshot
+    assert raw_path not in snapshot
+    assert validator._hdiutil_info_plist() == {}
+
+    result = validator._run_best_effort(['hdiutil', 'detach', str(tmp_path / 'missing')])
+
+    assert result.returncode == 7
+    warning = capsys.readouterr().out
+    assert '::warning::Best-effort command failed' in warning
+    assert 'best stdout' in warning
+    assert 'best stderr' in warning
+
+
+def test_validator_hdiutil_matching_helpers_handle_malformed_entries(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'target.dmg'
+    dmg_path.write_bytes(b'dmg')
+    other_path = tmp_path / 'other.dmg'
+    other_path.write_bytes(b'dmg')
+    mount_dir = tmp_path / 'mount'
+
+    original_resolve = validator.Path.resolve
+
+    def fake_resolve(self):
+        if str(self).startswith('/bad/path'):
+            raise OSError('unresolvable')
+        return original_resolve(self)
+
+    monkeypatch.setattr(validator.Path, 'resolve', fake_resolve)
+
+    assert validator._image_entries({'images': 'not-a-list'}) == []
+    assert not validator._image_matches_dmg({'image-path': 123}, dmg_path)
+    relative_dmg_path = Path('release-artifacts/target.dmg')
+    assert validator._path_matches_dmg('/bad/path/release-artifacts/target.dmg', relative_dmg_path)
+    assert not validator._path_matches_dmg('/bad/path/release-artifacts/other.dmg', relative_dmg_path)
+    assert not validator._mountpoint_referenced(
+        mount_dir,
+        {'images': [{'image-path': str(dmg_path), 'system-entities': 'not-a-list'}]},
+    )
+
+    devices = validator._matching_hdiutil_devices(
+        dmg_path,
+        {
+            'images': [
+                {'image-path': str(other_path), 'system-entities': [{'dev-entry': '/dev/disk2'}]},
+                {'image-path': str(dmg_path), 'system-entities': 'not-a-list'},
+                {
+                    'image-path': str(dmg_path),
+                    'system-entities': [
+                        'not-a-dict',
+                        {'dev-entry': 'not-a-disk'},
+                        {'dev-entry': '/dev/disk3'},
+                    ],
+                },
+            ]
+        },
+        raw_info=f'image-path: {dmg_path}\n/dev/disk3\n/dev/disk4\nimage-path: {other_path}\n/dev/disk9',
+    )
+
+    assert devices == ['/dev/disk3', '/dev/disk4']
+
+
+def test_validator_hdiutil_plist_and_retry_edge_branches(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = tmp_path / 'target.dmg'
+    dmg_path.write_bytes(b'dmg')
+    plist_payload = validator.plistlib.dumps({'images': []})
+    calls = []
+
+    def fake_run(cmd, *, check, capture_output, text=None):
+        calls.append(cmd)
+        if cmd == ['hdiutil', 'info', '-plist'] and len(calls) == 1:
+            return subprocess.CompletedProcess(cmd, 2, b'', b'plist failed')
+        if cmd == ['hdiutil', 'info', '-plist']:
+            return subprocess.CompletedProcess(cmd, 0, plist_payload, b'')
+        return subprocess.CompletedProcess(cmd, 0, '', '')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+
+    assert validator._hdiutil_info_plist() == {}
+    assert validator._hdiutil_info_plist() == {'images': []}
+    assert validator._path_matches_dmg(str(dmg_path.resolve()), dmg_path)
+
+    try:
+        validator._attach_dmg_with_retries(dmg_path, attempts=0)
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('expected zero-attempt attach helper call to exit')
+
+    assert 'no attempts were run' in message

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -406,14 +406,19 @@ def test_validator_cleanup_only_detaches_referenced_mountpoint_and_matched_devic
         return subprocess.CompletedProcess(cmd, 0, '', '')
 
     monkeypatch.setattr(validator, '_hdiutil_info_plist', fake_info_plist)
-    monkeypatch.setattr(validator, '_hdiutil_info_snapshot', lambda: snapshots.append('snapshot') or 'snapshot')
+    monkeypatch.setattr(validator, '_hdiutil_info_raw', lambda: ('hdiutil info raw', 0))
+    monkeypatch.setattr(
+        validator,
+        '_hdiutil_info_snapshot',
+        lambda raw_info=None, returncode=0: snapshots.append((raw_info, returncode)) or 'snapshot',
+    )
     monkeypatch.setattr(validator, '_run_best_effort', fake_run_best_effort)
 
     assert validator._cleanup_dmg_attach_state(dmg_path, mount_dir) == 'snapshot'
 
     assert calls == [['hdiutil', 'detach', str(mount_dir)], ['hdiutil', 'detach', '/dev/disk4s1']]
     assert len(plist_calls) == 2
-    assert snapshots == ['snapshot']
+    assert snapshots == [('hdiutil info raw', 0)]
     assert mount_dir.exists()
 
 
@@ -437,7 +442,8 @@ def test_validator_cleanup_skips_unreferenced_mountpoint(monkeypatch, tmp_path) 
             ]
         },
     )
-    monkeypatch.setattr(validator, '_hdiutil_info_snapshot', lambda: 'snapshot')
+    monkeypatch.setattr(validator, '_hdiutil_info_raw', lambda: ('hdiutil info raw', 0))
+    monkeypatch.setattr(validator, '_hdiutil_info_snapshot', lambda raw_info=None, returncode=0: 'snapshot')
     monkeypatch.setattr(
         validator,
         '_run_best_effort',
@@ -447,6 +453,36 @@ def test_validator_cleanup_skips_unreferenced_mountpoint(monkeypatch, tmp_path) 
     validator._cleanup_dmg_attach_state(dmg_path, mount_dir)
 
     assert calls == [['hdiutil', 'detach', '/dev/disk5']]
+
+
+def test_validator_cleanup_uses_raw_hdiutil_info_for_matching_but_redacts_diagnostics(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    dmg_path = Path('release-artifacts/token.place-desktop-0.1.2-apple-silicon.dmg')
+    mount_dir = tmp_path / 'mount'
+    mount_dir.mkdir()
+    calls = []
+    raw_info = """
+image-path: /private/var/folders/zz/redacted-test/release-artifacts/token.place-desktop-0.1.2-apple-silicon.dmg
+/dev/disk8           Apple_partition_scheme
+/dev/disk8s1         Apple_HFS
+image-path: /private/var/folders/zz/redacted-test/release-artifacts/other.dmg
+/dev/disk9           Apple_partition_scheme
+""".strip()
+
+    monkeypatch.setattr(validator, '_hdiutil_info_raw', lambda: (raw_info, 0))
+    monkeypatch.setattr(validator, '_hdiutil_info_plist', lambda: {})
+    monkeypatch.setattr(
+        validator,
+        '_run_best_effort',
+        lambda cmd: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0, '', ''),
+    )
+
+    diagnostic = validator._cleanup_dmg_attach_state(dmg_path, mount_dir)
+
+    assert calls == [['hdiutil', 'detach', '/dev/disk8'], ['hdiutil', 'detach', '/dev/disk8s1']]
+    assert '/dev/disk9' not in {call[-1] for call in calls}
+    assert '/private/var/folders/<redacted>' in diagnostic
+    assert '/private/var/folders/zz/redacted-test' not in diagnostic
 
 def test_validator_attach_stops_on_non_transient_failure(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()


### PR DESCRIPTION
### Motivation
- The CI macOS desktop release validation intermittently failed when `hdiutil attach` hit transient runner/device races (e.g. `Resource temporarily unavailable`), causing otherwise-valid builds to be rejected.

### Description
- Added a dedicated attach-and-retry flow (`_attach_dmg_with_retries`) that uses a fresh temporary mountpoint per attempt and bounded exponential backoff for known transient disk-image errors.
- Implemented best-effort cleanup helpers (`_cleanup_dmg_attach_state`, `_matching_hdiutil_devices`, `_hdiutil_info_snapshot`, `_run_best_effort`) to detach by mountpoint and by matching image device from `hdiutil info`, recreate the mountpoint, and redact sensitive paths in diagnostics.
- Tightened transient-detection with `_is_transient_hdiutil_attach_failure` so non-transient errors stop immediately and structural validation stays strict.
- Switched `_validate_dmg_contents` to use the new attach helper and ensured final detach and temporary-directory cleanup are executed in `finally` blocks.
- Added focused unit tests covering fresh mountpoint retries, cleanup behavior, and non-transient attach failure handling in `tests/unit/test_desktop_release_artifacts.py` without weakening any existing validations.

### Testing
- Ran unit tests: `pytest -q tests/unit/test_desktop_release_artifacts.py` — all tests passed (21 passed).
- Ensured the validator compiles: `python -m compileall -q scripts/validate_desktop_tauri_release_artifacts.py` — success.
- Checked script help: `python scripts/validate_desktop_tauri_release_artifacts.py --help || true` — success.
- Ran repository checks: `pre-commit run --all-files` — success.
- Searched for relevant callsites: `rg -n "hdiutil attach|validate_desktop_tauri_release_artifacts|Resource temporarily unavailable" scripts .github` — verified updated references.

Residual risk / follow-up: monitor macOS runner logs after rollout for any other diskimages-helper races and extend transient markers if new transient messages are observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c3cf6f3b0832fb3f8c435b42fd512)