### PR TITLE
Allow large API v1 messages to reach exact 8K/64K context admission

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -978,7 +978,7 @@ new Vue({
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
                 compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
-                compute_node_context_window_exceeded: 'This prompt exceeds the selected LLM server’s context window.',
+                compute_node_context_window_exceeded: "This prompt exceeds the selected LLM server's context window.",
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/static/chat.js
+++ b/static/chat.js
@@ -977,6 +977,8 @@ new Vue({
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
+                compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
+                compute_node_context_window_exceeded: 'This prompt exceeds the selected LLM server’s context window.',
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4158,15 +4158,10 @@ def test_api_v1_invalid_and_unsupported_options_do_not_call_worker(options, code
         [{"role": "tool", "content": "hello"}],
         [{"role": "user"}],
         [{"role": "user", "content": "x", "tool_calls": []}],
-        [{"role": "user", "content": "x" * (RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS + 1)}],
         [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}],
         [{"role": "user", "content": [{"type": "text", "text": ""}]}],
         [{"role": "user", "content": [{"type": "text", "text": "x", "extra": "no"}]}],
         [{"role": "user", "content": "x"}] * (RelayClient._API_V1_MAX_MESSAGES + 1),
-        [
-            {"role": "user", "content": "x" * RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS}
-        ]
-        * 5,
     ],
 )
 def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
@@ -4185,6 +4180,95 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
     assert error["code"] == "compute_node_invalid_request"
     manager.runtime.create_chat_completion.assert_not_called()
     assert (manager.worker_health, manager.recovery_count) == before
+
+
+def test_api_v1_large_messages_reach_structural_validation_boundaries():
+    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+
+    for length in (32769, 65536, limit):
+        messages = [{"role": "user", "content": "x" * length}]
+        result = RelayClient._validate_api_v1_chat_messages(messages)
+        assert result.valid is True
+        assert RelayClient._messages_are_valid_api_v1_chat(messages) is True
+        assert result.total_content_chars == length
+
+    too_large = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "x" * (limit + 1)}]
+    )
+    assert too_large.valid is False
+    assert too_large.code == "compute_node_request_too_large"
+    assert RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": "x" * (limit + 1)}]
+    ) is False
+
+
+def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
+    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    valid_blocks = [
+        {"type": "text", "text": "a" * 20000},
+        {"type": "input_text", "text": "b" * 20000},
+    ]
+
+    result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": valid_blocks}]
+    )
+    assert result.valid is True
+    assert result.total_content_chars == 40000
+
+    assert RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": [{"type": "text", "text": "x"}] * 33}]
+    ).code == "compute_node_invalid_request"
+    assert RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}]
+    ).code == "compute_node_invalid_request"
+    assert RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": [{"type": "unknown", "text": "x"}]}]
+    ).code == "compute_node_invalid_request"
+
+    too_large = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "x" * limit},
+                    {"type": "text", "text": "y"},
+                ],
+            }
+        ]
+    )
+    assert too_large.valid is False
+    assert too_large.code == "compute_node_request_too_large"
+
+
+def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(caplog):
+    manager = _ApiV1RuntimeManager()
+    client = _api_v1_validation_client(manager)
+    distinctive_text = "DISTINCTIVE_PRIVATE_PROMPT_TEXT"
+
+    with caplog.at_level("ERROR", logger="relay_client"):
+        envelope = client._generate_api_v1_response_with_runtime_model(
+            request_id="req-too-large",
+            model_id="llama-3-8b-instruct",
+            messages=[
+                {
+                    "role": "user",
+                    "content": distinctive_text
+                    + ("x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS),
+                }
+            ],
+            options={},
+        )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_request_too_large"
+    assert error["type"] == "validation_error"
+    assert error["message_count"] == 1
+    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["retryable"] is False
+    assert distinctive_text not in json.dumps(error)
+    assert distinctive_text not in caplog.text
+    assert "aggregate_content_too_large" in caplog.text
+    manager.runtime.create_chat_completion.assert_not_called()
 
 
 def test_api_v1_unsupported_option_error_message_caps_attacker_controlled_names():
@@ -4310,6 +4394,35 @@ def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget
     assert error["prompt_tokens"] == 28
     assert error["requested_output_tokens"] == 5
     assert error["required_total_tokens"] == 33
+
+
+def test_api_v1_large_structurally_valid_message_uses_exact_tier_admission():
+    large_content = "x" * 32769
+    eight_k = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=256)
+    eight_k_client = _api_v1_validation_client(eight_k)
+
+    rejected = _admission_envelope(eight_k_client, eight_k, large_content)
+    error = rejected["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 32789
+    assert error["requested_output_tokens"] == 256
+    assert error["required_total_tokens"] == 33045
+    assert eight_k.runtime.calls == []
+
+    sixty_four_k = _AdmissionManager(
+        tier="64k-full", window=65536, default_max_tokens=256
+    )
+    sixty_four_k_client = _api_v1_validation_client(sixty_four_k)
+    accepted = _admission_envelope(
+        sixty_four_k_client, sixty_four_k, large_content, requested_tier="64k-full"
+    )
+
+    assert accepted["api_v1_response"]["message"] == {
+        "role": "assistant",
+        "content": "ok",
+    }
+    assert sixty_four_k.runtime.calls
+    assert sixty_four_k.runtime.calls[-1]["max_tokens"] == 256
 
 
 def test_api_v1_context_admission_uses_default_output_budget_for_omitted_max_tokens():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4397,21 +4397,19 @@ def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget
 
 
 def test_api_v1_large_structurally_valid_message_uses_exact_tier_admission():
-    large_content = "x" * 32769
-    eight_k = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=256)
+    large_content = "x" * 65000
+    eight_k = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=5)
     eight_k_client = _api_v1_validation_client(eight_k)
 
     rejected = _admission_envelope(eight_k_client, eight_k, large_content)
     error = rejected["api_v1_response"]["error"]
     assert error["code"] == "compute_node_context_window_exceeded"
