### PR TITLE
Implement Qwen3 runtime support: GGUF/Jinja template, non-thinking mode, and 64K YaRN/RoPE

### DIFF
--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -64,7 +64,7 @@ def test_qwen3_profile_exists_but_is_not_public_catalog_default():
         "original_context_tokens": 32768,
     }
     assert qwen["public_catalog"] is False
-    assert qwen["runnable"] is False
+    assert qwen["runnable"] is True
     assert [profile["api_model_id"] for profile in iter_model_profiles(public_only=True)] == [
         "llama-3.1-8b-instruct"
     ]

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4008,3 +4008,90 @@ def test_get_llm_instance_with_recovery_attempts_replacement_when_unavailable(st
     assert standalone_model_manager.get_llm_instance_with_recovery() is replacement
     standalone_model_manager.get_llm_instance.assert_called_once_with()
     standalone_model_manager._ensure_replacement_llm.assert_called_once_with(7)
+
+
+def test_qwen_runtime_init_uses_gguf_template_without_llama_chat_format(tmp_path):
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    mock_config.get.side_effect = lambda key, default=None: {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'paths.models_dir': str(tmp_path),
+        'model.use_mock': False,
+        'model.context_size': 8192,
+        'model.n_gpu_layers': 0,
+        'model.gpu_memory_headroom_percent': 0.1,
+        'model.enforce_gpu_memory_headroom': False,
+    }.get(key, default)
+    (tmp_path / 'Qwen3-8B-Q4_K_M.gguf').write_bytes(b'fake')
+    manager = ModelManager(mock_config)
+    instance = MagicMock()
+    mock_llama = MagicMock(return_value=instance)
+
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama)):
+        assert manager.get_llm_instance() is instance
+
+    kwargs = mock_llama.call_args.kwargs
+    assert kwargs['model_path'].endswith('Qwen3-8B-Q4_K_M.gguf')
+    assert kwargs['n_ctx'] == 8192
+    assert 'chat_format' not in kwargs
+    assert 'rope_scaling_type' not in kwargs
+    assert instance.token_place_chat_template_kwargs == {'enable_thinking': False}
+    assert instance.token_place_model_diagnostics['chat_template_mode'] == 'gguf-jinja'
+    assert instance.token_place_model_diagnostics['rope_yarn_enabled'] is False
+
+
+def test_qwen_64k_runtime_init_enables_yarn_rope(tmp_path):
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    mock_config.get.side_effect = lambda key, default=None: {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'paths.models_dir': str(tmp_path),
+        'model.use_mock': False,
+        'model.context_size': 65536,
+        'model.n_gpu_layers': 0,
+        'model.gpu_memory_headroom_percent': 0.1,
+        'model.enforce_gpu_memory_headroom': False,
+    }.get(key, default)
+    (tmp_path / 'Qwen3-8B-Q4_K_M.gguf').write_bytes(b'fake')
+    manager = ModelManager(mock_config)
+    manager.context_tier = '64k-full'
+    instance = MagicMock()
+    mock_llama = MagicMock(return_value=instance)
+
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama)):
+        assert manager.get_llm_instance() is instance
+
+    kwargs = mock_llama.call_args.kwargs
+    assert kwargs['rope_scaling_type'] == 'yarn'
+    assert kwargs['yarn_ext_factor'] == 2.0
+    assert kwargs['yarn_orig_ctx'] == 32768
+    assert instance.token_place_model_diagnostics['rope_yarn_enabled'] is True
+    assert instance.token_place_model_diagnostics['yarn_original_context'] == 32768
+
+
+def test_qwen_64k_runtime_init_fails_when_yarn_kwargs_unsupported(tmp_path):
+    class UnsupportedLlama:
+        def __init__(self, model_path, n_gpu_layers, context_tokens, verbose_logging):
+            self.model_path = model_path
+            self.n_gpu_layers = n_gpu_layers
+            self.context_tokens = context_tokens
+            self.verbose_logging = verbose_logging
+
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    mock_config.get.side_effect = lambda key, default=None: {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'paths.models_dir': str(tmp_path),
+        'model.use_mock': False,
+        'model.context_size': 65536,
+        'model.n_gpu_layers': 0,
+        'model.gpu_memory_headroom_percent': 0.1,
+        'model.enforce_gpu_memory_headroom': False,
+    }.get(key, default)
+    (tmp_path / 'Qwen3-8B-Q4_K_M.gguf').write_bytes(b'fake')
+    manager = ModelManager(mock_config)
+
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=UnsupportedLlama)):
+        assert manager.get_llm_instance() is None
+
+    assert 'Qwen3 64K context requires llama-cpp-python YaRN/RoPE kwargs' in manager.last_runtime_init_error

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4782,3 +4782,48 @@ def test_api_v1_stop_unregister_terminates_heartbeat_cleanly():
     relay_client.stop()
 
     assert relay_client._api_v1_heartbeat_thread is None
