### PR TITLE
Bridge Qwen API v1 context admission through desktop runtime

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3959,15 +3959,22 @@ def test_subprocess_llama_proxy_prompt_helpers_use_runtime_stage_timeout(monkeyp
         captured_reads.append((stage, timeout_seconds))
         if stage == 'llama_cpp_prompt_render':
             return {'status': 'ok', 'result': '<|user|>\nhello'}
+        if stage == 'llama_cpp_prompt_render_tokenize':
+            return {'status': 'ok', 'result': {'prompt_tokens': 2}}
         return {'status': 'ok', 'result': [10, 11]}
 
     monkeypatch.setattr(model_manager_module, '_read_llama_subprocess_message', _fake_read)
 
     rendered = proxy.apply_chat_template([{'role': 'user', 'content': 'hello'}], tokenize=False)
     tokens = proxy.tokenize(rendered.encode('utf-8'), add_bos=False)
+    bridge_count = proxy.render_and_tokenize_chat(
+        [{'role': 'user', 'content': 'hello'}],
+        add_generation_prompt=True,
+    )
 
     assert rendered == '<|user|>\nhello'
     assert tokens == [10, 11]
+    assert bridge_count == {'prompt_tokens': 2}
     assert proxy._send.call_args_list == [
         call({
             'method': 'apply_chat_template',
@@ -3979,10 +3986,16 @@ def test_subprocess_llama_proxy_prompt_helpers_use_runtime_stage_timeout(monkeyp
             'args': ({'__token_place_bytes_utf8__': '<|user|>\nhello'},),
             'kwargs': {'add_bos': False},
         }),
+        call({
+            'method': 'render_and_tokenize_chat',
+            'args': ([{'role': 'user', 'content': 'hello'}],),
+            'kwargs': {'add_generation_prompt': True},
+        }),
     ]
     assert captured_reads == [
         ('llama_cpp_prompt_render', 3.25),
         ('llama_cpp_prompt_tokenize', 3.25),
+        ('llama_cpp_prompt_render_tokenize', 3.25),
     ]
 
 
@@ -4008,6 +4021,11 @@ def test_subprocess_llama_proxy_prompt_helpers_mark_closed_on_eof(monkeypatch):
     proxy._closed = False
     with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
         proxy.tokenize(b'hello', add_bos=False)
+    assert proxy._closed is True
+
+    proxy._closed = False
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
+        proxy.render_and_tokenize_chat([], add_generation_prompt=True)
     assert proxy._closed is True
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5008,3 +5008,103 @@ def test_qwen_profile_generation_defaults_include_top_k():
     assert kwargs['temperature'] == 0.7
     assert kwargs['top_p'] == 0.8
     assert kwargs['top_k'] == 20
+
+
+def test_qwen_context_admission_uses_subprocess_render_tokenize_bridge_without_prompt_roundtrip():
+    class BridgeRuntime(_AdmissionRuntime):
+        def __init__(self):
+            super().__init__()
+            self.tokenize_called = False
+
+        def render_and_tokenize_chat(self, messages, **kwargs):
+            self.calls.append({"bridge_kwargs": kwargs, "messages": messages})
+            assert messages[-1]["content"].startswith("/no_think\n")
+            return {"prompt_tokens": 12}
+
+        def tokenize(self, payload, *args):  # pragma: no cover - must not be used
+            self.tokenize_called = True
+            raise AssertionError("subprocess bridge should avoid returning rendered prompt")
+
+    manager = _AdmissionManager(window=32)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "chat_template_policy": "gguf-jinja",
+    }
+    manager.runtime = BridgeRuntime()
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-bridge",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.tokenize_called is False
+    assert manager.runtime.calls[0]["bridge_kwargs"] == {
+        "tokenize": False,
+        "add_generation_prompt": True,
+    }
+
+
+def test_api_v1_registration_fails_closed_when_qwen_bridge_missing(monkeypatch):
+    class Runtime:
+        def create_chat_completion(self, **kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.profile_id = "qwen3-8b-q4-k-m-8k"
+    manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "chat_template_policy": "gguf-jinja",
+    }
+    manager.last_compute_diagnostics = {"chat_template_mode": "gguf-jinja"}
+    manager.runtime = Runtime()
+    client = _api_v1_validation_client(manager)
+
+    def fail_post(*args, **kwargs):  # pragma: no cover - must not register
+        raise AssertionError("registration should be gated by readiness")
+
+    monkeypatch.setattr(relay_client_module.requests, "post", fail_post)
+
+    result = client.register_api_v1_compute_node("http://relay.test")
+
+    assert "context admission unavailable" in result["error"]
+    assert result["readiness_diagnostics"]["reason"] == "runtime_template_tokenizer_bridge_unavailable"
+    assert result["readiness_diagnostics"]["tokenizer_render_bridge_available"] is False
+    assert client._api_v1_registered_relays == set()
+
+
+def test_api_v1_registration_readiness_passes_for_qwen_64k_yarn(monkeypatch):
+    manager = _AdmissionManager(tier="64k-full", window=65536)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.profile_id = "qwen3-8b-q4-k-m-64k"
+    manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "chat_template_policy": "gguf-jinja",
+    }
+    manager.last_compute_diagnostics = {
+        "chat_template_mode": "gguf-jinja",
+        "rope_yarn_enabled": True,
+        "rope_yarn_factor": 2.0,
+    }
+    client = _api_v1_validation_client(manager)
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"next_ping_in_x_seconds": 30, "poll_wait_seconds": 0}
+    monkeypatch.setattr(relay_client_module.requests, "post", MagicMock(return_value=response))
+
+    result = client.register_api_v1_compute_node("http://relay.test")
+
+    assert result == {"next_ping_in_x_seconds": 30, "poll_wait_seconds": 0}
+    readiness = client._api_v1_last_readiness_diagnostics
+    assert readiness["readiness_result"] == "passed"
+    assert readiness["context_tier"] == "64k-full"
+    assert readiness["rope_yarn_enabled"] is True
+    assert readiness["rope_yarn_factor"] == 2.0

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -951,20 +951,37 @@ class _SubprocessLlamaProxy:
                 raise
         return message.get('result')
 
