### PR TITLE
Centralize API v1 model profiles and add Qwen3 metadata (non-default)

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -10,6 +10,12 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+from utils.llm.model_profiles import (
+    CANONICAL_LAUNCH_MODEL_ID,
+    MODEL_ALIASES,
+    get_public_catalog_profiles,
+)
+
 try:
     import llama_cpp as _llama_cpp_module
     from llama_cpp import Llama as _llama_runtime
@@ -103,41 +109,7 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"
-
-MODEL_ALIASES: Dict[str, str] = {
-    # Invisible compatibility aliases that route to the fixed Meta Llama 3.1
-    # 8B launch backend. They are accepted by request paths but are not listed
-    # as first-class API v1 models.
-    "llama-3-8b-instruct": CANONICAL_LAUNCH_MODEL_ID,
-    "gpt-3.5-turbo": CANONICAL_LAUNCH_MODEL_ID,
-    "gpt-5-chat-latest": CANONICAL_LAUNCH_MODEL_ID,
-}
-
-
-AVAILABLE_MODELS = [
-    {
-        "id": CANONICAL_LAUNCH_MODEL_ID,
-        "name": "Meta Llama 3.1 8B Instruct",
-        "description": (
-            "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
-            "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
-        ),
-        "owner": "Meta",
-        "owned_by": "Meta",
-        "provider": "meta",
-        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
-        "parameters": "8B",
-        "quantization": "Q4_K_M",
-        "context_length": 8192,
-        "url": (
-            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
-        ),
-        "file_name": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "adapters": [],
-    }
-]
+AVAILABLE_MODELS = [profile.to_catalog_entry() for profile in get_public_catalog_profiles()]
 
 
 # Dictionary mapping model IDs to loaded model instances

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+import importlib
 from typing import Any, Dict
 
 
@@ -21,6 +22,7 @@ from path_bootstrap import ensure_runtime_import_paths
 
 ensure_runtime_import_paths(__file__)
 from pathlib import Path
+
 
 try:
     from desktop_runtime_setup import ensure_desktop_python_dependencies
@@ -59,32 +61,66 @@ def _default_models_dir() -> Path:
     return Path.home() / ".local" / "share" / "token.place" / "models"
 
 
+def _fallback_default_profile() -> Any:
+    if importlib.util.find_spec("utils.llm.model_profiles") is not None:
+        profile_module = importlib.import_module("utils.llm.model_profiles")
+        return profile_module.get_default_model_profile()
+    return type("FallbackModelProfile", (), {
+        "api_model_id": "llama-3.1-8b-instruct",
+        "profile_id": "llama-3.1-8b-q4-k-m",
+        "display_name": "Meta Llama 3.1 8B Instruct",
+        "canonical_family_url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+        "filename": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        "download_url": "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        "gguf_repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
+        "quantization": "Q4_K_M",
+        "license": "llama3.1",
+        "native_context_tokens": 8192,
+        "maximum_validated_context_tokens": 8192,
+        "supported_context_tiers": ["8k-fast"],
+    })()
+
+
 def _fallback_model_metadata() -> Dict[str, Any]:
     models_dir = _default_models_dir()
     models_dir_override = os.environ.get("TOKEN_PLACE_MODELS_DIR")
     if models_dir_override:
         models_dir = Path(models_dir_override)
 
+    profile = _fallback_default_profile()
     canonical_family_url = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL",
-        "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+        profile.canonical_family_url,
     )
     filename = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_FILENAME",
-        "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        profile.filename,
     )
     url = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_URL",
