### PR TITLE
Add model-profile plumbing and Qwen3 metadata (non-default, test-covered)

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -10,6 +10,12 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+from utils.llm.model_profiles import (
+    MODEL_ALIASES,
+    public_catalog_profiles,
+    LLAMA_3_1_8B_Q4_K_M_PROFILE,
+)
+
 try:
     import llama_cpp as _llama_cpp_module
     from llama_cpp import Llama as _llama_runtime
@@ -103,41 +109,10 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"
-
-MODEL_ALIASES: Dict[str, str] = {
-    # Invisible compatibility aliases that route to the fixed Meta Llama 3.1
-    # 8B launch backend. They are accepted by request paths but are not listed
-    # as first-class API v1 models.
-    "llama-3-8b-instruct": CANONICAL_LAUNCH_MODEL_ID,
-    "gpt-3.5-turbo": CANONICAL_LAUNCH_MODEL_ID,
-    "gpt-5-chat-latest": CANONICAL_LAUNCH_MODEL_ID,
-}
+CANONICAL_LAUNCH_MODEL_ID = LLAMA_3_1_8B_Q4_K_M_PROFILE.api_model_id
 
 
-AVAILABLE_MODELS = [
-    {
-        "id": CANONICAL_LAUNCH_MODEL_ID,
-        "name": "Meta Llama 3.1 8B Instruct",
-        "description": (
-            "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
-            "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
-        ),
-        "owner": "Meta",
-        "owned_by": "Meta",
-        "provider": "meta",
-        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
-        "parameters": "8B",
-        "quantization": "Q4_K_M",
-        "context_length": 8192,
-        "url": (
-            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
-        ),
-        "file_name": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "adapters": [],
-    }
-]
+AVAILABLE_MODELS = [profile.catalog_entry() for profile in public_catalog_profiles()]
 
 
 # Dictionary mapping model IDs to loaded model instances

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -22,6 +22,24 @@ from path_bootstrap import ensure_runtime_import_paths
 ensure_runtime_import_paths(__file__)
 from pathlib import Path
 
+
+_DEFAULT_PROFILE_ID = "llama-3.1-8b-instruct-q4-k-m"
+_DEFAULT_API_MODEL_ID = "llama-3.1-8b-instruct"
+_DEFAULT_DISPLAY_NAME = "Meta Llama 3.1 8B Instruct"
+_DEFAULT_SOURCE_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
+_DEFAULT_GGUF_REPO = "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF"
+_DEFAULT_QUANTIZATION = "Q4_K_M"
+_DEFAULT_LICENSE = "llama3.1"
+_DEFAULT_NATIVE_CONTEXT_TOKENS = 8192
+_DEFAULT_MAXIMUM_VALIDATED_CONTEXT_TOKENS = 8192
+_DEFAULT_SUPPORTED_CONTEXT_TIERS = ["8k-fast"]
+_DEFAULT_CANONICAL_FAMILY_URL = "https://huggingface.co/meta-llama/Meta-Llama-3-8B"
+_DEFAULT_FILENAME = "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+_DEFAULT_URL = (
+    "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
+    "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+)
+
 try:
     from desktop_runtime_setup import ensure_desktop_python_dependencies
 except ModuleNotFoundError:
@@ -67,24 +85,36 @@ def _fallback_model_metadata() -> Dict[str, Any]:
 
     canonical_family_url = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL",
-        "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+        _DEFAULT_CANONICAL_FAMILY_URL,
     )
     filename = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_FILENAME",
-        "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        _DEFAULT_FILENAME,
     )
     url = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_URL",
