### PR TITLE
Fix desktop bridge startup diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -27,7 +27,6 @@ from path_bootstrap import ensure_runtime_import_paths
 
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
-from utils.context_profiles import apply_context_profile, get_context_profile
 
 try:
     from desktop_runtime_setup import (
@@ -520,6 +519,17 @@ def _bridge_session_id_from_env() -> str:
     return value or uuid.uuid4().hex
 
 
+def _startup_import_root() -> str:
+    explicit = os.environ.get("TOKEN_PLACE_PYTHON_IMPORT_ROOT", "").strip()
+    if explicit:
+        return explicit
+    for entry in sys.path:
+        candidate = Path(entry or os.getcwd())
+        if (candidate / "utils").is_dir() or (candidate / "config.py").is_file():
+            return str(candidate)
+    return "unknown"
+
+
 def _structured_startup_error_payload(
     args: argparse.Namespace,
     message: str,
@@ -543,7 +553,9 @@ def _structured_startup_error_payload(
         "backend_selected": "pending",
         "backend_used": "pending",
         "fallback_reason": None,
-        "model_path": getattr(args, "model", ""),
+        "context_tier": getattr(args, "context_tier", "8k-fast"),
+        "interpreter": sys.executable,
+        "import_root": _startup_import_root(),
         "last_error": message,
         "message": message,
         "warm_load_state": "failed",
@@ -614,6 +626,13 @@ def _normalize_relay_urls(*raw_relay_url_groups: Any) -> List[str]:
 
     return normalized or ["https://token.place"]
 
+
+def _load_context_profile_helpers() -> Tuple[Any, Any]:
+    from utils.context_profiles import apply_context_profile, get_context_profile
+
+    return apply_context_profile, get_context_profile
+
+
 def run(args: argparse.Namespace) -> int:
     bridge_session_id = _bridge_session_id_from_env()
     _reset_bridge_lifecycle_state(bridge_session_id)
@@ -632,6 +651,14 @@ def run(args: argparse.Namespace) -> int:
 
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
+
+    try:
+        apply_context_profile, get_context_profile = _load_context_profile_helpers()
+    except ModuleNotFoundError as exc:
+        emit_startup_error(f"runtime unavailable: {exc}")
+        return 1
+
+    args.context_tier = get_context_profile(getattr(args, "context_tier", "8k-fast")).profile_id
 
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
@@ -694,8 +721,6 @@ def run(args: argparse.Namespace) -> int:
     except ModuleNotFoundError as exc:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
-
-    args.context_tier = get_context_profile(getattr(args, "context_tier", "8k-fast")).profile_id
 
     relay_urls = _normalize_relay_urls(
         getattr(args, "relay_url", None),

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -1,5 +1,6 @@
 """Unit tests for the desktop compute-node bridge."""
 
+import argparse
 import importlib.util
 import json
 import os
@@ -615,7 +616,6 @@ def test_run_restart_falls_back_to_relay_client_start(capsys, monkeypatch):
     assert start_calls == ['start']
     output = capsys.readouterr()
     assert 'desktop.compute_node_bridge.relay_client.reset' in output.err
-
 
 def test_run_emits_operator_status_events_and_heartbeat_registration(capsys, monkeypatch):
     _reset_cancel_queue()
@@ -1972,7 +1972,10 @@ def test_main_emits_structured_error_when_last_resort_exception_path_runs(capsys
     assert payload["backend_available"] == "pending"
     assert payload["backend_selected"] == "pending"
     assert payload["backend_used"] == "pending"
-    assert payload["model_path"] == "/tmp/model.gguf"
+    assert "model_path" not in payload
+    assert payload["context_tier"] == "8k-fast"
+    assert payload["interpreter"] == sys.executable
+    assert payload["import_root"]
     assert payload["last_error"] == payload["message"]
     assert "compute-node bridge exited before emitting a startup event: boom" == payload["message"]
     assert payload["warm_load_state"] == "failed"
@@ -2002,6 +2005,83 @@ def test_main_does_not_import_compute_runtime_for_mode_normalization(monkeypatch
 
     assert compute_node_bridge.main() == 0
 
+
+def test_run_emits_structured_error_when_context_profiles_missing(capsys, monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'utils.context_profiles':
+            raise ModuleNotFoundError("No module named 'utils.context_profiles'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    args = argparse.Namespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url=['https://relay.example'],
+        relay_urls=None,
+        relay_port=None,
+        context_tier='8k-fast',
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    payload = next(event for event in events if event.get('type') == 'error')
+    assert payload['running'] is False
+    assert payload['registered'] is False
+    assert payload['relay_runtime_state'] == 'failed'
+    assert payload['context_tier'] == '8k-fast'
+    assert payload['interpreter'] == sys.executable
+    assert payload['import_root']
+    assert 'utils.context_profiles' in payload['message']
+    assert 'model_path' not in payload
+
+
+def test_packaged_bridge_prefers_bundled_context_profiles_over_site_utils(tmp_path):
+    resources_root = tmp_path / 'TokenPlace.app' / 'Contents' / 'Resources'
+    python_dir = resources_root / 'python'
+    import_root = resources_root / '_up_' / '_up_'
+    bundled_utils = import_root / 'utils'
+    site_packages = tmp_path / 'site-packages'
+    third_party_utils = site_packages / 'utils'
+    python_dir.mkdir(parents=True)
+    bundled_utils.mkdir(parents=True)
+    third_party_utils.mkdir(parents=True)
+    (python_dir / 'path_bootstrap.py').write_text(
+        (MODULE_PATH.parent / 'path_bootstrap.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (bundled_utils / '__init__.py').write_text('', encoding='utf-8')
+    (bundled_utils / 'context_profiles.py').write_text('SOURCE = "bundled"\n', encoding='utf-8')
+    (third_party_utils / '__init__.py').write_text('', encoding='utf-8')
+    (third_party_utils / 'context_profiles.py').write_text('SOURCE = "site"\n', encoding='utf-8')
+
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(site_packages)
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            (
+                'import json, sys; '
+                f'sys.path.insert(0, {str(python_dir)!r}); '
+                'from path_bootstrap import ensure_runtime_import_paths; '
+                'ensure_runtime_import_paths('
+                f'{str(python_dir / "compute_node_bridge.py")!r}, '
+                'avoid_llama_cpp_shadowing=True); '
+                'import utils.context_profiles as cp; '
+                'print(json.dumps({"source": cp.SOURCE, "file": cp.__file__}))'
+            ),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip())
+    assert payload['source'] == 'bundled'
+    assert str(bundled_utils.resolve()) in str(Path(payload['file']).resolve())
 
 def test_main_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_path):
     python_dir = tmp_path / 'bin' / 'resources' / 'python'


### PR DESCRIPTION
### Motivation
- Packaged desktop operator could exit before emitting a structured startup event when `utils.context_profiles` or bundled import roots were unavailable, leaving the UI with only a cryptic "before emitting a startup event" message.
- Improve actionable diagnostics for early, fail-closed startup failures while avoiding leakage of sensitive fields (e.g. local model paths).

### Description
- Defer import of `utils.context_profiles` until after the bridge can emit structured events by adding `_load_context_profile_helpers()` and loading the helpers inside `run()` to ensure startup errors are emitted in structured form instead of crashing early. (`desktop-tauri/src-tauri/python/compute_node_bridge.py`)
- Add `_startup_import_root()` to report a sanitized `import_root` in early startup errors using only safe, repo-root-like candidates rather than exposing full runtime internals. (`compute_node_bridge.py`)
- Replace `model_path` with safer fields in the early startup `error` payload: include `context_tier`, `interpreter`, and `import_root`, and preserve `runtime_path`/`relay_runtime_path`. This prevents leaking local model paths in last-resort startup diagnostics. (`compute_node_bridge.py`)
- If `utils.context_profiles` is missing, emit a fail-closed structured startup `error` (with sanitized diagnostics) and return nonzero instead of crashing without emitting an event. (`compute_node_bridge.py`)
- Add focused regression tests: a test that simulates missing `utils.context_profiles` and asserts the structured error payload and safe diagnostics, and a release-like packaged import test asserting bundled `utils.context_profiles` is preferred over site-packages. (`tests/unit/test_desktop_compute_node_bridge.py`)
- Keep changes minimal and focused to the bridge startup/import path and tests; preserve fail-closed registration semantics.

### Testing
- `python -m pytest tests/unit/test_context_profiles.py -q` — passed. 
- `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` — passed (new tests included).
- `cd desktop-tauri && npm test -- --run` — frontend unit tests passed (`vitest` succeeded).
- `cd desktop-tauri && npm run build` — frontend build succeeded (`vite build` succeeded).
- `pre-commit run --all-files` — passed.
- `git diff --check` — no whitespace/check issues.
- `cd desktop-tauri/src-tauri && cargo test` — not run to completion in this environment due to missing system dependency `glib-2.0` (`pkg-config`/`glib-2.0.pc`), so Rust tests were not fully executed here (environment limitation).

Residual risk / follow-up: verify a full desktop packaged build (native platform) and run `cargo test` in an environment with `glib-2.0` installed to exercise the Rust-side integration behavior end-to-end and confirm the UI surfaces the structured startup `error` text from the bridge during real packaged runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c41b4ed68832f98303daa4b1caa1e)