### PR TITLE
Add landing-page API v1 context-tier selector

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -3,6 +3,10 @@ const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an i
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
+const LANDING_CONTEXT_TIER_STORAGE_KEY = 'tokenplace.landing.api_v1.context_tier';
+const DEFAULT_CONTEXT_TIER = '8k-fast';
+const SUPPORTED_CONTEXT_TIERS = ['8k-fast', '64k-full'];
+const CONTEXT_TIER_RANK = { '8k-fast': 1, '64k-full': 2 };
 
 new Vue({
     el: '#app',
@@ -18,6 +22,8 @@ new Vue({
         clientPublicKey: null,
         availableModels: [],
         selectedModelId: '',
+        selectedContextTier: DEFAULT_CONTEXT_TIER,
+        selectedProfileMetadata: null,
         modelsLoading: false,
         modelsLoaded: false,
         modelsError: '',
@@ -32,6 +38,7 @@ new Vue({
     },
     mounted() {
         this.detectTouchInput();
+        this.loadPersistedContextTier();
         this.fetchModels();
         this.generateClientKeys();
         this.refreshComputeNodeCount();
@@ -88,6 +95,41 @@ new Vue({
         }
     },
     methods: {
+        normalizeContextTier(value) {
+            return SUPPORTED_CONTEXT_TIERS.includes(value) ? value : DEFAULT_CONTEXT_TIER;
+        },
+
+        loadPersistedContextTier() {
+            let storedTier = null;
+            try {
+                storedTier = window.localStorage.getItem(LANDING_CONTEXT_TIER_STORAGE_KEY);
+            } catch (error) {
+                console.warn('Unable to read landing context tier preference:', error);
+            }
+            this.selectedContextTier = this.normalizeContextTier(storedTier);
+            this.persistSelectedContextTier();
+        },
+
+        persistSelectedContextTier() {
+            this.selectedContextTier = this.normalizeContextTier(this.selectedContextTier);
+            try {
+                window.localStorage.setItem(LANDING_CONTEXT_TIER_STORAGE_KEY, this.selectedContextTier);
+            } catch (error) {
+                console.warn('Unable to persist landing context tier preference:', error);
+            }
+        },
+
+        handleContextTierChange() {
+            this.persistSelectedContextTier();
+            this.clearSelectedServer();
+        },
+
+        contextTierCanSatisfy(selectedTier, requestedTier) {
+            const selectedRank = CONTEXT_TIER_RANK[this.normalizeContextTier(selectedTier)];
+            const requestedRank = CONTEXT_TIER_RANK[this.normalizeContextTier(requestedTier)];
+            return selectedRank >= requestedRank;
+        },
+
         async refreshComputeNodeCount(options = {}) {
             // Failover capacity refreshes must be allowed to apply their own
             // successful diagnostics result even if the background poller starts
@@ -239,6 +281,7 @@ new Vue({
 
         async ensureSelectedServer(options = {}) {
             const forceReselect = Boolean(options.forceReselect);
+            const requestedContextTier = this.normalizeContextTier(this.selectedContextTier);
             if (forceReselect) {
                 this.clearSelectedServer();
             }
@@ -248,7 +291,10 @@ new Vue({
             }
 
             try {
-                const response = await fetch('/api/v1/relay/servers/next', { cache: 'no-store' });
+                const selectionParams = new URLSearchParams();
+                selectionParams.set('model', this.selectedModelId);
+                selectionParams.set('context_tier', requestedContextTier);
+                const response = await fetch(`/api/v1/relay/servers/next?${selectionParams.toString()}`, { cache: 'no-store' });
                 if (!response.ok) {
                     let errorData = null;
                     try {
@@ -264,6 +310,14 @@ new Vue({
                 }
 
                 const data = await response.json();
+                if (data && data.selected_context_tier && !this.contextTierCanSatisfy(data.selected_context_tier, requestedContextTier)) {
+                    return {
+                        error: {
+                            userMessage: 'The selected LLM server does not support the requested context tier. Please try again.'
+                        }
+                    };
+                }
+
                 const rawKey = data && data.server_public_key;
                 const normalizedKey = this.normalizeServerPublicKey(rawKey);
                 if (!normalizedKey) {
@@ -277,6 +331,12 @@ new Vue({
                     ? this.encodePemToBase64(normalizedKey)
                     : rawKeyText.replace(/\s+/g, '');
                 this.selectedServerKeyLabel = this.createServerKeyLabel(this.selectedServerPublicKeyB64);
+                this.selectedProfileMetadata = {
+                    selected_context_tier: data.selected_context_tier || null,
+                    selected_context_window_tokens: Number.isInteger(data.selected_context_window_tokens) ? data.selected_context_window_tokens : null,
+                    selected_model_support: Array.isArray(data.selected_model_support) ? data.selected_model_support.slice(0, 20) : [],
+                    selection_policy: typeof data.selection_policy === 'string' ? data.selection_policy : ''
+                };
                 return true;
             } catch (error) {
                 console.error('Error selecting API v1 compute node:', error);
@@ -305,6 +365,7 @@ new Vue({
             this.selectedServerPublicKeyB64 = null;
             this.serverPublicKey = null;
             this.selectedServerKeyLabel = '';
+            this.selectedProfileMetadata = null;
         },
 
         markSelectedServerTerminalFailure(message) {
@@ -755,7 +816,10 @@ new Vue({
                 api_v1_request: {
                     model: this.selectedModelId,
                     messages: this.createApiV1Messages(messageContent),
-                    options: {}
+                    options: {},
+                    routing: {
+                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                    }
                 }
             };
 
@@ -974,6 +1038,10 @@ new Vue({
             const errorCode = typeof error.code === 'string' ? error.code.trim() : '';
             const codeToMessage = {
                 no_registered_compute_nodes: 'No LLM servers are available right now. Your chat history is still here.',
+                no_matching_compute_node: 'No LLM servers are available for the selected model and context tier right now. Please choose a different tier or try again later.',
+                invalid_context_tier: 'The selected context tier is not supported. Please choose another tier.',
+                selected_server_unavailable: 'The selected LLM server is unavailable right now. Please try again.',
+                selected_server_expired: 'The selected LLM server is unavailable right now. Please try again.',
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',

--- a/static/index.html
+++ b/static/index.html
@@ -112,16 +112,19 @@
             border-color: rgba(255, 255, 255, 0.25);
             background-color: rgba(255, 255, 255, 0.08);
         }
-        .model-selector-container {
+        .model-selector-container,
+        .context-tier-selector-container {
             margin-bottom: 15px;
         }
-        .model-selector-container label {
+        .model-selector-container label,
+        .context-tier-selector-container label {
             display: block;
             margin-bottom: 6px;
             color: #cccccc;
             font-size: 14px;
         }
-        .model-select {
+        .model-select,
+        .context-tier-select {
             width: 100%;
             padding: 10px;
             box-sizing: border-box;
@@ -391,12 +394,14 @@
         }
 
         body.light-mode .message-input,
-        body.light-mode .model-select {
+        body.light-mode .model-select,
+        body.light-mode .context-tier-select {
             background-color: #ffffff;
             color: #333333;
         }
 
         body.light-mode .model-selector-container label,
+        body.light-mode .context-tier-selector-container label,
         body.light-mode .model-status {
             color: #555555;
         }
@@ -488,6 +493,7 @@
                 <select
                     id="model-select"
                     v-model="selectedModelId"
+                    @change="clearSelectedServer"
                     class="model-select"
                     aria-label="Model"
                     data-testid="landing-model-select"
@@ -500,6 +506,22 @@
                     <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
                 </select>
                 <p class="model-status" :class="{'model-error': modelsError}" v-text="modelsError || (modelsLoaded && availableModels.length === 0 ? 'No API v1 models available' : '')"></p>
+            </div>
+
+            <div class="context-tier-selector-container">
+                <label for="context-tier-select">Context tier</label>
+                <select
+                    id="context-tier-select"
+                    v-model="selectedContextTier"
+                    @change="handleContextTierChange"
+                    class="context-tier-select"
+                    aria-label="Context tier"
+                    data-testid="landing-context-tier-select"
+                    :disabled="isGeneratingResponse"
+                >
+                    <option value="8k-fast">8K Fast</option>
+                    <option value="64k-full">64K Full</option>
+                </select>
             </div>
             <p class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -143,3 +143,53 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "The previous LLM server disconnected. Continuing with another available server." in chat_js
     assert "No LLM servers are available right now. Your chat history is still here." in chat_js
     assert "this.clearSelectedServer()" in chat_js
+
+
+def test_landing_context_tier_selector_default_persistence_and_disabled_state():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert 'label for="context-tier-select">Context tier</label>' in index_html
+    assert 'data-testid="landing-context-tier-select"' in index_html
+    assert '<option value="8k-fast">8K Fast</option>' in index_html
+    assert '<option value="64k-full">64K Full</option>' in index_html
+    assert ':disabled="isGeneratingResponse"' in index_html
+    assert "LANDING_CONTEXT_TIER_STORAGE_KEY = 'tokenplace.landing.api_v1.context_tier'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "SUPPORTED_CONTEXT_TIERS = ['8k-fast', '64k-full']" in chat_js
+    assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
+    assert "loadPersistedContextTier" in chat_js
+    assert "localStorage.getItem(LANDING_CONTEXT_TIER_STORAGE_KEY)" in chat_js
+    assert "localStorage.setItem(LANDING_CONTEXT_TIER_STORAGE_KEY, this.selectedContextTier)" in chat_js
+    assert "return SUPPORTED_CONTEXT_TIERS.includes(value) ? value : DEFAULT_CONTEXT_TIER" in chat_js
+
+
+def test_landing_context_tier_selection_request_and_encrypted_routing_metadata():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "selectionParams.set('model', this.selectedModelId);" in chat_js
+    assert "selectionParams.set('context_tier', requestedContextTier);" in chat_js
+    assert "/api/v1/relay/servers/next?${selectionParams.toString()}" in chat_js
+    assert "selectedProfileMetadata" in chat_js
+    assert "selected_context_tier" in chat_js
+    assert "contextTierCanSatisfy(data.selected_context_tier, requestedContextTier)" in chat_js
+    assert "routing: {" in chat_js
+    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "server_public_key: this.selectedServerPublicKeyB64" in chat_js
+    assert "ciphertext: encryptedData.ciphertext" in chat_js
+    assert "messages: this.createApiV1Messages(messageContent)" in chat_js
+
+
+def test_landing_context_tier_error_messages_and_no_auto_escalation():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "no_matching_compute_node" in chat_js
+    assert "No LLM servers are available for the selected model and context tier right now." in chat_js
+    assert "The selected LLM server does not support the requested context tier. Please try again." in chat_js
+    assert "selected_server_unavailable" in chat_js
+    assert "selected_server_expired" in chat_js
+    assert "compute_node_context_window_exceeded" in chat_js
+    assert "compute_node_request_too_large" in chat_js
+    assert "64k-full'" in chat_js
+    assert "automatically" not in chat_js.lower()
+    assert "retry" not in chat_js.lower().replace("retry-chat-button", "").replace("landing-new-chat-retry", "")


### PR DESCRIPTION
### Motivation
- Provide a clear landing-page UI control so users (staging/prod) can explicitly request `8k-fast` or `64k-full` API v1 compute tiers and avoid accidental routing of large prompts to 8k nodes. 
- Keep the relay-blind E2EE API v1 contract and existing admission/failover semantics while surfacing only coarse, safe routing metadata to the relay/compute-selection path.

### Description
- Added a visible "Context tier" dropdown to the landing page with options `8k-fast` ("8K Fast") and `64k-full` ("64K Full"), defaulting to `8k-fast`, disabled during in-flight requests, and styled alongside the model selector in `static/index.html`.
- Implemented client-side persistence, normalization, and helpers in `static/chat.js` using a namespaced localStorage key `tokenplace.landing.api_v1.context_tier`, with unknown values normalized back to `8k-fast` and the selector clearing the chosen server on change.
- Updated compute-node selection to include coarse query parameters (`model` and `context_tier`) to `/api/v1/relay/servers/next`, validate the relay-returned `selected_context_tier` for compatibility, and stash safe `selectedProfileMetadata` in component state for diagnostics only.
- Included encrypted routing metadata `api_v1_request.routing.context_tier` inside the API v1 E2EE envelope and added user-facing mappings for new/related error cases (`no_matching_compute_node`, `invalid_context_tier`, `selected_server_unavailable/expired`) while preserving existing P15 error mappings and failover behavior.

### Testing
- Ran focused landing-page static tests with `python -m pytest tests/unit/test_touch_ui.py -q`, which passed (12 passed). 
- Ran the relay client unit suite with `python -m pytest tests/unit/test_relay_client.py -q`, which passed (229 passed). 
- Ran repository checks with `pre-commit run --all-files` and `git diff --check`, both of which passed without errors. 
- Captured a visual smoke-check screenshot of the landing page at `/tmp/token-place-context-tier-selector.png` using Playwright to confirm the selector renders in the page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d79d8ee48832fb74d6b7b50128ba3)