-    def tokenize(self, *args, **kwargs):
-        serializable_args = tuple(
+    @staticmethod
+    def _json_safe_args(args):
+        return tuple(
             {'__token_place_bytes_utf8__': arg.decode('utf-8')}
             if isinstance(arg, (bytes, bytearray))
             else arg
             for arg in args
         )
+
+    def tokenize(self, *args, **kwargs):
         with self._lock:
-            self._send({'method': 'tokenize', 'args': serializable_args, 'kwargs': kwargs})
+            self._send({'method': 'tokenize', 'args': self._json_safe_args(args), 'kwargs': kwargs})
             try:
                 message = _read_llama_subprocess_message(
                     self._process,
                     timeout_seconds=self._timeout_seconds,
                     stage='llama_cpp_prompt_tokenize',
+                )
+            except LlamaCppWorkerEOFError:
+                self._closed = True
+                raise
+        return message.get('result')
+
+    def render_and_tokenize_chat(self, *args, **kwargs):
+        with self._lock:
+            self._send({'method': 'render_and_tokenize_chat', 'args': self._json_safe_args(args), 'kwargs': kwargs})
+            try:
+                message = _read_llama_subprocess_message(
+                    self._process,
+                    timeout_seconds=self._timeout_seconds,
+                    stage='llama_cpp_prompt_render_tokenize',
                 )
             except LlamaCppWorkerEOFError:
                 self._closed = True
@@ -1107,14 +1124,14 @@ for line in sys.stdin:
             _emit(_safe_request_error('malformed_request'))
             continue
         method = request.get('method')
-        if method not in {'create_chat_completion', 'apply_chat_template', 'tokenize'}:
+        if method not in {'create_chat_completion', 'apply_chat_template', 'tokenize', 'render_and_tokenize_chat'}:
             _emit(_safe_request_error('unsupported_method', request=request))
             continue
         kwargs = request.get('kwargs', {})
         if not isinstance(kwargs, dict):
             _emit(_safe_request_error('malformed_kwargs', request=request))
             continue
-        if method == 'apply_chat_template':
+        if method in {'apply_chat_template', 'render_and_tokenize_chat'}:
             render = getattr(llama, 'apply_chat_template', None)
             if not callable(render):
                 tokenizer = getattr(llama, 'tokenizer', None)
@@ -1125,34 +1142,27 @@ for line in sys.stdin:
                         tokenizer = None
                 render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
             if not callable(render):
-                try:
-                    chat_format = getattr(llama, 'chat_format', None) or 'llama-2'
-                    chat_format_module = importlib.import_module('llama_cpp.llama_chat_format')
-                    formatter_key = str(chat_format).replace("-", "_")
-                    formatter_name = (
-                        "format_llama2"
-                        if formatter_key == "llama_2"
-                        else "format_" + formatter_key
-                    )
-                    if formatter_name == "format_llama_3":
-                        formatter_name = "format_llama3"
-                    formatter = getattr(chat_format_module, formatter_name, None)
-                    if not callable(formatter):
-                        _emit(_safe_request_error('prompt_render_unavailable', request=request))
-                        continue
-                    rendered = formatter(*request.get('args', []), **kwargs)
+                _emit(_safe_request_error('prompt_render_unavailable', request=request))
+                continue
+            try:
+                rendered = render(*request.get('args', []), **kwargs)
+                if method == 'render_and_tokenize_chat':
                     prompt = getattr(rendered, 'prompt', rendered)
-                    if kwargs.get('tokenize'):
+                    tokens = rendered if kwargs.get('tokenize') else None
+                    if tokens is None:
                         tokenize = getattr(llama, 'tokenize', None)
                         if not callable(tokenize):
                             _emit(_safe_request_error('tokenizer_unavailable', request=request))
                             continue
-                        prompt = tokenize(str(prompt).encode('utf-8'), add_bos=False)
-                    _emit({'status': 'ok', 'result': prompt})
-                except Exception as exc:
-                    _emit(_safe_request_error('prompt_render_unavailable', request=request, exc=exc))
-                continue
-            _emit({'status': 'ok', 'result': render(*request.get('args', []), **kwargs)})
+                        tokens = tokenize(str(prompt).encode('utf-8'), add_bos=False)
+                    if not isinstance(tokens, (list, tuple)):
+                        _emit(_safe_request_error('tokenizer_unavailable', request=request))
+                        continue
+                    _emit({'status': 'ok', 'result': {'prompt_tokens': len(tokens)}})
+                else:
+                    _emit({'status': 'ok', 'result': rendered})
+            except Exception as exc:
+                _emit(_safe_request_error('prompt_render_unavailable', request=request, exc=exc))
             continue
         if method == 'tokenize':
             tokenize = getattr(llama, 'tokenize', None)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -666,6 +666,8 @@ class RelayClient:
         self._api_v1_heartbeat_stop = threading.Event()
         self._api_v1_heartbeat_thread: Optional[threading.Thread] = None
         self._api_v1_heartbeat_stopping = False
+        self._api_v1_readiness_validated = False
+        self._api_v1_last_readiness_diagnostics: Dict[str, Any] = {}
 
 
     def _api_v1_start_heartbeat_worker(self) -> None:
@@ -1318,7 +1320,87 @@ class RelayClient:
             'relay_http_diagnostic': diagnostic,
         }
 
