### PR TITLE
API v1: allow large messages to reach exact 8K/64K context admission

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -977,6 +977,8 @@ new Vue({
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
+                compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
+                compute_node_context_window_exceeded: 'This prompt exceeds the selected LLM server\'s context window.',
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4,6 +4,7 @@ Unit tests for the relay client module.
 import base64
 import builtins
 import json
+import logging
 import math
 import pytest
 import sys
@@ -4158,15 +4159,10 @@ def test_api_v1_invalid_and_unsupported_options_do_not_call_worker(options, code
         [{"role": "tool", "content": "hello"}],
         [{"role": "user"}],
         [{"role": "user", "content": "x", "tool_calls": []}],
-        [{"role": "user", "content": "x" * (RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS + 1)}],
         [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}],
         [{"role": "user", "content": [{"type": "text", "text": ""}]}],
         [{"role": "user", "content": [{"type": "text", "text": "x", "extra": "no"}]}],
         [{"role": "user", "content": "x"}] * (RelayClient._API_V1_MAX_MESSAGES + 1),
-        [
-            {"role": "user", "content": "x" * RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS}
-        ]
-        * 5,
     ],
 )
 def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
@@ -4185,6 +4181,83 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
     assert error["code"] == "compute_node_invalid_request"
     manager.runtime.create_chat_completion.assert_not_called()
     assert (manager.worker_health, manager.recovery_count) == before