+
+
+def test_qwen_context_admission_uses_qwen_template_kwargs_without_llama_fallback(monkeypatch):
+    class QwenRuntime:
+        token_place_chat_template_kwargs = {'enable_thinking': False}
+        chat_format = 'llama-3'
+        def __init__(self):
+            self.template_kwargs = None
+            self.calls = []
+        def apply_chat_template(self, messages, **kwargs):
+            self.template_kwargs = kwargs
+            return '<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n'
+        def tokenize(self, payload, *args, **kwargs):
+            return [1, 2, 3]
+        def create_chat_completion(self, **kwargs):
+            self.calls.append(kwargs)
+            return {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+    manager = _AdmissionManager()
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.runtime = QwenRuntime()
+    manager.runtime_chat_template_kwargs = lambda: {'enable_thinking': False}
+    client = _api_v1_validation_client(manager)
+    monkeypatch.setattr(RelayClient, '_api_v1_llama_chat_format_module', MagicMock(side_effect=AssertionError('llama fallback used')))
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen', model_id='qwen3-8b-instruct', messages=[{'role': 'user', 'content': 'hi'}], options={}
+    )
+
+    assert 'message' in envelope['api_v1_response']
+    assert manager.runtime.template_kwargs['enable_thinking'] is False
+    assert manager.runtime.calls[0]['chat_template_kwargs'] == {'enable_thinking': False}
+
+
+def test_api_v1_rejects_think_blocks_from_runtime_output():
+    manager = _AdmissionManager()
+    manager.runtime.create_chat_completion = MagicMock(return_value={
+        'choices': [{'message': {'role': 'assistant', 'content': '<think>secret</think>final'}}]
+    })
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(client, manager, 'hi')
+
+    error = envelope['api_v1_response']['error']
+    assert error['code'] == 'compute_node_invalid_model_output'
+    assert '<think>' not in json.dumps(envelope)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -8,6 +8,7 @@ from utils.networking.http_requests_compat import requests
 import json
 import sys
 import importlib
+import inspect
 import subprocess
 import queue
 import signal
@@ -126,6 +127,28 @@ def _stdlib_safe_path_order(entries: Iterable[str]) -> list[str]:
 
 DESKTOP_RUNTIME_PROBE_ENV = 'TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON'
 _LLAMA_CPP_IMPORT_PATH_LOCK = Lock()
+
+
+def _callable_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
+    """Return whether a callable advertises support for a keyword argument."""
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD or name == kwarg
+        for name, parameter in signature.parameters.items()
+    )
+
+
+def _llama_init_supports_rope_yarn(Llama: Any) -> bool:
+    """llama-cpp-python exposes YaRN via rope_scaling_type/yarn_* Llama kwargs."""
+    required = (
+        'rope_scaling_type',
+        'yarn_ext_factor',
+        'yarn_orig_ctx',
+    )
+    return all(_callable_accepts_kwarg(Llama, kwarg) for kwarg in required)
 
 
 class LlamaCppInferenceRequestError(RuntimeError):
