### PR TITLE
Allow large API v1 messages to reach context admission

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -977,6 +977,8 @@ new Vue({
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
+                compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
+                compute_node_context_window_exceeded: 'This prompt exceeds the selected LLM server\'s context window.',
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4,6 +4,7 @@ Unit tests for the relay client module.
 import base64
 import builtins
 import json
+import logging
 import math
 import pytest
 import sys
@@ -4158,15 +4159,10 @@ def test_api_v1_invalid_and_unsupported_options_do_not_call_worker(options, code
         [{"role": "tool", "content": "hello"}],
         [{"role": "user"}],
         [{"role": "user", "content": "x", "tool_calls": []}],
-        [{"role": "user", "content": "x" * (RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS + 1)}],
         [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}],
         [{"role": "user", "content": [{"type": "text", "text": ""}]}],
         [{"role": "user", "content": [{"type": "text", "text": "x", "extra": "no"}]}],
         [{"role": "user", "content": "x"}] * (RelayClient._API_V1_MAX_MESSAGES + 1),
-        [
-            {"role": "user", "content": "x" * RelayClient._API_V1_MAX_MESSAGE_CONTENT_CHARS}
-        ]
-        * 5,
     ],
 )
 def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
@@ -4186,6 +4182,89 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
     manager.runtime.create_chat_completion.assert_not_called()
     assert (manager.worker_health, manager.recovery_count) == before
 