+
+
+def test_api_v1_large_string_messages_reach_structural_validation_and_size_cap():
+    assert RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": "x" * 32769}]
+    )
+    assert RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": "x" * 65536}]
+    )
+    assert RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": "x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS}]
+    )
+
+    result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "x" * (RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS + 1)}]
+    )
+
+    assert not result.valid
+    assert result.error_code == "compute_node_request_too_large"
+    assert result.total_content_chars == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS + 1
+
+
+def test_api_v1_text_blocks_allow_aggregate_cap_but_preserve_shape_limits():
+    valid_blocks = [
+        {"type": "text", "text": "x" * 20000},
+        {"type": "input_text", "text": "y" * 20000},
+    ]
+    assert RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": valid_blocks}]
+    )
+
+    too_many_blocks = [{"type": "text", "text": "x"}] * (RelayClient._API_V1_MAX_TEXT_BLOCKS + 1)
+    assert not RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": too_many_blocks}]
+    )
+    assert not RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}]
+    )
+    assert not RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": [{"type": "unknown", "text": "x"}]}]
+    )
+
+    oversized_blocks = [
+        {"type": "text", "text": "x" * 65536},
+        {"type": "input_text", "text": "y" * 65537},
+    ]
+    result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": oversized_blocks}]
+    )
+    assert not result.valid
+    assert result.error_code == "compute_node_request_too_large"
+
+
+def test_api_v1_oversized_request_returns_specific_safe_error_and_logs(caplog):
+    manager = _ApiV1RuntimeManager()
+    client = _api_v1_validation_client(manager)
+    distinctive = "DISTINCTIVE_SECRET_PROMPT"
+    content = distinctive + ("x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS)
+
+    with caplog.at_level(logging.ERROR, logger="relay_client"):
+        envelope = client._generate_api_v1_response_with_runtime_model(
+            request_id="req-too-large",
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": content}],
+            options={},
+        )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_request_too_large"
+    assert error["type"] == "request_too_large"
+    assert error["message_count"] == 1
+    assert error["total_content_chars"] == len(content)
+    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["retryable"] is False
+    assert distinctive not in json.dumps(error)
+    assert distinctive not in caplog.text
+    manager.runtime.create_chat_completion.assert_not_called()
 
 
 def test_api_v1_unsupported_option_error_message_caps_attacker_controlled_names():
@@ -4530,6 +4603,41 @@ def test_api_v1_context_admission_exact_64k_boundaries_and_unicode_structured_te
     assert error["prompt_tokens"] == 65536
     assert error["requested_output_tokens"] == 1
     assert error["retryable"] is False
+
+
+def test_api_v1_large_valid_message_reaches_exact_admission_on_8k_and_64k():
+    content = "x" * 9000
+    eight_k_manager = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=10)
+    eight_k_client = _api_v1_validation_client(eight_k_manager)
+
+    rejected = _admission_envelope(
+        eight_k_client,
+        eight_k_manager,
+        content,
+        options={"max_tokens": 10},
+        requested_tier="8k-fast",
+    )
+
+    error = rejected["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 9020
+    assert error["requested_output_tokens"] == 10
+    assert error["required_total_tokens"] == 9030
+    assert eight_k_manager.runtime.calls == []
+
+    full_manager = _AdmissionManager(tier="64k-full", window=65536, default_max_tokens=10)
+    full_client = _api_v1_validation_client(full_manager)
+
+    accepted = _admission_envelope(
+        full_client,
+        full_manager,
+        content,
+        options={"max_tokens": 10},
+        requested_tier="64k-full",
+    )
+
+    assert accepted["api_v1_response"]["message"]["content"] == "ok"
+    assert full_manager.runtime.calls[-1]["max_tokens"] == 10
 
 
 def test_api_v1_context_overflow_is_request_scoped_and_does_not_restart_worker():

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -67,10 +67,14 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "compute_node_bridge_timeout" in chat_js
     assert "compute_node_unreachable" in chat_js
     assert "compute_node_invalid_payload" in chat_js
+    assert "compute_node_request_too_large" in chat_js
+    assert "compute_node_context_window_exceeded" in chat_js
     assert "No LLM servers are available right now." in chat_js
     assert "The LLM server took too long to respond. Please try again." in chat_js
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js
+    assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
+    assert "This prompt exceeds the selected LLM server\\'s context window." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -14,7 +14,7 @@ import re
 import sys
 import threading
 import time
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 from utils.processing_result import RelayProcessingResult
 from urllib.parse import urlparse, urlunparse
@@ -25,6 +25,16 @@ from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile, no
 # Configure logging
 logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
+
+
+class _ApiV1ChatValidationResult(NamedTuple):
+    valid: bool
+    error_code: Optional[str] = None
+    reason: Optional[str] = None
+    message_count: int = 0
+    total_content_chars: int = 0
+    message_index: Optional[int] = None
+    message_content_chars: Optional[int] = None
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -524,8 +534,8 @@ class RelayClient:
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant"}
     _API_V1_MAX_MESSAGES = 64
-    _API_V1_MAX_MESSAGE_CONTENT_CHARS = 32768
     _API_V1_MAX_TEXT_BLOCKS = 32
+    # Aggregate plaintext abuse/transport ceiling; exact token admission decides tier fit.
     _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
@@ -1888,38 +1898,68 @@ class RelayClient:
         return None
 
     @classmethod
-    def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
-        if (
-            not isinstance(messages, list)
-            or not messages
-            or len(messages) > cls._API_V1_MAX_MESSAGES
-        ):
-            return False
+    def _validate_api_v1_chat_messages(cls, messages: Any) -> _ApiV1ChatValidationResult:
+        if not isinstance(messages, list) or not messages:
+            return _ApiV1ChatValidationResult(
+                False, "compute_node_invalid_request", "messages must be a non-empty list"
+            )
+        message_count = len(messages)
+        if message_count > cls._API_V1_MAX_MESSAGES:
+            return _ApiV1ChatValidationResult(
+                False, "compute_node_invalid_request", "too many messages", message_count
+            )
         total_content_chars = 0
-        for message in messages:
+        for index, message in enumerate(messages):
             if not isinstance(message, dict):
-                return False
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_invalid_request", "message must be an object",
+                    message_count, total_content_chars, index
+                )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
-                return False
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_invalid_request", "unknown message key",
+                    message_count, total_content_chars, index
+                )
             role = message.get("role")
             if (
                 not isinstance(role, str)
                 or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES
             ):
-                return False
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_invalid_request", "invalid role",
+                    message_count, total_content_chars, index
+                )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
-                return False
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_invalid_request", "invalid name",
+                    message_count, total_content_chars, index
+                )
             if "content" not in message:
-                return False
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_invalid_request", "missing content",
+                    message_count, total_content_chars, index
+                )
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
-                return False
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_invalid_request", "invalid content",
+                    message_count, total_content_chars, index
+                )
             total_content_chars += content_size
             if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
-                return False
-        return True
+                return _ApiV1ChatValidationResult(
+                    False, "compute_node_request_too_large", "aggregate content too large",
+                    message_count, total_content_chars, index, content_size
+                )
+        return _ApiV1ChatValidationResult(
+            True, None, None, message_count, total_content_chars
+        )
+
+    @classmethod
+    def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
+        return cls._validate_api_v1_chat_messages(messages).valid
 
     @staticmethod
     def _api_v1_stringify_content_blocks(content: Any) -> Any:
@@ -2296,8 +2336,6 @@ class RelayClient:
     @classmethod
     def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
         if isinstance(content, str):