+
+    def validate_api_v1_context_admission_readiness(self) -> Tuple[bool, Dict[str, Any]]:
+        model_profile = getattr(self.model_manager, "model_profile", {}) or {}
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        if not isinstance(diagnostics, dict):
+            diagnostics = {}
+        active_context_tier = normalize_context_tier(
+            getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)
+        )
+        profile = get_context_profile(active_context_tier)
+        configured_context_tokens = int(
+            getattr(
+                self.model_manager,
+                "context_window_tokens",
+                profile.total_context_tokens,
+            )
+            or profile.total_context_tokens
+        )
+        readiness = {
+            "active_model_id": getattr(self.model_manager, "api_model_id", None),
+            "active_profile_id": getattr(self.model_manager, "profile_id", None),
+            "context_tier": active_context_tier,
+            "context_window_tokens": configured_context_tokens,
+            "template_mode": model_profile.get("chat_template_policy")
+            or diagnostics.get("chat_template_mode"),
+            "tokenizer_render_bridge_available": False,
+            "non_thinking_enforced": model_profile.get("provider") != "qwen"
+            or model_profile.get("thinking_mode") == "disabled",
+            "rope_yarn_enabled": bool(diagnostics.get("rope_yarn_enabled")),
+            "rope_yarn_factor": diagnostics.get("rope_yarn_factor"),
+            "readiness_result": "failed",
+        }
+        is_qwen_profile = model_profile.get("provider") == "qwen"
+        if not is_qwen_profile:
+            readiness["readiness_result"] = "passed"
+            readiness["reason"] = "non_qwen_profile"
+            self._api_v1_last_readiness_diagnostics = readiness
+            return True, readiness
+        llm_instance = self.model_manager.get_llm_instance()
+        if llm_instance is None:
+            readiness["reason"] = "runtime_unavailable"
+            self._api_v1_last_readiness_diagnostics = readiness
+            return False, readiness
+        messages = self._api_v1_qwen_no_think_messages([{"role": "user", "content": "hi"}])
+        token_count = self._api_v1_render_tokenize_chat_count(
+            llm_instance,
+            messages,
+            enable_thinking=None,
+            allow_chat_format_fallback=False,
+        )
+        readiness["tokenizer_render_bridge_available"] = token_count is not None
+        if token_count is None:
+            readiness["reason"] = "runtime_template_tokenizer_bridge_unavailable"
+            self._api_v1_last_readiness_diagnostics = readiness
+            return False, readiness
+        readiness["readiness_result"] = "passed"
+        readiness["prompt_tokens"] = token_count
+        self._api_v1_last_readiness_diagnostics = readiness
+        log_info(
+            "api_v1.readiness active_model_id={} context_tier={} context_window_tokens={} template_mode={} tokenizer_render_bridge_available={} non_thinking_enforced={} rope_yarn_enabled={} rope_yarn_factor={} readiness_result={}",
+            readiness.get("active_model_id"),
+            active_context_tier,
+            configured_context_tokens,
+            readiness.get("template_mode"),
+            True,
+            readiness.get("non_thinking_enforced"),
+            readiness.get("rope_yarn_enabled"),
+            readiness.get("rope_yarn_factor"),
+            "passed",
+        )
+        return True, readiness
+
     def register_api_v1_compute_node(self, relay_url: Optional[str] = None) -> Dict[str, Any]:
