### PR TITLE
Implement Qwen3 runtime support: GGUF/Jinja templates, enforced non-thinking, and 64K YaRN/RoPE

### DIFF
--- a/tests/unit/test_api_v1_models_catalog_minimal.py
+++ b/tests/unit/test_api_v1_models_catalog_minimal.py
@@ -53,7 +53,7 @@ def test_qwen3_profile_exists_but_is_not_public_catalog_default():
     assert qwen["license"] == "apache-2.0"
     assert qwen["parameters"] == "8.2B"
     assert qwen["native_context_tokens"] == 32768
-    assert qwen["maximum_validated_context_tokens"] == 131072
+    assert qwen["maximum_validated_context_tokens"] == 65536
     assert qwen["supported_context_tiers"] == ["8k-fast", "64k-full"]
     assert qwen["thinking_mode"] == "disabled"
     assert qwen["chat_template_policy"] == "gguf-jinja"
@@ -64,7 +64,7 @@ def test_qwen3_profile_exists_but_is_not_public_catalog_default():
         "original_context_tokens": 32768,
     }
     assert qwen["public_catalog"] is False
-    assert qwen["runnable"] is False
+    assert qwen["runnable"] is True
     assert [profile["api_model_id"] for profile in iter_model_profiles(public_only=True)] == [
         "llama-3.1-8b-instruct"
     ]

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -245,7 +245,7 @@ class TestModelManager:
         assert metadata['source_model'] == 'Qwen/Qwen3-8B'
         assert metadata['quantization'] == 'Q4_K_M'
         assert metadata['native_context_tokens'] == 32768
-        assert metadata['maximum_validated_context_tokens'] == 131072
+        assert metadata['maximum_validated_context_tokens'] == 65536
         assert metadata['supported_context_tiers'] == ['8k-fast', '64k-full']
 
     def test_api_model_id_selection_resolves_qwen_profile_artifacts(self):
@@ -1298,6 +1298,166 @@ def standalone_model_manager(tmp_path):
 
     mock_config.get.side_effect = _get
     return ModelManager(mock_config)
