### PR TITLE
Restore Qwen API v1 admission bridge

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -429,7 +429,21 @@ def create_fake_llama_cpp_site(tmp_root: Path, layout_label: str) -> tuple[Path,
         "        self.args = args\n"
         "        self.kwargs = kwargs\n"
         "    def create_chat_completion(self, *args, **kwargs):\n"
-        "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake llama ok'}}]}\n",
+        "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake llama ok'}}]}\n"
+        "    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):\n"
+        "        rendered = '\\n'.join(str(message.get('content', '')) for message in messages)\n"
+        "        if add_generation_prompt:\n"
+        "            rendered += '\\nassistant:'\n"
+        "        if tokenize:\n"
+        "            return self.tokenize(rendered.encode('utf-8'), add_bos=False)\n"
+        "        return rendered\n"
+        "    def tokenize(self, payload, add_bos=False, **kwargs):\n"
+        "        if isinstance(payload, (bytes, bytearray)):\n"
+        "            text = payload.decode('utf-8')\n"
+        "        else:\n"
+        "            text = str(payload)\n"
+        "        tokens = [idx + 1 for idx, part in enumerate(text.split()) if part]\n"
+        "        return ([0] if add_bos else []) + tokens\n",
         encoding="utf-8",
     )
     return fake_site, fake_init
@@ -915,7 +929,21 @@ def create_fake_metal_llama_cpp_site(tmp_root: Path, layout_label: str) -> Path:
         "        self.args = args\n"
         "        self.kwargs = kwargs\n"
         "    def create_chat_completion(self, *args, **kwargs):\n"
-        "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake metal ok'}}]}\n",
+        "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake metal ok'}}]}\n"
+        "    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):\n"
+        "        rendered = '\\n'.join(str(message.get('content', '')) for message in messages)\n"
+        "        if add_generation_prompt:\n"
+        "            rendered += '\\nassistant:'\n"
+        "        if tokenize:\n"
+        "            return self.tokenize(rendered.encode('utf-8'), add_bos=False)\n"
+        "        return rendered\n"
+        "    def tokenize(self, payload, add_bos=False, **kwargs):\n"
+        "        if isinstance(payload, (bytes, bytearray)):\n"
+        "            text = payload.decode('utf-8')\n"
+        "        else:\n"
+        "            text = str(payload)\n"
+        "        tokens = [idx + 1 for idx, part in enumerate(text.split()) if part]\n"
+        "        return ([0] if add_bos else []) + tokens\n",
         encoding="utf-8",
     )
     return fake_site

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -205,10 +205,17 @@ def test_compute_node_runtime_qwen_blocks_registration_when_admission_bridge_mis
     model_manager.api_model_id = "qwen3-8b-instruct"
     model_manager.last_compute_diagnostics = {}
     model_manager.get_llm_instance.return_value = MissingBridgeRuntime()
+    relay_client = SimpleNamespace(
+        _api_v1_authoritative_context_admission=lambda **_kwargs: (
+            False,
+            {"code": "compute_node_context_admission_unavailable"},
+            None,
+        )
+    )
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
         model_manager=model_manager,
-        relay_client=MagicMock(),
+        relay_client=relay_client,
         crypto_manager=MagicMock(),
     )
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -208,7 +208,10 @@ def test_compute_node_runtime_qwen_blocks_registration_when_admission_bridge_mis
     relay_client = SimpleNamespace(
         _api_v1_authoritative_context_admission=lambda **_kwargs: (
             False,
-            {"code": "compute_node_context_admission_unavailable"},
+            {
+                "code": "compute_node_context_admission_unavailable",
+                "internal_reason": "runtime_template_tokenizer_bridge_unavailable",
+            },
             None,
         )
     )
@@ -230,6 +233,91 @@ def test_compute_node_runtime_qwen_blocks_registration_when_admission_bridge_mis
         ]
         is False
     )
