### PR TITLE
Restore packaged desktop dependency-preflight ordering

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -28,25 +28,6 @@ from path_bootstrap import ensure_runtime_import_paths
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
 
-_CONTEXT_PROFILES_IMPORT_ERROR: Optional[BaseException] = None
-try:
-    from utils.context_profiles import (
-        apply_context_profile,
-        get_context_profile,
-        normalize_context_tier,
-    )
-except Exception as exc:  # pragma: no cover - defensive packaged-startup fallback
-    _CONTEXT_PROFILES_IMPORT_ERROR = exc
-
-    def normalize_context_tier(_profile_id: Optional[str]) -> str:  # pragma: no cover
-        return "8k-fast"  # pragma: no cover
-
-    def get_context_profile(_profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
-    def apply_context_profile(_manager: object, _profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
 try:
     from desktop_runtime_setup import (
         desktop_gpu_runtime_failure_message,
@@ -538,11 +519,23 @@ def _bridge_session_id_from_env() -> str:
     return value or uuid.uuid4().hex
 
 
+def _safe_context_tier_for_startup(raw_context_tier: Any) -> str:
+    """Return a dependency-free context tier for early startup diagnostics."""
+
+    if isinstance(raw_context_tier, str) and raw_context_tier in {"8k-fast", "64k-full"}:
+        return raw_context_tier
+    return "8k-fast"
+
+
 def _startup_context_tier(args: argparse.Namespace) -> str:
-    raw_context_tier = getattr(args, "context_tier", "8k-fast")
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        return raw_context_tier if isinstance(raw_context_tier, str) and raw_context_tier else "8k-fast"
-    return normalize_context_tier(raw_context_tier)
+    return _safe_context_tier_for_startup(getattr(args, "context_tier", "8k-fast"))
+
+
+def _safe_exception_detail(exc: BaseException) -> str:
+    detail = str(exc).replace("\n", " ").strip()
+    if not detail:
+        detail = exc.__class__.__name__
+    return detail[:500]
 
 
 def _structured_startup_error_payload(
@@ -662,11 +655,6 @@ def run(args: argparse.Namespace) -> int:
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
 
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        setattr(args, "startup_error_code", "context_profiles_unavailable")
-        emit_startup_error(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")
-        return 1
-
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -716,6 +704,27 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     try:
+        from utils.context_profiles import (
+            apply_context_profile,
+            get_context_profile,
+            normalize_context_tier,
+        )
+    except Exception as exc:
+        setattr(args, "startup_error_code", "context_profiles_unavailable")
+        safe_tier = _safe_context_tier_for_startup(getattr(args, "context_tier", "8k-fast"))
+        setattr(args, "context_tier", safe_tier)
+        emit_startup_error(f"context profiles unavailable: {_safe_exception_detail(exc)}")
+        return 1
+
+    args.context_tier = normalize_context_tier(getattr(args, "context_tier", "8k-fast"))
+    try:
+        get_context_profile(args.context_tier)
+    except Exception as exc:
+        setattr(args, "startup_error_code", "context_profiles_unavailable")
+        emit_startup_error(f"context profiles unavailable: {_safe_exception_detail(exc)}")
+        return 1
+
+    try:
         from utils.compute_node_runtime import (
             apply_compute_mode,
             compute_mode_diagnostics,
@@ -728,8 +737,6 @@ def run(args: argparse.Namespace) -> int:
     except ModuleNotFoundError as exc:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
-
-    args.context_tier = normalize_context_tier(getattr(args, "context_tier", "8k-fast"))
 
     relay_urls = _normalize_relay_urls(
         getattr(args, "relay_url", None),

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2167,6 +2167,60 @@ class ComputeNodeRuntime:
     assert "No module named 'utils'" not in stdout
 
 
+def test_main_subprocess_imports_context_profiles_after_dependency_preflight(tmp_path):
+    python_dir = tmp_path / 'bin' / 'resources' / 'python'
+    import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
+    utils_dir = import_root / 'utils'
+    marker = tmp_path / 'preflight-complete'
+    python_dir.mkdir(parents=True)
+    utils_dir.mkdir(parents=True)
+
+    (python_dir / 'compute_node_bridge.py').write_text(
+        MODULE_PATH.read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (python_dir / 'path_bootstrap.py').write_text(
+        (MODULE_PATH.parent / 'path_bootstrap.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (python_dir / 'desktop_runtime_setup.py').write_text(
+        'from pathlib import Path\n'
+        f'MARKER = Path({str(marker)!r})\n'
+        'def desktop_gpu_runtime_failure_message(_mode, _runtime_setup):\n    return None\n'
+        'def ensure_desktop_llama_runtime(_mode):\n    return {"selected_backend": "cpu"}\n'
+        'def ensure_desktop_python_dependencies(*, repo_root=None):\n    MARKER.write_text("done", encoding="utf-8"); return {"ok": "true"}\n'
+        'def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):\n    return None\n',
+        encoding='utf-8',
+    )
+    (utils_dir / '__init__.py').write_text(
+        'if not __import__("pathlib").Path(%r).exists():\n'
+        '    raise ModuleNotFoundError("No module named \'cryptography\'")\n' % str(marker),
+        encoding='utf-8',
+    )
+    (utils_dir / 'context_profiles.py').write_text(
+        (Path(__file__).resolve().parents[2] / 'utils' / 'context_profiles.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (utils_dir / 'compute_node_runtime.py').write_text(
+        'raise RuntimeError("stop after context profile import")\n',
+        encoding='utf-8',
+    )
+
+    env = os.environ.copy()
+    env.pop('PYTHONPATH', None)
+    proc = subprocess.run(
+        [sys.executable, str(python_dir / 'compute_node_bridge.py'), '--model', '/tmp/model.gguf'],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    assert marker.exists()
+    assert "No module named 'cryptography'" not in proc.stdout
+    assert "context_profiles_unavailable" not in proc.stdout
+
+
 def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tmp_path):
     python_dir = tmp_path / 'bin' / 'resources' / 'python'
     import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
@@ -2217,7 +2271,7 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
     )
 
     assert proc.returncode == 1
-    assert "unexpected runtime setup" not in proc.stderr
+    assert "unexpected runtime setup" in proc.stderr
     events = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
     payload = next(event for event in events if event.get('type') == 'error')
     assert payload['error_code'] == 'context_profiles_unavailable'
@@ -2280,7 +2334,7 @@ def test_ensure_runtime_import_paths_prefers_bundled_context_profiles_over_site_
     assert Path(payload['origin']).resolve() == (bundled_utils / 'context_profiles.py').resolve()
 
 
-def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, capsys):
+def test_context_profiles_import_failure_after_preflight_reports_structured_error(monkeypatch, capsys):
     real_import = __import__
 
     def fake_import(name, *args, **kwargs):
@@ -2289,42 +2343,38 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr('builtins.__import__', fake_import)
-
-    module = ModuleType('compute_node_bridge_no_context_profiles')
-    module.__file__ = str(MODULE_PATH)
-    code = compile(MODULE_PATH.read_text(encoding='utf-8'), str(MODULE_PATH), 'exec')
-    exec(code, module.__dict__)
-
-    args = SimpleNamespace(
-        mode='auto',
-        relay_url='https://relay.example',
-        relay_urls=None,
-        context_tier='64k-full',
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        lambda _mode: {'selected_backend': 'cpu', 'detected_device': 'cpu'},
     )
-    payload = module._structured_startup_error_payload(args, 'context profiles unavailable')
-
-    assert module._CONTEXT_PROFILES_IMPORT_ERROR is not None
-    assert module.normalize_context_tier('unknown') == '8k-fast'
-    assert payload['context_tier'] == '64k-full'
-    assert payload['error_code'] == 'desktop_compute_node_startup_failed'
-    assert 'model_path' not in payload
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.get_context_profile('8k-fast')
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.apply_context_profile(object(), '8k-fast')
+    monkeypatch.setattr(compute_node_bridge, 'maybe_reexec_for_runtime_refresh', lambda _setup: None)
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_python_dependencies', lambda: {'ok': 'true'})
 
     run_args = SimpleNamespace(
         mode='auto',
         relay_url='https://relay.example',
         relay_urls=None,
+        relay_port=None,
         context_tier='64k-full',
     )
-    assert module.run(run_args) == 1
+
+    assert compute_node_bridge.run(run_args) == 1
     emitted = json.loads(capsys.readouterr().out.strip())
     assert emitted['error_code'] == 'context_profiles_unavailable'
     assert emitted['context_tier'] == '64k-full'
     assert emitted['registered'] is False
     assert 'model_path' not in emitted
+
+
+def test_utils_package_lazy_reexports_preserve_public_api():
+    import utils
+
+    assert callable(utils.get_temp_dir)
+    assert callable(utils.get_model_manager)
+    assert callable(utils.get_crypto_manager)
+    assert utils.RelayClient.__name__ == 'RelayClient'
+
 
 def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch):
     real_import = __import__

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,11 +2,22 @@
 Utilities package for token.place.
 """
 
-# Import key utilities for easier access
 from utils.path_handling import get_temp_dir
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
 
-# Re-export the high-level helpers and Relay client
 __all__ = ['get_model_manager', 'get_crypto_manager', 'get_temp_dir', 'RelayClient']
+
+
+def __getattr__(name):
+    if name == 'get_model_manager':
+        from utils.llm.model_manager import get_model_manager
+
+        return get_model_manager
+    if name == 'get_crypto_manager':
+        from utils.crypto.crypto_manager import get_crypto_manager
+
+        return get_crypto_manager
+    if name == 'RelayClient':
+        from utils.networking.relay_client import RelayClient
+
+        return RelayClient
+    raise AttributeError(f"module 'utils' has no attribute {name!r}")


### PR DESCRIPTION
### Motivation

- PR #1300 introduced a module-level `from utils.context_profiles import ...` in `compute_node_bridge.py`, which caused `utils.__init__` to eagerly import crypto/network/model helpers and reach `cryptography` before the app could run its bundled dependency preflight.  This regression breaks first-launch packaged apps.
- PR #1315 improved observability by surfacing that early failure as `context_profiles_unavailable`, but it still treated the early import failure as terminal before dependency preflight could run, so the underlying ordering bug stayed unfixed.
- The goal is to restore the startup invariant: run baseline desktop dependency preflight before importing context-profile or other crypto-dependent runtime modules, then warm the selected profile and register only after warm-load.

### Description

- Remove the module-scope `utils.context_profiles` import from `desktop-tauri/src-tauri/python/compute_node_bridge.py` and instead import/validate `utils.context_profiles` after `ensure_desktop_python_dependencies()` completes.  This preserves dependency preflight-before-import ordering.
- Add dependency-free startup helpers: `_safe_context_tier_for_startup` and `_safe_exception_detail` to allow structured early diagnostics without importing `utils` or other heavy modules.
- After preflight succeeds, import `apply_context_profile`, `get_context_profile`, and `normalize_context_tier`, normalize the CLI tier, validate `get_context_profile(...)` and then apply the profile to the runtime before warm-load/registration; post-preflight import failures emit a fail-closed `context_profiles_unavailable` structured error.
- Harden `utils/__init__.py` using PEP 562-style lazy `__getattr__` re-exports for `get_model_manager`, `get_crypto_manager`, and `RelayClient` while preserving `get_temp_dir`, to avoid eager crypto/network/model imports at package import time and preserve the public API.
- Add and adjust unit tests in `tests/unit/test_desktop_compute_node_bridge.py` to cover: packaged-layout first-start ordering (preflight runs before `utils` imports), post-preflight context-profile import failure behavior, packaged subprocess startup scenarios, and `utils` lazy re-export compatibility.

### Testing

- Ran `python -m pytest tests/unit/test_context_profiles.py -q` and all tests passed (3 passed). ✅
- Ran `python -m pytest tests/unit/test_desktop_runtime_setup.py -q` and all runtime-setup tests passed (82 passed). ✅
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and all bridge tests passed (108 passed), including the new packaged-layout and ordering regression tests. ✅
- Ran `pre-commit run --all-files` and project hooks passed. ✅
- Ran `git diff --check` with no issues. ✅
- Attempted `python desktop-tauri/scripts/test_packaged_operator_e2e.py` (packaged operator regression); the script produced no output and hung in this environment and was manually terminated, so full packaged E2E could not be completed here. ⚠️

Files changed: `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `utils/__init__.py`, and `tests/unit/test_desktop_compute_node_bridge.py`.

Residual note: I preserved the existing fail-closed semantics (no node registers unless profile warm-load succeeds) and did not change context profile IDs, token counts, registration semantics, or any relay/E2EE behavior per the scope lock.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc8561170832f8d0bbd6ac9e0957f)