+
+def test_api_v1_large_messages_reach_structural_validation_limit():
+    valid_lengths = [32769, 65536, RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS]
+    for length in valid_lengths:
+        messages = [{"role": "user", "content": "x" * length}]
+        result = RelayClient._api_v1_chat_validation_result(messages)
+        assert result["valid"] is True
+        assert RelayClient._messages_are_valid_api_v1_chat(messages) is True
+
+    too_large = [
+        {
+            "role": "user",
+            "content": "x" * (RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS + 1),
+        }
+    ]
+    result = RelayClient._api_v1_chat_validation_result(too_large)
+    assert result["valid"] is False
+    assert result["code"] == "compute_node_request_too_large"
+    assert result["total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS + 1
+
+
+def test_api_v1_text_blocks_share_aggregate_safety_limit_without_per_block_cap():
+    content = [{"type": "text", "text": "x" * 20000} for _ in range(2)]
+    result = RelayClient._api_v1_chat_validation_result(
+        [{"role": "user", "content": content}]
+    )
+    assert result["valid"] is True
+
+    too_many_blocks = [
+        {"type": "text", "text": "x"}
+        for _ in range(RelayClient._API_V1_MAX_TEXT_BLOCKS + 1)
+    ]
+    assert not RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": too_many_blocks}]
+    )
+    assert not RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": [{"type": "input_image", "image_url": "x"}]}]
+    )
+    assert not RelayClient._messages_are_valid_api_v1_chat(
+        [{"role": "user", "content": [{"type": "unknown", "text": "x"}]}]
+    )
+
+    over_limit_blocks = [
+        {"type": "text", "text": "x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS},
+        {"type": "text", "text": "y"},
+    ]
+    result = RelayClient._api_v1_chat_validation_result(
+        [{"role": "user", "content": over_limit_blocks}]
+    )
+    assert result["valid"] is False
+    assert result["code"] == "compute_node_request_too_large"
+
+
+def test_api_v1_too_large_error_and_validation_log_are_privacy_safe(caplog):
+    manager = _ApiV1RuntimeManager()
+    client = _api_v1_validation_client(manager)
+    distinctive = "DISTINCTIVE_SECRET_PROMPT"
+    messages = [
+        {
+            "role": "user",
+            "content": distinctive + ("x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS),
+        }
+    ]
+
+    with caplog.at_level(logging.INFO, logger="relay_client"):
+        envelope = client._generate_api_v1_response_with_runtime_model(
+            request_id="req-too-large",
+            model_id="llama-3-8b-instruct",
+            messages=messages,
+            options={},
+        )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_request_too_large"
+    assert error["type"] == "request_too_large"
+    assert error["retryable"] is False
+    assert error["message_count"] == 1
+    assert error["total_content_chars"] > RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert distinctive not in json.dumps(error)
+    assert distinctive not in caplog.text
+    assert "total_content_chars_exceeded" in caplog.text
+    manager.runtime.create_chat_completion.assert_not_called()
 
 def test_api_v1_unsupported_option_error_message_caps_attacker_controlled_names():
     manager = _ApiV1RuntimeManager()
@@ -4295,6 +4374,29 @@ def _admission_envelope(client, manager, content, *, options=None, requested_tie
         requested_context_tier=requested_tier or manager.context_tier,
     )
 
+
+def test_api_v1_large_structurally_valid_prompt_reaches_exact_admission_on_each_tier():
+    content = "x" * 40000
+
+    eight_k_manager = _AdmissionManager(tier="8k-fast", window=8192, default_max_tokens=7)
+    eight_k_client = _api_v1_validation_client(eight_k_manager)
+    eight_k = _admission_envelope(eight_k_client, eight_k_manager, content)
+
+    error = eight_k["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 40020
+    assert error["requested_output_tokens"] == 7
+    assert error["required_total_tokens"] == 40027
+    assert eight_k_manager.runtime.calls == []
+
+    full_manager = _AdmissionManager(tier="64k-full", window=65536, default_max_tokens=7)
+    full_client = _api_v1_validation_client(full_manager)
+    full = _admission_envelope(full_client, full_manager, content)
+
+    assert "error" not in full["api_v1_response"]
+    assert full_manager.runtime.calls
+    assert full_manager.runtime.calls[-1]["max_tokens"] == 7
+    assert full["api_v1_response"]["message"]["content"] == "ok"
 
 def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget():
     manager = _AdmissionManager(window=32)

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -64,6 +64,8 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "getUserFacingApiError" in chat_js
     assert "no_registered_compute_nodes" in chat_js
     assert "compute_node_timeout" in chat_js
+    assert "compute_node_request_too_large" in chat_js
+    assert "compute_node_context_window_exceeded" in chat_js
     assert "compute_node_bridge_timeout" in chat_js
     assert "compute_node_unreachable" in chat_js
     assert "compute_node_invalid_payload" in chat_js
@@ -71,6 +73,8 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "The LLM server took too long to respond. Please try again." in chat_js
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js
+    assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
+    assert "This prompt exceeds the selected LLM server\\'s context window." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -524,8 +524,9 @@ class RelayClient:
     _API_V1_LOCAL_ADAPTER_BASE_MODELS = {}
     _API_V1_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant"}
     _API_V1_MAX_MESSAGES = 64
-    _API_V1_MAX_MESSAGE_CONTENT_CHARS = 32768
     _API_V1_MAX_TEXT_BLOCKS = 32
+    # Aggregate plaintext content ceiling for abuse/transport safety only.
+    # Exact llama.cpp tokenization below remains authoritative for context fit.
     _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
@@ -1888,38 +1889,69 @@ class RelayClient:
         return None
 
     @classmethod
-    def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
-        if (
-            not isinstance(messages, list)
-            or not messages
-            or len(messages) > cls._API_V1_MAX_MESSAGES
-        ):
-            return False
+    def _api_v1_chat_validation_result(cls, messages: Any) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "valid": False,
+            "code": "compute_node_invalid_request",
+            "reason": "invalid_messages",
+            "message_count": len(messages) if isinstance(messages, list) else 0,
+            "message_index": None,
+            "message_content_chars": None,
+            "total_content_chars": 0,
+            "maximum_total_content_chars": cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+        }
+        if not isinstance(messages, list) or not messages:
+            return result
+        if len(messages) > cls._API_V1_MAX_MESSAGES:
+            result["reason"] = "too_many_messages"
+            return result
+
         total_content_chars = 0
-        for message in messages:
+        for index, message in enumerate(messages):
+            result["message_index"] = index
             if not isinstance(message, dict):
-                return False
+                result["reason"] = "message_not_object"
+                return result
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
-                return False
+                result["reason"] = "unknown_message_keys"
+                return result
             role = message.get("role")
             if (
                 not isinstance(role, str)
                 or role not in cls._API_V1_ALLOWED_MESSAGE_ROLES
             ):
-                return False
+                result["reason"] = "invalid_role"
+                return result
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
-                return False
+                result["reason"] = "invalid_name"
+                return result
             if "content" not in message:
-                return False
+                result["reason"] = "missing_content"
+                return result
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
-                return False
+                result["reason"] = "invalid_content"
+                return result
+            result["message_content_chars"] = content_size
             total_content_chars += content_size
+            result["total_content_chars"] = total_content_chars
             if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
-                return False
-        return True
+                result["code"] = "compute_node_request_too_large"
+                result["reason"] = "total_content_chars_exceeded"
+                return result
+
+        result["valid"] = True
+        result["code"] = None
+        result["reason"] = None
+        result["message_index"] = None
+        result["message_content_chars"] = None
+        return result
+
+    @classmethod
+    def _messages_are_valid_api_v1_chat(cls, messages: Any) -> bool:
+        return bool(cls._api_v1_chat_validation_result(messages)["valid"])
 
     @staticmethod
     def _api_v1_stringify_content_blocks(content: Any) -> Any:
@@ -2296,8 +2328,6 @@ class RelayClient:
     @classmethod
     def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
         if isinstance(content, str):
-            if len(content) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS:
-                return None
             return len(content)
         if (
             not isinstance(content, list)
@@ -2316,11 +2346,6 @@ class RelayClient:
             if not isinstance(text, str) or not text:
                 return None
             total += len(text)
-            if (
-                len(text) > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-                or total > cls._API_V1_MAX_MESSAGE_CONTENT_CHARS
-            ):
-                return None
         return total
 
     @staticmethod
@@ -2651,14 +2676,41 @@ class RelayClient:
             "recovery_succeeded": False,
         }
 
-        if not self._messages_are_valid_api_v1_chat(messages):
-            return self._api_v1_response_envelope(
-                request_id,
-                error={
+        validation = self._api_v1_chat_validation_result(messages)
+        if not validation["valid"]:
+            safe_error_code = validation["code"] or "compute_node_invalid_request"
+            log_info(
+                (
+                    "api_v1.chat_validation result=rejected safe_error_code={} "
+                    "reason={} message_count={} message_index={} "
+                    "message_content_chars={} total_content_chars={} "
+                    "maximum_total_content_chars={}"
+                ),
+                safe_error_code,
+                validation["reason"],
+                validation["message_count"],
+                validation["message_index"],
+                validation["message_content_chars"],
+                validation["total_content_chars"],
+                validation["maximum_total_content_chars"],
+            )
+            error: Dict[str, Any]
+            if safe_error_code == "compute_node_request_too_large":
+                error = {
+                    "code": "compute_node_request_too_large",
+                    "type": "request_too_large",
+                    "message": "Request message content exceeds the API v1 safety limit",
+                    "message_count": validation["message_count"],
+                    "total_content_chars": validation["total_content_chars"],
+                    "maximum_total_content_chars": validation["maximum_total_content_chars"],
+                    "retryable": False,
+                }
+            else:
+                error = {
                     "code": "compute_node_invalid_request",
                     "message": "Invalid chat message format",
-                },
-            )
+                }
+            return self._api_v1_response_envelope(request_id, error=error)
 
         get_llm_instance = getattr(self.model_manager, "get_llm_instance", None)
         recovery_completion = getattr(


### PR DESCRIPTION
### Motivation
- API v1 compute nodes were rejecting structurally valid large prompts due to an obsolete per-message 32,768-character guard instead of letting the authoritative tokenizer/context-admission decide fit.
- Preserve the existing aggregate plaintext safety ceiling (131,072 chars) while removing the stale per-message bottleneck so exact token admission determines 8K/64K behavior.

### Description
- Removed the per-message 32,768-character cap and documented the remaining aggregate ceiling; the ceiling is now explicitly an abuse/transport safety limit and not used for tier admission decisions (`utils/networking/relay_client.py`).
- Implemented a small validation result helper `_api_v1_chat_validation_result()` that separates structural/schema errors from aggregate-size violations and preserved `_messages_are_valid_api_v1_chat()` as a compatibility wrapper.
- Updated content-size helper to return string lengths without an internal per-message cap and updated the request handler to log privacy-safe metadata and return `compute_node_request_too_large` (with `code`, `type`, `message`, `message_count`, `total_content_chars`, `maximum_total_content_chars`, `retryable: false`) when the aggregate safety limit is exceeded, while structural failures still return `compute_node_invalid_request`.
- Ensured exact context admission remains authoritative and unchanged (render template -> tokenize with runtime tokenizer -> include output reservation -> compare against context window) and added minimal landing-page/user-facing mappings for the new error codes (`static/chat.js`).
- Added focused regression tests covering large single-string messages, aggregated text blocks, privacy-safe logging for too-large errors, and exact admission behavior across `8k-fast` and `64k-full` tiers (`tests/unit/test_relay_client.py`) and updated UI assertions (`tests/unit/test_touch_ui.py`).

### Testing
- Ran unit tests with `python -m pytest tests/unit/test_relay_client.py -q` and `python -m pytest tests/unit/test_touch_ui.py -q`, and all unit tests passed.
- Ran integration tests with `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and all integration tests passed.
- Executed repository checks with `pre-commit run --all-files` and `git diff --check`, and the pre-commit checks passed with no diff issues.
- New/updated tests exercised the following scenarios and passed: structural validation vs aggregate-size separation, single ~64K string acceptance into exact admission path, `8k-fast` rejection via `compute_node_context_window_exceeded`, `64k-full` admission and generation when within token budget, and `compute_node_request_too_large` for >131,072 chars.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d65760e94832fa4c03e730d915e7d)