-        "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        _DEFAULT_URL,
     )
     resolved_model_path = models_dir / filename
     exists = resolved_model_path.exists()
     size_bytes = resolved_model_path.stat().st_size if exists else None
 
     return {
+        "api_model_id": _DEFAULT_API_MODEL_ID,
+        "active_api_model_id": _DEFAULT_API_MODEL_ID,
+        "profile_id": _DEFAULT_PROFILE_ID,
+        "active_profile_id": _DEFAULT_PROFILE_ID,
+        "display_name": _DEFAULT_DISPLAY_NAME,
         "canonical_family_url": canonical_family_url,
         "filename": filename,
         "url": url,
+        "gguf_repo": _DEFAULT_GGUF_REPO,
+        "source_model": _DEFAULT_SOURCE_MODEL,
+        "quantization": _DEFAULT_QUANTIZATION,
+        "license": _DEFAULT_LICENSE,
+        "native_context_tokens": _DEFAULT_NATIVE_CONTEXT_TOKENS,
+        "maximum_validated_context_tokens": _DEFAULT_MAXIMUM_VALIDATED_CONTEXT_TOKENS,
+        "supported_context_tiers": _DEFAULT_SUPPORTED_CONTEXT_TIERS,
         "models_dir": str(models_dir),
         "resolved_model_path": str(resolved_model_path),
         "exists": exists,

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -1,7 +1,9 @@
 """Tests covering alias resolution behaviour for API v1 models."""
 
 import importlib
+import importlib.util
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -16,8 +18,11 @@ def _reload_models(env=None):
     fake_llama_module = MagicMock()
     with patch.dict("sys.modules", {"llama_cpp": fake_llama_module}):
         with patch.dict(os.environ, env_vars, clear=True):
-            import api.v1.models as models
-            importlib.reload(models)
+            module_path = Path(__file__).resolve().parents[2] / "api" / "v1" / "models.py"
+            spec = importlib.util.spec_from_file_location("api_v1_models_alias_test", module_path)
+            models = importlib.util.module_from_spec(spec)
+            assert spec and spec.loader
+            spec.loader.exec_module(models)
     return models
 
 
@@ -41,3 +46,10 @@ def test_resolve_model_alias_missing_target_logs_and_returns_none():
                 result = models.resolve_model_alias("local-alias")
     assert result is None
     mock_log_warning.assert_called_once()
+
+
+def test_qwen_is_not_aliased_to_llama_or_from_llama():
+    models = _reload_models()
+    assert models.resolve_model_alias("qwen3-8b-instruct") is None
+    assert "qwen3-8b-instruct" not in models.MODEL_ALIASES.values()
+    assert models.MODEL_ALIASES["gpt-5-chat-latest"] == "llama-3.1-8b-instruct"

--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -36,3 +36,43 @@ def test_llama_catalog_targets_latest_4090_ready_release():
     assert base_entry["name"] == "Meta Llama 3.1 8B Instruct"
     assert base_entry["file_name"] == "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
     assert base_entry["file_name"] in base_entry["url"]
+
+
+def test_model_profiles_include_non_default_qwen_metadata():
+    from utils.llm.model_profiles import (
+        DEFAULT_MODEL_PROFILE_ID,
+        LLAMA_3_1_8B_Q4_K_M_PROFILE,
+        MODEL_PROFILES,
+        QWEN3_8B_Q4_K_M_PROFILE,
+        get_active_model_profile,
+    )
+
+    assert DEFAULT_MODEL_PROFILE_ID == LLAMA_3_1_8B_Q4_K_M_PROFILE.profile_id
+    assert get_active_model_profile().api_model_id == "llama-3.1-8b-instruct"
+
+    qwen = MODEL_PROFILES["qwen3-8b-q4-k-m"]
+    assert qwen is QWEN3_8B_Q4_K_M_PROFILE
+    assert qwen.api_model_id == "qwen3-8b-instruct"
+    assert qwen.display_name == "Qwen3 8B Instruct"
+    assert qwen.source_model == "Qwen/Qwen3-8B"
+    assert qwen.gguf_repo == "Qwen/Qwen3-8B-GGUF"
+    assert qwen.filename == "Qwen3-8B-Q4_K_M.gguf"
+    assert qwen.quantization == "Q4_K_M"
+    assert qwen.license == "apache-2.0"
+    assert qwen.parameters == "8.2B"
+    assert qwen.native_context_tokens == 32768
+    assert qwen.maximum_validated_context_tokens == 131072
+    assert qwen.supported_context_tiers == ["8k-fast", "64k-full"]
+    assert qwen.thinking_mode == "disabled"
+    assert qwen.chat_template_policy == "gguf-jinja"
+    assert qwen.rope_scaling_policy["factor"] == 2.0
+    assert qwen.public_catalog is False
+
+
+@mock.patch.dict(os.environ, {"USE_MOCK_LLM": "1"})
+def test_qwen_profile_is_not_advertised_in_public_api_v1_catalog():
+    import api.v1.models as models
+
+    importlib.reload(models)
+
+    assert "qwen3-8b-instruct" not in [entry["id"] for entry in models.get_models_info()]

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -362,3 +362,35 @@ def test_download_fails_when_dependency_preflight_fails(capsys):
 
     assert status == 1
     assert json.loads(capsys.readouterr().out.strip()) == {'ok': False, 'error': 'deps bad'}
+
+
+def test_fallback_metadata_reports_llama_profile_by_default(monkeypatch):
+    module = model_bridge
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_FILENAME', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_URL', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_MODELS_DIR', raising=False)
+
+    metadata = module._fallback_model_metadata()
+
+    assert metadata['api_model_id'] == 'llama-3.1-8b-instruct'
+    assert metadata['profile_id'] == 'llama-3.1-8b-instruct-q4-k-m'
+    assert metadata['display_name'] == 'Meta Llama 3.1 8B Instruct'
+    assert metadata['filename'] == 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+    assert metadata['url'].endswith('/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf')
+
+
+def test_fallback_metadata_preserves_model_env_overrides(monkeypatch, tmp_path):
+    module = model_bridge
+    monkeypatch.setenv('TOKEN_PLACE_MODELS_DIR', str(tmp_path))
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_FILENAME', 'override.gguf')
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_URL', 'https://example.com/override.gguf')
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL', 'https://example.com/family')
+
+    metadata = module._fallback_model_metadata()
+
+    assert metadata['profile_id'] == 'llama-3.1-8b-instruct-q4-k-m'
+    assert metadata['filename'] == 'override.gguf'
+    assert metadata['url'] == 'https://example.com/override.gguf'
+    assert metadata['canonical_family_url'] == 'https://example.com/family'
+    assert metadata['resolved_model_path'] == str(tmp_path / 'override.gguf')

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -146,6 +146,13 @@ class TestModelManager:
         """Test runtime model metadata includes expected keys and file state."""
         metadata = model_manager.get_model_artifact_metadata()
 
+        assert metadata['api_model_id'] == 'llama-3.1-8b-instruct'
+        assert metadata['profile_id'] == 'llama-3.1-8b-instruct-q4-k-m'
+        assert metadata['display_name'] == 'Meta Llama 3.1 8B Instruct'
+        assert metadata['source_model'] == 'meta-llama/Llama-3.1-8B-Instruct'
+        assert metadata['quantization'] == 'Q4_K_M'
+        assert metadata['native_context_tokens'] == 8192
+        assert metadata['maximum_validated_context_tokens'] == 8192
         assert metadata['canonical_family_url'] == 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
         assert metadata['filename'] == 'test_model.gguf'
         assert metadata['url'] == 'https://example.com/model.gguf'

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -10,7 +10,9 @@ offer better auto-completion for developers.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict
+
+from utils.llm.model_profiles import LLAMA_3_1_8B_Q4_K_M_PROFILE
 
 class ServerSettings(TypedDict, total=False):
     host: str
@@ -57,6 +59,8 @@ class PathsSettings(TypedDict, total=False):
 
 
 class ModelSettings(TypedDict, total=False):
+    profile_id: str
+    api_model_id: str
     default_model: str
     fallback_model: str
     temperature: float
@@ -67,6 +71,12 @@ class ModelSettings(TypedDict, total=False):
     canonical_family_url: str
     context_size: int
     chat_format: str
+    chat_template_policy: str
+    thinking_mode: str
+    native_context_tokens: int
+    maximum_validated_context_tokens: int
+    supported_context_tiers: List[str]
+    rope_scaling_policy: Optional[Dict[str, Any]]
     download_chunk_size_mb: int
 
 
@@ -138,19 +148,24 @@ DEFAULT_CONFIG: AppConfig = {
         "config_dir": "",
     },
     "model": {
+        "profile_id": LLAMA_3_1_8B_Q4_K_M_PROFILE.profile_id,
+        "api_model_id": LLAMA_3_1_8B_Q4_K_M_PROFILE.api_model_id,
         "default_model": "gpt-5-chat-latest",
         "fallback_model": "gpt-5-chat-latest",
         "temperature": 0.7,
         "max_tokens": 1000,
         "use_mock": False,
-        "filename": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "url": (
-            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
-        ),
-        "canonical_family_url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-        "context_size": 8192,
+        "filename": LLAMA_3_1_8B_Q4_K_M_PROFILE.filename,
+        "url": LLAMA_3_1_8B_Q4_K_M_PROFILE.download_url,
+        "canonical_family_url": LLAMA_3_1_8B_Q4_K_M_PROFILE.canonical_family_url,
+        "context_size": LLAMA_3_1_8B_Q4_K_M_PROFILE.default_context_tokens,
         "chat_format": "llama-3",
+        "chat_template_policy": LLAMA_3_1_8B_Q4_K_M_PROFILE.chat_template_policy,
+        "thinking_mode": LLAMA_3_1_8B_Q4_K_M_PROFILE.thinking_mode,
+        "native_context_tokens": LLAMA_3_1_8B_Q4_K_M_PROFILE.native_context_tokens,
+        "maximum_validated_context_tokens": LLAMA_3_1_8B_Q4_K_M_PROFILE.maximum_validated_context_tokens,
+        "supported_context_tiers": LLAMA_3_1_8B_Q4_K_M_PROFILE.supported_context_tiers,
+        "rope_scaling_policy": LLAMA_3_1_8B_Q4_K_M_PROFILE.rope_scaling_policy,
         "download_chunk_size_mb": 10,
     },
     "constants": {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -18,6 +18,8 @@ from threading import Lock
 from unittest.mock import MagicMock
 from typing import Dict, List, Any, Optional, Iterable
 
+from utils.llm.model_profiles import get_active_model_profile
+
 from utils.system import resource_monitor
 
 # Configure logging
@@ -1557,20 +1559,18 @@ class ModelManager:
 
         self.config = config
 
-        # Llama model configuration
-        self.file_name = config.get(
-            'model.filename', 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
-        )
-        self.url = config.get(
-            'model.url',
-            (
-                'https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/'
-                'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
-            ),
-        )
+        # Model artifact configuration, seeded from the active profile while
+        # preserving explicit config/env overrides for filename and URLs.
+        self.model_profile = get_active_model_profile(config.get('model.profile_id'))
+        self.profile_id = config.get('model.profile_id', self.model_profile.profile_id)
+        if self.profile_id not in {self.model_profile.profile_id}:
+            self.profile_id = self.model_profile.profile_id
+        self.api_model_id = config.get('model.api_model_id', self.model_profile.api_model_id)
+        self.file_name = config.get('model.filename', self.model_profile.filename)
+        self.url = config.get('model.url', self.model_profile.download_url)
         self.canonical_family_url = config.get(
             'model.canonical_family_url',
-            'https://huggingface.co/meta-llama/Meta-Llama-3-8B',
+            self.model_profile.canonical_family_url,
         )
         self.chunk_size_mb = config.get('model.download_chunk_size_mb', 10)
         # Network timeout for model downloads (seconds)
@@ -1792,9 +1792,23 @@ class ModelManager:
         """Return runtime model metadata used by server and desktop bridges."""
         file_exists = os.path.exists(self.model_path)
         return {
+            'api_model_id': self.api_model_id,
+            'active_api_model_id': self.api_model_id,
+            'profile_id': self.model_profile.profile_id,
+            'active_profile_id': self.model_profile.profile_id,
+            'display_name': self.model_profile.display_name,
             'canonical_family_url': self.canonical_family_url,
             'filename': self.file_name,
             'url': self.url,
+            'gguf_repo': self.model_profile.gguf_repo,
+            'source_model': self.model_profile.source_model,
+            'quantization': self.model_profile.quantization,
+            'license': self.model_profile.license,
+            'native_context_tokens': self.model_profile.native_context_tokens,
+            'maximum_validated_context_tokens': self.model_profile.maximum_validated_context_tokens,
+            'supported_context_tiers': self.model_profile.supported_context_tiers,
+            'chat_template_policy': self.model_profile.chat_template_policy,
+            'thinking_mode': self.model_profile.thinking_mode,
             'models_dir': self.models_dir,
             'resolved_model_path': self.model_path,
             'exists': file_exists,

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -1,0 +1,152 @@
+"""Central model profile metadata for API v1 runtime artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    profile_id: str
+    api_model_id: str
+    display_name: str
+    description: str
+    owner: str
+    provider: str
+    source_model: str
+    parameters: str
+    quantization: str
+    license: str
+    gguf_repo: str
+    filename: str
+    download_url: str
+    canonical_family_url: str
+    native_context_tokens: int
+    maximum_validated_context_tokens: int
+    default_context_tokens: int
+    supported_context_tiers: List[str]
+    chat_template_policy: str
+    thinking_mode: str
+    generation_defaults: Dict[str, Any] = field(default_factory=dict)
+    aliases: List[str] = field(default_factory=list)
+    rope_scaling_policy: Optional[Dict[str, Any]] = None
+    public_catalog: bool = True
+    runtime_status: str = "default"
+
+    def catalog_entry(self) -> Dict[str, Any]:
+        """Return the backward-compatible API v1 model catalog shape."""
+        return {
+            "id": self.api_model_id,
+            "name": self.display_name,
+            "description": self.description,
+            "owner": self.owner,
+            "owned_by": self.owner,
+            "provider": self.provider,
+            "source_model": self.source_model,
+            "parameters": self.parameters,
+            "quantization": self.quantization,
+            "context_length": self.default_context_tokens,
+            "url": self.download_url,
+            "file_name": self.filename,
+            "adapters": [],
+        }
+
+
+LLAMA_3_1_8B_Q4_K_M_PROFILE = ModelProfile(
+    profile_id="llama-3.1-8b-instruct-q4-k-m",
+    api_model_id="llama-3.1-8b-instruct",
+    display_name="Meta Llama 3.1 8B Instruct",
+    description=(
+        "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
+        "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
+    ),
+    owner="Meta",
+    provider="meta",
+    source_model="meta-llama/Llama-3.1-8B-Instruct",
+    parameters="8B",
+    quantization="Q4_K_M",
+    license="llama3.1",
+    gguf_repo="bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+    filename="Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+    download_url=(
+        "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
+        "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+    ),
+    canonical_family_url="https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+    native_context_tokens=8192,
+    maximum_validated_context_tokens=8192,
+    default_context_tokens=8192,
+    supported_context_tiers=["8k-fast"],
+    chat_template_policy="llama-3",
+    thinking_mode="not-applicable",
+    generation_defaults={},
+    aliases=["llama-3-8b-instruct", "gpt-3.5-turbo", "gpt-5-chat-latest"],
+)
+
+QWEN3_8B_Q4_K_M_PROFILE = ModelProfile(
+    profile_id="qwen3-8b-q4-k-m",
+    api_model_id="qwen3-8b-instruct",
+    display_name="Qwen3 8B Instruct",
+    description=(
+        "Internal experimental metadata profile for Qwen3 8B Q4_K_M. Runtime "
+        "support, chat-template activation, non-thinking mode, and YaRN/RoPE "
+        "configuration are intentionally deferred."
+    ),
+    owner="Qwen",
+    provider="qwen",
+    source_model="Qwen/Qwen3-8B",
+    parameters="8.2B",
+    quantization="Q4_K_M",
+    license="apache-2.0",
+    gguf_repo="Qwen/Qwen3-8B-GGUF",
+    filename="Qwen3-8B-Q4_K_M.gguf",
+    download_url="https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf",
+    canonical_family_url="https://huggingface.co/Qwen/Qwen3-8B",
+    native_context_tokens=32768,
+    maximum_validated_context_tokens=131072,
+    default_context_tokens=8192,
+    supported_context_tiers=["8k-fast", "64k-full"],
+    chat_template_policy="gguf-jinja",
+    thinking_mode="disabled",
+    generation_defaults={"temperature": 0.6, "top_p": 0.95, "top_k": 20},
+    aliases=[],
+    rope_scaling_policy={
+        "type": "yarn",
+        "required_for_context_tier": "64k-full",
+        "factor": 2.0,
+        "native_context_tokens": 32768,
+        "target_context_tokens": 65536,
+    },
+    public_catalog=False,
+    runtime_status="internal-experimental",
+)
+
+DEFAULT_MODEL_PROFILE_ID = LLAMA_3_1_8B_Q4_K_M_PROFILE.profile_id
+_ACTIVE_API_MODEL_ID = LLAMA_3_1_8B_Q4_K_M_PROFILE.api_model_id
+
+MODEL_PROFILES: Dict[str, ModelProfile] = {
+    profile.profile_id: profile
+    for profile in (LLAMA_3_1_8B_Q4_K_M_PROFILE, QWEN3_8B_Q4_K_M_PROFILE)
+}
+MODEL_PROFILES_BY_API_ID: Dict[str, ModelProfile] = {
+    profile.api_model_id: profile for profile in MODEL_PROFILES.values()
+}
+MODEL_ALIASES: Dict[str, str] = {
+    alias: LLAMA_3_1_8B_Q4_K_M_PROFILE.api_model_id
+    for alias in LLAMA_3_1_8B_Q4_K_M_PROFILE.aliases
+}
+
+
+def get_model_profile(profile_id: str) -> ModelProfile:
+    return MODEL_PROFILES[profile_id]
+
+
+def get_active_model_profile(profile_id: Optional[str] = None) -> ModelProfile:
+    if profile_id and profile_id in MODEL_PROFILES:
+        return MODEL_PROFILES[profile_id]
+    return MODEL_PROFILES[DEFAULT_MODEL_PROFILE_ID]
+
+
+def public_catalog_profiles() -> List[ModelProfile]:
+    return [profile for profile in MODEL_PROFILES.values() if profile.public_catalog]


### PR DESCRIPTION
### Motivation
- Centralise API v1 model metadata so new model profiles (Qwen3) can be added as drop-in profiles without changing the current runtime defaults.  
- Preserve the existing Llama 3.1 8B Q4_K_M behaviour and surface-compatible aliases while preparing for a future switch to Qwen3.

### Description
- Added a typed model-profile abstraction and catalog in `utils/llm/model_profiles.py` containing the existing Llama profile and a non-public `qwen3-8b-q4-k-m` profile. 
- Updated `api/v1/models.py` to build the public API v1 model catalog and keep aliases from the centralized profiles, ensuring only public profiles (Llama) are advertised. 
- Extended `utils/config_schema.py` with profile-aware typed fields and defaults that resolve to the existing Llama profile (fields such as `model.profile_id`, `model.api_model_id`, `model.filename`, `model.url`, `model.canonical_family_url`, `model.chat_template_policy`, `model.thinking_mode`, `model.native_context_tokens`, `model.maximum_validated_context_tokens`, `model.supported_context_tiers`, `model.rope_scaling_policy`). 
- Updated `utils/llm/model_manager.py` to seed artifact configuration from the active model profile while preserving explicit config/env overrides, and expanded `get_model_artifact_metadata()` to include safe profile metadata keys (API/model ids, profile id, display name, gguf repo, source_model, quantization, license, native/maximum context tokens, supported tiers, resolved path, exists/size) while keeping previous keys for compatibility. 
- Updated `desktop-tauri/src-tauri/python/model_bridge.py` fallback metadata to mirror the profile defaults (reporting Llama by default) while preserving existing environment override semantics (`TOKEN_PLACE_DEFAULT_MODEL_FILENAME`, `TOKEN_PLACE_DEFAULT_MODEL_URL`, `TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL`, `TOKEN_PLACE_MODELS_DIR`). 
- Added and adjusted focused unit tests to assert: Llama remains default, Qwen profile exists but is not advertised, aliases remain stable, ModelManager metadata is profile-backed, desktop bridge fallback reports Llama by default and honours env overrides. Files touched only within allowed scope.

### Testing
- Ran focused unit tests and checks:  
  - `python -m pytest tests/unit/test_api_v1_models_catalog_minimal.py -q` — passed.  
  - `python -m pytest tests/unit/test_api_v1_models_aliases.py -q` — passed.  
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed.  
  - `python -m pytest tests/unit/test_context_profiles.py -q` — passed.  
  - `python -m pytest tests/unit/test_relay_client.py -q` — passed.  
  - `python -m pytest tests/unit/test_desktop_model_bridge.py -q` — passed.  
  - `pre-commit run --all-files` — passed.  
  - `git diff --check` — no problems found.  

All automated checks included in the acceptance criteria were executed and succeeded for the modified code. Residual follow-ups: wire actual Qwen runtime support, chat-template activation, YaRN/RoPE runtime plumbing, and switch defaults in a later change as planned (P23c/P23d).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40c731bafc832fa55b87a81015ae25)