### PR TITLE
Gate Qwen API v1 registration on context admission readiness

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -169,6 +169,122 @@ def test_compute_node_runtime_ensure_api_v1_runtime_ready_success():
     assert model_manager.last_compute_diagnostics["api_v1_runtime_ready"] is True
 
 
+def _qwen_model_manager(llm_runtime, *, context_tier="8k-fast"):
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_path = "/tmp/Qwen3-8B-Q4_K_M.gguf"
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.profile_id = "qwen3-8b-q4-k-m"
+    model_manager.context_tier = context_tier
+    model_manager.context_window_tokens = 65536 if context_tier == "64k-full" else 8192
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "chat_template_policy": "gguf-jinja",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {
+            "type": "yarn",
+            "required_for_tier": "64k-full",
+            "factor": 2.0,
+            "original_context_tokens": 32768,
+        },
+    }
+    model_manager.last_compute_diagnostics = {
+        "requested_mode": "gpu",
+        "rope_yarn_enabled": context_tier == "64k-full",
+        "rope_yarn_factor": 2.0 if context_tier == "64k-full" else None,
+        "yarn_original_context": 32768 if context_tier == "64k-full" else None,
+    }
+    model_manager.get_llm_instance.return_value = llm_runtime
+    return model_manager
+
+
+class QwenReadinessRuntime:
+    def __init__(self):
+        self.rendered_messages = None
+
+    def create_chat_completion(self, **_kwargs):
+        return {}
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        assert tokenize is False
+        assert add_generation_prompt is True
+        self.rendered_messages = messages
+        return "<qwen>" + "".join(str(message.get("content", "")) for message in messages)
+
+    def tokenize(self, prompt, add_bos=False):
+        assert add_bos is False
+        assert isinstance(prompt, (bytes, bytearray))
+        return [1, 2, 3, 4]
+
+
+def test_compute_node_runtime_qwen_readiness_smoke_requires_template_tokenizer_bridge(caplog):
+    llm_runtime = QwenReadinessRuntime()
+    model_manager = _qwen_model_manager(llm_runtime)
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    with caplog.at_level("INFO", logger="utils.compute_node_runtime"):
+        assert runtime.ensure_api_v1_runtime_ready() is True
+
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_runtime_ready"] is True
+    assert diagnostics["api_v1_context_admission_ready"] is True
+    assert diagnostics["api_v1_template_tokenizer_bridge_available"] is True
+    assert diagnostics["api_v1_non_thinking_enforced"] is True
+    assert "/no_think" in llm_runtime.rendered_messages[-1]["content"]
+    assert "/no_think\nhi" not in caplog.text
+    assert "<qwen>" not in caplog.text
+
+
+def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope_diagnostics():
+    llm_runtime = QwenReadinessRuntime()
+    model_manager = _qwen_model_manager(llm_runtime, context_tier="64k-full")
+
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_context_admission_ready"] is True
+    assert diagnostics["rope_yarn_enabled"] is True
+    assert diagnostics["rope_yarn_factor"] == 2.0
+    assert diagnostics["yarn_original_context"] == 32768
+
+
+def test_compute_node_runtime_qwen_missing_template_tokenizer_fails_pre_registration():
+    class MissingBridgeRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {}
+
+    model_manager = _qwen_model_manager(MissingBridgeRuntime())
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=MagicMock(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert (
+        model_manager.last_runtime_init_error
+        == "Qwen API v1 context admission unavailable: runtime template/tokenizer bridge missing"
+    )
+    assert model_manager.last_compute_diagnostics["api_v1_context_admission_ready"] is False
+    assert (
+        model_manager.last_compute_diagnostics["api_v1_context_admission_readiness_result"]
+        == "failed"
+    )
+
+
 @pytest.mark.parametrize(
     "llm_instance,getter,expected",
     [

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -387,6 +387,9 @@ class ComputeNodeRuntime:
             )
             return False
 
+        if not self._validate_api_v1_context_admission_ready(llm_runtime):
+            return False
+
         _log_info(f"API v1 runtime warmup model instantiated: {model_path}")
 
         diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
@@ -395,6 +398,110 @@ class ComputeNodeRuntime:
             self.model_manager.last_compute_diagnostics = diagnostics
 
         setattr(self.model_manager, 'last_runtime_init_error', None)
+        return True
+
+    def _validate_api_v1_context_admission_ready(self, llm_runtime: Any) -> bool:
+        """Run a safe pre-registration context-admission smoke for Qwen profiles."""
+
+        model_profile = getattr(self.model_manager, "model_profile", {}) or {}
+        if not isinstance(model_profile, dict) or model_profile.get("provider") != "qwen":
+            return True
+
+        from utils.networking.relay_client import RelayClient
+
+        active_context_tier = getattr(self.model_manager, "context_tier", "8k-fast")
+        configured_context_tokens = getattr(self.model_manager, "context_window_tokens", None)
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        if not isinstance(diagnostics, dict):
+            diagnostics = {}
+        diagnostics.update(
+            {
+                "api_v1_context_admission_ready": False,
+                "api_v1_context_admission_readiness_result": "pending",
+                "api_v1_template_tokenizer_bridge_available": False,
+                "active_model_id": getattr(self.model_manager, "api_model_id", None),
+                "active_profile_id": getattr(self.model_manager, "profile_id", None),
+                "context_tier": active_context_tier,
+                "context_window_tokens": configured_context_tokens,
+                "chat_template_mode": model_profile.get("chat_template_policy"),
+                "thinking_mode_disabled": model_profile.get("thinking_mode") == "disabled",
+            }
+        )
+        rope_policy = model_profile.get("rope_scaling_policy") or {}
+        diagnostics.setdefault(
+            "rope_yarn_enabled",
+            bool(rope_policy and active_context_tier == rope_policy.get("required_for_tier")),
+        )
+        diagnostics.setdefault("rope_yarn_factor", rope_policy.get("factor"))
+        diagnostics.setdefault("yarn_original_context", rope_policy.get("original_context_tokens"))
+
+        # Minimal plaintext is only used in-process to exercise the runtime
+        # template/tokenizer bridge; never log messages or rendered prompts.
+        messages = RelayClient._api_v1_qwen_no_think_messages(
+            [
+                {"role": "system", "content": "API v1 readiness smoke."},
+                {"role": "user", "content": "hi"},
+            ]
+        )
+        rendered_prompt = RelayClient._api_v1_render_chat_prompt(
+            llm_runtime,
+            messages,
+            enable_thinking=None,
+            allow_chat_format_fallback=False,
+        )
+        prompt_tokens = (
+            RelayClient._api_v1_tokenize_rendered_prompt(llm_runtime, rendered_prompt)
+            if rendered_prompt is not None
+            else None
+        )
+        non_thinking_enforced = any(
+            isinstance(message.get("content"), str) and "/no_think" in message["content"]
+            for message in messages
+            if message.get("role") == "user"
+        )
+        diagnostics["api_v1_template_tokenizer_bridge_available"] = prompt_tokens is not None
+        diagnostics["api_v1_non_thinking_enforced"] = non_thinking_enforced
+        if prompt_tokens is None or not non_thinking_enforced:
+            diagnostics["api_v1_context_admission_readiness_result"] = "failed"
+            self.model_manager.last_compute_diagnostics = diagnostics
+            setattr(
+                self.model_manager,
+                "last_runtime_init_error",
+                "Qwen API v1 context admission unavailable: runtime template/tokenizer bridge missing",
+            )
+            _log_error(
+                "api_v1.context_admission_readiness "
+                f"active_model_id={getattr(self.model_manager, 'api_model_id', None)} "
+                f"active_profile_id={getattr(self.model_manager, 'profile_id', None)} "
+                f"context_tier={active_context_tier} "
+                f"context_window_tokens={configured_context_tokens} "
+                f"template_mode={model_profile.get('chat_template_policy')} "
+                f"tokenizer_render_bridge_available={prompt_tokens is not None} "
+                f"non_thinking_enforced={non_thinking_enforced} "
+                f"rope_yarn_enabled={diagnostics.get('rope_yarn_enabled')} "
+                f"rope_yarn_factor={diagnostics.get('rope_yarn_factor')} "
+                f"yarn_original_context={diagnostics.get('yarn_original_context')} "
+                "result=failed reason=runtime_template_tokenizer_bridge_unavailable"
+            )
+            return False
+
+        diagnostics["api_v1_context_admission_ready"] = True
+        diagnostics["api_v1_context_admission_readiness_result"] = "passed"
+        self.model_manager.last_compute_diagnostics = diagnostics
+        _log_info(
+            "api_v1.context_admission_readiness "
+            f"active_model_id={getattr(self.model_manager, 'api_model_id', None)} "
+            f"active_profile_id={getattr(self.model_manager, 'profile_id', None)} "
+            f"context_tier={active_context_tier} "
+            f"context_window_tokens={configured_context_tokens} "
+            f"template_mode={model_profile.get('chat_template_policy')} "
+            "tokenizer_render_bridge_available=True "
+            f"non_thinking_enforced={non_thinking_enforced} "
+            f"rope_yarn_enabled={diagnostics.get('rope_yarn_enabled')} "
+            f"rope_yarn_factor={diagnostics.get('rope_yarn_factor')} "
+            f"yarn_original_context={diagnostics.get('yarn_original_context')} "
+            "result=passed"
+        )
         return True
 
     def start_relay_polling(self) -> threading.Thread:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2683,9 +2683,11 @@ class RelayClient:
         )
         if prompt_tokens is None:
             log_error(
-                "api_v1.context_admission active_tier={} result=rejected reason={} safe_error_code={}",
+                "api_v1.context_admission active_tier={} result=rejected reason={} "
+                "internal_reason={} safe_error_code={}",
                 active_context_tier,
                 "runtime_tokenizer_unavailable",
+                "runtime_template_tokenizer_bridge_unavailable",
                 "compute_node_context_admission_unavailable",
             )
             return (


### PR DESCRIPTION
### Motivation
- Packaged desktop Qwen nodes were warm-loading successfully but failing every API v1 request with `compute_node_context_admission_unavailable` because the parent/bridge path could not render/tokenize Qwen GGUF/Jinja templates.  Nodes must not register as API v1-capable when that bridge is missing.
- Admission must use the same runtime/template/tokenizer surface as generation (no Llama-format fallback) and must enforce Qwen non-thinking semantics so admission counts match generation.

### Description
- Added a Qwen-specific pre-registration readiness check `_validate_api_v1_context_admission_ready` in `utils/compute_node_runtime.py` that runs immediately after the runtime is instantiated and before registration proceeds; it uses the runtime-facing helpers to render and tokenize a tiny API v1 message shape (via `RelayClient._api_v1_qwen_no_think_messages`, `_api_v1_render_chat_prompt`, and `_api_v1_tokenize_rendered_prompt`) and enforces `/no_think` non-thinking control.
- The readiness check fails closed for Qwen when the runtime cannot expose GGUF/Jinja render/tokenize support, sets `model_manager.last_runtime_init_error` with an actionable message, and records safe diagnostics (active model/profile id, context tier, context window, template mode, tokenizer/render bridge availability, non-thinking enforcement, YaRN/RoPE fields).
- `ensure_api_v1_runtime_ready` now calls the readiness check and will prevent pre-registration if the bridge is missing.
- Added a more specific internal diagnostic reason `runtime_template_tokenizer_bridge_unavailable` in the API v1 admission logging path in `utils/networking/relay_client.py` while preserving the external `compute_node_context_admission_unavailable` structured error.
- Added unit tests in `tests/unit/test_compute_node_runtime.py` that exercise: successful Qwen 8K readiness with tokenizer/template bridge, Qwen 64K readiness with YaRN/RoPE diagnostics, and pre-registration failure when the render/tokenize bridge is missing; tests avoid logging prompt text or rendered prompt outputs.

### Testing
- Ran focused unit and integration suites; all executed commands passed: `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), `python -m pytest tests/unit/test_desktop_model_bridge.py -q` (passed), and `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed).
- Ran repository checks `pre-commit run --all-files` and `git diff --check` as part of verification and they passed.
- All added/updated tests are green in the local CI run; readiness diagnostics are written without logging prompt or rendered text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4220997e38832fb59f442f6cad9f48)