### PR TITLE
Let large API v1 messages reach exact 8K/64K context admission

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -977,6 +977,8 @@ new Vue({
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
+                compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
+                compute_node_context_window_exceeded: 'This prompt exceeds the selected LLM server’s context window.',
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4158,15 +4158,10 @@ def test_api_v1_invalid_and_unsupported_options_do_not_call_worker(options, code
         [{"role": "tool", "content": "hello"}],
         [{"role": "user"}],
         [{"role": "user", "content": "x", "tool_calls": []}],
-        [{"role": "user", "content": "x" * (RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS + 1)}],
         [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}],
         [{"role": "user", "content": [{"type": "text", "text": ""}]}],
         [{"role": "user", "content": [{"type": "text", "text": "x", "extra": "no"}]}],
         [{"role": "user", "content": "x"}] * (RelayClient._API_V1_MAX_MESSAGES + 1),
-        [
-            {"role": "user", "content": "x" * RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS}
-        ]
-        * 5,
     ],
 )
 def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
@@ -4185,6 +4180,112 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
     assert error["code"] == "compute_node_invalid_request"
     manager.runtime.create_chat_completion.assert_not_called()
     assert (manager.worker_health, manager.recovery_count) == before
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [{"role": "user", "content": "x" * 32769}],
+        [{"role": "user", "content": "x" * 65536}],
+        [{"role": "user", "content": "x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS}],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "x" * 20000},
+                    {"type": "input_text", "text": "y" * 20000},
+                ],
+            }
+        ],
+    ],
+)
+def test_api_v1_large_structurally_valid_messages_reach_exact_admission(messages):
+    manager = _ApiV1RuntimeManager()
+    manager.context_tier = "64k-full"
+    manager.context_window_tokens = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS + 1024
+    manager.runtime.tokenize.side_effect = lambda payload, _add_bos=False: [1]
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-large-valid",
+        model_id="llama-3-8b-instruct",
+        messages=messages,
+        options={},
+        requested_context_tier="64k-full",
+    )
+
+    assert "error" not in envelope["api_v1_response"]
+    manager.runtime.create_chat_completion.assert_called()
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [{"role": "user", "content": "x" * (RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS + 1)}],
+        [
+            {"role": "user", "content": "x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS},
+            {"role": "assistant", "content": "y"},
+        ],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS},
+                    {"type": "input_text", "text": "y"},
+                ],
+            }
+        ],
+    ],
+)
+def test_api_v1_aggregate_content_too_large_returns_specific_error_and_safe_logs(
+    messages,
+    caplog,
+):
+    manager = _ApiV1RuntimeManager()
+    client = _api_v1_validation_client(manager)
+    distinctive = "SECRET_PROMPT_SENTINEL"
+    if isinstance(messages[0]["content"], str):
+        messages[0]["content"] = distinctive + messages[0]["content"]
+
+    with caplog.at_level("ERROR", logger="relay_client"):
+        envelope = client._generate_api_v1_response_with_runtime_model(
+            request_id="req-too-large",
+            model_id="llama-3-8b-instruct",
+            messages=messages,
+            options={},
+        )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_request_too_large"
+    assert error["type"] == "validation_error"
+    assert error["message_count"] == len(messages)
+    assert error["total_content_chars"] > RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["retryable"] is False
+    assert distinctive not in json.dumps(error)
+    assert distinctive not in caplog.text
+    assert "compute_node_request_too_large" in caplog.text
+    manager.runtime.create_chat_completion.assert_not_called()
+
+
+def test_api_v1_text_block_count_limit_remains_structural_invalid_request():
+    manager = _ApiV1RuntimeManager()
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-too-many-blocks",
+        model_id="llama-3-8b-instruct",
+        messages=[
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "x"}] * (RelayClient._API_V1_MAX_TEXT_BLOCKS + 1),
+            }
+        ],
+        options={},
+    )
+
+    assert envelope["api_v1_response"]["error"]["code"] == "compute_node_invalid_request"
+    manager.runtime.create_chat_completion.assert_not_called()
 
 
 def test_api_v1_unsupported_option_error_message_caps_attacker_controlled_names():
@@ -4487,6 +4588,42 @@ def test_api_v1_64k_request_on_8k_runtime_reports_exact_admission_counts():
     assert error["recommended_context_tier"] == "64k-full"
     assert error["retryable"] is True
     assert manager.runtime.calls == []
