### PR TITLE
Add Auto context-tier selection and single 8K→64K retry for landing chat

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -4,7 +4,11 @@ const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
-const DEFAULT_CONTEXT_TIER = '8k-fast';
+const AUTO_CONTEXT_TIER = 'auto';
+const DEFAULT_CONTEXT_TIER = AUTO_CONTEXT_TIER;
+const AUTO_OUTPUT_RESERVATION_TOKENS = 1024;
+const AUTO_CONTEXT_SAFETY_MARGIN_TOKENS = 512;
+const AUTO_MESSAGE_OVERHEAD_TOKENS = 8;
 const CONTEXT_TIER_ORDER = {
     '8k-fast': 8192,
     '64k-full': 65536
@@ -26,6 +30,7 @@ new Vue({
         selectedModelId: '',
         selectedContextTier: DEFAULT_CONTEXT_TIER,
         selectedProfileMetadata: null,
+        contextTierStatus: '',
         modelsLoading: false,
         modelsLoaded: false,
         modelsError: '',
@@ -250,9 +255,18 @@ new Vue({
             return Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, value);
         },
 
+        isKnownContextTierSelectorValue(value) {
+            return value === AUTO_CONTEXT_TIER || this.isKnownContextTier(value);
+        },
+
         normalizeContextTier(value) {
             const normalizedValue = typeof value === 'string' ? value.trim() : value;
-            return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
+            return this.isKnownContextTierSelectorValue(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
+        },
+
+        normalizeWireContextTier(value) {
+            const normalizedValue = typeof value === 'string' ? value.trim() : value;
+            return this.isKnownContextTier(normalizedValue) ? normalizedValue : '8k-fast';
         },
 
         loadStoredContextTier() {
@@ -279,16 +293,18 @@ new Vue({
 
         handleContextTierChange() {
             this.selectedContextTier = this.normalizeContextTier(this.selectedContextTier);
+            this.contextTierStatus = '';
             this.persistContextTier(this.selectedContextTier);
             this.clearSelectedServer();
         },
 
         selectedContextTierCanSatisfy(selectedTier, requestedTier) {
-            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER[DEFAULT_CONTEXT_TIER]);
+            return (CONTEXT_TIER_ORDER[selectedTier] || 0) >= (CONTEXT_TIER_ORDER[requestedTier] || CONTEXT_TIER_ORDER['8k-fast']);
         },
 
         async ensureSelectedServer(options = {}) {
             const forceReselect = Boolean(options.forceReselect);
+            const requestedContextTier = this.normalizeWireContextTier(options.requestedContextTier || this.selectedContextTier);
             if (forceReselect) {
                 this.clearSelectedServer();
             }
@@ -298,7 +314,6 @@ new Vue({
             }
 
             try {
-                const requestedContextTier = this.normalizeContextTier(this.selectedContextTier);
                 const params = new URLSearchParams({
                     model: this.selectedModelId,
                     context_tier: requestedContextTier
@@ -401,6 +416,59 @@ new Vue({
             this.$nextTick(() => {
                 this.adjustMessageInputHeight();
             });
+        },
+
+        estimateApiV1MessagesForAutoContextTier(apiV1Messages) {
+            const messages = Array.isArray(apiV1Messages) ? apiV1Messages : [];
+            let totalCharacters = 0;
+            let totalWords = 0;
+            for (const message of messages) {
+                const content = message && typeof message.content === 'string' ? message.content : '';
+                totalCharacters += content.length;
+                const trimmed = content.trim();
+                if (trimmed) {
+                    totalWords += trimmed.split(/\s+/).length;
+                }
+            }
+            const characterEstimate = Math.ceil(totalCharacters / 4);
+            const wordEstimate = Math.ceil(totalWords * 1.35);
+            const messageOverhead = messages.length * AUTO_MESSAGE_OVERHEAD_TOKENS;
+            const promptEstimate = Math.max(characterEstimate, wordEstimate) + messageOverhead;
+            const requiredEstimate = promptEstimate + AUTO_OUTPUT_RESERVATION_TOKENS + AUTO_CONTEXT_SAFETY_MARGIN_TOKENS;
+            const resolvedTier = requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full';
+            return {
+                totalCharacters,
+                totalWords,
+                promptEstimate,
+                requiredEstimate,
+                resolvedTier
+            };
+        },
+
+        resolveContextTierForRequest(apiV1Messages, selectorValue) {
+            const normalizedSelector = this.normalizeContextTier(selectorValue);
+            if (normalizedSelector !== AUTO_CONTEXT_TIER) {
+                return {
+                    selectorMode: normalizedSelector,
+                    requestedContextTier: this.normalizeWireContextTier(normalizedSelector),
+                    autoEstimate: null
+                };
+            }
+            const autoEstimate = this.estimateApiV1MessagesForAutoContextTier(apiV1Messages);
+            return {
+                selectorMode: AUTO_CONTEXT_TIER,
+                requestedContextTier: autoEstimate.resolvedTier,
+                autoEstimate
+            };
+        },
+
+        setAutoContextTierStatus(resolvedTier) {
+            if (this.normalizeContextTier(this.selectedContextTier) !== AUTO_CONTEXT_TIER) {
+                this.contextTierStatus = '';
+                return;
+            }
+            const label = resolvedTier === '64k-full' ? '64K Full' : '8K Fast';
+            this.contextTierStatus = `Auto selected ${label} for this prompt`;
         },
 
         createApiV1Messages(messageContent) {
@@ -811,13 +879,20 @@ new Vue({
         },
 
         // Send a message through the relay-blind API v1 E2EE request routes.
-        async sendMessageApiOnce(messageContent) {
+        async sendMessageApiOnce(messageContent, options = {}) {
             if (!this.selectedModel) {
                 console.error('No API v1 catalogue model selected');
                 return null;
             }
 
-            const selectedServer = await this.ensureSelectedServer();
+            const requestedContextTier = this.normalizeWireContextTier(options.requestedContextTier || this.selectedContextTier);
+            const apiV1Messages = Array.isArray(options.apiV1Messages)
+                ? options.apiV1Messages
+                : this.createApiV1Messages(messageContent);
+            const selectedServer = await this.ensureSelectedServer({
+                forceReselect: Boolean(options.forceReselect),
+                requestedContextTier
+            });
             if (selectedServer !== true) {
                 return selectedServer;
             }
@@ -832,10 +907,10 @@ new Vue({
                 client_public_key: clientPublicKeyB64,
                 api_v1_request: {
                     model: this.selectedModelId,
-                    messages: this.createApiV1Messages(messageContent),
+                    messages: apiV1Messages,
                     options: {},
                     routing: {
-                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                        context_tier: requestedContextTier
                     }
                 }
             };
@@ -917,7 +992,14 @@ new Vue({
                     throw new Error('Invalid relay response envelope');
                 }
 
-                return responseEnvelope.api_v1_response;
+                return Object.assign({}, responseEnvelope.api_v1_response, {
+                    __landingContextTier: {
+                        requestedContextTier,
+                        selectedContextTier: this.selectedProfileMetadata && this.selectedProfileMetadata.selected_context_tier
+                            ? this.selectedProfileMetadata.selected_context_tier
+                            : ''
+                    }
+                });
             } catch (error) {
                 console.error('API v1 relay request error:', error);
                 return null;
@@ -925,6 +1007,14 @@ new Vue({
         },
 
         async sendMessageApi(messageContent) {
+            const apiV1Messages = this.createApiV1Messages(messageContent);
+            const selectorMode = this.normalizeContextTier(this.selectedContextTier);
+            const tierResolution = this.resolveContextTierForRequest(apiV1Messages, selectorMode);
+            let requestedContextTier = tierResolution.requestedContextTier;
+            const autoMode = tierResolution.selectorMode === AUTO_CONTEXT_TIER;
+            let autoRetryAttempted = false;
+            this.setAutoContextTierStatus(autoMode ? requestedContextTier : '');
+
             let maxFailovers = this.getFailoverAttemptLimit();
             let refreshedFailoverCapacity = false;
             let skippedFailedServerSelections = 0;
@@ -934,9 +1024,31 @@ new Vue({
 
             while (failovers <= maxFailovers) {
                 if (needsDispatch) {
-                    const response = await this.sendMessageApiOnce(messageContent);
+                    const response = await this.sendMessageApiOnce(messageContent, {
+                        apiV1Messages,
+                        requestedContextTier,
+                        forceReselect: autoMode
+                    });
                     if (response && response.error && response.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
                         terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
+                    }
+                    const normalizedError = this.normalizeApiV1ResponseError(response);
+                    const selectedContextTier = response && response.__landingContextTier
+                        ? response.__landingContextTier.selectedContextTier
+                        : '';
+                    const shouldAutoRetryOn64k = autoMode &&
+                        !autoRetryAttempted &&
+                        requestedContextTier === '8k-fast' &&
+                        normalizedError &&
+                        normalizedError.code === 'compute_node_context_window_exceeded' &&
+                        selectedContextTier !== '64k-full';
+                    if (shouldAutoRetryOn64k) {
+                        autoRetryAttempted = true;
+                        requestedContextTier = '64k-full';
+                        this.setAutoContextTierStatus(requestedContextTier);
+                        this.clearSelectedServer();
+                        needsDispatch = true;
+                        continue;
                     }
                     if (!response || !response.error || response.error.terminalSelectedServer !== true) {
                         if (response && !(response.error && response.error.terminalSelectedServer === true)) {
@@ -969,7 +1081,10 @@ new Vue({
 
                 this.clearSelectedServer();
                 this.markSelectedServerTerminalFailure('The previous LLM server disconnected. Continuing with another available server.');
-                const selectedServer = await this.ensureSelectedServer({ forceReselect: true });
+                const selectedServer = await this.ensureSelectedServer({
+                    forceReselect: true,
+                    requestedContextTier
+                });
                 if (selectedServer !== true) {
                     const userMessage = selectedServer && selectedServer.error && selectedServer.error.userMessage
                         ? selectedServer.error.userMessage

--- a/static/index.html
+++ b/static/index.html
@@ -518,9 +518,11 @@
                     :disabled="isGeneratingResponse"
                     @change="handleContextTierChange"
                 >
+                    <option value="auto">Auto</option>
                     <option value="8k-fast">8K Fast</option>
                     <option value="64k-full">64K Full</option>
                 </select>
+                <p class="context-tier-status" data-testid="landing-context-tier-status" v-text="contextTierStatus"></p>
             </div>
             <p class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,18 +30,21 @@ def test_landing_context_tier_selector_is_visible_persistent_and_disabled_while_
     assert 'data-testid="landing-context-tier-select"' in index_html
     assert 'v-model="selectedContextTier"' in index_html
     assert ':disabled="isGeneratingResponse"' in index_html
+    assert '<option value="auto">Auto</option>' in index_html
+    assert index_html.index('<option value="auto">Auto</option>') < index_html.index('<option value="8k-fast">8K Fast</option>')
     assert '<option value="8k-fast">8K Fast</option>' in index_html
     assert '<option value="64k-full">64K Full</option>' in index_html
 
     assert "CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1'" in chat_js
-    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "AUTO_CONTEXT_TIER = 'auto'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = AUTO_CONTEXT_TIER" in chat_js
     assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
     assert "loadStoredContextTier" in chat_js
     assert "persistContextTier" in chat_js
     assert "normalizeContextTier" in chat_js
     assert "isKnownContextTier" in chat_js
     assert "const normalizedValue = typeof value === 'string' ? value.trim() : value" in chat_js
-    assert "return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
+    assert "return this.isKnownContextTierSelectorValue(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER" in chat_js
     assert "if (stored !== null && stored !== normalized)" in chat_js
 
 
@@ -59,9 +62,31 @@ def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_rou
     assert "selectedProfileMetadata" in chat_js
 
     assert "routing: {" in chat_js
-    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "normalizeWireContextTier" in chat_js
     assert "ciphertext: encryptedData.ciphertext" in chat_js
     assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};\n", 1)[0]
+
+
+def test_landing_auto_context_tier_estimator_and_retry_guards():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "AUTO_OUTPUT_RESERVATION_TOKENS" in chat_js
+    assert "AUTO_CONTEXT_SAFETY_MARGIN_TOKENS" in chat_js
+    assert "AUTO_MESSAGE_OVERHEAD_TOKENS" in chat_js
+    assert "estimateApiV1MessagesForAutoContextTier" in chat_js
+    assert "const characterEstimate = Math.ceil(totalCharacters / 4);" in chat_js
+    assert "const wordEstimate = Math.ceil(totalWords * 1.35);" in chat_js
+    assert "const resolvedTier = requiredEstimate <= CONTEXT_TIER_ORDER['8k-fast'] ? '8k-fast' : '64k-full';" in chat_js
+    assert "return {" in chat_js and "resolvedTier" in chat_js
+    assert "requestedContextTier = '64k-full';" in chat_js
+    assert "normalizedError.code === 'compute_node_context_window_exceeded'" in chat_js
+    assert "!autoRetryAttempted" in chat_js
+    assert "selectedContextTier !== '64k-full'" in chat_js
+    assert "forceReselect: autoMode" in chat_js
+    assert "Auto selected ${label} for this prompt" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" not in chat_js
 
 
 def test_landing_context_tier_errors_have_safe_user_messages():
@@ -136,7 +161,8 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "createApiV1Messages" in chat_js
     assert "this.chatHistory" in chat_js
-    assert "messages: this.createApiV1Messages(messageContent)" in chat_js
+    assert "const apiV1Messages = this.createApiV1Messages(messageContent);" in chat_js
+    assert "messages: apiV1Messages" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
     assert "response.choices[0].message" in chat_js
 
@@ -185,7 +211,9 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "const maxSkippedFailedServerSelections = Math.max(maxFailovers + terminallyFailedServerPublicKeysB64.size, 1);" in chat_js
     assert "skippedFailedServerSelections >= maxSkippedFailedServerSelections" in chat_js
     assert "sendMessageApiOnce" in chat_js
-    assert "ensureSelectedServer({ forceReselect: true })" in chat_js
+    assert "ensureSelectedServer({" in chat_js
+    assert "forceReselect: true," in chat_js
+    assert "requestedContextTier" in chat_js
     assert "terminallyFailedServerPublicKeysB64.has(this.selectedServerPublicKeyB64)" in chat_js
     assert "skippedFailedServerSelections += 1;" in chat_js
     assert "skippedFailedServerSelections = 0;" in chat_js


### PR DESCRIPTION
### Motivation
- Provide a user-friendly `Auto` mode on the landing-page context-tier selector that cheaply decides between `8k-fast` and `64k-full` in the browser and preserves explicit 8K/64K rails.
- Avoid adding tokenizer or WASM dependencies by using a conservative browser-side estimator over the full outgoing API v1 message list and keep the relay wire-level routing values limited to `8k-fast` and `64k-full`.
- Implement a safe, bounded UX: force fresh server selection for Auto requests and retry exactly once from 8K→64K only when compute-side exact admission returns `compute_node_context_window_exceeded`.

### Description
- Add `Auto` selector and make it the default for new users while normalizing unknown stored values to `auto`, and expose a small safe status string `contextTierStatus` in the UI. (`static/index.html`, `static/chat.js`).
- Introduce browser-only selector handling and wire normalization with `isKnownContextTierSelectorValue`, `normalizeContextTier`, and `normalizeWireContextTier`, and add named estimator constants (`AUTO_OUTPUT_RESERVATION_TOKENS`, `AUTO_CONTEXT_SAFETY_MARGIN_TOKENS`, `AUTO_MESSAGE_OVERHEAD_TOKENS`).
- Add a lightweight estimator `estimateApiV1MessagesForAutoContextTier(apiV1Messages)` that uses the full `apiV1Messages` (character and word heuristics) and resolves Auto to `8k-fast` or `64k-full`; `sendMessageApi` now builds `apiV1Messages` once, resolves the tier, and reuses the same messages for selection, encryption, and retry.
- Refactor server-selection and dispatch so `ensureSelectedServer` accepts a `requestedContextTier`, `sendMessageApiOnce` accepts `apiV1Messages` and `requestedContextTier`, and Auto mode forces reselect and performs one bounded 8K→64K retry on structured `compute_node_context_window_exceeded` when appropriate. Tests updated to cover dropdown, estimator, routing, and retry guards. (changes in `static/chat.js` and `tests/unit/test_touch_ui.py`).

### Testing
- Ran landing-page unit tests with `python -m pytest tests/unit/test_touch_ui.py -q` and they passed (`13 passed`).
- Ran relay integration tests with `python -m pytest tests/test_relay.py -q` and they passed (`142 passed`).
- Ran relay-client unit tests with `python -m pytest tests/unit/test_relay_client.py -q` and they passed (`229 passed`).
- Ran repository checks with `pre-commit run --all-files` and it completed successfully with all configured hooks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3df4e92e48832fa0b62eff972aaf08)