### PR TITLE
Add Qwen3 runtime support: GGUF template, non-thinking mode, and 64K YaRN/RoPE

### DIFF
--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -53,7 +53,7 @@ def test_qwen3_profile_exists_but_is_not_public_catalog_default():
     assert qwen["license"] == "apache-2.0"
     assert qwen["parameters"] == "8.2B"
     assert qwen["native_context_tokens"] == 32768
-    assert qwen["maximum_validated_context_tokens"] == 131072
+    assert qwen["maximum_validated_context_tokens"] == 65536
     assert qwen["supported_context_tiers"] == ["8k-fast", "64k-full"]
     assert qwen["thinking_mode"] == "disabled"
     assert qwen["chat_template_policy"] == "gguf-jinja"
@@ -64,7 +64,7 @@ def test_qwen3_profile_exists_but_is_not_public_catalog_default():
         "original_context_tokens": 32768,
     }
     assert qwen["public_catalog"] is False
-    assert qwen["runnable"] is False
+    assert qwen["runnable"] is True
     assert [profile["api_model_id"] for profile in iter_model_profiles(public_only=True)] == [
         "llama-3.1-8b-instruct"
     ]

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -245,7 +245,7 @@ class TestModelManager:
         assert metadata['source_model'] == 'Qwen/Qwen3-8B'
         assert metadata['quantization'] == 'Q4_K_M'
         assert metadata['native_context_tokens'] == 32768
-        assert metadata['maximum_validated_context_tokens'] == 131072
+        assert metadata['maximum_validated_context_tokens'] == 65536
         assert metadata['supported_context_tiers'] == ['8k-fast', '64k-full']
 
     def test_api_model_id_selection_resolves_qwen_profile_artifacts(self):
