### PR TITLE
Fix desktop bridge startup diagnostics for missing context_profiles

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -27,7 +27,14 @@ from path_bootstrap import ensure_runtime_import_paths
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
-from utils.context_profiles import apply_context_profile, get_context_profile
+
+_CONTEXT_PROFILES_IMPORT_ERROR: Optional[BaseException] = None
+try:
+    from utils.context_profiles import apply_context_profile, normalize_context_tier
+except Exception as exc:  # pragma: no cover - exercised by subprocess startup tests
+    apply_context_profile = None  # type: ignore[assignment]
+    normalize_context_tier = None  # type: ignore[assignment]
+    _CONTEXT_PROFILES_IMPORT_ERROR = exc
 
 try:
     from desktop_runtime_setup import (
@@ -486,6 +493,32 @@ def emit(payload: Dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
+def _context_profiles_unavailable_message(exc: BaseException) -> str:
+    return (
+        "desktop context profile startup import failed "
+        f"(interpreter={sys.executable} import_root={_safe_import_root_for_diagnostics()}): {exc}"
+    )
+
+
+def _safe_import_root_for_diagnostics() -> str:
+    explicit = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    if explicit:
+        return explicit
+    for entry in sys.path:
+        if entry and os.path.isdir(os.path.join(entry, "utils")):
+            return entry
+    return "unknown"
+
+
+def _normalize_context_tier_for_bridge(profile_id: Optional[str]) -> str:
+    if _CONTEXT_PROFILES_IMPORT_ERROR is not None or normalize_context_tier is None:
+        fallback_error = RuntimeError("utils.context_profiles unavailable")
+        raise RuntimeError(
+            _context_profiles_unavailable_message(_CONTEXT_PROFILES_IMPORT_ERROR or fallback_error)
+        )
+    return normalize_context_tier(profile_id)
+
+
 def _relay_runtime_state(
     warm_load_state: str, *, running: bool, warm_load_enabled: bool = True
 ) -> str:
@@ -543,7 +576,6 @@ def _structured_startup_error_payload(
         "backend_selected": "pending",
         "backend_used": "pending",
         "fallback_reason": None,
-        "model_path": getattr(args, "model", ""),
         "last_error": message,
         "message": message,
         "warm_load_state": "failed",
@@ -682,6 +714,14 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     try:
+        args.context_tier = _normalize_context_tier_for_bridge(
+            getattr(args, "context_tier", "8k-fast")
+        )
+    except RuntimeError as exc:
+        emit_startup_error(str(exc))
+        return 1
+
+    try:
         from utils.compute_node_runtime import (
             apply_compute_mode,
             compute_mode_diagnostics,
@@ -691,11 +731,9 @@ def run(args: argparse.Namespace) -> int:
             resolve_relay_port,
             resolve_relay_url,
         )
-    except ModuleNotFoundError as exc:
+    except (ImportError, ModuleNotFoundError) as exc:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
-
-    args.context_tier = get_context_profile(getattr(args, "context_tier", "8k-fast")).profile_id
 
     relay_urls = _normalize_relay_urls(
         getattr(args, "relay_url", None),
@@ -763,6 +801,12 @@ def run(args: argparse.Namespace) -> int:
         )
 
     runtime.model_manager.model_path = args.model
+    if apply_context_profile is None:
+        fallback_error = RuntimeError("utils.context_profiles unavailable")
+        emit_startup_error(
+            _context_profiles_unavailable_message(_CONTEXT_PROFILES_IMPORT_ERROR or fallback_error)
+        )
+        return 1
     context_profile = apply_context_profile(runtime.model_manager, args.context_tier)
     apply_compute_mode(runtime.model_manager, args.mode)
     try:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1972,7 +1972,7 @@ def test_main_emits_structured_error_when_last_resort_exception_path_runs(capsys
     assert payload["backend_available"] == "pending"
     assert payload["backend_selected"] == "pending"
     assert payload["backend_used"] == "pending"
-    assert payload["model_path"] == "/tmp/model.gguf"
+    assert "model_path" not in payload
     assert payload["last_error"] == payload["message"]
     assert "compute-node bridge exited before emitting a startup event: boom" == payload["message"]
     assert payload["warm_load_state"] == "failed"
@@ -2001,6 +2001,74 @@ def test_main_does_not_import_compute_runtime_for_mode_normalization(monkeypatch
     )
 
     assert compute_node_bridge.main() == 0
+
+
+def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tmp_path):
+    python_dir = tmp_path / 'bin' / 'resources' / 'python'
+    import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
+    utils_dir = import_root / 'utils'
+    python_dir.mkdir(parents=True)
+    utils_dir.mkdir(parents=True)
+
+    (python_dir / 'compute_node_bridge.py').write_text(
+        MODULE_PATH.read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (python_dir / 'path_bootstrap.py').write_text(
+        (MODULE_PATH.parent / 'path_bootstrap.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (python_dir / 'desktop_runtime_setup.py').write_text(
+        """
+def desktop_gpu_runtime_failure_message(_mode, _runtime_setup):
+    return None
+
+def ensure_desktop_llama_runtime(_mode):
+    return {"selected_backend": "cpu", "detected_device": "cpu", "runtime_action": "skipped"}
+
+def ensure_desktop_python_dependencies(*, repo_root=None):
+    return {"ok": "true", "action": "already_satisfied", "missing": ""}
+
+def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):
+    return None
+""".strip() + "\n",
+        encoding='utf-8',
+    )
+    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_dir / 'compute_node_runtime.py').write_text('', encoding='utf-8')
+
+    env = os.environ.copy()
+    env.pop('PYTHONPATH', None)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(python_dir / 'compute_node_bridge.py'),
+            '--model',
+            '/tmp/model.gguf',
+            '--mode',
+            'auto',
+            '--relay-url',
+            'https://token.place',
+        ],
+        text=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        cwd=tmp_path,
+    )
+
+    assert proc.returncode == 1
+    events = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+    payload = next(event for event in events if event.get('type') == 'error')
+    assert payload['running'] is False
+    assert payload['registered'] is False
+    assert payload['relay_runtime_state'] == 'failed'
+    assert 'desktop context profile startup import failed' in payload['message']
+    assert "No module named 'utils.context_profiles'" in payload['message']
+    assert 'interpreter=' in payload['message']
+    assert 'import_root=' in payload['message']
+    assert 'model_path' not in payload
 
 
 def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):


### PR DESCRIPTION
### Motivation
- Packaged desktop operator startup could exit before emitting a startup event when `utils.context_profiles` failed to import in release-like resource layouts, leaving the UI with only the generic "compute-node bridge exited before emitting a startup event" message.

### Description
- Defer and catch `utils.context_profiles` import errors in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and record the exception so the bridge can emit a structured `error` event instead of crashing. 
- Add `_context_profiles_unavailable_message`, `_safe_import_root_for_diagnostics`, and `_normalize_context_tier_for_bridge` helpers to produce a sanitized diagnostic string that includes safe fields like `interpreter` and `import_root` but not secrets or model paths. 
- Normalize the requested context tier before importing the compute runtime and fail early with a structured startup `error` if context profile resources are unavailable. 
- Remove `model_path` from early startup `error` payloads to avoid exposing model paths on the earliest failures. 
- Add a release-like subprocess regression test in `tests/unit/test_desktop_compute_node_bridge.py` that simulates missing bundled `utils.context_profiles` and asserts the bridge emits a safe structured error; adjust an existing test to reflect `model_path` omission.

### Testing
- Ran `python -m pytest tests/unit/test_context_profiles.py -q` and it passed (3 tests). 
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and it passed (105 tests). 
- Ran desktop front-end checks with `cd desktop-tauri && npm test -- --run` and `npm run build`, both succeeded. 
- Attempted `cd desktop-tauri/src-tauri && cargo test` but the run is blocked by missing system dependency (`glib-2.0.pc` / `pkg-config`); cargo reported missing `glib-2.0` (environment issue). 
- Ran `pre-commit run --all-files` and `git diff --check`, both completed successfully. 
- Residual risk: packaged / installer layouts should be validated on actual platform artifacts (macOS/Windows packaged bundles) and a follow-up manual verification is recommended to ensure the bundled `utils` path semantics match installer resource layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c41cacf34832f9ac67105a4be842a)