-    assert error["prompt_tokens"] == 32789
-    assert error["requested_output_tokens"] == 256
-    assert error["required_total_tokens"] == 33045
+    assert error["prompt_tokens"] == 65020
+    assert error["requested_output_tokens"] == 5
+    assert error["required_total_tokens"] == 65025
     assert eight_k.runtime.calls == []
 
-    sixty_four_k = _AdmissionManager(
-        tier="64k-full", window=65536, default_max_tokens=256
-    )
+    sixty_four_k = _AdmissionManager(tier="64k-full", window=65536, default_max_tokens=5)
     sixty_four_k_client = _api_v1_validation_client(sixty_four_k)
     accepted = _admission_envelope(
         sixty_four_k_client, sixty_four_k, large_content, requested_tier="64k-full"
@@ -4422,7 +4420,7 @@ def test_api_v1_large_structurally_valid_message_uses_exact_tier_admission():
         "content": "ok",
     }
     assert sixty_four_k.runtime.calls
-    assert sixty_four_k.runtime.calls[-1]["max_tokens"] == 256
+    assert sixty_four_k.runtime.calls[-1]["max_tokens"] == 5
 
 
 def test_api_v1_context_admission_uses_default_output_budget_for_omitted_max_tokens():

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -67,10 +67,14 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "compute_node_bridge_timeout" in chat_js
     assert "compute_node_unreachable" in chat_js
     assert "compute_node_invalid_payload" in chat_js
+    assert "compute_node_request_too_large" in chat_js
+    assert "compute_node_context_window_exceeded" in chat_js
     assert "No LLM servers are available right now." in chat_js
     assert "The LLM server took too long to respond. Please try again." in chat_js
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js
+    assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
+    assert "This prompt exceeds the selected LLM server’s context window." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -74,7 +74,7 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js
     assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