-            if len(content) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS:
-                return None
             return len(content)
         if (
             not isinstance(content, list)
@@ -2316,11 +2354,6 @@ class RelayClient:
             if not isinstance(text, str) or not text:
                 return None
             total += len(text)
-            if (
-                len(text) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-                or total > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-            ):
-                return None
         return total
 
     @staticmethod
@@ -2651,14 +2684,40 @@ class RelayClient:
             "recovery_succeeded": False,
         }
 
-        if not self._messages_are_valid_api_v1_chat(messages):
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
+        message_validation = self._validate_api_v1_chat_messages(messages)
+        if not message_validation.valid:
+            safe_error_code = message_validation.error_code or "compute_node_invalid_request"
+            log_error(
+                (
+                    "API v1 chat validation rejected request: safe_error_code={} "
+                    "reason={} message_count={} message_index={} "
+                    "message_content_chars={} total_content_chars={} "
+                    "maximum_total_content_chars={}"
+                ),
+                safe_error_code,
+                message_validation.reason,
+                message_validation.message_count,
+                message_validation.message_index,
+                message_validation.message_content_chars,
+                message_validation.total_content_chars,
+                self._API_V1_MAX_TOTAL_REQUEST_CHARS,
+            )
+            if safe_error_code == "compute_node_request_too_large":
+                error = {
+                    "code": "compute_node_request_too_large",
+                    "type": "request_too_large",
+                    "message": "API v1 message content exceeds the configured request size limit",
+                    "message_count": message_validation.message_count,
+                    "total_content_chars": message_validation.total_content_chars,
+                    "maximum_total_content_chars": self._API_V1_MAX_TOTAL_REQUEST_CHARS,
+                    "retryable": False,
+                }
+            else:
+                error = {
                     "code": "compute_node_invalid_request",
                     "message": "Invalid chat message format",
-                },
-            )
+                }
+            return self._api_v1_response_envelope(request_id, error=error)
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
         recovery_completion = getattr(


### PR DESCRIPTION
### Motivation
- A stale per-message 32,768-character guard caused structurally valid large API v1 messages (≈64K) to be rejected before the runtime could run authoritative tokenizer/context-admission, producing misleading `compute_node_invalid_request` responses and preventing correct 8K/64K behavior.
- The aggregate safety ceiling of 131,072 characters must be preserved as an abuse/transport cap while exact tokenization should remain authoritative for context-window decisions.

### Description
- Replace boolean-only validation with a small result type `_ApiV1ChatValidationResult` and a new `._validate_api_v1_chat_messages()` helper that distinguishes structural/schema failures from aggregate-size overflow, while keeping `_messages_are_valid_api_v1_chat()` as a compatibility wrapper.
- Remove the obsolete per-message/text-block 32,768-character bottleneck: `_api_v1_content_validation_size()` no longer rejects long individual strings or blocks; it only enforces structural rules and the existing `_API_V1_MAX_TEXT_BLOCKS` limit.
- Preserve the aggregate plaintext cap `_API_V1_MAX_TOTAL_REQUEST_CHARS = 131072` and return a distinct encrypted error `compute_node_request_too_large` when that ceiling is exceeded; structural errors continue to return `compute_node_invalid_request`.
- Add privacy-safe diagnostics: validation logs only safe error code, reason, message counts/index, per-message character counts, aggregate char count, and configured limit; never log plaintext content.
- Ensure exact admission still runs for valid large messages by invoking the existing `_api_v1_authoritative_context_admission()` path after structural validation.
- Add user-facing mappings in `static/chat.js` for `compute_node_request_too_large` and `compute_node_context_window_exceeded` and add regression tests in `tests/unit/test_relay_client.py` plus focused UI assertions in `tests/unit/test_touch_ui.py` covering the new behavior.

### Testing
- Ran focused and integration test suites: `python -m pytest tests/unit/test_relay_client.py -q` (229 passed), `python -m pytest tests/unit/test_touch_ui.py -q` (9 passed), and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (10 passed). All reported tests passed.
- Ran repository checks: `pre-commit run --all-files` completed successfully and `git diff --check` produced no issues.
- Verification notes: tests assert that large single-string and combined text-block requests now pass structural validation up to the 131,072 aggregate cap, that requests over the cap return `compute_node_request_too_large` (with privacy-safe logs), and that exact admission rejects/admits requests correctly on `8k-fast` vs `64k-full` simulated runtimes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d656c0bcc832f8df5c741918f0dc9)