+        ready, readiness = self.validate_api_v1_context_admission_readiness()
+        if not ready:
+            return {
+                "error": "Qwen API v1 context admission unavailable: runtime template/tokenizer bridge missing",
+                "readiness_diagnostics": readiness,
+                "next_ping_in_x_seconds": self._request_timeout,
+            }
+        self._api_v1_readiness_validated = True
         target_url = relay_url or self.relay_url
         payload = {
             'server_public_key': self.crypto_manager.public_key_b64,
@@ -2532,6 +2614,50 @@ class RelayClient:
             return None
         return None
 
+
+    def _api_v1_render_tokenize_chat_count(
+        self,
+        llm_instance: Any,
+        messages: List[Dict[str, Any]],
+        *,
+        enable_thinking: Optional[bool] = None,
+        allow_chat_format_fallback: bool = True,
+    ) -> Optional[int]:
+        bridge = getattr(llm_instance, "render_and_tokenize_chat", None)
+        if callable(bridge):
+            kwargs = {"tokenize": False, "add_generation_prompt": True}
+            if enable_thinking is not None:
+                kwargs["enable_thinking"] = enable_thinking
+            try:
+                result = bridge(messages, **kwargs)
+            except TypeError:
+                if enable_thinking is not None:
+                    return None
+                try:
+                    result = bridge(messages)
+                except Exception:
+                    return None
+            except Exception:
+                return None
+            if isinstance(result, dict):
+                count = result.get("prompt_tokens")
+                if isinstance(count, int) and count >= 0:
+                    return count
+            if isinstance(result, (list, tuple)):
+                return len(result)
+            if isinstance(result, int) and result >= 0:
+                return result
+
+        rendered_prompt = self._api_v1_render_chat_prompt(
+            llm_instance,
+            messages,
+            enable_thinking=enable_thinking,
+            allow_chat_format_fallback=allow_chat_format_fallback,
+        )
+        if rendered_prompt is None:
+            return None
+        return self._api_v1_tokenize_rendered_prompt(llm_instance, rendered_prompt)
+
     @staticmethod
     def _api_v1_llama_chat_format_module() -> Any:
         """Import llama.cpp chat formatting without the repo-local llama_cpp stub."""
@@ -2664,7 +2790,7 @@ class RelayClient:
             model_profile.get("provider") == "qwen"
             and model_profile.get("thinking_mode") == "disabled"
         )
