### PR TITLE
Add landing-page API v1 context-tier selector

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -3,6 +3,12 @@ const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an i
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
+const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
+const DEFAULT_CONTEXT_TIER = '8k-fast';
+const CONTEXT_TIER_ORDER = {
+    '8k-fast': 8192,
+    '64k-full': 65536
+};
 
 new Vue({
     el: '#app',
@@ -18,6 +24,8 @@ new Vue({
         clientPublicKey: null,
         availableModels: [],
         selectedModelId: '',
+        selectedContextTier: DEFAULT_CONTEXT_TIER,
+        selectedProfileMetadata: null,
         modelsLoading: false,
         modelsLoaded: false,
         modelsError: '',
@@ -32,6 +40,7 @@ new Vue({
     },
     mounted() {
         this.detectTouchInput();
+        this.selectedContextTier = this.loadStoredContextTier();
         this.fetchModels();
         this.generateClientKeys();
         this.refreshComputeNodeCount();
@@ -237,6 +246,46 @@ new Vue({
             return `Server: ${fingerprint.slice(0, 8)}…${fingerprint.slice(-8)}`;
         },
 
+        isKnownContextTier(value) {
+            return Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, value);
+        },
+
+        normalizeContextTier(value) {
+            return this.isKnownContextTier(value) ? value : DEFAULT_CONTEXT_TIER;
+        },
+
+        loadStoredContextTier() {
+            let stored = null;
+            try {
+                stored = window.localStorage.getItem(CONTEXT_TIER_STORAGE_KEY);
+            } catch (error) {
+                console.warn('Unable to read context-tier preference:', error);
+            }
+            const normalized = this.normalizeContextTier(stored);
+            if (stored !== normalized) {
+                this.persistContextTier(normalized);
+            }
+            return normalized;
+        },
+
+        persistContextTier(value) {
+            try {
+                window.localStorage.setItem(CONTEXT_TIER_STORAGE_KEY, this.normalizeContextTier(value));
+            } catch (error) {
+                console.warn('Unable to store context-tier preference:', error);
+            }
+        },
+
+        handleContextTierChange() {
+            this.selectedContextTier = this.normalizeContextTier(this.selectedContextTier);
+            this.persistContextTier(this.selectedContextTier);
+            this.clearSelectedServer();
+        },
+
+        selectedContextTierCanSatisfy(selectedTier, requestedTier) {
+            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER[DEFAULT_CONTEXT_TIER]);
+        },
+
         async ensureSelectedServer(options = {}) {
             const forceReselect = Boolean(options.forceReselect);
             if (forceReselect) {
@@ -248,7 +297,12 @@ new Vue({
             }
 
             try {
-                const response = await fetch('/api/v1/relay/servers/next', { cache: 'no-store' });
+                const requestedContextTier = this.normalizeContextTier(this.selectedContextTier);
+                const params = new URLSearchParams({
+                    model: this.selectedModelId,
+                    context_tier: requestedContextTier
+                });
+                const response = await fetch(`/api/v1/relay/servers/next?${params.toString()}`, { cache: 'no-store' });
                 if (!response.ok) {
                     let errorData = null;
                     try {
@@ -264,6 +318,21 @@ new Vue({
                 }
 
                 const data = await response.json();
+                const rawSelectedContextTier = data && typeof data.selected_context_tier === 'string'
+                    ? data.selected_context_tier.trim()
+                    : '';
+                const selectedContextTier = this.isKnownContextTier(rawSelectedContextTier)
+                    ? rawSelectedContextTier
+                    : '';
+                if (!selectedContextTier || !this.selectedContextTierCanSatisfy(selectedContextTier, requestedContextTier)) {
+                    this.clearSelectedServer();
+                    return {
+                        error: {
+                            userMessage: 'The selected LLM server does not support the requested context tier. Please choose another tier or try again.'
+                        }
+                    };
+                }
+
                 const rawKey = data && data.server_public_key;
                 const normalizedKey = this.normalizeServerPublicKey(rawKey);
                 if (!normalizedKey) {
@@ -277,6 +346,13 @@ new Vue({
                     ? this.encodePemToBase64(normalizedKey)
                     : rawKeyText.replace(/\s+/g, '');
                 this.selectedServerKeyLabel = this.createServerKeyLabel(this.selectedServerPublicKeyB64);
+                this.selectedProfileMetadata = {
+                    selected_context_tier: selectedContextTier,
+                    selected_context_window_tokens: Number.isInteger(data && data.selected_context_window_tokens)
+                        ? data.selected_context_window_tokens
+                        : null,
+                    selection_policy: data && typeof data.selection_policy === 'string' ? data.selection_policy : ''
+                };
                 return true;
             } catch (error) {
                 console.error('Error selecting API v1 compute node:', error);
@@ -305,6 +381,7 @@ new Vue({
             this.selectedServerPublicKeyB64 = null;
             this.serverPublicKey = null;
             this.selectedServerKeyLabel = '';
+            this.selectedProfileMetadata = null;
         },
 
         markSelectedServerTerminalFailure(message) {
@@ -755,7 +832,10 @@ new Vue({
                 api_v1_request: {
                     model: this.selectedModelId,
                     messages: this.createApiV1Messages(messageContent),
-                    options: {}
+                    options: {},
+                    routing: {
+                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                    }
                 }
             };
 
@@ -974,11 +1054,14 @@ new Vue({
             const errorCode = typeof error.code === 'string' ? error.code.trim() : '';
             const codeToMessage = {
                 no_registered_compute_nodes: 'No LLM servers are available right now. Your chat history is still here.',
+                no_matching_compute_node: 'No LLM servers are available for the selected context tier right now. Choose another tier or try again later.',
+                invalid_context_tier: 'The selected context tier is unavailable. Please choose another tier and try again.',
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
                 compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
                 compute_node_context_window_exceeded: "This prompt exceeds the selected LLM server's context window.",
+                compute_node_context_tier_unsupported: 'The selected LLM server does not support the requested context tier. Please choose another tier or try again.',
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/static/chat.js
+++ b/static/chat.js
@@ -251,7 +251,8 @@ new Vue({
         },
 
         normalizeContextTier(value) {
-            return this.isKnownContextTier(value) ? value : DEFAULT_CONTEXT_TIER;
+            const normalizedValue = typeof value === 'string' ? value.trim() : value;
+            return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
         },
 
         loadStoredContextTier() {
@@ -262,7 +263,7 @@ new Vue({
                 console.warn('Unable to read context-tier preference:', error);
             }
             const normalized = this.normalizeContextTier(stored);
-            if (stored !== normalized) {
+            if (stored !== null && stored !== normalized) {
                 this.persistContextTier(normalized);
             }
             return normalized;

--- a/static/index.html
+++ b/static/index.html
@@ -112,16 +112,19 @@
             border-color: rgba(255, 255, 255, 0.25);
             background-color: rgba(255, 255, 255, 0.08);
         }
-        .model-selector-container {
+        .model-selector-container,
+        .context-tier-selector-container {
             margin-bottom: 15px;
         }
-        .model-selector-container label {
+        .model-selector-container label,
+        .context-tier-selector-container label {
             display: block;
             margin-bottom: 6px;
             color: #cccccc;
             font-size: 14px;
         }
-        .model-select {
+        .model-select,
+        .context-tier-select {
             width: 100%;
             padding: 10px;
             box-sizing: border-box;
@@ -391,12 +394,14 @@
         }
 
         body.light-mode .message-input,
-        body.light-mode .model-select {
+        body.light-mode .model-select,
+        body.light-mode .context-tier-select {
             background-color: #ffffff;
             color: #333333;
         }
 
         body.light-mode .model-selector-container label,
+        body.light-mode .context-tier-selector-container label,
         body.light-mode .model-status {
             color: #555555;
         }
@@ -493,6 +498,7 @@
                     data-testid="landing-model-select"
                     disabled
                     :disabled="modelsLoading || (!modelsError && availableModels.length === 0)"
+                    @change="clearSelectedServer"
                 >
                     <option v-if="modelsError" :value="selectedModelId" v-text="`${selectedModelId} (emergency fallback)`"></option>
                     <option v-else-if="modelsLoading || (!modelsLoaded && availableModels.length === 0)" value="" disabled></option>
@@ -500,6 +506,21 @@
                     <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
                 </select>
                 <p class="model-status" :class="{'model-error': modelsError}" v-text="modelsError || (modelsLoaded && availableModels.length === 0 ? 'No API v1 models available' : '')"></p>
+            </div>
+            <div class="context-tier-selector-container">
+                <label for="context-tier-select">Context tier</label>
+                <select
+                    id="context-tier-select"
+                    v-model="selectedContextTier"
+                    class="context-tier-select"
+                    aria-label="Context tier"
+                    data-testid="landing-context-tier-select"
+                    :disabled="isGeneratingResponse"
+                    @change="handleContextTierChange"
+                >
+                    <option value="8k-fast">8K Fast</option>
+                    <option value="64k-full">64K Full</option>
+                </select>
             </div>
             <p class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -22,6 +22,57 @@ def test_chat_js_defines_touch_detection_hook():
     assert "detectTouchInput" in chat_js, "chat.js must implement touch detection helper"
 
 
+def test_landing_context_tier_selector_is_visible_persistent_and_disabled_while_pending():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert 'label for="context-tier-select">Context tier</label>' in index_html
+    assert 'data-testid="landing-context-tier-select"' in index_html
+    assert 'v-model="selectedContextTier"' in index_html
+    assert ':disabled="isGeneratingResponse"' in index_html
+    assert '<option value="8k-fast">8K Fast</option>' in index_html
+    assert '<option value="64k-full">64K Full</option>' in index_html
+
+    assert "CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
+    assert "loadStoredContextTier" in chat_js
+    assert "persistContextTier" in chat_js
+    assert "normalizeContextTier" in chat_js
+    assert "isKnownContextTier" in chat_js
+    assert "return this.isKnownContextTier(value) ? value : DEFAULT_CONTEXT_TIER" in chat_js
+
+
+def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_routing():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "new URLSearchParams" in chat_js
+    assert "model: this.selectedModelId" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "`/api/v1/relay/servers/next?${params.toString()}`" in chat_js
+    assert "selected_context_tier" in chat_js
+    assert "selected_context_window_tokens" in chat_js
+    assert "selectedContextTierCanSatisfy(selectedContextTier, requestedContextTier)" in chat_js
+    assert "if (!selectedContextTier || !this.selectedContextTierCanSatisfy" in chat_js
+    assert "selectedProfileMetadata" in chat_js
+
+    assert "routing: {" in chat_js
+    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "ciphertext: encryptedData.ciphertext" in chat_js
+    assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};", 1)[0]
+
+
+def test_landing_context_tier_errors_have_safe_user_messages():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "no_matching_compute_node" in chat_js
+    assert "No LLM servers are available for the selected context tier right now." in chat_js
+    assert "invalid_context_tier" in chat_js
+    assert "compute_node_context_tier_unsupported" in chat_js
+    assert "does not support the requested context tier" in chat_js
+    assert "server_public_key" not in chat_js.split("const codeToMessage = {", 1)[1].split("};", 1)[0]
+
+
 def test_landing_chat_js_avoids_relay_v2_streaming_path():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "/api/v1/relay/servers/next" in chat_js, (

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -40,7 +40,9 @@ def test_landing_context_tier_selector_is_visible_persistent_and_disabled_while_
     assert "persistContextTier" in chat_js
     assert "normalizeContextTier" in chat_js
     assert "isKnownContextTier" in chat_js
-    assert "return this.isKnownContextTier(value) ? value : DEFAULT_CONTEXT_TIER" in chat_js
+    assert "const normalizedValue = typeof value === 'string' ? value.trim() : value" in chat_js
+    assert "return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
+    assert "if (stored !== null && stored !== normalized)" in chat_js
 
 
 def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_routing():
@@ -59,7 +61,7 @@ def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_rou
     assert "routing: {" in chat_js
     assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
     assert "ciphertext: encryptedData.ciphertext" in chat_js
-    assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};", 1)[0]
+    assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};\n", 1)[0]
 
 
 def test_landing_context_tier_errors_have_safe_user_messages():
@@ -70,7 +72,7 @@ def test_landing_context_tier_errors_have_safe_user_messages():
     assert "invalid_context_tier" in chat_js
     assert "compute_node_context_tier_unsupported" in chat_js
     assert "does not support the requested context tier" in chat_js
-    assert "server_public_key" not in chat_js.split("const codeToMessage = {", 1)[1].split("};", 1)[0]
+    assert "server_public_key" not in chat_js.split("const codeToMessage = {", 1)[1].split("};\n", 1)[0]
 
 
 def test_landing_chat_js_avoids_relay_v2_streaming_path():


### PR DESCRIPTION
### Motivation
- Provide a user-visible landing-page control so the website can explicitly request `8k-fast` or `64k-full` compute nodes and avoid accidentally routing large prompts to `8k-fast`.
- Preserve relay-blind E2EE and existing API v1 contracts by sending only coarse selection metadata to the relay and embedding routing context inside the encrypted API v1 envelope.

### Description
- Added a visible "Context tier" dropdown to the landing chat UI with options `8k-fast` (display "8K Fast") and `64k-full` (display "64K Full"), defaulting to `8k-fast`, disabling it while a request is in flight, and clearing the selected server when model/tier changes (files modified: `static/index.html`, `static/chat.js`).
- Persisted selection to `localStorage` using a namespaced key `token.place.landing.contextTier.v1` and normalized unknown stored values back to `8k-fast` via helper functions (`isKnownContextTier`, `normalizeContextTier`, `loadStoredContextTier`, `persistContextTier`).
- Updated compute-node selection to include both `model` and `context_tier` in the `/api/v1/relay/servers/next` query string, validated the relay-returned `selected_context_tier` against the requested tier before accepting a node, and saved only safe diagnostics metadata in component state (`selectedProfileMetadata`).
- Embedded routing metadata inside the encrypted API v1 envelope at `api_v1_request.routing.context_tier` (no plaintext prompt/chat content leaked to relay-visible fields).
- Added and refined user-facing error messages for no matching compute node, invalid context tier, and tier-incompatibility while preserving existing messages for `compute_node_context_window_exceeded` and `compute_node_request_too_large`.
- Added focused static UI unit tests to cover selector rendering, persistence, disabled-while-pending behavior, server selection query/routing metadata, and safe error message mappings (`tests/unit/test_touch_ui.py`).

### Testing
- `node --check static/chat.js` — success.
- `python -m pytest tests/unit/test_touch_ui.py -q` — 12 passed.
- `python -m pytest tests/unit/test_relay_client.py -q` — 229 passed.
- `pre-commit run --all-files` — passed all hooks.
- `git diff --check` — no issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d79e44cd8832f94f5c5ef7d7cc288)