+
+
+def test_compute_node_runtime_qwen_generic_admission_failure_keeps_safe_reason():
+    class BridgeRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {}
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 1}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = BridgeRuntime()
+    relay_client = SimpleNamespace(
+        _api_v1_authoritative_context_admission=lambda **_kwargs: (
+            False,
+            {
+                "code": "compute_node_context_tier_unsupported",
+                "reason": "requested_tier_not_active",
+            },
+            8,
+        )
+    )
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_runtime_init_error == (
+        "API v1 context admission readiness failed: "
+        "compute_node_context_tier_unsupported reason=requested_tier_not_active"
+    )
+    assert model_manager.last_compute_diagnostics["api_v1_readiness_error_reason"] == (
+        "requested_tier_not_active"
+    )
+
+
+def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope():
+    class ReadyRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {}
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {
+            "type": "yarn",
+            "factor": 2.0,
+            "original_context_tokens": 32768,
+        },
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = ReadyRuntime()
+    relay_client = SimpleNamespace(
+        _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+    )
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_yarn_rope_enabled"] is True
+    assert diagnostics["api_v1_readiness_yarn_rope_factor"] == 2.0
+    assert diagnostics["api_v1_readiness_yarn_original_context_tokens"] == 32768
+    assert diagnostics["api_v1_readiness_tokenizer_render_bridge_available"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import call, MagicMock
 
 import pytest
@@ -17,6 +18,26 @@ from utils.compute_node_runtime import (
     resolve_relay_port,
     resolve_relay_url,
 )
+
+
+def _ready_relay_client():
+    return SimpleNamespace(
+        _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 3)
+    )
+
+
+class _ReadyRuntime:
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, **_kwargs):
+        rendered = "".join(str(message.get("content", "")) for message in messages)
+        return rendered + ("<assistant>" if add_generation_prompt else "")
+
+    def tokenize(self, payload, *args, **_kwargs):
+        if isinstance(payload, bytes):
+            payload = payload.decode("utf-8")
+        return list(range(max(1, len(str(payload)))))
+
+    def create_chat_completion(self, **_kwargs):
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
 
 
 def test_first_env_skips_blank_values(monkeypatch):
@@ -72,13 +93,12 @@ def test_compute_node_runtime_warmup_logs_model_instantiation_stages(caplog):
     model_manager.use_mock_llm = True
     model_manager.model_path = "/tmp/model.gguf"
     model_manager.last_compute_diagnostics = {"requested_mode": "cpu"}
-    llm_runtime = MagicMock()
-    llm_runtime.create_chat_completion = lambda **_kwargs: {}
+    llm_runtime = _ReadyRuntime()
     model_manager.get_llm_instance.return_value = llm_runtime
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
         model_manager=model_manager,
-        relay_client=MagicMock(),
+        relay_client=_ready_relay_client(),
         crypto_manager=MagicMock(),
     )
 
@@ -156,17 +176,53 @@ def test_compute_node_runtime_ensure_api_v1_runtime_ready_success():
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
     model_manager.last_compute_diagnostics = {"requested_mode": "cpu"}
-    llm_runtime = MagicMock()
-    llm_runtime.create_chat_completion = lambda **_kwargs: {}
+    llm_runtime = _ReadyRuntime()
     model_manager.get_llm_instance.return_value = llm_runtime
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=_ready_relay_client(),
+        crypto_manager=MagicMock(),
+    )
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    assert model_manager.last_compute_diagnostics["api_v1_readiness_result"] == "passed"
+
+
+def test_compute_node_runtime_qwen_blocks_registration_when_admission_bridge_missing():
+    class MissingBridgeRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "chat_template_policy": "gguf-jinja",
+    }
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = MissingBridgeRuntime()
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
         model_manager=model_manager,
         relay_client=MagicMock(),
         crypto_manager=MagicMock(),
     )
-    assert runtime.ensure_api_v1_runtime_ready() is True
-    assert model_manager.last_compute_diagnostics["api_v1_runtime_ready"] is True
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_runtime_init_error == (
+        "Qwen API v1 context admission unavailable: runtime template/tokenizer bridge missing"
+    )
+    assert model_manager.last_compute_diagnostics["api_v1_readiness_result"] == "failed"
+    assert (
+        model_manager.last_compute_diagnostics[
+            "api_v1_readiness_tokenizer_render_bridge_available"
+        ]
+        is False
+    )
 
 
 @pytest.mark.parametrize(
@@ -215,19 +271,18 @@ def test_compute_node_runtime_ensure_api_v1_runtime_ready_without_diagnostics_di
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
     model_manager.last_compute_diagnostics = "not-a-dict"
-    llm_runtime = MagicMock()
-    llm_runtime.create_chat_completion = lambda **_kwargs: {}
+    llm_runtime = _ReadyRuntime()
     model_manager.get_llm_instance.return_value = llm_runtime
 
     runtime = ComputeNodeRuntime(
         ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
         model_manager=model_manager,
-        relay_client=MagicMock(),
+        relay_client=_ready_relay_client(),
         crypto_manager=MagicMock(),
     )
 
     assert runtime.ensure_api_v1_runtime_ready() is True
-    assert model_manager.last_compute_diagnostics == "not-a-dict"
+    assert model_manager.last_compute_diagnostics["api_v1_runtime_ready"] is True
 
 
 def test_compute_node_runtime_polling_thread_delegates_to_relay():

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -188,6 +188,46 @@ def test_compute_node_runtime_ensure_api_v1_runtime_ready_success():
     assert model_manager.last_compute_diagnostics["api_v1_readiness_result"] == "passed"
 
 
+def test_compute_node_runtime_readiness_admission_exception_is_generic_not_bridge_missing():
+    class BridgeRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {}
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 1}
+
+    def _raise_admission_error(**_kwargs):
+        raise TimeoutError("relay admission timed out")
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = BridgeRuntime()
+    relay_client = SimpleNamespace(
+        _api_v1_authoritative_context_admission=_raise_admission_error
+    )
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_runtime_init_error == (
+        "API v1 context admission readiness failed: "
+        "compute_node_context_admission_unavailable reason=unknown"
+    )
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_exception_type"] == "TimeoutError"
+    assert diagnostics["api_v1_readiness_packaged_bridge_available"] is True
+    assert diagnostics["api_v1_readiness_tokenizer_render_bridge_available"] is False
+
+
 def test_compute_node_runtime_qwen_blocks_registration_when_admission_bridge_missing():
     class MissingBridgeRuntime:
         def create_chat_completion(self, **_kwargs):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4,6 +4,7 @@ Unit tests for the model manager module.
 import logging
 import os
 import queue
