### PR TITLE
Add Auto context-tier selection and bounded 8K→64K retry for landing chat

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -4,7 +4,11 @@ const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
-const DEFAULT_CONTEXT_TIER = '8k-fast';
+const AUTO_CONTEXT_TIER = 'auto';
+const DEFAULT_CONTEXT_TIER = AUTO_CONTEXT_TIER;
+const AUTO_OUTPUT_RESERVATION_TOKENS = 1024;
+const AUTO_CONTEXT_SAFETY_MARGIN_TOKENS = 768;
+const AUTO_MESSAGE_OVERHEAD_TOKENS = 8;
 const CONTEXT_TIER_ORDER = {
     '8k-fast': 8192,
     '64k-full': 65536
@@ -250,9 +254,18 @@ new Vue({
             return Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, value);
         },
 
+        isKnownContextTierSelectorValue(value) {
+            return value === AUTO_CONTEXT_TIER || this.isKnownContextTier(value);
+        },
+
         normalizeContextTier(value) {
             const normalizedValue = typeof value === 'string' ? value.trim() : value;
-            return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
+            return this.isKnownContextTier(normalizedValue) ? normalizedValue : '8k-fast';
+        },
+
+        normalizeContextTierSelectorValue(value) {
+            const normalizedValue = typeof value === 'string' ? value.trim() : value;
+            return this.isKnownContextTierSelectorValue(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
         },
 
         loadStoredContextTier() {
@@ -262,7 +275,7 @@ new Vue({
             } catch (error) {
                 console.warn('Unable to read context-tier preference:', error);
             }
-            const normalized = this.normalizeContextTier(stored);
+            const normalized = this.normalizeContextTierSelectorValue(stored);
             if (stored !== null && stored !== normalized) {
                 this.persistContextTier(normalized);
             }
@@ -271,24 +284,25 @@ new Vue({
 
         persistContextTier(value) {
             try {
-                window.localStorage.setItem(CONTEXT_TIER_STORAGE_KEY, this.normalizeContextTier(value));
+                window.localStorage.setItem(CONTEXT_TIER_STORAGE_KEY, this.normalizeContextTierSelectorValue(value));
             } catch (error) {
                 console.warn('Unable to store context-tier preference:', error);
             }
         },
 
         handleContextTierChange() {
-            this.selectedContextTier = this.normalizeContextTier(this.selectedContextTier);
+            this.selectedContextTier = this.normalizeContextTierSelectorValue(this.selectedContextTier);
             this.persistContextTier(this.selectedContextTier);
             this.clearSelectedServer();
         },
 
         selectedContextTierCanSatisfy(selectedTier, requestedTier) {
-            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER[DEFAULT_CONTEXT_TIER]);
+            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER['8k-fast']);
         },
 
         async ensureSelectedServer(options = {}) {
             const forceReselect = Boolean(options.forceReselect);
+            const requestedContextTier = this.normalizeContextTier(options.requestedContextTier || this.selectedContextTier);
             if (forceReselect) {
                 this.clearSelectedServer();
             }
@@ -298,7 +312,6 @@ new Vue({
             }
 
             try {
-                const requestedContextTier = this.normalizeContextTier(this.selectedContextTier);
                 const params = new URLSearchParams({
                     model: this.selectedModelId,
                     context_tier: requestedContextTier
@@ -422,6 +435,56 @@ new Vue({
                 });
             }
             return messages;
+        },
+
+
+        estimateApiV1MessagesForAutoContextTier(apiV1Messages) {
+            const messages = Array.isArray(apiV1Messages) ? apiV1Messages : [];
+            const totals = messages.reduce((accumulator, message) => {
+                const content = message && typeof message.content === 'string' ? message.content : '';
+                accumulator.characters += content.length;
+                const words = content.trim() ? content.trim().split(/\s+/).length : 0;
+                accumulator.words += words;
+                return accumulator;
+            }, { characters: 0, words: 0 });
+            const characterEstimate = Math.ceil(totals.characters / 4);
+            const wordEstimate = Math.ceil(totals.words * 1.35);
+            const messageOverhead = messages.length * AUTO_MESSAGE_OVERHEAD_TOKENS;
+            const promptEstimate = Math.max(characterEstimate, wordEstimate) + messageOverhead;
+            const requiredEstimate = promptEstimate + AUTO_OUTPUT_RESERVATION_TOKENS + AUTO_CONTEXT_SAFETY_MARGIN_TOKENS;
+            return {
+                characters: totals.characters,
+                words: totals.words,
+                promptEstimate,
+                requiredEstimate,
+                resolvedContextTier: requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full'
+            };
+        },
+
+        resolveContextTierForRequest(apiV1Messages, options = {}) {
+            if (options.forceContextTier) {
+                return {
+                    selectorContextTier: this.normalizeContextTierSelectorValue(this.selectedContextTier),
+                    requestedContextTier: this.normalizeContextTier(options.forceContextTier),
+                    autoEstimate: null
+                };
+            }
+
+            const selectorContextTier = this.normalizeContextTierSelectorValue(this.selectedContextTier);
+            if (selectorContextTier !== AUTO_CONTEXT_TIER) {
+                return {
+                    selectorContextTier,
+                    requestedContextTier: this.normalizeContextTier(selectorContextTier),
+                    autoEstimate: null
+                };
+            }
+
+            const autoEstimate = this.estimateApiV1MessagesForAutoContextTier(apiV1Messages);
+            return {
+                selectorContextTier,
+                requestedContextTier: autoEstimate.resolvedContextTier,
+                autoEstimate
+            };
         },
 
         generateClientKeys() {
@@ -811,17 +874,24 @@ new Vue({
         },
 
         // Send a message through the relay-blind API v1 E2EE request routes.
-        async sendMessageApiOnce(messageContent) {
+        async sendMessageApiOnce(messageContent, options = {}) {
             if (!this.selectedModel) {
                 console.error('No API v1 catalogue model selected');
                 return null;
             }
 
-            const selectedServer = await this.ensureSelectedServer();
+            const apiV1Messages = options.apiV1Messages || this.createApiV1Messages(messageContent);
+            const tierResolution = this.resolveContextTierForRequest(apiV1Messages, options);
+            const requestedContextTier = tierResolution.requestedContextTier;
+            const selectedServer = await this.ensureSelectedServer({
+                requestedContextTier,
+                forceReselect: Boolean(options.forceReselect) || tierResolution.selectorContextTier === AUTO_CONTEXT_TIER
+            });
             if (selectedServer !== true) {
                 return selectedServer;
             }
 
+            const firstSelectedContextTier = this.selectedProfileMetadata && this.selectedProfileMetadata.selected_context_tier;
             const requestId = this.createRequestId();
             const cancelToken = this.createRequestId();
             const clientPublicKeyB64 = this.encodeClientPublicKeyForApi();
@@ -832,10 +902,10 @@ new Vue({
                 client_public_key: clientPublicKeyB64,
                 api_v1_request: {
                     model: this.selectedModelId,
-                    messages: this.createApiV1Messages(messageContent),
+                    messages: apiV1Messages,
                     options: {},
                     routing: {
-                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                        context_tier: requestedContextTier
                     }
                 }
             };
@@ -917,7 +987,18 @@ new Vue({
                     throw new Error('Invalid relay response envelope');
                 }
 
-                return responseEnvelope.api_v1_response;
+                const apiV1Response = responseEnvelope.api_v1_response;
+                if (apiV1Response && typeof apiV1Response === 'object') {
+                    apiV1Response._landingContextTierRequest = {
+                        selectorContextTier: tierResolution.selectorContextTier,
+                        requestedContextTier,
+                        selectedContextTier: firstSelectedContextTier || '',
+                        requestId,
+                        cancelToken,
+                        apiV1Messages
+                    };
+                }
+                return apiV1Response;
             } catch (error) {
                 console.error('API v1 relay request error:', error);
                 return null;
@@ -931,10 +1012,24 @@ new Vue({
             let failovers = 0;
             let needsDispatch = true;
             const terminallyFailedServerPublicKeysB64 = new Set();
+            const apiV1Messages = this.createApiV1Messages(messageContent);
 
             while (failovers <= maxFailovers) {
                 if (needsDispatch) {
-                    const response = await this.sendMessageApiOnce(messageContent);
+                    let response = await this.sendMessageApiOnce(messageContent, { apiV1Messages });
+                    const requestMeta = response && response._landingContextTierRequest ? response._landingContextTierRequest : null;
+                    const normalizedError = this.normalizeApiV1ResponseError(response);
+                    if (requestMeta && normalizedError &&
+                        requestMeta.selectorContextTier === AUTO_CONTEXT_TIER &&
+                        requestMeta.requestedContextTier === '8k-fast' &&
+                        requestMeta.selectedContextTier !== '64k-full' &&
+                        normalizedError.code === 'compute_node_context_window_exceeded') {
+                        response = await this.sendMessageApiOnce(messageContent, {
+                            apiV1Messages: requestMeta.apiV1Messages,
+                            forceContextTier: '64k-full',
+                            forceReselect: true
+                        });
+                    }
                     if (response && response.error && response.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
                         terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
                     }
@@ -969,7 +1064,11 @@ new Vue({
 
                 this.clearSelectedServer();
                 this.markSelectedServerTerminalFailure('The previous LLM server disconnected. Continuing with another available server.');
-                const selectedServer = await this.ensureSelectedServer({ forceReselect: true });
+                const failoverTierResolution = this.resolveContextTierForRequest(apiV1Messages);
+                const selectedServer = await this.ensureSelectedServer({
+                    forceReselect: true,
+                    requestedContextTier: failoverTierResolution.requestedContextTier
+                });
                 if (selectedServer !== true) {
                     const userMessage = selectedServer && selectedServer.error && selectedServer.error.userMessage
                         ? selectedServer.error.userMessage

--- a/static/index.html
+++ b/static/index.html
@@ -518,6 +518,7 @@
                     :disabled="isGeneratingResponse"
                     @change="handleContextTierChange"
                 >
+                    <option value="auto">Auto</option>
                     <option value="8k-fast">8K Fast</option>
                     <option value="64k-full">64K Full</option>
                 </select>

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,18 +30,21 @@ def test_landing_context_tier_selector_is_visible_persistent_and_disabled_while_
     assert 'data-testid="landing-context-tier-select"' in index_html
     assert 'v-model="selectedContextTier"' in index_html
     assert ':disabled="isGeneratingResponse"' in index_html
+    assert index_html.index('<option value="auto">Auto</option>') < index_html.index('<option value="8k-fast">8K Fast</option>')
     assert '<option value="8k-fast">8K Fast</option>' in index_html
     assert '<option value="64k-full">64K Full</option>' in index_html
 
     assert "CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1'" in chat_js
-    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "AUTO_CONTEXT_TIER = 'auto'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = AUTO_CONTEXT_TIER" in chat_js
     assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
     assert "loadStoredContextTier" in chat_js
     assert "persistContextTier" in chat_js
     assert "normalizeContextTier" in chat_js
     assert "isKnownContextTier" in chat_js
     assert "const normalizedValue = typeof value === 'string' ? value.trim() : value" in chat_js
-    assert "return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
+    assert "normalizeContextTierSelectorValue" in chat_js
+    assert "return this.isKnownContextTierSelectorValue(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
     assert "if (stored !== null && stored !== normalized)" in chat_js
 
 
@@ -59,10 +62,31 @@ def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_rou
     assert "selectedProfileMetadata" in chat_js
 
     assert "routing: {" in chat_js
-    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "requestedContextTier: autoEstimate.resolvedContextTier" in chat_js
     assert "ciphertext: encryptedData.ciphertext" in chat_js
     assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};\n", 1)[0]
 
+
+
+def test_landing_auto_context_tier_estimator_and_retry_guards():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "AUTO_OUTPUT_RESERVATION_TOKENS" in chat_js
+    assert "AUTO_CONTEXT_SAFETY_MARGIN_TOKENS" in chat_js
+    assert "AUTO_MESSAGE_OVERHEAD_TOKENS" in chat_js
+    assert "estimateApiV1MessagesForAutoContextTier" in chat_js
+    assert "Math.ceil(totals.characters / 4)" in chat_js
+    assert "Math.ceil(totals.words * 1.35)" in chat_js
+    assert "requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full'" in chat_js
+    assert "forceReselect: Boolean(options.forceReselect) || tierResolution.selectorContextTier === AUTO_CONTEXT_TIER" in chat_js
+    assert "normalizedError.code === 'compute_node_context_window_exceeded'" in chat_js
+    assert "forceContextTier: '64k-full'" in chat_js
+    assert "requestMeta.apiV1Messages" in chat_js
+    assert "requestedContextTier === '8k-fast'" in chat_js
+    assert "selectedContextTier !== '64k-full'" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "context_tier: this.selectedContextTier" not in chat_js
 
 def test_landing_context_tier_errors_have_safe_user_messages():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
@@ -136,7 +160,8 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "createApiV1Messages" in chat_js
     assert "this.chatHistory" in chat_js
-    assert "messages: this.createApiV1Messages(messageContent)" in chat_js
+    assert "const apiV1Messages = this.createApiV1Messages(messageContent)" in chat_js
+    assert "messages: apiV1Messages" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
     assert "response.choices[0].message" in chat_js
 
@@ -185,7 +210,8 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "const maxSkippedFailedServerSelections = Math.max(maxFailovers + terminallyFailedServerPublicKeysB64.size, 1);" in chat_js
     assert "skippedFailedServerSelections >= maxSkippedFailedServerSelections" in chat_js
     assert "sendMessageApiOnce" in chat_js
-    assert "ensureSelectedServer({ forceReselect: true })" in chat_js
+    assert "forceReselect: true" in chat_js
+    assert "requestedContextTier: failoverTierResolution.requestedContextTier" in chat_js
     assert "terminallyFailedServerPublicKeysB64.has(this.selectedServerPublicKeyB64)" in chat_js
     assert "skippedFailedServerSelections += 1;" in chat_js
     assert "skippedFailedServerSelections = 0;" in chat_js


### PR DESCRIPTION
### Motivation
- Provide a browser-only `Auto` mode for the landing-page context-tier selector so new users get a safe default that prefers 8K for small prompts and 64K for large prompts without changing relay/server scheduling. 
- Avoid stale server reuse and reduce manual user friction by resolving a wire-safe tier client-side and including only the resolved tier in the encrypted API v1 routing metadata. 
- Add a tightly bounded client-side recovery: retry exactly once from `8k-fast`→`64k-full` when the compute node returns the exact `compute_node_context_window_exceeded` admission error.

### Description
- Added `Auto` selector UI and persisted browser-only selector handling, defaulting new users to `auto` while preserving stored `8k-fast` and `64k-full` preferences, and normalizing unknown values to `auto` (`static/index.html`, `static/chat.js`).
- Implemented lightweight estimator constants and a conservative estimator that runs over the complete `apiV1Messages` list (history + new message) to resolve `auto` to either `8k-fast` or `64k-full` without sending `auto` to the relay, and reused the same `apiV1Messages` object for encryption and dispatch (`estimateApiV1MessagesForAutoContextTier`, `resolveContextTierForRequest`, `sendMessageApiOnce`).
- Refactored send flow so the resolved wire `requestedContextTier` is passed to `/api/v1/relay/servers/next` and set in `api_v1_request.routing.context_tier` inside the encrypted envelope, and forced reselection for `auto` requests to avoid stale cached-server reuse.
- Added an Auto-only bounded retry path that detects a structured `compute_node_context_window_exceeded` error for an initial `8k-fast` auto-resolved request and retries once with a forced `64k-full` selection while preserving the exact same `apiV1Messages` payload but using a new request id and cancel token.

### Testing
- Ran focused static checks and unit tests: `node --check static/chat.js` (passed) and `python -m pytest tests/unit/test_touch_ui.py -q` (13 passed), `python -m pytest tests/test_relay.py -q` (142 passed), and `python -m pytest tests/unit/test_relay_client.py -q` (229 passed). 
- Ran repository checks: `pre-commit run --all-files` (passed) and `git diff --check` (no issues). 
- Exercised page rendering with Playwright to produce a screenshot at `/tmp/token-place-auto-context-tier.png` to verify the `Auto` dropdown placement (captured). 
- All automated tests mentioned above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3df4d7a14c832fbab53a58bf44755f)