### PR TITLE
Restore packaged desktop dependency-preflight ordering

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -643,6 +643,7 @@ def run_compute_bridge_startup_probe(
 
         forbidden_output = (
             "No module named 'cryptography'",
+            "context_profiles_unavailable",
             "ModuleNotFoundError",
             "ImportError",
             "compute-node bridge exited before emitting a startup event",
@@ -1020,7 +1021,6 @@ def main() -> int:
         spaced_tmp_path = tmp_path / "Packaged Layout With Spaces"
         spaced_tmp_path.mkdir(parents=True, exist_ok=True)
         bridge_script = create_packaged_layout(tmp_path)
-        run_desktop_dependency_preflight(tmp_path)
         run_unified_root_import_policy_probe(tmp_path)
         run_model_bridge_inspect_probe(tmp_path)
         run_compute_bridge_import_probe(tmp_path)
@@ -1031,7 +1031,6 @@ def main() -> int:
 
         mac_bridge_script = create_macos_bundle_layout(tmp_path)
         mac_resources_root = tmp_path / "TokenPlace.app" / "Contents" / "Resources"
-        run_desktop_dependency_preflight(tmp_path, resources_root=mac_resources_root)
         run_unified_root_import_policy_probe(tmp_path, resources_root=mac_resources_root)
         run_model_bridge_inspect_probe(tmp_path, resources_root=mac_resources_root)
         run_compute_bridge_import_probe(tmp_path, resources_root=mac_resources_root)
@@ -1087,6 +1086,10 @@ def main() -> int:
                     relay_port=relay_port,
                     resources_root=probe_resources_root,
                     layout_label=layout_label,
+                )
+                run_desktop_dependency_preflight(
+                    tmp_path,
+                    resources_root=probe_resources_root,
                 )
                 run_operator_log_persistence_probe(
                     tmp_path,

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -526,16 +526,12 @@ def _startup_context_tier(args: argparse.Namespace) -> str:
     return "8k-fast"
 
 
-def _load_context_profile_helpers() -> Tuple[Any, Any, Any]:
+def _load_context_profile_helpers() -> Tuple[Any, Any]:
     """Import context-profile helpers after baseline dependency preflight."""
 
-    from utils.context_profiles import (
-        apply_context_profile,
-        get_context_profile,
-        normalize_context_tier,
-    )
+    from utils.context_profiles import apply_context_profile, normalize_context_tier
 
-    return apply_context_profile, get_context_profile, normalize_context_tier
+    return apply_context_profile, normalize_context_tier
 
 
 def _structured_startup_error_payload(
@@ -704,9 +700,7 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        apply_context_profile, _get_context_profile, normalize_context_tier = (
-            _load_context_profile_helpers()
-        )
+        apply_context_profile, normalize_context_tier = _load_context_profile_helpers()
     except Exception as exc:
         setattr(args, "startup_error_code", "context_profiles_unavailable")
         emit_startup_error(f"context profiles unavailable: {exc}")

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import queue
+import re
 import sys
 import threading
 import time
@@ -534,6 +535,20 @@ def _load_context_profile_helpers() -> Tuple[Any, Any]:
     return apply_context_profile, normalize_context_tier
 
 
+
+def _sanitize_context_profile_import_error(exc: BaseException) -> str:
+    """Return bounded, non-sensitive context-profile import failure details."""
+
+    detail = " ".join(str(exc).split()) or exc.__class__.__name__
+    detail = re.sub(
+        r"(?i)\b(model_path|prompt|ciphertext|decrypted|key)\s*=\s*\S+",
+        "<redacted>",
+        detail,
+    )
+    if len(detail) > 240:
+        detail = f"{detail[:237]}..."
+    return detail
+
 def _structured_startup_error_payload(
     args: argparse.Namespace,
     message: str,
@@ -703,7 +718,10 @@ def run(args: argparse.Namespace) -> int:
         apply_context_profile, normalize_context_tier = _load_context_profile_helpers()
     except Exception as exc:
         setattr(args, "startup_error_code", "context_profiles_unavailable")
-        emit_startup_error(f"context profiles unavailable: {exc}")
+        emit_startup_error(
+            "context profiles unavailable: "
+            f"{_sanitize_context_profile_import_error(exc)}"
+        )
         return 1
 
     try:

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -28,25 +28,6 @@ from path_bootstrap import ensure_runtime_import_paths
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
 
-_CONTEXT_PROFILES_IMPORT_ERROR: Optional[BaseException] = None
-try:
-    from utils.context_profiles import (
-        apply_context_profile,
-        get_context_profile,
-        normalize_context_tier,
-    )
-except Exception as exc:  # pragma: no cover - defensive packaged-startup fallback
-    _CONTEXT_PROFILES_IMPORT_ERROR = exc
-
-    def normalize_context_tier(_profile_id: Optional[str]) -> str:  # pragma: no cover
-        return "8k-fast"  # pragma: no cover
-
-    def get_context_profile(_profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
-    def apply_context_profile(_manager: object, _profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
 try:
     from desktop_runtime_setup import (
         desktop_gpu_runtime_failure_message,
@@ -540,9 +521,21 @@ def _bridge_session_id_from_env() -> str:
 
 def _startup_context_tier(args: argparse.Namespace) -> str:
     raw_context_tier = getattr(args, "context_tier", "8k-fast")
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        return raw_context_tier if isinstance(raw_context_tier, str) and raw_context_tier else "8k-fast"
-    return normalize_context_tier(raw_context_tier)
+    if raw_context_tier in {"8k-fast", "64k-full"}:
+        return raw_context_tier
+    return "8k-fast"
+
+
+def _load_context_profile_helpers() -> Tuple[Any, Any, Any]:
+    """Import context-profile helpers after baseline dependency preflight."""
+
+    from utils.context_profiles import (
+        apply_context_profile,
+        get_context_profile,
+        normalize_context_tier,
+    )
+
+    return apply_context_profile, get_context_profile, normalize_context_tier
 
 
 def _structured_startup_error_payload(
@@ -662,11 +655,6 @@ def run(args: argparse.Namespace) -> int:
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
 
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        setattr(args, "startup_error_code", "context_profiles_unavailable")
-        emit_startup_error(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")
-        return 1
-
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -713,6 +701,15 @@ def run(args: argparse.Namespace) -> int:
     gpu_runtime_error = desktop_gpu_runtime_failure_message(args.mode, runtime_setup)
     if gpu_runtime_error:
         emit_startup_error(gpu_runtime_error)
+        return 1
+
+    try:
+        apply_context_profile, _get_context_profile, normalize_context_tier = (
+            _load_context_profile_helpers()
+        )
+    except Exception as exc:
+        setattr(args, "startup_error_code", "context_profiles_unavailable")
+        emit_startup_error(f"context profiles unavailable: {exc}")
         return 1
 
     try:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2044,7 +2044,15 @@ def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):
         + "\n",
         encoding='utf-8',
     )
-    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    repo_utils = Path(__file__).resolve().parents[2] / 'utils'
+    (utils_dir / '__init__.py').write_text(
+        (repo_utils / '__init__.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (utils_dir / 'path_handling.py').write_text(
+        (repo_utils / 'path_handling.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
 SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid"}
@@ -2321,6 +2329,142 @@ def test_context_profile_error_after_dependency_preflight_fails_closed(monkeypat
     assert emitted['registered'] is False
     assert 'model_path' not in emitted
     assert "No module named 'utils.context_profiles'" in emitted['last_error']
+
+
+def test_context_profile_import_error_details_are_sanitized(monkeypatch, capsys):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+
+    sensitive_detail = (
+        "context load failed\n"
+        "model_path=/secret/model.gguf prompt=plaintext decrypted=ciphertext key=abc "
+        + "x" * 400
+    )
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        lambda: {'ok': 'true', 'import_root': '/runtime'},
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_load_context_profile_helpers',
+        lambda: (_ for _ in ()).throw(RuntimeError(sensitive_detail)),
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://relay.example',
+        relay_urls=None,
+        relay_port=None,
+        context_tier='64k-full',
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    emitted = json.loads(capsys.readouterr().out.strip())
+    assert emitted['error_code'] == 'context_profiles_unavailable'
+    assert emitted['registered'] is False
+    assert '\n' not in emitted['last_error']
+    assert len(emitted['last_error']) <= len('context profiles unavailable: ') + 240
+    assert 'model_path' not in emitted['last_error']
+    assert 'model.gguf' not in emitted['last_error']
+    assert 'prompt' not in emitted['last_error']
+    assert 'plaintext' not in emitted['last_error']
+    assert 'decrypted' not in emitted['last_error']
+    assert 'ciphertext' not in emitted['last_error']
+    assert 'key=abc' not in emitted['last_error']
+
+
+def test_dependency_preflight_failure_does_not_import_context_profiles(monkeypatch, capsys):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    calls = []
+
+    def fake_dependency_preflight():
+        calls.append('dependency_preflight')
+        return {
+            'ok': 'false',
+            'action': 'requirements_missing',
+            'missing': 'cryptography',
+            'interpreter': sys.executable,
+            'import_root': '/runtime',
+            'detail': 'cryptography unavailable',
+        }
+
+    def fail_context_profiles():
+        calls.append('context_profiles')
+        raise AssertionError('context profiles unavailable')
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        fake_dependency_preflight,
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_load_context_profile_helpers',
+        fail_context_profiles,
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://relay.example',
+        relay_urls=None,
+        relay_port=None,
+        context_tier='64k-full',
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    emitted = json.loads(capsys.readouterr().out.strip())
+    assert calls == ['dependency_preflight']
+    assert 'desktop runtime dependency preflight failed' in emitted['last_error']
+    assert 'missing=cryptography' in emitted['last_error']
+    assert 'context profiles unavailable' not in emitted['last_error']
+    assert emitted['registered'] is False
+
+
+def test_clean_first_launch_imports_context_profiles_after_dependency_preflight(monkeypatch):
+    _reset_cancel_queue()
+    observed = []
+    real_import = __import__
+    cryptography_available = {'value': False}
+
+    def fake_dependency_preflight():
+        observed.append('dependency_preflight')
+        cryptography_available['value'] = True
+        return {'ok': 'true', 'missing': '', 'action': 'already_satisfied'}
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'cryptography' and not cryptography_available['value']:
+            raise ModuleNotFoundError("No module named 'cryptography'")
+        if name == 'utils.context_profiles':
+            observed.append('context_profiles_import')
+            assert cryptography_available['value'] is True
+        return real_import(name, *args, **kwargs)
+
+    _install_fake_runtime_module(monkeypatch)
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        fake_dependency_preflight,
+    )
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://relay.example',
+        relay_urls=None,
+        relay_port=None,
+        context_tier='unknown',
+    )
+
+    assert compute_node_bridge.run(args) == 0
+    assert observed[:2] == ['dependency_preflight', 'context_profiles_import']
+    assert args.context_tier == '8k-fast'
 
 
 def test_module_import_does_not_load_context_profiles_before_preflight(monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2363,6 +2363,13 @@ def test_utils_package_keeps_lazy_convenience_exports():
     assert utils.get_model_manager
     assert utils.get_crypto_manager
     assert utils.RelayClient
+    assert {
+        'get_model_manager',
+        'get_crypto_manager',
+        'get_temp_dir',
+        'RelayClient',
+    } <= set(dir(utils))
+
 
 def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch):
     real_import = __import__

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2217,7 +2217,7 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
     )
 
     assert proc.returncode == 1
-    assert "unexpected runtime setup" not in proc.stderr
+    assert "unexpected runtime setup" in proc.stderr
     events = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
     payload = next(event for event in events if event.get('type') == 'error')
     assert payload['error_code'] == 'context_profiles_unavailable'
@@ -2280,12 +2280,58 @@ def test_ensure_runtime_import_paths_prefers_bundled_context_profiles_over_site_
     assert Path(payload['origin']).resolve() == (bundled_utils / 'context_profiles.py').resolve()
 
 
-def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, capsys):
+def test_context_profile_error_after_dependency_preflight_fails_closed(monkeypatch, capsys):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    events = []
+
+    def fake_dependency_preflight():
+        events.append('dependency_preflight')
+        return {'ok': 'true', 'import_root': '/runtime'}
+
+    def fail_context_profiles():
+        events.append('context_profiles')
+        raise ModuleNotFoundError("No module named 'utils.context_profiles'")
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        fake_dependency_preflight,
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_load_context_profile_helpers',
+        fail_context_profiles,
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://relay.example',
+        relay_urls=None,
+        relay_port=None,
+        context_tier='64k-full',
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    emitted = json.loads(capsys.readouterr().out.strip())
+    assert events == ['dependency_preflight', 'context_profiles']
+    assert emitted['error_code'] == 'context_profiles_unavailable'
+    assert emitted['context_tier'] == '64k-full'
+    assert emitted['registered'] is False
+    assert 'model_path' not in emitted
+    assert "No module named 'utils.context_profiles'" in emitted['last_error']
+
+
+def test_module_import_does_not_load_context_profiles_before_preflight(monkeypatch):
     real_import = __import__
+    imported_context_profiles = False
 
     def fake_import(name, *args, **kwargs):
+        nonlocal imported_context_profiles
         if name == 'utils.context_profiles':
-            raise ModuleNotFoundError("No module named 'utils.context_profiles'")
+            imported_context_profiles = True
+            raise AssertionError('context profiles imported at module scope')
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr('builtins.__import__', fake_import)
@@ -2295,6 +2341,8 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
     code = compile(MODULE_PATH.read_text(encoding='utf-8'), str(MODULE_PATH), 'exec')
     exec(code, module.__dict__)
 
+    assert imported_context_profiles is False
+
     args = SimpleNamespace(
         mode='auto',
         relay_url='https://relay.example',
@@ -2303,28 +2351,18 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
     )
     payload = module._structured_startup_error_payload(args, 'context profiles unavailable')
 
-    assert module._CONTEXT_PROFILES_IMPORT_ERROR is not None
-    assert module.normalize_context_tier('unknown') == '8k-fast'
     assert payload['context_tier'] == '64k-full'
     assert payload['error_code'] == 'desktop_compute_node_startup_failed'
     assert 'model_path' not in payload
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.get_context_profile('8k-fast')
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.apply_context_profile(object(), '8k-fast')
 
-    run_args = SimpleNamespace(
-        mode='auto',
-        relay_url='https://relay.example',
-        relay_urls=None,
-        context_tier='64k-full',
-    )
-    assert module.run(run_args) == 1
-    emitted = json.loads(capsys.readouterr().out.strip())
-    assert emitted['error_code'] == 'context_profiles_unavailable'
-    assert emitted['context_tier'] == '64k-full'
-    assert emitted['registered'] is False
-    assert 'model_path' not in emitted
+
+def test_utils_package_keeps_lazy_convenience_exports():
+    import utils
+
+    assert utils.get_temp_dir
+    assert utils.get_model_manager
+    assert utils.get_crypto_manager
+    assert utils.RelayClient
 
 def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch):
     real_import = __import__

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,12 @@ from utils.path_handling import get_temp_dir
 __all__ = ['get_model_manager', 'get_crypto_manager', 'get_temp_dir', 'RelayClient']
 
 
+def __dir__():
+    """List lazy convenience exports for star imports and IDE completion."""
+
+    return sorted(__all__)
+
+
 def __getattr__(name):
     """Lazily expose convenience imports without front-loading runtime dependencies."""
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,11 +2,24 @@
 Utilities package for token.place.
 """
 
-# Import key utilities for easier access
 from utils.path_handling import get_temp_dir
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
 
-# Re-export the high-level helpers and Relay client
 __all__ = ['get_model_manager', 'get_crypto_manager', 'get_temp_dir', 'RelayClient']
+
+
+def __getattr__(name):
+    """Lazily expose convenience imports without front-loading runtime dependencies."""
+
+    if name == 'get_model_manager':
+        from utils.llm.model_manager import get_model_manager
+
+        return get_model_manager
+    if name == 'get_crypto_manager':
+        from utils.crypto.crypto_manager import get_crypto_manager
+
+        return get_crypto_manager
+    if name == 'RelayClient':
+        from utils.networking.relay_client import RelayClient
+
+        return RelayClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
### Motivation

- A module-level import introduced in PR #1300 (`from utils.context_profiles ...` in `compute_node_bridge.py`) caused `utils.__init__` to eagerly import crypto/network/model modules and trigger `cryptography` imports before the app could run its desktop dependency preflight, producing startup failures like `context profiles unavailable: No module named 'cryptography'` on fresh packaged installs.  
- PR #1315 improved observability by surfacing that early failure, but it still treated a preflight-time missing dependency as a terminal context-profile error instead of restoring the original preflight-before-import ordering.  
- The goal is to ensure the bridge runs baseline dependency preflight before importing context-profile helpers (and to harden `utils` so importing the package itself does not pull heavy transitive dependencies). 

### Description

- Removed module-import-time `utils.context_profiles` loading from `desktop-tauri/src-tauri/python/compute_node_bridge.py` and added `_load_context_profile_helpers()` to import `apply_context_profile`, `get_context_profile`, and `normalize_context_tier` only after `ensure_desktop_python_dependencies()` succeeds.  
- Replaced the earlier cached `_CONTEXT_PROFILES_IMPORT_ERROR` terminal path with dependency-free early diagnostics that safely display `8k-fast`/`64k-full` and fail closed with `context_profiles_unavailable` only if the helpers fail after a successful preflight.  
- Hardened `utils/__init__.py` by converting eager convenience imports into lazy PEP 562-style lookups (`__getattr__`) so `import utils` does not pull `utils.llm`, `utils.crypto`, or `utils.networking` at module import time.  
- Added and updated tests and packaged E2E probes to assert the correct ordering: `tests/unit/test_desktop_compute_node_bridge.py` now covers that dependency preflight runs before context-profile imports and that lazy `utils` exports remain compatible, and `desktop-tauri/scripts/test_packaged_operator_e2e.py` was adjusted to exercise both standard and macOS resources layouts before/after dependency preflight checks. 

### Testing

- Ran unit suites: `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, and `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q`; all unit tests passed.  
- Executed the packaged operator regression script: `python desktop-tauri/scripts/test_packaged_operator_e2e.py`; the probe completed without emitting the prior `cryptography` / early `context_profiles_unavailable` startup failure.  
- Ran desktop JS checks: `cd desktop-tauri && npm test -- --run` and `npm run build`; JS tests and build succeeded.  
- Ran repository checks: `pre-commit run --all-files` succeeded and `git diff --check` reported no issues.  
- `cargo test` in `desktop-tauri/src-tauri` was attempted but is environment-blocked here by a missing system `glib-2.0.pc` (GLib dev package); this is an environment limitation and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc8503c38832f95b831a1cfcba8e9)