+import subprocess
 import threading
 import pytest
 import shutil
@@ -3959,20 +3960,33 @@ def test_subprocess_llama_proxy_prompt_helpers_use_runtime_stage_timeout(monkeyp
         captured_reads.append((stage, timeout_seconds))
         if stage == 'llama_cpp_prompt_render':
             return {'status': 'ok', 'result': '<|user|>\nhello'}
+        if stage == 'llama_cpp_prompt_render_tokenize':
+            return {'status': 'ok', 'result': {'prompt_tokens': 2}}
         return {'status': 'ok', 'result': [10, 11]}
 
     monkeypatch.setattr(model_manager_module, '_read_llama_subprocess_message', _fake_read)
 
     rendered = proxy.apply_chat_template([{'role': 'user', 'content': 'hello'}], tokenize=False)
+    token_summary = proxy.render_and_tokenize_chat(
+        [{'role': 'user', 'content': 'hello'}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
     tokens = proxy.tokenize(rendered.encode('utf-8'), add_bos=False)
 
     assert rendered == '<|user|>\nhello'
+    assert token_summary == {'prompt_tokens': 2}
     assert tokens == [10, 11]
     assert proxy._send.call_args_list == [
         call({
             'method': 'apply_chat_template',
             'args': ([{'role': 'user', 'content': 'hello'}],),
             'kwargs': {'tokenize': False},
+        }),
+        call({
+            'method': 'render_and_tokenize_chat',
+            'args': ([{'role': 'user', 'content': 'hello'}],),
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True},
         }),
         call({
             'method': 'tokenize',
@@ -3982,6 +3996,7 @@ def test_subprocess_llama_proxy_prompt_helpers_use_runtime_stage_timeout(monkeyp
     ]
     assert captured_reads == [
         ('llama_cpp_prompt_render', 3.25),
+        ('llama_cpp_prompt_render_tokenize', 3.25),
         ('llama_cpp_prompt_tokenize', 3.25),
     ]
 
@@ -4007,8 +4022,114 @@ def test_subprocess_llama_proxy_prompt_helpers_mark_closed_on_eof(monkeypatch):
 
     proxy._closed = False
     with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
+        proxy.render_and_tokenize_chat([], tokenize=False)
+    assert proxy._closed is True
+
+    proxy._closed = False
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
         proxy.tokenize(b'hello', add_bos=False)
     assert proxy._closed is True
+
+
+def _run_llama_worker_request(tmp_path, request, *, llama_body):
+    package_dir = tmp_path / 'llama_cpp'
+    package_dir.mkdir()
+    (package_dir / '__init__.py').write_text(llama_body)
+    env = os.environ.copy()
+    env['PYTHONPATH'] = os.pathsep.join([str(tmp_path), str(Path(__file__).parent.parent.parent)])
+    process = subprocess.Popen(
+        [sys.executable, '-c', 'from utils.llm.model_manager import _LLAMA_CPP_RUNTIME_WORKER_CODE; exec(_LLAMA_CPP_RUNTIME_WORKER_CODE)'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(json.dumps({'args': [], 'kwargs': {}}) + '\n')
+    process.stdin.flush()
+    init = process.stdout.readline()
+    assert init.startswith('TOKEN_PLACE_LLAMA_CPP_JSON:')
+    assert json.loads(init.split(':', 1)[1])['status'] == 'ok'
+    process.stdin.write(json.dumps(request) + '\n')
+    process.stdin.flush()
+    response = process.stdout.readline()
+    process.kill()
+    process.wait(timeout=5)
+    assert response.startswith('TOKEN_PLACE_LLAMA_CPP_JSON:')
+    return json.loads(response.split(':', 1)[1])
+
+
+def test_llama_worker_render_and_tokenize_chat_returns_only_token_count(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True},
+        },
+        llama_body="""
+class Llama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        return 'rendered secret prompt'
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt == b'rendered secret prompt'
+        return [1, 2, 3]
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 3}}
+    assert 'secret prompt' not in json.dumps(response)
+
+
+def test_llama_worker_apply_chat_template_fallback_still_supports_chat_format(tmp_path):
+    package_dir = tmp_path / 'llama_cpp'
+    package_dir.mkdir()
+    (package_dir / '__init__.py').write_text("""
+class Llama:
+    chat_format = 'llama-2'
+    def __init__(self, *args, **kwargs):
+        pass
+    def tokenize(self, prompt, add_bos=False):
+        return [7, 8]
+""")
+    (package_dir / 'llama_chat_format.py').write_text("""
+class Rendered:
+    prompt = '<fallback prompt>'
+def format_llama2(*args, **kwargs):
+    return Rendered()
+""")
+    env = os.environ.copy()
+    env['PYTHONPATH'] = os.pathsep.join([str(tmp_path), str(Path(__file__).parent.parent.parent)])
+    process = subprocess.Popen(
+        [sys.executable, '-c', 'from utils.llm.model_manager import _LLAMA_CPP_RUNTIME_WORKER_CODE; exec(_LLAMA_CPP_RUNTIME_WORKER_CODE)'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(json.dumps({'args': [], 'kwargs': {}}) + '\n')
+    process.stdin.flush()
+    assert json.loads(process.stdout.readline().split(':', 1)[1])['status'] == 'ok'
+    process.stdin.write(json.dumps({
+        'method': 'apply_chat_template',
+        'args': [[{'role': 'user', 'content': 'hello'}]],
+        'kwargs': {'tokenize': True},
+    }) + '\n')
+    process.stdin.flush()
+    response = json.loads(process.stdout.readline().split(':', 1)[1])
+    process.kill()
+    process.wait(timeout=5)
+
+    assert response == {'status': 'ok', 'result': [7, 8]}
 
 
 def test_get_llm_instance_with_recovery_returns_existing_runtime(standalone_model_manager):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4086,6 +4086,38 @@ class Llama:
     assert 'secret prompt' not in json.dumps(response)
 
 
+def test_llama_worker_render_and_tokenize_chat_retries_without_enable_thinking(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': '/no_think\nsecret prompt'}]],
+            'kwargs': {
+                'tokenize': False,
+                'add_generation_prompt': True,
+                'enable_thinking': False,
+            },
+        },
+        llama_body="""
+class Llama:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+    def apply_chat_template(self, messages, **kwargs):
+        self.calls.append(kwargs)
+        if 'enable_thinking' in kwargs:
+            raise TypeError('unexpected keyword argument enable_thinking')
+        return 'rendered fallback prompt'
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt == b'rendered fallback prompt'
+        return [1, 2]
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 2}}
+    assert 'secret prompt' not in json.dumps(response)
+    assert 'rendered fallback prompt' not in json.dumps(response)
+
+
 def test_llama_worker_apply_chat_template_fallback_still_supports_chat_format(tmp_path):
     package_dir = tmp_path / 'llama_cpp'
     package_dir.mkdir()

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4930,6 +4930,40 @@ def test_qwen_context_admission_uses_generation_aligned_no_think_messages_withou
     assert manager.runtime.calls[-1]['messages'][-1]['content'].startswith('/no_think\n')
 
 
+def test_qwen_context_admission_uses_packaged_render_tokenize_bridge():
+    class Runtime(_AdmissionRuntime):
+        def render_and_tokenize_chat(self, messages, tokenize=False, add_generation_prompt=True, **kwargs):
+            self.calls.append({
+                'bridge': 'render_and_tokenize_chat',
+                'messages': messages,
+                'template_kwargs': kwargs,
+            })
+            assert tokenize is False
+            assert add_generation_prompt is True
+            return {'prompt_tokens': 7}
+
+        def apply_chat_template(self, *args, **kwargs):  # pragma: no cover - should not be used
+            raise AssertionError('legacy parent render path should not be used')
+
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime = Runtime()
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-bridge',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    assert envelope['api_v1_response']['message']['content'] == 'ok'
+    assert manager.runtime.calls[0]['bridge'] == 'render_and_tokenize_chat'
+    assert manager.runtime.calls[0]['messages'][-1]['content'].startswith('/no_think\n')
+
+
 def test_qwen_no_think_messages_injects_text_block_when_user_content_list_has_no_text():
     prepared = RelayClient._api_v1_qwen_no_think_messages([
         {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,...'}}]},

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -396,14 +396,23 @@ class ComputeNodeRuntime:
         context_tier = getattr(self.model_manager, "context_tier", "8k-fast")
         context_window_tokens = getattr(self.model_manager, "context_window_tokens", None)
         rope_policy = model_profile.get("rope_scaling_policy") or {}
+        packaged_render_tokenize_bridge_available = callable(
+            getattr(llm_runtime, "render_and_tokenize_chat", None)
+        )
+        legacy_template_available = callable(getattr(llm_runtime, "apply_chat_template", None))
+        legacy_tokenizer_available = callable(getattr(llm_runtime, "tokenize", None))
         diagnostics.update({
             "api_v1_readiness_model_id": getattr(self.model_manager, "api_model_id", None),
             "api_v1_readiness_context_tier": context_tier,
             "api_v1_readiness_context_window_tokens": context_window_tokens,
             "api_v1_readiness_template_mode": model_profile.get("chat_template_policy") or "llama-3",
-            "api_v1_readiness_tokenizer_render_bridge_available": callable(
-                getattr(llm_runtime, "render_and_tokenize_chat", None)
-            ) or callable(getattr(llm_runtime, "apply_chat_template", None)),
+            "api_v1_readiness_packaged_bridge_available": packaged_render_tokenize_bridge_available,
+            "api_v1_readiness_legacy_template_available": legacy_template_available,
+            "api_v1_readiness_legacy_tokenizer_available": legacy_tokenizer_available,
+            "api_v1_readiness_tokenizer_render_bridge_available": (
+                packaged_render_tokenize_bridge_available
+                or (legacy_template_available and legacy_tokenizer_available)
+            ),
             "api_v1_readiness_non_thinking_enforced": (
                 model_profile.get("provider") == "qwen"
                 and model_profile.get("thinking_mode") == "disabled"
@@ -440,11 +449,17 @@ class ComputeNodeRuntime:
         })
         self.model_manager.last_compute_diagnostics = diagnostics
         if not admitted:
+            admission_code = (admission_error or {}).get("code") or "unknown"
+            qwen_bridge_missing = (
+                diagnostics.get("api_v1_readiness_non_thinking_enforced")
+                and not diagnostics.get("api_v1_readiness_packaged_bridge_available")
+                and admission_code == "compute_node_context_admission_unavailable"
+            )
             message = (
                 "Qwen API v1 context admission unavailable: "
                 "runtime template/tokenizer bridge missing"
-                if model_profile.get("provider") == "qwen"
-                else "API v1 context admission readiness failed"
+                if qwen_bridge_missing
+                else f"API v1 context admission readiness failed: {admission_code}"
             )
             setattr(self.model_manager, 'last_runtime_init_error', message)
             _log_error(message)

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -390,9 +390,65 @@ class ComputeNodeRuntime:
         _log_info(f"API v1 runtime warmup model instantiated: {model_path}")
 
         diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
-        if isinstance(diagnostics, dict):
-            diagnostics["api_v1_runtime_ready"] = True
-            self.model_manager.last_compute_diagnostics = diagnostics
+        if not isinstance(diagnostics, dict):
+            diagnostics = {}
+        model_profile = getattr(self.model_manager, "model_profile", {}) or {}
+        context_tier = getattr(self.model_manager, "context_tier", "8k-fast")
+        context_window_tokens = getattr(self.model_manager, "context_window_tokens", None)
+        rope_policy = model_profile.get("rope_scaling_policy") or {}
+        diagnostics.update({
+            "api_v1_readiness_model_id": getattr(self.model_manager, "api_model_id", None),
+            "api_v1_readiness_context_tier": context_tier,
+            "api_v1_readiness_context_window_tokens": context_window_tokens,
+            "api_v1_readiness_template_mode": model_profile.get("chat_template_policy") or "llama-3",
+            "api_v1_readiness_tokenizer_render_bridge_available": callable(
+                getattr(llm_runtime, "render_and_tokenize_chat", None)
+            ) or callable(getattr(llm_runtime, "apply_chat_template", None)),
+            "api_v1_readiness_non_thinking_enforced": (
+                model_profile.get("provider") == "qwen"
+                and model_profile.get("thinking_mode") == "disabled"
+            ),
+            "api_v1_readiness_yarn_rope_enabled": bool(rope_policy.get("type") == "yarn"),
+            "api_v1_readiness_yarn_rope_factor": rope_policy.get("factor"),
+        })
+
+        try:
+            from utils.networking.relay_client import RelayClient
+
+            smoke_messages = [{"role": "system", "content": "ok"}, {"role": "user", "content": "hi"}]
+            if diagnostics["api_v1_readiness_non_thinking_enforced"]:
+                smoke_messages = RelayClient._api_v1_qwen_no_think_messages(smoke_messages)
+            admitted, admission_error, prompt_tokens = (
+                self.relay_client._api_v1_authoritative_context_admission(
+                    llm_instance=llm_runtime,
+                    messages=smoke_messages,
+                    requested_output_tokens=1,
+                    requested_context_tier=str(context_tier),
+                )
+            )
+        except Exception as exc:
+            admitted = False
+            admission_error = {"code": "compute_node_context_admission_unavailable"}
+            prompt_tokens = None
+            diagnostics["api_v1_readiness_exception_type"] = type(exc).__name__
+
+        diagnostics.update({
+            "api_v1_runtime_ready": bool(admitted),
+            "api_v1_readiness_result": "passed" if admitted else "failed",
+            "api_v1_readiness_prompt_tokens": prompt_tokens,
+            "api_v1_readiness_error_code": (admission_error or {}).get("code") if not admitted else None,
+        })
+        self.model_manager.last_compute_diagnostics = diagnostics
+        if not admitted:
+            message = (
+                "Qwen API v1 context admission unavailable: "
+                "runtime template/tokenizer bridge missing"
+                if model_profile.get("provider") == "qwen"
+                else "API v1 context admission readiness failed"
+            )
+            setattr(self.model_manager, 'last_runtime_init_error', message)
+            _log_error(message)
+            return False
 
         setattr(self.model_manager, 'last_runtime_init_error', None)
         return True

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -409,16 +409,20 @@ class ComputeNodeRuntime:
             "api_v1_readiness_packaged_bridge_available": packaged_render_tokenize_bridge_available,
             "api_v1_readiness_legacy_template_available": legacy_template_available,
             "api_v1_readiness_legacy_tokenizer_available": legacy_tokenizer_available,
-            "api_v1_readiness_tokenizer_render_bridge_available": (
+            "api_v1_readiness_tokenizer_render_bridge_capability_available": (
                 packaged_render_tokenize_bridge_available
                 or (legacy_template_available and legacy_tokenizer_available)
             ),
+            "api_v1_readiness_tokenizer_render_bridge_available": False,
             "api_v1_readiness_non_thinking_enforced": (
                 model_profile.get("provider") == "qwen"
                 and model_profile.get("thinking_mode") == "disabled"
             ),
             "api_v1_readiness_yarn_rope_enabled": bool(rope_policy.get("type") == "yarn"),
             "api_v1_readiness_yarn_rope_factor": rope_policy.get("factor"),
+            "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
+                "original_context_tokens"
+            ),
         })
 
         try:
@@ -441,25 +445,50 @@ class ComputeNodeRuntime:
             prompt_tokens = None
             diagnostics["api_v1_readiness_exception_type"] = type(exc).__name__
 
+        prompt_tokens_available = isinstance(prompt_tokens, int) and prompt_tokens > 0
         diagnostics.update({
             "api_v1_runtime_ready": bool(admitted),
             "api_v1_readiness_result": "passed" if admitted else "failed",
             "api_v1_readiness_prompt_tokens": prompt_tokens,
+            "api_v1_readiness_tokenizer_render_bridge_available": bool(
+                admitted and prompt_tokens_available
+            ),
             "api_v1_readiness_error_code": (admission_error or {}).get("code") if not admitted else None,
+            "api_v1_readiness_error_reason": (
+                (admission_error or {}).get("internal_reason")
+                or (admission_error or {}).get("reason")
+            ) if not admitted else None,
         })
         self.model_manager.last_compute_diagnostics = diagnostics
         if not admitted:
             admission_code = (admission_error or {}).get("code") or "unknown"
+            admission_reason = (
+                (admission_error or {}).get("internal_reason")
+                or (admission_error or {}).get("reason")
+                or "unknown"
+            )
+            bridge_capability_missing = not diagnostics.get(
+                "api_v1_readiness_tokenizer_render_bridge_capability_available"
+            )
+            bridge_admission_failure = (
+                admission_reason == "runtime_template_tokenizer_bridge_unavailable"
+                or (
+                    admission_code == "compute_node_context_admission_unavailable"
+                    and bridge_capability_missing
+                )
+            )
             qwen_bridge_missing = (
                 diagnostics.get("api_v1_readiness_non_thinking_enforced")
-                and not diagnostics.get("api_v1_readiness_packaged_bridge_available")
-                and admission_code == "compute_node_context_admission_unavailable"
+                and bridge_admission_failure
             )
             message = (
                 "Qwen API v1 context admission unavailable: "
                 "runtime template/tokenizer bridge missing"
                 if qwen_bridge_missing
-                else f"API v1 context admission readiness failed: {admission_code}"
+                else (
+                    "API v1 context admission readiness failed: "
+                    f"{admission_code} reason={admission_reason}"
+                )
             )
             setattr(self.model_manager, 'last_runtime_init_error', message)
             _log_error(message)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1143,7 +1143,17 @@ for line in sys.stdin:
                     _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request))
                     continue
                 try:
-                    rendered_prompt = render(*request.get('args', []), **kwargs)
+                    try:
+                        rendered_prompt = render(*request.get('args', []), **kwargs)
+                    except TypeError:
+                        if 'enable_thinking' not in kwargs:
+                            raise
+                        compatibility_kwargs = dict(kwargs)
+                        compatibility_kwargs.pop('enable_thinking', None)
+                        rendered_prompt = render(
+                            *request.get('args', []),
+                            **compatibility_kwargs,
+                        )
                     if not isinstance(rendered_prompt, str):
                         _emit(_safe_request_error('prompt_render_unavailable', request=request))
                         continue

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -951,6 +951,20 @@ class _SubprocessLlamaProxy:
                 raise
         return message.get('result')
 
+    def render_and_tokenize_chat(self, *args, **kwargs):
+        with self._lock:
+            self._send({'method': 'render_and_tokenize_chat', 'args': args, 'kwargs': kwargs})
+            try:
+                message = _read_llama_subprocess_message(
+                    self._process,
+                    timeout_seconds=self._timeout_seconds,
+                    stage='llama_cpp_prompt_render_tokenize',
+                )
+            except LlamaCppWorkerEOFError:
+                self._closed = True
+                raise
+        return message.get('result')
+
     def tokenize(self, *args, **kwargs):
         serializable_args = tuple(
             {'__token_place_bytes_utf8__': arg.decode('utf-8')}
@@ -1107,14 +1121,14 @@ for line in sys.stdin:
             _emit(_safe_request_error('malformed_request'))
             continue
         method = request.get('method')
-        if method not in {'create_chat_completion', 'apply_chat_template', 'tokenize'}:
+        if method not in {'create_chat_completion', 'apply_chat_template', 'tokenize', 'render_and_tokenize_chat'}:
             _emit(_safe_request_error('unsupported_method', request=request))
             continue
         kwargs = request.get('kwargs', {})
         if not isinstance(kwargs, dict):
             _emit(_safe_request_error('malformed_kwargs', request=request))
             continue
-        if method == 'apply_chat_template':
+        if method in {'apply_chat_template', 'render_and_tokenize_chat'}:
             render = getattr(llama, 'apply_chat_template', None)
             if not callable(render):
                 tokenizer = getattr(llama, 'tokenizer', None)
@@ -1124,6 +1138,27 @@ for line in sys.stdin:
                     except Exception:
                         tokenizer = None
                 render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
+            if method == 'render_and_tokenize_chat':
+                if not callable(render):
+                    _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request))
+                    continue
+                try:
+                    rendered_prompt = render(*request.get('args', []), **kwargs)
+                    if not isinstance(rendered_prompt, str):
+                        _emit(_safe_request_error('prompt_render_unavailable', request=request))
+                        continue
+                    tokenize = getattr(llama, 'tokenize', None)
+                    if not callable(tokenize):
+                        _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request))
+                        continue
+                    tokens = tokenize(rendered_prompt.encode('utf-8'), add_bos=False)
+                    if not isinstance(tokens, (list, tuple)):
+                        _emit(_safe_request_error('tokenizer_unavailable', request=request))
+                        continue
+                    _emit({'status': 'ok', 'result': {'prompt_tokens': len(tokens)}})
+                except Exception as exc:
+                    _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request, exc=exc))
+                continue
             if not callable(render):
                 try:
                     chat_format = getattr(llama, 'chat_format', None) or 'llama-2'

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2431,6 +2431,42 @@ class RelayClient:
             total += len(text)
         return total
 
