### PR TITLE
Add Auto context-tier selection for landing chat

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -4,7 +4,12 @@ const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'llama-3.1-8b-instruct';
 const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
-const DEFAULT_CONTEXT_TIER = '8k-fast';
+const DEFAULT_CONTEXT_TIER = 'auto';
+const AUTO_CONTEXT_TIER = 'auto';
+const DEFAULT_WIRE_CONTEXT_TIER = '8k-fast';
+const AUTO_OUTPUT_RESERVATION_TOKENS = 1024;
+const AUTO_CONTEXT_SAFETY_MARGIN_TOKENS = 512;
+const AUTO_MESSAGE_OVERHEAD_TOKENS = 8;
 const CONTEXT_TIER_ORDER = {
     '8k-fast': 8192,
     '64k-full': 65536
@@ -26,6 +31,7 @@ new Vue({
         selectedModelId: '',
         selectedContextTier: DEFAULT_CONTEXT_TIER,
         selectedProfileMetadata: null,
+        autoContextTierStatus: '',
         modelsLoading: false,
         modelsLoaded: false,
         modelsError: '',
@@ -247,12 +253,21 @@ new Vue({
         },
 
         isKnownContextTier(value) {
+            return value === AUTO_CONTEXT_TIER || Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, value);
+        },
+
+        isKnownWireContextTier(value) {
             return Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, value);
         },
 
         normalizeContextTier(value) {
             const normalizedValue = typeof value === 'string' ? value.trim() : value;
             return this.isKnownContextTier(normalizedValue) ? normalizedValue : DEFAULT_CONTEXT_TIER;
+        },
+
+        normalizeWireContextTier(value) {
+            const normalizedValue = typeof value === 'string' ? value.trim() : value;
+            return this.isKnownWireContextTier(normalizedValue) ? normalizedValue : DEFAULT_WIRE_CONTEXT_TIER;
         },
 
         loadStoredContextTier() {
@@ -281,6 +296,7 @@ new Vue({
             this.selectedContextTier = this.normalizeContextTier(this.selectedContextTier);
             this.persistContextTier(this.selectedContextTier);
             this.clearSelectedServer();
+            this.autoContextTierStatus = '';
         },
 
         selectedContextTierCanSatisfy(selectedTier, requestedTier) {
@@ -289,6 +305,7 @@ new Vue({
 
         async ensureSelectedServer(options = {}) {
             const forceReselect = Boolean(options.forceReselect);
+            const requestedContextTier = this.normalizeWireContextTier(options.requestedContextTier || this.selectedContextTier);
             if (forceReselect) {
                 this.clearSelectedServer();
             }
@@ -298,7 +315,6 @@ new Vue({
             }
 
             try {
-                const requestedContextTier = this.normalizeContextTier(this.selectedContextTier);
                 const params = new URLSearchParams({
                     model: this.selectedModelId,
                     context_tier: requestedContextTier
@@ -322,7 +338,7 @@ new Vue({
                 const rawSelectedContextTier = data && typeof data.selected_context_tier === 'string'
                     ? data.selected_context_tier.trim()
                     : '';
-                const selectedContextTier = this.isKnownContextTier(rawSelectedContextTier)
+                const selectedContextTier = this.isKnownWireContextTier(rawSelectedContextTier)
                     ? rawSelectedContextTier
                     : '';
                 if (!selectedContextTier || !this.selectedContextTierCanSatisfy(selectedContextTier, requestedContextTier)) {
@@ -383,6 +399,54 @@ new Vue({
             this.serverPublicKey = null;
             this.selectedServerKeyLabel = '';
             this.selectedProfileMetadata = null;
+        },
+
+        estimateApiV1MessagesForAutoContextTier(apiV1Messages) {
+            const messages = Array.isArray(apiV1Messages) ? apiV1Messages : [];
+            let totalCharacters = 0;
+            let totalWords = 0;
+            messages.forEach((message) => {
+                const content = message && typeof message.content === 'string' ? message.content : '';
+                totalCharacters += content.length;
+                const trimmed = content.trim();
+                if (trimmed) {
+                    totalWords += trimmed.split(/\s+/).length;
+                }
+            });
+            const characterEstimate = Math.ceil(totalCharacters / 4);
+            const wordEstimate = Math.ceil(totalWords * 1.35);
+            const messageOverhead = messages.length * AUTO_MESSAGE_OVERHEAD_TOKENS;
+            const promptEstimate = Math.max(characterEstimate, wordEstimate) + messageOverhead;
+            const requiredEstimate = promptEstimate + AUTO_OUTPUT_RESERVATION_TOKENS + AUTO_CONTEXT_SAFETY_MARGIN_TOKENS;
+            return {
+                totalCharacters,
+                totalWords,
+                characterEstimate,
+                wordEstimate,
+                messageOverhead,
+                promptEstimate,
+                requiredEstimate
+            };
+        },
+
+        resolveContextTierForRequest(apiV1Messages, selectorMode) {
+            const normalizedMode = this.normalizeContextTier(selectorMode);
+            if (normalizedMode !== AUTO_CONTEXT_TIER) {
+                return {
+                    selectorMode: normalizedMode,
+                    resolvedContextTier: this.normalizeWireContextTier(normalizedMode),
+                    estimate: null
+                };
+            }
+            const estimate = this.estimateApiV1MessagesForAutoContextTier(apiV1Messages);
+            const resolvedContextTier = estimate.requiredEstimate <= CONTEXT_TIER_ORDER[DEFAULT_WIRE_CONTEXT_TIER]
+                ? '8k-fast'
+                : '64k-full';
+            return {
+                selectorMode: AUTO_CONTEXT_TIER,
+                resolvedContextTier,
+                estimate
+            };
         },
 
         markSelectedServerTerminalFailure(message) {
@@ -811,13 +875,24 @@ new Vue({
         },
 
         // Send a message through the relay-blind API v1 E2EE request routes.
-        async sendMessageApiOnce(messageContent) {
+        async sendMessageApiOnce(messageContent, options = {}) {
             if (!this.selectedModel) {
                 console.error('No API v1 catalogue model selected');
                 return null;
             }
 
-            const selectedServer = await this.ensureSelectedServer();
+            const apiV1Messages = Array.isArray(options.apiV1Messages)
+                ? options.apiV1Messages
+                : this.createApiV1Messages(messageContent);
+            const selectorMode = this.normalizeContextTier(options.selectorMode || this.selectedContextTier);
+            const resolved = options.requestedContextTier
+                ? { selectorMode, resolvedContextTier: this.normalizeWireContextTier(options.requestedContextTier), estimate: null }
+                : this.resolveContextTierForRequest(apiV1Messages, selectorMode);
+            const requestedContextTier = resolved.resolvedContextTier;
+            const selectedServer = await this.ensureSelectedServer({
+                forceReselect: Boolean(options.forceReselect) || selectorMode === AUTO_CONTEXT_TIER,
+                requestedContextTier
+            });
             if (selectedServer !== true) {
                 return selectedServer;
             }
@@ -832,10 +907,10 @@ new Vue({
                 client_public_key: clientPublicKeyB64,
                 api_v1_request: {
                     model: this.selectedModelId,
-                    messages: this.createApiV1Messages(messageContent),
+                    messages: apiV1Messages,
                     options: {},
                     routing: {
-                        context_tier: this.normalizeContextTier(this.selectedContextTier)
+                        context_tier: requestedContextTier
                     }
                 }
             };
@@ -917,7 +992,18 @@ new Vue({
                     throw new Error('Invalid relay response envelope');
                 }
 
-                return responseEnvelope.api_v1_response;
+                const apiResponse = responseEnvelope.api_v1_response;
+                if (apiResponse && typeof apiResponse === 'object') {
+                    apiResponse.landingContextTierMeta = {
+                        selectorMode,
+                        resolvedContextTier: requestedContextTier,
+                        selectedContextTier: this.selectedProfileMetadata && this.selectedProfileMetadata.selected_context_tier
+                            ? this.selectedProfileMetadata.selected_context_tier
+                            : '',
+                        autoRetried: Boolean(options.autoRetried)
+                    };
+                }
+                return apiResponse;
             } catch (error) {
                 console.error('API v1 relay request error:', error);
                 return null;
@@ -925,6 +1011,18 @@ new Vue({
         },
 
         async sendMessageApi(messageContent) {
+            const selectorMode = this.normalizeContextTier(this.selectedContextTier);
+            const apiV1Messages = this.createApiV1Messages(messageContent);
+            const initialResolved = this.resolveContextTierForRequest(apiV1Messages, selectorMode);
+            if (selectorMode === AUTO_CONTEXT_TIER) {
+                this.autoContextTierStatus = initialResolved.resolvedContextTier === '8k-fast'
+                    ? 'Auto selected 8K Fast for this prompt'
+                    : 'Auto selected 64K Full for this prompt';
+            } else {
+                this.autoContextTierStatus = '';
+            }
+            let autoContextRetryUsed = false;
+            let currentRequestedContextTier = initialResolved.resolvedContextTier;
             let maxFailovers = this.getFailoverAttemptLimit();
             let refreshedFailoverCapacity = false;
             let skippedFailedServerSelections = 0;
@@ -934,15 +1032,56 @@ new Vue({
 
             while (failovers <= maxFailovers) {
                 if (needsDispatch) {
-                    const response = await this.sendMessageApiOnce(messageContent);
+                    const response = await this.sendMessageApiOnce(messageContent, {
+                        apiV1Messages,
+                        selectorMode,
+                        requestedContextTier: currentRequestedContextTier,
+                        forceReselect: selectorMode === AUTO_CONTEXT_TIER,
+                        autoRetried: autoContextRetryUsed
+                    });
                     if (response && response.error && response.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
                         terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
                     }
                     if (!response || !response.error || response.error.terminalSelectedServer !== true) {
-                        if (response && !(response.error && response.error.terminalSelectedServer === true)) {
-                            this.clearSelectedServerNotice();
+                        const responseErrorCode = response && response.error && typeof response.error.code === 'string'
+                            ? response.error.code.trim()
+                            : '';
+                        const selectedContextTier = response && response.landingContextTierMeta
+                            ? response.landingContextTierMeta.selectedContextTier
+                            : '';
+                        if (
+                            selectorMode === AUTO_CONTEXT_TIER &&
+                            initialResolved.resolvedContextTier === '8k-fast' &&
+                            responseErrorCode === 'compute_node_context_window_exceeded' &&
+                            selectedContextTier !== '64k-full' &&
+                            !autoContextRetryUsed
+                        ) {
+                            autoContextRetryUsed = true;
+                            this.autoContextTierStatus = 'Auto selected 64K Full for this prompt';
+                            currentRequestedContextTier = '64k-full';
+                            this.clearSelectedServer();
+                            const retryResponse = await this.sendMessageApiOnce(messageContent, {
+                                apiV1Messages,
+                                selectorMode,
+                                requestedContextTier: '64k-full',
+                                forceReselect: true,
+                                autoRetried: true
+                            });
+                            if (retryResponse && retryResponse.error && retryResponse.error.terminalSelectedServer === true && this.selectedServerPublicKeyB64) {
+                                terminallyFailedServerPublicKeysB64.add(this.selectedServerPublicKeyB64);
+                            }
+                            if (!retryResponse || !retryResponse.error || retryResponse.error.terminalSelectedServer !== true) {
+                                if (retryResponse && !(retryResponse.error && retryResponse.error.terminalSelectedServer === true)) {
+                                    this.clearSelectedServerNotice();
+                                }
+                                return retryResponse;
+                            }
+                        } else {
+                            if (response && !(response.error && response.error.terminalSelectedServer === true)) {
+                                this.clearSelectedServerNotice();
+                            }
+                            return response;
                         }
-                        return response;
                     }
                 }
                 needsDispatch = false;
@@ -969,7 +1108,10 @@ new Vue({
 
                 this.clearSelectedServer();
                 this.markSelectedServerTerminalFailure('The previous LLM server disconnected. Continuing with another available server.');
-                const selectedServer = await this.ensureSelectedServer({ forceReselect: true });
+                const selectedServer = await this.ensureSelectedServer({
+                    forceReselect: true,
+                    requestedContextTier: currentRequestedContextTier
+                });
                 if (selectedServer !== true) {
                     const userMessage = selectedServer && selectedServer.error && selectedServer.error.userMessage
                         ? selectedServer.error.userMessage

--- a/static/index.html
+++ b/static/index.html
@@ -518,10 +518,12 @@
                     :disabled="isGeneratingResponse"
                     @change="handleContextTierChange"
                 >
+                    <option value="auto">Auto</option>
                     <option value="8k-fast">8K Fast</option>
                     <option value="64k-full">64K Full</option>
                 </select>
             </div>
+            <p class="model-status" data-testid="landing-auto-context-tier-status" v-text="autoContextTierStatus"></p>
             <p class="server-key-label" data-testid="landing-server-key-label" v-text="selectedServerKeyLabel"></p>
             <div
                 v-if="selectedServerTerminalFailure"

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -30,11 +30,13 @@ def test_landing_context_tier_selector_is_visible_persistent_and_disabled_while_
     assert 'data-testid="landing-context-tier-select"' in index_html
     assert 'v-model="selectedContextTier"' in index_html
     assert ':disabled="isGeneratingResponse"' in index_html
+    assert index_html.index('<option value="auto">Auto</option>') < index_html.index('<option value="8k-fast">8K Fast</option>')
     assert '<option value="8k-fast">8K Fast</option>' in index_html
     assert '<option value="64k-full">64K Full</option>' in index_html
 
     assert "CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1'" in chat_js
-    assert "DEFAULT_CONTEXT_TIER = '8k-fast'" in chat_js
+    assert "DEFAULT_CONTEXT_TIER = 'auto'" in chat_js
+    assert "DEFAULT_WIRE_CONTEXT_TIER = '8k-fast'" in chat_js
     assert "selectedContextTier: DEFAULT_CONTEXT_TIER" in chat_js
     assert "loadStoredContextTier" in chat_js
     assert "persistContextTier" in chat_js
@@ -59,10 +61,35 @@ def test_landing_context_tier_selection_is_sent_to_next_server_and_encrypted_rou
     assert "selectedProfileMetadata" in chat_js
 
     assert "routing: {" in chat_js
-    assert "context_tier: this.normalizeContextTier(this.selectedContextTier)" in chat_js
+    assert "context_tier: requestedContextTier" in chat_js
+    assert "normalizeWireContextTier" in chat_js
+    assert "Never send auto" not in chat_js
     assert "ciphertext: encryptedData.ciphertext" in chat_js
     assert "messageContent" not in chat_js.split("const relayPayload = {", 1)[1].split("};\n", 1)[0]
 
+
+
+def test_landing_auto_context_tier_estimator_and_retry_guards_are_present():
+    chat_js = Path("static/chat.js").read_text(encoding="utf-8")
+
+    assert "AUTO_OUTPUT_RESERVATION_TOKENS" in chat_js
+    assert "AUTO_CONTEXT_SAFETY_MARGIN_TOKENS" in chat_js
+    assert "AUTO_MESSAGE_OVERHEAD_TOKENS" in chat_js
+    assert "estimateApiV1MessagesForAutoContextTier" in chat_js
+    assert "totalCharacters += content.length" in chat_js
+    assert "totalWords += trimmed.split(/\\s+/).length" in chat_js
+    assert "Math.ceil(totalCharacters / 4)" in chat_js
+    assert "Math.ceil(totalWords * 1.35)" in chat_js
+    assert "estimate.requiredEstimate <= CONTEXT_TIER_ORDER[DEFAULT_WIRE_CONTEXT_TIER]" in chat_js
+    assert "resolvedContextTier" in chat_js
+    assert "? '8k-fast'" in chat_js
+    assert ": '64k-full'" in chat_js
+    assert "resolvedContextTier: 'auto'" not in chat_js
+    assert "forceReselect: Boolean(options.forceReselect) || selectorMode === AUTO_CONTEXT_TIER" in chat_js
+    assert "responseErrorCode === 'compute_node_context_window_exceeded'" in chat_js
+    assert "!autoContextRetryUsed" in chat_js
+    assert "requestedContextTier: '64k-full'" in chat_js
+    assert "autoContextTierStatus" in chat_js
 
 def test_landing_context_tier_errors_have_safe_user_messages():
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
@@ -136,7 +163,8 @@ def test_landing_chat_js_preserves_context_and_handles_api_v1_message_envelopes(
     chat_js = Path("static/chat.js").read_text(encoding="utf-8")
     assert "createApiV1Messages" in chat_js
     assert "this.chatHistory" in chat_js
-    assert "messages: this.createApiV1Messages(messageContent)" in chat_js
+    assert "const apiV1Messages = this.createApiV1Messages(messageContent)" in chat_js
+    assert "messages: apiV1Messages" in chat_js
     assert "response.message && typeof response.message === 'object'" in chat_js
     assert "response.choices[0].message" in chat_js
 
@@ -185,7 +213,8 @@ def test_landing_chat_js_reselects_or_cancels_on_terminal_relay_states():
     assert "const maxSkippedFailedServerSelections = Math.max(maxFailovers + terminallyFailedServerPublicKeysB64.size, 1);" in chat_js
     assert "skippedFailedServerSelections >= maxSkippedFailedServerSelections" in chat_js
     assert "sendMessageApiOnce" in chat_js
-    assert "ensureSelectedServer({ forceReselect: true })" in chat_js
+    assert "forceReselect: true" in chat_js
+    assert "requestedContextTier: currentRequestedContextTier" in chat_js
     assert "terminallyFailedServerPublicKeysB64.has(this.selectedServerPublicKeyB64)" in chat_js
     assert "skippedFailedServerSelections += 1;" in chat_js
     assert "skippedFailedServerSelections = 0;" in chat_js


### PR DESCRIPTION
### Motivation
- Provide a browser-only `Auto` context-tier option that cheaply estimates full outgoing API v1 messages and picks the smallest capable wire tier (`8k-fast` or `64k-full`) to reduce cost while preserving relay-blind E2EE.
- Retry exactly once from 8K→64K only when the compute node returns `compute_node_context_window_exceeded`, keeping explicit `8K Fast` and `64K Full` modes unchanged.
- Preserve existing privacy and failover invariants by never sending `auto` on the wire, reusing the exact encrypted messages for retry, and forcing safe reselect behavior for Auto requests.

### Description
- Added a browser-only `auto` selector and made it the default for new users via `DEFAULT_CONTEXT_TIER = 'auto'` while keeping wire-level defaults (`8k-fast`, `64k-full`).
- Implemented a lightweight estimator with named constants (`AUTO_OUTPUT_RESERVATION_TOKENS`, `AUTO_CONTEXT_SAFETY_MARGIN_TOKENS`, `AUTO_MESSAGE_OVERHEAD_TOKENS`) and functions `estimateApiV1MessagesForAutoContextTier` and `resolveContextTierForRequest` that operate on the full `apiV1Messages` list.
- Refactored dispatch flow so `sendMessageApi` builds `apiV1Messages` once, resolves the wire tier, calls `ensureSelectedServer({ requestedContextTier })`, encrypts the same messages with `routing.context_tier` set to the resolved tier, and reuses that payload for a bounded retry.
- Added Auto-only safety: force reselect for every Auto request, include resolved wire tier in encrypted routing metadata (never `auto`), and perform exactly one forced reselect+retry to `64k-full` when the first 8K attempt yields `compute_node_context_window_exceeded`.
- Updated landing dropdown UI to include `Auto` first and display a safe status string like `Auto selected 8K Fast for this prompt` without exposing prompt text, and cleared cached selected-server when selector changes.
- Updated and added focused landing-page unit tests to assert dropdown ordering/default, estimator presence and constants, server selection query param behavior, encrypted routing metadata, reuse of `apiV1Messages`, and the Auto retry guard conditions.

### Testing
- Ran unit landing tests with `python -m pytest tests/unit/test_touch_ui.py -q` and they all passed (`13 passed`).
- Ran relay integration tests with `python -m pytest tests/test_relay.py -q` and they all passed (`142 passed`).
- Ran relay client unit tests with `python -m pytest tests/unit/test_relay_client.py -q` and they all passed (`229 passed`).
- Verified JS syntax with `node --check static/chat.js` and it passed, and ran `pre-commit run --all-files` and `git diff --check` which also passed.
- Commands executed: `python -m pytest tests/unit/test_touch_ui.py -q`, `python -m pytest tests/test_relay.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `node --check static/chat.js`, `pre-commit run --all-files`, and `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3df4f02dd4832f8ff238f3daf912ba)