### PR TITLE
Centralize model profiles and add Qwen3 metadata (non-default)

### DIFF
--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -10,6 +10,12 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+from utils.llm.model_profiles import (
+    CANONICAL_API_V1_MODEL_ID,
+    build_model_aliases,
+    iter_model_profiles,
+)
+
 try:
     import llama_cpp as _llama_cpp_module
     from llama_cpp import Llama as _llama_runtime
@@ -103,42 +109,42 @@ if ENVIRONMENT != 'prod':
     logger.info(f"API v1 Models module loaded with USE_MOCK_LLM={USE_MOCK_LLM}, raw env value: '{os.environ.get('USE_MOCK_LLM', 'NOT_SET')}'")
 
 # Available model metadata
-CANONICAL_LAUNCH_MODEL_ID = "llama-3.1-8b-instruct"
+CANONICAL_LAUNCH_MODEL_ID = CANONICAL_API_V1_MODEL_ID
 
-MODEL_ALIASES: Dict[str, str] = {
-    # Invisible compatibility aliases that route to the fixed Meta Llama 3.1
-    # 8B launch backend. They are accepted by request paths but are not listed
-    # as first-class API v1 models.
-    "llama-3-8b-instruct": CANONICAL_LAUNCH_MODEL_ID,
-    "gpt-3.5-turbo": CANONICAL_LAUNCH_MODEL_ID,
-    "gpt-5-chat-latest": CANONICAL_LAUNCH_MODEL_ID,
-}
+MODEL_ALIASES: Dict[str, str] = build_model_aliases()
 
 
-AVAILABLE_MODELS = [
-    {
-        "id": CANONICAL_LAUNCH_MODEL_ID,
-        "name": "Meta Llama 3.1 8B Instruct",
-        "description": (
-            "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
-            "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
-        ),
-        "owner": "Meta",
-        "owned_by": "Meta",
-        "provider": "meta",
-        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
-        "parameters": "8B",
-        "quantization": "Q4_K_M",
-        "context_length": 8192,
-        "url": (
-            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
-        ),
-        "file_name": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+def _profile_to_catalog_entry(profile: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a centralized model profile into the legacy API v1 catalog shape."""
+
+    return {
+        "id": profile["api_model_id"],
+        "profile_id": profile["profile_id"],
+        "name": profile["display_name"],
+        "display_name": profile["display_name"],
+        "description": profile["description"],
+        "owner": profile["owner"],
+        "owned_by": profile["owner"],
+        "provider": profile["provider"],
+        "source_model": profile["source_model"],
+        "parameters": profile["parameters"],
+        "quantization": profile["quantization"],
+        "license": profile.get("license"),
+        "gguf_repo": profile.get("gguf_repo"),
+        "context_length": profile["default_context_tokens"],
+        "native_context_tokens": profile["native_context_tokens"],
+        "maximum_validated_context_tokens": profile["maximum_validated_context_tokens"],
+        "supported_context_tiers": profile["supported_context_tiers"],
+        "chat_template_policy": profile["chat_template_policy"],
+        "thinking_mode": profile["thinking_mode"],
+        "runnable": profile.get("runnable", False),
+        "url": profile["download_url"],
+        "file_name": profile["filename"],
         "adapters": [],
     }
-]
 
+
+AVAILABLE_MODELS = [_profile_to_catalog_entry(profile) for profile in iter_model_profiles(public_only=True)]
 
 # Dictionary mapping model IDs to loaded model instances
 _loaded_models = {}

--- a/desktop-tauri/src-tauri/python/model_bridge.py
+++ b/desktop-tauri/src-tauri/python/model_bridge.py
@@ -22,6 +22,8 @@ from path_bootstrap import ensure_runtime_import_paths
 ensure_runtime_import_paths(__file__)
 from pathlib import Path
 
+from utils.llm.model_profiles import get_default_model_profile
+
 try:
     from desktop_runtime_setup import ensure_desktop_python_dependencies
 except ModuleNotFoundError:
@@ -65,26 +67,42 @@ def _fallback_model_metadata() -> Dict[str, Any]:
     if models_dir_override:
         models_dir = Path(models_dir_override)
 
+    profile = get_default_model_profile()
     canonical_family_url = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL",
-        "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+        profile["canonical_family_url"],
     )
     filename = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_FILENAME",
-        "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        profile["filename"],
     )
     url = os.environ.get(
         "TOKEN_PLACE_DEFAULT_MODEL_URL",
-        "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        profile["download_url"],
     )
     resolved_model_path = models_dir / filename
     exists = resolved_model_path.exists()
     size_bytes = resolved_model_path.stat().st_size if exists else None
 
     return {
+        "api_model_id": profile["api_model_id"],
+        "active_api_model_id": profile["api_model_id"],
+        "profile_id": profile["profile_id"],
+        "active_profile_id": profile["profile_id"],
+        "display_name": profile["display_name"],
         "canonical_family_url": canonical_family_url,
         "filename": filename,
         "url": url,
+        "download_url": url,
+        "gguf_repo": profile.get("gguf_repo"),
+        "source_model": profile.get("source_model"),
+        "quantization": profile.get("quantization"),
+        "license": profile.get("license"),
+        "native_context_tokens": profile.get("native_context_tokens"),
+        "maximum_validated_context_tokens": profile.get("maximum_validated_context_tokens"),
+        "supported_context_tiers": profile.get("supported_context_tiers"),
+        "chat_template_policy": profile.get("chat_template_policy"),
+        "thinking_mode": profile.get("thinking_mode"),
         "models_dir": str(models_dir),
         "resolved_model_path": str(resolved_model_path),
         "exists": exists,

--- a/tests/unit/test_api_v1_models_aliases.py
+++ b/tests/unit/test_api_v1_models_aliases.py
@@ -2,6 +2,7 @@
 
 import importlib
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -14,7 +15,12 @@ def _reload_models(env=None):
 
     # Ensure the module is reloaded under the patched environment and dependencies.
     fake_llama_module = MagicMock()
-    with patch.dict("sys.modules", {"llama_cpp": fake_llama_module}):
+    fake_routes_module = SimpleNamespace(bp=MagicMock())
+    with patch.dict("sys.modules", {
+        "llama_cpp": fake_llama_module,
+        "api.v1.routes": fake_routes_module,
+        "api.v2.routes": fake_routes_module,
+    }):
         with patch.dict(os.environ, env_vars, clear=True):
             import api.v1.models as models
             importlib.reload(models)

--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -36,3 +36,35 @@ def test_llama_catalog_targets_latest_4090_ready_release():
     assert base_entry["name"] == "Meta Llama 3.1 8B Instruct"
     assert base_entry["file_name"] == "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
     assert base_entry["file_name"] in base_entry["url"]
+
+
+def test_qwen3_profile_exists_but_is_not_public_catalog_default():
+    from utils.llm.model_profiles import get_model_profile, iter_model_profiles
+
+    qwen = get_model_profile("qwen3-8b-q4-k-m")
+
+    assert qwen is not None
+    assert qwen["api_model_id"] == "qwen3-8b-instruct"
+    assert qwen["display_name"] == "Qwen3 8B Instruct"
+    assert qwen["source_model"] == "Qwen/Qwen3-8B"
+    assert qwen["gguf_repo"] == "Qwen/Qwen3-8B-GGUF"
+    assert qwen["filename"] == "Qwen3-8B-Q4_K_M.gguf"
+    assert qwen["quantization"] == "Q4_K_M"
+    assert qwen["license"] == "apache-2.0"
+    assert qwen["parameters"] == "8.2B"
+    assert qwen["native_context_tokens"] == 32768
+    assert qwen["maximum_validated_context_tokens"] == 131072
+    assert qwen["supported_context_tiers"] == ["8k-fast", "64k-full"]
+    assert qwen["thinking_mode"] == "disabled"
+    assert qwen["chat_template_policy"] == "gguf-jinja"
+    assert qwen["rope_scaling_policy"] == {
+        "type": "yarn",
+        "required_for_tier": "64k-full",
+        "factor": 2.0,
+        "original_context_tokens": 32768,
+    }
+    assert qwen["public_catalog"] is False
+    assert qwen["runnable"] is False
+    assert [profile["api_model_id"] for profile in iter_model_profiles(public_only=True)] == [
+        "llama-3.1-8b-instruct"
+    ]

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -252,7 +252,7 @@ def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_
     resources_dir = tmp_path / 'bin' / 'resources'
     import_root = resources_dir / '_up_' / '_up_'
     utils_llm_dir = import_root / 'utils' / 'llm'
-    model_profiles_path = Path('utils/llm/model_profiles.py')
+    model_profiles_path = MODULE_PATH.parents[3] / 'utils' / 'llm' / 'model_profiles.py'
     python_dir.mkdir(parents=True)
     utils_llm_dir.mkdir(parents=True)
 

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -252,6 +252,7 @@ def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_
     resources_dir = tmp_path / 'bin' / 'resources'
     import_root = resources_dir / '_up_' / '_up_'
     utils_llm_dir = import_root / 'utils' / 'llm'
+    model_profiles_path = Path('utils/llm/model_profiles.py')
     python_dir.mkdir(parents=True)
     utils_llm_dir.mkdir(parents=True)
 
@@ -265,6 +266,7 @@ def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_
     (python_dir / 'requirements_desktop_runtime.txt').write_text('psutil==7.1.0\nrequests==2.32.5\npython-dotenv==1.1.1\ncryptography==46.0.1\n', encoding='utf-8')
     (import_root / 'utils' / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / '__init__.py').write_text('', encoding='utf-8')
+    (utils_llm_dir / 'model_profiles.py').write_text(model_profiles_path.read_text(encoding='utf-8'), encoding='utf-8')
     (utils_llm_dir / 'model_manager.py').write_text(
         """
 class _Manager:
@@ -362,3 +364,33 @@ def test_download_fails_when_dependency_preflight_fails(capsys):
 
     assert status == 1
     assert json.loads(capsys.readouterr().out.strip()) == {'ok': False, 'error': 'deps bad'}
+
+
+def test_fallback_model_metadata_reports_llama_profile_by_default(monkeypatch):
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_FILENAME', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_URL', raising=False)
+    monkeypatch.delenv('TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL', raising=False)
+    monkeypatch.setenv('TOKEN_PLACE_MODELS_DIR', '/tmp/token-place-models')
+
+    payload = model_bridge._fallback_model_metadata()
+
+    assert payload['api_model_id'] == 'llama-3.1-8b-instruct'
+    assert payload['profile_id'] == 'llama-3.1-8b-q4-k-m'
+    assert payload['display_name'] == 'Meta Llama 3.1 8B Instruct'
+    assert payload['filename'] == 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+    assert payload['url'].endswith('/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf')
+    assert payload['canonical_family_url'] == 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
+
+
+def test_fallback_model_metadata_preserves_model_env_overrides(monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_FILENAME', 'override.gguf')
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_URL', 'https://example.com/override.gguf')
+    monkeypatch.setenv('TOKEN_PLACE_DEFAULT_MODEL_FAMILY_URL', 'https://example.com/family')
+    monkeypatch.setenv('TOKEN_PLACE_MODELS_DIR', '/tmp/token-place-models')
+
+    payload = model_bridge._fallback_model_metadata()
+
+    assert payload['profile_id'] == 'llama-3.1-8b-q4-k-m'
+    assert payload['filename'] == 'override.gguf'
+    assert payload['url'] == 'https://example.com/override.gguf'
+    assert payload['canonical_family_url'] == 'https://example.com/family'

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -146,9 +146,19 @@ class TestModelManager:
         """Test runtime model metadata includes expected keys and file state."""
         metadata = model_manager.get_model_artifact_metadata()
 
+        assert metadata['api_model_id'] == 'llama-3.1-8b-instruct'
+        assert metadata['profile_id'] == 'llama-3.1-8b-q4-k-m'
+        assert metadata['display_name'] == 'Meta Llama 3.1 8B Instruct'
         assert metadata['canonical_family_url'] == 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
         assert metadata['filename'] == 'test_model.gguf'
         assert metadata['url'] == 'https://example.com/model.gguf'
+        assert metadata['gguf_repo'] == 'bartowski/Meta-Llama-3.1-8B-Instruct-GGUF'
+        assert metadata['source_model'] == 'meta-llama/Llama-3.1-8B-Instruct'
+        assert metadata['quantization'] == 'Q4_K_M'
+        assert metadata['license'] == 'llama3.1'
+        assert metadata['native_context_tokens'] == 8192
+        assert metadata['maximum_validated_context_tokens'] == 8192
+        assert metadata['supported_context_tiers'] == ['8k-fast']
         assert metadata['models_dir'] == self._temp_dir
         assert metadata['resolved_model_path'] == os.path.join(self._temp_dir, 'test_model.gguf')
         assert metadata['exists'] is True

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -169,6 +169,68 @@ class TestModelManager:
         assert missing_metadata['exists'] is False
         assert missing_metadata['size_bytes'] is None
 
+    def test_profile_artifacts_follow_selected_profile_when_defaults_are_seeded(self):
+        """Selecting a profile should replace seeded Llama artifact defaults."""
+        from utils.config_schema import DEFAULT_CONFIG
+
+        mock_config = MagicMock()
+        mock_config.is_production = False
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            def get_config(key, default=None):
+                config_values = {
+                    'model.profile_id': 'qwen3-8b-q4-k-m',
+                    'model.api_model_id': DEFAULT_CONFIG['model']['api_model_id'],
+                    'model.filename': DEFAULT_CONFIG['model']['filename'],
+                    'model.url': DEFAULT_CONFIG['model']['url'],
+                    'model.canonical_family_url': DEFAULT_CONFIG['model']['canonical_family_url'],
+                    'model.download_chunk_size_mb': 1,
+                    'paths.models_dir': temp_dir,
+                    'model.use_mock': False,
+                    'model.n_gpu_layers': -1,
+                    'model.gpu_memory_headroom_percent': 0.1,
+                    'model.enforce_gpu_memory_headroom': True,
+                }
+                return config_values.get(key, default)
+
+            mock_config.get.side_effect = get_config
+            manager = ModelManager(mock_config)
+
+        assert manager.profile_id == 'qwen3-8b-q4-k-m'
+        assert manager.api_model_id == 'qwen3-8b-instruct'
+        assert manager.file_name == 'Qwen3-8B-Q4_K_M.gguf'
+        assert manager.url == 'https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf'
+        assert manager.canonical_family_url == 'https://huggingface.co/Qwen/Qwen3-8B'
+
+    def test_profile_artifacts_preserve_explicit_overrides(self):
+        """Non-default profiles still honor artifact values that differ from seeded defaults."""
+        mock_config = MagicMock()
+        mock_config.is_production = False
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            def get_config(key, default=None):
+                config_values = {
+                    'model.profile_id': 'qwen3-8b-q4-k-m',
+                    'model.filename': 'custom.gguf',
+                    'model.url': 'https://example.com/custom.gguf',
+                    'model.canonical_family_url': 'https://example.com/family',
+                    'model.download_chunk_size_mb': 1,
+                    'paths.models_dir': temp_dir,
+                    'model.use_mock': False,
+                    'model.n_gpu_layers': -1,
+                    'model.gpu_memory_headroom_percent': 0.1,
+                    'model.enforce_gpu_memory_headroom': True,
+                }
+                return config_values.get(key, default)
+
+            mock_config.get.side_effect = get_config
+            manager = ModelManager(mock_config)
+
+        assert manager.api_model_id == 'qwen3-8b-instruct'
+        assert manager.file_name == 'custom.gguf'
+        assert manager.url == 'https://example.com/custom.gguf'
+        assert manager.canonical_family_url == 'https://example.com/family'
+
     def test_create_models_directory(self, model_manager):
         """Test create_models_directory method."""
         # Create a new temporary directory path that doesn't exist

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -55,6 +55,27 @@ class _DictAttributeOnly:
 class TestModelManager:
     """Test class for ModelManager."""
 
+    def _build_manager_with_model_config(self, model_config):
+        """Create a ModelManager with focused model config overrides."""
+        mock_config = MagicMock()
+        mock_config.is_production = False
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            def get_config(key, default=None):
+                config_values = {
+                    'model.download_chunk_size_mb': 1,
+                    'paths.models_dir': temp_dir,
+                    'model.use_mock': False,
+                    'model.n_gpu_layers': -1,
+                    'model.gpu_memory_headroom_percent': 0.1,
+                    'model.enforce_gpu_memory_headroom': True,
+                    **model_config,
+                }
+                return config_values.get(key, default)
+
+            mock_config.get.side_effect = get_config
+            return ModelManager(mock_config)
+
     @pytest.fixture
     def model_manager(self):
         """Fixture that returns a model manager instance with mocked config."""
@@ -169,6 +190,25 @@ class TestModelManager:
         assert missing_metadata['exists'] is False
         assert missing_metadata['size_bytes'] is None
 
+    def test_default_model_artifact_metadata_remains_llama_profile(self):
+        """Unselected profiles should keep the existing Llama artifact defaults."""
+        manager = self._build_manager_with_model_config({})
+        metadata = manager.get_model_artifact_metadata()
+
+        assert metadata['api_model_id'] == 'llama-3.1-8b-instruct'
+        assert metadata['profile_id'] == 'llama-3.1-8b-q4-k-m'
+        assert metadata['filename'] == 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+        assert metadata['url'] == (
+            'https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/'
+            'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+        )
+        assert metadata['canonical_family_url'] == 'https://huggingface.co/meta-llama/Meta-Llama-3-8B'
+        assert metadata['source_model'] == 'meta-llama/Llama-3.1-8B-Instruct'
+        assert metadata['quantization'] == 'Q4_K_M'
+        assert metadata['native_context_tokens'] == 8192
+        assert metadata['maximum_validated_context_tokens'] == 8192
+        assert metadata['supported_context_tiers'] == ['8k-fast']
+
     def test_profile_artifacts_follow_selected_profile_when_defaults_are_seeded(self):
         """Selecting a profile should replace seeded Llama artifact defaults."""
         from utils.config_schema import DEFAULT_CONFIG
@@ -201,6 +241,26 @@ class TestModelManager:
         assert manager.file_name == 'Qwen3-8B-Q4_K_M.gguf'
         assert manager.url == 'https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf'
         assert manager.canonical_family_url == 'https://huggingface.co/Qwen/Qwen3-8B'
+        metadata = manager.get_model_artifact_metadata()
+        assert metadata['source_model'] == 'Qwen/Qwen3-8B'
+        assert metadata['quantization'] == 'Q4_K_M'
+        assert metadata['native_context_tokens'] == 32768
+        assert metadata['maximum_validated_context_tokens'] == 131072
+        assert metadata['supported_context_tiers'] == ['8k-fast', '64k-full']
+
+    def test_api_model_id_selection_resolves_qwen_profile_artifacts(self):
+        """Selecting the Qwen API id should resolve the matching non-default profile."""
+        manager = self._build_manager_with_model_config({'model.api_model_id': 'qwen3-8b-instruct'})
+        metadata = manager.get_model_artifact_metadata()
+
+        assert manager.profile_id == 'qwen3-8b-q4-k-m'
+        assert manager.api_model_id == 'qwen3-8b-instruct'
+        assert manager.file_name == 'Qwen3-8B-Q4_K_M.gguf'
+        assert manager.url == 'https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf'
+        assert manager.canonical_family_url == 'https://huggingface.co/Qwen/Qwen3-8B'
+        assert metadata['source_model'] == 'Qwen/Qwen3-8B'
+        assert metadata['quantization'] == 'Q4_K_M'
+        assert metadata['supported_context_tiers'] == ['8k-fast', '64k-full']
 
     def test_profile_artifacts_preserve_explicit_overrides(self):
         """Non-default profiles still honor artifact values that differ from seeded defaults."""

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -16,6 +16,7 @@ from utils.llm.model_profiles import get_default_model_profile
 
 _DEFAULT_MODEL_PROFILE = get_default_model_profile()
 
+
 class ServerSettings(TypedDict, total=False):
     host: str
     port: int

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -10,7 +10,11 @@ offer better auto-completion for developers.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict
+
+from utils.llm.model_profiles import get_default_model_profile
+
+_DEFAULT_MODEL_PROFILE = get_default_model_profile()
 
 class ServerSettings(TypedDict, total=False):
     host: str
@@ -59,6 +63,8 @@ class PathsSettings(TypedDict, total=False):
 class ModelSettings(TypedDict, total=False):
     default_model: str
     fallback_model: str
+    profile_id: str
+    api_model_id: str
     temperature: float
     max_tokens: int
     use_mock: bool
@@ -67,6 +73,12 @@ class ModelSettings(TypedDict, total=False):
     canonical_family_url: str
     context_size: int
     chat_format: str
+    chat_template_policy: str
+    thinking_mode: str
+    native_context_tokens: int
+    maximum_validated_context_tokens: int
+    supported_context_tiers: List[str]
+    rope_scaling_policy: Optional[Dict[str, Any]]
     download_chunk_size_mb: int
 
 
@@ -143,14 +155,19 @@ DEFAULT_CONFIG: AppConfig = {
         "temperature": 0.7,
         "max_tokens": 1000,
         "use_mock": False,
-        "filename": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-        "url": (
-            "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
-        ),
-        "canonical_family_url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-        "context_size": 8192,
+        "profile_id": _DEFAULT_MODEL_PROFILE["profile_id"],
+        "api_model_id": _DEFAULT_MODEL_PROFILE["api_model_id"],
+        "filename": _DEFAULT_MODEL_PROFILE["filename"],
+        "url": _DEFAULT_MODEL_PROFILE["download_url"],
+        "canonical_family_url": _DEFAULT_MODEL_PROFILE["canonical_family_url"],
+        "context_size": _DEFAULT_MODEL_PROFILE["default_context_tokens"],
         "chat_format": "llama-3",
+        "chat_template_policy": _DEFAULT_MODEL_PROFILE["chat_template_policy"],
+        "thinking_mode": _DEFAULT_MODEL_PROFILE["thinking_mode"],
+        "native_context_tokens": _DEFAULT_MODEL_PROFILE["native_context_tokens"],
+        "maximum_validated_context_tokens": _DEFAULT_MODEL_PROFILE["maximum_validated_context_tokens"],
+        "supported_context_tiers": _DEFAULT_MODEL_PROFILE["supported_context_tiers"],
+        "rope_scaling_policy": _DEFAULT_MODEL_PROFILE["rope_scaling_policy"],
         "download_chunk_size_mb": 10,
     },
     "constants": {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1564,17 +1564,15 @@ class ModelManager:
             config.get('model.profile_id', None),
             config.get('model.api_model_id', None),
         )
-        self.model_profile = get_model_profile(self.profile_id) or get_model_profile(
-            resolve_profile_id(None, None)
-        )
+        self.model_profile = get_model_profile(self.profile_id)
         assert self.model_profile is not None
-        self.api_model_id = config.get('model.api_model_id', self.model_profile['api_model_id'])
+        self.api_model_id = self.model_profile['api_model_id']
         self.display_name = self.model_profile['display_name']
-        self.file_name = config.get('model.filename', self.model_profile['filename'])
-        self.url = config.get('model.url', self.model_profile['download_url'])
-        self.canonical_family_url = config.get(
-            'model.canonical_family_url',
-            self.model_profile['canonical_family_url'],
+        self.file_name = self._get_profile_artifact_config('filename', 'filename')
+        self.url = self._get_profile_artifact_config('url', 'download_url')
+        self.canonical_family_url = self._get_profile_artifact_config(
+            'canonical_family_url',
+            'canonical_family_url',
         )
         self.chunk_size_mb = config.get('model.download_chunk_size_mb', 10)
         # Network timeout for model downloads (seconds)
@@ -1791,6 +1789,18 @@ class ModelManager:
             'n_gpu_layers': -1,
             'fallback_reason': None,
         }
+
+    def _get_profile_artifact_config(self, config_key: str, profile_key: str) -> Any:
+        """Return a model artifact config override or the active profile default."""
+        profile_value = self.model_profile[profile_key]
+        configured_value = self.config.get(f'model.{config_key}', profile_value)
+        from utils.config_schema import DEFAULT_CONFIG
+
+        default_model_config = DEFAULT_CONFIG.get('model', {})
+        default_value = default_model_config.get(config_key)
+        if self.profile_id != default_model_config.get('profile_id') and configured_value == default_value:
+            return profile_value
+        return configured_value
 
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
         """Return runtime model metadata used by server and desktop bridges."""

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 from typing import Dict, List, Any, Optional, Iterable
 
 from utils.system import resource_monitor
+from utils.llm.model_profiles import get_model_profile, resolve_profile_id
 
 # Configure logging
 logger = logging.getLogger('model_manager')
@@ -1557,20 +1558,23 @@ class ModelManager:
 
         self.config = config
 
-        # Llama model configuration
-        self.file_name = config.get(
-            'model.filename', 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
+        # Model artifact configuration is sourced from the active API v1 profile,
+        # while preserving explicit config/env overrides for existing deployments.
+        self.profile_id = resolve_profile_id(
+            config.get('model.profile_id', None),
+            config.get('model.api_model_id', None),
         )
-        self.url = config.get(
-            'model.url',
-            (
-                'https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/'
-                'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf'
-            ),
+        self.model_profile = get_model_profile(self.profile_id) or get_model_profile(
+            resolve_profile_id(None, None)
         )
+        assert self.model_profile is not None
+        self.api_model_id = config.get('model.api_model_id', self.model_profile['api_model_id'])
+        self.display_name = self.model_profile['display_name']
+        self.file_name = config.get('model.filename', self.model_profile['filename'])
+        self.url = config.get('model.url', self.model_profile['download_url'])
         self.canonical_family_url = config.get(
             'model.canonical_family_url',
-            'https://huggingface.co/meta-llama/Meta-Llama-3-8B',
+            self.model_profile['canonical_family_url'],
         )
         self.chunk_size_mb = config.get('model.download_chunk_size_mb', 10)
         # Network timeout for model downloads (seconds)
@@ -1792,9 +1796,24 @@ class ModelManager:
         """Return runtime model metadata used by server and desktop bridges."""
         file_exists = os.path.exists(self.model_path)
         return {
+            'api_model_id': self.api_model_id,
+            'active_api_model_id': self.api_model_id,
+            'profile_id': self.profile_id,
+            'active_profile_id': self.profile_id,
+            'display_name': self.display_name,
             'canonical_family_url': self.canonical_family_url,
             'filename': self.file_name,
             'url': self.url,
+            'download_url': self.url,
+            'gguf_repo': self.model_profile.get('gguf_repo'),
+            'source_model': self.model_profile.get('source_model'),
+            'quantization': self.model_profile.get('quantization'),
+            'license': self.model_profile.get('license'),
+            'native_context_tokens': self.model_profile.get('native_context_tokens'),
+            'maximum_validated_context_tokens': self.model_profile.get('maximum_validated_context_tokens'),
+            'supported_context_tiers': self.model_profile.get('supported_context_tiers'),
+            'chat_template_policy': self.model_profile.get('chat_template_policy'),
+            'thinking_mode': self.model_profile.get('thinking_mode'),
             'models_dir': self.models_dir,
             'resolved_model_path': self.model_path,
             'exists': file_exists,

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import logging
 from typing import Any, Dict, Iterable, Optional, TypedDict
 
+logger = logging.getLogger(__name__)
 
-class ModelProfile(TypedDict, total=False):
+
+class _ModelProfileRequired(TypedDict):
     profile_id: str
     api_model_id: str
     display_name: str
@@ -16,8 +19,6 @@ class ModelProfile(TypedDict, total=False):
     source_model: str
     parameters: str
     quantization: str
-    license: str
-    gguf_repo: str
     filename: str
     download_url: str
     canonical_family_url: str
@@ -29,9 +30,14 @@ class ModelProfile(TypedDict, total=False):
     thinking_mode: str
     generation_defaults: Dict[str, Any]
     aliases: list[str]
-    rope_scaling_policy: Optional[Dict[str, Any]]
     public_catalog: bool
     runnable: bool
+
+
+class ModelProfile(_ModelProfileRequired, total=False):
+    license: str
+    gguf_repo: str
+    rope_scaling_policy: Optional[Dict[str, Any]]
 
 
 LLAMA_3_1_8B_PROFILE_ID = "llama-3.1-8b-q4-k-m"
@@ -113,7 +119,13 @@ def get_model_profile(profile_id: str) -> Optional[ModelProfile]:
 
 
 def get_default_model_profile() -> ModelProfile:
-    return get_model_profile(LLAMA_3_1_8B_PROFILE_ID)  # type: ignore[return-value]
+    profile = get_model_profile(LLAMA_3_1_8B_PROFILE_ID)
+    if profile is None:
+        raise RuntimeError(
+            f"Default model profile '{LLAMA_3_1_8B_PROFILE_ID}' not found in MODEL_PROFILES. "
+            "Ensure the Llama profile has not been removed."
+        )
+    return profile
 
 
 def iter_model_profiles(*, public_only: bool = False) -> Iterable[ModelProfile]:
@@ -130,6 +142,13 @@ def resolve_profile_id(profile_id: Optional[str], api_model_id: Optional[str] = 
         for candidate_id, profile in MODEL_PROFILES.items():
             if profile["api_model_id"] == api_model_id:
                 return candidate_id
+    if profile_id or api_model_id:
+        logger.warning(
+            "Unknown model profile selection (profile_id=%r, api_model_id=%r); falling back to %s",
+            profile_id,
+            api_model_id,
+            LLAMA_3_1_8B_PROFILE_ID,
+        )
     return LLAMA_3_1_8B_PROFILE_ID
 
 

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -1,0 +1,142 @@
+"""Centralized API v1 model profile metadata."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Iterable, Optional, TypedDict
+
+
+class ModelProfile(TypedDict, total=False):
+    profile_id: str
+    api_model_id: str
+    display_name: str
+    description: str
+    owner: str
+    provider: str
+    source_model: str
+    parameters: str
+    quantization: str
+    license: str
+    gguf_repo: str
+    filename: str
+    download_url: str
+    canonical_family_url: str
+    native_context_tokens: int
+    maximum_validated_context_tokens: int
+    default_context_tokens: int
+    supported_context_tiers: list[str]
+    chat_template_policy: str
+    thinking_mode: str
+    generation_defaults: Dict[str, Any]
+    aliases: list[str]
+    rope_scaling_policy: Optional[Dict[str, Any]]
+    public_catalog: bool
+    runnable: bool
+
+
+LLAMA_3_1_8B_PROFILE_ID = "llama-3.1-8b-q4-k-m"
+CANONICAL_API_V1_MODEL_ID = "llama-3.1-8b-instruct"
+QWEN3_8B_PROFILE_ID = "qwen3-8b-q4-k-m"
+QWEN3_API_MODEL_ID = "qwen3-8b-instruct"
+
+LLAMA_DOWNLOAD_URL = (
+    "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/"
+    "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+)
+LLAMA_FILENAME = "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+LLAMA_FAMILY_URL = "https://huggingface.co/meta-llama/Meta-Llama-3-8B"
+
+MODEL_PROFILES: Dict[str, ModelProfile] = {
+    LLAMA_3_1_8B_PROFILE_ID: {
+        "profile_id": LLAMA_3_1_8B_PROFILE_ID,
+        "api_model_id": CANONICAL_API_V1_MODEL_ID,
+        "display_name": "Meta Llama 3.1 8B Instruct",
+        "description": (
+            "Meta's July 2024 refresh of the 8B instruction-tuned model using the "
+            "Q4_K_M quantisation that comfortably fits within a 24 GB RTX 4090."
+        ),
+        "owner": "Meta",
+        "provider": "meta",
+        "source_model": "meta-llama/Llama-3.1-8B-Instruct",
+        "parameters": "8B",
+        "quantization": "Q4_K_M",
+        "license": "llama3.1",
+        "gguf_repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+        "filename": LLAMA_FILENAME,
+        "download_url": LLAMA_DOWNLOAD_URL,
+        "canonical_family_url": LLAMA_FAMILY_URL,
+        "native_context_tokens": 8192,
+        "maximum_validated_context_tokens": 8192,
+        "default_context_tokens": 8192,
+        "supported_context_tiers": ["8k-fast"],
+        "chat_template_policy": "llama-3",
+        "thinking_mode": "not-applicable",
+        "generation_defaults": {},
+        "aliases": ["llama-3-8b-instruct", "gpt-3.5-turbo", "gpt-5-chat-latest"],
+        "rope_scaling_policy": None,
+        "public_catalog": True,
+        "runnable": True,
+    },
+    QWEN3_8B_PROFILE_ID: {
+        "profile_id": QWEN3_8B_PROFILE_ID,
+        "api_model_id": QWEN3_API_MODEL_ID,
+        "display_name": "Qwen3 8B Instruct",
+        "description": "Internal non-default profile metadata for future Qwen3 8B API v1 support.",
+        "owner": "Qwen",
+        "provider": "qwen",
+        "source_model": "Qwen/Qwen3-8B",
+        "parameters": "8.2B",
+        "quantization": "Q4_K_M",
+        "license": "apache-2.0",
+        "gguf_repo": "Qwen/Qwen3-8B-GGUF",
+        "filename": "Qwen3-8B-Q4_K_M.gguf",
+        "download_url": "https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf",
+        "canonical_family_url": "https://huggingface.co/Qwen/Qwen3-8B",
+        "native_context_tokens": 32768,
+        "maximum_validated_context_tokens": 131072,
+        "default_context_tokens": 8192,
+        "supported_context_tiers": ["8k-fast", "64k-full"],
+        "chat_template_policy": "gguf-jinja",
+        "thinking_mode": "disabled",
+        "generation_defaults": {"temperature": 0.7, "top_p": 0.8, "top_k": 20, "min_p": 0.0},
+        "aliases": [],
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+        "public_catalog": False,
+        "runnable": False,
+    },
+}
+
+
+def get_model_profile(profile_id: str) -> Optional[ModelProfile]:
+    profile = MODEL_PROFILES.get(profile_id)
+    return deepcopy(profile) if profile else None
+
+
+def get_default_model_profile() -> ModelProfile:
+    return get_model_profile(LLAMA_3_1_8B_PROFILE_ID)  # type: ignore[return-value]
+
+
+def iter_model_profiles(*, public_only: bool = False) -> Iterable[ModelProfile]:
+    for profile in MODEL_PROFILES.values():
+        if public_only and not profile.get("public_catalog", False):
+            continue
+        yield deepcopy(profile)
+
+
+def resolve_profile_id(profile_id: Optional[str], api_model_id: Optional[str] = None) -> str:
+    if profile_id and profile_id in MODEL_PROFILES:
+        return profile_id
+    if api_model_id:
+        for candidate_id, profile in MODEL_PROFILES.items():
+            if profile["api_model_id"] == api_model_id:
+                return candidate_id
+    return LLAMA_3_1_8B_PROFILE_ID
+
+
+def build_model_aliases() -> Dict[str, str]:
+    aliases: Dict[str, str] = {}
+    for profile in MODEL_PROFILES.values():
+        target = profile["api_model_id"]
+        for alias in profile.get("aliases", []):
+            aliases[alias] = target
+    return aliases


### PR DESCRIPTION
### Motivation
- Centralize API v1 model metadata so token.place can represent Qwen3-8B-Q4_K_M as a drop-in profile without changing the current Llama default runtime behavior.
- Provide a single source of truth for model artifact metadata, aliases, and catalog generation to reduce scattered hardcoded values.

### Description
- Added a centralized model profile catalog in `utils/llm/model_profiles.py` containing the existing Llama 3.1 8B profile and a non-default internal `qwen3-8b-q4-k-m` profile with the requested metadata and YaRN/RoPE scaffolding.
- Updated `api/v1/models.py` to generate the public API v1 catalog and compatibility aliases from profiles while keeping only the Llama profile public/runnable by default.
- Extended typed config defaults in `utils/config_schema.py` to include profile-related keys and wired defaults to the Llama profile so existing behavior remains unchanged.
- Modified `utils/llm/model_manager.py` to resolve artifact metadata from the active model profile (while preserving explicit config/env overrides) and to return expanded, backward-compatible metadata in `get_model_artifact_metadata()`.
- Updated `desktop-tauri/src-tauri/python/model_bridge.py` fallback metadata to mirror the active/default profile (still Llama by default) while preserving the existing `TOKEN_PLACE_DEFAULT_MODEL_*` env override semantics.
- Added focused unit tests and small test adjustments to assert: Qwen profile exists and is non-public, the public catalog remains Llama-only, aliases resolve to the canonical Llama API id, ModelManager metadata reflects profile-driven values, and the desktop bridge fallback preserves env overrides.

### Testing
- Ran `python -m pytest tests/unit/test_api_v1_models_catalog_minimal.py -q` and it passed.
- Ran `python -m pytest tests/unit/test_api_v1_models_aliases.py -q` and it passed.
- Ran `python -m pytest tests/unit/test_model_manager.py -q` and it passed (focused model_manager assertions included).
- Ran `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, and `python -m pytest tests/unit/test_desktop_model_bridge.py -q` and they all passed in the run that exercised the updated behavior (full unit run reported all tests passing).
- Ran `git diff --check` and `pre-commit run --all-files` and both checks passed.

All automated checks above completed successfully; the PR is scaffolding only and does not change the default runtime model or attempt to download/load Qwen by default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40c741b3e4832f85b3c23cffb5d79b)