+
+    @staticmethod
+    def _api_v1_render_and_tokenize_chat_prompt(
+        llm_instance: Any,
+        messages: List[Dict[str, Any]],
+        *,
+        enable_thinking: Optional[bool] = None,
+    ) -> Optional[int]:
+        """Render and tokenize in one runtime bridge call when the facade exposes it."""
+
+        render_and_tokenize = getattr(llm_instance, "render_and_tokenize_chat", None)
+        if not callable(render_and_tokenize):
+            return None
+        kwargs = {"tokenize": False, "add_generation_prompt": True}
+        if enable_thinking is not None:
+            kwargs["enable_thinking"] = enable_thinking
+        try:
+            result = render_and_tokenize(messages, **kwargs)
+        except TypeError:
+            if enable_thinking is not None:
+                logger.warning(
+                    "api_v1.chat_template_render result=rejected "
+                    "reason=enable_thinking_unsupported safe_error_code=%s",
+                    "compute_node_context_admission_unavailable",
+                )
+            return None
+        except Exception:
+            return None
+        if isinstance(result, dict):
+            prompt_tokens = result.get("prompt_tokens")
+        else:
+            prompt_tokens = result
+        if isinstance(prompt_tokens, int) and prompt_tokens >= 0:
+            return prompt_tokens
+        return None
+
     @staticmethod
     def _api_v1_tokenize_rendered_prompt(llm_instance: Any, rendered_prompt: str) -> Optional[int]:
         """Count prompt tokens with the active llama.cpp runtime tokenizer."""
