### PR TITLE
Restore packaged desktop dependency-preflight ordering

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -643,6 +643,7 @@ def run_compute_bridge_startup_probe(
 
         forbidden_output = (
             "No module named 'cryptography'",
+            "context_profiles_unavailable",
             "ModuleNotFoundError",
             "ImportError",
             "compute-node bridge exited before emitting a startup event",

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -28,25 +28,6 @@ from path_bootstrap import ensure_runtime_import_paths
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
 
-_CONTEXT_PROFILES_IMPORT_ERROR: Optional[BaseException] = None
-try:
-    from utils.context_profiles import (
-        apply_context_profile,
-        get_context_profile,
-        normalize_context_tier,
-    )
-except Exception as exc:  # pragma: no cover - defensive packaged-startup fallback
-    _CONTEXT_PROFILES_IMPORT_ERROR = exc
-
-    def normalize_context_tier(_profile_id: Optional[str]) -> str:  # pragma: no cover
-        return "8k-fast"  # pragma: no cover
-
-    def get_context_profile(_profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
-    def apply_context_profile(_manager: object, _profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
 try:
     from desktop_runtime_setup import (
         desktop_gpu_runtime_failure_message,
@@ -87,6 +68,23 @@ def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
     except ModuleNotFoundError:
         return False
     return _shim_detector(module_path)
+
+
+def _safe_context_tier(profile_id: Optional[str]) -> str:
+    """Return a dependency-free display tier for pre-profile diagnostics."""
+
+    return profile_id if profile_id in {"8k-fast", "64k-full"} else "8k-fast"
+
+
+def _load_context_profile_helpers() -> Tuple[Any, Any]:
+    """Import context-profile helpers after desktop dependency preflight."""
+
+    from utils.context_profiles import (
+        apply_context_profile,
+        normalize_context_tier,
+    )
+
+    return apply_context_profile, normalize_context_tier
 
 _stdin_lines: queue.Queue[str] = queue.Queue()
 _stdin_reader_started = False
@@ -540,9 +538,7 @@ def _bridge_session_id_from_env() -> str:
 
 def _startup_context_tier(args: argparse.Namespace) -> str:
     raw_context_tier = getattr(args, "context_tier", "8k-fast")
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        return raw_context_tier if isinstance(raw_context_tier, str) and raw_context_tier else "8k-fast"
-    return normalize_context_tier(raw_context_tier)
+    return _safe_context_tier(raw_context_tier if isinstance(raw_context_tier, str) else None)
 
 
 def _structured_startup_error_payload(
@@ -662,11 +658,6 @@ def run(args: argparse.Namespace) -> int:
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
 
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        setattr(args, "startup_error_code", "context_profiles_unavailable")
-        emit_startup_error(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")
-        return 1
-
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -701,6 +692,14 @@ def run(args: argparse.Namespace) -> int:
             f"missing={missing}): {detail}"
         )
         return 1
+
+    try:
+        apply_context_profile, normalize_context_tier = _load_context_profile_helpers()
+    except Exception as exc:
+        setattr(args, "startup_error_code", "context_profiles_unavailable")
+        emit_startup_error(f"context profiles unavailable: {exc}")
+        return 1
+
     repo_llama_cpp_shim_imported = _is_repo_llama_cpp_shim(
         runtime_setup.get("llama_module_path", "")
     )

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2044,7 +2044,14 @@ def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):
         + "\n",
         encoding='utf-8',
     )
-    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_dir / '__init__.py').write_text(
+        (Path(__file__).resolve().parents[2] / 'utils' / '__init__.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (utils_dir / 'path_handling.py').write_text(
+        (Path(__file__).resolve().parents[2] / 'utils' / 'path_handling.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
 SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid"}
@@ -2167,7 +2174,7 @@ class ComputeNodeRuntime:
     assert "No module named 'utils'" not in stdout
 
 
-def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tmp_path):
+def test_main_subprocess_emits_structured_error_when_context_profiles_missing_after_preflight(tmp_path):
     python_dir = tmp_path / 'bin' / 'resources' / 'python'
     import_root = tmp_path / 'bin' / 'resources' / '_up_' / '_up_'
     utils_dir = import_root / 'utils'
@@ -2185,13 +2192,19 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
     (python_dir / 'desktop_runtime_setup.py').write_text(
         'def desktop_gpu_runtime_failure_message(_mode, _runtime_setup):\n    return None\n'
         'def ensure_desktop_llama_runtime(_mode):\n'
-        '    print("unexpected runtime setup", file=__import__("sys").stderr)\n'
         '    return {"selected_backend": "cpu"}\n'
         'def ensure_desktop_python_dependencies(*, repo_root=None):\n    return {"ok": "true"}\n'
         'def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):\n    return None\n',
         encoding='utf-8',
     )
-    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_dir / '__init__.py').write_text(
+        (Path(__file__).resolve().parents[2] / 'utils' / '__init__.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (utils_dir / 'path_handling.py').write_text(
+        (Path(__file__).resolve().parents[2] / 'utils' / 'path_handling.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
 
     env = os.environ.copy()
     env.pop('PYTHONPATH', None)
@@ -2217,7 +2230,6 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
     )
 
     assert proc.returncode == 1
-    assert "unexpected runtime setup" not in proc.stderr
     events = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
     payload = next(event for event in events if event.get('type') == 'error')
     assert payload['error_code'] == 'context_profiles_unavailable'
@@ -2228,6 +2240,84 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
     assert payload['log_file_path'] == str(tmp_path / 'operator.log')
     assert 'context profiles unavailable' in payload['message']
     assert 'model_path' not in payload
+
+
+def test_run_runs_dependency_preflight_before_context_profile_import(capsys, monkeypatch):
+    _reset_cancel_queue()
+    _install_fake_runtime_module(monkeypatch)
+    order = []
+
+    def fake_dependency_preflight(*, repo_root=None):
+        order.append('preflight')
+        return {'ok': 'true', 'action': 'fake_installed'}
+
+    real_import = __import__
+
+    def tracking_import(name, *args, **kwargs):
+        if name == 'utils.context_profiles':
+            order.append('context_profiles_import')
+            assert 'preflight' in order
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        fake_dependency_preflight,
+    )
+    monkeypatch.setattr('builtins.__import__', tracking_import)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: True)
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_port=None,
+        context_tier='8k-fast',
+    )
+
+    assert compute_node_bridge.run(args) == 0
+    assert order[:2] == ['preflight', 'context_profiles_import']
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[0]['type'] == 'started'
+
+
+def test_run_dependency_preflight_failure_is_not_context_profile_error(capsys, monkeypatch):
+    _reset_cancel_queue()
+    import_attempts = []
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        lambda: {
+            'ok': 'false',
+            'missing': 'cryptography',
+            'detail': 'mock install failed',
+            'interpreter': sys.executable,
+            'import_root': '/tmp/import-root',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_load_context_profile_helpers',
+        lambda: import_attempts.append('context') or (_ for _ in ()).throw(AssertionError()),
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='cpu',
+        relay_url='https://token.place',
+        relay_urls=None,
+        relay_port=None,
+        context_tier='8k-fast',
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    assert import_attempts == []
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload['error_code'] == 'desktop_compute_node_startup_failed'
+    assert 'desktop runtime dependency preflight failed' in payload['message']
+    assert 'context profiles unavailable' not in payload['message']
+    assert payload['registered'] is False
 
 
 def test_ensure_runtime_import_paths_prefers_bundled_context_profiles_over_site_packages(tmp_path):
@@ -2280,7 +2370,7 @@ def test_ensure_runtime_import_paths_prefers_bundled_context_profiles_over_site_
     assert Path(payload['origin']).resolve() == (bundled_utils / 'context_profiles.py').resolve()
 
 
-def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, capsys):
+def test_post_preflight_context_profile_import_failure_is_structured(monkeypatch, capsys):
     real_import = __import__
 
     def fake_import(name, *args, **kwargs):
@@ -2294,6 +2384,7 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
     module.__file__ = str(MODULE_PATH)
     code = compile(MODULE_PATH.read_text(encoding='utf-8'), str(MODULE_PATH), 'exec')
     exec(code, module.__dict__)
+    module.ensure_desktop_python_dependencies = lambda: {'ok': 'true'}
 
     args = SimpleNamespace(
         mode='auto',
@@ -2303,15 +2394,9 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
     )
     payload = module._structured_startup_error_payload(args, 'context profiles unavailable')
 
-    assert module._CONTEXT_PROFILES_IMPORT_ERROR is not None
-    assert module.normalize_context_tier('unknown') == '8k-fast'
     assert payload['context_tier'] == '64k-full'
     assert payload['error_code'] == 'desktop_compute_node_startup_failed'
     assert 'model_path' not in payload
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.get_context_profile('8k-fast')
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.apply_context_profile(object(), '8k-fast')
 
     run_args = SimpleNamespace(
         mode='auto',

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,11 +2,24 @@
 Utilities package for token.place.
 """
 
-# Import key utilities for easier access
 from utils.path_handling import get_temp_dir
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
 
-# Re-export the high-level helpers and Relay client
 __all__ = ['get_model_manager', 'get_crypto_manager', 'get_temp_dir', 'RelayClient']
+
+
+def __getattr__(name):
+    """Lazily re-export convenience helpers without eager crypto/runtime imports."""
+
+    if name == 'get_model_manager':
+        from utils.llm.model_manager import get_model_manager
+
+        return get_model_manager
+    if name == 'get_crypto_manager':
+        from utils.crypto.crypto_manager import get_crypto_manager
+
+        return get_crypto_manager
+    if name == 'RelayClient':
+        from utils.networking.relay_client import RelayClient
+
+        return RelayClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
### Motivation
- Restore the packaged-desktop startup invariant that path bootstrap and baseline dependency preflight must run before any imports that can transitively require `cryptography`, preventing first-start failures on clean installs.  
- Identify PR #1300's module-level `from utils.context_profiles import ...` in `compute_node_bridge.py` as the regression point because importing that module caused `utils/__init__.py` to eager-import crypto/network/model helpers before preflight.  
- Explain that PR #1315 improved observability by surfacing the early import failure as `context_profiles_unavailable` but did not restore correct ordering, so packaged apps still failed before dependency bootstrap could install `cryptography`.  

### Description
- Remove the module-scope `utils.context_profiles` import and defer loading of `apply_context_profile` / `normalize_context_tier` until after `ensure_desktop_python_dependencies()` succeeds, using `_load_context_profile_helpers()`.  
- Add a dependency-free early display helper `_safe_context_tier()` so pre-profile startup diagnostics can report a safe tier (`8k-fast`/`64k-full`) without importing `utils`.  
- Make `utils/__init__.py` lazily re-export convenience helpers via `__getattr__` (PEP 562-style) to avoid eager crypto/runtime imports while preserving the public API (`get_temp_dir`, `get_model_manager`, `get_crypto_manager`, `RelayClient`).  
- Update unit and packaged-layout tests to exercise a real `utils/__init__.py`, add ordering tests that assert preflight runs before `utils.context_profiles` is imported, and tighten the packaged E2E forbidden-output list to reject `context_profiles_unavailable` during successful startup.  

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_context_profiles.py -q` (passed), `python -m pytest tests/unit/test_desktop_runtime_setup.py -q` (passed), and `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` (all tests passed).  
- Ran packaged regression and integration checks: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` (probe suite passed for the modified checks), `cd desktop-tauri && npm test -- --run` (JS tests passed), and `cd desktop-tauri && npm run build` (build succeeded).  
- Ran repository checks: `pre-commit run --all-files` (passed) and `git diff --check` (clean).  
- Noted limitation: `cd desktop-tauri/src-tauri && cargo test` is blocked in this environment due to missing system `glib-2.0`/`pkg-config` (`glib-2.0.pc`) and should be executed in CI or a developer macOS/linux environment with system deps installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc85c7308832fbe5475ef0ec89ee4)