-        rendered_prompt = self._api_v1_render_chat_prompt(
+        prompt_tokens = self._api_v1_render_tokenize_chat_count(
             llm_instance,
             messages,
             # Qwen generation below is controlled by the message-level
@@ -2676,16 +2802,11 @@ class RelayClient:
             enable_thinking=None,
             allow_chat_format_fallback=not is_qwen_non_thinking,
         )
-        prompt_tokens = (
-            self._api_v1_tokenize_rendered_prompt(llm_instance, rendered_prompt)
-            if rendered_prompt is not None
-            else None
-        )
         if prompt_tokens is None:
             log_error(
                 "api_v1.context_admission active_tier={} result=rejected reason={} safe_error_code={}",
                 active_context_tier,
-                "runtime_tokenizer_unavailable",
+                "runtime_template_tokenizer_bridge_unavailable",
                 "compute_node_context_admission_unavailable",
             )
             return (


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop nodes loaded Qwen in the subprocess worker but the parent/context-admission path could not render/tokenize Qwen prompts, causing API v1 requests to fail with `compute_node_context_admission_unavailable`.
- The node must fail pre-registration when the runtime template/tokenizer bridge is missing and admission must use the exact same template/tokenizer surface used for generation.

### Description
- Add a subprocess-facing RPC `render_and_tokenize_chat` and a safe JSON argument helper in `_SubprocessLlamaProxy` so rendering+tokenization executes inside the loaded llama.cpp worker and returns prompt token counts without leaking rendered text (see `utils/llm/model_manager.py`).
- Remove the worker-side fallback to repo-local llama chat-format rendering for the apply/tokenize path so Qwen requires the GGUF/Jinja template/tokenizer surface and cannot silently fall back to Llama formatting.
- Add `RelayClient._api_v1_render_tokenize_chat_count` and `validate_api_v1_context_admission_readiness` to perform a tiny admission smoke (Qwen `/no_think` message shape, bridge availability, YaRN/RoPE diagnostics) and gate `register_api_v1_compute_node` so registration fails closed with safe diagnostics when the bridge is missing (see `utils/networking/relay_client.py`).
- Align `_api_v1_authoritative_context_admission` to prefer the new render/tokenize bridge and surface the more specific internal reason `runtime_template_tokenizer_bridge_unavailable` while preserving the external `compute_node_context_admission_unavailable` error shape.
- Add focused tests and test updates exercising the subprocess bridge, Qwen admission via the bridge, fail-closed registration when the bridge is missing, and 64K YaRN readiness diagnostics (see `tests/unit/test_model_manager.py` and `tests/unit/test_relay_client.py`).

### Testing
- Ran unit and integration suites relevant to the change: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, and `python -m pytest tests/unit/test_desktop_model_bridge.py -q`, and all affected tests passed locally.
- Ran repository checks `pre-commit run --all-files` and `git diff --check` and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4220a067c4832fa0499385c70d347f)