@@ -2083,16 +2106,26 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            self.llm = Llama(
-                                model_path=self.model_path,
-                                n_gpu_layers=n_gpu_layers,
-                                n_ctx=self.config.get('model.context_size', 8192),
-                                chat_format=self.config.get('model.chat_format', 'llama-3'),
-                                verbose=llama_cpp_verbose_logging_enabled(),
+                            llama_init_kwargs = self._llama_init_kwargs(Llama, n_gpu_layers)
+                            self.llm = Llama(**llama_init_kwargs)
+                            if self._runtime_chat_template_kwargs():
+                                setattr(
+                                    self.llm,
+                                    'token_place_chat_template_kwargs',
+                                    self._runtime_chat_template_kwargs(),
+                                )
+                            runtime_model_diagnostics = self._runtime_model_diagnostics(llama_init_kwargs)
+                            setattr(self.llm, 'token_place_model_diagnostics', runtime_model_diagnostics)
+                            self.log_info(
+                                "runtime_model "
+                                + " ".join(f"{key}={value}" for key, value in runtime_model_diagnostics.items())
                             )
                             compute_plan['n_gpu_layers'] = n_gpu_layers
                             compute_plan['context_tier'] = getattr(self, 'context_tier', '8k-fast')
-                            compute_plan['context_window_tokens'] = self.config.get('model.context_size', 8192)
+                            compute_plan['context_window_tokens'] = llama_init_kwargs.get(
+                                'n_ctx',
+                                self.config.get('model.context_size', 8192),
+                            )
                             compute_plan['kv_cache_device'] = (
                                 compute_plan['backend_used']
                                 if n_gpu_layers < 0
@@ -2144,6 +2177,72 @@ class ModelManager:
                             return None
 
         return self.llm
+
+    def _is_qwen_profile(self) -> bool:
+        return str(self.model_profile.get('provider') or '').lower() == 'qwen'
+
+    def runtime_chat_template_kwargs(self) -> Dict[str, Any]:
+        return self._runtime_chat_template_kwargs()
+
+    def _runtime_chat_template_kwargs(self) -> Dict[str, Any]:
+        if self._is_qwen_profile():
+            # Qwen3 GGUF/Jinja templates support enable_thinking; API v1 requires
+            # non-thinking output so context admission and generation share this flag.
+            return {'enable_thinking': False}
+        return {}
+
+    def _llama_init_kwargs(self, Llama: Any, n_gpu_layers: int) -> Dict[str, Any]:
+        context_tokens = int(self.config.get('model.context_size', 8192))
+        kwargs: Dict[str, Any] = {
+            'model_path': self.model_path,
+            'n_gpu_layers': n_gpu_layers,
+            'n_ctx': context_tokens,
+            'verbose': llama_cpp_verbose_logging_enabled(),
+        }
+        if self._is_qwen_profile():
+            # Do not pass chat_format='llama-3' for Qwen. Omitting chat_format lets
+            # llama-cpp-python use the GGUF tokenizer.chat_template/Jinja path.
+            # If the active 64K profile extends past Qwen3's native 32768 context,
+            # llama-cpp-python must advertise the exact YaRN/RoPE kwargs below.
+            rope_policy = self.model_profile.get('rope_scaling_policy') or {}
+            native_context = int(
+                self.model_profile.get('native_context_tokens') or context_tokens
+            )
+            if context_tokens > native_context:
+                if not _llama_init_supports_rope_yarn(Llama):
+                    raise RuntimeError(
+                        'Qwen3 64K context requires llama-cpp-python YaRN/RoPE kwargs '
+                        '(rope_scaling_type, yarn_ext_factor, yarn_orig_ctx), but this runtime '
+                        'does not advertise them'
+                    )
+                kwargs.update({
+                    'rope_scaling_type': rope_policy.get('type', 'yarn'),
+                    'yarn_ext_factor': float(rope_policy.get('factor', 2.0)),
+                    'yarn_orig_ctx': int(
+                        rope_policy.get('original_context_tokens', native_context)
+                    ),
+                })
+            return kwargs
+        kwargs['chat_format'] = self.config.get('model.chat_format', 'llama-3')
+        return kwargs
+
+    def _runtime_model_diagnostics(self, init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        rope_enabled = 'rope_scaling_type' in init_kwargs
+        return {
+            'active_model_id': self.api_model_id,
+            'active_profile_id': self.profile_id,
+            'gguf_filename': self.file_name,
+            'quantization': self.model_profile.get('quantization'),
+            'chat_template_mode': self.model_profile.get('chat_template_policy'),
+            'thinking_mode_disabled': self.model_profile.get('thinking_mode') == 'disabled',
+            'n_ctx': init_kwargs.get('n_ctx'),
+            'native_context_tokens': self.model_profile.get('native_context_tokens'),
+            'maximum_validated_context_tokens': self.model_profile.get('maximum_validated_context_tokens'),
+            'rope_yarn_enabled': rope_enabled,
+            'rope_yarn_factor': init_kwargs.get('yarn_ext_factor'),
+            'yarn_original_context': init_kwargs.get('yarn_orig_ctx'),
+        }
+
 
     def _close_llm_proxy(self, llm: Any) -> None:
         close = getattr(llm, 'close', None)

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -108,7 +108,7 @@ MODEL_PROFILES: Dict[str, ModelProfile] = {
         "aliases": [],
         "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
         "public_catalog": False,
-        "runnable": False,
+        "runnable": True,
     },
 }
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2465,7 +2465,10 @@ class RelayClient:
         if callable(apply_chat_template):
             try:
                 rendered = apply_chat_template(
-                    messages, tokenize=False, add_generation_prompt=True
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                    **getattr(llm_instance, "token_place_chat_template_kwargs", {}),
                 )
             except TypeError:
                 try:
@@ -2487,12 +2490,20 @@ class RelayClient:
             if callable(tokenizer_template):
                 try:
                     rendered = tokenizer_template(
-                        messages, tokenize=False, add_generation_prompt=True
+                        messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        **getattr(llm_instance, "token_place_chat_template_kwargs", {}),
                     )
                 except Exception:
                     rendered = None
                 if isinstance(rendered, str):
                     return rendered
+        if getattr(llm_instance, "token_place_chat_template_kwargs", None):
+            # Qwen must use the GGUF/Jinja template path with enable_thinking=False;
+            # falling back to llama_cpp.llama_chat_format would silently select a
+            # Llama formatter and desynchronise context admission from generation.
+            return None
         try:
             if not hasattr(llm_instance, "chat_format"):
                 return None
@@ -2722,6 +2733,16 @@ class RelayClient:
             "stream": False,
         }
         completion_kwargs.update(safe_options)
+        template_kwargs = getattr(self.model_manager, "runtime_chat_template_kwargs", None)
+        if callable(template_kwargs):
+            template_kwargs = template_kwargs()
+        else:
+            runtime = getattr(self.model_manager, "runtime", None)
+            template_kwargs = getattr(runtime, "token_place_chat_template_kwargs", None)
+        if template_kwargs:
+            # llama-cpp-python passes chat_template_kwargs through to the GGUF/Jinja
+            # renderer. Qwen3 API v1 requires enable_thinking=False.
+            completion_kwargs["chat_template_kwargs"] = dict(template_kwargs)
         return completion_kwargs
 
     def _assistant_message_from_runtime_completion(
@@ -2895,6 +2916,20 @@ class RelayClient:
                 )
                 assistant_message = self._assistant_message_from_runtime_completion(
                     completion
+                )
+
+            if (
+                assistant_message is not None
+                and isinstance(assistant_message.get("content"), str)
+                and "<think" in assistant_message["content"].lower()
+            ):
+                log_error("Desktop runtime returned disallowed Qwen thinking content")
+                return self._api_v1_response_envelope(
+                    request_id,
+                    error={
+                        "code": "compute_node_invalid_model_output",
+                        "message": "Desktop runtime returned invalid assistant output",
+                    },
                 )
 
             if assistant_message is None:


### PR DESCRIPTION
### Motivation
- Make the Qwen3-8B-Q4_K_M model profile actually runnable for API v1 while keeping Llama as the published/default model. 
- Ensure API v1 exact context admission and generation use the same Qwen chat-template policy (GGUF/Jinja) and prevent accidental Llama-format fallbacks. 
- Enforce non-thinking operation for Qwen (no `<think>` content) and add safe failure/sanitisation when thinking blocks are present. 
- Support 64K extended contexts for Qwen only when llama-cpp-python advertises YaRN/RoPE kwargs, and fail warm-load when required kwargs are missing. 

### Description
- Added runtime capability probes and helpers in `utils/llm/model_manager.py` to detect whether the imported `Llama` callable accepts YaRN/RoPE kwargs and to build safe init kwargs via `_llama_init_kwargs`, omitting `chat_format` for Qwen and attaching `token_place_chat_template_kwargs` and `token_place_model_diagnostics` to the runtime instance. 
- Implemented explicit YaRN/RoPE wiring for Qwen 64K: when active context > native (65536 > 32768) and `rope_scaling_policy` requires it, the manager sets `rope_scaling_type`, `yarn_ext_factor=2.0`, and `yarn_orig_ctx=32768`; if the runtime does not advertise the required kwargs the init fails with a clear error. 
- Stopped forcing the Llama chat template path for Qwen by changing the template render/tokenize paths in `utils/networking/relay_client.py` to pass `token_place_chat_template_kwargs` to `apply_chat_template`/tokenizer and to short-circuit llama_cpp fallback when the runtime indicates Qwen-specific template kwargs are present. 
- Enforced non-thinking behavior: set `enable_thinking=False` for Qwen template kwargs and add a runtime validation in `relay_client` to reject API v1 assistant outputs that include `<think>` blocks with an API-style `compute_node_invalid_model_output` failure. 
- Added runtime diagnostics metadata emitted on init, including active profile id, GGUF filename, `n_ctx`, native/max tokens, `rope_yarn_enabled`/factor/original context, and thinking-mode flag without logging any prompt/text. 
- Kept Llama defaults and behavior unchanged; Qwen is runnable but remains non-public by profile settings until a later change updates platform defaults. 
- Tests and small test harness changes: added unit tests to `tests/unit/test_model_manager.py` and `tests/unit/test_relay_client.py` covering Qwen init (8K/64K), YaRN wiring and fail-closed behaviour, context-admission template alignment, and `<think>` rejection; updated minimal catalog test `tests/unit/test_api_v1_models_catalog_minimal.py` to reflect the Qwen profile being runnable but not public. 

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_model_manager.py -q` (passed) and `python -m pytest tests/unit/test_relay_client.py -q` (passed). 
- Ran integration tests: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed). 
- Ran profile/context tests: `python -m pytest tests/unit/test_context_profiles.py -q` (passed) and `python -m pytest tests/unit/test_api_v1_models_catalog_minimal.py -q` (passed). 
- Ran combined regression checks: `python -m pytest tests/unit/test_model_manager.py tests/unit/test_relay_client.py tests/unit/test_api_v1_models_catalog_minimal.py -q` (passed). 
- Repository hygiene: `git diff --check` (no issues) and `pre-commit run --all-files` (passed). 

All automated tests mentioned above succeeded in the local verification run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40df837a94832fbe41b44ec9b7f7e9)