-        "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        profile.download_url,
     )
     resolved_model_path = models_dir / filename
     exists = resolved_model_path.exists()
     size_bytes = resolved_model_path.stat().st_size if exists else None
 
     return {
+        "api_model_id": profile.api_model_id,
+        "active_api_model_id": profile.api_model_id,
+        "profile_id": profile.profile_id,
+        "active_profile_id": profile.profile_id,
+        "display_name": profile.display_name,
         "canonical_family_url": canonical_family_url,
         "filename": filename,
         "url": url,
+        "gguf_repo": profile.gguf_repo,
+        "source_model": profile.source_model,
+        "quantization": profile.quantization,
+        "license": profile.license,
+        "native_context_tokens": profile.native_context_tokens,
+        "maximum_validated_context_tokens": profile.maximum_validated_context_tokens,
+        "supported_context_tiers": list(profile.supported_context_tiers),
         "models_dir": str(models_dir),
         "resolved_model_path": str(resolved_model_path),
         "exists": exists,

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -2,7 +2,8 @@
 
 import importlib
 import os
-from unittest.mock import MagicMock, patch
+import sys
+from unittest.mock import patch
 
 
 def _reload_models(env=None):
@@ -12,12 +13,13 @@ def _reload_models(env=None):
     if env:
         env_vars.update(env)
 
-    # Ensure the module is reloaded under the patched environment and dependencies.
-    fake_llama_module = MagicMock()
-    with patch.dict("sys.modules", {"llama_cpp": fake_llama_module}):
-        with patch.dict(os.environ, env_vars, clear=True):
+    # Ensure the module is reloaded under the patched environment.
+    with patch.dict(os.environ, env_vars, clear=False):
+        if "api.v1.models" in sys.modules:
+            models = sys.modules["api.v1.models"]
+        else:
             import api.v1.models as models
-            importlib.reload(models)
+        importlib.reload(models)
     return models
 
 
@@ -41,3 +43,9 @@ def test_resolve_model_alias_missing_target_logs_and_returns_none():
                 result = models.resolve_model_alias("local-alias")
     assert result is None
     mock_log_warning.assert_called_once()
+
+
+def test_qwen_is_not_alias_for_llama_or_default():
+    models = _reload_models()
+    assert models.resolve_model_alias("qwen3-8b-instruct") is None
+    assert models.resolve_model_alias("llama-3.1-8b-instruct") is None

--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -36,3 +36,28 @@ def test_llama_catalog_targets_latest_4090_ready_release():
     assert base_entry["name"] == "Meta Llama 3.1 8B Instruct"
     assert base_entry["file_name"] == "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
     assert base_entry["file_name"] in base_entry["url"]
+
+
+def test_qwen_profile_exists_but_is_not_public_catalog_default():
+    from utils.llm.model_profiles import get_model_profile
+    import api.v1.models as models
+
+    qwen = get_model_profile("qwen3-8b-q4-k-m")
+
+    assert qwen.api_model_id == "qwen3-8b-instruct"
+    assert qwen.display_name == "Qwen3 8B Instruct"
+    assert qwen.source_model == "Qwen/Qwen3-8B"
+    assert qwen.gguf_repo == "Qwen/Qwen3-8B-GGUF"
+    assert qwen.filename == "Qwen3-8B-Q4_K_M.gguf"
+    assert qwen.quantization == "Q4_K_M"
+    assert qwen.license == "apache-2.0"
+    assert qwen.parameters == "8.2B"
+    assert qwen.native_context_tokens == 32768
+    assert qwen.maximum_validated_context_tokens == 131072
+    assert qwen.supported_context_tiers == ["8k-fast", "64k-full"]
+    assert qwen.thinking_mode == "disabled"
+    assert qwen.chat_template_policy == "gguf-jinja"
+    assert qwen.rope_scaling_policy["factor"] == 2.0
+    assert qwen.runnable is False
+    assert qwen.public_catalog is False
+    assert "qwen3-8b-instruct" not in [entry["id"] for entry in models.get_models_info()]

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -230,6 +230,34 @@ def test_inspect_returns_fallback_when_dotenv_missing(capsys):
         assert key in response['payload']
 
 
+
+def test_fallback_model_metadata_uses_llama_profile_defaults(monkeypatch):
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_FILENAME', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_URL', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL', raising=False)
+
+    payload = model_bridge._fallback_model_metadata()
+
+    assert payload['api_model_id'] == 'llama-3.1-8b-instruct'
+    assert payload['profile_id'] == 'llama-3.1-8b-q4-k-m'
+    assert payload['display_name'] == 'Meta Llama 3.1 8B Instruct'
+    assert payload['filename'] == 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+    assert payload['canonical_family_url'] == 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
+    assert payload['source_model'] == 'meta-llama/Llama-3.1-8B-Instruct'
+
+
+def test_fallback_model_metadata_preserves_environment_overrides(monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_FILENAME', 'custom.gguf')
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_URL', 'https://example.com/custom.gguf')
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL', 'https://example.com/family')
+
+    payload = model_bridge._fallback_model_metadata()
+
+    assert payload['filename'] == 'custom.gguf'
+    assert payload['url'] == 'https://example.com/custom.gguf'
+    assert payload['canonical_family_url'] == 'https://example.com/family'
+    assert payload['api_model_id'] == 'llama-3.1-8b-instruct'
+
 def test_main_dispatches_inspect_action():
     with patch.object(model_bridge.argparse.ArgumentParser, 'parse_args', return_value=SimpleNamespace(action='inspect')):
         with patch.object(model_bridge, 'inspect_model', return_value=0) as inspect_model:

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -146,7 +146,15 @@ class TestModelManager:
         """Test runtime model metadata includes expected keys and file state."""
         metadata = model_manager.get_model_artifact_metadata()
 
+        assert metadata['api_model_id'] == 'llama-3.1-8b-instruct'
+        assert metadata['profile_id'] == 'llama-3.1-8b-q4-k-m'
+        assert metadata['display_name'] == 'Meta Llama 3.1 8B Instruct'
         assert metadata['canonical_family_url'] == 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
+        assert metadata['gguf_repo'] == 'bartowski/Meta-Llama-3.1-8B-Instruct-GGUF'
+        assert metadata['source_model'] == 'meta-llama/Llama-3.1-8B-Instruct'
+        assert metadata['quantization'] == 'Q4_K_M'
+        assert metadata['native_context_tokens'] == 8192
+        assert metadata['maximum_validated_context_tokens'] == 8192
         assert metadata['filename'] == 'test_model.gguf'
         assert metadata['url'] == 'https://example.com/model.gguf'
         assert metadata['models_dir'] == self._temp_dir

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -10,7 +10,9 @@ offer better auto-completion for developers.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict
+
+from utils.llm.model_profiles import get_default_model_profile
 
 class ServerSettings(TypedDict, total=False):
     host: str
@@ -59,12 +61,19 @@ class PathsSettings(TypedDict, total=False):
 class ModelSettings(TypedDict, total=False):
     default_model: str
     fallback_model: str
+    profile_id: str
+    api_model_id: str
     temperature: float
     max_tokens: int
     use_mock: bool
     filename: str
     url: str
     canonical_family_url: str
+    chat_template_policy: str
+    thinking_mode: str
+    native_context_tokens: int
+    maximum_validated_context_tokens: int
+    rope_scaling_policy: Optional[Dict[str, Any]]
     context_size: int
     chat_format: str
     download_chunk_size_mb: int
@@ -95,6 +104,8 @@ class PartialAppConfig(TypedDict, total=False):
     model: ModelSettings
     constants: ConstantsSettings
 
+
+_DEFAULT_MODEL_PROFILE = get_default_model_profile()
 
 # Default configuration values used to seed :class:`~config.Config`.
 DEFAULT_CONFIG: AppConfig = {
@@ -140,17 +151,21 @@ DEFAULT_CONFIG: AppConfig = {
     "model": {
         "default_model": "gpt-5-chat-latest",
         "fallback_model": "gpt-5-chat-latest",
+        "profile_id": _DEFAULT_MODEL_PROFILE.profile_id,
+        "api_model_id": _DEFAULT_MODEL_PROFILE.api_model_id,
         "temperature": 0.7,
         "max_tokens": 1000,
         "use_mock": False,
-        "filename": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "url": (
-            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
-        ),
-        "canonical_family_url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-        "context_size": 8192,
-        "chat_format": "llama-3",
+        "filename": _DEFAULT_MODEL_PROFILE.filename,
+        "url": _DEFAULT_MODEL_PROFILE.download_url,
+        "canonical_family_url": _DEFAULT_MODEL_PROFILE.canonical_family_url,
+        "chat_template_policy": _DEFAULT_MODEL_PROFILE.chat_template_policy,
+        "thinking_mode": _DEFAULT_MODEL_PROFILE.thinking_mode,
+        "native_context_tokens": _DEFAULT_MODEL_PROFILE.native_context_tokens,
+        "maximum_validated_context_tokens": _DEFAULT_MODEL_PROFILE.maximum_validated_context_tokens,
+        "rope_scaling_policy": _DEFAULT_MODEL_PROFILE.rope_scaling_policy,
+        "context_size": _DEFAULT_MODEL_PROFILE.default_context_tokens,
+        "chat_format": _DEFAULT_MODEL_PROFILE.chat_format,
         "download_chunk_size_mb": 10,
     },
     "constants": {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 from typing import Dict, List, Any, Optional, Iterable
 
 from utils.system import resource_monitor
+from utils.llm.model_profiles import get_model_profile, resolve_profile_id
 
 # Configure logging
 logger = logging.getLogger('model_manager')
@@ -1557,20 +1558,19 @@ class ModelManager:
 
         self.config = config
 
-        # Llama model configuration
-        self.file_name = config.get(
-            'model.filename', 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+        # Model artifact configuration is sourced from the active profile, with
+        # existing config/env override keys preserved for backwards compatibility.
+        requested_profile_id = config.get('model.profile_id', None)
+        requested_api_model_id = config.get('model.api_model_id', None)
+        self.model_profile = get_model_profile(
+            resolve_profile_id(requested_profile_id, requested_api_model_id)
         )
-        self.url = config.get(
-            'model.url',
-            (
-                'https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/'
-                'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
-            ),
-        )
+        self.active_profile_id = self.model_profile.profile_id
+        self.active_api_model_id = self.model_profile.api_model_id
+        self.file_name = config.get('model.filename', self.model_profile.filename)
+        self.url = config.get('model.url', self.model_profile.download_url)
         self.canonical_family_url = config.get(
-            'model.canonical_family_url',
-            'https://huggingface.co/meta-llama/Meta-Llama-3-8B',
+            'model.canonical_family_url', self.model_profile.canonical_family_url
         )
         self.chunk_size_mb = config.get('model.download_chunk_size_mb', 10)
         # Network timeout for model downloads (seconds)
@@ -1792,9 +1792,21 @@ class ModelManager:
         """Return runtime model metadata used by server and desktop bridges."""
         file_exists = os.path.exists(self.model_path)
         return {
+            'api_model_id': self.active_api_model_id,
+            'active_api_model_id': self.active_api_model_id,
+            'profile_id': self.active_profile_id,
+            'active_profile_id': self.active_profile_id,
+            'display_name': self.model_profile.display_name,
             'canonical_family_url': self.canonical_family_url,
             'filename': self.file_name,
             'url': self.url,
+            'gguf_repo': self.model_profile.gguf_repo,
+            'source_model': self.model_profile.source_model,
+            'quantization': self.model_profile.quantization,
+            'license': self.model_profile.license,
+            'native_context_tokens': self.model_profile.native_context_tokens,
+            'maximum_validated_context_tokens': self.model_profile.maximum_validated_context_tokens,
+            'supported_context_tiers': list(self.model_profile.supported_context_tiers),
             'models_dir': self.models_dir,
             'resolved_model_path': self.model_path,
             'exists': file_exists,

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -1,0 +1,182 @@
+"""Central model profile metadata for token.place API v1 runtimes."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+
+CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"
+DEFAULT_PROFILE_ID = "llama-3.1-8b-q4-k-m"
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    profile_id: str
+    api_model_id: str
+    display_name: str
+    description: str
+    owner: str
+    provider: str
+    source_model: str
+    parameters: str
+    quantization: str
+    license: str
+    gguf_repo: str
+    filename: str
+    download_url: str
+    canonical_family_url: str
+    native_context_tokens: int
+    maximum_validated_context_tokens: int
+    default_context_tokens: int
+    supported_context_tiers: List[str]
+    chat_template_policy: str
+    thinking_mode: str
+    generation_defaults: Dict[str, Any]
+    aliases: List[str]
+    rope_scaling_policy: Optional[Dict[str, Any]] = None
+    public_catalog: bool = False
+    runnable: bool = False
+    chat_format: str = "llama-3"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return deepcopy(asdict(self))
+
+    def to_catalog_entry(self) -> Dict[str, Any]:
+        entry = {
+            "id": self.api_model_id,
+            "name": self.display_name,
+            "description": self.description,
+            "owner": self.owner,
+            "owned_by": self.owner,
+            "provider": self.provider,
+            "source_model": self.source_model,
+            "parameters": self.parameters,
+            "quantization": self.quantization,
+            "license": self.license,
+            "gguf_repo": self.gguf_repo,
+            "context_length": self.default_context_tokens,
+            "native_context_tokens": self.native_context_tokens,
+            "maximum_validated_context_tokens": self.maximum_validated_context_tokens,
+            "supported_context_tiers": list(self.supported_context_tiers),
+            "chat_template_policy": self.chat_template_policy,
+            "thinking_mode": self.thinking_mode,
+            "url": self.download_url,
+            "file_name": self.filename,
+            "profile_id": self.profile_id,
+            "runnable": self.runnable,
+            "adapters": [],
+        }
+        if self.rope_scaling_policy is not None:
+            entry["rope_scaling_policy"] = deepcopy(self.rope_scaling_policy)
+        return entry
+
+
+LLAMA_3_1_8B_Q4_K_M = ModelProfile(
+    profile_id=DEFAULT_PROFILE_ID,
+    api_model_id=CANONICAL_LAUNCH_MODEL_ID,
+    display_name="Meta Llama 3.1 8B Instruct",
+    description=(
+        "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
+        "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
+    ),
+    owner="Meta",
+    provider="meta",
+    source_model="meta-llama/Llama-3.1-8B-Instruct",
+    parameters="8B",
+    quantization="Q4_K_M",
+    license="llama3.1",
+    gguf_repo="bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+    filename="Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+    download_url=(
+        "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
+        "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+    ),
+    canonical_family_url="https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+    native_context_tokens=8192,
+    maximum_validated_context_tokens=8192,
+    default_context_tokens=8192,
+    supported_context_tiers=["8k-fast"],
+    chat_template_policy="llama-cpp-chat-format",
+    thinking_mode="not-applicable",
+    generation_defaults={"temperature": 0.7, "max_tokens": 1000},
+    aliases=["llama-3-8b-instruct", "gpt-3.5-turbo", "gpt-5-chat-latest"],
+    public_catalog=True,
+    runnable=True,
+    chat_format="llama-3",
+)
+
+
+QWEN3_8B_Q4_K_M = ModelProfile(
+    profile_id="qwen3-8b-q4-k-m",
+    api_model_id="qwen3-8b-instruct",
+    display_name="Qwen3 8B Instruct",
+    description=(
+        "Internal scaffold for Qwen3 8B Q4_K_M API v1 support. Runtime loading, "
+        "chat-template behavior, and extended-context YaRN/RoPE settings are not active yet."
+    ),
+    owner="Qwen",
+    provider="qwen",
+    source_model="Qwen/Qwen3-8B",
+    parameters="8.2B",
+    quantization="Q4_K_M",
+    license="apache-2.0",
+    gguf_repo="Qwen/Qwen3-8B-GGUF",
+    filename="Qwen3-8B-Q4_K_M.gguf",
+    download_url="https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf",
+    canonical_family_url="https://huggingface.co/Qwen/Qwen3-8B",
+    native_context_tokens=32768,
+    maximum_validated_context_tokens=131072,
+    default_context_tokens=8192,
+    supported_context_tiers=["8k-fast", "64k-full"],
+    chat_template_policy="gguf-jinja",
+    thinking_mode="disabled",
+    generation_defaults={"temperature": 0.6, "top_p": 0.95, "top_k": 20, "min_p": 0.0},
+    aliases=[],
+    rope_scaling_policy={
+        "type": "yarn",
+        "status": "planned",
+        "native_context_tokens": 32768,
+        "target_context_tokens": 65536,
+        "factor": 2.0,
+        "required_for_tier": "64k-full",
+    },
+    public_catalog=False,
+    runnable=False,
+    chat_format="chatml",
+)
+
+
+MODEL_PROFILES: Dict[str, ModelProfile] = {
+    LLAMA_3_1_8B_Q4_K_M.profile_id: LLAMA_3_1_8B_Q4_K_M,
+    QWEN3_8B_Q4_K_M.profile_id: QWEN3_8B_Q4_K_M,
+}
+
+API_MODEL_ID_TO_PROFILE_ID: Dict[str, str] = {
+    profile.api_model_id: profile.profile_id for profile in MODEL_PROFILES.values()
+}
+
+MODEL_ALIASES: Dict[str, str] = {
+    alias: LLAMA_3_1_8B_Q4_K_M.api_model_id for alias in LLAMA_3_1_8B_Q4_K_M.aliases
+}
+
+
+def get_model_profile(profile_id: str = DEFAULT_PROFILE_ID) -> ModelProfile:
+    return MODEL_PROFILES[profile_id]
+
+
+def get_default_model_profile() -> ModelProfile:
+    return get_model_profile(DEFAULT_PROFILE_ID)
+
+
+def get_public_catalog_profiles() -> List[ModelProfile]:
+    return [profile for profile in MODEL_PROFILES.values() if profile.public_catalog]
+
+
+def resolve_profile_id(profile_id: Optional[str] = None, api_model_id: Optional[str] = None) -> str:
+    if profile_id and profile_id in MODEL_PROFILES:
+        return profile_id
+    if api_model_id and api_model_id in API_MODEL_ID_TO_PROFILE_ID:
+        return API_MODEL_ID_TO_PROFILE_ID[api_model_id]
+    return DEFAULT_PROFILE_ID


### PR DESCRIPTION
### Motivation
- Centralise model metadata and runtime artifact configuration so token.place can represent Qwen3-8B-Q4_K_M as a drop-in profile without changing the existing Llama runtime defaults.
- Preserve all existing Llama behaviour, aliases, and API v1 catalog responses while enabling future P23c/P23d work to enable Qwen runtime and defaults.
- Surface profile-driven keys in config and desktop bridge fallback so runtime and desktop metadata resolve from a single authoritative source.

### Description
- Added a new central model profile module at `utils/llm/model_profiles.py` exposing `ModelProfile`, the default Llama profile and a non-public, non-runnable `qwen3-8b-q4-k-m` profile. 
- Switched the public API v1 catalog to generate entries from `get_public_catalog_profiles()` so the public catalog remains Llama-only for P23b and compatibility aliases still resolve to Llama. (`api/v1/models.py`).
- Extended config schema/defaults to include profile-related keys and resolved defaults to the existing Llama profile (`utils/config_schema.py`).
- Updated `ModelManager` to resolve the active profile and source artifact metadata from it, and expanded `get_model_artifact_metadata()` to include safe profile fields (api/profile ids, display name, gguf repo, quantization, context tokens, supported tiers) while preserving config/env overrides (`utils/llm/model_manager.py`).
- Made the desktop bridge fallback metadata profile-aware but robust when `utils.llm.model_profiles` is not importable, and preserved environment overrides (`desktop-tauri/src-tauri/python/model_bridge.py`).
- Added and adjusted focused unit tests to assert: Llama remains default and unchanged, Qwen profile exists but is not public/runnable, ModelManager metadata reflects profile values, desktop bridge fallback reports Llama by default and respects env overrides, and alias behavior remains stable (tests under `tests/unit/*`).

### Testing
- Ran focused unit tests verifying catalog, aliases, model manager, context profiles, relay client, and desktop bridge: `python -m pytest tests/unit/test_api_v1_models_catalog_minimal.py -q` (passed), `python -m pytest tests/unit/test_api_v1_models_aliases.py -q` (passed), `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), and `python -m pytest tests/unit/test_desktop_model_bridge.py -q` (passed).
- Ran project checks: `pre-commit run --all-files` (passed) and `git diff --check` (no issues).
- Residual risks / follow-ups: runtime Qwen loading, chat-template wiring, and YaRN/RoPE behaviour are intentionally not implemented here and will be covered in P23c/P23d; ensure those follow-ups reuse `ModelProfile` fields added in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40c721a994832f8cde73786066fefc)