### PR TITLE
Add landing-page API v1 context-tier selector

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -3,6 +3,9 @@ const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an i
 const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
+const LANDING_CONTEXT_TIER_STORAGE_KEY = 'tokenplace.landing.api_v1.context_tier';
+const DEFAULT_CONTEXT_TIER = '8k-fast';
+const SUPPORTED_CONTEXT_TIERS = ['8k-fast', '64k-full'];
 
 new Vue({
     el: '#app',
@@ -14,6 +17,8 @@ new Vue({
         selectedServerPublicKey: null,
         selectedServerKeyLabel: '',
         selectedServerTerminalFailure: '',
+        selectedContextTier: DEFAULT_CONTEXT_TIER,
+        selectedProfileMetadata: null,
         clientPrivateKey: null,
         clientPublicKey: null,
         availableModels: [],
@@ -32,6 +37,7 @@ new Vue({
     },
     mounted() {
         this.detectTouchInput();
+        this.loadPersistedContextTier();
         this.fetchModels();
         this.generateClientKeys();
         this.refreshComputeNodeCount();
@@ -88,6 +94,41 @@ new Vue({
         }
     },
     methods: {
+        normalizeContextTier(value) {
+            return SUPPORTED_CONTEXT_TIERS.includes(value) ? value : DEFAULT_CONTEXT_TIER;
+        },
+
+        loadPersistedContextTier() {
+            let storedValue = DEFAULT_CONTEXT_TIER;
+            try {
+                storedValue = localStorage.getItem(LANDING_CONTEXT_TIER_STORAGE_KEY) || DEFAULT_CONTEXT_TIER;
+            } catch (error) {
+                console.warn('Unable to read persisted API v1 context tier:', error);
+            }
+            this.selectedContextTier = this.normalizeContextTier(storedValue);
+            this.persistContextTier();
+        },
+
+        persistContextTier() {
+            this.selectedContextTier = this.normalizeContextTier(this.selectedContextTier);
+            try {
+                localStorage.setItem(LANDING_CONTEXT_TIER_STORAGE_KEY, this.selectedContextTier);
+            } catch (error) {
+                console.warn('Unable to persist API v1 context tier:', error);
+            }
+        },
+
+        handleContextTierChange() {
+            this.persistContextTier();
+            this.clearSelectedServer();
+        },
+
+        contextTierCanSatisfy(selectedTier, requestedTier) {
+            const selectedIndex = SUPPORTED_CONTEXT_TIERS.indexOf(this.normalizeContextTier(selectedTier));
+            const requestedIndex = SUPPORTED_CONTEXT_TIERS.indexOf(this.normalizeContextTier(requestedTier));
+            return selectedIndex >= requestedIndex;
+        },
+
         async refreshComputeNodeCount(options = {}) {
             // Failover capacity refreshes must be allowed to apply their own
             // successful diagnostics result even if the background poller starts
@@ -248,7 +289,11 @@ new Vue({
             }
 
             try {
-                const response = await fetch('/api/v1/relay/servers/next', { cache: 'no-store' });
+                const selectionUrl = new URL('/api/v1/relay/servers/next', window.location.origin);
+                selectionUrl.searchParams.set('model', this.selectedModelId);
+                selectionUrl.searchParams.set('context_tier', this.selectedContextTier);
+                selectionUrl.searchParams.set('selected_profile_echo_v1', '1');
+                const response = await fetch(`${selectionUrl.pathname}${selectionUrl.search}`, { cache: 'no-store' });
                 if (!response.ok) {
                     let errorData = null;
                     try {
@@ -265,6 +310,16 @@ new Vue({
 
                 const data = await response.json();
                 const rawKey = data && data.server_public_key;
+                const selectedContextTier = data && typeof data.selected_context_tier === 'string'
+                    ? this.normalizeContextTier(data.selected_context_tier)
+                    : this.selectedContextTier;
+                if (!this.contextTierCanSatisfy(selectedContextTier, this.selectedContextTier)) {
+                    return {
+                        error: {
+                            userMessage: 'The relay selected an LLM server that does not match the requested context tier. Please try again.'
+                        }
+                    };
+                }
                 const normalizedKey = this.normalizeServerPublicKey(rawKey);
                 if (!normalizedKey) {
                     throw new Error('Relay returned an invalid compute-node public key');
@@ -277,6 +332,11 @@ new Vue({
                     ? this.encodePemToBase64(normalizedKey)
                     : rawKeyText.replace(/\s+/g, '');
                 this.selectedServerKeyLabel = this.createServerKeyLabel(this.selectedServerPublicKeyB64);
+                this.selectedProfileMetadata = {
+                    selected_context_tier: selectedContextTier,
+                    selected_context_window_tokens: Number.isInteger(data && data.selected_context_window_tokens) ? data.selected_context_window_tokens : null,
+                    selection_policy: typeof (data && data.selection_policy) === 'string' ? data.selection_policy : ''
+                };
                 return true;
             } catch (error) {
                 console.error('Error selecting API v1 compute node:', error);
@@ -305,6 +365,7 @@ new Vue({
             this.selectedServerPublicKeyB64 = null;
             this.serverPublicKey = null;
             this.selectedServerKeyLabel = '';
+            this.selectedProfileMetadata = null;
         },
 
         markSelectedServerTerminalFailure(message) {
@@ -755,7 +816,10 @@ new Vue({
                 api_v1_request: {
                     model: this.selectedModelId,
                     messages: this.createApiV1Messages(messageContent),
-                    options: {}
+                    options: {},
+                    routing: {
+                        context_tier: this.selectedContextTier
+                    }
                 }
             };
 
@@ -974,11 +1038,15 @@ new Vue({
             const errorCode = typeof error.code === 'string' ? error.code.trim() : '';
             const codeToMessage = {
                 no_registered_compute_nodes: 'No LLM servers are available right now. Your chat history is still here.',
+                no_matching_compute_node: 'No LLM server is available for the selected context tier right now. Your chat history is still here.',
+                invalid_context_tier: 'The selected context tier is not available. Please choose another tier and try again.',
                 compute_node_model_unsupported: 'The selected model is not available on this LLM server. Please try again.',
                 compute_node_options_unsupported: 'The selected LLM server does not support one of the requested options. Please try again.',
                 compute_node_invalid_request: 'The LLM server rejected the request format. Please try again.',
                 compute_node_request_too_large: 'This request exceeds the current API size limit. Please shorten it and try again.',
                 compute_node_context_window_exceeded: "This prompt exceeds the selected LLM server's context window.",
+                compute_node_context_tier_mismatch: 'The selected LLM server cannot satisfy the requested context tier. Please try again.',
+                compute_node_context_tier_unsupported: 'The selected LLM server cannot satisfy the requested context tier. Please try again.',
                 compute_node_invalid_model_output: 'The LLM server returned an invalid response. Please try again.',
                 compute_node_internal_error: 'The LLM server failed while generating a response. Please try again.',
                 compute_node_timeout: 'The LLM server took too long to respond. Please try again.',

--- a/static/index.html
+++ b/static/index.html
@@ -112,16 +112,19 @@
             border-color: rgba(255, 255, 255, 0.25);
             background-color: rgba(255, 255, 255, 0.08);
         }
-        .model-selector-container {
+        .model-selector-container,
+        .context-tier-selector-container {
             margin-bottom: 15px;
         }
-        .model-selector-container label {
+        .model-selector-container label,
+        .context-tier-selector-container label {
             display: block;
             margin-bottom: 6px;
             color: #cccccc;
             font-size: 14px;
         }
-        .model-select {
+        .model-select,
+        .context-tier-select {
             width: 100%;
             padding: 10px;
             box-sizing: border-box;
@@ -500,6 +503,21 @@
                     <option v-for="model in availableModels" :key="model.id" :value="model.id" v-text="model.id"></option>
                 </select>
                 <p class="model-status" :class="{'model-error': modelsError}" v-text="modelsError || (modelsLoaded && availableModels.length === 0 ? 'No API v1 models available' : '')"></p>
+            </div>
+            <div class="context-tier-selector-container">
+                <label for="context-tier-select">Context tier</label>
+                <select
+                    id="context-tier-select"
+                    v-model="selectedContextTier"
+                    class="context-tier-select"
+                    aria-label="Context tier"
+                    data-testid="landing-context-tier-select"
+                    :disabled="isGeneratingResponse"
+                    @change="handleContextTierChange"
+                >
+                    <option value="8k-fast">8K Fast</option>
+                    <option value="64k-full">64K Full</option>
+                </select>
             </div>
             <p class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -22,6 +22,61 @@ def test_chat_js_defines_touch_detection_hook():
     assert "detectTouchInput" in chat_js, "chat.js must implement touch detection helper"
 
 
+
+def test_landing_context_tier_selector_template_and_persistence_contract():
+    index_html = Path("static/index.html").read_text(encoding="utf-8")
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert 'for="context-tier-select"' in index_html
+    assert 'Context tier' in index_html
+    assert 'data-testid="landing-context-tier-select"' in index_html
+    assert 'v-model="selectedContextTier"' in index_html
+    assert ':disabled="isGeneratingResponse"' in index_html
+    assert 'value="8k-fast"' in index_html
+    assert '8K Fast' in index_html
+    assert 'value="64k-full"' in index_html
+    assert '64K Full' in index_html
+
+    assert "LANDING_CONTEXT_TIER_STORAGE_KEY = 'tokenplace.landing.api_v1.context_tier'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "SUPPORTED_CONTEXT_TIERS = ['8k-fast', '64k-full']" in chat_js
+    assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
+    assert "loadPersistedContextTier()" in chat_js
+    assert "localStorage.getItem(LANDING_CONTEXT_TIER_STORAGE_KEY)" in chat_js
+    assert "localStorage.setItem(LANDING_CONTEXT_TIER_STORAGE_KEY, this.selectedContextTier)" in chat_js
+    assert "return SUPPORTED_CONTEXT_TIERS.includes(value) ? value : DEFAULT_CONTEXT_TIER" in chat_js
+    assert "handleContextTierChange()" in chat_js
+
+
+def test_landing_next_server_selection_includes_model_and_context_tier():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "selectionUrl.searchParams.set('model', this.selectedModelId);" in chat_js
+    assert "selectionUrl.searchParams.set('context_tier', this.selectedContextTier);" in chat_js
+    assert "selectionUrl.searchParams.set('selected_profile_echo_v1', '1');" in chat_js
+    assert "selected_context_tier" in chat_js
+    assert "contextTierCanSatisfy(selectedContextTier, this.selectedContextTier)" in chat_js
+    assert "selectedProfileMetadata" in chat_js
+
+
+def test_landing_encrypted_api_v1_routing_contains_context_tier_without_plaintext_dispatch():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "routing: {" in chat_js
+    assert "context_tier: this.selectedContextTier" in chat_js
+    assert "body: JSON.stringify(relayPayload)" in chat_js
+    relay_payload_start = chat_js.index("const relayPayload = {")
+    relay_payload_end = chat_js.index("const dispatchResponse", relay_payload_start)
+    relay_payload_block = chat_js[relay_payload_start:relay_payload_end]
+    assert "ciphertext: encryptedData.ciphertext" in relay_payload_block
+    assert "cipherkey: encryptedData.cipherkey" in relay_payload_block
+    assert "iv: encryptedData.iv" in relay_payload_block
+    assert "messages" not in relay_payload_block
+    assert "prompt" not in relay_payload_block
+    assert "content" not in relay_payload_block
+    assert "token_count" not in relay_payload_block
+    assert "prompt_length" not in relay_payload_block
+
 def test_landing_chat_js_avoids_relay_v2_streaming_path():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "/api/v1/relay/servers/next" in chat_js, (
@@ -63,18 +118,23 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "getUserFacingApiError" in chat_js
     assert "no_registered_compute_nodes" in chat_js
+    assert "no_matching_compute_node" in chat_js
     assert "compute_node_timeout" in chat_js
     assert "compute_node_bridge_timeout" in chat_js
     assert "compute_node_unreachable" in chat_js
     assert "compute_node_invalid_payload" in chat_js
     assert "compute_node_request_too_large" in chat_js
     assert "compute_node_context_window_exceeded" in chat_js
+    assert "compute_node_context_tier_mismatch" in chat_js
+    assert "compute_node_context_tier_unsupported" in chat_js
     assert "No LLM servers are available right now." in chat_js
+    assert "No LLM server is available for the selected context tier right now." in chat_js
     assert "The LLM server took too long to respond. Please try again." in chat_js
     assert "The LLM server is unavailable right now. Please try again." in chat_js
     assert "The LLM server returned an invalid response. Please try again." in chat_js
     assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
     assert "This prompt exceeds the selected LLM server's context window." in chat_js
+    assert "The selected LLM server cannot satisfy the requested context tier." in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 


### PR DESCRIPTION
### Motivation
- Let the landing-page chat UI explicitly request a compute `context_tier` (either `8k-fast` or `64k-full`) so staging/prod can exercise the appropriate API v1 compute nodes and avoid accidentally routing large prompts to an 8K node.

### Description
- Add a labeled Context tier dropdown to the landing UI with options `8k-fast` (display `8K Fast`) and `64k-full` (display `64K Full`), defaulting to `8k-fast`, disabled while a request is in flight, and testable via `data-testid="landing-context-tier-select"` (`static/index.html`).
- Persist and normalize the selection in `localStorage` under `tokenplace.landing.api_v1.context_tier`, normalize unknown values to `8k-fast`, and reselection clears the chosen server (`static/chat.js`).
- Send the selected `model` and `context_tier` (and the existing `selected_profile_echo_v1` capability flag) as query params to `GET /api/v1/relay/servers/next`, validate the relay `selected_context_tier` before accepting a returned server, and keep safe selected-profile metadata in component state for diagnostics (`static/chat.js`).
- Embed coarse routing metadata inside the encrypted API v1 envelope as `api_v1_request.routing.context_tier` while keeping relay-visible dispatch ciphertext-only; do not include prompt text, token counts, or other plaintexts in relay-visible fields (`static/chat.js`).
- Add UI-friendly error mappings for selected-tier unavailability/incompatibility and preserve existing `compute_node_context_window_exceeded` / `compute_node_request_too_large` mappings; update focused static UI tests to cover selector template, persistence, next-server metadata, and encrypted routing invariants (`tests/unit/test_touch_ui.py`).

### Testing
- Ran focused UI unit tests with `python -m pytest tests/unit/test_touch_ui.py -q` and they passed.
- Ran relay client unit tests with `python -m pytest tests/unit/test_relay_client.py -q` and they passed.
- Ran full project checks via `./run_all_tests.sh` and they completed successfully (all tests passed in this environment).
- Ran repository checks `pre-commit run --all-files` and `git diff --check` with no issues.
- Captured a landing-page screenshot during verification at `/tmp/tokenplace-landing-context-tier.png` after serving the `static/` tree locally with `python -m http.server`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d79ea38e4832f82415fb1da900203)