-    assert "This prompt exceeds the selected LLM server’s context window." in chat_js
+    assert "This prompt exceeds the selected LLM server's context window." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -14,7 +14,7 @@ import re
 import sys
 import threading
 import time
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 from utils.processing_result import RelayProcessingResult
 from urllib.parse import urlparse, urlunparse
@@ -25,6 +25,16 @@ from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile, no
 # Configure logging
 logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
+
+
+class _ApiV1ChatValidationResult(NamedTuple):
+    valid: bool
+    code: Optional[str] = None
+    reason: Optional[str] = None
+    message_count: int = 0
+    message_index: Optional[int] = None
+    message_content_chars: Optional[int] = None
+    total_content_chars: int = 0
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -524,8 +534,8 @@ class RelayClient:
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant"}
     _API_V1_MAX_MESSAGES = 64
-    _API_V1_MAX_MESSAGE_CONTENT_CHARS = 32768
     _API_V1_MAX_TEXT_BLOCKS = 32
+    # Aggregate plaintext abuse/transport safety ceiling, not a token estimate.
     _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
@@ -1889,37 +1899,143 @@ class RelayClient:
 
     @classmethod
     def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
+        return cls._validate_api_v1_chat_messages(messages).valid
+
+    @classmethod
+    def _validate_api_v1_chat_messages(cls, messages: Any) -> _ApiV1ChatValidationResult:
         if (
             not isinstance(messages, list)
             or not messages
             or len(messages) > cls._API_V1_MAX_MESSAGES
         ):
-            return False
+            message_count = len(messages) if isinstance(messages, list) else 0
+            return _ApiV1ChatValidationResult(
+                False,
+                "compute_node_invalid_request",
+                "invalid_message_list",
+                message_count,
+            )
         total_content_chars = 0
-        for message in messages:
+        for index, message in enumerate(messages):
             if not isinstance(message, dict):
-                return False
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_invalid_request",
+                    "message_not_object",
+                    len(messages),
+                    index,
+                    total_content_chars=total_content_chars,
+                )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
-                return False
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_invalid_request",
+                    "unknown_message_keys",
+                    len(messages),
+                    index,
+                    total_content_chars=total_content_chars,
+                )
             role = message.get("role")
             if (
                 not isinstance(role, str)
                 or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES
             ):
-                return False
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_invalid_request",
+                    "invalid_role",
+                    len(messages),
+                    index,
+                    total_content_chars=total_content_chars,
+                )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
-                return False
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_invalid_request",
+                    "invalid_name",
+                    len(messages),
+                    index,
+                    total_content_chars=total_content_chars,
+                )
             if "content" not in message:
-                return False
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_invalid_request",
+                    "missing_content",
+                    len(messages),
+                    index,
+                    total_content_chars=total_content_chars,
+                )
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
-                return False
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_invalid_request",
+                    "invalid_content",
+                    len(messages),
+                    index,
+                    total_content_chars=total_content_chars,
+                )
             total_content_chars += content_size
             if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
-                return False
-        return True
+                return _ApiV1ChatValidationResult(
+                    False,
+                    "compute_node_request_too_large",
+                    "aggregate_content_too_large",
+                    len(messages),
+                    index,
+                    content_size,
+                    total_content_chars,
+                )
+        return _ApiV1ChatValidationResult(
+            True,
+            message_count=len(messages),
+            total_content_chars=total_content_chars,
+        )
+
+    @classmethod
+    def _log_api_v1_chat_validation_rejection(
+        cls, result: _ApiV1ChatValidationResult
+    ) -> None:
+        log_error(
+            (
+                "api_v1.chat_validation_rejected safe_error_code={} reason={} "
+                "message_count={} message_index={} message_content_chars={} "
+                "total_content_chars={} maximum_total_content_chars={}"
+            ),
+            result.code or "compute_node_invalid_request",
+            result.reason or "unknown",
+            result.message_count,
+            result.message_index if result.message_index is not None else "none",
+            (
+                result.message_content_chars
+                if result.message_content_chars is not None
+                else "unknown"
+            ),
+            result.total_content_chars,
+            cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+        )
+
+    @classmethod
+    def _api_v1_chat_validation_error(
+        cls, result: _ApiV1ChatValidationResult
+    ) -> Dict[str, Any]:
+        if result.code == "compute_node_request_too_large":
+            return {
+                "code": "compute_node_request_too_large",
+                "type": "validation_error",
+                "message": "API v1 request message content exceeds the aggregate safety limit",
+                "message_count": result.message_count,
+                "total_content_chars": result.total_content_chars,
+                "maximum_total_content_chars": cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+                "retryable": False,
+            }
+        return {
+            "code": "compute_node_invalid_request",
+            "message": "Invalid chat message format",
+        }
 
     @staticmethod
     def _api_v1_stringify_content_blocks(content: Any) -> Any:
@@ -2296,8 +2412,6 @@ class RelayClient:
     @classmethod
     def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
         if isinstance(content, str):
-            if len(content) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS:
-                return None
             return len(content)
         if (
             not isinstance(content, list)
@@ -2316,11 +2430,6 @@ class RelayClient:
             if not isinstance(text, str) or not text:
                 return None
             total += len(text)
-            if (
-                len(text) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-                or total > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-            ):
-                return None
         return total
 
     @staticmethod
@@ -2651,13 +2760,12 @@ class RelayClient:
             "recovery_succeeded": False,
         }
 
-        if not self._messages_are_valid_api_v1_chat(messages):
+        validation_result = self._validate_api_v1_chat_messages(messages)
+        if not validation_result.valid:
+            self._log_api_v1_chat_validation_rejection(validation_result)
             return self._api_v1_response_envelope(
                 request_id,
-                error={
-                    "code": "compute_node_invalid_request",
-                    "message": "Invalid chat message format",
-                },
+                error=self._api_v1_chat_validation_error(validation_result),
             )
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)


### PR DESCRIPTION
### Motivation
- The old per-message 32,768-character guard wrongly rejected large-but-structurally-valid API v1 prompts before authoritative tokenizer/context admission could run.  
- Preserve the existing aggregate plaintext safety ceiling (131,072 chars) while letting a single message consume the aggregate allowance and deferring tier-fit to exact tokenization.  
- Provide distinct, privacy-safe validation outcomes for malformed requests, transport-size abuse, and exact context overflow so callers/UI can surface clearer errors.

### Description
- Replaced the boolean-only validator with a small structured validation result (`_ApiV1ChatValidationResult`) and added `_validate_api_v1_chat_messages()` that separates structural validation from aggregate-size reporting.  
- Removed the stale lower per-message character cap from `_api_v1_content_validation_size()` so a single string or combined text blocks may use up to the aggregate cap, while keeping `_API_V1_MAX_TEXT_BLOCKS` and the 131,072 aggregate limit.  
- Return `compute_node_request_too_large` (with safe fields `message_count`, `total_content_chars`, `maximum_total_content_chars`, `retryable: false`) for aggregate oversize and keep `compute_node_invalid_request` for structural/schema failures, and preserve `compute_node_context_window_exceeded` for tokenizer admission overflow.  
- Wire validation logging to emit only safe diagnostics (codes, reasons, counts, offending index where applicable), update the API v1 admission flow to run exact rendered-token admission for valid large messages, add UI mappings for the new error codes, and add focused unit/integration tests.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_relay_client.py -q` — all tests passed (229 passed).  
- Ran landing UI unit tests: `python -m pytest tests/unit/test_touch_ui.py -q` — all tests passed (9 passed).  
- Ran integration desktop E2EE test: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — all tests passed (10 passed).  
- Ran repository checks: `pre-commit run --all-files` and `git diff --check`; pre-commit succeeded and no git-diff problems were reported.  
- New/regression tests added exercise: large single-string messages, multi-block text aggregates, aggregate-boundary rejection (`compute_node_request_too_large`), and exact 8k/64k admission behavior (expected `compute_node_context_window_exceeded` vs admitted on 64k).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d65552394832f97e5a0593a2ed5e9)