@@ -4008,3 +4008,102 @@ def test_get_llm_instance_with_recovery_attempts_replacement_when_unavailable(st
     assert standalone_model_manager.get_llm_instance_with_recovery() is replacement
     standalone_model_manager.get_llm_instance.assert_called_once_with()
     standalone_model_manager._ensure_replacement_llm.assert_called_once_with(7)
+
+
+def _qwen_manager(tmp_path, context_size=8192, tier="8k-fast"):
+    model_path = tmp_path / "Qwen3-8B-Q4_K_M.gguf"
+    model_path.write_bytes(b"fake")
+    config = MagicMock()
+    config.is_production = False
+    values = {
+        "model.profile_id": "qwen3-8b-q4-k-m",
+        "model.download_chunk_size_mb": 1,
+        "paths.models_dir": str(tmp_path),
+        "model.use_mock": False,
+        "model.n_gpu_layers": 0,
+        "model.gpu_memory_headroom_percent": 0.1,
+        "model.enforce_gpu_memory_headroom": False,
+        "model.context_size": context_size,
+        "model.chat_format": "llama-3",
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    manager = ModelManager(config)
+    manager.context_tier = tier
+    manager.context_window_tokens = context_size
+    return manager
+
+
+class _SupportedLlama:
+    def __init__(
+        self,
+        *,
+        model_path,
+        n_gpu_layers=0,
+        n_ctx=512,
+        chat_format=None,
+        rope_scaling_type=-1,
+        yarn_ext_factor=-1.0,
+        yarn_orig_ctx=0,
+        verbose=True,
+    ):
+        self._init_args = (model_path, n_gpu_layers, n_ctx, chat_format, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx, verbose)
+
+
+class _NoYarnLlama:
+    def __init__(self, *, model_path, n_gpu_layers=0, n_ctx=512, chat_format=None, verbose=True):
+        self._init_args = (model_path, n_gpu_layers, n_ctx, chat_format, verbose)
+
+
+def test_qwen_8k_runtime_init_uses_gguf_template_without_yarn(tmp_path):
+    manager = _qwen_manager(tmp_path, context_size=8192, tier="8k-fast")
+
+    kwargs = manager._build_llama_init_kwargs(_SupportedLlama, n_gpu_layers=0)
+
+    assert kwargs["chat_format"] is None
+    assert "rope_scaling_type" not in kwargs
+    assert "yarn_ext_factor" not in kwargs
+    assert manager.last_runtime_model_diagnostics["rope_yarn_enabled"] is False
+    assert manager.last_runtime_model_diagnostics["chat_template_mode"] == "gguf-jinja"
+
+
+def test_qwen_64k_runtime_init_enables_yarn_factor_two(tmp_path):
+    manager = _qwen_manager(tmp_path, context_size=65536, tier="64k-full")
+
+    kwargs = manager._build_llama_init_kwargs(_SupportedLlama, n_gpu_layers=0)
+
+    assert kwargs["chat_format"] is None
+    assert kwargs["rope_scaling_type"] == 2
+    assert kwargs["yarn_ext_factor"] == 2.0
+    assert kwargs["yarn_orig_ctx"] == 32768
+    assert manager.last_runtime_model_diagnostics["rope_yarn_enabled"] is True
+
+
+def test_qwen_64k_runtime_init_fails_when_yarn_kwargs_unsupported(tmp_path):
+    manager = _qwen_manager(tmp_path, context_size=65536, tier="64k-full")
+
+    with pytest.raises(RuntimeError, match="YaRN/RoPE kwargs"):
+        manager._build_llama_init_kwargs(_NoYarnLlama, n_gpu_layers=0)
+
+
+def test_llama_runtime_init_still_forces_configured_llama_chat_format(tmp_path):
+    model_path = tmp_path / "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+    model_path.write_bytes(b"fake")
+    config = MagicMock()
+    config.is_production = False
+    values = {
+        "model.download_chunk_size_mb": 1,
+        "paths.models_dir": str(tmp_path),
+        "model.use_mock": False,
+        "model.n_gpu_layers": 0,
+        "model.gpu_memory_headroom_percent": 0.1,
+        "model.enforce_gpu_memory_headroom": False,
+        "model.context_size": 8192,
+        "model.chat_format": "llama-3",
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    manager = ModelManager(config)
+
+    kwargs = manager._build_llama_init_kwargs(_SupportedLlama, n_gpu_layers=0)
+
+    assert kwargs["chat_format"] == "llama-3"
+    assert "yarn_ext_factor" not in kwargs

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4782,3 +4782,118 @@ def test_api_v1_stop_unregister_terminates_heartbeat_cleanly():
     relay_client.stop()
 
     assert relay_client._api_v1_heartbeat_thread is None
+
+
+def test_api_v1_qwen_context_admission_uses_enable_thinking_not_llama_fallback(monkeypatch):
+    calls = []
+
+    class QwenRuntime:
+        def apply_chat_template(self, messages, **kwargs):
+            calls.append((messages, kwargs))
+            return "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n"
+
+        def tokenize(self, content, add_bos=False):
+            return [1, 2, 3]
+
+    client = RelayClient.__new__(RelayClient)
+    client.model_manager = SimpleNamespace(
+        context_tier="8k-fast",
+        context_window_tokens=8192,
+        model_profile={"provider": "qwen", "thinking_mode": "disabled"},
+    )
+    monkeypatch.setattr(RelayClient, "_api_v1_llama_chat_format_module", MagicMock())
+
+    admitted, error, prompt_tokens = client._api_v1_authoritative_context_admission(
+        llm_instance=QwenRuntime(),
+        messages=[{"role": "user", "content": "hi"}],
+        requested_output_tokens=10,
+        requested_context_tier="8k-fast",
+    )
+
+    assert admitted is True
+    assert error is None
+    assert prompt_tokens == 3
+    assert calls[0][1]["enable_thinking"] is False
+    RelayClient._api_v1_llama_chat_format_module.assert_not_called()
+
+
+def test_api_v1_qwen_template_falls_back_to_no_think_without_llama_formatter(monkeypatch):
+    calls = []
+
+    class QwenRuntime:
+        def apply_chat_template(self, messages, **kwargs):
+            calls.append((messages, kwargs))
+            if "enable_thinking" in kwargs:
+                raise TypeError("unsupported kw")
+            return messages[-1]["content"]
+
+    monkeypatch.setattr(RelayClient, "_api_v1_llama_chat_format_module", MagicMock())
+    rendered = RelayClient._api_v1_render_chat_prompt(
+        QwenRuntime(),
+        [{"role": "user", "content": "hi"}],
+        model_profile={"provider": "qwen", "thinking_mode": "disabled"},
+    )
+
+    assert rendered.endswith("/no_think")
+    RelayClient._api_v1_llama_chat_format_module.assert_not_called()
+
+
+def test_api_v1_rejects_think_blocks_from_runtime_output():
+    message = RelayClient._assistant_message_from_runtime_completion(
+        RelayClient.__new__(RelayClient),
+        {"choices": [{"message": {"role": "assistant", "content": "<think>secret</think> answer"}}]},
+    )
+
+    assert message is None
+
+
+def test_api_v1_qwen_generation_defaults_include_top_k():
+    client = RelayClient.__new__(RelayClient)
+    client.model_manager = SimpleNamespace(
+        config=SimpleNamespace(get=lambda key, default=None: default),
+        model_profile={"generation_defaults": {"temperature": 0.7, "top_p": 0.8, "top_k": 20}},
+    )
+
+    kwargs = client._api_v1_runtime_completion_kwargs({})
+
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] == 0.8
+    assert kwargs["top_k"] == 20
+
+
+def test_api_v1_qwen_generation_messages_include_no_think_control():
+    completion_calls = []
+
+    class Runtime:
+        def apply_chat_template(self, messages, **kwargs):
+            return "rendered"
+
+        def tokenize(self, content, add_bos=False):
+            return [1]
+
+        def create_chat_completion(self, **kwargs):
+            completion_calls.append(kwargs)
+            return {"choices": [{"message": {"role": "assistant", "content": "answer"}}]}
+
+    client = RelayClient.__new__(RelayClient)
+    runtime = Runtime()
+    client.model_manager = SimpleNamespace(
+        config=SimpleNamespace(get=lambda key, default=None: default),
+        context_tier="8k-fast",
+        context_window_tokens=8192,
+        model_profile={"provider": "qwen", "thinking_mode": "disabled", "generation_defaults": {}},
+        get_llm_instance=lambda: runtime,
+        create_chat_completion_with_recovery=None,
+    )
+    client._runtime_model_can_satisfy = lambda model_id: True
+
+    response = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-no-think",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={},
+        requested_context_tier="8k-fast",
+    )
+
+    assert response["api_v1_response"]["message"]["content"] == "answer"
+    assert completion_calls[0]["messages"][-1]["content"].endswith("/no_think")

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -8,6 +8,7 @@ from utils.networking.http_requests_compat import requests
 import json
 import sys
 import importlib
+import inspect
 import subprocess
 import queue
 import signal
@@ -20,6 +21,7 @@ from typing import Dict, List, Any, Optional, Iterable
 
 from utils.system import resource_monitor
 from utils.llm.model_profiles import get_model_profile, resolve_profile_id
+from utils.context_profiles import normalize_context_tier
 
 # Configure logging
 logger = logging.getLogger('model_manager')
@@ -1830,6 +1832,88 @@ class ModelManager:
             'size_bytes': os.path.getsize(self.model_path) if file_exists else None,
         }
 