+
+
+def _qwen_model_manager(tmp_path, *, context_size=8192, context_tier="8k-fast"):
+    from utils.context_profiles import apply_context_profile
+
+    mock_config = MagicMock()
+    mock_config.is_production = False
+    model_file = tmp_path / 'Qwen3-8B-Q4_K_M.gguf'
+    model_file.write_bytes(b'fake model data')
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.download_chunk_size_mb': 1,
+        'paths.models_dir': str(tmp_path),
+        'model.use_mock': False,
+        'model.context_size': context_size,
+        'model.chat_format': 'llama-3',
+        'model.n_gpu_layers': 0,
+        'model.hybrid_n_gpu_layers': 24,
+        'model.gpu_memory_headroom_percent': 0.1,
+        'model.enforce_gpu_memory_headroom': False,
+    }
+
+    def _get(key, default=None):
+        return values.get(key, default)
+
+    def _set(key, value):
+        values[key] = value
+
+    mock_config.get.side_effect = _get
+    mock_config.set.side_effect = _set
+    manager = ModelManager(mock_config)
+    apply_context_profile(manager, context_tier)
+    if context_size != manager.config.get('model.context_size'):
+        manager.config.set('model.context_size', context_size)
+        manager.context_window_tokens = context_size
+    manager.requested_compute_mode = 'cpu'
+    return manager
+
+
+def test_qwen_runtime_init_omits_llama_chat_format_for_gguf_template(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    captured = {}
+
+    class FakeLlama:
+        def __init__(self, *, model_path, n_gpu_layers, n_ctx, verbose):
+            captured.update({
+                'model_path': model_path,
+                'n_gpu_layers': n_gpu_layers,
+                'n_ctx': n_ctx,
+                'verbose': verbose,
+            })
+
+    monkeypatch.setattr(
+        model_manager_module,
+        '_import_llama_cpp_runtime',
+        lambda **_kwargs: SimpleNamespace(Llama=FakeLlama, __file__='/site/llama_cpp/__init__.py'),
+    )
+    manager = _qwen_model_manager(tmp_path)
+
+    assert manager.get_llm_instance() is not None
+    assert 'chat_format' not in captured
+    assert captured['n_ctx'] == 8192
+    assert manager.last_compute_diagnostics['chat_template_mode'] == 'gguf-jinja'
+    assert manager.last_compute_diagnostics['thinking_mode_disabled'] is True
+    assert manager.last_compute_diagnostics['rope_yarn_enabled'] is False
+
+
+def test_qwen_64k_runtime_init_enables_yarn_rope_kwargs(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    captured = {}
+
+    class FakeLlama:
+        def __init__(
+            self,
+            *,
+            model_path,
+            n_gpu_layers,
+            n_ctx,
+            verbose,
+            rope_scaling_type,
+            rope_freq_scale,
+            yarn_ext_factor,
+            yarn_orig_ctx,
+        ):
+            captured.update({
+                'model_path': model_path,
+                'n_gpu_layers': n_gpu_layers,
+                'n_ctx': n_ctx,
+                'verbose': verbose,
+                'rope_scaling_type': rope_scaling_type,
+                'rope_freq_scale': rope_freq_scale,
+                'yarn_ext_factor': yarn_ext_factor,
+                'yarn_orig_ctx': yarn_orig_ctx,
+            })
+
+    monkeypatch.setattr(
+        model_manager_module,
+        '_import_llama_cpp_runtime',
+        lambda **_kwargs: SimpleNamespace(
+            Llama=FakeLlama,
+            LLAMA_ROPE_SCALING_TYPE_YARN=2,
+            __file__='/site/llama_cpp/__init__.py',
+        ),
+    )
+    manager = _qwen_model_manager(tmp_path, context_size=65536, context_tier='64k-full')
+
+    assert manager.get_llm_instance() is not None
+    assert captured['rope_scaling_type'] == 2
+    assert captured['rope_freq_scale'] == 0.5
+    assert captured['yarn_ext_factor'] == 2.0
+    assert captured['yarn_orig_ctx'] == 32768
+    assert manager.last_compute_diagnostics['rope_yarn_enabled'] is True
+    assert manager.last_compute_diagnostics['rope_yarn_factor'] == 2.0
+    assert manager.last_compute_diagnostics['yarn_original_context'] == 32768
+
+
+def test_qwen_64k_runtime_init_fails_when_yarn_kwargs_unsupported(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeLlama:
+        def __init__(self, *, model_path, n_gpu_layers, n_ctx, verbose):
+            _ = (model_path, n_gpu_layers, n_ctx, verbose)
+            raise AssertionError("unsupported runtime must fail before construction")
+
+    monkeypatch.setattr(
+        model_manager_module,
+        '_import_llama_cpp_runtime',
+        lambda **_kwargs: SimpleNamespace(
+            Llama=FakeLlama,
+            LLAMA_ROPE_SCALING_TYPE_YARN=2,
+            __file__='/site/llama_cpp/__init__.py',
+        ),
+    )
+    manager = _qwen_model_manager(tmp_path, context_size=65536, context_tier='64k-full')
+
+    assert manager.get_llm_instance() is None
+    assert 'Qwen 64K context requires llama-cpp-python YaRN/RoPE init kwargs' in manager.last_runtime_init_error
+
+
+def test_llama_runtime_init_keeps_existing_chat_format(standalone_model_manager, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    captured = {}
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        model_manager_module,
+        '_import_llama_cpp_runtime',
+        lambda **_kwargs: SimpleNamespace(Llama=FakeLlama, __file__='/site/llama_cpp/__init__.py'),
+    )
+    standalone_model_manager.requested_compute_mode = 'cpu'
+
+    assert standalone_model_manager.get_llm_instance() is not None
+    assert captured['chat_format'] == 'llama-3'
+    assert 'rope_scaling_type' not in captured
 
 
 def test_get_llm_instance_records_bounded_runtime_discovery_timeout(standalone_model_manager):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4423,6 +4423,101 @@ def test_api_v1_large_structurally_valid_message_uses_exact_tier_admission():
     assert sixty_four_k.runtime.calls[-1]["max_tokens"] == 5
 
 
+def test_qwen_context_admission_uses_non_thinking_template_kwargs():
+    from utils.llm.model_profiles import get_model_profile
+
+    class QwenRuntime:
+        def __init__(self):
+            self.template_calls = []
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=True):
+            self.template_calls.append(
+                {
+                    "tokenize": tokenize,
+                    "add_generation_prompt": add_generation_prompt,
+                    "enable_thinking": enable_thinking,
+                }
+            )
+            return "<|user|>hello<|assistant|>"
+
+        def tokenize(self, payload, *args, **kwargs):
+            return [1, 2, 3]
+
+        def create_chat_completion(self, **kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    manager = _ApiV1RuntimeManager()
+    manager.runtime = QwenRuntime()
+    manager.model_profile = get_model_profile("qwen3-8b-q4-k-m")
+    manager.api_model_id = "qwen3-8b-instruct"
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-template",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={},
+    )
+
+    assert "error" not in envelope["api_v1_response"]
+    assert manager.runtime.template_calls[-1]["enable_thinking"] is False
+
+
+def test_qwen_context_admission_does_not_use_llama_formatter_fallback():
+    from utils.llm.model_profiles import get_model_profile
+
+    manager = _ApiV1RuntimeManager()
+    manager.model_profile = get_model_profile("qwen3-8b-q4-k-m")
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.runtime.apply_chat_template.side_effect = TypeError("enable_thinking unsupported")
+    manager.runtime.chat_format = "llama-3"
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-no-llama-fallback",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={},
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_admission_unavailable"
+    manager.runtime.create_chat_completion.assert_not_called()
+
+
+def test_qwen_runtime_completion_forces_non_thinking_and_rejects_think_output():
+    from utils.llm.model_profiles import get_model_profile
+
+    manager = _ApiV1RuntimeManager()
+    manager.model_profile = get_model_profile("qwen3-8b-q4-k-m")
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.runtime.apply_chat_template.side_effect = (
+        lambda messages, tokenize=False, add_generation_prompt=True, enable_thinking=False:
+        "".join(f"<{message['role']}>{message['content']}" for message in messages)
+        + ("<assistant>" if add_generation_prompt else "")
+    )
+    manager.runtime.create_chat_completion.return_value = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "<think>secret</think> visible"}}
+        ]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-think",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={},
+    )
+
+    kwargs = manager.runtime.create_chat_completion.call_args.kwargs
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] == 0.8
+    assert kwargs["chat_template_kwargs"] == {"enable_thinking": False}
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_model_output"
+
+
 def test_api_v1_context_admission_uses_default_output_budget_for_omitted_max_tokens():
     manager = _AdmissionManager(window=32, default_max_tokens=4)
     client = _api_v1_validation_client(manager)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -8,6 +8,7 @@ from utils.networking.http_requests_compat import requests
 import json
 import sys
 import importlib
