### PR TITLE
Fix desktop bridge startup diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -27,7 +27,21 @@ from path_bootstrap import ensure_runtime_import_paths
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
-from utils.context_profiles import apply_context_profile, get_context_profile
+
+_CONTEXT_PROFILES_IMPORT_ERROR: Optional[BaseException] = None
+try:
+    from utils.context_profiles import (
+        apply_context_profile,
+        get_context_profile,
+        normalize_context_tier,
+    )
+except Exception as exc:  # resolved into a structured startup error from run()/main()
+    _CONTEXT_PROFILES_IMPORT_ERROR = exc
+    apply_context_profile = None  # type: ignore[assignment]
+    get_context_profile = None  # type: ignore[assignment]
+
+    def normalize_context_tier(profile_id: Optional[str]) -> str:
+        return profile_id if profile_id in {"8k-fast", "64k-full"} else "8k-fast"
 
 try:
     from desktop_runtime_setup import (
@@ -543,7 +557,10 @@ def _structured_startup_error_payload(
         "backend_selected": "pending",
         "backend_used": "pending",
         "fallback_reason": None,
-        "model_path": getattr(args, "model", ""),
+        "context_tier": normalize_context_tier(getattr(args, "context_tier", "8k-fast")),
+        "interpreter": sys.executable,
+        "import_root": os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "unknown") or "unknown",
+        "log_path": os.environ.get("TOKENPLACE_COMPUTE_NODE_LOG_PATH", "unknown") or "unknown",
         "last_error": message,
         "message": message,
         "warm_load_state": "failed",
@@ -633,6 +650,10 @@ def run(args: argparse.Namespace) -> int:
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
 
+    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
+        emit_startup_error(f"runtime unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")
+        return 1
+
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -695,7 +716,12 @@ def run(args: argparse.Namespace) -> int:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
 
-    args.context_tier = get_context_profile(getattr(args, "context_tier", "8k-fast")).profile_id
+    try:
+        args.context_tier = get_context_profile(
+            getattr(args, "context_tier", "8k-fast")
+        ).profile_id
+    except ValueError:
+        args.context_tier = normalize_context_tier(getattr(args, "context_tier", "8k-fast"))
 
     relay_urls = _normalize_relay_urls(
         getattr(args, "relay_url", None),

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -910,6 +910,9 @@ pub async fn start_compute_node(
     );
     configure_runtime_bootstrap_env(&mut bridge_command, &request.mode);
     bridge_command.env("TOKENPLACE_COMPUTE_NODE_SESSION_ID", &session_id);
+    if let Some(path) = &log_file_path {
+        bridge_command.env("TOKENPLACE_COMPUTE_NODE_LOG_PATH", path);
+    }
 
     let spawn_result = bridge_command
         .arg("--model")

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1972,7 +1972,11 @@ def test_main_emits_structured_error_when_last_resort_exception_path_runs(capsys
     assert payload["backend_available"] == "pending"
     assert payload["backend_selected"] == "pending"
     assert payload["backend_used"] == "pending"
-    assert payload["model_path"] == "/tmp/model.gguf"
+    assert "model_path" not in payload
+    assert payload["context_tier"] == "8k-fast"
+    assert payload["interpreter"] == sys.executable
+    assert "import_root" in payload
+    assert "log_path" in payload
     assert payload["last_error"] == payload["message"]
     assert "compute-node bridge exited before emitting a startup event: boom" == payload["message"]
     assert payload["warm_load_state"] == "failed"
@@ -2157,6 +2161,38 @@ class ComputeNodeRuntime:
     assert any(event.get('type') == 'started' for event in events)
     assert any(event.get('type') == 'stopped' for event in events)
     assert "No module named 'utils'" not in stdout
+
+
+def test_context_profiles_import_failure_emits_structured_startup_error(capsys, monkeypatch):
+    _reset_cancel_queue()
+    monkeypatch.setattr(
+        compute_node_bridge,
+        "_CONTEXT_PROFILES_IMPORT_ERROR",
+        ModuleNotFoundError("No module named 'utils.context_profiles'"),
+    )
+    monkeypatch.setenv("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "/app/Resources/_up/_up")
+    monkeypatch.setenv("TOKENPLACE_COMPUTE_NODE_LOG_PATH", "/tmp/operator.log")
+    args = SimpleNamespace(
+        model="/tmp/secret-model.gguf",
+        mode="auto",
+        relay_url="https://token.place",
+        relay_port=None,
+        context_tier="does-not-exist",
+    )
+
+    assert compute_node_bridge.run(args) == 1
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    payload = events[0]
+    assert payload["type"] == "error"
+    assert payload["registered"] is False
+    assert payload["context_tier"] == "8k-fast"
+    assert payload["interpreter"] == sys.executable
+    assert payload["import_root"] == "/app/Resources/_up/_up"
+    assert payload["log_path"] == "/tmp/operator.log"
+    assert "utils.context_profiles" in payload["message"]
+    assert "model_path" not in payload
+    assert "/tmp/secret-model.gguf" not in json.dumps(payload)
 
 
 def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch):


### PR DESCRIPTION
### Motivation
- The packaged desktop compute-node bridge could exit before emitting a structured startup event when `utils.context_profiles` (or other runtime imports) failed, leaving the UI with only a generic "bridge exited before emitting a startup event" message.
- Startup failures need safer, actionable diagnostics (without secrets) so the desktop UI can surface a helpful error and make the operator log path discoverable.
- Preserve fail-closed behavior: if the runtime cannot start or warm-load fails, the node must not register.

### Description
- Defer and capture `utils.context_profiles` import failures at module import time and surface them as a structured startup `error` event from `run()` instead of letting the process exit silently. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Extend structured startup error payload with safe fields: `context_tier`, `interpreter`, `import_root`, and `log_path`, and stop including `model_path` in those early failure payloads to avoid leaking model paths. (`compute_node_bridge.py`)
- Pass the per-session operator log path from the Rust launcher into the Python bridge via `TOKENPLACE_COMPUTE_NODE_LOG_PATH` so startup errors can include the recoverable log file location. (`desktop-tauri/src-tauri/src/compute_node.rs`)
- Add regression test coverage verifying structured startup errors for context-profile import failures, normalization of unknown context tiers to `8k-fast`, and that the model path is not leaked in the startup error payload. (`tests/unit/test_desktop_compute_node_bridge.py`)

### Testing
- Ran unit tests for context profiles: `python -m pytest tests/unit/test_context_profiles.py -q` — PASSED.
- Ran the full compute-node bridge unit suite: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` — PASSED (105 tests).
- Ran the focused new regression test: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py::test_context_profiles_import_failure_emits_structured_startup_error -q` — PASSED.
- Ran desktop JS tests and build: `cd desktop-tauri && npm test -- --run` — PASSED; `cd desktop-tauri && npm run build` — PASSED.
- Ran repository hooks: `pre-commit run --all-files` — PASSED and `git diff --check` — no problems.
- Attempted Rust `cargo test` for the desktop tauri target (`cd desktop-tauri/src-tauri && cargo test compute_node`) but it failed in this environment due to a missing system dependency (`glib-2.0.pc` / `glib-2.0` required by `glib-sys`); this blocked running the Rust unit tests here.

Notes / follow-ups
- The change preserves fail-closed semantics and only enhances diagnostics; if additional packaging issues are observed on a target platform (missing runtime files), follow-ups should adjust resource bundling or `ensure_runtime_import_paths` probing as needed.
- A maintainer with a native build environment should run the Rust `cargo test` smoke tests and verify packaged release binaries on macOS/Windows installers to confirm end-to-end startup behavior in real packaged layouts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c41ac2404832f8932663c155eaf90)