### PR TITLE
Restore packaged desktop dependency-preflight ordering

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -28,24 +28,9 @@ from path_bootstrap import ensure_runtime_import_paths
 ensure_runtime_import_paths(__file__, avoid_llama_cpp_shadowing=True)
 from pathlib import Path
 
-_CONTEXT_PROFILES_IMPORT_ERROR: Optional[BaseException] = None
-try:
-    from utils.context_profiles import (
-        apply_context_profile,
-        get_context_profile,
-        normalize_context_tier,
-    )
-except Exception as exc:  # pragma: no cover - defensive packaged-startup fallback
-    _CONTEXT_PROFILES_IMPORT_ERROR = exc
-
-    def normalize_context_tier(_profile_id: Optional[str]) -> str:  # pragma: no cover
-        return "8k-fast"  # pragma: no cover
-
-    def get_context_profile(_profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
-
-    def apply_context_profile(_manager: object, _profile_id: Optional[str]) -> object:  # pragma: no cover
-        raise RuntimeError(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")  # pragma: no cover
+apply_context_profile: Optional[Any] = None
+get_context_profile: Optional[Any] = None
+normalize_context_tier: Optional[Any] = None
 
 try:
     from desktop_runtime_setup import (
@@ -540,9 +525,34 @@ def _bridge_session_id_from_env() -> str:
 
 def _startup_context_tier(args: argparse.Namespace) -> str:
     raw_context_tier = getattr(args, "context_tier", "8k-fast")
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        return raw_context_tier if isinstance(raw_context_tier, str) and raw_context_tier else "8k-fast"
-    return normalize_context_tier(raw_context_tier)
+    if callable(normalize_context_tier):
+        return normalize_context_tier(raw_context_tier)
+    if isinstance(raw_context_tier, str) and raw_context_tier in {"8k-fast", "64k-full"}:
+        return raw_context_tier
+    return "8k-fast"
+
+
+def _load_context_profile_helpers() -> Tuple[Any, Any, Any]:
+    """Import context profile helpers after dependency preflight has completed."""
+
+    global apply_context_profile, get_context_profile, normalize_context_tier
+    if (
+        callable(apply_context_profile)
+        and callable(get_context_profile)
+        and callable(normalize_context_tier)
+    ):
+        return apply_context_profile, get_context_profile, normalize_context_tier
+
+    from utils.context_profiles import (
+        apply_context_profile as imported_apply_context_profile,
+        get_context_profile as imported_get_context_profile,
+        normalize_context_tier as imported_normalize_context_tier,
+    )
+
+    apply_context_profile = imported_apply_context_profile
+    get_context_profile = imported_get_context_profile
+    normalize_context_tier = imported_normalize_context_tier
+    return apply_context_profile, get_context_profile, normalize_context_tier
 
 
 def _structured_startup_error_payload(
@@ -662,11 +672,6 @@ def run(args: argparse.Namespace) -> int:
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
 
-    if _CONTEXT_PROFILES_IMPORT_ERROR is not None:
-        setattr(args, "startup_error_code", "context_profiles_unavailable")
-        emit_startup_error(f"context profiles unavailable: {_CONTEXT_PROFILES_IMPORT_ERROR}")
-        return 1
-
     runtime_setup = ensure_desktop_llama_runtime(args.mode)
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
@@ -701,6 +706,18 @@ def run(args: argparse.Namespace) -> int:
             f"missing={missing}): {detail}"
         )
         return 1
+
+    try:
+        (
+            apply_context_profile_helper,
+            _get_context_profile_helper,
+            normalize_context_tier_helper,
+        ) = _load_context_profile_helpers()
+    except Exception as exc:
+        setattr(args, "startup_error_code", "context_profiles_unavailable")
+        emit_startup_error(f"context profiles unavailable: {exc}")
+        return 1
+
     repo_llama_cpp_shim_imported = _is_repo_llama_cpp_shim(
         runtime_setup.get("llama_module_path", "")
     )
@@ -729,7 +746,7 @@ def run(args: argparse.Namespace) -> int:
         emit_startup_error(f"runtime unavailable: {exc}")
         return 1
 
-    args.context_tier = normalize_context_tier(getattr(args, "context_tier", "8k-fast"))
+    args.context_tier = normalize_context_tier_helper(getattr(args, "context_tier", "8k-fast"))
 
     relay_urls = _normalize_relay_urls(
         getattr(args, "relay_url", None),
@@ -797,7 +814,7 @@ def run(args: argparse.Namespace) -> int:
         )
 
     runtime.model_manager.model_path = args.model
-    context_profile = apply_context_profile(runtime.model_manager, args.context_tier)
+    context_profile = apply_context_profile_helper(runtime.model_manager, args.context_tier)
     apply_compute_mode(runtime.model_manager, args.mode)
     try:
         runtime.model_manager.desktop_runtime_probe = dict(runtime_setup)

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2044,7 +2044,9 @@ def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):
         + "\n",
         encoding='utf-8',
     )
-    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    repo_utils = Path(__file__).resolve().parents[2] / 'utils'
+    (utils_dir / '__init__.py').write_text((repo_utils / '__init__.py').read_text(encoding='utf-8'), encoding='utf-8')
+    (utils_dir / 'path_handling.py').write_text((repo_utils / 'path_handling.py').read_text(encoding='utf-8'), encoding='utf-8')
     (utils_dir / 'compute_node_runtime.py').write_text(
         """
 SUPPORTED_COMPUTE_MODES = {"auto", "cpu", "gpu", "hybrid"}
@@ -2124,7 +2126,7 @@ class ComputeNodeRuntime:
         encoding='utf-8',
     )
     (utils_dir / 'context_profiles.py').write_text(
-        (Path(__file__).resolve().parents[2] / 'utils' / 'context_profiles.py').read_text(encoding='utf-8'),
+        (repo_utils / 'context_profiles.py').read_text(encoding='utf-8'),
         encoding='utf-8',
     )
 
@@ -2191,7 +2193,9 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
         'def maybe_reexec_for_runtime_refresh(_runtime_setup, *, allow_reexec=True):\n    return None\n',
         encoding='utf-8',
     )
-    (utils_dir / '__init__.py').write_text('', encoding='utf-8')
+    repo_utils = Path(__file__).resolve().parents[2] / 'utils'
+    (utils_dir / '__init__.py').write_text((repo_utils / '__init__.py').read_text(encoding='utf-8'), encoding='utf-8')
+    (utils_dir / 'path_handling.py').write_text((repo_utils / 'path_handling.py').read_text(encoding='utf-8'), encoding='utf-8')
 
     env = os.environ.copy()
     env.pop('PYTHONPATH', None)
@@ -2217,7 +2221,7 @@ def test_main_subprocess_emits_structured_error_when_context_profiles_missing(tm
     )
 
     assert proc.returncode == 1
-    assert "unexpected runtime setup" not in proc.stderr
+    assert "unexpected runtime setup" in proc.stderr
     events = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
     payload = next(event for event in events if event.get('type') == 'error')
     assert payload['error_code'] == 'context_profiles_unavailable'
@@ -2280,16 +2284,7 @@ def test_ensure_runtime_import_paths_prefers_bundled_context_profiles_over_site_
     assert Path(payload['origin']).resolve() == (bundled_utils / 'context_profiles.py').resolve()
 
 
-def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, capsys):
-    real_import = __import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == 'utils.context_profiles':
-            raise ModuleNotFoundError("No module named 'utils.context_profiles'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr('builtins.__import__', fake_import)
-
+def test_context_profiles_import_is_deferred_until_after_dependency_preflight(monkeypatch, capsys):
     module = ModuleType('compute_node_bridge_no_context_profiles')
     module.__file__ = str(MODULE_PATH)
     code = compile(MODULE_PATH.read_text(encoding='utf-8'), str(MODULE_PATH), 'exec')
@@ -2303,15 +2298,24 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
     )
     payload = module._structured_startup_error_payload(args, 'context profiles unavailable')
 
-    assert module._CONTEXT_PROFILES_IMPORT_ERROR is not None
-    assert module.normalize_context_tier('unknown') == '8k-fast'
+    assert module.apply_context_profile is None
+    assert module.normalize_context_tier is None
     assert payload['context_tier'] == '64k-full'
     assert payload['error_code'] == 'desktop_compute_node_startup_failed'
     assert 'model_path' not in payload
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.get_context_profile('8k-fast')
-    with pytest.raises(RuntimeError, match='context profiles unavailable'):
-        module.apply_context_profile(object(), '8k-fast')
+
+    calls = []
+
+    def fake_dependencies(*, repo_root=None):
+        calls.append('dependency_preflight')
+        return {'ok': 'true'}
+
+    def fake_context_profiles():
+        calls.append('context_profiles_import')
+        raise ModuleNotFoundError("No module named 'utils.context_profiles'")
+
+    monkeypatch.setattr(module, 'ensure_desktop_python_dependencies', fake_dependencies)
+    monkeypatch.setattr(module, '_load_context_profile_helpers', fake_context_profiles)
 
     run_args = SimpleNamespace(
         mode='auto',
@@ -2320,11 +2324,47 @@ def test_module_level_fallback_when_context_profiles_import_fails(monkeypatch, c
         context_tier='64k-full',
     )
     assert module.run(run_args) == 1
+    assert calls == ['dependency_preflight', 'context_profiles_import']
     emitted = json.loads(capsys.readouterr().out.strip())
     assert emitted['error_code'] == 'context_profiles_unavailable'
     assert emitted['context_tier'] == '64k-full'
     assert emitted['registered'] is False
     assert 'model_path' not in emitted
+
+
+def test_dependency_preflight_failure_is_not_mislabeled_as_context_profiles(capsys, monkeypatch):
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_python_dependencies',
+        lambda: {
+            'ok': 'false',
+            'missing': 'cryptography',
+            'detail': 'install failed',
+            'interpreter': sys.executable,
+            'import_root': '/tmp/deps',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_load_context_profile_helpers',
+        lambda: (_ for _ in ()).throw(AssertionError('context profiles imported before preflight success')),
+    )
+
+    args = SimpleNamespace(
+        model='/tmp/model.gguf',
+        mode='auto',
+        relay_url='https://relay.example',
+        relay_urls=None,
+        relay_port=None,
+        context_tier='64k-full',
+    )
+
+    assert compute_node_bridge.run(args) == 1
+    emitted = json.loads(capsys.readouterr().out.strip())
+    assert emitted['error_code'] == 'desktop_compute_node_startup_failed'
+    assert 'desktop runtime dependency preflight failed' in emitted['message']
+    assert 'context profiles unavailable' not in emitted['message']
+    assert emitted['registered'] is False
 
 def test_module_level_fallback_when_desktop_runtime_setup_is_missing(monkeypatch):
     real_import = __import__

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,11 +2,24 @@
 Utilities package for token.place.
 """
 
-# Import key utilities for easier access
 from utils.path_handling import get_temp_dir
-from utils.llm.model_manager import get_model_manager
-from utils.crypto.crypto_manager import get_crypto_manager
-from utils.networking.relay_client import RelayClient
 
-# Re-export the high-level helpers and Relay client
-__all__ = ['get_model_manager', 'get_crypto_manager', 'get_temp_dir', 'RelayClient']
+__all__ = ["get_model_manager", "get_crypto_manager", "get_temp_dir", "RelayClient"]
+
+
+def __getattr__(name):
+    """Lazily expose convenience imports without eager crypto/runtime imports."""
+
+    if name == "get_model_manager":
+        from utils.llm.model_manager import get_model_manager
+
+        return get_model_manager
+    if name == "get_crypto_manager":
+        from utils.crypto.crypto_manager import get_crypto_manager
+
+        return get_crypto_manager
+    if name == "RelayClient":
+        from utils.networking.relay_client import RelayClient
+
+        return RelayClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
### Motivation

- A first-launch packaged desktop app could fail before the app-managed dependency bootstrap with the error `context profiles unavailable: No module named 'cryptography'` because PR #1300 added a module-level `from utils.context_profiles` import in `compute_node_bridge.py` that executed `utils/__init__.py` and eagerly pulled crypto/runtime helpers before `ensure_desktop_python_dependencies()` ran.  
- PR #1315 improved observability by surfacing that early failure as `context_profiles_unavailable`, but it did not restore the required ordering that runs dependency preflight before any imports that can transitively require `cryptography`.  
- This change restores the packaged startup contract so baseline dependency preflight runs before loading context profiles, preserving warm-load-before-register semantics and fail-closed behavior for true post-preflight context-profile errors.

### Description

- Stop importing `utils.context_profiles` at module import time in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and instead load the helpers after `ensure_desktop_python_dependencies()` completes via a new `_load_context_profile_helpers()` helper.  
- Preserve dependency-free early diagnostics by safely deriving a display tier without importing `utils`, defaulting unknown tiers to `8k-fast`.  
- If context-profile helpers still fail after a successful preflight, emit the structured `error_code: context_profiles_unavailable` payload and exit fail-closed; if dependency preflight fails, emit the existing `desktop runtime dependency preflight failed` message (not mislabel it).  
- Harden `utils/__init__.py` to lazily export convenience APIs via `__getattr__` (PEP 562 style) so importing `utils` does not eagerly import crypto/network/model modules.  
- Update and extend packaged-layout/unit tests in `tests/unit/test_desktop_compute_node_bridge.py` to use the real bundled `utils/__init__.py`, verify the ordering (preflight runs before context-profile import), and add a failure-path test that dependency preflight failures are not mislabeled as context-profile errors.

### Testing

- Ran unit tests: `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, and `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q`; all suites passed (including the new ordering/failure tests).  
- Exercised the packaged-layout script: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and it succeeded in this environment.  
- Repository checks: `pre-commit run --all-files` and desktop frontend checks `cd desktop-tauri && npm test -- --run && npm run build` passed; `cargo test` in `desktop-tauri/src-tauri` could not run in this container due to a missing system `glib-2.0`/`glib-2.0.pc` dependency (build blocked by `glib-sys`), so native Rust tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc8644cd8832fae14a7d71ddb9f37)