+import inspect
 import subprocess
 import queue
 import signal
@@ -20,12 +21,14 @@ from typing import Dict, List, Any, Optional, Iterable
 
 from utils.system import resource_monitor
 from utils.llm.model_profiles import get_model_profile, resolve_profile_id
+from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile
 
 # Configure logging
 logger = logging.getLogger('model_manager')
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 DEFAULT_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
+QWEN3_8B_PROFILE_ID = "qwen3-8b-q4-k-m"
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -1802,6 +1805,98 @@ class ModelManager:
             return profile_value
         return configured_value
 
+    def _is_qwen_profile(self) -> bool:
+        return self.profile_id == QWEN3_8B_PROFILE_ID or self.model_profile.get('provider') == 'qwen'
+
+    @staticmethod
+    def _callable_accepts_kwargs(callable_obj: Any, required_kwargs: Iterable[str]) -> bool:
+        """Return whether a callable advertises support for all required kwargs.
+
+        llama-cpp-python exposes YaRN/RoPE controls as explicit ``Llama`` init
+        kwargs on supported releases.  We accept a ``**kwargs`` signature as
+        supported because some test fakes and wrapper classes preserve runtime
+        validation behind a variadic Python signature; otherwise every required
+        kwarg must be present so unsupported YaRN never gets silently guessed.
+        """
+
+        try:
+            signature = inspect.signature(callable_obj)
+        except (TypeError, ValueError):
+            return False
+        parameters = signature.parameters
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
+            return True
+        return all(name in parameters for name in required_kwargs)
+
+    def _qwen_runtime_init_kwargs(self, Llama: Any, llama_cpp: Any) -> Dict[str, Any]:
+        """Build Qwen-specific llama.cpp init kwargs after capability checks."""
+
+        if not self._is_qwen_profile():
+            return {}
+
+        policy = self.model_profile.get('chat_template_policy')
+        if policy != 'gguf-jinja':
+            raise RuntimeError(f"unsupported Qwen chat template policy: {policy}")
+
+        # Verified implementation choice:
+        # - Qwen must not set ``chat_format='llama-3'``. Omitting chat_format lets
+        #   llama-cpp-python use the GGUF/Jinja chat template embedded in Qwen GGUFs.
+        # - Context admission calls ``apply_chat_template(..., enable_thinking=False)``
+        #   through the same runtime surface used by generation.
+        kwargs: Dict[str, Any] = {}
+        active_tier = getattr(self, 'context_tier', DEFAULT_CONTEXT_TIER)
+        context_tokens = int(self.config.get('model.context_size', 8192) or 8192)
+        native_tokens = int(self.model_profile.get('native_context_tokens') or 0)
+        rope_policy = self.model_profile.get('rope_scaling_policy') or {}
+        required_tier = rope_policy.get('required_for_tier')
+        requires_extension = (
+            required_tier == active_tier
+            and native_tokens > 0
+            and context_tokens > native_tokens
+        )
+        if not requires_extension:
+            return kwargs
+
+        yarn_scaling_type = getattr(llama_cpp, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
+        if yarn_scaling_type is None:
+            raise RuntimeError(
+                "Qwen 64K context requires llama-cpp-python LLAMA_ROPE_SCALING_TYPE_YARN support"
+            )
+        factor = float(rope_policy.get('factor', 1.0))
+        rope_kwargs = {
+            'rope_scaling_type': yarn_scaling_type,
+            'rope_freq_scale': 1.0 / factor,
+            'yarn_ext_factor': factor,
+            'yarn_orig_ctx': int(rope_policy.get('original_context_tokens') or native_tokens),
+        }
+        required_kwargs = tuple(rope_kwargs)
+        if not self._callable_accepts_kwargs(Llama, required_kwargs):
+            raise RuntimeError(
+                "Qwen 64K context requires llama-cpp-python YaRN/RoPE init kwargs "
+                f"{sorted(required_kwargs)}, but this runtime does not advertise them"
+            )
+        return rope_kwargs
+
+    def _runtime_init_diagnostics(self, *, init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        rope_policy = self.model_profile.get('rope_scaling_policy') or {}
+        rope_enabled = bool(rope_policy.get('type') == 'yarn' and 'rope_scaling_type' in init_kwargs)
+        return {
+            'model_profile_id': self.profile_id,
+            'api_model_id': self.api_model_id,
+            'gguf_filename': self.file_name,
+            'quantization': self.model_profile.get('quantization'),
+            'chat_template_mode': self.model_profile.get('chat_template_policy'),
+            'thinking_mode_disabled': self.model_profile.get('thinking_mode') == 'disabled',
+            'n_ctx': self.config.get('model.context_size', 8192),
+            'native_context_tokens': self.model_profile.get('native_context_tokens'),
+            'maximum_validated_context_tokens': (
+                get_context_profile(getattr(self, 'context_tier', DEFAULT_CONTEXT_TIER)).total_context_tokens
+            ),
+            'rope_yarn_enabled': rope_enabled,
+            'rope_yarn_factor': rope_policy.get('factor') if rope_enabled else None,
+            'yarn_original_context': rope_policy.get('original_context_tokens') if rope_enabled else None,
+        }
+
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
         """Return runtime model metadata used by server and desktop bridges."""
         file_exists = os.path.exists(self.model_path)
@@ -2083,13 +2178,33 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            self.llm = Llama(
-                                model_path=self.model_path,
-                                n_gpu_layers=n_gpu_layers,
-                                n_ctx=self.config.get('model.context_size', 8192),
-                                chat_format=self.config.get('model.chat_format', 'llama-3'),
-                                verbose=llama_cpp_verbose_logging_enabled(),
+                            init_kwargs: Dict[str, Any] = {
+                                'model_path': self.model_path,
+                                'n_gpu_layers': n_gpu_layers,
+                                'n_ctx': self.config.get('model.context_size', 8192),
+                                'verbose': llama_cpp_verbose_logging_enabled(),
+                            }
+                            if self._is_qwen_profile():
+                                init_kwargs.update(self._qwen_runtime_init_kwargs(Llama, llama_cpp))
+                            else:
+                                init_kwargs['chat_format'] = self.config.get('model.chat_format', 'llama-3')
+                            runtime_model_diagnostics = self._runtime_init_diagnostics(init_kwargs=init_kwargs)
+                            self.log_info(
+                                "llm.runtime_profile "
+                                f"model_profile_id={runtime_model_diagnostics['model_profile_id']} "
+                                f"api_model_id={runtime_model_diagnostics['api_model_id']} "
+                                f"gguf_filename={runtime_model_diagnostics['gguf_filename']} "
+                                f"quantization={runtime_model_diagnostics['quantization']} "
+                                f"chat_template_mode={runtime_model_diagnostics['chat_template_mode']} "
+                                f"thinking_mode_disabled={runtime_model_diagnostics['thinking_mode_disabled']} "
+                                f"n_ctx={runtime_model_diagnostics['n_ctx']} "
+                                f"native_context_tokens={runtime_model_diagnostics['native_context_tokens']} "
+                                f"maximum_validated_context_tokens={runtime_model_diagnostics['maximum_validated_context_tokens']} "
+                                f"rope_yarn_enabled={runtime_model_diagnostics['rope_yarn_enabled']} "
+                                f"rope_yarn_factor={runtime_model_diagnostics['rope_yarn_factor']} "
+                                f"yarn_original_context={runtime_model_diagnostics['yarn_original_context']}"
                             )
+                            self.llm = Llama(**init_kwargs)
                             compute_plan['n_gpu_layers'] = n_gpu_layers
                             compute_plan['context_tier'] = getattr(self, 'context_tier', '8k-fast')
                             compute_plan['context_window_tokens'] = self.config.get('model.context_size', 8192)
@@ -2103,6 +2218,7 @@ class ModelManager:
                             )
                             compute_plan['device_backend'] = compute_plan['backend_used']
                             compute_plan['device_name'] = 'unreported'
+                            compute_plan.update(runtime_model_diagnostics)
                             self.last_compute_diagnostics = compute_plan
                             if compute_plan['requested_mode'] == 'cpu':
                                 runtime_identity = {

--- a/utils/llm/model_profiles.py
+++ b/utils/llm/model_profiles.py
@@ -99,7 +99,7 @@ MODEL_PROFILES: Dict[str, ModelProfile] = {
         "download_url": "https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf",
         "canonical_family_url": "https://huggingface.co/Qwen/Qwen3-8B",
         "native_context_tokens": 32768,
-        "maximum_validated_context_tokens": 131072,
+        "maximum_validated_context_tokens": 65536,
         "default_context_tokens": 8192,
         "supported_context_tiers": ["8k-fast", "64k-full"],
         "chat_template_policy": "gguf-jinja",
@@ -108,7 +108,7 @@ MODEL_PROFILES: Dict[str, ModelProfile] = {
         "aliases": [],
         "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
         "public_catalog": False,
-        "runnable": False,
+        "runnable": True,
     },
 }
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -21,10 +21,13 @@ from urllib.parse import urlparse, urlunparse
 
 from utils.networking.http_requests_compat import requests
 from utils.context_profiles import DEFAULT_CONTEXT_TIER, get_context_profile, normalize_context_tier
+from utils.llm.model_profiles import get_model_profile, resolve_profile_id
 
 # Configure logging
 logger = logging.getLogger('relay_client')
 DEFAULT_API_V1_LEASE_SECONDS = 30.0
+QWEN3_8B_PROFILE_ID = "qwen3-8b-q4-k-m"
+_API_V1_THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think\s*>", re.IGNORECASE + re.DOTALL)
 
 
 class _ApiV1ChatValidationResult(NamedTuple):
@@ -2457,17 +2460,40 @@ class RelayClient:
             return None
         return None
 
-    @staticmethod
-    def _api_v1_render_chat_prompt(llm_instance: Any, messages: List[Dict[str, Any]]) -> Optional[str]:
+    def _active_model_profile(self) -> Dict[str, Any]:
+        manager = getattr(self, "model_manager", None)
+        profile = getattr(manager, "model_profile", None)
+        if isinstance(profile, dict):
+            return profile
+        config = getattr(manager, "config", None)
+        config_get = getattr(config, "get", None)
+        profile_id = None
+        api_model_id = None
+        if callable(config_get):
+            profile_id = config_get("model.profile_id", None)
+            api_model_id = config_get("model.api_model_id", None)
+        return get_model_profile(resolve_profile_id(profile_id, api_model_id)) or {}
+
+    def _active_model_is_qwen(self) -> bool:
+        profile = self._active_model_profile()
+        return profile.get("profile_id") == QWEN3_8B_PROFILE_ID or profile.get("provider") == "qwen"
+
+    def _qwen_non_thinking_template_kwargs(self) -> Dict[str, Any]:
+        return {"enable_thinking": False} if self._active_model_is_qwen() else {}
+
+    def _api_v1_render_chat_prompt(self, llm_instance: Any, messages: List[Dict[str, Any]]) -> Optional[str]:
         """Render chat messages with the active runtime chat template."""
 
         apply_chat_template = getattr(llm_instance, "apply_chat_template", None)
+        template_kwargs = self._qwen_non_thinking_template_kwargs()
         if callable(apply_chat_template):
             try:
                 rendered = apply_chat_template(
-                    messages, tokenize=False, add_generation_prompt=True
+                    messages, tokenize=False, add_generation_prompt=True, **template_kwargs
                 )
             except TypeError:
+                if template_kwargs:
+                    return None
                 try:
                     rendered = apply_chat_template(messages)
                 except Exception:
@@ -2487,12 +2513,21 @@ class RelayClient:
             if callable(tokenizer_template):
                 try:
                     rendered = tokenizer_template(
-                        messages, tokenize=False, add_generation_prompt=True
+                        messages, tokenize=False, add_generation_prompt=True, **template_kwargs
                     )
+                except TypeError:
+                    if template_kwargs:
+                        rendered = None
+                    else:
+                        raise
                 except Exception:
                     rendered = None
                 if isinstance(rendered, str):
                     return rendered
+        if self._active_model_is_qwen():
+            # Qwen must use its GGUF/Jinja template.  The llama-cpp chat-format
+            # fallback below only exists to preserve legacy Llama admission.
+            return None
         try:
             if not hasattr(llm_instance, "chat_format"):
                 return None
@@ -2721,6 +2756,15 @@ class RelayClient:
             "stop": configured("model.stop_tokens", []),
             "stream": False,
         }
+        profile_defaults = self._active_model_profile().get("generation_defaults") or {}
+        if self._active_model_is_qwen():
+            for key in ("temperature", "top_p"):
+                if key in profile_defaults:
+                    completion_kwargs[key] = profile_defaults[key]
+            # llama-cpp-python forwards chat_template_kwargs to the Jinja/GGUF
+            # template renderer; for Qwen3 this is the verified non-thinking
+            # control and keeps generation aligned with context admission.
+            completion_kwargs["chat_template_kwargs"] = self._qwen_non_thinking_template_kwargs()
         completion_kwargs.update(safe_options)
         return completion_kwargs
 
@@ -2735,9 +2779,18 @@ class RelayClient:
             and completion["choices"]
             and isinstance(completion["choices"][0], dict)
         ):
-            return self._valid_api_v1_assistant_message(
+            assistant = self._valid_api_v1_assistant_message(
                 completion["choices"][0].get("message")
             )
+            if assistant is None:
+                return None
+            content = assistant.get("content")
+            if isinstance(content, str) and _API_V1_THINK_BLOCK_RE.search(content):
+                # Fail closed rather than stripping so hidden reasoning is never
+                # leaked or silently transformed for API v1 clients.
+                log_error("Desktop runtime returned Qwen thinking content; rejecting assistant output")
+                return None
+            return assistant
 
         # API v1 relay inference is explicitly non-streaming; runtimes must return
         # a complete chat completion object for this path.


### PR DESCRIPTION
### Motivation

- Make the internal Qwen3 8B profile runnable through the API v1 runtime without changing the system default model (Llama remains default). 
- Ensure API v1 exact-context admission and generation use the same Qwen template surface and that assistant outputs cannot leak hidden reasoning (`<think>`). 
- Support 64K context for Qwen via YaRN/RoPE scaling when the runtime advertises the required llama-cpp symbols and kwargs, and fail warm-load safely otherwise.

### Description

- Added Qwen profile runtime plumbing and diagnostics in `utils/llm/model_manager.py`, including Qwen detection, build-time/runtime checks for YaRN/RoPE support, selective init kwargs for 64K (`rope_scaling_type`, `rope_freq_scale`, `yarn_ext_factor`, `yarn_orig_ctx`), and verbose model/template/context/rope diagnostics.
- Stopped forcing `chat_format='llama-3'` for Qwen; when a profile uses `gguf-jinja` the code omits `chat_format` so the GGUF/Jinja template is used, and it fails fast if the required template/kwargs are unavailable.
- Aligned API v1 context-admission and generation to use the same runtime apply-chat-template path for Qwen in `utils/networking/relay_client.py`, added a Qwen non-thinking template kwarg (`enable_thinking=False`) path and ensured that missing support causes admission to return the existing unavailable error.
- Enforced non-thinking for Qwen: runtime generation is invoked with `chat_template_kwargs` carrying `enable_thinking=False` and API v1 now rejects assistant outputs that contain `<think>` blocks instead of silently stripping them.
- Implemented verified YaRN/RoPE handling for Qwen 64K only (original context 32768 -> target 65536, factor 2.0) and made startup/warm-load fail with a clear runtime-init error if the llama-cpp runtime does not advertise the required symbols/kwargs.
- Added tests and test helpers that allow explicitly instantiating the Qwen profile in tests/dev without changing production defaults, and extended unit tests to cover: Qwen init behavior (8K vs 64K), YaRN kwargs application and failure, template alignment, non-thinking enforcement, and `<think>` output rejection.
- Files touched: `utils/llm/model_manager.py`, `utils/networking/relay_client.py`, `utils/llm/model_profiles.py`, plus focused unit tests in `tests/unit/test_model_manager.py`, `tests/unit/test_relay_client.py`, and catalog tests.

### Testing

- Ran focused unit and integration suites and lint/hooks; all automated checks passed after changes: `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), `python -m pytest tests/unit/test_api_v1_models_catalog_minimal.py -q` (passed), and `python -m pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py -q` (passed). 
- Ran `python -m pytest tests/unit -q` (full unit subset used during development) and `pre-commit run --all-files` (hooks) and resolved issues until hooks passed; both completed successfully. 

Residual risks and follow-ups: runtime YaRN/RoPE is enabled only when the active llama-cpp build advertises the expected symbols/kwargs and otherwise warm-load fails safely; a follow-up PR (P23d) will flip defaults and update UI/docs when Qwen is intended to become the default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40df7bb570832f9cd0253307719dd1)