### PR TITLE
Add landing-page API v1 context-tier selector

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -3,6 +3,9 @@ const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an i
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
+const LANDING_CONTEXT_TIER_STORAGE_KEY = 'tokenplace.landing.api_v1.context_tier';
+const DEFAULT_CONTEXT_TIER = '8k-fast';
+const SUPPORTED_CONTEXT_TIERS = ['8k-fast', '64k-full'];
 
 new Vue({
     el: '#app',
@@ -18,6 +21,8 @@ new Vue({
         clientPublicKey: null,
         availableModels: [],
         selectedModelId: '',
+        selectedContextTier: DEFAULT_CONTEXT_TIER,
+        selectedProfileMetadata: null,
         modelsLoading: false,
         modelsLoaded: false,
         modelsError: '',
@@ -31,6 +36,7 @@ new Vue({
         computeNodeCountRequestId: 0
     },
     mounted() {
+        this.selectedContextTier = this.loadPersistedContextTier();
         this.detectTouchInput();
         this.fetchModels();
         this.generateClientKeys();
@@ -78,6 +84,12 @@ new Vue({
         hasClientKeypair() {
             return Boolean(this.clientPrivateKey && this.clientPublicKey);
         },
+        contextTierOptions() {
+            return [
+                { id: '8k-fast', label: '8K Fast' },
+                { id: '64k-full', label: '64K Full' }
+            ];
+        },
         canSendMessage() {
             return Boolean(
                 this.newMessage.trim() &&
@@ -87,7 +99,58 @@ new Vue({
             );
         }
     },
+    watch: {
+        selectedModelId() {
+            this.clearSelectedServer();
+        },
+        selectedContextTier(newValue) {
+            const normalized = this.normalizeContextTier(newValue);
+            if (newValue !== normalized) {
+                this.selectedContextTier = normalized;
+                return;
+            }
+            this.persistContextTier(normalized);
+            this.clearSelectedServer();
+        }
+    },
     methods: {
+        normalizeContextTier(value) {
+            return SUPPORTED_CONTEXT_TIERS.includes(value) ? value : DEFAULT_CONTEXT_TIER;
+        },
+
+        loadPersistedContextTier() {
+            try {
+                const stored = typeof localStorage !== 'undefined'
+                    ? localStorage.getItem(LANDING_CONTEXT_TIER_STORAGE_KEY)
+                    : null;
+                const normalized = this.normalizeContextTier(stored);
+                if (stored !== normalized) {
+                    this.persistContextTier(normalized);
+                }
+                return normalized;
+            } catch (error) {
+                console.warn('Unable to load landing context tier:', error);
+                return DEFAULT_CONTEXT_TIER;
+            }
+        },
+
+        persistContextTier(value) {
+            try {
+                if (typeof localStorage !== 'undefined') {
+                    localStorage.setItem(LANDING_CONTEXT_TIER_STORAGE_KEY, this.normalizeContextTier(value));
+                }
+            } catch (error) {
+                console.warn('Unable to persist landing context tier:', error);
+            }
+        },
+
+        contextTierCanSatisfy(activeTier, requestedTier) {
+            const order = { '8k-fast': 8192, '64k-full': 65536 };
+            const active = this.normalizeContextTier(activeTier);
+            const requested = this.normalizeContextTier(requestedTier);
+            return order[active] >= order[requested];
+        },
+
         async refreshComputeNodeCount(options = {}) {
             // Failover capacity refreshes must be allowed to apply their own
             // successful diagnostics result even if the background poller starts
@@ -248,7 +311,11 @@ new Vue({
             }
 
             try {
-                const response = await fetch('/api/v1/relay/servers/next', { cache: 'no-store' });
+                const selectionParams = new URLSearchParams({
+                    model: this.selectedModelId,
+                    context_tier: this.normalizeContextTier(this.selectedContextTier)
+                });
+                const response = await fetch(`/api/v1/relay/servers/next?${selectionParams.toString()}`, { cache: 'no-store' });
                 if (!response.ok) {
                     let errorData = null;
                     try {
@@ -265,6 +332,16 @@ new Vue({
 
                 const data = await response.json();
                 const rawKey = data && data.server_public_key;
+                const selectedContextTier = data && typeof data.selected_context_tier === 'string'
+                    ? data.selected_context_tier.trim()
+                    : '';
+                if (selectedContextTier && !this.contextTierCanSatisfy(selectedContextTier, this.selectedContextTier)) {
+                    return {
+                        error: {
+                            userMessage: 'The selected context tier is unavailable right now. Please choose another tier or try again later.'
+                        }
+                    };
+                }
                 const normalizedKey = this.normalizeServerPublicKey(rawKey);
                 if (!normalizedKey) {
                     throw new Error('Relay returned an invalid compute-node public key');
@@ -277,6 +354,13 @@ new Vue({
                     ? this.encodePemToBase64(normalizedKey)
                     : rawKeyText.replace(/\s+/g, '');
                 this.selectedServerKeyLabel = this.createServerKeyLabel(this.selectedServerPublicKeyB64);
+                this.selectedProfileMetadata = {
+                    selected_context_tier: selectedContextTier || null,
+                    selected_context_window_tokens: Number.isInteger(data && data.selected_context_window_tokens)
+                        ? data.selected_context_window_tokens
+                        : null,
+                    selection_policy: data && typeof data.selection_policy === 'string' ? data.selection_policy : ''
+                };
                 return true;
             } catch (error) {
                 console.error('Error selecting API v1 compute node:', error);
@@ -305,6 +389,7 @@ new Vue({
             this.selectedServerPublicKeyB64 = null;
             this.serverPublicKey = null;
             this.selectedServerKeyLabel = '';
+            this.selectedProfileMetadata = null;
         },
 
         markSelectedServerTerminalFailure(message) {
@@ -755,7 +840,10 @@ new Vue({
                 api_v1_request: {
                     model: this.selectedModelId,
                     messages: this.createApiV1Messages(messageContent),
-                    options: {}
+                    options: {},
+                    routing: {
+                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                    }
                 }
             };
 
@@ -974,6 +1062,12 @@ new Vue({
             const errorCode = typeof error.code === 'string' ? error.code.trim() : '';
             const codeToMessage = {
                 no_registered_compute_nodes: 'No LLM servers are available right now. Your chat history is still here.',
+                no_matching_compute_node: 'No LLM server is available for the selected model and context tier right now. Please choose another tier or try again later.',
+                invalid_context_tier: 'The selected context tier is not supported. Please choose another tier.',
+                selected_server_unavailable: 'The selected LLM server is unavailable or expired. Please try again.',
+                selected_server_expired: 'The selected LLM server is unavailable or expired. Please try again.',
+                selected_server_removed: 'The selected LLM server is unavailable or expired. Please try again.',
+                compute_node_context_tier_unsupported: 'The selected LLM server cannot satisfy the requested context tier. Please choose another tier or try again later.',
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',

--- a/static/index.html
+++ b/static/index.html
@@ -115,6 +115,12 @@
         .model-selector-container {
             margin-bottom: 15px;
         }
+        .chat-selectors {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 12px;
+            margin-bottom: 15px;
+        }
         .model-selector-container label {
             display: block;
             margin-bottom: 6px;
@@ -483,23 +489,38 @@
             <small class="compute-node-status-updated" v-text="computeNodeCountLastUpdatedLabel"></small>
         </div>
         <div class="chat-container">
-            <div class="model-selector-container">
-                <label for="model-select">Model</label>
-                <select
-                    id="model-select"
-                    v-model="selectedModelId"
-                    class="model-select"
-                    aria-label="Model"
-                    data-testid="landing-model-select"
-                    disabled
-                    :disabled="modelsLoading || (!modelsError && availableModels.length === 0)"
-                >
-                    <option v-if="modelsError" :value="selectedModelId" v-text="`${selectedModelId} (emergency fallback)`"></option>
-                    <option v-else-if="modelsLoading || (!modelsLoaded && availableModels.length === 0)" value="" disabled></option>
-                    <option v-else-if="availableModels.length === 0" value="" disabled v-text="'No API v1 models available'"></option>
-                    <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
-                </select>
-                <p class="model-status" :class="{'model-error': modelsError}" v-text="modelsError || (modelsLoaded && availableModels.length === 0 ? 'No API v1 models available' : '')"></p>
+            <div class="chat-selectors">
+                <div class="model-selector-container">
+                    <label for="model-select">Model</label>
+                    <select
+                        id="model-select"
+                        v-model="selectedModelId"
+                        class="model-select"
+                        aria-label="Model"
+                        data-testid="landing-model-select"
+                        disabled
+                        :disabled="modelsLoading || (!modelsError && availableModels.length === 0) || isGeneratingResponse"
+                    >
+                        <option v-if="modelsError" :value="selectedModelId" v-text="`${selectedModelId} (emergency fallback)`"></option>
+                        <option v-else-if="modelsLoading || (!modelsLoaded && availableModels.length === 0)" value="" disabled></option>
+                        <option v-else-if="availableModels.length === 0" value="" disabled v-text="'No API v1 models available'"></option>
+                        <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
+                    </select>
+                    <p class="model-status" :class="{'model-error': modelsError}" v-text="modelsError || (modelsLoaded && availableModels.length === 0 ? 'No API v1 models available' : '')"></p>
+                </div>
+                <div class="model-selector-container">
+                    <label for="context-tier-select">Context tier</label>
+                    <select
+                        id="context-tier-select"
+                        v-model="selectedContextTier"
+                        class="model-select"
+                        aria-label="Context tier"
+                        data-testid="landing-context-tier-select"
+                        :disabled="isGeneratingResponse"
+                    >
+                        <option v-for="tier in contextTierOptions" :key="tier.id" :value="tier.id" v-text="tier.label"></option>
+                    </select>
+                </div>
             </div>
             <p class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -143,3 +143,62 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "The previous LLM server disconnected. Continuing with another available server." in chat_js
     assert "No LLM servers are available right now. Your chat history is still here." in chat_js
     assert "this.clearSelectedServer()" in chat_js
+
+
+def test_landing_context_tier_selector_template():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    assert "Context tier" in index_html
+    assert "landing-context-tier-select" in index_html
+    assert "v-model=\"selectedContextTier\"" in index_html
+    assert ":disabled=\"isGeneratingResponse\"" in index_html
+    assert "8K Fast" in Path("static/chat.js").read_text(encoding="utf-8")
+    assert "64K Full" in Path("static/chat.js").read_text(encoding="utf-8")
+
+
+def test_landing_context_tier_persistence_and_default_contract():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "LANDING_CONTEXT_TIER_STORAGE_KEY = 'tokenplace.landing.api_v1.context_tier'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "SUPPORTED_CONTEXT_TIERS = ['8k-fast', '64k-full']" in chat_js
+    assert "normalizeContextTier(value)" in chat_js
+    assert "return SUPPORTED_CONTEXT_TIERS.includes(value) ? value : DEFAULT_CONTEXT_TIER;" in chat_js
+    assert "loadPersistedContextTier" in chat_js
+    assert "localStorage.getItem(LANDING_CONTEXT_TIER_STORAGE_KEY)" in chat_js
+    assert "localStorage.setItem(LANDING_CONTEXT_TIER_STORAGE_KEY" in chat_js
+
+
+def test_landing_next_server_selection_includes_model_and_context_tier():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "new URLSearchParams" in chat_js
+    assert "model: this.selectedModelId" in chat_js
+    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "`/api/v1/relay/servers/next?${selectionParams.toString()}`" in chat_js
+    assert "selected_context_tier" in chat_js
+    assert "contextTierCanSatisfy(selectedContextTier, this.selectedContextTier)" in chat_js
+    assert "selectedProfileMetadata" in chat_js
+
+
+def test_landing_encrypted_routing_contains_context_tier_without_plaintext_dispatch():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "api_v1_request" in chat_js
+    assert "routing: {" in chat_js
+    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    relay_payload_match = re.search(r"const relayPayload = \{([\s\S]*?)\n\s*\};", chat_js)
+    assert relay_payload_match, "relay payload literal not found"
+    relay_payload = relay_payload_match.group(1)
+    assert "ciphertext" in relay_payload
+    assert "cipherkey" in relay_payload
+    assert "iv" in relay_payload
+    assert "messages" not in relay_payload
+    assert "messageContent" not in relay_payload
+    assert "context_tier" not in relay_payload
+
+
+def test_landing_context_tier_error_messages():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+    assert "no_matching_compute_node" in chat_js
+    assert "No LLM server is available for the selected model and context tier right now." in chat_js
+    assert "invalid_context_tier" in chat_js
+    assert "compute_node_context_tier_unsupported" in chat_js
+    assert "The selected LLM server cannot satisfy the requested context tier." in chat_js
+    assert "The selected LLM server is unavailable or expired. Please try again." in chat_js


### PR DESCRIPTION
### Motivation
- Expose a user-visible selector so landing-page traffic can explicitly target `8k-fast` or `64k-full` API v1 compute nodes and avoid accidental routing of large prompts to 8K nodes. 
- Preserve relay-blind E2EE and the existing coarse selection contract while supplying the relay with the requested coarse `model` and `context_tier`. 

### Description
- Add client-side constants and state for context-tier selection, including `LANDING_CONTEXT_TIER_STORAGE_KEY`, `DEFAULT_CONTEXT_TIER`, and `SUPPORTED_CONTEXT_TIERS`, plus persistence helpers that normalize unknown values back to `8k-fast`. 
- Add a visible “Context tier” dropdown in the landing UI (next to the model selector) that defaults to `8k-fast`, persists to `localStorage`, and is disabled during in-flight requests. 
- When selecting a compute node call `/api/v1/relay/servers/next` with `model` and `context_tier` query parameters, validate the relay-returned `selected_context_tier` against the requested tier and store safe selected-profile metadata in component state for diagnostics only. 
- Include `api_v1_request.routing.context_tier` inside the encrypted API v1 envelope while keeping relay-visible dispatch ciphertext-only, and add user-facing mappings for tier/unavailability and selected-server errors without leaking internal diagnostics. 
- Add focused static UI tests that assert presence and behavior of the selector, persistence, server selection query params, encrypted routing inclusion, ciphertext-only dispatch, and tier-related user messages. 

### Testing
- Ran `python -m pytest tests/unit/test_touch_ui.py -q` and it passed (`14 passed`). 
- Ran `python -m pytest tests/unit/test_relay_client.py -q` and it passed (`229 passed`). 
- Ran `pre-commit run --all-files` and `git diff --check` and both checks passed. 
- Attempted a Playwright-based visual verification (`npx playwright install` + headless Chromium navigation/screenshot) but the environment lacked a usable Playwright Chromium binary so the screenshot step failed; this is an environment limitation and does not affect the static JS/HTML tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d79f48ad8832faa05b5912bcbc337)