+    def _llama_init_supported_kwargs(self, Llama: Any) -> set[str]:
+        """Return explicitly supported llama-cpp-python Llama init keyword names."""
+
+        try:
+            signature = inspect.signature(Llama)
+        except (TypeError, ValueError):
+            return set()
+        return {
+            name for name, parameter in signature.parameters.items()
+            if parameter.kind in {
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            }
+        }
+
+    def _build_llama_init_kwargs(self, Llama: Any, n_gpu_layers: int) -> Dict[str, Any]:
+        """Build runtime init kwargs with profile-specific template/RoPE policy.
+
+        The current inspected llama-cpp-python API exposes YaRN/RoPE as
+        ``rope_scaling_type``, ``yarn_ext_factor`` and ``yarn_orig_ctx``.  It also
+        accepts ``chat_format=None`` so GGUF/Jinja chat templates can be used by
+        create_chat_completion instead of forcing a Llama formatter.  Qwen3 is
+        therefore initialized without ``chat_format='llama-3'`` and fails closed
+        when required YaRN kwargs cannot be verified.
+        """
+
+        supported = self._llama_init_supported_kwargs(Llama)
+        n_ctx = int(self.config.get('model.context_size', 8192))
+        init_kwargs: Dict[str, Any] = {
+            'model_path': self.model_path,
+            'n_gpu_layers': n_gpu_layers,
+            'n_ctx': n_ctx,
+            'verbose': llama_cpp_verbose_logging_enabled(),
+        }
+        provider = str(self.model_profile.get('provider', '')).lower()
+        if provider == 'qwen':
+            # Qwen3 GGUFs carry a Jinja chat template.  llama-cpp-python uses
+            # the GGUF template automatically when chat_format is omitted/None;
+            # setting llama-3 here would silently render the wrong protocol.
+            if 'chat_format' in supported:
+                init_kwargs['chat_format'] = None
+        else:
+            init_kwargs['chat_format'] = self.config.get('model.chat_format', 'llama-3')
+
+        native_context = int(self.model_profile.get('native_context_tokens') or n_ctx)
+        rope_policy = self.model_profile.get('rope_scaling_policy') or {}
+        context_tier = normalize_context_tier(getattr(self, 'context_tier', '8k-fast'))
+        rope_enabled = (
+            provider == 'qwen'
+            and context_tier == rope_policy.get('required_for_tier')
+            and n_ctx > native_context
+        )
+        if rope_enabled:
+            required = {'rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx'}
+            missing = sorted(required - supported)
+            if missing:
+                raise RuntimeError(
+                    "Qwen 64K context requires llama-cpp-python YaRN/RoPE kwargs "
+                    f"that are unavailable: {', '.join(missing)}"
+                )
+            init_kwargs.update({
+                # llama.cpp enum value 2 is LLAMA_ROPE_SCALING_TYPE_YARN.
+                'rope_scaling_type': 2,
+                'yarn_ext_factor': float(rope_policy.get('factor', 2.0)),
+                'yarn_orig_ctx': int(rope_policy.get('original_context_tokens', native_context)),
+            })
+        self.last_runtime_model_diagnostics = {
+            'active_model_id': self.api_model_id,
+            'active_profile_id': self.profile_id,
+            'gguf_filename': self.file_name,
+            'quantization': self.model_profile.get('quantization'),
+            'chat_template_mode': self.model_profile.get('chat_template_policy'),
+            'thinking_mode_disabled': self.model_profile.get('thinking_mode') == 'disabled',
+            'n_ctx': n_ctx,
+            'native_context_tokens': native_context,
+            'maximum_validated_context_tokens': self.model_profile.get('maximum_validated_context_tokens'),
+            'rope_yarn_enabled': rope_enabled,
+            'rope_yarn_factor': init_kwargs.get('yarn_ext_factor'),
+            'yarn_original_context': init_kwargs.get('yarn_orig_ctx'),
+        }
+        return init_kwargs
+
     def _log(self, level: int, message: str, **kwargs) -> None:
         """Log a message when not in production."""
         if self.config.is_production:
@@ -2083,16 +2167,12 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            self.llm = Llama(
-                                model_path=self.model_path,
-                                n_gpu_layers=n_gpu_layers,
-                                n_ctx=self.config.get('model.context_size', 8192),
-                                chat_format=self.config.get('model.chat_format', 'llama-3'),
-                                verbose=llama_cpp_verbose_logging_enabled(),
-                            )
+                            llama_init_kwargs = self._build_llama_init_kwargs(Llama, n_gpu_layers)
+                            self.llm = Llama(**llama_init_kwargs)
                             compute_plan['n_gpu_layers'] = n_gpu_layers
                             compute_plan['context_tier'] = getattr(self, 'context_tier', '8k-fast')
                             compute_plan['context_window_tokens'] = self.config.get('model.context_size', 8192)
+                            compute_plan['runtime_model'] = getattr(self, 'last_runtime_model_diagnostics', {})
                             compute_plan['kv_cache_device'] = (
                                 compute_plan['backend_used']
                                 if n_gpu_layers < 0
@@ -2111,6 +2191,21 @@ class ModelManager:
                                 }
                             else:
                                 runtime_identity = self._runtime_capabilities()
+                            self.log_info(
+                                "model_runtime "
+                                f"active_model_id={self.api_model_id} "
+                                f"profile_id={self.profile_id} "
+                                f"gguf_filename={self.file_name} "
+                                f"quantization={self.model_profile.get('quantization')} "
+                                f"chat_template_mode={self.model_profile.get('chat_template_policy')} "
+                                f"thinking_mode_disabled={self.model_profile.get('thinking_mode') == 'disabled'} "
+                                f"n_ctx={llama_init_kwargs.get('n_ctx')} "
+                                f"native_context_tokens={self.model_profile.get('native_context_tokens')} "
+                                f"maximum_validated_context_tokens={self.model_profile.get('maximum_validated_context_tokens')} "
+                                f"rope_yarn_enabled={getattr(self, 'last_runtime_model_diagnostics', {}).get('rope_yarn_enabled')} "
+                                f"rope_yarn_factor={getattr(self, 'last_runtime_model_diagnostics', {}).get('rope_yarn_factor')} "
+                                f"yarn_original_context={getattr(self, 'last_runtime_model_diagnostics', {}).get('yarn_original_context')}"
+                            )
                             self.log_info(
                                 "compute_runtime "
                                 f"requested={compute_plan['requested_mode']} "

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -99,7 +99,7 @@ MODEL_PROFILES: Dict[str, ModelProfile] = {
         "download_url": "https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf",
         "canonical_family_url": "https://huggingface.co/Qwen/Qwen3-8B",
         "native_context_tokens": 32768,
-        "maximum_validated_context_tokens": 131072,
+        "maximum_validated_context_tokens": 65536,
         "default_context_tokens": 8192,
         "supported_context_tiers": ["8k-fast", "64k-full"],
         "chat_template_policy": "gguf-jinja",
@@ -108,7 +108,7 @@ MODEL_PROFILES: Dict[str, ModelProfile] = {
         "aliases": [],
         "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
         "public_catalog": False,
-        "runnable": False,
+        "runnable": True,
     },
 }
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1892,6 +1892,8 @@ class RelayClient:
         content = message.get("content")
         tool_calls = message.get("tool_calls")
         if isinstance(content, str) and content.strip():
+            if re.search(r"<think\b", content, flags=re.IGNORECASE):
+                return None
             return dict(message)
         if isinstance(tool_calls, list) and tool_calls:
             return dict(message)
@@ -2458,18 +2460,34 @@ class RelayClient:
         return None
 
     @staticmethod
-    def _api_v1_render_chat_prompt(llm_instance: Any, messages: List[Dict[str, Any]]) -> Optional[str]:
+    def _api_v1_render_chat_prompt(
+        llm_instance: Any,
+        messages: List[Dict[str, Any]],
+        *,
+        model_profile: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
         """Render chat messages with the active runtime chat template."""
+
+        provider = str((model_profile or {}).get("provider") or "").lower()
+        template_kwargs = {"tokenize": False, "add_generation_prompt": True}
+        if (model_profile or {}).get("thinking_mode") == "disabled":
+            # llama-cpp-python forwards extra kwargs to the GGUF/Jinja template
+            # when supported. Qwen3 templates understand enable_thinking=False;
+            # older runtimes raise TypeError and are retried below with /no_think.
+            template_kwargs["enable_thinking"] = False
 
         apply_chat_template = getattr(llm_instance, "apply_chat_template", None)
         if callable(apply_chat_template):
             try:
-                rendered = apply_chat_template(
-                    messages, tokenize=False, add_generation_prompt=True
-                )
+                rendered = apply_chat_template(messages, **template_kwargs)
             except TypeError:
                 try:
-                    rendered = apply_chat_template(messages)
+                    rendered = apply_chat_template(
+                        RelayClient._api_v1_qwen_no_think_messages(messages)
+                        if provider == "qwen" else messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                    )
                 except Exception:
                     rendered = None
             except Exception:
@@ -2486,13 +2504,24 @@ class RelayClient:
             tokenizer_template = getattr(tokenizer, "apply_chat_template", None)
             if callable(tokenizer_template):
                 try:
-                    rendered = tokenizer_template(
-                        messages, tokenize=False, add_generation_prompt=True
-                    )
+                    rendered = tokenizer_template(messages, **template_kwargs)
+                except TypeError:
+                    try:
+                        rendered = tokenizer_template(
+                            RelayClient._api_v1_qwen_no_think_messages(messages)
+                            if provider == "qwen" else messages,
+                            tokenize=False,
+                            add_generation_prompt=True,
+                        )
+                    except Exception:
+                        rendered = None
                 except Exception:
                     rendered = None
                 if isinstance(rendered, str):
                     return rendered
+        if provider == "qwen":
+            # Qwen must not fall back to llama_cpp.llama_chat_format format_llama3.
+            return None
         try:
             if not hasattr(llm_instance, "chat_format"):
                 return None
@@ -2515,6 +2544,19 @@ class RelayClient:
         except Exception:
             return None
         return None
+
+    @staticmethod
+    def _api_v1_qwen_no_think_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Inject a minimal Qwen-supported non-thinking control without logging content."""
+
+        prepared = [dict(message) for message in messages]
+        for message in reversed(prepared):
+            if message.get("role") == "user" and isinstance(message.get("content"), str):
+                content = message["content"]
+                if "/no_think" not in content:
+                    message["content"] = f"{content}\n/no_think"
+                return prepared
+        return [{"role": "user", "content": "/no_think"}] + prepared
 
     @staticmethod
     def _api_v1_llama_chat_format_module() -> Any:
@@ -2643,7 +2685,11 @@ class RelayClient:
             )
             or active_profile.total_context_tokens
         )
-        rendered_prompt = self._api_v1_render_chat_prompt(llm_instance, messages)
+        rendered_prompt = self._api_v1_render_chat_prompt(
+            llm_instance,
+            messages,
+            model_profile=getattr(self.model_manager, "model_profile", None),
+        )
         prompt_tokens = (
             self._api_v1_tokenize_rendered_prompt(llm_instance, rendered_prompt)
             if rendered_prompt is not None
@@ -2721,6 +2767,13 @@ class RelayClient:
             "stop": configured("model.stop_tokens", []),
             "stream": False,
         }
+        profile_defaults = getattr(self.model_manager, "model_profile", {}).get(
+            "generation_defaults", {}
+        )
+        if isinstance(profile_defaults, dict):
+            for key in ("temperature", "top_p", "top_k"):
+                if key in profile_defaults:
+                    completion_kwargs[key] = profile_defaults[key]
         completion_kwargs.update(safe_options)
         return completion_kwargs
 
@@ -2826,6 +2879,17 @@ class RelayClient:
             )
 
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
+        active_model_profile = getattr(self.model_manager, "model_profile", {})
+        if (
+            active_model_profile.get("thinking_mode") == "disabled"
+            and str(active_model_profile.get("provider") or "").lower() == "qwen"
+        ):
+            # create_chat_completion does not expose Qwen's enable_thinking
+            # template kwarg in the inspected llama-cpp-python API, so generation
+            # uses Qwen's documented /no_think message control. Context admission
+            # receives the same runtime_messages and additionally passes
+            # enable_thinking=False when template rendering supports it.
+            runtime_messages = self._api_v1_qwen_no_think_messages(runtime_messages)
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             llm_instance = get_llm_instance() if callable(get_llm_instance) else None


### PR DESCRIPTION
### Motivation
- Enable the Qwen3-8B-Q4_K_M profile to be runnable via the API v1 desktop runtime while keeping Llama as the default/catalog model.
- Ensure context admission and generation use the same chat-template policy and enforce a non-thinking mode so no `<think>` reasoning leaks to clients.
- Add verified YaRN/RoPE support for the Qwen 64K context tier and fail early when the runtime does not support required kwargs.

### Description
- Marked the Qwen3 profile runnable and adjusted its validated context ceiling to 64K in `utils/llm/model_profiles.py` while leaving it out of the public/default catalogue. 
- Added `ModelManager._llama_init_supported_kwargs` and `_build_llama_init_kwargs` which inspect the imported `llama_cpp.Llama` signature, prefer GGUF/Jinja templates for Qwen (do not force `chat_format='llama-3'`), and gate YaRN/RoPE init kwargs (`rope_scaling_type`, `yarn_ext_factor`, `yarn_orig_ctx`) with a fail-fast error when unavailable. (Changes in `utils/llm/model_manager.py`.)
- Aligned API v1 context admission and generation template handling in `utils/networking/relay_client.py` by attempting `enable_thinking=False` on template rendering, preventing fallback to Llama-format templates for Qwen, and injecting a `/no_think` control into generation messages when the inspected `create_chat_completion` does not expose the enable_thinking API; generation also uses profile-driven defaults (`temperature`, `top_p`, `top_k`).
- Added runtime output protection rejecting assistant outputs that contain `<think>` blocks (treated as invalid model output) and added startup/runtime diagnostics for active model id/profile, GGUF filename, quantization, chat template mode, thinking enforcement, `n_ctx`, native/max context tokens, and yarn/rope flags.
- Tests: added unit tests that verify Qwen 8K/64K init kwargs and behavior, that Qwen 64K fails when YaRN kwargs are unsupported, that Qwen does not use the Llama chat template for admission, that `/no_think` injection or `enable_thinking=False` handling is applied, that `<think>` output is rejected, and that generation defaults are applied; preserved and exercised existing Llama behavior.

### Testing
- Ran unit and integration suites: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, and `python -m pytest tests/unit/test_api_v1_models_catalog_minimal.py -q`, all of which passed in the CI-like local runs reported above.
- Ran repository checks: `pre-commit run --all-files` and `git diff --check`, both completed successfully after fixes; vulture issues spotted during iteration were resolved before commit.
- The runtime was probed to inspect `llama_cpp.Llama` and `create_chat_completion` signatures to determine supported kwargs, and tests use fakes/mocks where a real llama_cpp runtime is not available; these verification steps passed in the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40df6efe18832fab26d11cc3023711)