### PR TITLE
Add Auto context-tier selection and bounded 8K→64K retry on landing chat

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -4,7 +4,11 @@ const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
-const DEFAULT_CONTEXT_TIER = '8k-fast';
+const DEFAULT_CONTEXT_TIER = 'auto';
+const AUTO_CONTEXT_TIER = 'auto';
+const AUTO_OUTPUT_RESERVATION_TOKENS = 1024;
+const AUTO_CONTEXT_SAFETY_MARGIN_TOKENS = 1024;
+const AUTO_MESSAGE_OVERHEAD_TOKENS = 8;
 const CONTEXT_TIER_ORDER = {
     '8k-fast': 8192,
     '64k-full': 65536
@@ -250,9 +254,18 @@ new Vue({
             return Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, value);
         },
 
+        isKnownContextTierSelectorValue(value) {
+            return value === AUTO_CONTEXT_TIER || this.isKnownContextTier(value);
+        },
+
         normalizeContextTier(value) {
             const normalizedValue = typeof value === 'string' ? value.trim() : value;
-            return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
+            return this.isKnownContextTierSelectorValue(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
+        },
+
+        normalizeWireContextTier(value) {
+            const normalizedValue = typeof value === 'string' ? value.trim() : value;
+            return this.isKnownContextTier(normalizedValue) ? normalizedValue : '8k-fast';
         },
 
         loadStoredContextTier() {
@@ -284,11 +297,66 @@ new Vue({
         },
 
         selectedContextTierCanSatisfy(selectedTier, requestedTier) {
-            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER[DEFAULT_CONTEXT_TIER]);
+            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER['8k-fast']);
+        },
+
+        estimateApiV1MessagesForAutoContextTier(apiV1Messages) {
+            const messages = Array.isArray(apiV1Messages) ? apiV1Messages : [];
+            const totalCharacters = messages.reduce((sum, message) => {
+                const content = message && typeof message.content === 'string' ? message.content : '';
+                return sum + content.length;
+            }, 0);
+            const totalWords = messages.reduce((sum, message) => {
+                const content = message && typeof message.content === 'string' ? message.content.trim() : '';
+                return sum + (content ? content.split(/\s+/).length : 0);
+            }, 0);
+            const characterEstimate = Math.ceil(totalCharacters / 4);
+            const wordEstimate = Math.ceil(totalWords * 1.35);
+            const messageOverhead = messages.length * AUTO_MESSAGE_OVERHEAD_TOKENS;
+            const promptEstimate = Math.max(characterEstimate, wordEstimate) + messageOverhead;
+            const requiredEstimate = promptEstimate + AUTO_OUTPUT_RESERVATION_TOKENS + AUTO_CONTEXT_SAFETY_MARGIN_TOKENS;
+            return {
+                totalCharacters,
+                totalWords,
+                promptEstimate,
+                requiredEstimate,
+                resolvedContextTier: requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full'
+            };
+        },
+
+        resolveContextTierForRequest(apiV1Messages, selectorValue) {
+            const normalizedSelectorValue = this.normalizeContextTier(selectorValue);
+            if (normalizedSelectorValue !== AUTO_CONTEXT_TIER) {
+                return {
+                    selectorMode: normalizedSelectorValue,
+                    requestedContextTier: this.normalizeWireContextTier(normalizedSelectorValue),
+                    estimate: null
+                };
+            }
+            const estimate = this.estimateApiV1MessagesForAutoContextTier(apiV1Messages);
+            return {
+                selectorMode: AUTO_CONTEXT_TIER,
+                requestedContextTier: estimate.resolvedContextTier,
+                estimate
+            };
+        },
+
+        shouldRetryAutoContextTier(response, attempt) {
+            const error = response && typeof response === 'object' ? response.error : null;
+            const errorCode = error && typeof error.code === 'string' ? error.code.trim() : '';
+            return Boolean(
+                attempt &&
+                attempt.selectorMode === AUTO_CONTEXT_TIER &&
+                attempt.requestedContextTier === '8k-fast' &&
+                attempt.retryAttempted !== true &&
+                attempt.selectedServerContextTier !== '64k-full' &&
+                errorCode === 'compute_node_context_window_exceeded'
+            );
         },
 
         async ensureSelectedServer(options = {}) {
             const forceReselect = Boolean(options.forceReselect);
+            const requestedContextTier = this.normalizeWireContextTier(options.requestedContextTier || this.selectedContextTier);
             if (forceReselect) {
                 this.clearSelectedServer();
             }
@@ -298,7 +366,6 @@ new Vue({
             }
 
             try {
-                const requestedContextTier = this.normalizeContextTier(this.selectedContextTier);
                 const params = new URLSearchParams({
                     model: this.selectedModelId,
                     context_tier: requestedContextTier
@@ -811,16 +878,25 @@ new Vue({
         },
 
         // Send a message through the relay-blind API v1 E2EE request routes.
-        async sendMessageApiOnce(messageContent) {
+        async sendMessageApiOnce(messageContent, options = {}) {
             if (!this.selectedModel) {
                 console.error('No API v1 catalogue model selected');
                 return null;
             }
 
-            const selectedServer = await this.ensureSelectedServer();
+            const apiV1Messages = options.apiV1Messages || this.createApiV1Messages(messageContent);
+            const tierResolution = options.tierResolution || this.resolveContextTierForRequest(apiV1Messages, this.selectedContextTier);
+            const forceReselect = Boolean(options.forceReselect) || tierResolution.selectorMode === AUTO_CONTEXT_TIER;
+            const selectedServer = await this.ensureSelectedServer({
+                requestedContextTier: tierResolution.requestedContextTier,
+                forceReselect
+            });
             if (selectedServer !== true) {
                 return selectedServer;
             }
+            const selectedServerContextTier = this.selectedProfileMetadata && this.selectedProfileMetadata.selected_context_tier
+                ? this.selectedProfileMetadata.selected_context_tier
+                : '';
 
             const requestId = this.createRequestId();
             const cancelToken = this.createRequestId();
@@ -832,10 +908,10 @@ new Vue({
                 client_public_key: clientPublicKeyB64,
                 api_v1_request: {
                     model: this.selectedModelId,
-                    messages: this.createApiV1Messages(messageContent),
+                    messages: apiV1Messages,
                     options: {},
                     routing: {
-                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                        context_tier: tierResolution.requestedContextTier
                     }
                 }
             };
@@ -917,7 +993,16 @@ new Vue({
                     throw new Error('Invalid relay response envelope');
                 }
 
-                return responseEnvelope.api_v1_response;
+                const apiV1Response = responseEnvelope.api_v1_response;
+                if (apiV1Response && typeof apiV1Response === 'object') {
+                    apiV1Response._autoContextAttempt = {
+                        selectorMode: tierResolution.selectorMode,
+                        requestedContextTier: tierResolution.requestedContextTier,
+                        selectedServerContextTier,
+                        retryAttempted: Boolean(options.retryAttempted)
+                    };
+                }
+                return apiV1Response;
             } catch (error) {
                 console.error('API v1 relay request error:', error);
                 return null;
@@ -925,6 +1010,9 @@ new Vue({
         },
 
         async sendMessageApi(messageContent) {
+            const apiV1Messages = this.createApiV1Messages(messageContent);
+            const initialTierResolution = this.resolveContextTierForRequest(apiV1Messages, this.selectedContextTier);
+            let autoContextRetryAttempted = false;
             let maxFailovers = this.getFailoverAttemptLimit();
             let refreshedFailoverCapacity = false;
             let skippedFailedServerSelections = 0;
@@ -934,9 +1022,22 @@ new Vue({
 
             while (failovers <= maxFailovers) {
                 if (needsDispatch) {
-                    const response = await this.sendMessageApiOnce(messageContent);
+                    const response = await this.sendMessageApiOnce(messageContent, {
+                        apiV1Messages,
+                        tierResolution: autoContextRetryAttempted
+                            ? { selectorMode: AUTO_CONTEXT_TIER, requestedContextTier: '64k-full', estimate: initialTierResolution.estimate }
+                            : initialTierResolution,
+                        forceReselect: autoContextRetryAttempted,
+                        retryAttempted: autoContextRetryAttempted
+                    });
                     if (response && response.error && response.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
                         terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
+                    }
+                    if (response && this.shouldRetryAutoContextTier(response, response._autoContextAttempt)) {
+                        autoContextRetryAttempted = true;
+                        this.clearSelectedServer();
+                        needsDispatch = true;
+                        continue;
                     }
                     if (!response || !response.error || response.error.terminalSelectedServer !== true) {
                         if (response && !(response.error && response.error.terminalSelectedServer === true)) {
@@ -969,7 +1070,10 @@ new Vue({
 
                 this.clearSelectedServer();
                 this.markSelectedServerTerminalFailure('The previous LLM server disconnected. Continuing with another available server.');
-                const selectedServer = await this.ensureSelectedServer({ forceReselect: true });
+                const selectedServer = await this.ensureSelectedServer({
+                    forceReselect: true,
+                    requestedContextTier: autoContextRetryAttempted ? '64k-full' : initialTierResolution.requestedContextTier
+                });
                 if (selectedServer !== true) {
                     const userMessage = selectedServer && selectedServer.error && selectedServer.error.userMessage
                         ? selectedServer.error.userMessage

--- a/static/chat.js
+++ b/static/chat.js
@@ -1030,6 +1030,7 @@ new Vue({
             let failovers = 0;
             let needsDispatch = true;
             let preserveSelectedServerForDispatch = false;
+            let forceReselectForDispatch = false;
             const terminallyFailedServerPublicKeysB64 = new Set();
 
             while (failovers <= maxFailovers) {
@@ -1039,17 +1040,19 @@ new Vue({
                         tierResolution: autoContextRetryAttempted
                             ? { selectorMode: AUTO_CONTEXT_TIER, requestedContextTier: '64k-full', estimate: initialTierResolution.estimate }
                             : initialTierResolution,
-                        forceReselect: autoContextRetryAttempted,
+                        forceReselect: forceReselectForDispatch,
                         preserveSelectedServer: preserveSelectedServerForDispatch,
                         retryAttempted: autoContextRetryAttempted
                     });
                     preserveSelectedServerForDispatch = false;
+                    forceReselectForDispatch = false;
                     if (response && response.error && response.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
                         terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
                     }
                     if (response && this.shouldRetryAutoContextTier(response, response._autoContextAttempt)) {
                         autoContextRetryAttempted = true;
                         this.clearSelectedServer();
+                        forceReselectForDispatch = true;
                         needsDispatch = true;
                         continue;
                     }

--- a/static/chat.js
+++ b/static/chat.js
@@ -302,14 +302,21 @@ new Vue({
 
         estimateApiV1MessagesForAutoContextTier(apiV1Messages) {
             const messages = Array.isArray(apiV1Messages) ? apiV1Messages : [];
-            const totalCharacters = messages.reduce((sum, message) => {
+            const totals = messages.reduce((accumulator, message) => {
                 const content = message && typeof message.content === 'string' ? message.content : '';
-                return sum + content.length;
-            }, 0);
-            const totalWords = messages.reduce((sum, message) => {
-                const content = message && typeof message.content === 'string' ? message.content.trim() : '';
-                return sum + (content ? content.split(/\s+/).length : 0);
-            }, 0);
+                accumulator.totalCharacters += content.length;
+                let inWord = false;
+                for (const character of content) {
+                    if (/\s/.test(character)) {
+                        inWord = false;
+                    } else if (!inWord) {
+                        accumulator.totalWords += 1;
+                        inWord = true;
+                    }
+                }
+                return accumulator;
+            }, { totalCharacters: 0, totalWords: 0 });
+            const { totalCharacters, totalWords } = totals;
             const characterEstimate = Math.ceil(totalCharacters / 4);
             const wordEstimate = Math.ceil(totalWords * 1.35);
             const messageOverhead = messages.length * AUTO_MESSAGE_OVERHEAD_TOKENS;
@@ -886,7 +893,8 @@ new Vue({
 
             const apiV1Messages = options.apiV1Messages || this.createApiV1Messages(messageContent);
             const tierResolution = options.tierResolution || this.resolveContextTierForRequest(apiV1Messages, this.selectedContextTier);
-            const forceReselect = Boolean(options.forceReselect) || tierResolution.selectorMode === AUTO_CONTEXT_TIER;
+            const forceReselect = Boolean(options.forceReselect)
+                || (tierResolution.selectorMode === AUTO_CONTEXT_TIER && options.preserveSelectedServer !== true);
             const selectedServer = await this.ensureSelectedServer({
                 requestedContextTier: tierResolution.requestedContextTier,
                 forceReselect
@@ -994,12 +1002,15 @@ new Vue({
                 }
 
                 const apiV1Response = responseEnvelope.api_v1_response;
-                if (apiV1Response && typeof apiV1Response === 'object') {
-                    apiV1Response._autoContextAttempt = {
-                        selectorMode: tierResolution.selectorMode,
-                        requestedContextTier: tierResolution.requestedContextTier,
-                        selectedServerContextTier,
-                        retryAttempted: Boolean(options.retryAttempted)
+                if (apiV1Response && typeof apiV1Response === 'object' && !Array.isArray(apiV1Response)) {
+                    return {
+                        ...apiV1Response,
+                        _autoContextAttempt: {
+                            selectorMode: tierResolution.selectorMode,
+                            requestedContextTier: tierResolution.requestedContextTier,
+                            selectedServerContextTier,
+                            retryAttempted: Boolean(options.retryAttempted)
+                        }
                     };
                 }
                 return apiV1Response;
@@ -1018,6 +1029,7 @@ new Vue({
             let skippedFailedServerSelections = 0;
             let failovers = 0;
             let needsDispatch = true;
+            let preserveSelectedServerForDispatch = false;
             const terminallyFailedServerPublicKeysB64 = new Set();
 
             while (failovers <= maxFailovers) {
@@ -1028,8 +1040,10 @@ new Vue({
                             ? { selectorMode: AUTO_CONTEXT_TIER, requestedContextTier: '64k-full', estimate: initialTierResolution.estimate }
                             : initialTierResolution,
                         forceReselect: autoContextRetryAttempted,
+                        preserveSelectedServer: preserveSelectedServerForDispatch,
                         retryAttempted: autoContextRetryAttempted
                     });
+                    preserveSelectedServerForDispatch = false;
                     if (response && response.error && response.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
                         terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
                     }
@@ -1089,6 +1103,7 @@ new Vue({
                 }
                 skippedFailedServerSelections = 0;
                 failovers += 1;
+                preserveSelectedServerForDispatch = true;
                 needsDispatch = true;
             }
 

--- a/static/index.html
+++ b/static/index.html
@@ -518,6 +518,7 @@
                     :disabled="isGeneratingResponse"
                     @change="handleContextTierChange"
                 >
+                    <option value="auto">Auto</option>
                     <option value="8k-fast">8K Fast</option>
                     <option value="64k-full">64K Full</option>
                 </select>

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -80,6 +80,8 @@ def test_landing_auto_context_tier_estimator_and_retry_are_bounded():
     assert "resolveContextTierForRequest(apiV1Messages, this.selectedContextTier)" in chat_js
     assert "requestedContextTier: estimate.resolvedContextTier" in chat_js
     assert "options.preserveSelectedServer !== true" in chat_js
+    assert "let forceReselectForDispatch = false;" in chat_js
+    assert "forceReselect: forceReselectForDispatch" in chat_js
     assert "content.split(/\\s+/)" not in chat_js
     assert "errorCode === 'compute_node_context_window_exceeded'" in chat_js
     assert "attempt.requestedContextTier === '8k-fast'" in chat_js
@@ -87,6 +89,7 @@ def test_landing_auto_context_tier_estimator_and_retry_are_bounded():
     assert "attempt.selectedServerContextTier !== '64k-full'" in chat_js
     assert "requestedContextTier: '64k-full'" in chat_js
     assert "autoContextRetryAttempted = true" in chat_js
+    assert "forceReselectForDispatch = true;" in chat_js
     assert "context_tier: requestedContextTier" in chat_js
     assert "context_tier: AUTO_CONTEXT_TIER" not in chat_js
     assert "context_tier: 'auto'" not in chat_js
@@ -219,8 +222,10 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "skippedFailedServerSelections += 1;" in chat_js
     assert "skippedFailedServerSelections = 0;" in chat_js
     assert "let preserveSelectedServerForDispatch = false;" in chat_js
+    assert "let forceReselectForDispatch = false;" in chat_js
     assert "preserveSelectedServerForDispatch = true;" in chat_js
     assert "preserveSelectedServer: preserveSelectedServerForDispatch" in chat_js
+    assert "forceReselect: forceReselectForDispatch" in chat_js
     assert "originalFailedServerPublicKeyB64" not in chat_js
     assert "failedServerPublicKeyB64" not in chat_js
     assert "reselectAttempts" not in chat_js

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -79,7 +79,8 @@ def test_landing_auto_context_tier_estimator_and_retry_are_bounded():
     assert "resolvedContextTier: requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full'" in chat_js
     assert "resolveContextTierForRequest(apiV1Messages, this.selectedContextTier)" in chat_js
     assert "requestedContextTier: estimate.resolvedContextTier" in chat_js
-    assert "forceReselect = Boolean(options.forceReselect) || tierResolution.selectorMode === AUTO_CONTEXT_TIER" in chat_js
+    assert "options.preserveSelectedServer !== true" in chat_js
+    assert "content.split(/\\s+/)" not in chat_js
     assert "errorCode === 'compute_node_context_window_exceeded'" in chat_js
     assert "attempt.requestedContextTier === '8k-fast'" in chat_js
     assert "attempt.retryAttempted !== true" in chat_js
@@ -217,6 +218,9 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "terminallyFailedServerPublicKeysB64.has(this.selectedServerPublicKeyB64)" in chat_js
     assert "skippedFailedServerSelections += 1;" in chat_js
     assert "skippedFailedServerSelections = 0;" in chat_js
+    assert "let preserveSelectedServerForDispatch = false;" in chat_js
+    assert "preserveSelectedServerForDispatch = true;" in chat_js
+    assert "preserveSelectedServer: preserveSelectedServerForDispatch" in chat_js
     assert "originalFailedServerPublicKeyB64" not in chat_js
     assert "failedServerPublicKeyB64" not in chat_js
     assert "reselectAttempts" not in chat_js

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,18 +30,20 @@ def test_landing_context_tier_selector_is_visible_persistent_and_disabled_while_
     assert 'data-testid="landing-context-tier-select"' in index_html
     assert 'v-model="selectedContextTier"' in index_html
     assert ':disabled="isGeneratingResponse"' in index_html
+    assert index_html.index('<option value="auto">Auto</option>') < index_html.index('<option value="8k-fast">8K Fast</option>')
     assert '<option value="8k-fast">8K Fast</option>' in index_html
     assert '<option value="64k-full">64K Full</option>' in index_html
 
     assert "CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1'" in chat_js
-    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = 'auto'" in chat_js
+    assert "AUTO_CONTEXT_TIER = 'auto'" in chat_js
     assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
     assert "loadStoredContextTier" in chat_js
     assert "persistContextTier" in chat_js
     assert "normalizeContextTier" in chat_js
     assert "isKnownContextTier" in chat_js
     assert "const normalizedValue = typeof value === 'string' ? value.trim() : value" in chat_js
-    assert "return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
+    assert "return this.isKnownContextTierSelectorValue(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
     assert "if (stored !== null && stored !== normalized)" in chat_js
 
 
@@ -59,9 +61,34 @@ def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_rou
     assert "selectedProfileMetadata" in chat_js
 
     assert "routing: {" in chat_js
-    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "context_tier: tierResolution.requestedContextTier" in chat_js
+    assert "normalizeWireContextTier" in chat_js
     assert "ciphertext: encryptedData.ciphertext" in chat_js
     assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};\n", 1)[0]
+
+
+def test_landing_auto_context_tier_estimator_and_retry_are_bounded():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "AUTO_OUTPUT_RESERVATION_TOKENS" in chat_js
+    assert "AUTO_CONTEXT_SAFETY_MARGIN_TOKENS" in chat_js
+    assert "AUTO_MESSAGE_OVERHEAD_TOKENS" in chat_js
+    assert "estimateApiV1MessagesForAutoContextTier" in chat_js
+    assert "Math.ceil(totalCharacters / 4)" in chat_js
+    assert "Math.ceil(totalWords * 1.35)" in chat_js
+    assert "resolvedContextTier: requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full'" in chat_js
+    assert "resolveContextTierForRequest(apiV1Messages, this.selectedContextTier)" in chat_js
+    assert "requestedContextTier: estimate.resolvedContextTier" in chat_js
+    assert "forceReselect = Boolean(options.forceReselect) || tierResolution.selectorMode === AUTO_CONTEXT_TIER" in chat_js
+    assert "errorCode === 'compute_node_context_window_exceeded'" in chat_js
+    assert "attempt.requestedContextTier === '8k-fast'" in chat_js
+    assert "attempt.retryAttempted !== true" in chat_js
+    assert "attempt.selectedServerContextTier !== '64k-full'" in chat_js
+    assert "requestedContextTier: '64k-full'" in chat_js
+    assert "autoContextRetryAttempted = true" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "context_tier: AUTO_CONTEXT_TIER" not in chat_js
+    assert "context_tier: 'auto'" not in chat_js
 
 
 def test_landing_context_tier_errors_have_safe_user_messages():
@@ -136,7 +163,8 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "createApiV1Messages" in chat_js
     assert "this.chatHistory" in chat_js
-    assert "messages: this.createApiV1Messages(messageContent)" in chat_js
+    assert "const apiV1Messages = this.createApiV1Messages(messageContent);" in chat_js
+    assert "messages: apiV1Messages" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
     assert "response.choices[0].message" in chat_js
 
@@ -185,7 +213,7 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "const maxSkippedFailedServerSelections = Math.max(maxFailovers + terminallyFailedServerPublicKeysB64.size, 1);" in chat_js
     assert "skippedFailedServerSelections >= maxSkippedFailedServerSelections" in chat_js
     assert "sendMessageApiOnce" in chat_js
-    assert "ensureSelectedServer({ forceReselect: true })" in chat_js
+    assert "forceReselect: true" in chat_js
     assert "terminallyFailedServerPublicKeysB64.has(this.selectedServerPublicKeyB64)" in chat_js
     assert "skippedFailedServerSelections += 1;" in chat_js
     assert "skippedFailedServerSelections = 0;" in chat_js


### PR DESCRIPTION
### Motivation
- Provide a browser-only `Auto` option that cheaply estimates the full outgoing API v1 message list and selects the smallest capable context tier (`8k-fast` or `64k-full`) without exposing plaintext or token estimates to the relay.
- Default new users to `Auto` while preserving existing explicit `8k-fast` and `64k-full` preferences as diagnostic rails.
- Retry exactly once from `8k-fast`→`64k-full` only when the compute node returns the structured `compute_node_context_window_exceeded` error, preserving failover and privacy invariants.

### Description
- Added `auto` as the first dropdown option in `static/index.html` and changed the landing default selector to `DEFAULT_CONTEXT_TIER = 'auto'` while keeping wire-tier values limited to `8k-fast` and `64k-full` in `static/chat.js`.
- Added lightweight estimator constants (`AUTO_OUTPUT_RESERVATION_TOKENS`, `AUTO_CONTEXT_SAFETY_MARGIN_TOKENS`, `AUTO_MESSAGE_OVERHEAD_TOKENS`) and functions `estimateApiV1MessagesForAutoContextTier`, `resolveContextTierForRequest`, and `shouldRetryAutoContextTier` to resolve a wire tier from the full `apiV1Messages` list (built once and reused).
- Refactored send flow so `sendMessageApiOnce` accepts prebuilt `apiV1Messages` and a `tierResolution`; `ensureSelectedServer` now accepts `requestedContextTier` and `forceReselect` so the resolved tier is requested from `/api/v1/relay/servers/next` and the same messages are encrypted with `routing.context_tier` set to the resolved wire tier.
- Implemented Auto-only bounded retry: when in `auto` mode and a first request resolved to `8k-fast` returns `compute_node_context_window_exceeded`, the UI forces a reselect for `64k-full`, re-encrypts the identical `apiV1Messages` with a new request id and cancel token, and retries exactly once; explicit modes do not auto-escalate.
- Cleared cached selected server on selector change and forced reselection for every Auto request to avoid stale-server reuse; preserved existing terminal-selected-server failover logic.
- Updated focused landing-page tests in `tests/unit/test_touch_ui.py` to assert the new `Auto` option, estimator constants and functions, prebuilt message reuse, resolved wire-tier request paths, and bounded retry guards.

### Testing
- Ran `python -m pytest tests/unit/test_touch_ui.py -q` and all landing-page unit tests passed (13/13).
- Ran `python -m pytest tests/test_relay.py -q` and relay test-suite passed (142/142).
- Ran `python -m pytest tests/unit/test_relay_client.py -q` and relay-client unit tests passed (229/229).
- Ran `pre-commit run --all-files` and hooks passed, and `git diff --check` returned clean.
- All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3df4e35954832f9ee3a49add916e2a)