+
+
+def test_api_v1_large_valid_message_overflows_8k_after_exact_token_admission():
+    manager = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=5)
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        "x" * 9000,
+        options={"max_tokens": 5},
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 9020
+    assert error["requested_output_tokens"] == 5
+    assert error["required_total_tokens"] == 9025
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_large_valid_message_is_admitted_on_64k_when_exact_tokens_fit():
+    manager = _AdmissionManager(tier="64k-full", window=65536, default_max_tokens=5)
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        "x" * 65000,
+        options={"max_tokens": 5},
+        requested_tier="64k-full",
+    )
+
+    assert "error" not in envelope["api_v1_response"]
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.calls[-1]["max_tokens"] == 5
 
 
 def test_api_v1_64k_request_on_8k_runtime_reports_tier_unsupported_when_it_fits():

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -67,10 +67,14 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "compute_node_bridge_timeout" in chat_js
     assert "compute_node_unreachable" in chat_js
     assert "compute_node_invalid_payload" in chat_js
+    assert "compute_node_request_too_large" in chat_js
+    assert "compute_node_context_window_exceeded" in chat_js
     assert "No LLM servers are available right now." in chat_js
     assert "The LLM server took too long to respond. Please try again." in chat_js
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js
+    assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
+    assert "This prompt exceeds the selected LLM server’s context window." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -14,6 +14,7 @@ import re
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from utils.processing_result import RelayProcessingResult
@@ -25,6 +26,18 @@ from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile, no
 # Configure logging
 logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class _ApiV1ChatValidationResult:
+    valid: bool
+    code: Optional[str] = None
+    reason: str = ""
+    message_count: int = 0
+    offending_message_index: Optional[int] = None
+    per_message_content_chars: Optional[int] = None
+    total_content_chars: int = 0
+    maximum_total_content_chars: int = 0
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -524,8 +537,8 @@ class RelayClient:
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant"}
     _API_V1_MAX_MESSAGES = 64
-    _API_V1_MAX_MESSAGE_CONTENT_CHARS = 32768
     _API_V1_MAX_TEXT_BLOCKS = 32
+    # Aggregate plaintext transport/abuse ceiling. Exact context admission is token-based.
     _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
@@ -1889,37 +1902,157 @@ class RelayClient:
 
     @classmethod
     def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
+        return cls._validate_api_v1_chat_messages(messages).valid
+
+    @classmethod
+    def _validate_api_v1_chat_messages(cls, messages: Any) -> _ApiV1ChatValidationResult:
+        maximum_total_content_chars = cls._API_V1_MAX_TOTAL_REQUEST_CHARS
         if (
             not isinstance(messages, list)
             or not messages
             or len(messages) > cls._API_V1_MAX_MESSAGES
         ):
-            return False
+            message_count = len(messages) if isinstance(messages, list) else 0
+            return _ApiV1ChatValidationResult(
+                valid=False,
+                code="compute_node_invalid_request",
+                reason="message_count",
+                message_count=message_count,
+                maximum_total_content_chars=maximum_total_content_chars,
+            )
         total_content_chars = 0
-        for message in messages:
+        for index, message in enumerate(messages):
             if not isinstance(message, dict):
-                return False
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_invalid_request",
+                    reason="message_object",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
-                return False
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_invalid_request",
+                    reason="unknown_message_key",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
             role = message.get("role")
             if (
                 not isinstance(role, str)
                 or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES
             ):
-                return False
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_invalid_request",
+                    reason="role",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
-                return False
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_invalid_request",
+                    reason="name",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
             if "content" not in message:
-                return False
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_invalid_request",
+                    reason="missing_content",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
-                return False
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_invalid_request",
+                    reason="content_shape",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
             total_content_chars += content_size
             if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
-                return False
-        return True
+                return _ApiV1ChatValidationResult(
+                    valid=False,
+                    code="compute_node_request_too_large",
+                    reason="aggregate_content_chars",
+                    message_count=len(messages),
+                    offending_message_index=index,
+                    per_message_content_chars=content_size,
+                    total_content_chars=total_content_chars,
+                    maximum_total_content_chars=maximum_total_content_chars,
+                )
+        return _ApiV1ChatValidationResult(
+            valid=True,
+            message_count=len(messages),
+            total_content_chars=total_content_chars,
+            maximum_total_content_chars=maximum_total_content_chars,
+        )
+
+    @staticmethod
+    def _api_v1_invalid_request_message_validation_error(
+        validation: _ApiV1ChatValidationResult,
+    ) -> Dict[str, Any]:
+        if validation.code == "compute_node_request_too_large":
+            return {
+                "code": "compute_node_request_too_large",
+                "type": "validation_error",
+                "message": "API v1 request content exceeds the current aggregate size limit",
+                "message_count": validation.message_count,
+                "total_content_chars": validation.total_content_chars,
+                "maximum_total_content_chars": validation.maximum_total_content_chars,
+                "retryable": False,
+            }
+        return {
+            "code": "compute_node_invalid_request",
+            "message": "Invalid chat message format",
+        }
+
+    @staticmethod
+    def _log_api_v1_message_validation_rejection(
+        validation: _ApiV1ChatValidationResult,
+    ) -> None:
+        log_error(
+            (
+                "api_v1.message_validation result=rejected safe_error_code={} reason={} "
+                "message_count={} offending_message_index={} per_message_content_chars={} "
+                "total_content_chars={} maximum_total_content_chars={}"
+            ),
+            validation.code or "compute_node_invalid_request",
+            validation.reason or "unknown",
+            validation.message_count,
+            (
+                validation.offending_message_index
+                if validation.offending_message_index is not None
+                else "none"
+            ),
+            (
+                validation.per_message_content_chars
+                if validation.per_message_content_chars is not None
+                else "unknown"
+            ),
+            validation.total_content_chars,
+            validation.maximum_total_content_chars,
+        )
 
     @staticmethod
     def _api_v1_stringify_content_blocks(content: Any) -> Any:
@@ -2296,8 +2429,6 @@ class RelayClient:
     @classmethod
     def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
         if isinstance(content, str):
-            if len(content) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS:
-                return None
             return len(content)
         if (
             not isinstance(content, list)
@@ -2316,11 +2447,6 @@ class RelayClient:
             if not isinstance(text, str) or not text:
                 return None
             total += len(text)
-            if (
-                len(text) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-                or total > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-            ):
-                return None
         return total
 
     @staticmethod
@@ -2651,13 +2777,14 @@ class RelayClient:
             "recovery_succeeded": False,
         }
 
-        if not self._messages_are_valid_api_v1_chat(messages):
+        message_validation = self._validate_api_v1_chat_messages(messages)
+        if not message_validation.valid:
+            self._log_api_v1_message_validation_rejection(message_validation)
             return self._api_v1_response_envelope(
                 request_id,
-                error={
-                    "code": "compute_node_invalid_request",
-                    "message": "Invalid chat message format",
-                },
+                error=self._api_v1_invalid_request_message_validation_error(
+                    message_validation
+                ),
             )
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)


### PR DESCRIPTION
### Motivation
- The prior per-message 32,768-character guard caused structurally valid large prompts (e.g. ~64K characters) to be rejected as `compute_node_invalid_request` before the authoritative chat-template/tokenizer admission ran. 
- The aggregate safety ceiling of 131,072 characters must remain but must not be used to decide 8K vs 64K admission; exact tokenization must be authoritative. 
- The change must preserve privacy (no plaintext in logs/responses), keep structural checks, and return distinct error codes for schema vs aggregate-size vs context overflow failures.

### Description
- Removed the stale lower per-message bottleneck and consolidated the limits so only the aggregate plaintext ceiling `_API_V1_MAX_TOTAL_REQUEST_CHARS` (131,072) is enforced in pre-admission checks, while allowing a single message to consume the aggregate allowance. 
- Replaced boolean-only validation with `_ApiV1ChatValidationResult` plus `_validate_api_v1_chat_messages()` to distinguish structural failures (`compute_node_invalid_request`) from aggregate oversize (`compute_node_request_too_large`) while preserving `_messages_are_valid_api_v1_chat()` for compatibility. 
- Adjusted `_api_v1_content_validation_size()` to stop enforcing the old single-message char cap and kept the 32-block limit and other structural guards. 
- Added privacy-safe diagnostics logging for validation rejections (counts/reason/index/char totals only) and a helper to render the new `compute_node_request_too_large` error envelope with safe fields, while leaving context-admission logic (`_api_v1_authoritative_context_admission`) unchanged so exact tokenization runs for valid large inputs. 
- Added unit/integration regression tests for large single-string and text-block messages, aggregate-too-large behavior, text-block-count enforcement, and exact admission behavior for `8k-fast` vs `64k-full`, and added UI mappings in `static/chat.js` for the new user-facing messages.

### Testing
- Ran unit tests with `python -m pytest tests/unit/test_relay_client.py -q` and `python -m pytest tests/unit/test_touch_ui.py -q`, and all unit UI tests passed (`235 passed` and `9 passed` respectively). 
- Ran focused integration `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and all integration checks passed (`10 passed`). 
- Ran repository checks `pre-commit run --all-files` and `git diff --check` which completed successfully (pre-commit hooks passed and no diff/whitespace errors). 
- The new/updated tests cover: large structurally valid single-string and text-block messages reaching exact admission, aggregate-over-cap returns `compute_node_request_too_large`, text-block count remains enforced, `8k-fast` overflow and `64k-full` admission scenarios, and privacy-safe logging assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d65491548832fa341812c455ed119)