@@ -2664,28 +2700,38 @@ class RelayClient:
             model_profile.get("provider") == "qwen"
             and model_profile.get("thinking_mode") == "disabled"
         )
-        rendered_prompt = self._api_v1_render_chat_prompt(
+        # Prefer a packaged-runtime bridge that renders and tokenizes inside the
+        # loaded worker process. This keeps Qwen admission aligned with the same
+        # GGUF/Jinja template surface used by generation and avoids returning or
+        # logging rendered prompt text in the parent process.
+        prompt_tokens = self._api_v1_render_and_tokenize_chat_prompt(
             llm_instance,
             messages,
-            # Qwen generation below is controlled by the message-level
-            # ``/no_think`` directive because llama-cpp-python's
-            # ``create_chat_completion`` API does not expose template kwargs.
-            # Admission must render the same message shape, rather than adding
-            # an admission-only ``enable_thinking=False`` assistant prefix that
-            # over-counts near-limit requests.
             enable_thinking=None,
-            allow_chat_format_fallback=not is_qwen_non_thinking,
         )
-        prompt_tokens = (
-            self._api_v1_tokenize_rendered_prompt(llm_instance, rendered_prompt)
-            if rendered_prompt is not None
-            else None
-        )
+        if prompt_tokens is None:
+            rendered_prompt = self._api_v1_render_chat_prompt(
+                llm_instance,
+                messages,
+                # Qwen generation below is controlled by the message-level
+                # ``/no_think`` directive because llama-cpp-python's
+                # ``create_chat_completion`` API does not expose template kwargs.
+                # Admission must render the same message shape, rather than adding
+                # an admission-only ``enable_thinking=False`` assistant prefix that
+                # over-counts near-limit requests.
+                enable_thinking=None,
+                allow_chat_format_fallback=not is_qwen_non_thinking,
+            )
+            prompt_tokens = (
+                self._api_v1_tokenize_rendered_prompt(llm_instance, rendered_prompt)
+                if rendered_prompt is not None
+                else None
+            )
         if prompt_tokens is None:
             log_error(
                 "api_v1.context_admission active_tier={} result=rejected reason={} safe_error_code={}",
                 active_context_tier,
-                "runtime_tokenizer_unavailable",
+                "runtime_template_tokenizer_bridge_unavailable",
                 "compute_node_context_admission_unavailable",
             )
             return (

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2634,6 +2634,7 @@ class RelayClient:
             "requested_context_tier": requested_context_tier,
             "configured_context_tokens": configured_context_tokens,
             "retryable": False,
+            "internal_reason": "runtime_template_tokenizer_bridge_unavailable",
         }
 
     def _api_v1_context_admission_error(


### PR DESCRIPTION
### Motivation
- Packaged desktop Qwen runtimes could warm-load and generate inside a subprocess worker while the parent process lacked the same GGUF/Jinja template/tokenizer surface for API v1 context admission, causing repeated request failures (`compute_node_context_admission_unavailable`).
- A node must fail pre-registration if it cannot authoritatively render/tokenize Qwen prompts so we do not register broken API v1 capable nodes.

### Description
- Added a packaged-runtime RPC `render_and_tokenize_chat` implemented on the subprocess facade so rendering + tokenization run inside the loaded llama.cpp worker (file changed: `utils/llm/model_manager.py`).
- Extended the packaged llama.cpp worker stub to handle `render_and_tokenize_chat` and return prompt token counts without returning/logging rendered prompt text (file changed: `utils/llm/model_manager.py`).
- Updated API v1 admission to prefer the packaged render+tokenize bridge (`_api_v1_render_and_tokenize_chat_prompt`) and fall back to existing parent-render+tokenize only when needed, and to surface the more specific internal reason `runtime_template_tokenizer_bridge_unavailable` while preserving the external `compute_node_context_admission_unavailable` behavior (file changed: `utils/networking/relay_client.py`).
- Added pre-registration readiness smoke that invokes authoritative admission using the active profile (including Qwen non-thinking message shape) and records safe diagnostics (model id/profile, context tier/window, template mode, bridge availability, non-thinking enforcement, YaRN/RoPE flags); nodes now fail to register when admission fails (file changed: `utils/compute_node_runtime.py`).
- Added focused tests covering the packaged bridge render/tokenize path and Qwen admission gating: `tests/unit/test_relay_client.py` and `tests/unit/test_compute_node_runtime.py` were extended to include bridge-success and bridge-missing cases.

### Testing
- Ran unit and integration suites locally and all targeted tests passed: `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), `python -m pytest tests/unit/test_desktop_model_bridge.py -q` (passed), and `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed).
- Ran repository checks: `pre-commit run --all-files` completed with all hooks passing and `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4220a937d4832fae807f62bc782cad)